### PR TITLE
us_equities_panel: the stage-06+ notebooks reviewed and fixed before the run

### DIFF
--- a/case_studies/us_equities_panel/06_linear.ipynb
+++ b/case_studies/us_equities_panel/06_linear.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "6fbfcab5",
+   "id": "ea3910bc",
    "metadata": {},
    "source": [
     "# US equities panel: what a penalized linear map of the cross-section is worth\n",
@@ -72,7 +72,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6f6de8e2",
+   "id": "50dd0254",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -103,7 +103,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f4561e67",
+   "id": "cae82776",
    "metadata": {
     "tags": [
      "parameters"
@@ -124,7 +124,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ba2285b1",
+   "id": "72d48813",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -133,7 +133,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ba05b499",
+   "id": "b18f6d8b",
    "metadata": {},
    "source": [
     "## 1. Which labels, and which models\n",
@@ -151,7 +151,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4c76c789",
+   "id": "7d8d9cce",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -160,7 +160,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0d89429c",
+   "id": "fe626120",
    "metadata": {},
    "source": [
     "Each name in a menu resolves to a preset in `case_studies/config/{model_type}/`, which holds\n",
@@ -177,17 +177,19 @@
     "- **Lasso** penalizes the sum of absolute coefficients, which drives some of them exactly to\n",
     "  zero: it selects features rather than shrinking them. **ElasticNet** mixes the two.\n",
     "\n",
-    "Lasso and ElasticNet are parameterized here by `alpha_frac` rather than a raw penalty. For any\n",
-    "fold there is a threshold penalty $\\alpha_{\\max}$ - the smallest one that zeros every\n",
-    "coefficient - computed from that fold's own data. `alpha_frac` is the fraction of it to apply,\n",
-    "so one declared `alpha_frac` means the same thing on every fold, while a fixed raw penalty would\n",
-    "mean something different on each."
+    "Lasso and ElasticNet are declared with a raw `alpha`, two values each an order of magnitude\n",
+    "apart, and ElasticNet also carries `l1_ratio` - the share of the penalty that is L1 rather than\n",
+    "L2. An L1 penalty behaves differently from Ridge in one way that matters for reading the grid:\n",
+    "for any fold there is a threshold penalty $\\alpha_{\\max}$, the smallest one that zeros every\n",
+    "coefficient, and where it falls depends on that fold's own design matrix. So one declared\n",
+    "`alpha` is a different fraction of the way to that threshold on every fold, and a configuration\n",
+    "can zero out on some folds and not on others. Section 4's coverage column is what shows it."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "42c693cd",
+   "id": "ffacdd29",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -202,7 +204,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a4babc47",
+   "id": "6a432857",
    "metadata": {},
    "source": [
     "`LABELS` and `CONFIG_NAMES` both narrow what is fitted, and a narrowed run declares a different\n",
@@ -214,7 +216,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8349ac33",
+   "id": "917f2393",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -243,7 +245,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9381006c",
+   "id": "34bed931",
    "metadata": {},
    "source": [
     "## 2. Binding the declarations to the data\n",
@@ -279,7 +281,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c239abf3",
+   "id": "ea86e432",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -308,7 +310,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5f82a196",
+   "id": "e379d6da",
    "metadata": {},
    "source": [
     "`checkpoints` is 1 on every row, and that is the structural difference between this notebook and\n",
@@ -320,7 +322,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4983be75",
+   "id": "22bcc6fc",
    "metadata": {},
    "source": [
     "## 3. Fitting the population\n",
@@ -360,21 +362,23 @@
     "prediction identities, so anything that moves a training identity - a changed estimator\n",
     "parameter as much as a changed menu - produces a different population under the same name, and\n",
     "the registry refuses to write it without being told which snapshot it supersedes. That lineage\n",
-    "is the only record of which generation is which."
+    "is the only record of which generation is which.\n",
+    "\n",
+    "A declared `SUPERSEDES_POPULATION` hash only means something where a generation of this name\n",
+    "already exists. A preview run, a first canonical run against an empty `run_log/`, and a run\n",
+    "under a caller-chosen `POPULATION_NAME` are all refused by `OfficialPopulation.create` if one\n",
+    "is passed anyway, so `supersedes_for_run` works out which of those cases this run is and\n",
+    "resolves the hash accordingly."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cd0042ba",
+   "id": "c3065f57",
    "metadata": {},
    "outputs": [],
    "source": [
     "population_name = POPULATION_NAME or \"us-equities-linear-checkpoints-v1\"\n",
-    "# The declared hash is only meaningful where a generation of this name already exists. A\n",
-    "# preview run, a first canonical run against an empty `run_log/`, and a run under a\n",
-    "# caller-chosen `POPULATION_NAME` are all refused by `OfficialPopulation.create` if it is\n",
-    "# passed anyway. The resolution lives in shared code so no notebook branches on the tier.\n",
     "supersedes = supersedes_for_run(\n",
     "    study,\n",
     "    population_name=population_name,\n",
@@ -396,7 +400,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "66a817e2",
+   "id": "97e3accc",
    "metadata": {},
    "source": [
     "`reused` is not zero on a second run. Every identity is re-derived from the inputs, the registry\n",
@@ -432,7 +436,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2835b3d7",
+   "id": "6e6900d0",
    "metadata": {},
    "source": [
     "## 4. What came out\n",
@@ -458,7 +462,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "099698c3",
+   "id": "8a77f8a4",
    "metadata": {
     "tags": [
      "results"
@@ -513,7 +517,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6621d682",
+   "id": "8fd11d00",
    "metadata": {},
    "source": [
     "## Freeze the compatible result sets\n",
@@ -543,7 +547,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2c0fd183",
+   "id": "6e74b24c",
    "metadata": {
     "tags": [
      "results"
@@ -592,7 +596,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "437d80d9",
+   "id": "7ebd00a7",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -610,7 +614,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "de782d9a",
+   "id": "eb860794",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -692,7 +696,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c5195fc4",
+   "id": "7f2a89a5",
    "metadata": {},
    "source": [
     "### What shrinkage does on its own\n",
@@ -706,7 +710,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a76c4947",
+   "id": "84d49490",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -788,7 +792,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d1677ec7",
+   "id": "66c93d88",
    "metadata": {},
    "source": [
     "## 5. What to notice\n",
@@ -796,10 +800,10 @@
     "**Where the Ridge curve turns tells you how collinear the design matrix is.** It is flat while\n",
     "the penalty is too weak to bind, rises as shrinkage starts collapsing groups of near-duplicate\n",
     "features onto their common direction, and falls once the penalty is strong enough to erode the\n",
-    "signal along with the noise. The distance from the peak back to unregularized OLS is the part of\n",
-    "the signal that multicollinearity was burying. On a feature set close to orthogonal the same\n",
-    "curve would be nearly flat, and that comparison is worth making on your own data before spending\n",
-    "a grid on it.\n",
+    "signal along with the noise. How far it climbs above its own flat left end is how much of the\n",
+    "signal collinearity was burying, because the left end is where the penalty is too weak to change\n",
+    "what the fit does. On a feature set close to orthogonal the curve would be nearly flat\n",
+    "throughout, and that comparison is worth making on your own data before spending a grid on it.\n",
     "\n",
     "**Whether the three horizons agree is the second thing to read.** They are the same features and\n",
     "the same folds, differing only in how far ahead the label looks. Where the orderings agree, the\n",

--- a/case_studies/us_equities_panel/06_linear.ipynb
+++ b/case_studies/us_equities_panel/06_linear.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "ea3910bc",
+   "id": "825a66ca",
    "metadata": {},
    "source": [
     "# US equities panel: what a penalized linear map of the cross-section is worth\n",
@@ -72,7 +72,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "50dd0254",
+   "id": "8e26b4fc",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -103,7 +103,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cae82776",
+   "id": "db7c25d9",
    "metadata": {
     "tags": [
      "parameters"
@@ -124,7 +124,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "72d48813",
+   "id": "eda922ab",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -133,7 +133,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b18f6d8b",
+   "id": "8380f6bf",
    "metadata": {},
    "source": [
     "## 1. Which labels, and which models\n",
@@ -151,7 +151,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7d8d9cce",
+   "id": "4b4178fe",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -160,7 +160,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fe626120",
+   "id": "8606e4c6",
    "metadata": {},
    "source": [
     "Each name in a menu resolves to a preset in `case_studies/config/{model_type}/`, which holds\n",
@@ -189,7 +189,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ffacdd29",
+   "id": "79230241",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -204,7 +204,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6a432857",
+   "id": "46b59da5",
    "metadata": {},
    "source": [
     "`LABELS` and `CONFIG_NAMES` both narrow what is fitted, and a narrowed run declares a different\n",
@@ -216,7 +216,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "917f2393",
+   "id": "b8eb25f8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -245,7 +245,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "34bed931",
+   "id": "a93cdc0e",
    "metadata": {},
    "source": [
     "## 2. Binding the declarations to the data\n",
@@ -281,7 +281,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ea86e432",
+   "id": "a85bf7d4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -310,7 +310,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e379d6da",
+   "id": "98c24ce2",
    "metadata": {},
    "source": [
     "`checkpoints` is 1 on every row, and that is the structural difference between this notebook and\n",
@@ -322,7 +322,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "22bcc6fc",
+   "id": "788dd17d",
    "metadata": {},
    "source": [
     "## 3. Fitting the population\n",
@@ -374,7 +374,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c3065f57",
+   "id": "b35a5778",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -400,7 +400,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "97e3accc",
+   "id": "9f72b651",
    "metadata": {},
    "source": [
     "`reused` is not zero on a second run. Every identity is re-derived from the inputs, the registry\n",
@@ -436,7 +436,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6e6900d0",
+   "id": "19712b71",
    "metadata": {},
    "source": [
     "## 4. What came out\n",
@@ -462,7 +462,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8a77f8a4",
+   "id": "b4fea8ee",
    "metadata": {
     "tags": [
      "results"
@@ -517,7 +517,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8fd11d00",
+   "id": "c0778e44",
    "metadata": {},
    "source": [
     "## Freeze the compatible result sets\n",
@@ -533,11 +533,12 @@
     "backtest whatever subset of names does resolve. A missing name is a silently narrower strategy\n",
     "chain, which is the failure the named-set design exists to prevent.\n",
     "\n",
-    "The diagnostic subset is bounded on purpose. `15` holds every diagnostic member's prediction\n",
-    "frame in memory at once and correlates them pairwise, so the cost is quadratic in members. The\n",
-    "full grid is sixteen configurations on each of three labels; `ols` is the unpenalized baseline\n",
-    "every penalized configuration is a shrinkage of, which makes it the one that means something on\n",
-    "its own.\n",
+    "The diagnostic subset is bounded hard, and the reason is arithmetic. `15` loads every diagnostic\n",
+    "member's raw prediction frame and holds them all while it joins them pairwise; one frame on this\n",
+    "panel is 7.2 million rows and about 225 MB in memory. So the set is one member per label and\n",
+    "family: the diagnostic configuration at its last checkpoint. Here that is `ols`, the unpenalized\n",
+    "baseline every penalized configuration is a shrinkage of, and a linear model has one fitted\n",
+    "state, so its last checkpoint is its only one.\n",
     "\n",
     "Only an unnarrowed canonical run publishes. The guard on `narrows_declared_catalog` above already\n",
     "refuses to publish the canonical *population* from a narrowed run; the same condition governs the\n",
@@ -547,7 +548,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6e74b24c",
+   "id": "28bdd307",
    "metadata": {
     "tags": [
      "results"
@@ -564,7 +565,14 @@
     "            label_rows,\n",
     "            name=f\"us-equities-{label_name}-linear-v1\",\n",
     "        )\n",
-    "        diagnostic_rows = label_rows.filter(pl.col(\"config_name\").is_in(DIAGNOSTIC_CONFIG_NAMES))\n",
+    "        diagnostic_rows = label_rows.filter(\n",
+    "            pl.col(\"config_name\").is_in(DIAGNOSTIC_CONFIG_NAMES)\n",
+    "            # `.fill_null(True)` covers a family that publishes no checkpoint value at all, where\n",
+    "            # the comparison is null rather than false and would otherwise empty the frame.\n",
+    "            & (\n",
+    "                pl.col(\"checkpoint_value\") == pl.col(\"checkpoint_value\").max().over(\"config_name\")\n",
+    "            ).fill_null(True)\n",
+    "        )\n",
     "        if diagnostic_rows.height == 0:\n",
     "            raise ValueError(\n",
     "                f\"no {label_value} rows for diagnostic configurations {DIAGNOSTIC_CONFIG_NAMES}\"\n",
@@ -596,7 +604,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7ebd00a7",
+   "id": "58e8b82b",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -614,7 +622,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "eb860794",
+   "id": "deea7e1a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -696,7 +704,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7f2a89a5",
+   "id": "c039b858",
    "metadata": {},
    "source": [
     "### What shrinkage does on its own\n",
@@ -710,7 +718,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "84d49490",
+   "id": "bd8aa749",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -792,7 +800,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "66c93d88",
+   "id": "2359a3d9",
    "metadata": {},
    "source": [
     "## 5. What to notice\n",

--- a/case_studies/us_equities_panel/06_linear.ipynb
+++ b/case_studies/us_equities_panel/06_linear.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "825a66ca",
+   "id": "fe5950ca",
    "metadata": {},
    "source": [
     "# US equities panel: what a penalized linear map of the cross-section is worth\n",
@@ -72,7 +72,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8e26b4fc",
+   "id": "2dfc0349",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -86,6 +86,7 @@
     "from plotly.subplots import make_subplots\n",
     "\n",
     "from case_studies.research import (\n",
+    "    candidate_set_supersedes,\n",
     "    declared_labels,\n",
     "    load_model_configs,\n",
     "    model_requests,\n",
@@ -103,7 +104,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "db7c25d9",
+   "id": "bab524c2",
    "metadata": {
     "tags": [
      "parameters"
@@ -118,13 +119,14 @@
     "CONFIG_NAMES: list[str] = []\n",
     "DIAGNOSTIC_CONFIG_NAMES = [\"ols\"]\n",
     "POPULATION_NAME = \"\"\n",
-    "SUPERSEDES_POPULATION: str = \"\""
+    "SUPERSEDES_POPULATION: str = \"\"\n",
+    "SUPERSEDES_SETS: dict = {}"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "eda922ab",
+   "id": "57f1890c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -133,7 +135,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8380f6bf",
+   "id": "f432419d",
    "metadata": {},
    "source": [
     "## 1. Which labels, and which models\n",
@@ -151,7 +153,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4b4178fe",
+   "id": "3cf1bae2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -160,7 +162,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8606e4c6",
+   "id": "76a90b86",
    "metadata": {},
    "source": [
     "Each name in a menu resolves to a preset in `case_studies/config/{model_type}/`, which holds\n",
@@ -189,7 +191,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "79230241",
+   "id": "bfe70234",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -204,7 +206,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "46b59da5",
+   "id": "94f66187",
    "metadata": {},
    "source": [
     "`LABELS` and `CONFIG_NAMES` both narrow what is fitted, and a narrowed run declares a different\n",
@@ -216,7 +218,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b8eb25f8",
+   "id": "e5afb014",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -245,7 +247,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a93cdc0e",
+   "id": "d5ce3b31",
    "metadata": {},
    "source": [
     "## 2. Binding the declarations to the data\n",
@@ -281,7 +283,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a85bf7d4",
+   "id": "18e29809",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -310,7 +312,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "98c24ce2",
+   "id": "2a1e2d74",
    "metadata": {},
    "source": [
     "`checkpoints` is 1 on every row, and that is the structural difference between this notebook and\n",
@@ -322,7 +324,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "788dd17d",
+   "id": "f5e8870a",
    "metadata": {},
    "source": [
     "## 3. Fitting the population\n",
@@ -374,7 +376,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b35a5778",
+   "id": "6001a468",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -400,7 +402,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9f72b651",
+   "id": "6067f7cf",
    "metadata": {},
    "source": [
     "`reused` is not zero on a second run. Every identity is re-derived from the inputs, the registry\n",
@@ -436,7 +438,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "19712b71",
+   "id": "cd223867",
    "metadata": {},
    "source": [
     "## 4. What came out\n",
@@ -462,7 +464,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b4fea8ee",
+   "id": "1992a888",
    "metadata": {
     "tags": [
      "results"
@@ -517,7 +519,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c0778e44",
+   "id": "33d0b9df",
    "metadata": {},
    "source": [
     "## Freeze the compatible result sets\n",
@@ -535,7 +537,7 @@
     "\n",
     "The diagnostic subset is bounded hard, and the reason is arithmetic. `15` loads every diagnostic\n",
     "member's raw prediction frame and holds them all while it joins them pairwise; one frame on this\n",
-    "panel is 7.2 million rows and about 225 MB in memory. So the set is one member per label and\n",
+    "panel is over seven million rows and about 225 MB in memory. So the set is one member per label and\n",
     "family: the diagnostic configuration at its last checkpoint. Here that is `ols`, the unpenalized\n",
     "baseline every penalized configuration is a shrinkage of, and a linear model has one fitted\n",
     "state, so its last checkpoint is its only one.\n",
@@ -548,7 +550,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "28bdd307",
+   "id": "cc2b5e77",
    "metadata": {
     "tags": [
      "results"
@@ -561,9 +563,13 @@
     "    for label_value in panel_labels:\n",
     "        label_name = label_value.replace(\"_\", \"-\")\n",
     "        label_rows = execution.catalog_rows.filter(pl.col(\"label\") == label_value)\n",
+    "        full_set_name = f\"us-equities-{label_name}-linear-v1\"\n",
     "        full_set = study.predictions.freeze(\n",
     "            label_rows,\n",
-    "            name=f\"us-equities-{label_name}-linear-v1\",\n",
+    "            name=full_set_name,\n",
+    "            supersedes=candidate_set_supersedes(\n",
+    "                study, name=full_set_name, declared=SUPERSEDES_SETS.get(full_set_name, \"\")\n",
+    "            ),\n",
     "        )\n",
     "        diagnostic_rows = label_rows.filter(\n",
     "            pl.col(\"config_name\").is_in(DIAGNOSTIC_CONFIG_NAMES)\n",
@@ -577,9 +583,15 @@
     "            raise ValueError(\n",
     "                f\"no {label_value} rows for diagnostic configurations {DIAGNOSTIC_CONFIG_NAMES}\"\n",
     "            )\n",
+    "        diagnostic_set_name = f\"us-equities-{label_name}-linear-diagnostics-v1\"\n",
     "        diagnostic_set = study.predictions.freeze(\n",
     "            diagnostic_rows,\n",
-    "            name=f\"us-equities-{label_name}-linear-diagnostics-v1\",\n",
+    "            name=diagnostic_set_name,\n",
+    "            supersedes=candidate_set_supersedes(\n",
+    "                study,\n",
+    "                name=diagnostic_set_name,\n",
+    "                declared=SUPERSEDES_SETS.get(diagnostic_set_name, \"\"),\n",
+    "            ),\n",
     "        )\n",
     "        set_rows.extend(\n",
     "            [\n",
@@ -604,7 +616,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "58e8b82b",
+   "id": "8094346d",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -622,7 +634,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "deea7e1a",
+   "id": "9b6c823d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -704,7 +716,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c039b858",
+   "id": "5fcec864",
    "metadata": {},
    "source": [
     "### What shrinkage does on its own\n",
@@ -718,7 +730,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bd8aa749",
+   "id": "fedc502a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -800,7 +812,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2359a3d9",
+   "id": "fd78a0e1",
    "metadata": {},
    "source": [
     "## 5. What to notice\n",

--- a/case_studies/us_equities_panel/06_linear.py
+++ b/case_studies/us_equities_panel/06_linear.py
@@ -88,6 +88,7 @@ import polars as pl
 from plotly.subplots import make_subplots
 
 from case_studies.research import (
+    candidate_set_supersedes,
     declared_labels,
     load_model_configs,
     model_requests,
@@ -110,6 +111,7 @@ CONFIG_NAMES: list[str] = []
 DIAGNOSTIC_CONFIG_NAMES = ["ols"]
 POPULATION_NAME = ""
 SUPERSEDES_POPULATION: str = ""
+SUPERSEDES_SETS: dict = {}
 
 # %%
 study = open_study("us_equities_panel", execution_tier=EXECUTION_TIER, workspace=WORKSPACE or None)
@@ -428,7 +430,7 @@ catalog.select(
 #
 # The diagnostic subset is bounded hard, and the reason is arithmetic. `15` loads every diagnostic
 # member's raw prediction frame and holds them all while it joins them pairwise; one frame on this
-# panel is 7.2 million rows and about 225 MB in memory. So the set is one member per label and
+# panel is over seven million rows and about 225 MB in memory. So the set is one member per label and
 # family: the diagnostic configuration at its last checkpoint. Here that is `ols`, the unpenalized
 # baseline every penalized configuration is a shrinkage of, and a linear model has one fitted
 # state, so its last checkpoint is its only one.
@@ -443,9 +445,13 @@ if is_published_population:
     for label_value in panel_labels:
         label_name = label_value.replace("_", "-")
         label_rows = execution.catalog_rows.filter(pl.col("label") == label_value)
+        full_set_name = f"us-equities-{label_name}-linear-v1"
         full_set = study.predictions.freeze(
             label_rows,
-            name=f"us-equities-{label_name}-linear-v1",
+            name=full_set_name,
+            supersedes=candidate_set_supersedes(
+                study, name=full_set_name, declared=SUPERSEDES_SETS.get(full_set_name, "")
+            ),
         )
         diagnostic_rows = label_rows.filter(
             pl.col("config_name").is_in(DIAGNOSTIC_CONFIG_NAMES)
@@ -459,9 +465,15 @@ if is_published_population:
             raise ValueError(
                 f"no {label_value} rows for diagnostic configurations {DIAGNOSTIC_CONFIG_NAMES}"
             )
+        diagnostic_set_name = f"us-equities-{label_name}-linear-diagnostics-v1"
         diagnostic_set = study.predictions.freeze(
             diagnostic_rows,
-            name=f"us-equities-{label_name}-linear-diagnostics-v1",
+            name=diagnostic_set_name,
+            supersedes=candidate_set_supersedes(
+                study,
+                name=diagnostic_set_name,
+                declared=SUPERSEDES_SETS.get(diagnostic_set_name, ""),
+            ),
         )
         set_rows.extend(
             [

--- a/case_studies/us_equities_panel/06_linear.py
+++ b/case_studies/us_equities_panel/06_linear.py
@@ -426,11 +426,12 @@ catalog.select(
 # backtest whatever subset of names does resolve. A missing name is a silently narrower strategy
 # chain, which is the failure the named-set design exists to prevent.
 #
-# The diagnostic subset is bounded on purpose. `15` holds every diagnostic member's prediction
-# frame in memory at once and correlates them pairwise, so the cost is quadratic in members. The
-# full grid is sixteen configurations on each of three labels; `ols` is the unpenalized baseline
-# every penalized configuration is a shrinkage of, which makes it the one that means something on
-# its own.
+# The diagnostic subset is bounded hard, and the reason is arithmetic. `15` loads every diagnostic
+# member's raw prediction frame and holds them all while it joins them pairwise; one frame on this
+# panel is 7.2 million rows and about 225 MB in memory. So the set is one member per label and
+# family: the diagnostic configuration at its last checkpoint. Here that is `ols`, the unpenalized
+# baseline every penalized configuration is a shrinkage of, and a linear model has one fitted
+# state, so its last checkpoint is its only one.
 #
 # Only an unnarrowed canonical run publishes. The guard on `narrows_declared_catalog` above already
 # refuses to publish the canonical *population* from a narrowed run; the same condition governs the
@@ -446,7 +447,14 @@ if is_published_population:
             label_rows,
             name=f"us-equities-{label_name}-linear-v1",
         )
-        diagnostic_rows = label_rows.filter(pl.col("config_name").is_in(DIAGNOSTIC_CONFIG_NAMES))
+        diagnostic_rows = label_rows.filter(
+            pl.col("config_name").is_in(DIAGNOSTIC_CONFIG_NAMES)
+            # `.fill_null(True)` covers a family that publishes no checkpoint value at all, where
+            # the comparison is null rather than false and would otherwise empty the frame.
+            & (
+                pl.col("checkpoint_value") == pl.col("checkpoint_value").max().over("config_name")
+            ).fill_null(True)
+        )
         if diagnostic_rows.height == 0:
             raise ValueError(
                 f"no {label_value} rows for diagnostic configurations {DIAGNOSTIC_CONFIG_NAMES}"

--- a/case_studies/us_equities_panel/06_linear.py
+++ b/case_studies/us_equities_panel/06_linear.py
@@ -144,11 +144,13 @@ declared_labels(study, "linear")
 # - **Lasso** penalizes the sum of absolute coefficients, which drives some of them exactly to
 #   zero: it selects features rather than shrinking them. **ElasticNet** mixes the two.
 #
-# Lasso and ElasticNet are parameterized here by `alpha_frac` rather than a raw penalty. For any
-# fold there is a threshold penalty $\alpha_{\max}$ - the smallest one that zeros every
-# coefficient - computed from that fold's own data. `alpha_frac` is the fraction of it to apply,
-# so one declared `alpha_frac` means the same thing on every fold, while a fixed raw penalty would
-# mean something different on each.
+# Lasso and ElasticNet are declared with a raw `alpha`, two values each an order of magnitude
+# apart, and ElasticNet also carries `l1_ratio` - the share of the penalty that is L1 rather than
+# L2. An L1 penalty behaves differently from Ridge in one way that matters for reading the grid:
+# for any fold there is a threshold penalty $\alpha_{\max}$, the smallest one that zeros every
+# coefficient, and where it falls depends on that fold's own design matrix. So one declared
+# `alpha` is a different fraction of the way to that threshold on every fold, and a configuration
+# can zero out on some folds and not on others. Section 4's coverage column is what shows it.
 
 # %%
 configs = load_model_configs(
@@ -287,13 +289,15 @@ planned.select(
 # parameter as much as a changed menu - produces a different population under the same name, and
 # the registry refuses to write it without being told which snapshot it supersedes. That lineage
 # is the only record of which generation is which.
+#
+# A declared `SUPERSEDES_POPULATION` hash only means something where a generation of this name
+# already exists. A preview run, a first canonical run against an empty `run_log/`, and a run
+# under a caller-chosen `POPULATION_NAME` are all refused by `OfficialPopulation.create` if one
+# is passed anyway, so `supersedes_for_run` works out which of those cases this run is and
+# resolves the hash accordingly.
 
 # %%
 population_name = POPULATION_NAME or "us-equities-linear-checkpoints-v1"
-# The declared hash is only meaningful where a generation of this name already exists. A
-# preview run, a first canonical run against an empty `run_log/`, and a run under a
-# caller-chosen `POPULATION_NAME` are all refused by `OfficialPopulation.create` if it is
-# passed anyway. The resolution lives in shared code so no notebook branches on the tier.
 supersedes = supersedes_for_run(
     study,
     population_name=population_name,
@@ -648,10 +652,10 @@ else:
 # **Where the Ridge curve turns tells you how collinear the design matrix is.** It is flat while
 # the penalty is too weak to bind, rises as shrinkage starts collapsing groups of near-duplicate
 # features onto their common direction, and falls once the penalty is strong enough to erode the
-# signal along with the noise. The distance from the peak back to unregularized OLS is the part of
-# the signal that multicollinearity was burying. On a feature set close to orthogonal the same
-# curve would be nearly flat, and that comparison is worth making on your own data before spending
-# a grid on it.
+# signal along with the noise. How far it climbs above its own flat left end is how much of the
+# signal collinearity was burying, because the left end is where the penalty is too weak to change
+# what the fit does. On a feature set close to orthogonal the curve would be nearly flat
+# throughout, and that comparison is worth making on your own data before spending a grid on it.
 #
 # **Whether the three horizons agree is the second thing to read.** They are the same features and
 # the same folds, differing only in how far ahead the label looks. Where the orderings agree, the

--- a/case_studies/us_equities_panel/07_gbm.ipynb
+++ b/case_studies/us_equities_panel/07_gbm.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "8841b2a5",
+   "id": "414ccef9",
    "metadata": {},
    "source": [
     "# US equities panel: capacity, loss function, and when to stop adding trees\n",
@@ -76,7 +76,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b9d89797",
+   "id": "0b03680a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -105,7 +105,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "96942bdb",
+   "id": "91fc7421",
    "metadata": {
     "tags": [
      "parameters"
@@ -126,7 +126,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8a403280",
+   "id": "b6ead0d4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -135,7 +135,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1be92ed0",
+   "id": "f83e11f6",
    "metadata": {},
    "source": [
     "## 1. Which labels, and which models\n",
@@ -153,7 +153,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c25aa031",
+   "id": "09879cc2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -162,7 +162,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f35e0da2",
+   "id": "82e1456f",
    "metadata": {},
    "source": [
     "Each name resolves to a preset in `case_studies/config/lgb/` holding the complete LightGBM\n",
@@ -199,7 +199,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "52a3acac",
+   "id": "679568e0",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -214,7 +214,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1a6bcb5c",
+   "id": "d74b3bf9",
    "metadata": {},
    "source": [
     "`LABELS` and `CONFIG_NAMES` both narrow what is fitted, and a narrowed run declares a different\n",
@@ -226,7 +226,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "59916ab9",
+   "id": "0dddcaf0",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -255,7 +255,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f4186447",
+   "id": "532847b3",
    "metadata": {},
    "source": [
     "## 2. Binding the declarations to the data\n",
@@ -283,7 +283,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f5e60e3b",
+   "id": "bd9195d4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -312,7 +312,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7b53324d",
+   "id": "9f877767",
    "metadata": {},
    "source": [
     "## 3. Fitting the population\n",
@@ -352,21 +352,23 @@
     "`SUPERSEDES_POPULATION` names the population hash this run replaces. A changed estimator\n",
     "parameter moves every training identity as surely as a changed menu does, so the refit is a\n",
     "different population under the same name and the registry refuses to write it without being told\n",
-    "which snapshot it supersedes. That lineage is the only record of which generation is which."
+    "which snapshot it supersedes. That lineage is the only record of which generation is which.\n",
+    "\n",
+    "A declared `SUPERSEDES_POPULATION` hash only means something where a generation of this name\n",
+    "already exists. A preview run, a first canonical run against an empty `run_log/`, and a run\n",
+    "under a caller-chosen `POPULATION_NAME` are all refused by `OfficialPopulation.create` if one\n",
+    "is passed anyway, so `supersedes_for_run` works out which of those cases this run is and\n",
+    "resolves the hash accordingly."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cdd317e4",
+   "id": "0a4d85f7",
    "metadata": {},
    "outputs": [],
    "source": [
     "population_name = POPULATION_NAME or \"us-equities-gbm-checkpoints-v1\"\n",
-    "# The declared hash is only meaningful where a generation of this name already exists. A\n",
-    "# preview run, a first canonical run against an empty `run_log/`, and a run under a\n",
-    "# caller-chosen `POPULATION_NAME` are all refused by `OfficialPopulation.create` if it is\n",
-    "# passed anyway. The resolution lives in shared code so no notebook branches on the tier.\n",
     "supersedes = supersedes_for_run(\n",
     "    study,\n",
     "    population_name=population_name,\n",
@@ -388,7 +390,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c3dfb657",
+   "id": "347b73a9",
    "metadata": {},
    "source": [
     "### Running configurations of your own\n",
@@ -416,7 +418,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8fbddca3",
+   "id": "3c7a4d4f",
    "metadata": {},
    "source": [
     "## 4. What came out\n",
@@ -439,7 +441,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2aabecd0",
+   "id": "484e42ac",
    "metadata": {},
    "source": [
     "### What the run produced, and the sets it publishes\n",
@@ -471,7 +473,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6d675c0a",
+   "id": "2fec1386",
    "metadata": {
     "tags": [
      "results"
@@ -569,7 +571,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7f1a3165",
+   "id": "a0acf66d",
    "metadata": {},
    "source": [
     "### What more trees do\n",
@@ -588,7 +590,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4e63c640",
+   "id": "6b74f344",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -677,7 +679,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "650b9a93",
+   "id": "ac06a888",
    "metadata": {},
    "source": [
     "Whether the lines trend, and which way, is not something to read off a page of overlapping\n",
@@ -691,7 +693,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ee35bb82",
+   "id": "d8c83e84",
    "metadata": {
     "tags": [
      "results"
@@ -730,7 +732,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5dd09a2f",
+   "id": "6d562132",
    "metadata": {},
    "source": [
     "### Comparing every configuration at the same training length\n",
@@ -745,19 +747,21 @@
     "declares the same `max_iterations`, so that is also a comparison at equal training length, and\n",
     "the line printed under the frame says so rather than assuming it. The configurations are held in one order across\n",
     "the panels - their ranking on the primary label - so a panel that does not descend is a horizon\n",
-    "that orders the grid differently."
+    "that orders the grid differently.\n",
+    "\n",
+    "The final state below is each configuration's own last checkpoint, so a configuration declaring\n",
+    "a shorter schedule than its neighbours is still compared at the state it reached. Every preset\n",
+    "in this grid declares the same `max_iterations`, so today those last checkpoints coincide, and\n",
+    "the line printed under the agreement frame reports the iteration count they all landed on."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f53ce5f8",
+   "id": "c0f6c7d2",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Each configuration's own last checkpoint, not the label's. They are the same number while every\n",
-    "# preset declares the same `max_iterations`, and taking the label-wide maximum would silently drop\n",
-    "# a configuration with a shorter schedule instead of comparing it at the state it reached.\n",
     "final = (\n",
     "    catalog.filter(\n",
     "        pl.col(\"checkpoint_value\") == pl.col(\"checkpoint_value\").max().over(\"label\", \"config_name\")\n",
@@ -819,7 +823,7 @@
     "    col=1,\n",
     ")\n",
     "fig_final.update_layout(\n",
-    "    title=\"The grid does not keep one order across the three horizons\",\n",
+    "    title=\"Validation IC at the final iteration, in the primary label's order\",\n",
     "    height=300 * len(panel_labels),\n",
     "    width=1000,\n",
     "    margin=dict(t=90),\n",
@@ -837,7 +841,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "773cf9ed",
+   "id": "1da9ed27",
    "metadata": {},
    "source": [
     "The frame below puts a number on what the chart shows: for each label, the rank correlation\n",
@@ -849,7 +853,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4d6af4b4",
+   "id": "8e58bf4a",
    "metadata": {
     "tags": [
      "results"
@@ -882,7 +886,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c40a9365",
+   "id": "b78ccd94",
    "metadata": {},
    "source": [
     "## 5. What to notice\n",

--- a/case_studies/us_equities_panel/07_gbm.ipynb
+++ b/case_studies/us_equities_panel/07_gbm.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "b042beeb",
+   "id": "6e5f4736",
    "metadata": {},
    "source": [
     "# US equities panel: capacity, loss function, and when to stop adding trees\n",
@@ -76,7 +76,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "dd02d0a2",
+   "id": "698c98f4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -88,6 +88,7 @@
     "from plotly.subplots import make_subplots\n",
     "\n",
     "from case_studies.research import (\n",
+    "    candidate_set_supersedes,\n",
     "    declared_labels,\n",
     "    load_model_configs,\n",
     "    model_requests,\n",
@@ -105,7 +106,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6ac4b343",
+   "id": "79861326",
    "metadata": {
     "tags": [
      "parameters"
@@ -120,13 +121,14 @@
     "CONFIG_NAMES: list[str] = []\n",
     "DIAGNOSTIC_CONFIG_NAMES = [\"default_mse\"]\n",
     "POPULATION_NAME = \"\"\n",
-    "SUPERSEDES_POPULATION: str = \"\""
+    "SUPERSEDES_POPULATION: str = \"\"\n",
+    "SUPERSEDES_SETS: dict = {}"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "48ea33ae",
+   "id": "20aa41b3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -135,7 +137,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "453ff18a",
+   "id": "dd5a4c7a",
    "metadata": {},
    "source": [
     "## 1. Which labels, and which models\n",
@@ -153,7 +155,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "91167197",
+   "id": "f1c1c951",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -162,7 +164,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2fe09b55",
+   "id": "0a1efb06",
    "metadata": {},
    "source": [
     "Each name resolves to a preset in `case_studies/config/lgb/` holding the complete LightGBM\n",
@@ -172,24 +174,25 @@
     "- **Three objectives**, as described above.\n",
     "\n",
     "**`default` is not a fifth rung, and the grid does not isolate capacity.** The `params` block of\n",
-    "each `default_*` preset holds only `objective` and `seed`. `default_huber` also declares a\n",
-    "top-level `huber_alpha_scale: 0.5`, but every `leaves_*_huber` declares the same value, so it\n",
-    "separates the objectives from each other and not `default` from the ladder. Everything else in a\n",
-    "`default_*` fit is whatever LightGBM supplies: `num_leaves` 31 - which is the `leaves_31` rung,\n",
-    "not a value outside the ladder - a `learning_rate` of 0.1 against the 0.05 the twelve `leaves_*`\n",
-    "presets declare, and none of the `bagging_fraction` 0.8, `bagging_freq` 1, `feature_fraction` 0.7,\n",
-    "`lambda_l1` 0.5, `lambda_l2` 5.0 or `min_child_samples` 50 that all four ladder profiles carry.\n",
-    "Measured on LightGBM 4.6.0, those omissions resolve to `lambda_l1` and `lambda_l2` at 0,\n",
-    "subsampling disabled outright because `bagging_freq` defaults to 0, and `min_child_samples` at 20\n",
-    "rather than the ladder's 50. So `default` and `leaves_31` share a leaf limit, not a capacity: the\n",
-    "same `num_leaves` reached under a leaf-size constraint less than half as strict, with no penalty\n",
-    "term, no subsampling and double the learning rate - seven declared parameters apart rather than\n",
-    "none.\n",
+    "each `default_*` preset holds only `objective` and `seed`; the frame above shows both blocks side\n",
+    "by side. `default_huber` also declares a top-level `huber_alpha_scale`, but every `leaves_*_huber`\n",
+    "declares the same value, so it separates the objectives from each other and not `default` from the\n",
+    "ladder.\n",
+    "\n",
+    "Everything a `default_*` preset leaves out is filled by LightGBM's own default, and that is where\n",
+    "the two profiles part company. Its default leaf limit is the `leaves_31` rung, so the two agree on\n",
+    "the axis the ladder varies. It runs at twice the learning rate the twelve `leaves_*` presets\n",
+    "declare. And it carries none of their `bagging_fraction`, `bagging_freq`, `feature_fraction`,\n",
+    "`lambda_l1`, `lambda_l2` or `min_child_samples`, which resolve to no L1 or L2 penalty at all,\n",
+    "subsampling switched off rather than merely weakened, and a minimum leaf size well under half the\n",
+    "ladder's. So `default` and `leaves_31` share a leaf limit and not a capacity: seven declared\n",
+    "parameters apart rather than none.\n",
     "\n",
     "Read the gap between them as capacity and you will be reading the wrong axis. The two sit side\n",
     "by side in the final-iteration chart in Section 4 at identical leaf counts, and whatever\n",
     "separates them there is those seven parameters rather than the number of regions a tree may\n",
-    "carve.\n",
+    "carve. A library default is a property of the installed version, so the resolved values the fit\n",
+    "actually used are the ones in the training specification the run registers, not these.\n",
     "\n",
     "What the grid does hold fixed is training length - every configuration declares\n",
     "`max_iterations: 500` and `checkpoint_interval: 50` - so the checkpoint comparison below is\n",
@@ -199,7 +202,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "06601cee",
+   "id": "47b393a9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -214,7 +217,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "06617e6a",
+   "id": "2bbe7822",
    "metadata": {},
    "source": [
     "`LABELS` and `CONFIG_NAMES` both narrow what is fitted, and a narrowed run declares a different\n",
@@ -226,7 +229,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a21570dd",
+   "id": "f9d06973",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -255,7 +258,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b567977f",
+   "id": "da367e37",
    "metadata": {},
    "source": [
     "## 2. Binding the declarations to the data\n",
@@ -283,7 +286,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "01e89e63",
+   "id": "9c706ff7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -312,7 +315,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cb581ffb",
+   "id": "37af0b25",
    "metadata": {},
    "source": [
     "## 3. Fitting the population\n",
@@ -364,7 +367,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b01ac887",
+   "id": "c0d49a05",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -390,7 +393,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4213d802",
+   "id": "6903edc0",
    "metadata": {},
    "source": [
     "### Running configurations of your own\n",
@@ -418,7 +421,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ce364d5c",
+   "id": "285cff06",
    "metadata": {},
    "source": [
     "## 4. What came out\n",
@@ -441,7 +444,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "96d636cd",
+   "id": "1758bafd",
    "metadata": {},
    "source": [
     "### What the run produced, and the sets it publishes\n",
@@ -462,7 +465,7 @@
     "\n",
     "The diagnostic subset is bounded hard, and the reason is arithmetic. `15` loads every diagnostic\n",
     "member's raw prediction frame and holds them all while it joins them pairwise; one frame on this\n",
-    "panel is 7.2 million rows and about 225 MB in memory. So the set is one member per label and\n",
+    "panel is over seven million rows and about 225 MB in memory. So the set is one member per label and\n",
     "family: the diagnostic configuration at its last checkpoint. `default_mse` is that configuration\n",
     "here - the untuned starting point the leaf and objective sweeps vary from - and its last\n",
     "checkpoint is the state a reader would compare against another family's finished fit. The\n",
@@ -477,7 +480,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "eabcc924",
+   "id": "fd641d02",
    "metadata": {
     "tags": [
      "results"
@@ -539,9 +542,13 @@
     "    for label_value in panel_labels:\n",
     "        label_name = label_value.replace(\"_\", \"-\")\n",
     "        label_rows = execution.catalog_rows.filter(pl.col(\"label\") == label_value)\n",
+    "        full_set_name = f\"us-equities-{label_name}-gbm-v1\"\n",
     "        full_set = study.predictions.freeze(\n",
     "            label_rows,\n",
-    "            name=f\"us-equities-{label_name}-gbm-v1\",\n",
+    "            name=full_set_name,\n",
+    "            supersedes=candidate_set_supersedes(\n",
+    "                study, name=full_set_name, declared=SUPERSEDES_SETS.get(full_set_name, \"\")\n",
+    "            ),\n",
     "        )\n",
     "        diagnostic_rows = label_rows.filter(\n",
     "            pl.col(\"config_name\").is_in(DIAGNOSTIC_CONFIG_NAMES)\n",
@@ -555,9 +562,15 @@
     "            raise ValueError(\n",
     "                f\"no {label_value} rows for diagnostic configurations {DIAGNOSTIC_CONFIG_NAMES}\"\n",
     "            )\n",
+    "        diagnostic_set_name = f\"us-equities-{label_name}-gbm-diagnostics-v1\"\n",
     "        diagnostic_set = study.predictions.freeze(\n",
     "            diagnostic_rows,\n",
-    "            name=f\"us-equities-{label_name}-gbm-diagnostics-v1\",\n",
+    "            name=diagnostic_set_name,\n",
+    "            supersedes=candidate_set_supersedes(\n",
+    "                study,\n",
+    "                name=diagnostic_set_name,\n",
+    "                declared=SUPERSEDES_SETS.get(diagnostic_set_name, \"\"),\n",
+    "            ),\n",
     "        )\n",
     "        set_rows.extend(\n",
     "            [\n",
@@ -582,7 +595,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ff6ebb05",
+   "id": "0cd61bb3",
    "metadata": {},
    "source": [
     "### What more trees do\n",
@@ -601,7 +614,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3070f699",
+   "id": "067b8697",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -690,7 +703,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d21ce1e8",
+   "id": "979b41df",
    "metadata": {},
    "source": [
     "Whether the lines trend, and which way, is not something to read off a page of overlapping\n",
@@ -704,7 +717,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d4396d2c",
+   "id": "aa24d489",
    "metadata": {
     "tags": [
      "results"
@@ -743,7 +756,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3a91366a",
+   "id": "8e45acf2",
    "metadata": {},
    "source": [
     "### Comparing every configuration at the same training length\n",
@@ -769,7 +782,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "664efdcb",
+   "id": "af21041c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -852,7 +865,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fd3de603",
+   "id": "e64f9848",
    "metadata": {},
    "source": [
     "The frame below puts a number on what the chart shows: for each label, the rank correlation\n",
@@ -864,7 +877,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "156f6294",
+   "id": "71028659",
    "metadata": {
     "tags": [
      "results"
@@ -897,7 +910,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "30a2696f",
+   "id": "c27bc87f",
    "metadata": {},
    "source": [
     "## 5. What to notice\n",
@@ -936,8 +949,8 @@
     "**Known limitations.** The IC here is an average of per-date rank correlations with no\n",
     "adjustment for the serial dependence that overlapping forward returns create, so it is a ranking\n",
     "diagnostic rather than a test. The grid varies capacity and loss at fixed features and fixed\n",
-    "training length, but not at a fixed learning rate - the `default` profile runs at 0.1 and the\n",
-    "four ladder profiles at 0.05 - so the `default` rows are not comparable with the rest on\n",
+    "training length, but not at a fixed learning rate - the `default` profile runs at twice the\n",
+    "ladder's - so the `default` rows are not comparable with the rest on\n",
     "capacity alone, and nothing here separates a learning-rate effect from a regularization one.\n",
     "Every number is measured on\n",
     "the validation folds, which have been read many times over by the time a case study reaches this\n",

--- a/case_studies/us_equities_panel/07_gbm.ipynb
+++ b/case_studies/us_equities_panel/07_gbm.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "414ccef9",
+   "id": "b042beeb",
    "metadata": {},
    "source": [
     "# US equities panel: capacity, loss function, and when to stop adding trees\n",
@@ -76,7 +76,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0b03680a",
+   "id": "dd02d0a2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -105,7 +105,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "91fc7421",
+   "id": "6ac4b343",
    "metadata": {
     "tags": [
      "parameters"
@@ -126,7 +126,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b6ead0d4",
+   "id": "48ea33ae",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -135,7 +135,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f83e11f6",
+   "id": "453ff18a",
    "metadata": {},
    "source": [
     "## 1. Which labels, and which models\n",
@@ -153,7 +153,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "09879cc2",
+   "id": "91167197",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -162,7 +162,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "82e1456f",
+   "id": "2fe09b55",
    "metadata": {},
    "source": [
     "Each name resolves to a preset in `case_studies/config/lgb/` holding the complete LightGBM\n",
@@ -199,7 +199,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "679568e0",
+   "id": "06601cee",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -214,7 +214,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d74b3bf9",
+   "id": "06617e6a",
    "metadata": {},
    "source": [
     "`LABELS` and `CONFIG_NAMES` both narrow what is fitted, and a narrowed run declares a different\n",
@@ -226,7 +226,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0dddcaf0",
+   "id": "a21570dd",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -255,7 +255,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "532847b3",
+   "id": "b567977f",
    "metadata": {},
    "source": [
     "## 2. Binding the declarations to the data\n",
@@ -283,7 +283,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bd9195d4",
+   "id": "01e89e63",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -312,7 +312,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9f877767",
+   "id": "cb581ffb",
    "metadata": {},
    "source": [
     "## 3. Fitting the population\n",
@@ -364,7 +364,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0a4d85f7",
+   "id": "b01ac887",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -390,7 +390,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "347b73a9",
+   "id": "4213d802",
    "metadata": {},
    "source": [
     "### Running configurations of your own\n",
@@ -418,7 +418,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3c7a4d4f",
+   "id": "ce364d5c",
    "metadata": {},
    "source": [
     "## 4. What came out\n",
@@ -441,7 +441,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "484e42ac",
+   "id": "96d636cd",
    "metadata": {},
    "source": [
     "### What the run produced, and the sets it publishes\n",
@@ -460,10 +460,14 @@
     "backtest whatever subset of names does resolve. A missing name is a silently narrower strategy\n",
     "chain, which is the failure the named-set design exists to prevent.\n",
     "\n",
-    "The diagnostic subset is bounded on purpose. `15` holds every diagnostic member's prediction\n",
-    "frame in memory at once and correlates them pairwise, so the cost is quadratic in members - and\n",
-    "the full set here is one row per configuration *per checkpoint*, which is larger again than the\n",
-    "linear grid. `default_mse` is the untuned starting point the leaf and objective sweeps vary from.\n",
+    "The diagnostic subset is bounded hard, and the reason is arithmetic. `15` loads every diagnostic\n",
+    "member's raw prediction frame and holds them all while it joins them pairwise; one frame on this\n",
+    "panel is 7.2 million rows and about 225 MB in memory. So the set is one member per label and\n",
+    "family: the diagnostic configuration at its last checkpoint. `default_mse` is that configuration\n",
+    "here - the untuned starting point the leaf and objective sweeps vary from - and its last\n",
+    "checkpoint is the state a reader would compare against another family's finished fit. The\n",
+    "checkpoint dimension is not lost by bounding it away: the learning curves above are where it is\n",
+    "read, and they are drawn from registry metrics rather than from raw frames.\n",
     "\n",
     "Only an unnarrowed canonical run publishes. The guard on `narrows_declared_catalog` above already\n",
     "refuses to publish the canonical *population* from a narrowed run; the same condition governs the\n",
@@ -473,7 +477,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2fec1386",
+   "id": "eabcc924",
    "metadata": {
     "tags": [
      "results"
@@ -539,7 +543,14 @@
     "            label_rows,\n",
     "            name=f\"us-equities-{label_name}-gbm-v1\",\n",
     "        )\n",
-    "        diagnostic_rows = label_rows.filter(pl.col(\"config_name\").is_in(DIAGNOSTIC_CONFIG_NAMES))\n",
+    "        diagnostic_rows = label_rows.filter(\n",
+    "            pl.col(\"config_name\").is_in(DIAGNOSTIC_CONFIG_NAMES)\n",
+    "            # `.fill_null(True)` covers a family that publishes no checkpoint value at all, where\n",
+    "            # the comparison is null rather than false and would otherwise empty the frame.\n",
+    "            & (\n",
+    "                pl.col(\"checkpoint_value\") == pl.col(\"checkpoint_value\").max().over(\"config_name\")\n",
+    "            ).fill_null(True)\n",
+    "        )\n",
     "        if diagnostic_rows.height == 0:\n",
     "            raise ValueError(\n",
     "                f\"no {label_value} rows for diagnostic configurations {DIAGNOSTIC_CONFIG_NAMES}\"\n",
@@ -571,7 +582,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a0acf66d",
+   "id": "ff6ebb05",
    "metadata": {},
    "source": [
     "### What more trees do\n",
@@ -590,7 +601,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6b74f344",
+   "id": "3070f699",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -679,7 +690,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ac06a888",
+   "id": "d21ce1e8",
    "metadata": {},
    "source": [
     "Whether the lines trend, and which way, is not something to read off a page of overlapping\n",
@@ -693,7 +704,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d8c83e84",
+   "id": "d4396d2c",
    "metadata": {
     "tags": [
      "results"
@@ -732,7 +743,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6d562132",
+   "id": "3a91366a",
    "metadata": {},
    "source": [
     "### Comparing every configuration at the same training length\n",
@@ -758,7 +769,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c0f6c7d2",
+   "id": "664efdcb",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -841,7 +852,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1da9ed27",
+   "id": "fd3de603",
    "metadata": {},
    "source": [
     "The frame below puts a number on what the chart shows: for each label, the rank correlation\n",
@@ -853,7 +864,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8e58bf4a",
+   "id": "156f6294",
    "metadata": {
     "tags": [
      "results"
@@ -886,7 +897,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b78ccd94",
+   "id": "30a2696f",
    "metadata": {},
    "source": [
     "## 5. What to notice\n",

--- a/case_studies/us_equities_panel/07_gbm.py
+++ b/case_studies/us_equities_panel/07_gbm.py
@@ -369,10 +369,14 @@ print(f"population {population.name}: {len(population.members)} prediction sets"
 # backtest whatever subset of names does resolve. A missing name is a silently narrower strategy
 # chain, which is the failure the named-set design exists to prevent.
 #
-# The diagnostic subset is bounded on purpose. `15` holds every diagnostic member's prediction
-# frame in memory at once and correlates them pairwise, so the cost is quadratic in members - and
-# the full set here is one row per configuration *per checkpoint*, which is larger again than the
-# linear grid. `default_mse` is the untuned starting point the leaf and objective sweeps vary from.
+# The diagnostic subset is bounded hard, and the reason is arithmetic. `15` loads every diagnostic
+# member's raw prediction frame and holds them all while it joins them pairwise; one frame on this
+# panel is 7.2 million rows and about 225 MB in memory. So the set is one member per label and
+# family: the diagnostic configuration at its last checkpoint. `default_mse` is that configuration
+# here - the untuned starting point the leaf and objective sweeps vary from - and its last
+# checkpoint is the state a reader would compare against another family's finished fit. The
+# checkpoint dimension is not lost by bounding it away: the learning curves above are where it is
+# read, and they are drawn from registry metrics rather than from raw frames.
 #
 # Only an unnarrowed canonical run publishes. The guard on `narrows_declared_catalog` above already
 # refuses to publish the canonical *population* from a narrowed run; the same condition governs the
@@ -437,7 +441,14 @@ if is_published_population:
             label_rows,
             name=f"us-equities-{label_name}-gbm-v1",
         )
-        diagnostic_rows = label_rows.filter(pl.col("config_name").is_in(DIAGNOSTIC_CONFIG_NAMES))
+        diagnostic_rows = label_rows.filter(
+            pl.col("config_name").is_in(DIAGNOSTIC_CONFIG_NAMES)
+            # `.fill_null(True)` covers a family that publishes no checkpoint value at all, where
+            # the comparison is null rather than false and would otherwise empty the frame.
+            & (
+                pl.col("checkpoint_value") == pl.col("checkpoint_value").max().over("config_name")
+            ).fill_null(True)
+        )
         if diagnostic_rows.height == 0:
             raise ValueError(
                 f"no {label_value} rows for diagnostic configurations {DIAGNOSTIC_CONFIG_NAMES}"

--- a/case_studies/us_equities_panel/07_gbm.py
+++ b/case_studies/us_equities_panel/07_gbm.py
@@ -284,13 +284,15 @@ planned.select(
 # parameter moves every training identity as surely as a changed menu does, so the refit is a
 # different population under the same name and the registry refuses to write it without being told
 # which snapshot it supersedes. That lineage is the only record of which generation is which.
+#
+# A declared `SUPERSEDES_POPULATION` hash only means something where a generation of this name
+# already exists. A preview run, a first canonical run against an empty `run_log/`, and a run
+# under a caller-chosen `POPULATION_NAME` are all refused by `OfficialPopulation.create` if one
+# is passed anyway, so `supersedes_for_run` works out which of those cases this run is and
+# resolves the hash accordingly.
 
 # %%
 population_name = POPULATION_NAME or "us-equities-gbm-checkpoints-v1"
-# The declared hash is only meaningful where a generation of this name already exists. A
-# preview run, a first canonical run against an empty `run_log/`, and a run under a
-# caller-chosen `POPULATION_NAME` are all refused by `OfficialPopulation.create` if it is
-# passed anyway. The resolution lives in shared code so no notebook branches on the tier.
 supersedes = supersedes_for_run(
     study,
     population_name=population_name,
@@ -611,11 +613,13 @@ trees_effect
 # the line printed under the frame says so rather than assuming it. The configurations are held in one order across
 # the panels - their ranking on the primary label - so a panel that does not descend is a horizon
 # that orders the grid differently.
+#
+# The final state below is each configuration's own last checkpoint, so a configuration declaring
+# a shorter schedule than its neighbours is still compared at the state it reached. Every preset
+# in this grid declares the same `max_iterations`, so today those last checkpoints coincide, and
+# the line printed under the agreement frame reports the iteration count they all landed on.
 
 # %%
-# Each configuration's own last checkpoint, not the label's. They are the same number while every
-# preset declares the same `max_iterations`, and taking the label-wide maximum would silently drop
-# a configuration with a shorter schedule instead of comparing it at the state it reached.
 final = (
     catalog.filter(
         pl.col("checkpoint_value") == pl.col("checkpoint_value").max().over("label", "config_name")
@@ -677,7 +681,7 @@ fig_final.update_xaxes(
     col=1,
 )
 fig_final.update_layout(
-    title="The grid does not keep one order across the three horizons",
+    title="Validation IC at the final iteration, in the primary label's order",
     height=300 * len(panel_labels),
     width=1000,
     margin=dict(t=90),

--- a/case_studies/us_equities_panel/07_gbm.py
+++ b/case_studies/us_equities_panel/07_gbm.py
@@ -90,6 +90,7 @@ from IPython.display import display
 from plotly.subplots import make_subplots
 
 from case_studies.research import (
+    candidate_set_supersedes,
     declared_labels,
     load_model_configs,
     model_requests,
@@ -112,6 +113,7 @@ CONFIG_NAMES: list[str] = []
 DIAGNOSTIC_CONFIG_NAMES = ["default_mse"]
 POPULATION_NAME = ""
 SUPERSEDES_POPULATION: str = ""
+SUPERSEDES_SETS: dict = {}
 
 # %%
 study = open_study("us_equities_panel", execution_tier=EXECUTION_TIER, workspace=WORKSPACE or None)
@@ -139,24 +141,25 @@ declared_labels(study, "gbm")
 # - **Three objectives**, as described above.
 #
 # **`default` is not a fifth rung, and the grid does not isolate capacity.** The `params` block of
-# each `default_*` preset holds only `objective` and `seed`. `default_huber` also declares a
-# top-level `huber_alpha_scale: 0.5`, but every `leaves_*_huber` declares the same value, so it
-# separates the objectives from each other and not `default` from the ladder. Everything else in a
-# `default_*` fit is whatever LightGBM supplies: `num_leaves` 31 - which is the `leaves_31` rung,
-# not a value outside the ladder - a `learning_rate` of 0.1 against the 0.05 the twelve `leaves_*`
-# presets declare, and none of the `bagging_fraction` 0.8, `bagging_freq` 1, `feature_fraction` 0.7,
-# `lambda_l1` 0.5, `lambda_l2` 5.0 or `min_child_samples` 50 that all four ladder profiles carry.
-# Measured on LightGBM 4.6.0, those omissions resolve to `lambda_l1` and `lambda_l2` at 0,
-# subsampling disabled outright because `bagging_freq` defaults to 0, and `min_child_samples` at 20
-# rather than the ladder's 50. So `default` and `leaves_31` share a leaf limit, not a capacity: the
-# same `num_leaves` reached under a leaf-size constraint less than half as strict, with no penalty
-# term, no subsampling and double the learning rate - seven declared parameters apart rather than
-# none.
+# each `default_*` preset holds only `objective` and `seed`; the frame above shows both blocks side
+# by side. `default_huber` also declares a top-level `huber_alpha_scale`, but every `leaves_*_huber`
+# declares the same value, so it separates the objectives from each other and not `default` from the
+# ladder.
+#
+# Everything a `default_*` preset leaves out is filled by LightGBM's own default, and that is where
+# the two profiles part company. Its default leaf limit is the `leaves_31` rung, so the two agree on
+# the axis the ladder varies. It runs at twice the learning rate the twelve `leaves_*` presets
+# declare. And it carries none of their `bagging_fraction`, `bagging_freq`, `feature_fraction`,
+# `lambda_l1`, `lambda_l2` or `min_child_samples`, which resolve to no L1 or L2 penalty at all,
+# subsampling switched off rather than merely weakened, and a minimum leaf size well under half the
+# ladder's. So `default` and `leaves_31` share a leaf limit and not a capacity: seven declared
+# parameters apart rather than none.
 #
 # Read the gap between them as capacity and you will be reading the wrong axis. The two sit side
 # by side in the final-iteration chart in Section 4 at identical leaf counts, and whatever
 # separates them there is those seven parameters rather than the number of regions a tree may
-# carve.
+# carve. A library default is a property of the installed version, so the resolved values the fit
+# actually used are the ones in the training specification the run registers, not these.
 #
 # What the grid does hold fixed is training length - every configuration declares
 # `max_iterations: 500` and `checkpoint_interval: 50` - so the checkpoint comparison below is
@@ -371,7 +374,7 @@ print(f"population {population.name}: {len(population.members)} prediction sets"
 #
 # The diagnostic subset is bounded hard, and the reason is arithmetic. `15` loads every diagnostic
 # member's raw prediction frame and holds them all while it joins them pairwise; one frame on this
-# panel is 7.2 million rows and about 225 MB in memory. So the set is one member per label and
+# panel is over seven million rows and about 225 MB in memory. So the set is one member per label and
 # family: the diagnostic configuration at its last checkpoint. `default_mse` is that configuration
 # here - the untuned starting point the leaf and objective sweeps vary from - and its last
 # checkpoint is the state a reader would compare against another family's finished fit. The
@@ -437,9 +440,13 @@ if is_published_population:
     for label_value in panel_labels:
         label_name = label_value.replace("_", "-")
         label_rows = execution.catalog_rows.filter(pl.col("label") == label_value)
+        full_set_name = f"us-equities-{label_name}-gbm-v1"
         full_set = study.predictions.freeze(
             label_rows,
-            name=f"us-equities-{label_name}-gbm-v1",
+            name=full_set_name,
+            supersedes=candidate_set_supersedes(
+                study, name=full_set_name, declared=SUPERSEDES_SETS.get(full_set_name, "")
+            ),
         )
         diagnostic_rows = label_rows.filter(
             pl.col("config_name").is_in(DIAGNOSTIC_CONFIG_NAMES)
@@ -453,9 +460,15 @@ if is_published_population:
             raise ValueError(
                 f"no {label_value} rows for diagnostic configurations {DIAGNOSTIC_CONFIG_NAMES}"
             )
+        diagnostic_set_name = f"us-equities-{label_name}-gbm-diagnostics-v1"
         diagnostic_set = study.predictions.freeze(
             diagnostic_rows,
-            name=f"us-equities-{label_name}-gbm-diagnostics-v1",
+            name=diagnostic_set_name,
+            supersedes=candidate_set_supersedes(
+                study,
+                name=diagnostic_set_name,
+                declared=SUPERSEDES_SETS.get(diagnostic_set_name, ""),
+            ),
         )
         set_rows.extend(
             [
@@ -773,8 +786,8 @@ agreement
 # **Known limitations.** The IC here is an average of per-date rank correlations with no
 # adjustment for the serial dependence that overlapping forward returns create, so it is a ranking
 # diagnostic rather than a test. The grid varies capacity and loss at fixed features and fixed
-# training length, but not at a fixed learning rate - the `default` profile runs at 0.1 and the
-# four ladder profiles at 0.05 - so the `default` rows are not comparable with the rest on
+# training length, but not at a fixed learning rate - the `default` profile runs at twice the
+# ladder's - so the `default` rows are not comparable with the rest on
 # capacity alone, and nothing here separates a learning-rate effect from a regularization one.
 # Every number is measured on
 # the validation folds, which have been read many times over by the time a case study reaches this

--- a/case_studies/us_equities_panel/08_tabular_dl.ipynb
+++ b/case_studies/us_equities_panel/08_tabular_dl.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "2d7d40a3",
+   "id": "80337123",
    "metadata": {},
    "source": [
     "# US equities panel: a neural network on the same flat table, and what an ensemble of them costs\n",
@@ -78,20 +78,23 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1ca41250",
+   "id": "4c3f99ac",
    "metadata": {},
    "outputs": [],
    "source": [
     "\"\"\"Generate TabM validation predictions through the shared research interface.\"\"\"\n",
     "\n",
-    "import os\n",
-    "from pathlib import Path\n",
-    "\n",
     "import matplotlib.pyplot as plt\n",
     "import polars as pl\n",
     "import yaml\n",
     "\n",
-    "from case_studies.research import open_study, plan_models\n",
+    "from case_studies.research import (\n",
+    "    candidate_set_supersedes,\n",
+    "    open_study,\n",
+    "    plan_models,\n",
+    "    run_model_population,\n",
+    "    supersedes_for_run,\n",
+    ")\n",
     "from utils.modeling import load_configs\n",
     "from utils.paths import get_case_study_dir\n",
     "from utils.style import FIGSIZE, add_message_title, ml4t_palette, show_with_alt, zero_line"
@@ -100,7 +103,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2e5c86e6",
+   "id": "4a6a8ae4",
    "metadata": {
     "tags": [
      "parameters"
@@ -114,9 +117,12 @@
     "COMMON_OVERRIDES = {}\n",
     "CONFIG_OVERRIDES = {}\n",
     "DIAGNOSTIC_CONFIG_NAMES = [\"tabm_s\"]\n",
+    "POPULATION_NAME = \"\"\n",
+    "SUPERSEDES_POPULATION = \"\"\n",
+    "SUPERSEDES_SETS: dict = {}\n",
     "DEVICE = \"cuda\"\n",
     "EXECUTION_TIER = \"canonical\"\n",
-    "WORKSPACE = \"experiments\"\n",
+    "WORKSPACE = \"\"\n",
     "MAX_SYMBOLS = 0\n",
     "MAX_FOLDS = 0\n",
     "PREVIEW_N_EPOCHS = 0\n",
@@ -125,7 +131,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f34676cb",
+   "id": "933e8157",
    "metadata": {},
    "source": [
     "## 1. Which configurations, and on which label\n",
@@ -146,7 +152,7 @@
     "- **`DIAGNOSTIC_CONFIG_NAMES`** names the configuration [`15_model_analysis`](15_model_analysis.ipynb)\n",
     "  reads raw predictions for. It is bounded hard: that comparison loads every diagnostic member's\n",
     "  prediction frame and holds them all while it joins them pairwise, and one frame on this panel\n",
-    "  is 7.2 million rows and about 225 MB in memory. The frozen set below is the named\n",
+    "  is over seven million rows and about 225 MB in memory. The frozen set below is the named\n",
     "  configuration at its last epoch checkpoint - one member for this label and family.\n",
     "- **`EXECUTION_TIER`** is `canonical` or `preview`. A canonical run fits the whole panel on every\n",
     "  fold at the published epoch schedule. A preview run has to declare at least one reduction, and\n",
@@ -157,7 +163,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "58fcd35e",
+   "id": "13de282f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -194,9 +200,53 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "339bd791",
+   "metadata": {},
+   "source": [
+    "A run that narrows the selection, overrides a parameter or fits on another device produces a\n",
+    "different set of predictions from the one the canonical name stands for. Publishing it under\n",
+    "that name would leave the name meaning two different member sets at two different times, so the\n",
+    "guard below requires such a run to say what to call its own population, and the frozen set names\n",
+    "in Section 6 are withheld from it for the same reason."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8272e03d",
+   "id": "d2b748e7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "is_published_population = (\n",
+    "    EXECUTION_TIER == \"canonical\"\n",
+    "    and selected_names == published_names\n",
+    "    and not COMMON_OVERRIDES\n",
+    "    and not CONFIG_OVERRIDES\n",
+    "    and DEVICE == \"cuda\"\n",
+    ")\n",
+    "if EXECUTION_TIER == \"canonical\" and not is_published_population and not POPULATION_NAME:\n",
+    "    raise ValueError(\n",
+    "        \"this run narrows or overrides what the menu declares, so it cannot publish the canonical \"\n",
+    "        \"population; pass POPULATION_NAME to give it its own\"\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "31ba845c",
+   "metadata": {},
+   "source": [
+    "Both tiers resolve the study through `open_study`. It reads the labels and features in place\n",
+    "and redirects only writes, so a preview run scores the same inputs a canonical one does and\n",
+    "cannot publish over it. A preview must be given a workspace to write into; a canonical run\n",
+    "leaves `WORKSPACE` empty and regenerates the case study's own artifacts in place."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "066d1879",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -210,28 +260,12 @@
     "if PREVIEW_CHECKPOINT_INTERVAL:\n",
     "    preview_reductions[\"checkpoint_interval\"] = int(PREVIEW_CHECKPOINT_INTERVAL)\n",
     "\n",
-    "# Both tiers resolve the study through `open_study`. It reads the labels and features in place and\n",
-    "# redirects only writes, so a preview run scores the same inputs a canonical one does and cannot\n",
-    "# publish over it.\n",
-    "if EXECUTION_TIER == \"canonical\":\n",
-    "    if preview_reductions:\n",
-    "        raise ValueError(\"Canonical execution cannot declare preview reductions\")\n",
-    "    study = open_study(CASE_STUDY_ID, execution_tier=EXECUTION_TIER)\n",
-    "elif EXECUTION_TIER == \"preview\":\n",
-    "    if not preview_reductions:\n",
-    "        raise ValueError(\"Preview execution requires at least one declared reduction\")\n",
-    "    study = open_study(\n",
-    "        CASE_STUDY_ID,\n",
-    "        execution_tier=EXECUTION_TIER,\n",
-    "        workspace=Path(os.environ.get(\"ML4T_OUTPUT_DIR\") or WORKSPACE),\n",
-    "    )\n",
-    "else:\n",
-    "    raise ValueError(\"EXECUTION_TIER must be 'canonical' or 'preview'\")"
+    "study = open_study(CASE_STUDY_ID, execution_tier=EXECUTION_TIER, workspace=WORKSPACE or None)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "9180bd78",
+   "id": "8ecb4a81",
    "metadata": {},
    "source": [
     "## 2. Binding the declarations to the data\n",
@@ -244,7 +278,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0041d971",
+   "id": "951d2d45",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -283,7 +317,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3c3bf680",
+   "id": "efe28523",
    "metadata": {},
    "source": [
     "## 3. Planning, then fitting\n",
@@ -306,16 +340,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0b14cad7",
+   "id": "5bd4b22a",
    "metadata": {},
    "outputs": [],
    "source": [
     "plan = plan_models(study, requests=requests)\n",
-    "official_population = None\n",
-    "if EXECUTION_TIER == \"canonical\":\n",
-    "    official_population = plan.create_population(\n",
-    "        name=\"us-equities-tabular-dl-checkpoints-v1\",\n",
-    "    )\n",
     "\n",
     "planned_population = pl.DataFrame(\n",
     "    {\n",
@@ -331,18 +360,50 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "83668120",
+   "metadata": {},
+   "source": [
+    "`run_model_population` takes the plan, writes the population down, fits every member and then\n",
+    "checks that what came out is what was declared. The same call serves both tiers: a canonical run\n",
+    "registers an immutable population that the later notebooks bind to, and a preview run gets a\n",
+    "declaration that is verified and then discarded with its workspace, so no notebook here has to\n",
+    "branch on the tier to decide what to publish.\n",
+    "\n",
+    "`SUPERSEDES_POPULATION` names the population hash this run replaces. A population is a set of\n",
+    "prediction identities, so anything that moves a training identity - a changed preset as much as a\n",
+    "changed menu - produces a different population under the same name, and the registry refuses to\n",
+    "write it without being told which snapshot it supersedes. Leaving it empty is right for a first\n",
+    "run and for a reader's clean clone, and `supersedes_for_run` withholds a declared hash wherever\n",
+    "offering it would be refused."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "id": "44be77d7",
+   "id": "2da8d4bc",
    "metadata": {},
    "outputs": [],
    "source": [
-    "execution = plan.run()"
+    "population_name = POPULATION_NAME or \"us-equities-tabular-dl-checkpoints-v1\"\n",
+    "execution, official_population = run_model_population(\n",
+    "    study,\n",
+    "    plan,\n",
+    "    population_name=population_name,\n",
+    "    supersedes=supersedes_for_run(\n",
+    "        study,\n",
+    "        population_name=population_name,\n",
+    "        declared=SUPERSEDES_POPULATION,\n",
+    "        execution_tier=EXECUTION_TIER,\n",
+    "    ),\n",
+    ")\n",
+    "\n",
+    "print(f\"population {official_population.name}: {len(official_population.members)} prediction sets\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "27b5b32b",
+   "id": "c84f3bc3",
    "metadata": {},
    "source": [
     "## 4. What was actually fitted\n",
@@ -356,7 +417,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "820edc9f",
+   "id": "72cc7518",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -385,7 +446,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7e8b206b",
+   "id": "acd414c1",
    "metadata": {},
    "source": [
     "## 5. What came out\n",
@@ -403,7 +464,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f303483b",
+   "id": "1b0cd773",
    "metadata": {
     "tags": [
      "results"
@@ -432,7 +493,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "895af142",
+   "id": "5facb057",
    "metadata": {},
    "source": [
     "A prediction set can be registered complete and still have scored no dates. Cross-sectional\n",
@@ -445,7 +506,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "19a922f0",
+   "id": "dee942a0",
    "metadata": {
     "tags": [
      "results"
@@ -462,7 +523,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e888065b",
+   "id": "707f03a0",
    "metadata": {},
    "source": [
     "### Where more training stopped helping\n",
@@ -487,7 +548,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "10264b7f",
+   "id": "be0b83f4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -544,7 +605,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0e5c9d8b",
+   "id": "03ee81bc",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -572,15 +633,13 @@
     "        )\n",
     "\n",
     "coverage_table = pl.DataFrame(coverage_rows).sort(\"config_name\", \"checkpoint\")\n",
-    "if official_population is not None:\n",
-    "    official_population.require_complete()\n",
     "coverage_table"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8dbbd177",
+   "id": "22d7601f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -590,7 +649,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d2b00f24",
+   "id": "096f893c",
    "metadata": {},
    "source": [
     "## 6. Naming the sets the later notebooks open\n",
@@ -609,7 +668,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "154edb56",
+   "id": "bd16031e",
    "metadata": {
     "tags": [
      "results"
@@ -618,18 +677,15 @@
    "outputs": [],
    "source": [
     "set_rows = []\n",
-    "is_published_population = (\n",
-    "    EXECUTION_TIER == \"canonical\"\n",
-    "    and selected_names == published_names\n",
-    "    and not COMMON_OVERRIDES\n",
-    "    and not CONFIG_OVERRIDES\n",
-    "    and DEVICE == \"cuda\"\n",
-    ")\n",
     "if is_published_population:\n",
     "    label_name = label.replace(\"_\", \"-\")\n",
+    "    full_set_name = f\"us-equities-{label_name}-tabular-dl-v1\"\n",
     "    full_set = study.predictions.freeze(\n",
     "        execution.catalog_rows,\n",
-    "        name=f\"us-equities-{label_name}-tabular-dl-v1\",\n",
+    "        name=full_set_name,\n",
+    "        supersedes=candidate_set_supersedes(\n",
+    "            study, name=full_set_name, declared=SUPERSEDES_SETS.get(full_set_name, \"\")\n",
+    "        ),\n",
     "    )\n",
     "    diagnostic_rows = execution.catalog_rows.filter(\n",
     "        pl.col(\"config_name\").is_in(DIAGNOSTIC_CONFIG_NAMES)\n",
@@ -639,9 +695,13 @@
     "            pl.col(\"checkpoint_value\") == pl.col(\"checkpoint_value\").max().over(\"config_name\")\n",
     "        ).fill_null(True)\n",
     "    )\n",
+    "    diagnostic_set_name = f\"us-equities-{label_name}-tabular-dl-diagnostics-v1\"\n",
     "    diagnostic_set = study.predictions.freeze(\n",
     "        diagnostic_rows,\n",
-    "        name=f\"us-equities-{label_name}-tabular-dl-diagnostics-v1\",\n",
+    "        name=diagnostic_set_name,\n",
+    "        supersedes=candidate_set_supersedes(\n",
+    "            study, name=diagnostic_set_name, declared=SUPERSEDES_SETS.get(diagnostic_set_name, \"\")\n",
+    "        ),\n",
     "    )\n",
     "    set_rows = [\n",
     "        {\n",
@@ -664,7 +724,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "806ac989",
+   "id": "1f25c6cf",
    "metadata": {},
    "source": [
     "`15_model_analysis.py` reopens the named compatible and diagnostic sets. `16_backtest.py` passes\n",
@@ -674,7 +734,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2e353f4a",
+   "id": "3388437f",
    "metadata": {},
    "source": [
     "## What to notice\n",

--- a/case_studies/us_equities_panel/08_tabular_dl.ipynb
+++ b/case_studies/us_equities_panel/08_tabular_dl.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "80337123",
+   "id": "19b1487f",
    "metadata": {},
    "source": [
     "# US equities panel: a neural network on the same flat table, and what an ensemble of them costs\n",
@@ -78,7 +78,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4c3f99ac",
+   "id": "688be172",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -103,7 +103,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4a6a8ae4",
+   "id": "add80372",
    "metadata": {
     "tags": [
      "parameters"
@@ -123,15 +123,15 @@
     "DEVICE = \"cuda\"\n",
     "EXECUTION_TIER = \"canonical\"\n",
     "WORKSPACE = \"\"\n",
-    "MAX_SYMBOLS = 0\n",
-    "MAX_FOLDS = 0\n",
+    "PREVIEW_MAX_SYMBOLS = 0\n",
+    "PREVIEW_MAX_FOLDS = 0\n",
     "PREVIEW_N_EPOCHS = 0\n",
     "PREVIEW_CHECKPOINT_INTERVAL = 0"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "933e8157",
+   "id": "f5d7da14",
    "metadata": {},
    "source": [
     "## 1. Which configurations, and on which label\n",
@@ -163,7 +163,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "13de282f",
+   "id": "bd42a3ba",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -201,7 +201,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "339bd791",
+   "id": "8788b7ef",
    "metadata": {},
    "source": [
     "A run that narrows the selection, overrides a parameter or fits on another device produces a\n",
@@ -214,7 +214,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d2b748e7",
+   "id": "977e03e8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -234,7 +234,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "31ba845c",
+   "id": "c1215168",
    "metadata": {},
    "source": [
     "Both tiers resolve the study through `open_study`. It reads the labels and features in place\n",
@@ -246,15 +246,15 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "066d1879",
+   "id": "6e9b4898",
    "metadata": {},
    "outputs": [],
    "source": [
     "preview_reductions = {}\n",
-    "if MAX_SYMBOLS:\n",
-    "    preview_reductions[\"max_symbols\"] = int(MAX_SYMBOLS)\n",
-    "if MAX_FOLDS:\n",
-    "    preview_reductions[\"folds\"] = list(range(int(MAX_FOLDS)))\n",
+    "if PREVIEW_MAX_SYMBOLS:\n",
+    "    preview_reductions[\"max_symbols\"] = int(PREVIEW_MAX_SYMBOLS)\n",
+    "if PREVIEW_MAX_FOLDS:\n",
+    "    preview_reductions[\"folds\"] = list(range(int(PREVIEW_MAX_FOLDS)))\n",
     "if PREVIEW_N_EPOCHS:\n",
     "    preview_reductions[\"n_epochs\"] = int(PREVIEW_N_EPOCHS)\n",
     "if PREVIEW_CHECKPOINT_INTERVAL:\n",
@@ -265,7 +265,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8ecb4a81",
+   "id": "0d79b1bc",
    "metadata": {},
    "source": [
     "## 2. Binding the declarations to the data\n",
@@ -278,7 +278,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "951d2d45",
+   "id": "22292fba",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -317,7 +317,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "efe28523",
+   "id": "3e4d4348",
    "metadata": {},
    "source": [
     "## 3. Planning, then fitting\n",
@@ -340,7 +340,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5bd4b22a",
+   "id": "b2266c88",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -361,7 +361,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "83668120",
+   "id": "fa9b92c7",
    "metadata": {},
    "source": [
     "`run_model_population` takes the plan, writes the population down, fits every member and then\n",
@@ -381,7 +381,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2da8d4bc",
+   "id": "aa3e963d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -403,7 +403,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c84f3bc3",
+   "id": "0e3d7b77",
    "metadata": {},
    "source": [
     "## 4. What was actually fitted\n",
@@ -417,7 +417,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "72cc7518",
+   "id": "7c7d1c1f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -446,7 +446,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "acd414c1",
+   "id": "2f06930c",
    "metadata": {},
    "source": [
     "## 5. What came out\n",
@@ -464,7 +464,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1b0cd773",
+   "id": "49c21fdc",
    "metadata": {
     "tags": [
      "results"
@@ -493,7 +493,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5facb057",
+   "id": "4656cc80",
    "metadata": {},
    "source": [
     "A prediction set can be registered complete and still have scored no dates. Cross-sectional\n",
@@ -506,7 +506,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "dee942a0",
+   "id": "3e3bcf6c",
    "metadata": {
     "tags": [
      "results"
@@ -523,7 +523,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "707f03a0",
+   "id": "e263792e",
    "metadata": {},
    "source": [
     "### Where more training stopped helping\n",
@@ -548,7 +548,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "be0b83f4",
+   "id": "180f7f2e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -605,7 +605,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "03ee81bc",
+   "id": "9a038edb",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -639,7 +639,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "22d7601f",
+   "id": "8e575acc",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -649,7 +649,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "096f893c",
+   "id": "6af24e75",
    "metadata": {},
    "source": [
     "## 6. Naming the sets the later notebooks open\n",
@@ -668,7 +668,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bd16031e",
+   "id": "efbc25b1",
    "metadata": {
     "tags": [
      "results"
@@ -724,7 +724,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1f25c6cf",
+   "id": "8a4b7eb0",
    "metadata": {},
    "source": [
     "`15_model_analysis.py` reopens the named compatible and diagnostic sets. `16_backtest.py` passes\n",
@@ -734,7 +734,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3388437f",
+   "id": "e90e6ec8",
    "metadata": {},
    "source": [
     "## What to notice\n",

--- a/case_studies/us_equities_panel/08_tabular_dl.ipynb
+++ b/case_studies/us_equities_panel/08_tabular_dl.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "77c4e8a4",
+   "id": "16c55fc5",
    "metadata": {},
    "source": [
     "# US equities panel: a neural network on the same flat table, and what an ensemble of them costs\n",
@@ -78,7 +78,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "03c50ae5",
+   "id": "3e2f3cff",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -98,7 +98,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "96f72b92",
+   "id": "dd83eb9a",
    "metadata": {
     "tags": [
      "parameters"
@@ -123,7 +123,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8ea96883",
+   "id": "2d4f8325",
    "metadata": {},
    "source": [
     "## 1. Which configurations, and on which label\n",
@@ -141,10 +141,11 @@
     "  **`CONFIG_OVERRIDES`** changes one named configuration, taking precedence. An override moves a\n",
     "  training identity, so an overridden run registers beside the published one rather than\n",
     "  replacing it.\n",
-    "- **`DIAGNOSTIC_CONFIG_NAMES`** names the small subset [`15_model_analysis`](15_model_analysis.ipynb)\n",
-    "  compares predictions across. It is bounded on purpose: that comparison holds every member's\n",
-    "  prediction frame in memory at once and correlates them pairwise, so its cost grows with the\n",
-    "  square of the membership.\n",
+    "- **`DIAGNOSTIC_CONFIG_NAMES`** names the configuration [`15_model_analysis`](15_model_analysis.ipynb)\n",
+    "  reads raw predictions for. It is bounded hard: that comparison loads every diagnostic member's\n",
+    "  prediction frame and holds them all while it joins them pairwise, and one frame on this panel\n",
+    "  is 7.2 million rows and about 225 MB in memory. The frozen set below is the named\n",
+    "  configuration at its last epoch checkpoint - one member for this label and family.\n",
     "- **`EXECUTION_TIER`** is `canonical` or `preview`. A canonical run fits the whole panel on every\n",
     "  fold at the published epoch schedule. A preview run has to declare at least one reduction, and\n",
     "  its results carry that reduction in their identity so they can never be compared against\n",
@@ -154,7 +155,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cf17909c",
+   "id": "bda0ddd9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -193,7 +194,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e38933dd",
+   "id": "2074ec7a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -228,7 +229,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "21ca05db",
+   "id": "7d52749f",
    "metadata": {},
    "source": [
     "## 2. Binding the declarations to the data\n",
@@ -241,7 +242,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7159c3fe",
+   "id": "8a86b149",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -280,7 +281,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2754a31a",
+   "id": "e9083090",
    "metadata": {},
    "source": [
     "## 3. Planning, then fitting\n",
@@ -303,7 +304,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "99c231d8",
+   "id": "31bfdd1d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -330,7 +331,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8894329a",
+   "id": "8002fe4e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -339,7 +340,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ab4a7ccd",
+   "id": "6bbd3fc8",
    "metadata": {},
    "source": [
     "## 4. What was actually fitted\n",
@@ -353,7 +354,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "37d21703",
+   "id": "951ed6a7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -382,7 +383,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5a801088",
+   "id": "b59ce2b6",
    "metadata": {},
    "source": [
     "## 5. What came out\n",
@@ -400,7 +401,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "35540c72",
+   "id": "ce51b4c2",
    "metadata": {
     "tags": [
      "results"
@@ -429,7 +430,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d97ad042",
+   "id": "d6fed189",
    "metadata": {},
    "source": [
     "A prediction set can be registered complete and still have scored no dates. Cross-sectional\n",
@@ -442,7 +443,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3f050d08",
+   "id": "8cfb0c27",
    "metadata": {
     "tags": [
      "results"
@@ -460,7 +461,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d6dd6dc4",
+   "id": "c7d9cbf2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -496,7 +497,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "72e7f81e",
+   "id": "485e4904",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -506,7 +507,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "da6411fe",
+   "id": "2a2f52fa",
    "metadata": {},
    "source": [
     "## 6. Naming the sets the later notebooks open\n",
@@ -525,7 +526,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0df81bf4",
+   "id": "50ec0a32",
    "metadata": {
     "tags": [
      "results"
@@ -547,8 +548,16 @@
     "        execution.catalog_rows,\n",
     "        name=f\"us-equities-{label_name}-tabular-dl-v1\",\n",
     "    )\n",
+    "    diagnostic_rows = execution.catalog_rows.filter(\n",
+    "        pl.col(\"config_name\").is_in(DIAGNOSTIC_CONFIG_NAMES)\n",
+    "        # `.fill_null(True)` covers a family that publishes no checkpoint value at all, where the\n",
+    "        # comparison is null rather than false and would otherwise empty the frame.\n",
+    "        & (\n",
+    "            pl.col(\"checkpoint_value\") == pl.col(\"checkpoint_value\").max().over(\"config_name\")\n",
+    "        ).fill_null(True)\n",
+    "    )\n",
     "    diagnostic_set = study.predictions.freeze(\n",
-    "        execution.catalog_rows.filter(pl.col(\"config_name\").is_in(DIAGNOSTIC_CONFIG_NAMES)),\n",
+    "        diagnostic_rows,\n",
     "        name=f\"us-equities-{label_name}-tabular-dl-diagnostics-v1\",\n",
     "    )\n",
     "    set_rows = [\n",
@@ -572,7 +581,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "af92cc91",
+   "id": "2293a4a4",
    "metadata": {},
    "source": [
     "`15_model_analysis.py` reopens the named compatible and diagnostic sets. `16_backtest.py` passes\n",
@@ -582,7 +591,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3edd1a82",
+   "id": "7bef3426",
    "metadata": {},
    "source": [
     "## What to notice\n",

--- a/case_studies/us_equities_panel/08_tabular_dl.ipynb
+++ b/case_studies/us_equities_panel/08_tabular_dl.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "16c55fc5",
+   "id": "2d7d40a3",
    "metadata": {},
    "source": [
     "# US equities panel: a neural network on the same flat table, and what an ensemble of them costs\n",
@@ -78,7 +78,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3e2f3cff",
+   "id": "1ca41250",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -87,18 +87,20 @@
     "import os\n",
     "from pathlib import Path\n",
     "\n",
+    "import matplotlib.pyplot as plt\n",
     "import polars as pl\n",
     "import yaml\n",
     "\n",
     "from case_studies.research import open_study, plan_models\n",
     "from utils.modeling import load_configs\n",
-    "from utils.paths import get_case_study_dir"
+    "from utils.paths import get_case_study_dir\n",
+    "from utils.style import FIGSIZE, add_message_title, ml4t_palette, show_with_alt, zero_line"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "dd83eb9a",
+   "id": "2e5c86e6",
    "metadata": {
     "tags": [
      "parameters"
@@ -123,7 +125,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2d4f8325",
+   "id": "f34676cb",
    "metadata": {},
    "source": [
     "## 1. Which configurations, and on which label\n",
@@ -155,7 +157,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bda0ddd9",
+   "id": "58fcd35e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -194,7 +196,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2074ec7a",
+   "id": "8272e03d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -229,7 +231,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7d52749f",
+   "id": "9180bd78",
    "metadata": {},
    "source": [
     "## 2. Binding the declarations to the data\n",
@@ -242,7 +244,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8a86b149",
+   "id": "0041d971",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -281,7 +283,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e9083090",
+   "id": "3c3bf680",
    "metadata": {},
    "source": [
     "## 3. Planning, then fitting\n",
@@ -304,7 +306,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "31bfdd1d",
+   "id": "0b14cad7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -331,7 +333,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8002fe4e",
+   "id": "44be77d7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -340,7 +342,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6bbd3fc8",
+   "id": "27b5b32b",
    "metadata": {},
    "source": [
     "## 4. What was actually fitted\n",
@@ -354,7 +356,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "951ed6a7",
+   "id": "820edc9f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -383,7 +385,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b59ce2b6",
+   "id": "7e8b206b",
    "metadata": {},
    "source": [
     "## 5. What came out\n",
@@ -401,7 +403,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ce51b4c2",
+   "id": "f303483b",
    "metadata": {
     "tags": [
      "results"
@@ -430,7 +432,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d6fed189",
+   "id": "895af142",
    "metadata": {},
    "source": [
     "A prediction set can be registered complete and still have scored no dates. Cross-sectional\n",
@@ -443,7 +445,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8cfb0c27",
+   "id": "19a922f0",
    "metadata": {
     "tags": [
      "results"
@@ -459,9 +461,90 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "e888065b",
+   "metadata": {},
+   "source": [
+    "### Where more training stopped helping\n",
+    "\n",
+    "Each line traces one configuration's validation information coefficient as epochs are added to\n",
+    "it. This is the figure the checkpoint dimension exists to produce, and it separates two things a\n",
+    "single end-of-training number cannot.\n",
+    "\n",
+    "A line that rises and then falls has an interior optimum: the model was still learning, then\n",
+    "began fitting the training windows at the expense of the validation folds. That is the evidence about whether the capacity\n",
+    "ladder outruns what this panel supports, and it is the only place the three rungs can be\n",
+    "compared at equal training length.\n",
+    "A line that wanders around zero without trend never had anything to learn, and its highest point\n",
+    "is wherever the noise happened to peak. Both produce a respectable-looking maximum, which is why\n",
+    "the curve rather than the maximum is what to read.\n",
+    "\n",
+    "Nothing here selects a checkpoint. Every one of them is registered as its own candidate, and\n",
+    "which one a strategy would use is decided by validation backtest Sharpe in\n",
+    "[`16_backtest`](16_backtest.ipynb)."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c7d9cbf2",
+   "id": "10264b7f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "curves = scored.sort(\"config_name\", \"checkpoint_value\")\n",
+    "config_names = curves.get_column(\"config_name\").unique(maintain_order=True).to_list()\n",
+    "# `ml4t_palette` returns a list of that many colours, so it is called once and indexed.\n",
+    "palette = ml4t_palette(len(config_names), categorical=True)\n",
+    "\n",
+    "fig, ax = plt.subplots(figsize=FIGSIZE[\"single\"])\n",
+    "for index, config_name in enumerate(config_names):\n",
+    "    series = curves.filter(pl.col(\"config_name\") == config_name)\n",
+    "    ax.plot(\n",
+    "        series.get_column(\"checkpoint_value\"),\n",
+    "        series.get_column(\"ic_mean\"),\n",
+    "        marker=\"o\",\n",
+    "        markersize=4,\n",
+    "        lw=1.4,\n",
+    "        color=palette[index],\n",
+    "        label=config_name,\n",
+    "    )\n",
+    "zero_line(ax)\n",
+    "ax.set_xlabel(\"Training epochs\")\n",
+    "ax.set_ylabel(\"Mean validation IC\")\n",
+    "ax.legend(fontsize=8, frameon=False)\n",
+    "add_message_title(\n",
+    "    ax,\n",
+    "    \"Mean validation IC against training epoch\",\n",
+    "    subtitle=\"One line per configuration, over the epochs the schedule checkpoints at\",\n",
+    ")\n",
+    "# The alt text counts rather than asserts: whether a curve turns over is the question the figure\n",
+    "# exists to answer, and a line described as peaking when it does not is a claim the data refutes.\n",
+    "_peaks = (\n",
+    "    curves.group_by(\"config_name\")\n",
+    "    .agg(\n",
+    "        peak=pl.col(\"checkpoint_value\").sort_by(\"ic_mean\", descending=True).first(),\n",
+    "        first=pl.col(\"checkpoint_value\").min(),\n",
+    "        last=pl.col(\"checkpoint_value\").max(),\n",
+    "    )\n",
+    "    .with_columns(\n",
+    "        interior=pl.col(\"peak\").is_between(pl.col(\"first\"), pl.col(\"last\"), closed=\"none\")\n",
+    "    )\n",
+    ")\n",
+    "_n_interior = int(_peaks.get_column(\"interior\").sum())\n",
+    "show_with_alt(\n",
+    "    fig,\n",
+    "    \"A line chart of mean validation information coefficient against training epoch, one line per \"\n",
+    "    \"configuration, with a dashed line at zero. Counted from the underlying frame, \"\n",
+    "    f\"{_n_interior} of {_peaks.height} configurations reach their highest information coefficient \"\n",
+    "    \"at an epoch that is neither the first nor the last, which is what an interior optimum looks \"\n",
+    "    \"like on this chart.\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0e5c9d8b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -497,7 +580,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "485e4904",
+   "id": "8dbbd177",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -507,7 +590,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2a2f52fa",
+   "id": "d2b00f24",
    "metadata": {},
    "source": [
     "## 6. Naming the sets the later notebooks open\n",
@@ -526,7 +609,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "50ec0a32",
+   "id": "154edb56",
    "metadata": {
     "tags": [
      "results"
@@ -581,7 +664,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2293a4a4",
+   "id": "806ac989",
    "metadata": {},
    "source": [
     "`15_model_analysis.py` reopens the named compatible and diagnostic sets. `16_backtest.py` passes\n",
@@ -591,7 +674,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7bef3426",
+   "id": "2e353f4a",
    "metadata": {},
    "source": [
     "## What to notice\n",

--- a/case_studies/us_equities_panel/08_tabular_dl.py
+++ b/case_studies/us_equities_panel/08_tabular_dl.py
@@ -89,12 +89,14 @@
 import os
 from pathlib import Path
 
+import matplotlib.pyplot as plt
 import polars as pl
 import yaml
 
 from case_studies.research import open_study, plan_models
 from utils.modeling import load_configs
 from utils.paths import get_case_study_dir
+from utils.style import FIGSIZE, add_message_title, ml4t_palette, show_with_alt, zero_line
 
 # %% tags=["parameters"]
 CASE_STUDY_ID = "us_equities_panel"
@@ -353,6 +355,75 @@ unscored = scored.filter(pl.col("ic_n_days").is_null() | (pl.col("ic_n_days") <=
 if not unscored.is_empty():
     raise RuntimeError(f"prediction sets scored no dates: {unscored.to_dicts()}")
 scored
+
+# %% [markdown]
+# ### Where more training stopped helping
+#
+# Each line traces one configuration's validation information coefficient as epochs are added to
+# it. This is the figure the checkpoint dimension exists to produce, and it separates two things a
+# single end-of-training number cannot.
+#
+# A line that rises and then falls has an interior optimum: the model was still learning, then
+# began fitting the training windows at the expense of the validation folds. That is the evidence about whether the capacity
+# ladder outruns what this panel supports, and it is the only place the three rungs can be
+# compared at equal training length.
+# A line that wanders around zero without trend never had anything to learn, and its highest point
+# is wherever the noise happened to peak. Both produce a respectable-looking maximum, which is why
+# the curve rather than the maximum is what to read.
+#
+# Nothing here selects a checkpoint. Every one of them is registered as its own candidate, and
+# which one a strategy would use is decided by validation backtest Sharpe in
+# [`16_backtest`](16_backtest.ipynb).
+
+# %%
+curves = scored.sort("config_name", "checkpoint_value")
+config_names = curves.get_column("config_name").unique(maintain_order=True).to_list()
+# `ml4t_palette` returns a list of that many colours, so it is called once and indexed.
+palette = ml4t_palette(len(config_names), categorical=True)
+
+fig, ax = plt.subplots(figsize=FIGSIZE["single"])
+for index, config_name in enumerate(config_names):
+    series = curves.filter(pl.col("config_name") == config_name)
+    ax.plot(
+        series.get_column("checkpoint_value"),
+        series.get_column("ic_mean"),
+        marker="o",
+        markersize=4,
+        lw=1.4,
+        color=palette[index],
+        label=config_name,
+    )
+zero_line(ax)
+ax.set_xlabel("Training epochs")
+ax.set_ylabel("Mean validation IC")
+ax.legend(fontsize=8, frameon=False)
+add_message_title(
+    ax,
+    "Mean validation IC against training epoch",
+    subtitle="One line per configuration, over the epochs the schedule checkpoints at",
+)
+# The alt text counts rather than asserts: whether a curve turns over is the question the figure
+# exists to answer, and a line described as peaking when it does not is a claim the data refutes.
+_peaks = (
+    curves.group_by("config_name")
+    .agg(
+        peak=pl.col("checkpoint_value").sort_by("ic_mean", descending=True).first(),
+        first=pl.col("checkpoint_value").min(),
+        last=pl.col("checkpoint_value").max(),
+    )
+    .with_columns(
+        interior=pl.col("peak").is_between(pl.col("first"), pl.col("last"), closed="none")
+    )
+)
+_n_interior = int(_peaks.get_column("interior").sum())
+show_with_alt(
+    fig,
+    "A line chart of mean validation information coefficient against training epoch, one line per "
+    "configuration, with a dashed line at zero. Counted from the underlying frame, "
+    f"{_n_interior} of {_peaks.height} configurations reach their highest information coefficient "
+    "at an epoch that is neither the first nor the last, which is what an interior optimum looks "
+    "like on this chart.",
+)
 
 # %%
 coverage_rows = []

--- a/case_studies/us_equities_panel/08_tabular_dl.py
+++ b/case_studies/us_equities_panel/08_tabular_dl.py
@@ -86,14 +86,17 @@
 # %%
 """Generate TabM validation predictions through the shared research interface."""
 
-import os
-from pathlib import Path
-
 import matplotlib.pyplot as plt
 import polars as pl
 import yaml
 
-from case_studies.research import open_study, plan_models
+from case_studies.research import (
+    candidate_set_supersedes,
+    open_study,
+    plan_models,
+    run_model_population,
+    supersedes_for_run,
+)
 from utils.modeling import load_configs
 from utils.paths import get_case_study_dir
 from utils.style import FIGSIZE, add_message_title, ml4t_palette, show_with_alt, zero_line
@@ -105,9 +108,12 @@ CONFIG_NAMES = []
 COMMON_OVERRIDES = {}
 CONFIG_OVERRIDES = {}
 DIAGNOSTIC_CONFIG_NAMES = ["tabm_s"]
+POPULATION_NAME = ""
+SUPERSEDES_POPULATION = ""
+SUPERSEDES_SETS: dict = {}
 DEVICE = "cuda"
 EXECUTION_TIER = "canonical"
-WORKSPACE = "experiments"
+WORKSPACE = ""
 MAX_SYMBOLS = 0
 MAX_FOLDS = 0
 PREVIEW_N_EPOCHS = 0
@@ -132,7 +138,7 @@ PREVIEW_CHECKPOINT_INTERVAL = 0
 # - **`DIAGNOSTIC_CONFIG_NAMES`** names the configuration [`15_model_analysis`](15_model_analysis.ipynb)
 #   reads raw predictions for. It is bounded hard: that comparison loads every diagnostic member's
 #   prediction frame and holds them all while it joins them pairwise, and one frame on this panel
-#   is 7.2 million rows and about 225 MB in memory. The frozen set below is the named
+#   is over seven million rows and about 225 MB in memory. The frozen set below is the named
 #   configuration at its last epoch checkpoint - one member for this label and family.
 # - **`EXECUTION_TIER`** is `canonical` or `preview`. A canonical run fits the whole panel on every
 #   fold at the published epoch schedule. A preview run has to declare at least one reduction, and
@@ -171,6 +177,33 @@ menu = pl.DataFrame(
 )
 menu
 
+# %% [markdown]
+# A run that narrows the selection, overrides a parameter or fits on another device produces a
+# different set of predictions from the one the canonical name stands for. Publishing it under
+# that name would leave the name meaning two different member sets at two different times, so the
+# guard below requires such a run to say what to call its own population, and the frozen set names
+# in Section 6 are withheld from it for the same reason.
+
+# %%
+is_published_population = (
+    EXECUTION_TIER == "canonical"
+    and selected_names == published_names
+    and not COMMON_OVERRIDES
+    and not CONFIG_OVERRIDES
+    and DEVICE == "cuda"
+)
+if EXECUTION_TIER == "canonical" and not is_published_population and not POPULATION_NAME:
+    raise ValueError(
+        "this run narrows or overrides what the menu declares, so it cannot publish the canonical "
+        "population; pass POPULATION_NAME to give it its own"
+    )
+
+# %% [markdown]
+# Both tiers resolve the study through `open_study`. It reads the labels and features in place
+# and redirects only writes, so a preview run scores the same inputs a canonical one does and
+# cannot publish over it. A preview must be given a workspace to write into; a canonical run
+# leaves `WORKSPACE` empty and regenerates the case study's own artifacts in place.
+
 # %%
 preview_reductions = {}
 if MAX_SYMBOLS:
@@ -182,23 +215,7 @@ if PREVIEW_N_EPOCHS:
 if PREVIEW_CHECKPOINT_INTERVAL:
     preview_reductions["checkpoint_interval"] = int(PREVIEW_CHECKPOINT_INTERVAL)
 
-# Both tiers resolve the study through `open_study`. It reads the labels and features in place and
-# redirects only writes, so a preview run scores the same inputs a canonical one does and cannot
-# publish over it.
-if EXECUTION_TIER == "canonical":
-    if preview_reductions:
-        raise ValueError("Canonical execution cannot declare preview reductions")
-    study = open_study(CASE_STUDY_ID, execution_tier=EXECUTION_TIER)
-elif EXECUTION_TIER == "preview":
-    if not preview_reductions:
-        raise ValueError("Preview execution requires at least one declared reduction")
-    study = open_study(
-        CASE_STUDY_ID,
-        execution_tier=EXECUTION_TIER,
-        workspace=Path(os.environ.get("ML4T_OUTPUT_DIR") or WORKSPACE),
-    )
-else:
-    raise ValueError("EXECUTION_TIER must be 'canonical' or 'preview'")
+study = open_study(CASE_STUDY_ID, execution_tier=EXECUTION_TIER, workspace=WORKSPACE or None)
 
 # %% [markdown]
 # ## 2. Binding the declarations to the data
@@ -259,11 +276,6 @@ request_table
 
 # %%
 plan = plan_models(study, requests=requests)
-official_population = None
-if EXECUTION_TIER == "canonical":
-    official_population = plan.create_population(
-        name="us-equities-tabular-dl-checkpoints-v1",
-    )
 
 planned_population = pl.DataFrame(
     {
@@ -277,8 +289,35 @@ planned_population = pl.DataFrame(
 )
 planned_population
 
+# %% [markdown]
+# `run_model_population` takes the plan, writes the population down, fits every member and then
+# checks that what came out is what was declared. The same call serves both tiers: a canonical run
+# registers an immutable population that the later notebooks bind to, and a preview run gets a
+# declaration that is verified and then discarded with its workspace, so no notebook here has to
+# branch on the tier to decide what to publish.
+#
+# `SUPERSEDES_POPULATION` names the population hash this run replaces. A population is a set of
+# prediction identities, so anything that moves a training identity - a changed preset as much as a
+# changed menu - produces a different population under the same name, and the registry refuses to
+# write it without being told which snapshot it supersedes. Leaving it empty is right for a first
+# run and for a reader's clean clone, and `supersedes_for_run` withholds a declared hash wherever
+# offering it would be refused.
+
 # %%
-execution = plan.run()
+population_name = POPULATION_NAME or "us-equities-tabular-dl-checkpoints-v1"
+execution, official_population = run_model_population(
+    study,
+    plan,
+    population_name=population_name,
+    supersedes=supersedes_for_run(
+        study,
+        population_name=population_name,
+        declared=SUPERSEDES_POPULATION,
+        execution_tier=EXECUTION_TIER,
+    ),
+)
+
+print(f"population {official_population.name}: {len(official_population.members)} prediction sets")
 
 # %% [markdown]
 # ## 4. What was actually fitted
@@ -450,8 +489,6 @@ for run in execution.runs:
         )
 
 coverage_table = pl.DataFrame(coverage_rows).sort("config_name", "checkpoint")
-if official_population is not None:
-    official_population.require_complete()
 coverage_table
 
 # %%
@@ -473,18 +510,15 @@ execution_diagnostics
 
 # %% tags=["results"]
 set_rows = []
-is_published_population = (
-    EXECUTION_TIER == "canonical"
-    and selected_names == published_names
-    and not COMMON_OVERRIDES
-    and not CONFIG_OVERRIDES
-    and DEVICE == "cuda"
-)
 if is_published_population:
     label_name = label.replace("_", "-")
+    full_set_name = f"us-equities-{label_name}-tabular-dl-v1"
     full_set = study.predictions.freeze(
         execution.catalog_rows,
-        name=f"us-equities-{label_name}-tabular-dl-v1",
+        name=full_set_name,
+        supersedes=candidate_set_supersedes(
+            study, name=full_set_name, declared=SUPERSEDES_SETS.get(full_set_name, "")
+        ),
     )
     diagnostic_rows = execution.catalog_rows.filter(
         pl.col("config_name").is_in(DIAGNOSTIC_CONFIG_NAMES)
@@ -494,9 +528,13 @@ if is_published_population:
             pl.col("checkpoint_value") == pl.col("checkpoint_value").max().over("config_name")
         ).fill_null(True)
     )
+    diagnostic_set_name = f"us-equities-{label_name}-tabular-dl-diagnostics-v1"
     diagnostic_set = study.predictions.freeze(
         diagnostic_rows,
-        name=f"us-equities-{label_name}-tabular-dl-diagnostics-v1",
+        name=diagnostic_set_name,
+        supersedes=candidate_set_supersedes(
+            study, name=diagnostic_set_name, declared=SUPERSEDES_SETS.get(diagnostic_set_name, "")
+        ),
     )
     set_rows = [
         {

--- a/case_studies/us_equities_panel/08_tabular_dl.py
+++ b/case_studies/us_equities_panel/08_tabular_dl.py
@@ -127,10 +127,11 @@ PREVIEW_CHECKPOINT_INTERVAL = 0
 #   **`CONFIG_OVERRIDES`** changes one named configuration, taking precedence. An override moves a
 #   training identity, so an overridden run registers beside the published one rather than
 #   replacing it.
-# - **`DIAGNOSTIC_CONFIG_NAMES`** names the small subset [`15_model_analysis`](15_model_analysis.ipynb)
-#   compares predictions across. It is bounded on purpose: that comparison holds every member's
-#   prediction frame in memory at once and correlates them pairwise, so its cost grows with the
-#   square of the membership.
+# - **`DIAGNOSTIC_CONFIG_NAMES`** names the configuration [`15_model_analysis`](15_model_analysis.ipynb)
+#   reads raw predictions for. It is bounded hard: that comparison loads every diagnostic member's
+#   prediction frame and holds them all while it joins them pairwise, and one frame on this panel
+#   is 7.2 million rows and about 225 MB in memory. The frozen set below is the named
+#   configuration at its last epoch checkpoint - one member for this label and family.
 # - **`EXECUTION_TIER`** is `canonical` or `preview`. A canonical run fits the whole panel on every
 #   fold at the published epoch schedule. A preview run has to declare at least one reduction, and
 #   its results carry that reduction in their identity so they can never be compared against
@@ -414,8 +415,16 @@ if is_published_population:
         execution.catalog_rows,
         name=f"us-equities-{label_name}-tabular-dl-v1",
     )
+    diagnostic_rows = execution.catalog_rows.filter(
+        pl.col("config_name").is_in(DIAGNOSTIC_CONFIG_NAMES)
+        # `.fill_null(True)` covers a family that publishes no checkpoint value at all, where the
+        # comparison is null rather than false and would otherwise empty the frame.
+        & (
+            pl.col("checkpoint_value") == pl.col("checkpoint_value").max().over("config_name")
+        ).fill_null(True)
+    )
     diagnostic_set = study.predictions.freeze(
-        execution.catalog_rows.filter(pl.col("config_name").is_in(DIAGNOSTIC_CONFIG_NAMES)),
+        diagnostic_rows,
         name=f"us-equities-{label_name}-tabular-dl-diagnostics-v1",
     )
     set_rows = [

--- a/case_studies/us_equities_panel/08_tabular_dl.py
+++ b/case_studies/us_equities_panel/08_tabular_dl.py
@@ -114,8 +114,8 @@ SUPERSEDES_SETS: dict = {}
 DEVICE = "cuda"
 EXECUTION_TIER = "canonical"
 WORKSPACE = ""
-MAX_SYMBOLS = 0
-MAX_FOLDS = 0
+PREVIEW_MAX_SYMBOLS = 0
+PREVIEW_MAX_FOLDS = 0
 PREVIEW_N_EPOCHS = 0
 PREVIEW_CHECKPOINT_INTERVAL = 0
 
@@ -206,10 +206,10 @@ if EXECUTION_TIER == "canonical" and not is_published_population and not POPULAT
 
 # %%
 preview_reductions = {}
-if MAX_SYMBOLS:
-    preview_reductions["max_symbols"] = int(MAX_SYMBOLS)
-if MAX_FOLDS:
-    preview_reductions["folds"] = list(range(int(MAX_FOLDS)))
+if PREVIEW_MAX_SYMBOLS:
+    preview_reductions["max_symbols"] = int(PREVIEW_MAX_SYMBOLS)
+if PREVIEW_MAX_FOLDS:
+    preview_reductions["folds"] = list(range(int(PREVIEW_MAX_FOLDS)))
 if PREVIEW_N_EPOCHS:
     preview_reductions["n_epochs"] = int(PREVIEW_N_EPOCHS)
 if PREVIEW_CHECKPOINT_INTERVAL:

--- a/case_studies/us_equities_panel/09_dl_nlinear.ipynb
+++ b/case_studies/us_equities_panel/09_dl_nlinear.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "1a517fdb",
+   "id": "dd190b2a",
    "metadata": {},
    "source": [
     "# US equities panel: the simplest thing that reads a window\n",
@@ -78,7 +78,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fbf270f7",
+   "id": "943cfd2e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -87,18 +87,20 @@
     "import os\n",
     "from pathlib import Path\n",
     "\n",
+    "import matplotlib.pyplot as plt\n",
     "import polars as pl\n",
     "import yaml\n",
     "\n",
     "from case_studies.research import open_study, plan_models\n",
     "from utils.modeling import load_configs\n",
-    "from utils.paths import get_case_study_dir"
+    "from utils.paths import get_case_study_dir\n",
+    "from utils.style import FIGSIZE, add_message_title, ml4t_palette, show_with_alt, zero_line"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6ba4a13e",
+   "id": "581c58f6",
    "metadata": {
     "tags": [
      "parameters"
@@ -122,7 +124,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9d910170",
+   "id": "a9a966e8",
    "metadata": {},
    "source": [
     "## 1. Which configurations, and on which label\n",
@@ -153,7 +155,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fed88d1e",
+   "id": "697281e3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -196,7 +198,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "beaae2fc",
+   "id": "64445b44",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -229,7 +231,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2d713e6c",
+   "id": "f895a945",
    "metadata": {},
    "source": [
     "## 2. Binding the declarations to the data\n",
@@ -240,7 +242,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "29459caa",
+   "id": "f62a5025",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -280,7 +282,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "48314bba",
+   "id": "d5659068",
    "metadata": {},
    "source": [
     "## 3. Planning, then fitting\n",
@@ -296,7 +298,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "84bfdb53",
+   "id": "22cbea7f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -323,7 +325,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "94a08e94",
+   "id": "23390a85",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -332,7 +334,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "074743b8",
+   "id": "4f019ffc",
    "metadata": {},
    "source": [
     "## 4. What was actually fitted\n",
@@ -344,7 +346,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "515cbde7",
+   "id": "da823031",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -374,7 +376,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0dcf7ecc",
+   "id": "857c3271",
    "metadata": {},
    "source": [
     "## 5. What came out\n",
@@ -387,7 +389,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "885c0600",
+   "id": "95746125",
    "metadata": {
     "tags": [
      "results"
@@ -416,7 +418,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3b76ea40",
+   "id": "abf61bf1",
    "metadata": {},
    "source": [
     "A prediction set can be registered complete and still have scored no dates. Cross-sectional\n",
@@ -429,7 +431,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cb01df4a",
+   "id": "a46bb2ed",
    "metadata": {
     "tags": [
      "results"
@@ -445,9 +447,90 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "cea22396",
+   "metadata": {},
+   "source": [
+    "### Where more training stopped helping\n",
+    "\n",
+    "Each line traces one configuration's validation information coefficient as epochs are added to\n",
+    "it. This is the figure the checkpoint dimension exists to produce, and it separates two things a\n",
+    "single end-of-training number cannot.\n",
+    "\n",
+    "A line that rises and then falls has an interior optimum: the model was still learning, then\n",
+    "began fitting the training windows at the expense of the validation folds. For a model this small - one linear map per feature\n",
+    "column and no nonlinearity - an interior optimum is evidence that even that much capacity\n",
+    "outruns the number of windows this panel yields.\n",
+    "A line that wanders around zero without trend never had anything to learn, and its highest point\n",
+    "is wherever the noise happened to peak. Both produce a respectable-looking maximum, which is why\n",
+    "the curve rather than the maximum is what to read.\n",
+    "\n",
+    "Nothing here selects a checkpoint. Every one of them is registered as its own candidate, and\n",
+    "which one a strategy would use is decided by validation backtest Sharpe in\n",
+    "[`16_backtest`](16_backtest.ipynb)."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c0788155",
+   "id": "41cdcbc6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "curves = scored.sort(\"config_name\", \"checkpoint_value\")\n",
+    "config_names = curves.get_column(\"config_name\").unique(maintain_order=True).to_list()\n",
+    "# `ml4t_palette` returns a list of that many colours, so it is called once and indexed.\n",
+    "palette = ml4t_palette(len(config_names), categorical=True)\n",
+    "\n",
+    "fig, ax = plt.subplots(figsize=FIGSIZE[\"single\"])\n",
+    "for index, config_name in enumerate(config_names):\n",
+    "    series = curves.filter(pl.col(\"config_name\") == config_name)\n",
+    "    ax.plot(\n",
+    "        series.get_column(\"checkpoint_value\"),\n",
+    "        series.get_column(\"ic_mean\"),\n",
+    "        marker=\"o\",\n",
+    "        markersize=4,\n",
+    "        lw=1.4,\n",
+    "        color=palette[index],\n",
+    "        label=config_name,\n",
+    "    )\n",
+    "zero_line(ax)\n",
+    "ax.set_xlabel(\"Training epochs\")\n",
+    "ax.set_ylabel(\"Mean validation IC\")\n",
+    "ax.legend(fontsize=8, frameon=False)\n",
+    "add_message_title(\n",
+    "    ax,\n",
+    "    \"Mean validation IC against training epoch\",\n",
+    "    subtitle=\"One line per configuration, over the epochs the schedule checkpoints at\",\n",
+    ")\n",
+    "# The alt text counts rather than asserts: whether a curve turns over is the question the figure\n",
+    "# exists to answer, and a line described as peaking when it does not is a claim the data refutes.\n",
+    "_peaks = (\n",
+    "    curves.group_by(\"config_name\")\n",
+    "    .agg(\n",
+    "        peak=pl.col(\"checkpoint_value\").sort_by(\"ic_mean\", descending=True).first(),\n",
+    "        first=pl.col(\"checkpoint_value\").min(),\n",
+    "        last=pl.col(\"checkpoint_value\").max(),\n",
+    "    )\n",
+    "    .with_columns(\n",
+    "        interior=pl.col(\"peak\").is_between(pl.col(\"first\"), pl.col(\"last\"), closed=\"none\")\n",
+    "    )\n",
+    ")\n",
+    "_n_interior = int(_peaks.get_column(\"interior\").sum())\n",
+    "show_with_alt(\n",
+    "    fig,\n",
+    "    \"A line chart of mean validation information coefficient against training epoch, one line per \"\n",
+    "    \"configuration, with a dashed line at zero. Counted from the underlying frame, \"\n",
+    "    f\"{_n_interior} of {_peaks.height} configurations reach their highest information coefficient \"\n",
+    "    \"at an epoch that is neither the first nor the last, which is what an interior optimum looks \"\n",
+    "    \"like on this chart.\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7630218f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -483,7 +566,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "82fc2ad2",
+   "id": "c71164d2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -493,7 +576,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4f582b2f",
+   "id": "eac3e679",
    "metadata": {},
    "source": [
     "## 6. Naming the sets the later notebooks open\n",
@@ -517,7 +600,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e538caaa",
+   "id": "415d03e2",
    "metadata": {
     "tags": [
      "results"
@@ -571,7 +654,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "40e313e6",
+   "id": "979ae826",
    "metadata": {},
    "source": [
     "`15_model_analysis` reopens both names: the full set to confirm the run filled every member it\n",
@@ -582,7 +665,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4ef257a8",
+   "id": "63570c49",
    "metadata": {},
    "source": [
     "## What to notice\n",

--- a/case_studies/us_equities_panel/09_dl_nlinear.ipynb
+++ b/case_studies/us_equities_panel/09_dl_nlinear.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "dd190b2a",
+   "id": "9b8a2bd3",
    "metadata": {},
    "source": [
     "# US equities panel: the simplest thing that reads a window\n",
@@ -78,20 +78,23 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "943cfd2e",
+   "id": "e86976c2",
    "metadata": {},
    "outputs": [],
    "source": [
     "\"\"\"Generate NLinear validation predictions through the shared research interface.\"\"\"\n",
     "\n",
-    "import os\n",
-    "from pathlib import Path\n",
-    "\n",
     "import matplotlib.pyplot as plt\n",
     "import polars as pl\n",
     "import yaml\n",
     "\n",
-    "from case_studies.research import open_study, plan_models\n",
+    "from case_studies.research import (\n",
+    "    candidate_set_supersedes,\n",
+    "    open_study,\n",
+    "    plan_models,\n",
+    "    run_model_population,\n",
+    "    supersedes_for_run,\n",
+    ")\n",
     "from utils.modeling import load_configs\n",
     "from utils.paths import get_case_study_dir\n",
     "from utils.style import FIGSIZE, add_message_title, ml4t_palette, show_with_alt, zero_line"
@@ -100,7 +103,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "581c58f6",
+   "id": "02f9bea1",
    "metadata": {
     "tags": [
      "parameters"
@@ -113,9 +116,12 @@
     "CONFIG_NAMES = []\n",
     "COMMON_OVERRIDES = {}\n",
     "CONFIG_OVERRIDES = {}\n",
+    "POPULATION_NAME = \"\"\n",
+    "SUPERSEDES_POPULATION = \"\"\n",
+    "SUPERSEDES_SETS: dict = {}\n",
     "DEVICE = \"cuda\"\n",
     "EXECUTION_TIER = \"canonical\"\n",
-    "WORKSPACE = \"experiments\"\n",
+    "WORKSPACE = \"\"\n",
     "MAX_SYMBOLS = 0\n",
     "FOLD_IDS = []\n",
     "MAX_TRAIN_SEQUENCES = 0\n",
@@ -124,7 +130,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a9a966e8",
+   "id": "5ca5ecea",
    "metadata": {},
    "source": [
     "## 1. Which configurations, and on which label\n",
@@ -155,7 +161,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "697281e3",
+   "id": "ef126f62",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -196,9 +202,53 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "61f846c3",
+   "metadata": {},
+   "source": [
+    "A run that narrows the selection, overrides a parameter or fits on another device produces a\n",
+    "different set of predictions from the one the canonical name stands for. Publishing it under\n",
+    "that name would leave the name meaning two different member sets at two different times, so the\n",
+    "guard below requires such a run to say what to call its own population, and the frozen set names\n",
+    "in Section 6 are withheld from it for the same reason."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "id": "64445b44",
+   "id": "61cfd95d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "is_published_population = (\n",
+    "    EXECUTION_TIER == \"canonical\"\n",
+    "    and selected_names == published_names\n",
+    "    and not COMMON_OVERRIDES\n",
+    "    and not CONFIG_OVERRIDES\n",
+    "    and DEVICE == \"cuda\"\n",
+    ")\n",
+    "if EXECUTION_TIER == \"canonical\" and not is_published_population and not POPULATION_NAME:\n",
+    "    raise ValueError(\n",
+    "        \"this run narrows or overrides what the menu declares, so it cannot publish the canonical \"\n",
+    "        \"population; pass POPULATION_NAME to give it its own\"\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ee00237c",
+   "metadata": {},
+   "source": [
+    "Both tiers resolve the study through `open_study`. It reads the labels and features in place\n",
+    "and redirects only writes, so a preview run scores the same inputs a canonical one does and\n",
+    "cannot publish over it. A preview must be given a workspace to write into; a canonical run\n",
+    "leaves `WORKSPACE` empty and regenerates the case study's own artifacts in place."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f215c4ff",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -210,28 +260,12 @@
     "if MAX_TRAIN_SEQUENCES:\n",
     "    preview_reductions[\"max_train_sequences\"] = int(MAX_TRAIN_SEQUENCES)\n",
     "\n",
-    "# Both tiers resolve the study through `open_study`. It reads the labels and features in place and\n",
-    "# redirects only writes, so a preview run scores the same inputs a canonical one does and cannot\n",
-    "# publish over it.\n",
-    "if EXECUTION_TIER == \"canonical\":\n",
-    "    if preview_reductions or PREVIEW_N_EPOCHS:\n",
-    "        raise ValueError(\"Canonical execution cannot declare preview reductions\")\n",
-    "    study = open_study(CASE_STUDY_ID, execution_tier=EXECUTION_TIER)\n",
-    "elif EXECUTION_TIER == \"preview\":\n",
-    "    if not preview_reductions:\n",
-    "        raise ValueError(\"Preview execution requires a data or fold reduction\")\n",
-    "    study = open_study(\n",
-    "        CASE_STUDY_ID,\n",
-    "        execution_tier=EXECUTION_TIER,\n",
-    "        workspace=Path(os.environ.get(\"ML4T_OUTPUT_DIR\") or WORKSPACE),\n",
-    "    )\n",
-    "else:\n",
-    "    raise ValueError(\"EXECUTION_TIER must be 'canonical' or 'preview'\")"
+    "study = open_study(CASE_STUDY_ID, execution_tier=EXECUTION_TIER, workspace=WORKSPACE or None)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "f895a945",
+   "id": "20663d1a",
    "metadata": {},
    "source": [
     "## 2. Binding the declarations to the data\n",
@@ -242,7 +276,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f62a5025",
+   "id": "00344992",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -282,7 +316,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d5659068",
+   "id": "7d8bf472",
    "metadata": {},
    "source": [
     "## 3. Planning, then fitting\n",
@@ -298,16 +332,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "22cbea7f",
+   "id": "ca27640b",
    "metadata": {},
    "outputs": [],
    "source": [
     "plan = plan_models(study, requests=requests)\n",
-    "official_population = None\n",
-    "if EXECUTION_TIER == \"canonical\":\n",
-    "    official_population = plan.create_population(\n",
-    "        name=\"us-equities-nlinear-checkpoints-v1\",\n",
-    "    )\n",
     "\n",
     "planned_population = pl.DataFrame(\n",
     "    {\n",
@@ -323,18 +352,50 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "67c1cc47",
+   "metadata": {},
+   "source": [
+    "`run_model_population` takes the plan, writes the population down, fits every member and then\n",
+    "checks that what came out is what was declared. The same call serves both tiers: a canonical run\n",
+    "registers an immutable population that the later notebooks bind to, and a preview run gets a\n",
+    "declaration that is verified and then discarded with its workspace, so no notebook here has to\n",
+    "branch on the tier to decide what to publish.\n",
+    "\n",
+    "`SUPERSEDES_POPULATION` names the population hash this run replaces. A population is a set of\n",
+    "prediction identities, so anything that moves a training identity - a changed preset as much as a\n",
+    "changed menu - produces a different population under the same name, and the registry refuses to\n",
+    "write it without being told which snapshot it supersedes. Leaving it empty is right for a first\n",
+    "run and for a reader's clean clone, and `supersedes_for_run` withholds a declared hash wherever\n",
+    "offering it would be refused."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "id": "23390a85",
+   "id": "1ea29179",
    "metadata": {},
    "outputs": [],
    "source": [
-    "execution = plan.run()"
+    "population_name = POPULATION_NAME or \"us-equities-nlinear-checkpoints-v1\"\n",
+    "execution, official_population = run_model_population(\n",
+    "    study,\n",
+    "    plan,\n",
+    "    population_name=population_name,\n",
+    "    supersedes=supersedes_for_run(\n",
+    "        study,\n",
+    "        population_name=population_name,\n",
+    "        declared=SUPERSEDES_POPULATION,\n",
+    "        execution_tier=EXECUTION_TIER,\n",
+    "    ),\n",
+    ")\n",
+    "\n",
+    "print(f\"population {official_population.name}: {len(official_population.members)} prediction sets\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "4f019ffc",
+   "id": "9e005000",
    "metadata": {},
    "source": [
     "## 4. What was actually fitted\n",
@@ -346,7 +407,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "da823031",
+   "id": "3ad1b3d1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -376,7 +437,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "857c3271",
+   "id": "04afa4c6",
    "metadata": {},
    "source": [
     "## 5. What came out\n",
@@ -389,7 +450,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "95746125",
+   "id": "24e2af70",
    "metadata": {
     "tags": [
      "results"
@@ -418,7 +479,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "abf61bf1",
+   "id": "52d9cc01",
    "metadata": {},
    "source": [
     "A prediction set can be registered complete and still have scored no dates. Cross-sectional\n",
@@ -431,7 +492,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a46bb2ed",
+   "id": "0e80dd95",
    "metadata": {
     "tags": [
      "results"
@@ -448,7 +509,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cea22396",
+   "id": "ac32e050",
    "metadata": {},
    "source": [
     "### Where more training stopped helping\n",
@@ -473,7 +534,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "41cdcbc6",
+   "id": "2ee58876",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -530,7 +591,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7630218f",
+   "id": "a694b878",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -558,15 +619,13 @@
     "        )\n",
     "\n",
     "coverage_table = pl.DataFrame(coverage_rows).sort(\"config_name\", \"checkpoint\")\n",
-    "if official_population is not None:\n",
-    "    official_population.require_complete()\n",
     "coverage_table"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c71164d2",
+   "id": "df644b8c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -576,7 +635,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "eac3e679",
+   "id": "d010435c",
    "metadata": {},
    "source": [
     "## 6. Naming the sets the later notebooks open\n",
@@ -589,8 +648,8 @@
     "\n",
     "The second is the **bounded diagnostic set**, and it is bounded hard.\n",
     "[`15_model_analysis`](15_model_analysis.ipynb) loads every diagnostic member's raw prediction\n",
-    "frame and holds them all while it joins them pairwise; one frame on this panel is 7.2 million\n",
-    "rows and about 225 MB in memory, so a set that grew with the checkpoint count would not fit\n",
+    "frame and holds them all while it joins them pairwise; one frame on this panel is over seven\n",
+    "million rows and about 225 MB in memory, so a set that grew with the checkpoint count would not fit\n",
     "beside the other seven families'. The bound is the last checkpoint of each published\n",
     "configuration - one member here, because the menu declares one NLinear configuration. The\n",
     "epoch dimension is still read, in the learning-curve figure above, which is drawn from registry\n",
@@ -600,7 +659,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "415d03e2",
+   "id": "7d1877f5",
    "metadata": {
     "tags": [
      "results"
@@ -609,18 +668,15 @@
    "outputs": [],
    "source": [
     "set_rows = []\n",
-    "is_published_population = (\n",
-    "    EXECUTION_TIER == \"canonical\"\n",
-    "    and selected_names == published_names\n",
-    "    and not COMMON_OVERRIDES\n",
-    "    and not CONFIG_OVERRIDES\n",
-    "    and DEVICE == \"cuda\"\n",
-    ")\n",
     "if is_published_population:\n",
     "    label_name = label.replace(\"_\", \"-\")\n",
+    "    full_set_name = f\"us-equities-{label_name}-nlinear-v1\"\n",
     "    full_set = study.predictions.freeze(\n",
     "        execution.catalog_rows,\n",
-    "        name=f\"us-equities-{label_name}-nlinear-v1\",\n",
+    "        name=full_set_name,\n",
+    "        supersedes=candidate_set_supersedes(\n",
+    "            study, name=full_set_name, declared=SUPERSEDES_SETS.get(full_set_name, \"\")\n",
+    "        ),\n",
     "    )\n",
     "    diagnostic_rows = execution.catalog_rows.filter(\n",
     "        # `.fill_null(True)` covers a family that publishes no checkpoint value at all, where the\n",
@@ -629,9 +685,13 @@
     "            pl.col(\"checkpoint_value\") == pl.col(\"checkpoint_value\").max().over(\"config_name\")\n",
     "        ).fill_null(True)\n",
     "    )\n",
+    "    diagnostic_set_name = f\"us-equities-{label_name}-nlinear-diagnostics-v1\"\n",
     "    diagnostic_set = study.predictions.freeze(\n",
     "        diagnostic_rows,\n",
-    "        name=f\"us-equities-{label_name}-nlinear-diagnostics-v1\",\n",
+    "        name=diagnostic_set_name,\n",
+    "        supersedes=candidate_set_supersedes(\n",
+    "            study, name=diagnostic_set_name, declared=SUPERSEDES_SETS.get(diagnostic_set_name, \"\")\n",
+    "        ),\n",
     "    )\n",
     "    set_rows = [\n",
     "        {\n",
@@ -654,7 +714,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "979ae826",
+   "id": "72a8f27b",
    "metadata": {},
    "source": [
     "`15_model_analysis` reopens both names: the full set to confirm the run filled every member it\n",
@@ -665,7 +725,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "63570c49",
+   "id": "62f09431",
    "metadata": {},
    "source": [
     "## What to notice\n",

--- a/case_studies/us_equities_panel/09_dl_nlinear.ipynb
+++ b/case_studies/us_equities_panel/09_dl_nlinear.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "9fb8d6f1",
+   "id": "1a517fdb",
    "metadata": {},
    "source": [
     "# US equities panel: the simplest thing that reads a window\n",
@@ -78,7 +78,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8d85b572",
+   "id": "fbf270f7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -98,7 +98,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fbe3849a",
+   "id": "6ba4a13e",
    "metadata": {
     "tags": [
      "parameters"
@@ -122,7 +122,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ca225548",
+   "id": "9d910170",
    "metadata": {},
    "source": [
     "## 1. Which configurations, and on which label\n",
@@ -153,7 +153,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "441fdb1d",
+   "id": "fed88d1e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -196,7 +196,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "159de393",
+   "id": "beaae2fc",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -229,7 +229,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "16ff75fa",
+   "id": "2d713e6c",
    "metadata": {},
    "source": [
     "## 2. Binding the declarations to the data\n",
@@ -240,7 +240,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d36aba11",
+   "id": "29459caa",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -280,7 +280,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e13efe23",
+   "id": "48314bba",
    "metadata": {},
    "source": [
     "## 3. Planning, then fitting\n",
@@ -296,7 +296,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "dd2cc7a5",
+   "id": "84bfdb53",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -323,7 +323,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bcc92346",
+   "id": "94a08e94",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -332,7 +332,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3d43ae6f",
+   "id": "074743b8",
    "metadata": {},
    "source": [
     "## 4. What was actually fitted\n",
@@ -344,7 +344,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0635f8d9",
+   "id": "515cbde7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -374,7 +374,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a41720f3",
+   "id": "0dcf7ecc",
    "metadata": {},
    "source": [
     "## 5. What came out\n",
@@ -387,7 +387,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "98b2a00e",
+   "id": "885c0600",
    "metadata": {
     "tags": [
      "results"
@@ -416,7 +416,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "009e8b70",
+   "id": "3b76ea40",
    "metadata": {},
    "source": [
     "A prediction set can be registered complete and still have scored no dates. Cross-sectional\n",
@@ -429,7 +429,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "87d2dae7",
+   "id": "cb01df4a",
    "metadata": {
     "tags": [
      "results"
@@ -447,7 +447,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "aa36ee81",
+   "id": "c0788155",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -483,7 +483,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5a25338d",
+   "id": "82fc2ad2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -493,20 +493,31 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4368e625",
+   "id": "4f582b2f",
    "metadata": {},
    "source": [
-    "## 6. Naming the set the later notebooks open\n",
+    "## 6. Naming the sets the later notebooks open\n",
     "\n",
-    "A canonical default CUDA run freezes every returned NLinear prediction row under a stable name.\n",
-    "The same bounded family set supplies raw diagnostics because this notebook has one published\n",
-    "configuration. Preview and customized canonical requests do not publish an official set."
+    "A canonical default CUDA run freezes what it produced under two stable names, and preview or\n",
+    "customized canonical requests publish neither.\n",
+    "\n",
+    "The first name is the **full set**: every prediction row this run returned, which\n",
+    "[`16_backtest`](16_backtest.ipynb) backtests member by member.\n",
+    "\n",
+    "The second is the **bounded diagnostic set**, and it is bounded hard.\n",
+    "[`15_model_analysis`](15_model_analysis.ipynb) loads every diagnostic member's raw prediction\n",
+    "frame and holds them all while it joins them pairwise; one frame on this panel is 7.2 million\n",
+    "rows and about 225 MB in memory, so a set that grew with the checkpoint count would not fit\n",
+    "beside the other seven families'. The bound is the last checkpoint of each published\n",
+    "configuration - one member here, because the menu declares one NLinear configuration. The\n",
+    "epoch dimension is still read, in the learning-curve figure above, which is drawn from registry\n",
+    "metrics rather than from raw frames."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f34345bb",
+   "id": "e538caaa",
    "metadata": {
     "tags": [
      "results"
@@ -528,12 +539,28 @@
     "        execution.catalog_rows,\n",
     "        name=f\"us-equities-{label_name}-nlinear-v1\",\n",
     "    )\n",
+    "    diagnostic_rows = execution.catalog_rows.filter(\n",
+    "        # `.fill_null(True)` covers a family that publishes no checkpoint value at all, where the\n",
+    "        # comparison is null rather than false and would otherwise empty the frame.\n",
+    "        (\n",
+    "            pl.col(\"checkpoint_value\") == pl.col(\"checkpoint_value\").max().over(\"config_name\")\n",
+    "        ).fill_null(True)\n",
+    "    )\n",
+    "    diagnostic_set = study.predictions.freeze(\n",
+    "        diagnostic_rows,\n",
+    "        name=f\"us-equities-{label_name}-nlinear-diagnostics-v1\",\n",
+    "    )\n",
     "    set_rows = [\n",
     "        {\n",
-    "            \"role\": \"backtest and diagnostic population\",\n",
+    "            \"role\": \"backtest population\",\n",
     "            \"set_name\": full_set.name,\n",
     "            \"members\": len(full_set.members),\n",
-    "        }\n",
+    "        },\n",
+    "        {\n",
+    "            \"role\": \"bounded diagnostics\",\n",
+    "            \"set_name\": diagnostic_set.name,\n",
+    "            \"members\": len(diagnostic_set.members),\n",
+    "        },\n",
     "    ]\n",
     "compatible_sets = pl.DataFrame(\n",
     "    set_rows,\n",
@@ -544,17 +571,18 @@
   },
   {
    "cell_type": "markdown",
-   "id": "91647dcb",
+   "id": "40e313e6",
    "metadata": {},
    "source": [
-    "`15_model_analysis.py` reopens the named set for descriptive analysis. `16_backtest.py` passes\n",
-    "every catalog row directly to the shared backtest runner. Model metrics do not choose a\n",
-    "configuration or checkpoint."
+    "`15_model_analysis` reopens both names: the full set to confirm the run filled every member it\n",
+    "promised, and the diagnostic set to read raw predictions. `16_backtest` passes every full-set\n",
+    "catalog row to the shared backtest runner. Neither the metrics here nor the ones there choose a\n",
+    "configuration or a checkpoint; selection is on validation backtest Sharpe in `16_backtest`."
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "c7488b80",
+   "id": "4ef257a8",
    "metadata": {},
    "source": [
     "## What to notice\n",

--- a/case_studies/us_equities_panel/09_dl_nlinear.ipynb
+++ b/case_studies/us_equities_panel/09_dl_nlinear.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "9b8a2bd3",
+   "id": "d935ab53",
    "metadata": {},
    "source": [
     "# US equities panel: the simplest thing that reads a window\n",
@@ -78,7 +78,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e86976c2",
+   "id": "389e2d67",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -103,7 +103,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "02f9bea1",
+   "id": "13f6005b",
    "metadata": {
     "tags": [
      "parameters"
@@ -122,15 +122,14 @@
     "DEVICE = \"cuda\"\n",
     "EXECUTION_TIER = \"canonical\"\n",
     "WORKSPACE = \"\"\n",
-    "MAX_SYMBOLS = 0\n",
-    "FOLD_IDS = []\n",
-    "MAX_TRAIN_SEQUENCES = 0\n",
-    "PREVIEW_N_EPOCHS = 0"
+    "PREVIEW_MAX_SYMBOLS = 0\n",
+    "PREVIEW_FOLD_IDS = []\n",
+    "PREVIEW_MAX_TRAIN_SEQUENCES = 0"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "5ca5ecea",
+   "id": "856b12b6",
    "metadata": {},
    "source": [
     "## 1. Which configurations, and on which label\n",
@@ -153,15 +152,21 @@
     "  every fold at the published epoch schedule. A preview run has to declare at least one\n",
     "  reduction and carries it in the identity, so its results can never be compared against\n",
     "  canonical ones or reach a holdout decision.\n",
-    "- **`PREVIEW_N_EPOCHS`** shortens the schedule for a preview. It is part of the identity rather\n",
-    "  than a runtime detail, because a model trained for fewer epochs is a different model rather\n",
-    "  than the same one measured sooner."
+    "\n",
+    "A shortened training schedule is not among the reductions a preview may declare, and\n",
+    "deliberately. This family's preview contract - `SEQUENCE_PREVIEW_FIELDS` in\n",
+    "`case_studies/utils/preview_fields.py` - accepts a narrower universe, a fold subset and a cap on\n",
+    "training sequences, and no epoch count, because a model trained for fewer epochs is a different\n",
+    "model rather than the same one measured sooner. To train a short schedule, pass `n_epochs` in\n",
+    "`COMMON_OVERRIDES`. It moves the training identity, so the result registers beside the published\n",
+    "one, and a run carrying any override publishes neither the canonical population nor the\n",
+    "canonical set names."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ef126f62",
+   "id": "3c4b5e37",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -203,7 +208,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "61f846c3",
+   "id": "854453e3",
    "metadata": {},
    "source": [
     "A run that narrows the selection, overrides a parameter or fits on another device produces a\n",
@@ -216,7 +221,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "61cfd95d",
+   "id": "56f4d3a8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -236,7 +241,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ee00237c",
+   "id": "0bf614c9",
    "metadata": {},
    "source": [
     "Both tiers resolve the study through `open_study`. It reads the labels and features in place\n",
@@ -248,24 +253,24 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f215c4ff",
+   "id": "0eb38a68",
    "metadata": {},
    "outputs": [],
    "source": [
     "preview_reductions = {}\n",
-    "if MAX_SYMBOLS:\n",
-    "    preview_reductions[\"max_symbols\"] = int(MAX_SYMBOLS)\n",
-    "if FOLD_IDS:\n",
-    "    preview_reductions[\"folds\"] = [int(fold) for fold in FOLD_IDS]\n",
-    "if MAX_TRAIN_SEQUENCES:\n",
-    "    preview_reductions[\"max_train_sequences\"] = int(MAX_TRAIN_SEQUENCES)\n",
+    "if PREVIEW_MAX_SYMBOLS:\n",
+    "    preview_reductions[\"max_symbols\"] = int(PREVIEW_MAX_SYMBOLS)\n",
+    "if PREVIEW_FOLD_IDS:\n",
+    "    preview_reductions[\"folds\"] = [int(fold) for fold in PREVIEW_FOLD_IDS]\n",
+    "if PREVIEW_MAX_TRAIN_SEQUENCES:\n",
+    "    preview_reductions[\"max_train_sequences\"] = int(PREVIEW_MAX_TRAIN_SEQUENCES)\n",
     "\n",
     "study = open_study(CASE_STUDY_ID, execution_tier=EXECUTION_TIER, workspace=WORKSPACE or None)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "20663d1a",
+   "id": "3f435ed6",
    "metadata": {},
    "source": [
     "## 2. Binding the declarations to the data\n",
@@ -276,7 +281,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "00344992",
+   "id": "8e5f43cd",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -287,8 +292,6 @@
     "        **COMMON_OVERRIDES,\n",
     "        **dict(CONFIG_OVERRIDES.get(config_name, {})),\n",
     "    }\n",
-    "    if PREVIEW_N_EPOCHS:\n",
-    "        overrides[\"n_epochs\"] = int(PREVIEW_N_EPOCHS)\n",
     "    requests.append(\n",
     "        study.model(\n",
     "            family=\"deep_learning\",\n",
@@ -316,7 +319,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7d8bf472",
+   "id": "d59f01ad",
    "metadata": {},
    "source": [
     "## 3. Planning, then fitting\n",
@@ -332,7 +335,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ca27640b",
+   "id": "3dde532b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -353,7 +356,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "67c1cc47",
+   "id": "0671c6a6",
    "metadata": {},
    "source": [
     "`run_model_population` takes the plan, writes the population down, fits every member and then\n",
@@ -373,7 +376,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1ea29179",
+   "id": "91a4ae18",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -395,7 +398,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9e005000",
+   "id": "361bcaac",
    "metadata": {},
    "source": [
     "## 4. What was actually fitted\n",
@@ -407,7 +410,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3ad1b3d1",
+   "id": "5c3cc6d8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -437,7 +440,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "04afa4c6",
+   "id": "7ce4eae8",
    "metadata": {},
    "source": [
     "## 5. What came out\n",
@@ -450,7 +453,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "24e2af70",
+   "id": "284f8f39",
    "metadata": {
     "tags": [
      "results"
@@ -479,7 +482,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "52d9cc01",
+   "id": "e6d710ab",
    "metadata": {},
    "source": [
     "A prediction set can be registered complete and still have scored no dates. Cross-sectional\n",
@@ -492,7 +495,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0e80dd95",
+   "id": "f8278bd4",
    "metadata": {
     "tags": [
      "results"
@@ -509,7 +512,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ac32e050",
+   "id": "571dc58c",
    "metadata": {},
    "source": [
     "### Where more training stopped helping\n",
@@ -534,7 +537,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2ee58876",
+   "id": "6c38b9bd",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -591,7 +594,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a694b878",
+   "id": "26e39730",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -625,7 +628,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "df644b8c",
+   "id": "bb55a2d2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -635,7 +638,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d010435c",
+   "id": "71351e83",
    "metadata": {},
    "source": [
     "## 6. Naming the sets the later notebooks open\n",
@@ -659,7 +662,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7d1877f5",
+   "id": "63d8d00f",
    "metadata": {
     "tags": [
      "results"
@@ -714,7 +717,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "72a8f27b",
+   "id": "bb7b33c2",
    "metadata": {},
    "source": [
     "`15_model_analysis` reopens both names: the full set to confirm the run filled every member it\n",
@@ -725,7 +728,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "62f09431",
+   "id": "0016c03a",
    "metadata": {},
    "source": [
     "## What to notice\n",

--- a/case_studies/us_equities_panel/09_dl_nlinear.ipynb
+++ b/case_studies/us_equities_panel/09_dl_nlinear.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "d935ab53",
+   "id": "2152789f",
    "metadata": {},
    "source": [
     "# US equities panel: the simplest thing that reads a window\n",
@@ -32,10 +32,10 @@
     "one number the notebook predicts. There is no nonlinearity, no recurrence and no attention\n",
     "anywhere in it.\n",
     "\n",
-    "It is here as the control the two notebooks after it have to beat. A recurrent network and a\n",
-    "mixing architecture are both far more expressive, and expressiveness is only worth its cost if\n",
-    "it buys something a linear map on a normalised window did not already have. Running the\n",
-    "elaborate models without this one would leave no way to tell a good result from an easy one.\n",
+    "It is here as the control the two notebooks after it are read against. A recurrent network and a\n",
+    "mixing architecture are both far more expressive, and expressiveness is only worth its cost if it\n",
+    "buys something a linear map on a normalised window did not already have. This number is what\n",
+    "tells a good result from an easy one.\n",
     "\n",
     "**The subtract-and-add-back is the whole of the normalisation, and on price-derived features it\n",
     "matters.** A feature that drifts makes a model reading raw levels spend its capacity tracking\n",
@@ -78,7 +78,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "389e2d67",
+   "id": "8bb3d40f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -103,7 +103,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "13f6005b",
+   "id": "cb70c970",
    "metadata": {
     "tags": [
      "parameters"
@@ -129,7 +129,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "856b12b6",
+   "id": "6c5b1374",
    "metadata": {},
    "source": [
     "## 1. Which configurations, and on which label\n",
@@ -137,7 +137,7 @@
     "The menu at `config/training/{label}.yaml` lists the sequence configurations declared for a\n",
     "label, and this notebook takes the ones whose architecture is `nlinear`. Each name resolves to a\n",
     "preset holding the full parameter set - here a 60-session lookback, 100 epochs, a checkpoint\n",
-    "every 5, and a dropout of 0.1.\n",
+    "every 5, and dropout on the hidden units. The frame below prints the resolved values.\n",
     "\n",
     "What each setting a run may pass decides:\n",
     "\n",
@@ -166,7 +166,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3c4b5e37",
+   "id": "7b621e62",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -208,7 +208,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "854453e3",
+   "id": "d1b018d2",
    "metadata": {},
    "source": [
     "A run that narrows the selection, overrides a parameter or fits on another device produces a\n",
@@ -221,7 +221,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "56f4d3a8",
+   "id": "34efe45f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -241,7 +241,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0bf614c9",
+   "id": "42486883",
    "metadata": {},
    "source": [
     "Both tiers resolve the study through `open_study`. It reads the labels and features in place\n",
@@ -253,7 +253,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0eb38a68",
+   "id": "052f73cf",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -270,7 +270,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3f435ed6",
+   "id": "7bc9b854",
    "metadata": {},
    "source": [
     "## 2. Binding the declarations to the data\n",
@@ -281,7 +281,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8e5f43cd",
+   "id": "2f66b3b2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -319,7 +319,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d59f01ad",
+   "id": "0d60258f",
    "metadata": {},
    "source": [
     "## 3. Planning, then fitting\n",
@@ -335,7 +335,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3dde532b",
+   "id": "2d458076",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -356,7 +356,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0671c6a6",
+   "id": "378f0079",
    "metadata": {},
    "source": [
     "`run_model_population` takes the plan, writes the population down, fits every member and then\n",
@@ -376,7 +376,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "91a4ae18",
+   "id": "03b8077f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -398,7 +398,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "361bcaac",
+   "id": "85b515be",
    "metadata": {},
    "source": [
     "## 4. What was actually fitted\n",
@@ -410,7 +410,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5c3cc6d8",
+   "id": "914153df",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -440,7 +440,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7ce4eae8",
+   "id": "132b4dcc",
    "metadata": {},
    "source": [
     "## 5. What came out\n",
@@ -453,7 +453,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "284f8f39",
+   "id": "12300b91",
    "metadata": {
     "tags": [
      "results"
@@ -482,7 +482,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e6d710ab",
+   "id": "c950474c",
    "metadata": {},
    "source": [
     "A prediction set can be registered complete and still have scored no dates. Cross-sectional\n",
@@ -495,7 +495,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f8278bd4",
+   "id": "564ad61b",
    "metadata": {
     "tags": [
      "results"
@@ -512,7 +512,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "571dc58c",
+   "id": "ab980497",
    "metadata": {},
    "source": [
     "### Where more training stopped helping\n",
@@ -537,7 +537,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6c38b9bd",
+   "id": "ca363724",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -594,7 +594,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "26e39730",
+   "id": "228bf3a8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -628,7 +628,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bb55a2d2",
+   "id": "b49d3d76",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -638,7 +638,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "71351e83",
+   "id": "143dafcb",
    "metadata": {},
    "source": [
     "## 6. Naming the sets the later notebooks open\n",
@@ -662,7 +662,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "63d8d00f",
+   "id": "fea3163d",
    "metadata": {
     "tags": [
      "results"
@@ -717,7 +717,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bb7b33c2",
+   "id": "e1b0f0ab",
    "metadata": {},
    "source": [
     "`15_model_analysis` reopens both names: the full set to confirm the run filled every member it\n",
@@ -728,7 +728,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0016c03a",
+   "id": "ed0256c0",
    "metadata": {},
    "source": [
     "## What to notice\n",

--- a/case_studies/us_equities_panel/09_dl_nlinear.py
+++ b/case_studies/us_equities_panel/09_dl_nlinear.py
@@ -41,10 +41,10 @@
 # one number the notebook predicts. There is no nonlinearity, no recurrence and no attention
 # anywhere in it.
 #
-# It is here as the control the two notebooks after it have to beat. A recurrent network and a
-# mixing architecture are both far more expressive, and expressiveness is only worth its cost if
-# it buys something a linear map on a normalised window did not already have. Running the
-# elaborate models without this one would leave no way to tell a good result from an easy one.
+# It is here as the control the two notebooks after it are read against. A recurrent network and a
+# mixing architecture are both far more expressive, and expressiveness is only worth its cost if it
+# buys something a linear map on a normalised window did not already have. This number is what
+# tells a good result from an easy one.
 #
 # **The subtract-and-add-back is the whole of the normalisation, and on price-derived features it
 # matters.** A feature that drifts makes a model reading raw levels spend its capacity tracking
@@ -123,7 +123,7 @@ PREVIEW_MAX_TRAIN_SEQUENCES = 0
 # The menu at `config/training/{label}.yaml` lists the sequence configurations declared for a
 # label, and this notebook takes the ones whose architecture is `nlinear`. Each name resolves to a
 # preset holding the full parameter set - here a 60-session lookback, 100 epochs, a checkpoint
-# every 5, and a dropout of 0.1.
+# every 5, and dropout on the hidden units. The frame below prints the resolved values.
 #
 # What each setting a run may pass decides:
 #

--- a/case_studies/us_equities_panel/09_dl_nlinear.py
+++ b/case_studies/us_equities_panel/09_dl_nlinear.py
@@ -89,12 +89,14 @@
 import os
 from pathlib import Path
 
+import matplotlib.pyplot as plt
 import polars as pl
 import yaml
 
 from case_studies.research import open_study, plan_models
 from utils.modeling import load_configs
 from utils.paths import get_case_study_dir
+from utils.style import FIGSIZE, add_message_title, ml4t_palette, show_with_alt, zero_line
 
 # %% tags=["parameters"]
 CASE_STUDY_ID = "us_equities_panel"
@@ -339,6 +341,75 @@ unscored = scored.filter(pl.col("ic_n_days").is_null() | (pl.col("ic_n_days") <=
 if not unscored.is_empty():
     raise RuntimeError(f"prediction sets scored no dates: {unscored.to_dicts()}")
 scored
+
+# %% [markdown]
+# ### Where more training stopped helping
+#
+# Each line traces one configuration's validation information coefficient as epochs are added to
+# it. This is the figure the checkpoint dimension exists to produce, and it separates two things a
+# single end-of-training number cannot.
+#
+# A line that rises and then falls has an interior optimum: the model was still learning, then
+# began fitting the training windows at the expense of the validation folds. For a model this small - one linear map per feature
+# column and no nonlinearity - an interior optimum is evidence that even that much capacity
+# outruns the number of windows this panel yields.
+# A line that wanders around zero without trend never had anything to learn, and its highest point
+# is wherever the noise happened to peak. Both produce a respectable-looking maximum, which is why
+# the curve rather than the maximum is what to read.
+#
+# Nothing here selects a checkpoint. Every one of them is registered as its own candidate, and
+# which one a strategy would use is decided by validation backtest Sharpe in
+# [`16_backtest`](16_backtest.ipynb).
+
+# %%
+curves = scored.sort("config_name", "checkpoint_value")
+config_names = curves.get_column("config_name").unique(maintain_order=True).to_list()
+# `ml4t_palette` returns a list of that many colours, so it is called once and indexed.
+palette = ml4t_palette(len(config_names), categorical=True)
+
+fig, ax = plt.subplots(figsize=FIGSIZE["single"])
+for index, config_name in enumerate(config_names):
+    series = curves.filter(pl.col("config_name") == config_name)
+    ax.plot(
+        series.get_column("checkpoint_value"),
+        series.get_column("ic_mean"),
+        marker="o",
+        markersize=4,
+        lw=1.4,
+        color=palette[index],
+        label=config_name,
+    )
+zero_line(ax)
+ax.set_xlabel("Training epochs")
+ax.set_ylabel("Mean validation IC")
+ax.legend(fontsize=8, frameon=False)
+add_message_title(
+    ax,
+    "Mean validation IC against training epoch",
+    subtitle="One line per configuration, over the epochs the schedule checkpoints at",
+)
+# The alt text counts rather than asserts: whether a curve turns over is the question the figure
+# exists to answer, and a line described as peaking when it does not is a claim the data refutes.
+_peaks = (
+    curves.group_by("config_name")
+    .agg(
+        peak=pl.col("checkpoint_value").sort_by("ic_mean", descending=True).first(),
+        first=pl.col("checkpoint_value").min(),
+        last=pl.col("checkpoint_value").max(),
+    )
+    .with_columns(
+        interior=pl.col("peak").is_between(pl.col("first"), pl.col("last"), closed="none")
+    )
+)
+_n_interior = int(_peaks.get_column("interior").sum())
+show_with_alt(
+    fig,
+    "A line chart of mean validation information coefficient against training epoch, one line per "
+    "configuration, with a dashed line at zero. Counted from the underlying frame, "
+    f"{_n_interior} of {_peaks.height} configurations reach their highest information coefficient "
+    "at an epoch that is neither the first nor the last, which is what an interior optimum looks "
+    "like on this chart.",
+)
 
 # %%
 coverage_rows = []

--- a/case_studies/us_equities_panel/09_dl_nlinear.py
+++ b/case_studies/us_equities_panel/09_dl_nlinear.py
@@ -113,10 +113,9 @@ SUPERSEDES_SETS: dict = {}
 DEVICE = "cuda"
 EXECUTION_TIER = "canonical"
 WORKSPACE = ""
-MAX_SYMBOLS = 0
-FOLD_IDS = []
-MAX_TRAIN_SEQUENCES = 0
-PREVIEW_N_EPOCHS = 0
+PREVIEW_MAX_SYMBOLS = 0
+PREVIEW_FOLD_IDS = []
+PREVIEW_MAX_TRAIN_SEQUENCES = 0
 
 # %% [markdown]
 # ## 1. Which configurations, and on which label
@@ -139,9 +138,15 @@ PREVIEW_N_EPOCHS = 0
 #   every fold at the published epoch schedule. A preview run has to declare at least one
 #   reduction and carries it in the identity, so its results can never be compared against
 #   canonical ones or reach a holdout decision.
-# - **`PREVIEW_N_EPOCHS`** shortens the schedule for a preview. It is part of the identity rather
-#   than a runtime detail, because a model trained for fewer epochs is a different model rather
-#   than the same one measured sooner.
+#
+# A shortened training schedule is not among the reductions a preview may declare, and
+# deliberately. This family's preview contract - `SEQUENCE_PREVIEW_FIELDS` in
+# `case_studies/utils/preview_fields.py` - accepts a narrower universe, a fold subset and a cap on
+# training sequences, and no epoch count, because a model trained for fewer epochs is a different
+# model rather than the same one measured sooner. To train a short schedule, pass `n_epochs` in
+# `COMMON_OVERRIDES`. It moves the training identity, so the result registers beside the published
+# one, and a run carrying any override publishes neither the canonical population nor the
+# canonical set names.
 
 # %%
 case_dir = get_case_study_dir(CASE_STUDY_ID)
@@ -208,12 +213,12 @@ if EXECUTION_TIER == "canonical" and not is_published_population and not POPULAT
 
 # %%
 preview_reductions = {}
-if MAX_SYMBOLS:
-    preview_reductions["max_symbols"] = int(MAX_SYMBOLS)
-if FOLD_IDS:
-    preview_reductions["folds"] = [int(fold) for fold in FOLD_IDS]
-if MAX_TRAIN_SEQUENCES:
-    preview_reductions["max_train_sequences"] = int(MAX_TRAIN_SEQUENCES)
+if PREVIEW_MAX_SYMBOLS:
+    preview_reductions["max_symbols"] = int(PREVIEW_MAX_SYMBOLS)
+if PREVIEW_FOLD_IDS:
+    preview_reductions["folds"] = [int(fold) for fold in PREVIEW_FOLD_IDS]
+if PREVIEW_MAX_TRAIN_SEQUENCES:
+    preview_reductions["max_train_sequences"] = int(PREVIEW_MAX_TRAIN_SEQUENCES)
 
 study = open_study(CASE_STUDY_ID, execution_tier=EXECUTION_TIER, workspace=WORKSPACE or None)
 
@@ -230,8 +235,6 @@ for config_name in selected_names:
         **COMMON_OVERRIDES,
         **dict(CONFIG_OVERRIDES.get(config_name, {})),
     }
-    if PREVIEW_N_EPOCHS:
-        overrides["n_epochs"] = int(PREVIEW_N_EPOCHS)
     requests.append(
         study.model(
             family="deep_learning",

--- a/case_studies/us_equities_panel/09_dl_nlinear.py
+++ b/case_studies/us_equities_panel/09_dl_nlinear.py
@@ -374,11 +374,22 @@ execution_diagnostics = pl.DataFrame(execution.diagnostics)
 execution_diagnostics
 
 # %% [markdown]
-# ## 6. Naming the set the later notebooks open
+# ## 6. Naming the sets the later notebooks open
 #
-# A canonical default CUDA run freezes every returned NLinear prediction row under a stable name.
-# The same bounded family set supplies raw diagnostics because this notebook has one published
-# configuration. Preview and customized canonical requests do not publish an official set.
+# A canonical default CUDA run freezes what it produced under two stable names, and preview or
+# customized canonical requests publish neither.
+#
+# The first name is the **full set**: every prediction row this run returned, which
+# [`16_backtest`](16_backtest.ipynb) backtests member by member.
+#
+# The second is the **bounded diagnostic set**, and it is bounded hard.
+# [`15_model_analysis`](15_model_analysis.ipynb) loads every diagnostic member's raw prediction
+# frame and holds them all while it joins them pairwise; one frame on this panel is 7.2 million
+# rows and about 225 MB in memory, so a set that grew with the checkpoint count would not fit
+# beside the other seven families'. The bound is the last checkpoint of each published
+# configuration - one member here, because the menu declares one NLinear configuration. The
+# epoch dimension is still read, in the learning-curve figure above, which is drawn from registry
+# metrics rather than from raw frames.
 
 # %% tags=["results"]
 set_rows = []
@@ -395,12 +406,28 @@ if is_published_population:
         execution.catalog_rows,
         name=f"us-equities-{label_name}-nlinear-v1",
     )
+    diagnostic_rows = execution.catalog_rows.filter(
+        # `.fill_null(True)` covers a family that publishes no checkpoint value at all, where the
+        # comparison is null rather than false and would otherwise empty the frame.
+        (
+            pl.col("checkpoint_value") == pl.col("checkpoint_value").max().over("config_name")
+        ).fill_null(True)
+    )
+    diagnostic_set = study.predictions.freeze(
+        diagnostic_rows,
+        name=f"us-equities-{label_name}-nlinear-diagnostics-v1",
+    )
     set_rows = [
         {
-            "role": "backtest and diagnostic population",
+            "role": "backtest population",
             "set_name": full_set.name,
             "members": len(full_set.members),
-        }
+        },
+        {
+            "role": "bounded diagnostics",
+            "set_name": diagnostic_set.name,
+            "members": len(diagnostic_set.members),
+        },
     ]
 compatible_sets = pl.DataFrame(
     set_rows,
@@ -409,9 +436,10 @@ compatible_sets = pl.DataFrame(
 compatible_sets
 
 # %% [markdown]
-# `15_model_analysis.py` reopens the named set for descriptive analysis. `16_backtest.py` passes
-# every catalog row directly to the shared backtest runner. Model metrics do not choose a
-# configuration or checkpoint.
+# `15_model_analysis` reopens both names: the full set to confirm the run filled every member it
+# promised, and the diagnostic set to read raw predictions. `16_backtest` passes every full-set
+# catalog row to the shared backtest runner. Neither the metrics here nor the ones there choose a
+# configuration or a checkpoint; selection is on validation backtest Sharpe in `16_backtest`.
 
 # %% [markdown]
 # ## What to notice

--- a/case_studies/us_equities_panel/09_dl_nlinear.py
+++ b/case_studies/us_equities_panel/09_dl_nlinear.py
@@ -86,14 +86,17 @@
 # %%
 """Generate NLinear validation predictions through the shared research interface."""
 
-import os
-from pathlib import Path
-
 import matplotlib.pyplot as plt
 import polars as pl
 import yaml
 
-from case_studies.research import open_study, plan_models
+from case_studies.research import (
+    candidate_set_supersedes,
+    open_study,
+    plan_models,
+    run_model_population,
+    supersedes_for_run,
+)
 from utils.modeling import load_configs
 from utils.paths import get_case_study_dir
 from utils.style import FIGSIZE, add_message_title, ml4t_palette, show_with_alt, zero_line
@@ -104,9 +107,12 @@ PRIMARY_LABEL = ""
 CONFIG_NAMES = []
 COMMON_OVERRIDES = {}
 CONFIG_OVERRIDES = {}
+POPULATION_NAME = ""
+SUPERSEDES_POPULATION = ""
+SUPERSEDES_SETS: dict = {}
 DEVICE = "cuda"
 EXECUTION_TIER = "canonical"
-WORKSPACE = "experiments"
+WORKSPACE = ""
 MAX_SYMBOLS = 0
 FOLD_IDS = []
 MAX_TRAIN_SEQUENCES = 0
@@ -173,6 +179,33 @@ menu = pl.DataFrame(
 )
 menu
 
+# %% [markdown]
+# A run that narrows the selection, overrides a parameter or fits on another device produces a
+# different set of predictions from the one the canonical name stands for. Publishing it under
+# that name would leave the name meaning two different member sets at two different times, so the
+# guard below requires such a run to say what to call its own population, and the frozen set names
+# in Section 6 are withheld from it for the same reason.
+
+# %%
+is_published_population = (
+    EXECUTION_TIER == "canonical"
+    and selected_names == published_names
+    and not COMMON_OVERRIDES
+    and not CONFIG_OVERRIDES
+    and DEVICE == "cuda"
+)
+if EXECUTION_TIER == "canonical" and not is_published_population and not POPULATION_NAME:
+    raise ValueError(
+        "this run narrows or overrides what the menu declares, so it cannot publish the canonical "
+        "population; pass POPULATION_NAME to give it its own"
+    )
+
+# %% [markdown]
+# Both tiers resolve the study through `open_study`. It reads the labels and features in place
+# and redirects only writes, so a preview run scores the same inputs a canonical one does and
+# cannot publish over it. A preview must be given a workspace to write into; a canonical run
+# leaves `WORKSPACE` empty and regenerates the case study's own artifacts in place.
+
 # %%
 preview_reductions = {}
 if MAX_SYMBOLS:
@@ -182,23 +215,7 @@ if FOLD_IDS:
 if MAX_TRAIN_SEQUENCES:
     preview_reductions["max_train_sequences"] = int(MAX_TRAIN_SEQUENCES)
 
-# Both tiers resolve the study through `open_study`. It reads the labels and features in place and
-# redirects only writes, so a preview run scores the same inputs a canonical one does and cannot
-# publish over it.
-if EXECUTION_TIER == "canonical":
-    if preview_reductions or PREVIEW_N_EPOCHS:
-        raise ValueError("Canonical execution cannot declare preview reductions")
-    study = open_study(CASE_STUDY_ID, execution_tier=EXECUTION_TIER)
-elif EXECUTION_TIER == "preview":
-    if not preview_reductions:
-        raise ValueError("Preview execution requires a data or fold reduction")
-    study = open_study(
-        CASE_STUDY_ID,
-        execution_tier=EXECUTION_TIER,
-        workspace=Path(os.environ.get("ML4T_OUTPUT_DIR") or WORKSPACE),
-    )
-else:
-    raise ValueError("EXECUTION_TIER must be 'canonical' or 'preview'")
+study = open_study(CASE_STUDY_ID, execution_tier=EXECUTION_TIER, workspace=WORKSPACE or None)
 
 # %% [markdown]
 # ## 2. Binding the declarations to the data
@@ -251,11 +268,6 @@ request_table
 
 # %%
 plan = plan_models(study, requests=requests)
-official_population = None
-if EXECUTION_TIER == "canonical":
-    official_population = plan.create_population(
-        name="us-equities-nlinear-checkpoints-v1",
-    )
 
 planned_population = pl.DataFrame(
     {
@@ -269,8 +281,35 @@ planned_population = pl.DataFrame(
 )
 planned_population
 
+# %% [markdown]
+# `run_model_population` takes the plan, writes the population down, fits every member and then
+# checks that what came out is what was declared. The same call serves both tiers: a canonical run
+# registers an immutable population that the later notebooks bind to, and a preview run gets a
+# declaration that is verified and then discarded with its workspace, so no notebook here has to
+# branch on the tier to decide what to publish.
+#
+# `SUPERSEDES_POPULATION` names the population hash this run replaces. A population is a set of
+# prediction identities, so anything that moves a training identity - a changed preset as much as a
+# changed menu - produces a different population under the same name, and the registry refuses to
+# write it without being told which snapshot it supersedes. Leaving it empty is right for a first
+# run and for a reader's clean clone, and `supersedes_for_run` withholds a declared hash wherever
+# offering it would be refused.
+
 # %%
-execution = plan.run()
+population_name = POPULATION_NAME or "us-equities-nlinear-checkpoints-v1"
+execution, official_population = run_model_population(
+    study,
+    plan,
+    population_name=population_name,
+    supersedes=supersedes_for_run(
+        study,
+        population_name=population_name,
+        declared=SUPERSEDES_POPULATION,
+        execution_tier=EXECUTION_TIER,
+    ),
+)
+
+print(f"population {official_population.name}: {len(official_population.members)} prediction sets")
 
 # %% [markdown]
 # ## 4. What was actually fitted
@@ -436,8 +475,6 @@ for run in execution.runs:
         )
 
 coverage_table = pl.DataFrame(coverage_rows).sort("config_name", "checkpoint")
-if official_population is not None:
-    official_population.require_complete()
 coverage_table
 
 # %%
@@ -455,8 +492,8 @@ execution_diagnostics
 #
 # The second is the **bounded diagnostic set**, and it is bounded hard.
 # [`15_model_analysis`](15_model_analysis.ipynb) loads every diagnostic member's raw prediction
-# frame and holds them all while it joins them pairwise; one frame on this panel is 7.2 million
-# rows and about 225 MB in memory, so a set that grew with the checkpoint count would not fit
+# frame and holds them all while it joins them pairwise; one frame on this panel is over seven
+# million rows and about 225 MB in memory, so a set that grew with the checkpoint count would not fit
 # beside the other seven families'. The bound is the last checkpoint of each published
 # configuration - one member here, because the menu declares one NLinear configuration. The
 # epoch dimension is still read, in the learning-curve figure above, which is drawn from registry
@@ -464,18 +501,15 @@ execution_diagnostics
 
 # %% tags=["results"]
 set_rows = []
-is_published_population = (
-    EXECUTION_TIER == "canonical"
-    and selected_names == published_names
-    and not COMMON_OVERRIDES
-    and not CONFIG_OVERRIDES
-    and DEVICE == "cuda"
-)
 if is_published_population:
     label_name = label.replace("_", "-")
+    full_set_name = f"us-equities-{label_name}-nlinear-v1"
     full_set = study.predictions.freeze(
         execution.catalog_rows,
-        name=f"us-equities-{label_name}-nlinear-v1",
+        name=full_set_name,
+        supersedes=candidate_set_supersedes(
+            study, name=full_set_name, declared=SUPERSEDES_SETS.get(full_set_name, "")
+        ),
     )
     diagnostic_rows = execution.catalog_rows.filter(
         # `.fill_null(True)` covers a family that publishes no checkpoint value at all, where the
@@ -484,9 +518,13 @@ if is_published_population:
             pl.col("checkpoint_value") == pl.col("checkpoint_value").max().over("config_name")
         ).fill_null(True)
     )
+    diagnostic_set_name = f"us-equities-{label_name}-nlinear-diagnostics-v1"
     diagnostic_set = study.predictions.freeze(
         diagnostic_rows,
-        name=f"us-equities-{label_name}-nlinear-diagnostics-v1",
+        name=diagnostic_set_name,
+        supersedes=candidate_set_supersedes(
+            study, name=diagnostic_set_name, declared=SUPERSEDES_SETS.get(diagnostic_set_name, "")
+        ),
     )
     set_rows = [
         {

--- a/case_studies/us_equities_panel/10_dl_lstm.ipynb
+++ b/case_studies/us_equities_panel/10_dl_lstm.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "4fb24854",
+   "id": "fd4913f8",
    "metadata": {},
    "source": [
     "# US equities panel: a model that carries state across the window\n",
@@ -73,7 +73,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2addc792",
+   "id": "e36bd0cc",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -95,7 +95,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "42520cee",
+   "id": "d54f1b64",
    "metadata": {
     "tags": [
      "parameters"
@@ -119,7 +119,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "10e2f08c",
+   "id": "4674c3d0",
    "metadata": {},
    "source": [
     "## 1. Which configurations, and on which label\n",
@@ -150,7 +150,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0d7f193f",
+   "id": "8541bf55",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -193,7 +193,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "94673b92",
+   "id": "a6ee2ccd",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -226,7 +226,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b6181192",
+   "id": "18aacf85",
    "metadata": {},
    "source": [
     "## 2. Binding the declarations to the data\n",
@@ -237,7 +237,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a07aba8b",
+   "id": "0182a11c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -277,7 +277,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5b701b9a",
+   "id": "1c7da5b2",
    "metadata": {},
    "source": [
     "## 3. Planning, then fitting\n",
@@ -293,7 +293,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "15af80f2",
+   "id": "051e6332",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -320,7 +320,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "23e87310",
+   "id": "e228ffed",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -329,7 +329,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0a8efa7c",
+   "id": "3c4fc800",
    "metadata": {},
    "source": [
     "## 4. What was actually fitted\n",
@@ -341,7 +341,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1ab52770",
+   "id": "415b8b45",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -371,7 +371,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "18f707cc",
+   "id": "2f4c325b",
    "metadata": {},
    "source": [
     "## 5. What came out\n",
@@ -384,7 +384,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8b4cf6aa",
+   "id": "2829bcca",
    "metadata": {
     "tags": [
      "results"
@@ -413,7 +413,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "50c36f4d",
+   "id": "16d0328a",
    "metadata": {},
    "source": [
     "A prediction set can be registered complete and still have scored no dates. Cross-sectional\n",
@@ -426,7 +426,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "aada9f98",
+   "id": "9d1c37be",
    "metadata": {
     "tags": [
      "results"
@@ -443,7 +443,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "72e2e3d7",
+   "id": "45ebca8b",
    "metadata": {},
    "source": [
     "### Where more training stopped helping\n",
@@ -463,7 +463,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ef170a08",
+   "id": "71f772ed",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -490,7 +490,7 @@
     "ax.legend(fontsize=8, frameon=False)\n",
     "add_message_title(\n",
     "    ax,\n",
-    "    \"Whether the recurrent network was still learning when training stopped\",\n",
+    "    \"Mean validation IC against training epoch\",\n",
     "    subtitle=\"Out-of-sample information coefficient against epoch, one line per configuration\",\n",
     ")\n",
     "# The alt text counts rather than asserts: whether a curve turns over is the question the figure\n",
@@ -520,7 +520,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "eae4e779",
+   "id": "96ae35e6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -556,7 +556,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e992ca6e",
+   "id": "4b679cf6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -566,7 +566,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "eb7445c0",
+   "id": "21b0642f",
    "metadata": {},
    "source": [
     "## 6. Naming the sets the later notebooks open\n",
@@ -590,7 +590,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0c1a0dc2",
+   "id": "d664b778",
    "metadata": {
     "tags": [
      "results"
@@ -644,7 +644,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "df2b2cec",
+   "id": "1951d504",
    "metadata": {},
    "source": [
     "`15_model_analysis` reopens both names: the full set to confirm the run filled every member it\n",
@@ -655,7 +655,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "afe271c5",
+   "id": "2b143d76",
    "metadata": {},
    "source": [
     "## What to notice\n",

--- a/case_studies/us_equities_panel/10_dl_lstm.ipynb
+++ b/case_studies/us_equities_panel/10_dl_lstm.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "d7efc961",
+   "id": "ba58da64",
    "metadata": {},
    "source": [
     "# US equities panel: a model that carries state across the window\n",
@@ -73,7 +73,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "77ceb798",
+   "id": "fdc9287b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -98,7 +98,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d0e1ea79",
+   "id": "ef159e9c",
    "metadata": {
     "tags": [
      "parameters"
@@ -117,15 +117,14 @@
     "DEVICE = \"cuda\"\n",
     "EXECUTION_TIER = \"canonical\"\n",
     "WORKSPACE = \"\"\n",
-    "MAX_SYMBOLS = 0\n",
-    "FOLD_IDS = []\n",
-    "MAX_TRAIN_SEQUENCES = 0\n",
-    "PREVIEW_N_EPOCHS = 0"
+    "PREVIEW_MAX_SYMBOLS = 0\n",
+    "PREVIEW_FOLD_IDS = []\n",
+    "PREVIEW_MAX_TRAIN_SEQUENCES = 0"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "966cc4a1",
+   "id": "841d5751",
    "metadata": {},
    "source": [
     "## 1. Which configurations, and on which label\n",
@@ -148,15 +147,21 @@
     "  every fold at the published epoch schedule. A preview run has to declare at least one\n",
     "  reduction and carries it in the identity, so its results can never be compared against\n",
     "  canonical ones or reach a holdout decision.\n",
-    "- **`PREVIEW_N_EPOCHS`** shortens the schedule for a preview. It is part of the identity rather\n",
-    "  than a runtime detail, because a model trained for fewer epochs is a different model rather\n",
-    "  than the same one measured sooner."
+    "\n",
+    "A shortened training schedule is not among the reductions a preview may declare, and\n",
+    "deliberately. This family's preview contract - `SEQUENCE_PREVIEW_FIELDS` in\n",
+    "`case_studies/utils/preview_fields.py` - accepts a narrower universe, a fold subset and a cap on\n",
+    "training sequences, and no epoch count, because a model trained for fewer epochs is a different\n",
+    "model rather than the same one measured sooner. To train a short schedule, pass `n_epochs` in\n",
+    "`COMMON_OVERRIDES`. It moves the training identity, so the result registers beside the published\n",
+    "one, and a run carrying any override publishes neither the canonical population nor the\n",
+    "canonical set names."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "263b6e62",
+   "id": "e64655a7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -198,7 +203,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "69d15bf5",
+   "id": "4cd6e483",
    "metadata": {},
    "source": [
     "A run that narrows the selection, overrides a parameter or fits on another device produces a\n",
@@ -211,7 +216,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a70eb0eb",
+   "id": "8632ab86",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -231,7 +236,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e47b5af2",
+   "id": "c86e63c6",
    "metadata": {},
    "source": [
     "Both tiers resolve the study through `open_study`. It reads the labels and features in place\n",
@@ -243,24 +248,24 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7b7cbbd1",
+   "id": "12084188",
    "metadata": {},
    "outputs": [],
    "source": [
     "preview_reductions = {}\n",
-    "if MAX_SYMBOLS:\n",
-    "    preview_reductions[\"max_symbols\"] = int(MAX_SYMBOLS)\n",
-    "if FOLD_IDS:\n",
-    "    preview_reductions[\"folds\"] = [int(fold) for fold in FOLD_IDS]\n",
-    "if MAX_TRAIN_SEQUENCES:\n",
-    "    preview_reductions[\"max_train_sequences\"] = int(MAX_TRAIN_SEQUENCES)\n",
+    "if PREVIEW_MAX_SYMBOLS:\n",
+    "    preview_reductions[\"max_symbols\"] = int(PREVIEW_MAX_SYMBOLS)\n",
+    "if PREVIEW_FOLD_IDS:\n",
+    "    preview_reductions[\"folds\"] = [int(fold) for fold in PREVIEW_FOLD_IDS]\n",
+    "if PREVIEW_MAX_TRAIN_SEQUENCES:\n",
+    "    preview_reductions[\"max_train_sequences\"] = int(PREVIEW_MAX_TRAIN_SEQUENCES)\n",
     "\n",
     "study = open_study(CASE_STUDY_ID, execution_tier=EXECUTION_TIER, workspace=WORKSPACE or None)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "c62f87e3",
+   "id": "7c0d6831",
    "metadata": {},
    "source": [
     "## 2. Binding the declarations to the data\n",
@@ -271,7 +276,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c5f08261",
+   "id": "1c702ea1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -282,8 +287,6 @@
     "        **COMMON_OVERRIDES,\n",
     "        **dict(CONFIG_OVERRIDES.get(config_name, {})),\n",
     "    }\n",
-    "    if PREVIEW_N_EPOCHS:\n",
-    "        overrides[\"n_epochs\"] = int(PREVIEW_N_EPOCHS)\n",
     "    requests.append(\n",
     "        study.model(\n",
     "            family=\"deep_learning\",\n",
@@ -311,7 +314,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c7a212fb",
+   "id": "ca396e7b",
    "metadata": {},
    "source": [
     "## 3. Planning, then fitting\n",
@@ -327,7 +330,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ac6bce9d",
+   "id": "7fa2edc5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -348,7 +351,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "901c7414",
+   "id": "fc23c215",
    "metadata": {},
    "source": [
     "`run_model_population` takes the plan, writes the population down, fits every member and then\n",
@@ -368,7 +371,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "775c5d4d",
+   "id": "4e940883",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -390,7 +393,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "da4431cf",
+   "id": "b4ff71f7",
    "metadata": {},
    "source": [
     "## 4. What was actually fitted\n",
@@ -402,7 +405,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "33fb10b6",
+   "id": "ed5d0633",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -432,7 +435,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "065d12be",
+   "id": "1f1301e3",
    "metadata": {},
    "source": [
     "## 5. What came out\n",
@@ -445,7 +448,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "df8dd499",
+   "id": "9d04d838",
    "metadata": {
     "tags": [
      "results"
@@ -474,7 +477,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "70fb0128",
+   "id": "b1579592",
    "metadata": {},
    "source": [
     "A prediction set can be registered complete and still have scored no dates. Cross-sectional\n",
@@ -487,7 +490,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3b26497a",
+   "id": "84c03f97",
    "metadata": {
     "tags": [
      "results"
@@ -504,7 +507,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "572945ef",
+   "id": "27b88756",
    "metadata": {},
    "source": [
     "### Where more training stopped helping\n",
@@ -524,7 +527,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1af6bffe",
+   "id": "d840298b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -581,7 +584,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "babcd75c",
+   "id": "ce874ca3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -615,7 +618,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "08be13c1",
+   "id": "dd234dfa",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -625,7 +628,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e1621e67",
+   "id": "93ba7141",
    "metadata": {},
    "source": [
     "## 6. Naming the sets the later notebooks open\n",
@@ -649,7 +652,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a39dffc2",
+   "id": "98d9d299",
    "metadata": {
     "tags": [
      "results"
@@ -704,7 +707,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e96e5341",
+   "id": "0e919fb8",
    "metadata": {},
    "source": [
     "`15_model_analysis` reopens both names: the full set to confirm the run filled every member it\n",
@@ -715,7 +718,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "53f537ee",
+   "id": "b75645e6",
    "metadata": {},
    "source": [
     "## What to notice\n",

--- a/case_studies/us_equities_panel/10_dl_lstm.ipynb
+++ b/case_studies/us_equities_panel/10_dl_lstm.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "ba58da64",
+   "id": "b99d1a06",
    "metadata": {},
    "source": [
     "# US equities panel: a model that carries state across the window\n",
@@ -73,7 +73,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fdc9287b",
+   "id": "7bdf1eae",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -98,7 +98,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ef159e9c",
+   "id": "a9c72e08",
    "metadata": {
     "tags": [
      "parameters"
@@ -124,7 +124,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "841d5751",
+   "id": "0c730d5a",
    "metadata": {},
    "source": [
     "## 1. Which configurations, and on which label\n",
@@ -132,7 +132,7 @@
     "The menu at `config/training/{label}.yaml` lists the sequence configurations declared for a\n",
     "label, and this notebook takes the ones whose architecture is `lstm`. Each name resolves to a\n",
     "preset holding the full parameter set - here a 60-session lookback, 100 epochs, a checkpoint\n",
-    "every 5, and a dropout of 0.1.\n",
+    "every 5, and dropout on the hidden units. The frame below prints the resolved values.\n",
     "\n",
     "What each setting a run may pass decides:\n",
     "\n",
@@ -161,7 +161,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e64655a7",
+   "id": "3760a955",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -203,7 +203,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4cd6e483",
+   "id": "f3c32b1b",
    "metadata": {},
    "source": [
     "A run that narrows the selection, overrides a parameter or fits on another device produces a\n",
@@ -216,7 +216,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8632ab86",
+   "id": "0567209a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -236,7 +236,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c86e63c6",
+   "id": "b57efd18",
    "metadata": {},
    "source": [
     "Both tiers resolve the study through `open_study`. It reads the labels and features in place\n",
@@ -248,7 +248,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "12084188",
+   "id": "9ca90720",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -265,7 +265,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7c0d6831",
+   "id": "cd028b9d",
    "metadata": {},
    "source": [
     "## 2. Binding the declarations to the data\n",
@@ -276,7 +276,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1c702ea1",
+   "id": "56f837f9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -314,7 +314,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ca396e7b",
+   "id": "5387f392",
    "metadata": {},
    "source": [
     "## 3. Planning, then fitting\n",
@@ -330,7 +330,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7fa2edc5",
+   "id": "633ac395",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -351,7 +351,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fc23c215",
+   "id": "9e5189b4",
    "metadata": {},
    "source": [
     "`run_model_population` takes the plan, writes the population down, fits every member and then\n",
@@ -371,7 +371,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4e940883",
+   "id": "195a2747",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -393,7 +393,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b4ff71f7",
+   "id": "88e60520",
    "metadata": {},
    "source": [
     "## 4. What was actually fitted\n",
@@ -405,7 +405,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ed5d0633",
+   "id": "5c44469d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -435,7 +435,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1f1301e3",
+   "id": "c5d31d6f",
    "metadata": {},
    "source": [
     "## 5. What came out\n",
@@ -448,7 +448,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9d04d838",
+   "id": "c92c8a76",
    "metadata": {
     "tags": [
      "results"
@@ -477,7 +477,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b1579592",
+   "id": "2c11dc96",
    "metadata": {},
    "source": [
     "A prediction set can be registered complete and still have scored no dates. Cross-sectional\n",
@@ -490,7 +490,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "84c03f97",
+   "id": "251fe508",
    "metadata": {
     "tags": [
      "results"
@@ -507,7 +507,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "27b88756",
+   "id": "830ca863",
    "metadata": {},
    "source": [
     "### Where more training stopped helping\n",
@@ -527,7 +527,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d840298b",
+   "id": "6b7ed247",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -584,7 +584,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ce874ca3",
+   "id": "b23934d9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -618,7 +618,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "dd234dfa",
+   "id": "6861cab2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -628,7 +628,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "93ba7141",
+   "id": "bc88acc5",
    "metadata": {},
    "source": [
     "## 6. Naming the sets the later notebooks open\n",
@@ -652,7 +652,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "98d9d299",
+   "id": "52855ab7",
    "metadata": {
     "tags": [
      "results"
@@ -707,7 +707,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0e919fb8",
+   "id": "2e93daa2",
    "metadata": {},
    "source": [
     "`15_model_analysis` reopens both names: the full set to confirm the run filled every member it\n",
@@ -718,7 +718,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b75645e6",
+   "id": "bd6c4974",
    "metadata": {},
    "source": [
     "## What to notice\n",

--- a/case_studies/us_equities_panel/10_dl_lstm.ipynb
+++ b/case_studies/us_equities_panel/10_dl_lstm.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "fd4913f8",
+   "id": "d7efc961",
    "metadata": {},
    "source": [
     "# US equities panel: a model that carries state across the window\n",
@@ -73,20 +73,23 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e36bd0cc",
+   "id": "77ceb798",
    "metadata": {},
    "outputs": [],
    "source": [
     "\"\"\"Generate LSTM validation predictions through the shared research interface.\"\"\"\n",
     "\n",
-    "import os\n",
-    "from pathlib import Path\n",
-    "\n",
     "import matplotlib.pyplot as plt\n",
     "import polars as pl\n",
     "import yaml\n",
     "\n",
-    "from case_studies.research import open_study, plan_models\n",
+    "from case_studies.research import (\n",
+    "    candidate_set_supersedes,\n",
+    "    open_study,\n",
+    "    plan_models,\n",
+    "    run_model_population,\n",
+    "    supersedes_for_run,\n",
+    ")\n",
     "from utils.modeling import load_configs\n",
     "from utils.paths import get_case_study_dir\n",
     "from utils.style import FIGSIZE, add_message_title, ml4t_palette, show_with_alt, zero_line"
@@ -95,7 +98,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d54f1b64",
+   "id": "d0e1ea79",
    "metadata": {
     "tags": [
      "parameters"
@@ -108,9 +111,12 @@
     "CONFIG_NAMES = []\n",
     "COMMON_OVERRIDES = {}\n",
     "CONFIG_OVERRIDES = {}\n",
+    "POPULATION_NAME = \"\"\n",
+    "SUPERSEDES_POPULATION = \"\"\n",
+    "SUPERSEDES_SETS: dict = {}\n",
     "DEVICE = \"cuda\"\n",
     "EXECUTION_TIER = \"canonical\"\n",
-    "WORKSPACE = \"experiments\"\n",
+    "WORKSPACE = \"\"\n",
     "MAX_SYMBOLS = 0\n",
     "FOLD_IDS = []\n",
     "MAX_TRAIN_SEQUENCES = 0\n",
@@ -119,7 +125,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4674c3d0",
+   "id": "966cc4a1",
    "metadata": {},
    "source": [
     "## 1. Which configurations, and on which label\n",
@@ -150,7 +156,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8541bf55",
+   "id": "263b6e62",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -191,9 +197,53 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "69d15bf5",
+   "metadata": {},
+   "source": [
+    "A run that narrows the selection, overrides a parameter or fits on another device produces a\n",
+    "different set of predictions from the one the canonical name stands for. Publishing it under\n",
+    "that name would leave the name meaning two different member sets at two different times, so the\n",
+    "guard below requires such a run to say what to call its own population, and the frozen set names\n",
+    "in Section 6 are withheld from it for the same reason."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a6ee2ccd",
+   "id": "a70eb0eb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "is_published_population = (\n",
+    "    EXECUTION_TIER == \"canonical\"\n",
+    "    and selected_names == published_names\n",
+    "    and not COMMON_OVERRIDES\n",
+    "    and not CONFIG_OVERRIDES\n",
+    "    and DEVICE == \"cuda\"\n",
+    ")\n",
+    "if EXECUTION_TIER == \"canonical\" and not is_published_population and not POPULATION_NAME:\n",
+    "    raise ValueError(\n",
+    "        \"this run narrows or overrides what the menu declares, so it cannot publish the canonical \"\n",
+    "        \"population; pass POPULATION_NAME to give it its own\"\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e47b5af2",
+   "metadata": {},
+   "source": [
+    "Both tiers resolve the study through `open_study`. It reads the labels and features in place\n",
+    "and redirects only writes, so a preview run scores the same inputs a canonical one does and\n",
+    "cannot publish over it. A preview must be given a workspace to write into; a canonical run\n",
+    "leaves `WORKSPACE` empty and regenerates the case study's own artifacts in place."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7b7cbbd1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -205,28 +255,12 @@
     "if MAX_TRAIN_SEQUENCES:\n",
     "    preview_reductions[\"max_train_sequences\"] = int(MAX_TRAIN_SEQUENCES)\n",
     "\n",
-    "# Both tiers resolve the study through `open_study`. It reads the labels and features in place and\n",
-    "# redirects only writes, so a preview run scores the same inputs a canonical one does and cannot\n",
-    "# publish over it.\n",
-    "if EXECUTION_TIER == \"canonical\":\n",
-    "    if preview_reductions or PREVIEW_N_EPOCHS:\n",
-    "        raise ValueError(\"Canonical execution cannot declare preview reductions\")\n",
-    "    study = open_study(CASE_STUDY_ID, execution_tier=EXECUTION_TIER)\n",
-    "elif EXECUTION_TIER == \"preview\":\n",
-    "    if not preview_reductions:\n",
-    "        raise ValueError(\"Preview execution requires a data or fold reduction\")\n",
-    "    study = open_study(\n",
-    "        CASE_STUDY_ID,\n",
-    "        execution_tier=EXECUTION_TIER,\n",
-    "        workspace=Path(os.environ.get(\"ML4T_OUTPUT_DIR\") or WORKSPACE),\n",
-    "    )\n",
-    "else:\n",
-    "    raise ValueError(\"EXECUTION_TIER must be 'canonical' or 'preview'\")"
+    "study = open_study(CASE_STUDY_ID, execution_tier=EXECUTION_TIER, workspace=WORKSPACE or None)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "18aacf85",
+   "id": "c62f87e3",
    "metadata": {},
    "source": [
     "## 2. Binding the declarations to the data\n",
@@ -237,7 +271,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0182a11c",
+   "id": "c5f08261",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -277,7 +311,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1c7da5b2",
+   "id": "c7a212fb",
    "metadata": {},
    "source": [
     "## 3. Planning, then fitting\n",
@@ -293,16 +327,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "051e6332",
+   "id": "ac6bce9d",
    "metadata": {},
    "outputs": [],
    "source": [
     "plan = plan_models(study, requests=requests)\n",
-    "official_population = None\n",
-    "if EXECUTION_TIER == \"canonical\":\n",
-    "    official_population = plan.create_population(\n",
-    "        name=\"us-equities-lstm-checkpoints-v1\",\n",
-    "    )\n",
     "\n",
     "planned_population = pl.DataFrame(\n",
     "    {\n",
@@ -318,18 +347,50 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "901c7414",
+   "metadata": {},
+   "source": [
+    "`run_model_population` takes the plan, writes the population down, fits every member and then\n",
+    "checks that what came out is what was declared. The same call serves both tiers: a canonical run\n",
+    "registers an immutable population that the later notebooks bind to, and a preview run gets a\n",
+    "declaration that is verified and then discarded with its workspace, so no notebook here has to\n",
+    "branch on the tier to decide what to publish.\n",
+    "\n",
+    "`SUPERSEDES_POPULATION` names the population hash this run replaces. A population is a set of\n",
+    "prediction identities, so anything that moves a training identity - a changed preset as much as a\n",
+    "changed menu - produces a different population under the same name, and the registry refuses to\n",
+    "write it without being told which snapshot it supersedes. Leaving it empty is right for a first\n",
+    "run and for a reader's clean clone, and `supersedes_for_run` withholds a declared hash wherever\n",
+    "offering it would be refused."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e228ffed",
+   "id": "775c5d4d",
    "metadata": {},
    "outputs": [],
    "source": [
-    "execution = plan.run()"
+    "population_name = POPULATION_NAME or \"us-equities-lstm-checkpoints-v1\"\n",
+    "execution, official_population = run_model_population(\n",
+    "    study,\n",
+    "    plan,\n",
+    "    population_name=population_name,\n",
+    "    supersedes=supersedes_for_run(\n",
+    "        study,\n",
+    "        population_name=population_name,\n",
+    "        declared=SUPERSEDES_POPULATION,\n",
+    "        execution_tier=EXECUTION_TIER,\n",
+    "    ),\n",
+    ")\n",
+    "\n",
+    "print(f\"population {official_population.name}: {len(official_population.members)} prediction sets\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "3c4fc800",
+   "id": "da4431cf",
    "metadata": {},
    "source": [
     "## 4. What was actually fitted\n",
@@ -341,7 +402,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "415b8b45",
+   "id": "33fb10b6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -371,7 +432,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2f4c325b",
+   "id": "065d12be",
    "metadata": {},
    "source": [
     "## 5. What came out\n",
@@ -384,7 +445,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2829bcca",
+   "id": "df8dd499",
    "metadata": {
     "tags": [
      "results"
@@ -413,7 +474,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "16d0328a",
+   "id": "70fb0128",
    "metadata": {},
    "source": [
     "A prediction set can be registered complete and still have scored no dates. Cross-sectional\n",
@@ -426,7 +487,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9d1c37be",
+   "id": "3b26497a",
    "metadata": {
     "tags": [
      "results"
@@ -443,7 +504,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "45ebca8b",
+   "id": "572945ef",
    "metadata": {},
    "source": [
     "### Where more training stopped helping\n",
@@ -463,7 +524,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "71f772ed",
+   "id": "1af6bffe",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -520,7 +581,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "96ae35e6",
+   "id": "babcd75c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -548,15 +609,13 @@
     "        )\n",
     "\n",
     "coverage_table = pl.DataFrame(coverage_rows).sort(\"config_name\", \"checkpoint\")\n",
-    "if official_population is not None:\n",
-    "    official_population.require_complete()\n",
     "coverage_table"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4b679cf6",
+   "id": "08be13c1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -566,7 +625,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "21b0642f",
+   "id": "e1621e67",
    "metadata": {},
    "source": [
     "## 6. Naming the sets the later notebooks open\n",
@@ -579,8 +638,8 @@
     "\n",
     "The second is the **bounded diagnostic set**, and it is bounded hard.\n",
     "[`15_model_analysis`](15_model_analysis.ipynb) loads every diagnostic member's raw prediction\n",
-    "frame and holds them all while it joins them pairwise; one frame on this panel is 7.2 million\n",
-    "rows and about 225 MB in memory, so a set that grew with the checkpoint count would not fit\n",
+    "frame and holds them all while it joins them pairwise; one frame on this panel is over seven\n",
+    "million rows and about 225 MB in memory, so a set that grew with the checkpoint count would not fit\n",
     "beside the other seven families'. The bound is the last checkpoint of each published\n",
     "configuration - one member here, because the menu declares one LSTM configuration. The\n",
     "epoch dimension is still read, in the learning-curve figure above, which is drawn from registry\n",
@@ -590,7 +649,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d664b778",
+   "id": "a39dffc2",
    "metadata": {
     "tags": [
      "results"
@@ -599,18 +658,15 @@
    "outputs": [],
    "source": [
     "set_rows = []\n",
-    "is_published_population = (\n",
-    "    EXECUTION_TIER == \"canonical\"\n",
-    "    and selected_names == published_names\n",
-    "    and not COMMON_OVERRIDES\n",
-    "    and not CONFIG_OVERRIDES\n",
-    "    and DEVICE == \"cuda\"\n",
-    ")\n",
     "if is_published_population:\n",
     "    label_name = label.replace(\"_\", \"-\")\n",
+    "    full_set_name = f\"us-equities-{label_name}-lstm-v1\"\n",
     "    full_set = study.predictions.freeze(\n",
     "        execution.catalog_rows,\n",
-    "        name=f\"us-equities-{label_name}-lstm-v1\",\n",
+    "        name=full_set_name,\n",
+    "        supersedes=candidate_set_supersedes(\n",
+    "            study, name=full_set_name, declared=SUPERSEDES_SETS.get(full_set_name, \"\")\n",
+    "        ),\n",
     "    )\n",
     "    diagnostic_rows = execution.catalog_rows.filter(\n",
     "        # `.fill_null(True)` covers a family that publishes no checkpoint value at all, where the\n",
@@ -619,9 +675,13 @@
     "            pl.col(\"checkpoint_value\") == pl.col(\"checkpoint_value\").max().over(\"config_name\")\n",
     "        ).fill_null(True)\n",
     "    )\n",
+    "    diagnostic_set_name = f\"us-equities-{label_name}-lstm-diagnostics-v1\"\n",
     "    diagnostic_set = study.predictions.freeze(\n",
     "        diagnostic_rows,\n",
-    "        name=f\"us-equities-{label_name}-lstm-diagnostics-v1\",\n",
+    "        name=diagnostic_set_name,\n",
+    "        supersedes=candidate_set_supersedes(\n",
+    "            study, name=diagnostic_set_name, declared=SUPERSEDES_SETS.get(diagnostic_set_name, \"\")\n",
+    "        ),\n",
     "    )\n",
     "    set_rows = [\n",
     "        {\n",
@@ -644,7 +704,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1951d504",
+   "id": "e96e5341",
    "metadata": {},
    "source": [
     "`15_model_analysis` reopens both names: the full set to confirm the run filled every member it\n",
@@ -655,7 +715,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2b143d76",
+   "id": "53f537ee",
    "metadata": {},
    "source": [
     "## What to notice\n",

--- a/case_studies/us_equities_panel/10_dl_lstm.ipynb
+++ b/case_studies/us_equities_panel/10_dl_lstm.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "b54ebaa5",
+   "id": "4fb24854",
    "metadata": {},
    "source": [
     "# US equities panel: a model that carries state across the window\n",
@@ -73,7 +73,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "edc8f692",
+   "id": "2addc792",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -95,7 +95,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4d8d4e8b",
+   "id": "42520cee",
    "metadata": {
     "tags": [
      "parameters"
@@ -119,7 +119,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "08a2a094",
+   "id": "10e2f08c",
    "metadata": {},
    "source": [
     "## 1. Which configurations, and on which label\n",
@@ -150,7 +150,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "330f127c",
+   "id": "0d7f193f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -193,7 +193,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "906cbdec",
+   "id": "94673b92",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -226,7 +226,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f6378ca1",
+   "id": "b6181192",
    "metadata": {},
    "source": [
     "## 2. Binding the declarations to the data\n",
@@ -237,7 +237,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5592e7dc",
+   "id": "a07aba8b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -277,7 +277,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "abb48699",
+   "id": "5b701b9a",
    "metadata": {},
    "source": [
     "## 3. Planning, then fitting\n",
@@ -293,7 +293,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "89011cb2",
+   "id": "15af80f2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -320,7 +320,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e006849e",
+   "id": "23e87310",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -329,7 +329,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9a670d32",
+   "id": "0a8efa7c",
    "metadata": {},
    "source": [
     "## 4. What was actually fitted\n",
@@ -341,7 +341,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c00080d3",
+   "id": "1ab52770",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -371,7 +371,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1cd01f94",
+   "id": "18f707cc",
    "metadata": {},
    "source": [
     "## 5. What came out\n",
@@ -384,7 +384,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f414d826",
+   "id": "8b4cf6aa",
    "metadata": {
     "tags": [
      "results"
@@ -413,7 +413,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b9267691",
+   "id": "50c36f4d",
    "metadata": {},
    "source": [
     "A prediction set can be registered complete and still have scored no dates. Cross-sectional\n",
@@ -426,7 +426,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cf6d0f60",
+   "id": "aada9f98",
    "metadata": {
     "tags": [
      "results"
@@ -443,7 +443,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c928334d",
+   "id": "72e2e3d7",
    "metadata": {},
    "source": [
     "### Where more training stopped helping\n",
@@ -463,7 +463,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "be190ee5",
+   "id": "ef170a08",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -493,7 +493,6 @@
     "    \"Whether the recurrent network was still learning when training stopped\",\n",
     "    subtitle=\"Out-of-sample information coefficient against epoch, one line per configuration\",\n",
     ")\n",
-    "fig.tight_layout()\n",
     "# The alt text counts rather than asserts: whether a curve turns over is the question the figure\n",
     "# exists to answer, and a line described as peaking when it does not is a claim the data refutes.\n",
     "_peaks = (\n",
@@ -521,7 +520,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "af49cf02",
+   "id": "eae4e779",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -557,7 +556,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "775c9e16",
+   "id": "e992ca6e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -567,20 +566,31 @@
   },
   {
    "cell_type": "markdown",
-   "id": "861afccb",
+   "id": "eb7445c0",
    "metadata": {},
    "source": [
-    "## 6. Naming the set the later notebooks open\n",
+    "## 6. Naming the sets the later notebooks open\n",
     "\n",
-    "A canonical default CUDA run freezes every returned LSTM prediction row under a stable name. The\n",
-    "same bounded family set supplies raw diagnostics because this notebook has one published\n",
-    "configuration. Preview and customized canonical requests do not publish an official set."
+    "A canonical default CUDA run freezes what it produced under two stable names, and preview or\n",
+    "customized canonical requests publish neither.\n",
+    "\n",
+    "The first name is the **full set**: every prediction row this run returned, which\n",
+    "[`16_backtest`](16_backtest.ipynb) backtests member by member.\n",
+    "\n",
+    "The second is the **bounded diagnostic set**, and it is bounded hard.\n",
+    "[`15_model_analysis`](15_model_analysis.ipynb) loads every diagnostic member's raw prediction\n",
+    "frame and holds them all while it joins them pairwise; one frame on this panel is 7.2 million\n",
+    "rows and about 225 MB in memory, so a set that grew with the checkpoint count would not fit\n",
+    "beside the other seven families'. The bound is the last checkpoint of each published\n",
+    "configuration - one member here, because the menu declares one LSTM configuration. The\n",
+    "epoch dimension is still read, in the learning-curve figure above, which is drawn from registry\n",
+    "metrics rather than from raw frames."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a818c09e",
+   "id": "0c1a0dc2",
    "metadata": {
     "tags": [
      "results"
@@ -602,12 +612,28 @@
     "        execution.catalog_rows,\n",
     "        name=f\"us-equities-{label_name}-lstm-v1\",\n",
     "    )\n",
+    "    diagnostic_rows = execution.catalog_rows.filter(\n",
+    "        # `.fill_null(True)` covers a family that publishes no checkpoint value at all, where the\n",
+    "        # comparison is null rather than false and would otherwise empty the frame.\n",
+    "        (\n",
+    "            pl.col(\"checkpoint_value\") == pl.col(\"checkpoint_value\").max().over(\"config_name\")\n",
+    "        ).fill_null(True)\n",
+    "    )\n",
+    "    diagnostic_set = study.predictions.freeze(\n",
+    "        diagnostic_rows,\n",
+    "        name=f\"us-equities-{label_name}-lstm-diagnostics-v1\",\n",
+    "    )\n",
     "    set_rows = [\n",
     "        {\n",
-    "            \"role\": \"backtest and diagnostic population\",\n",
+    "            \"role\": \"backtest population\",\n",
     "            \"set_name\": full_set.name,\n",
     "            \"members\": len(full_set.members),\n",
-    "        }\n",
+    "        },\n",
+    "        {\n",
+    "            \"role\": \"bounded diagnostics\",\n",
+    "            \"set_name\": diagnostic_set.name,\n",
+    "            \"members\": len(diagnostic_set.members),\n",
+    "        },\n",
     "    ]\n",
     "compatible_sets = pl.DataFrame(\n",
     "    set_rows,\n",
@@ -618,17 +644,18 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9daf8e89",
+   "id": "df2b2cec",
    "metadata": {},
    "source": [
-    "`15_model_analysis.py` reopens the named set for descriptive analysis. `16_backtest.py` passes\n",
-    "every catalog row directly to the shared backtest runner. Model metrics do not choose a\n",
-    "configuration or checkpoint."
+    "`15_model_analysis` reopens both names: the full set to confirm the run filled every member it\n",
+    "promised, and the diagnostic set to read raw predictions. `16_backtest` passes every full-set\n",
+    "catalog row to the shared backtest runner. Neither the metrics here nor the ones there choose a\n",
+    "configuration or a checkpoint; selection is on validation backtest Sharpe in `16_backtest`."
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "cf0a673a",
+   "id": "afe271c5",
    "metadata": {},
    "source": [
     "## What to notice\n",

--- a/case_studies/us_equities_panel/10_dl_lstm.py
+++ b/case_studies/us_equities_panel/10_dl_lstm.py
@@ -81,14 +81,17 @@
 # %%
 """Generate LSTM validation predictions through the shared research interface."""
 
-import os
-from pathlib import Path
-
 import matplotlib.pyplot as plt
 import polars as pl
 import yaml
 
-from case_studies.research import open_study, plan_models
+from case_studies.research import (
+    candidate_set_supersedes,
+    open_study,
+    plan_models,
+    run_model_population,
+    supersedes_for_run,
+)
 from utils.modeling import load_configs
 from utils.paths import get_case_study_dir
 from utils.style import FIGSIZE, add_message_title, ml4t_palette, show_with_alt, zero_line
@@ -99,9 +102,12 @@ PRIMARY_LABEL = ""
 CONFIG_NAMES = []
 COMMON_OVERRIDES = {}
 CONFIG_OVERRIDES = {}
+POPULATION_NAME = ""
+SUPERSEDES_POPULATION = ""
+SUPERSEDES_SETS: dict = {}
 DEVICE = "cuda"
 EXECUTION_TIER = "canonical"
-WORKSPACE = "experiments"
+WORKSPACE = ""
 MAX_SYMBOLS = 0
 FOLD_IDS = []
 MAX_TRAIN_SEQUENCES = 0
@@ -168,6 +174,33 @@ menu = pl.DataFrame(
 )
 menu
 
+# %% [markdown]
+# A run that narrows the selection, overrides a parameter or fits on another device produces a
+# different set of predictions from the one the canonical name stands for. Publishing it under
+# that name would leave the name meaning two different member sets at two different times, so the
+# guard below requires such a run to say what to call its own population, and the frozen set names
+# in Section 6 are withheld from it for the same reason.
+
+# %%
+is_published_population = (
+    EXECUTION_TIER == "canonical"
+    and selected_names == published_names
+    and not COMMON_OVERRIDES
+    and not CONFIG_OVERRIDES
+    and DEVICE == "cuda"
+)
+if EXECUTION_TIER == "canonical" and not is_published_population and not POPULATION_NAME:
+    raise ValueError(
+        "this run narrows or overrides what the menu declares, so it cannot publish the canonical "
+        "population; pass POPULATION_NAME to give it its own"
+    )
+
+# %% [markdown]
+# Both tiers resolve the study through `open_study`. It reads the labels and features in place
+# and redirects only writes, so a preview run scores the same inputs a canonical one does and
+# cannot publish over it. A preview must be given a workspace to write into; a canonical run
+# leaves `WORKSPACE` empty and regenerates the case study's own artifacts in place.
+
 # %%
 preview_reductions = {}
 if MAX_SYMBOLS:
@@ -177,23 +210,7 @@ if FOLD_IDS:
 if MAX_TRAIN_SEQUENCES:
     preview_reductions["max_train_sequences"] = int(MAX_TRAIN_SEQUENCES)
 
-# Both tiers resolve the study through `open_study`. It reads the labels and features in place and
-# redirects only writes, so a preview run scores the same inputs a canonical one does and cannot
-# publish over it.
-if EXECUTION_TIER == "canonical":
-    if preview_reductions or PREVIEW_N_EPOCHS:
-        raise ValueError("Canonical execution cannot declare preview reductions")
-    study = open_study(CASE_STUDY_ID, execution_tier=EXECUTION_TIER)
-elif EXECUTION_TIER == "preview":
-    if not preview_reductions:
-        raise ValueError("Preview execution requires a data or fold reduction")
-    study = open_study(
-        CASE_STUDY_ID,
-        execution_tier=EXECUTION_TIER,
-        workspace=Path(os.environ.get("ML4T_OUTPUT_DIR") or WORKSPACE),
-    )
-else:
-    raise ValueError("EXECUTION_TIER must be 'canonical' or 'preview'")
+study = open_study(CASE_STUDY_ID, execution_tier=EXECUTION_TIER, workspace=WORKSPACE or None)
 
 # %% [markdown]
 # ## 2. Binding the declarations to the data
@@ -246,11 +263,6 @@ request_table
 
 # %%
 plan = plan_models(study, requests=requests)
-official_population = None
-if EXECUTION_TIER == "canonical":
-    official_population = plan.create_population(
-        name="us-equities-lstm-checkpoints-v1",
-    )
 
 planned_population = pl.DataFrame(
     {
@@ -264,8 +276,35 @@ planned_population = pl.DataFrame(
 )
 planned_population
 
+# %% [markdown]
+# `run_model_population` takes the plan, writes the population down, fits every member and then
+# checks that what came out is what was declared. The same call serves both tiers: a canonical run
+# registers an immutable population that the later notebooks bind to, and a preview run gets a
+# declaration that is verified and then discarded with its workspace, so no notebook here has to
+# branch on the tier to decide what to publish.
+#
+# `SUPERSEDES_POPULATION` names the population hash this run replaces. A population is a set of
+# prediction identities, so anything that moves a training identity - a changed preset as much as a
+# changed menu - produces a different population under the same name, and the registry refuses to
+# write it without being told which snapshot it supersedes. Leaving it empty is right for a first
+# run and for a reader's clean clone, and `supersedes_for_run` withholds a declared hash wherever
+# offering it would be refused.
+
 # %%
-execution = plan.run()
+population_name = POPULATION_NAME or "us-equities-lstm-checkpoints-v1"
+execution, official_population = run_model_population(
+    study,
+    plan,
+    population_name=population_name,
+    supersedes=supersedes_for_run(
+        study,
+        population_name=population_name,
+        declared=SUPERSEDES_POPULATION,
+        execution_tier=EXECUTION_TIER,
+    ),
+)
+
+print(f"population {official_population.name}: {len(official_population.members)} prediction sets")
 
 # %% [markdown]
 # ## 4. What was actually fitted
@@ -426,8 +465,6 @@ for run in execution.runs:
         )
 
 coverage_table = pl.DataFrame(coverage_rows).sort("config_name", "checkpoint")
-if official_population is not None:
-    official_population.require_complete()
 coverage_table
 
 # %%
@@ -445,8 +482,8 @@ execution_diagnostics
 #
 # The second is the **bounded diagnostic set**, and it is bounded hard.
 # [`15_model_analysis`](15_model_analysis.ipynb) loads every diagnostic member's raw prediction
-# frame and holds them all while it joins them pairwise; one frame on this panel is 7.2 million
-# rows and about 225 MB in memory, so a set that grew with the checkpoint count would not fit
+# frame and holds them all while it joins them pairwise; one frame on this panel is over seven
+# million rows and about 225 MB in memory, so a set that grew with the checkpoint count would not fit
 # beside the other seven families'. The bound is the last checkpoint of each published
 # configuration - one member here, because the menu declares one LSTM configuration. The
 # epoch dimension is still read, in the learning-curve figure above, which is drawn from registry
@@ -454,18 +491,15 @@ execution_diagnostics
 
 # %% tags=["results"]
 set_rows = []
-is_published_population = (
-    EXECUTION_TIER == "canonical"
-    and selected_names == published_names
-    and not COMMON_OVERRIDES
-    and not CONFIG_OVERRIDES
-    and DEVICE == "cuda"
-)
 if is_published_population:
     label_name = label.replace("_", "-")
+    full_set_name = f"us-equities-{label_name}-lstm-v1"
     full_set = study.predictions.freeze(
         execution.catalog_rows,
-        name=f"us-equities-{label_name}-lstm-v1",
+        name=full_set_name,
+        supersedes=candidate_set_supersedes(
+            study, name=full_set_name, declared=SUPERSEDES_SETS.get(full_set_name, "")
+        ),
     )
     diagnostic_rows = execution.catalog_rows.filter(
         # `.fill_null(True)` covers a family that publishes no checkpoint value at all, where the
@@ -474,9 +508,13 @@ if is_published_population:
             pl.col("checkpoint_value") == pl.col("checkpoint_value").max().over("config_name")
         ).fill_null(True)
     )
+    diagnostic_set_name = f"us-equities-{label_name}-lstm-diagnostics-v1"
     diagnostic_set = study.predictions.freeze(
         diagnostic_rows,
-        name=f"us-equities-{label_name}-lstm-diagnostics-v1",
+        name=diagnostic_set_name,
+        supersedes=candidate_set_supersedes(
+            study, name=diagnostic_set_name, declared=SUPERSEDES_SETS.get(diagnostic_set_name, "")
+        ),
     )
     set_rows = [
         {

--- a/case_studies/us_equities_panel/10_dl_lstm.py
+++ b/case_studies/us_equities_panel/10_dl_lstm.py
@@ -378,7 +378,6 @@ add_message_title(
     "Whether the recurrent network was still learning when training stopped",
     subtitle="Out-of-sample information coefficient against epoch, one line per configuration",
 )
-fig.tight_layout()
 # The alt text counts rather than asserts: whether a curve turns over is the question the figure
 # exists to answer, and a line described as peaking when it does not is a claim the data refutes.
 _peaks = (
@@ -436,11 +435,22 @@ execution_diagnostics = pl.DataFrame(execution.diagnostics)
 execution_diagnostics
 
 # %% [markdown]
-# ## 6. Naming the set the later notebooks open
+# ## 6. Naming the sets the later notebooks open
 #
-# A canonical default CUDA run freezes every returned LSTM prediction row under a stable name. The
-# same bounded family set supplies raw diagnostics because this notebook has one published
-# configuration. Preview and customized canonical requests do not publish an official set.
+# A canonical default CUDA run freezes what it produced under two stable names, and preview or
+# customized canonical requests publish neither.
+#
+# The first name is the **full set**: every prediction row this run returned, which
+# [`16_backtest`](16_backtest.ipynb) backtests member by member.
+#
+# The second is the **bounded diagnostic set**, and it is bounded hard.
+# [`15_model_analysis`](15_model_analysis.ipynb) loads every diagnostic member's raw prediction
+# frame and holds them all while it joins them pairwise; one frame on this panel is 7.2 million
+# rows and about 225 MB in memory, so a set that grew with the checkpoint count would not fit
+# beside the other seven families'. The bound is the last checkpoint of each published
+# configuration - one member here, because the menu declares one LSTM configuration. The
+# epoch dimension is still read, in the learning-curve figure above, which is drawn from registry
+# metrics rather than from raw frames.
 
 # %% tags=["results"]
 set_rows = []
@@ -457,12 +467,28 @@ if is_published_population:
         execution.catalog_rows,
         name=f"us-equities-{label_name}-lstm-v1",
     )
+    diagnostic_rows = execution.catalog_rows.filter(
+        # `.fill_null(True)` covers a family that publishes no checkpoint value at all, where the
+        # comparison is null rather than false and would otherwise empty the frame.
+        (
+            pl.col("checkpoint_value") == pl.col("checkpoint_value").max().over("config_name")
+        ).fill_null(True)
+    )
+    diagnostic_set = study.predictions.freeze(
+        diagnostic_rows,
+        name=f"us-equities-{label_name}-lstm-diagnostics-v1",
+    )
     set_rows = [
         {
-            "role": "backtest and diagnostic population",
+            "role": "backtest population",
             "set_name": full_set.name,
             "members": len(full_set.members),
-        }
+        },
+        {
+            "role": "bounded diagnostics",
+            "set_name": diagnostic_set.name,
+            "members": len(diagnostic_set.members),
+        },
     ]
 compatible_sets = pl.DataFrame(
     set_rows,
@@ -471,9 +497,10 @@ compatible_sets = pl.DataFrame(
 compatible_sets
 
 # %% [markdown]
-# `15_model_analysis.py` reopens the named set for descriptive analysis. `16_backtest.py` passes
-# every catalog row directly to the shared backtest runner. Model metrics do not choose a
-# configuration or checkpoint.
+# `15_model_analysis` reopens both names: the full set to confirm the run filled every member it
+# promised, and the diagnostic set to read raw predictions. `16_backtest` passes every full-set
+# catalog row to the shared backtest runner. Neither the metrics here nor the ones there choose a
+# configuration or a checkpoint; selection is on validation backtest Sharpe in `16_backtest`.
 
 # %% [markdown]
 # ## What to notice

--- a/case_studies/us_equities_panel/10_dl_lstm.py
+++ b/case_studies/us_equities_panel/10_dl_lstm.py
@@ -375,7 +375,7 @@ ax.set_ylabel("Mean validation IC")
 ax.legend(fontsize=8, frameon=False)
 add_message_title(
     ax,
-    "Whether the recurrent network was still learning when training stopped",
+    "Mean validation IC against training epoch",
     subtitle="Out-of-sample information coefficient against epoch, one line per configuration",
 )
 # The alt text counts rather than asserts: whether a curve turns over is the question the figure

--- a/case_studies/us_equities_panel/10_dl_lstm.py
+++ b/case_studies/us_equities_panel/10_dl_lstm.py
@@ -108,10 +108,9 @@ SUPERSEDES_SETS: dict = {}
 DEVICE = "cuda"
 EXECUTION_TIER = "canonical"
 WORKSPACE = ""
-MAX_SYMBOLS = 0
-FOLD_IDS = []
-MAX_TRAIN_SEQUENCES = 0
-PREVIEW_N_EPOCHS = 0
+PREVIEW_MAX_SYMBOLS = 0
+PREVIEW_FOLD_IDS = []
+PREVIEW_MAX_TRAIN_SEQUENCES = 0
 
 # %% [markdown]
 # ## 1. Which configurations, and on which label
@@ -134,9 +133,15 @@ PREVIEW_N_EPOCHS = 0
 #   every fold at the published epoch schedule. A preview run has to declare at least one
 #   reduction and carries it in the identity, so its results can never be compared against
 #   canonical ones or reach a holdout decision.
-# - **`PREVIEW_N_EPOCHS`** shortens the schedule for a preview. It is part of the identity rather
-#   than a runtime detail, because a model trained for fewer epochs is a different model rather
-#   than the same one measured sooner.
+#
+# A shortened training schedule is not among the reductions a preview may declare, and
+# deliberately. This family's preview contract - `SEQUENCE_PREVIEW_FIELDS` in
+# `case_studies/utils/preview_fields.py` - accepts a narrower universe, a fold subset and a cap on
+# training sequences, and no epoch count, because a model trained for fewer epochs is a different
+# model rather than the same one measured sooner. To train a short schedule, pass `n_epochs` in
+# `COMMON_OVERRIDES`. It moves the training identity, so the result registers beside the published
+# one, and a run carrying any override publishes neither the canonical population nor the
+# canonical set names.
 
 # %%
 case_dir = get_case_study_dir(CASE_STUDY_ID)
@@ -203,12 +208,12 @@ if EXECUTION_TIER == "canonical" and not is_published_population and not POPULAT
 
 # %%
 preview_reductions = {}
-if MAX_SYMBOLS:
-    preview_reductions["max_symbols"] = int(MAX_SYMBOLS)
-if FOLD_IDS:
-    preview_reductions["folds"] = [int(fold) for fold in FOLD_IDS]
-if MAX_TRAIN_SEQUENCES:
-    preview_reductions["max_train_sequences"] = int(MAX_TRAIN_SEQUENCES)
+if PREVIEW_MAX_SYMBOLS:
+    preview_reductions["max_symbols"] = int(PREVIEW_MAX_SYMBOLS)
+if PREVIEW_FOLD_IDS:
+    preview_reductions["folds"] = [int(fold) for fold in PREVIEW_FOLD_IDS]
+if PREVIEW_MAX_TRAIN_SEQUENCES:
+    preview_reductions["max_train_sequences"] = int(PREVIEW_MAX_TRAIN_SEQUENCES)
 
 study = open_study(CASE_STUDY_ID, execution_tier=EXECUTION_TIER, workspace=WORKSPACE or None)
 
@@ -225,8 +230,6 @@ for config_name in selected_names:
         **COMMON_OVERRIDES,
         **dict(CONFIG_OVERRIDES.get(config_name, {})),
     }
-    if PREVIEW_N_EPOCHS:
-        overrides["n_epochs"] = int(PREVIEW_N_EPOCHS)
     requests.append(
         study.model(
             family="deep_learning",

--- a/case_studies/us_equities_panel/10_dl_lstm.py
+++ b/case_studies/us_equities_panel/10_dl_lstm.py
@@ -118,7 +118,7 @@ PREVIEW_MAX_TRAIN_SEQUENCES = 0
 # The menu at `config/training/{label}.yaml` lists the sequence configurations declared for a
 # label, and this notebook takes the ones whose architecture is `lstm`. Each name resolves to a
 # preset holding the full parameter set - here a 60-session lookback, 100 epochs, a checkpoint
-# every 5, and a dropout of 0.1.
+# every 5, and dropout on the hidden units. The frame below prints the resolved values.
 #
 # What each setting a run may pass decides:
 #

--- a/case_studies/us_equities_panel/11_dl_tsmixer.ipynb
+++ b/case_studies/us_equities_panel/11_dl_tsmixer.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "0d093a6f",
+   "id": "d037cc48",
    "metadata": {},
    "source": [
     "# US equities panel: mixing along time and across features instead of recurring\n",
@@ -80,7 +80,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "32f7176c",
+   "id": "f4b6aaf2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -100,7 +100,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9cf6abd1",
+   "id": "c697d026",
    "metadata": {
     "tags": [
      "parameters"
@@ -124,7 +124,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d9b17bf6",
+   "id": "07a2d8bc",
    "metadata": {},
    "source": [
     "## 1. Which configurations, and on which label\n",
@@ -155,7 +155,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0d0c61da",
+   "id": "bafbf626",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -198,7 +198,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "100a6239",
+   "id": "272a2206",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -231,7 +231,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3b9439fc",
+   "id": "3bb86c26",
    "metadata": {},
    "source": [
     "## 2. Binding the declarations to the data\n",
@@ -242,7 +242,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ba47d4e3",
+   "id": "8d3a281c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -282,7 +282,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "043d8e4e",
+   "id": "580985e7",
    "metadata": {},
    "source": [
     "## 3. Planning, then fitting\n",
@@ -298,7 +298,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "76e4d35d",
+   "id": "7c29aa1a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -325,7 +325,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4eb62a82",
+   "id": "46a259f0",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -334,7 +334,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f635ddc0",
+   "id": "c16a866e",
    "metadata": {},
    "source": [
     "## 4. What was actually fitted\n",
@@ -346,7 +346,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d950489e",
+   "id": "651c2aed",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -376,7 +376,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b410d861",
+   "id": "137f4135",
    "metadata": {},
    "source": [
     "## 5. What came out\n",
@@ -389,7 +389,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2aa88f49",
+   "id": "7ec234f0",
    "metadata": {
     "tags": [
      "results"
@@ -418,7 +418,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e7a5019b",
+   "id": "d9d073c6",
    "metadata": {},
    "source": [
     "A prediction set can be registered complete and still have scored no dates. Cross-sectional\n",
@@ -431,7 +431,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "17bab754",
+   "id": "414db429",
    "metadata": {
     "tags": [
      "results"
@@ -449,7 +449,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "845956bc",
+   "id": "c66fa349",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -485,7 +485,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a44552ff",
+   "id": "1a80004a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -495,20 +495,31 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b2f5c2ca",
+   "id": "e8f654ad",
    "metadata": {},
    "source": [
-    "## 6. Naming the set the later notebooks open\n",
+    "## 6. Naming the sets the later notebooks open\n",
     "\n",
-    "A canonical default CUDA run freezes every returned TSMixer prediction row under a stable name.\n",
-    "The same bounded family set supplies raw diagnostics because this notebook has one published\n",
-    "configuration. Preview and customized canonical requests do not publish an official set."
+    "A canonical default CUDA run freezes what it produced under two stable names, and preview or\n",
+    "customized canonical requests publish neither.\n",
+    "\n",
+    "The first name is the **full set**: every prediction row this run returned, which\n",
+    "[`16_backtest`](16_backtest.ipynb) backtests member by member.\n",
+    "\n",
+    "The second is the **bounded diagnostic set**, and it is bounded hard.\n",
+    "[`15_model_analysis`](15_model_analysis.ipynb) loads every diagnostic member's raw prediction\n",
+    "frame and holds them all while it joins them pairwise; one frame on this panel is 7.2 million\n",
+    "rows and about 225 MB in memory, so a set that grew with the checkpoint count would not fit\n",
+    "beside the other seven families'. The bound is the last checkpoint of each published\n",
+    "configuration - one member here, because the menu declares one TSMixer configuration. The\n",
+    "epoch dimension is still read, in the learning-curve figure above, which is drawn from registry\n",
+    "metrics rather than from raw frames."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d9dde8a7",
+   "id": "3b7208f8",
    "metadata": {
     "tags": [
      "results"
@@ -530,12 +541,28 @@
     "        execution.catalog_rows,\n",
     "        name=f\"us-equities-{label_name}-tsmixer-v1\",\n",
     "    )\n",
+    "    diagnostic_rows = execution.catalog_rows.filter(\n",
+    "        # `.fill_null(True)` covers a family that publishes no checkpoint value at all, where the\n",
+    "        # comparison is null rather than false and would otherwise empty the frame.\n",
+    "        (\n",
+    "            pl.col(\"checkpoint_value\") == pl.col(\"checkpoint_value\").max().over(\"config_name\")\n",
+    "        ).fill_null(True)\n",
+    "    )\n",
+    "    diagnostic_set = study.predictions.freeze(\n",
+    "        diagnostic_rows,\n",
+    "        name=f\"us-equities-{label_name}-tsmixer-diagnostics-v1\",\n",
+    "    )\n",
     "    set_rows = [\n",
     "        {\n",
-    "            \"role\": \"backtest and diagnostic population\",\n",
+    "            \"role\": \"backtest population\",\n",
     "            \"set_name\": full_set.name,\n",
     "            \"members\": len(full_set.members),\n",
-    "        }\n",
+    "        },\n",
+    "        {\n",
+    "            \"role\": \"bounded diagnostics\",\n",
+    "            \"set_name\": diagnostic_set.name,\n",
+    "            \"members\": len(diagnostic_set.members),\n",
+    "        },\n",
     "    ]\n",
     "compatible_sets = pl.DataFrame(\n",
     "    set_rows,\n",
@@ -546,17 +573,18 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ac01b512",
+   "id": "f844f7d2",
    "metadata": {},
    "source": [
-    "`15_model_analysis.py` reopens the named set for descriptive analysis. `16_backtest.py` passes\n",
-    "every catalog row directly to the shared backtest runner. Model metrics do not choose a\n",
-    "configuration or checkpoint."
+    "`15_model_analysis` reopens both names: the full set to confirm the run filled every member it\n",
+    "promised, and the diagnostic set to read raw predictions. `16_backtest` passes every full-set\n",
+    "catalog row to the shared backtest runner. Neither the metrics here nor the ones there choose a\n",
+    "configuration or a checkpoint; selection is on validation backtest Sharpe in `16_backtest`."
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "1086e737",
+   "id": "5c534d68",
    "metadata": {},
    "source": [
     "## What to notice\n",

--- a/case_studies/us_equities_panel/11_dl_tsmixer.ipynb
+++ b/case_studies/us_equities_panel/11_dl_tsmixer.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "44bb396a",
+   "id": "9d3c9397",
    "metadata": {},
    "source": [
     "# US equities panel: mixing along time and across features instead of recurring\n",
@@ -80,7 +80,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a5789c67",
+   "id": "5ac54cdd",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -105,7 +105,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d34556a5",
+   "id": "07adbb76",
    "metadata": {
     "tags": [
      "parameters"
@@ -124,15 +124,14 @@
     "DEVICE = \"cuda\"\n",
     "EXECUTION_TIER = \"canonical\"\n",
     "WORKSPACE = \"\"\n",
-    "MAX_SYMBOLS = 0\n",
-    "FOLD_IDS = []\n",
-    "MAX_TRAIN_SEQUENCES = 0\n",
-    "PREVIEW_N_EPOCHS = 0"
+    "PREVIEW_MAX_SYMBOLS = 0\n",
+    "PREVIEW_FOLD_IDS = []\n",
+    "PREVIEW_MAX_TRAIN_SEQUENCES = 0"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "784869a6",
+   "id": "b870a079",
    "metadata": {},
    "source": [
     "## 1. Which configurations, and on which label\n",
@@ -155,15 +154,21 @@
     "  every fold at the published epoch schedule. A preview run has to declare at least one\n",
     "  reduction and carries it in the identity, so its results can never be compared against\n",
     "  canonical ones or reach a holdout decision.\n",
-    "- **`PREVIEW_N_EPOCHS`** shortens the schedule for a preview. It is part of the identity rather\n",
-    "  than a runtime detail, because a model trained for fewer epochs is a different model rather\n",
-    "  than the same one measured sooner."
+    "\n",
+    "A shortened training schedule is not among the reductions a preview may declare, and\n",
+    "deliberately. This family's preview contract - `SEQUENCE_PREVIEW_FIELDS` in\n",
+    "`case_studies/utils/preview_fields.py` - accepts a narrower universe, a fold subset and a cap on\n",
+    "training sequences, and no epoch count, because a model trained for fewer epochs is a different\n",
+    "model rather than the same one measured sooner. To train a short schedule, pass `n_epochs` in\n",
+    "`COMMON_OVERRIDES`. It moves the training identity, so the result registers beside the published\n",
+    "one, and a run carrying any override publishes neither the canonical population nor the\n",
+    "canonical set names."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b126c8d5",
+   "id": "204db82c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -205,7 +210,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2dbe0dea",
+   "id": "f1a1bcfd",
    "metadata": {},
    "source": [
     "A run that narrows the selection, overrides a parameter or fits on another device produces a\n",
@@ -218,7 +223,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2ae6e82b",
+   "id": "43f4bcaa",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -238,7 +243,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e8a94fa5",
+   "id": "3a065dde",
    "metadata": {},
    "source": [
     "Both tiers resolve the study through `open_study`. It reads the labels and features in place\n",
@@ -250,24 +255,24 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2b123139",
+   "id": "9e7901c1",
    "metadata": {},
    "outputs": [],
    "source": [
     "preview_reductions = {}\n",
-    "if MAX_SYMBOLS:\n",
-    "    preview_reductions[\"max_symbols\"] = int(MAX_SYMBOLS)\n",
-    "if FOLD_IDS:\n",
-    "    preview_reductions[\"folds\"] = [int(fold) for fold in FOLD_IDS]\n",
-    "if MAX_TRAIN_SEQUENCES:\n",
-    "    preview_reductions[\"max_train_sequences\"] = int(MAX_TRAIN_SEQUENCES)\n",
+    "if PREVIEW_MAX_SYMBOLS:\n",
+    "    preview_reductions[\"max_symbols\"] = int(PREVIEW_MAX_SYMBOLS)\n",
+    "if PREVIEW_FOLD_IDS:\n",
+    "    preview_reductions[\"folds\"] = [int(fold) for fold in PREVIEW_FOLD_IDS]\n",
+    "if PREVIEW_MAX_TRAIN_SEQUENCES:\n",
+    "    preview_reductions[\"max_train_sequences\"] = int(PREVIEW_MAX_TRAIN_SEQUENCES)\n",
     "\n",
     "study = open_study(CASE_STUDY_ID, execution_tier=EXECUTION_TIER, workspace=WORKSPACE or None)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "91c74106",
+   "id": "5658e72c",
    "metadata": {},
    "source": [
     "## 2. Binding the declarations to the data\n",
@@ -278,7 +283,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "00008032",
+   "id": "06c8b65a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -289,8 +294,6 @@
     "        **COMMON_OVERRIDES,\n",
     "        **dict(CONFIG_OVERRIDES.get(config_name, {})),\n",
     "    }\n",
-    "    if PREVIEW_N_EPOCHS:\n",
-    "        overrides[\"n_epochs\"] = int(PREVIEW_N_EPOCHS)\n",
     "    requests.append(\n",
     "        study.model(\n",
     "            family=\"deep_learning\",\n",
@@ -318,7 +321,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f7e04a98",
+   "id": "31471ee4",
    "metadata": {},
    "source": [
     "## 3. Planning, then fitting\n",
@@ -334,7 +337,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4df5488d",
+   "id": "4cabddf4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -355,7 +358,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ed1cdcdd",
+   "id": "b8b542ca",
    "metadata": {},
    "source": [
     "`run_model_population` takes the plan, writes the population down, fits every member and then\n",
@@ -375,7 +378,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "25a88b52",
+   "id": "da473886",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -397,7 +400,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e3fb0334",
+   "id": "5d2599cb",
    "metadata": {},
    "source": [
     "## 4. What was actually fitted\n",
@@ -409,7 +412,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b317c6ab",
+   "id": "3afdea30",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -439,7 +442,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bee0307c",
+   "id": "b3a962b7",
    "metadata": {},
    "source": [
     "## 5. What came out\n",
@@ -452,7 +455,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4192681a",
+   "id": "1e5440d1",
    "metadata": {
     "tags": [
      "results"
@@ -481,7 +484,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "36cd3090",
+   "id": "413eba17",
    "metadata": {},
    "source": [
     "A prediction set can be registered complete and still have scored no dates. Cross-sectional\n",
@@ -494,7 +497,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "36f6f060",
+   "id": "71e9fba1",
    "metadata": {
     "tags": [
      "results"
@@ -511,7 +514,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "393ce056",
+   "id": "12ffd312",
    "metadata": {},
    "source": [
     "### Where more training stopped helping\n",
@@ -536,7 +539,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2462eb7d",
+   "id": "696cc551",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -593,7 +596,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e3b3c8a0",
+   "id": "875d060c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -627,7 +630,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "05c1e063",
+   "id": "3bf79fff",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -637,7 +640,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0f1ad796",
+   "id": "5ffb8e9e",
    "metadata": {},
    "source": [
     "## 6. Naming the sets the later notebooks open\n",
@@ -661,7 +664,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b89d3f77",
+   "id": "85cc32a9",
    "metadata": {
     "tags": [
      "results"
@@ -716,7 +719,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "24f5d539",
+   "id": "09e7022d",
    "metadata": {},
    "source": [
     "`15_model_analysis` reopens both names: the full set to confirm the run filled every member it\n",
@@ -727,7 +730,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ea226c59",
+   "id": "c1c9d4ed",
    "metadata": {},
    "source": [
     "## What to notice\n",

--- a/case_studies/us_equities_panel/11_dl_tsmixer.ipynb
+++ b/case_studies/us_equities_panel/11_dl_tsmixer.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "d03227f5",
+   "id": "44bb396a",
    "metadata": {},
    "source": [
     "# US equities panel: mixing along time and across features instead of recurring\n",
@@ -80,20 +80,23 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "757cac59",
+   "id": "a5789c67",
    "metadata": {},
    "outputs": [],
    "source": [
     "\"\"\"Generate TSMixer validation predictions through the shared research interface.\"\"\"\n",
     "\n",
-    "import os\n",
-    "from pathlib import Path\n",
-    "\n",
     "import matplotlib.pyplot as plt\n",
     "import polars as pl\n",
     "import yaml\n",
     "\n",
-    "from case_studies.research import open_study, plan_models\n",
+    "from case_studies.research import (\n",
+    "    candidate_set_supersedes,\n",
+    "    open_study,\n",
+    "    plan_models,\n",
+    "    run_model_population,\n",
+    "    supersedes_for_run,\n",
+    ")\n",
     "from utils.modeling import load_configs\n",
     "from utils.paths import get_case_study_dir\n",
     "from utils.style import FIGSIZE, add_message_title, ml4t_palette, show_with_alt, zero_line"
@@ -102,7 +105,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3b4e38e8",
+   "id": "d34556a5",
    "metadata": {
     "tags": [
      "parameters"
@@ -115,9 +118,12 @@
     "CONFIG_NAMES = []\n",
     "COMMON_OVERRIDES = {}\n",
     "CONFIG_OVERRIDES = {}\n",
+    "POPULATION_NAME = \"\"\n",
+    "SUPERSEDES_POPULATION = \"\"\n",
+    "SUPERSEDES_SETS: dict = {}\n",
     "DEVICE = \"cuda\"\n",
     "EXECUTION_TIER = \"canonical\"\n",
-    "WORKSPACE = \"experiments\"\n",
+    "WORKSPACE = \"\"\n",
     "MAX_SYMBOLS = 0\n",
     "FOLD_IDS = []\n",
     "MAX_TRAIN_SEQUENCES = 0\n",
@@ -126,7 +132,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8b7e236f",
+   "id": "784869a6",
    "metadata": {},
    "source": [
     "## 1. Which configurations, and on which label\n",
@@ -157,7 +163,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "45b829bd",
+   "id": "b126c8d5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -198,9 +204,53 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "2dbe0dea",
+   "metadata": {},
+   "source": [
+    "A run that narrows the selection, overrides a parameter or fits on another device produces a\n",
+    "different set of predictions from the one the canonical name stands for. Publishing it under\n",
+    "that name would leave the name meaning two different member sets at two different times, so the\n",
+    "guard below requires such a run to say what to call its own population, and the frozen set names\n",
+    "in Section 6 are withheld from it for the same reason."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9e55a719",
+   "id": "2ae6e82b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "is_published_population = (\n",
+    "    EXECUTION_TIER == \"canonical\"\n",
+    "    and selected_names == published_names\n",
+    "    and not COMMON_OVERRIDES\n",
+    "    and not CONFIG_OVERRIDES\n",
+    "    and DEVICE == \"cuda\"\n",
+    ")\n",
+    "if EXECUTION_TIER == \"canonical\" and not is_published_population and not POPULATION_NAME:\n",
+    "    raise ValueError(\n",
+    "        \"this run narrows or overrides what the menu declares, so it cannot publish the canonical \"\n",
+    "        \"population; pass POPULATION_NAME to give it its own\"\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e8a94fa5",
+   "metadata": {},
+   "source": [
+    "Both tiers resolve the study through `open_study`. It reads the labels and features in place\n",
+    "and redirects only writes, so a preview run scores the same inputs a canonical one does and\n",
+    "cannot publish over it. A preview must be given a workspace to write into; a canonical run\n",
+    "leaves `WORKSPACE` empty and regenerates the case study's own artifacts in place."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2b123139",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -212,28 +262,12 @@
     "if MAX_TRAIN_SEQUENCES:\n",
     "    preview_reductions[\"max_train_sequences\"] = int(MAX_TRAIN_SEQUENCES)\n",
     "\n",
-    "# Both tiers resolve the study through `open_study`. It reads the labels and features in place and\n",
-    "# redirects only writes, so a preview run scores the same inputs a canonical one does and cannot\n",
-    "# publish over it.\n",
-    "if EXECUTION_TIER == \"canonical\":\n",
-    "    if preview_reductions or PREVIEW_N_EPOCHS:\n",
-    "        raise ValueError(\"Canonical execution cannot declare preview reductions\")\n",
-    "    study = open_study(CASE_STUDY_ID, execution_tier=EXECUTION_TIER)\n",
-    "elif EXECUTION_TIER == \"preview\":\n",
-    "    if not preview_reductions:\n",
-    "        raise ValueError(\"Preview execution requires a data or fold reduction\")\n",
-    "    study = open_study(\n",
-    "        CASE_STUDY_ID,\n",
-    "        execution_tier=EXECUTION_TIER,\n",
-    "        workspace=Path(os.environ.get(\"ML4T_OUTPUT_DIR\") or WORKSPACE),\n",
-    "    )\n",
-    "else:\n",
-    "    raise ValueError(\"EXECUTION_TIER must be 'canonical' or 'preview'\")"
+    "study = open_study(CASE_STUDY_ID, execution_tier=EXECUTION_TIER, workspace=WORKSPACE or None)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "ae077104",
+   "id": "91c74106",
    "metadata": {},
    "source": [
     "## 2. Binding the declarations to the data\n",
@@ -244,7 +278,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6d947b37",
+   "id": "00008032",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -284,7 +318,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3a2dc833",
+   "id": "f7e04a98",
    "metadata": {},
    "source": [
     "## 3. Planning, then fitting\n",
@@ -300,16 +334,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d1b9f5af",
+   "id": "4df5488d",
    "metadata": {},
    "outputs": [],
    "source": [
     "plan = plan_models(study, requests=requests)\n",
-    "official_population = None\n",
-    "if EXECUTION_TIER == \"canonical\":\n",
-    "    official_population = plan.create_population(\n",
-    "        name=\"us-equities-tsmixer-checkpoints-v1\",\n",
-    "    )\n",
     "\n",
     "planned_population = pl.DataFrame(\n",
     "    {\n",
@@ -325,18 +354,50 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "ed1cdcdd",
+   "metadata": {},
+   "source": [
+    "`run_model_population` takes the plan, writes the population down, fits every member and then\n",
+    "checks that what came out is what was declared. The same call serves both tiers: a canonical run\n",
+    "registers an immutable population that the later notebooks bind to, and a preview run gets a\n",
+    "declaration that is verified and then discarded with its workspace, so no notebook here has to\n",
+    "branch on the tier to decide what to publish.\n",
+    "\n",
+    "`SUPERSEDES_POPULATION` names the population hash this run replaces. A population is a set of\n",
+    "prediction identities, so anything that moves a training identity - a changed preset as much as a\n",
+    "changed menu - produces a different population under the same name, and the registry refuses to\n",
+    "write it without being told which snapshot it supersedes. Leaving it empty is right for a first\n",
+    "run and for a reader's clean clone, and `supersedes_for_run` withholds a declared hash wherever\n",
+    "offering it would be refused."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "id": "da8a283e",
+   "id": "25a88b52",
    "metadata": {},
    "outputs": [],
    "source": [
-    "execution = plan.run()"
+    "population_name = POPULATION_NAME or \"us-equities-tsmixer-checkpoints-v1\"\n",
+    "execution, official_population = run_model_population(\n",
+    "    study,\n",
+    "    plan,\n",
+    "    population_name=population_name,\n",
+    "    supersedes=supersedes_for_run(\n",
+    "        study,\n",
+    "        population_name=population_name,\n",
+    "        declared=SUPERSEDES_POPULATION,\n",
+    "        execution_tier=EXECUTION_TIER,\n",
+    "    ),\n",
+    ")\n",
+    "\n",
+    "print(f\"population {official_population.name}: {len(official_population.members)} prediction sets\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "6e708627",
+   "id": "e3fb0334",
    "metadata": {},
    "source": [
     "## 4. What was actually fitted\n",
@@ -348,7 +409,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "afbeb3f9",
+   "id": "b317c6ab",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -378,7 +439,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d2461a75",
+   "id": "bee0307c",
    "metadata": {},
    "source": [
     "## 5. What came out\n",
@@ -391,7 +452,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e21f8647",
+   "id": "4192681a",
    "metadata": {
     "tags": [
      "results"
@@ -420,7 +481,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b2e3028d",
+   "id": "36cd3090",
    "metadata": {},
    "source": [
     "A prediction set can be registered complete and still have scored no dates. Cross-sectional\n",
@@ -433,7 +494,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "045b7cac",
+   "id": "36f6f060",
    "metadata": {
     "tags": [
      "results"
@@ -450,7 +511,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "009406c9",
+   "id": "393ce056",
    "metadata": {},
    "source": [
     "### Where more training stopped helping\n",
@@ -475,7 +536,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5d7fe057",
+   "id": "2462eb7d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -532,7 +593,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a2c4f160",
+   "id": "e3b3c8a0",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -560,15 +621,13 @@
     "        )\n",
     "\n",
     "coverage_table = pl.DataFrame(coverage_rows).sort(\"config_name\", \"checkpoint\")\n",
-    "if official_population is not None:\n",
-    "    official_population.require_complete()\n",
     "coverage_table"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d092e682",
+   "id": "05c1e063",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -578,7 +637,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e406cb7b",
+   "id": "0f1ad796",
    "metadata": {},
    "source": [
     "## 6. Naming the sets the later notebooks open\n",
@@ -591,8 +650,8 @@
     "\n",
     "The second is the **bounded diagnostic set**, and it is bounded hard.\n",
     "[`15_model_analysis`](15_model_analysis.ipynb) loads every diagnostic member's raw prediction\n",
-    "frame and holds them all while it joins them pairwise; one frame on this panel is 7.2 million\n",
-    "rows and about 225 MB in memory, so a set that grew with the checkpoint count would not fit\n",
+    "frame and holds them all while it joins them pairwise; one frame on this panel is over seven\n",
+    "million rows and about 225 MB in memory, so a set that grew with the checkpoint count would not fit\n",
     "beside the other seven families'. The bound is the last checkpoint of each published\n",
     "configuration - one member here, because the menu declares one TSMixer configuration. The\n",
     "epoch dimension is still read, in the learning-curve figure above, which is drawn from registry\n",
@@ -602,7 +661,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0accc129",
+   "id": "b89d3f77",
    "metadata": {
     "tags": [
      "results"
@@ -611,18 +670,15 @@
    "outputs": [],
    "source": [
     "set_rows = []\n",
-    "is_published_population = (\n",
-    "    EXECUTION_TIER == \"canonical\"\n",
-    "    and selected_names == published_names\n",
-    "    and not COMMON_OVERRIDES\n",
-    "    and not CONFIG_OVERRIDES\n",
-    "    and DEVICE == \"cuda\"\n",
-    ")\n",
     "if is_published_population:\n",
     "    label_name = label.replace(\"_\", \"-\")\n",
+    "    full_set_name = f\"us-equities-{label_name}-tsmixer-v1\"\n",
     "    full_set = study.predictions.freeze(\n",
     "        execution.catalog_rows,\n",
-    "        name=f\"us-equities-{label_name}-tsmixer-v1\",\n",
+    "        name=full_set_name,\n",
+    "        supersedes=candidate_set_supersedes(\n",
+    "            study, name=full_set_name, declared=SUPERSEDES_SETS.get(full_set_name, \"\")\n",
+    "        ),\n",
     "    )\n",
     "    diagnostic_rows = execution.catalog_rows.filter(\n",
     "        # `.fill_null(True)` covers a family that publishes no checkpoint value at all, where the\n",
@@ -631,9 +687,13 @@
     "            pl.col(\"checkpoint_value\") == pl.col(\"checkpoint_value\").max().over(\"config_name\")\n",
     "        ).fill_null(True)\n",
     "    )\n",
+    "    diagnostic_set_name = f\"us-equities-{label_name}-tsmixer-diagnostics-v1\"\n",
     "    diagnostic_set = study.predictions.freeze(\n",
     "        diagnostic_rows,\n",
-    "        name=f\"us-equities-{label_name}-tsmixer-diagnostics-v1\",\n",
+    "        name=diagnostic_set_name,\n",
+    "        supersedes=candidate_set_supersedes(\n",
+    "            study, name=diagnostic_set_name, declared=SUPERSEDES_SETS.get(diagnostic_set_name, \"\")\n",
+    "        ),\n",
     "    )\n",
     "    set_rows = [\n",
     "        {\n",
@@ -656,7 +716,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9ec68d7b",
+   "id": "24f5d539",
    "metadata": {},
    "source": [
     "`15_model_analysis` reopens both names: the full set to confirm the run filled every member it\n",
@@ -667,7 +727,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ec6483ac",
+   "id": "ea226c59",
    "metadata": {},
    "source": [
     "## What to notice\n",

--- a/case_studies/us_equities_panel/11_dl_tsmixer.ipynb
+++ b/case_studies/us_equities_panel/11_dl_tsmixer.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "d037cc48",
+   "id": "d03227f5",
    "metadata": {},
    "source": [
     "# US equities panel: mixing along time and across features instead of recurring\n",
@@ -80,7 +80,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f4b6aaf2",
+   "id": "757cac59",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -89,18 +89,20 @@
     "import os\n",
     "from pathlib import Path\n",
     "\n",
+    "import matplotlib.pyplot as plt\n",
     "import polars as pl\n",
     "import yaml\n",
     "\n",
     "from case_studies.research import open_study, plan_models\n",
     "from utils.modeling import load_configs\n",
-    "from utils.paths import get_case_study_dir"
+    "from utils.paths import get_case_study_dir\n",
+    "from utils.style import FIGSIZE, add_message_title, ml4t_palette, show_with_alt, zero_line"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c697d026",
+   "id": "3b4e38e8",
    "metadata": {
     "tags": [
      "parameters"
@@ -124,7 +126,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "07a2d8bc",
+   "id": "8b7e236f",
    "metadata": {},
    "source": [
     "## 1. Which configurations, and on which label\n",
@@ -155,7 +157,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bafbf626",
+   "id": "45b829bd",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -198,7 +200,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "272a2206",
+   "id": "9e55a719",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -231,7 +233,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3bb86c26",
+   "id": "ae077104",
    "metadata": {},
    "source": [
     "## 2. Binding the declarations to the data\n",
@@ -242,7 +244,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8d3a281c",
+   "id": "6d947b37",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -282,7 +284,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "580985e7",
+   "id": "3a2dc833",
    "metadata": {},
    "source": [
     "## 3. Planning, then fitting\n",
@@ -298,7 +300,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7c29aa1a",
+   "id": "d1b9f5af",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -325,7 +327,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "46a259f0",
+   "id": "da8a283e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -334,7 +336,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c16a866e",
+   "id": "6e708627",
    "metadata": {},
    "source": [
     "## 4. What was actually fitted\n",
@@ -346,7 +348,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "651c2aed",
+   "id": "afbeb3f9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -376,7 +378,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "137f4135",
+   "id": "d2461a75",
    "metadata": {},
    "source": [
     "## 5. What came out\n",
@@ -389,7 +391,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7ec234f0",
+   "id": "e21f8647",
    "metadata": {
     "tags": [
      "results"
@@ -418,7 +420,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d9d073c6",
+   "id": "b2e3028d",
    "metadata": {},
    "source": [
     "A prediction set can be registered complete and still have scored no dates. Cross-sectional\n",
@@ -431,7 +433,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "414db429",
+   "id": "045b7cac",
    "metadata": {
     "tags": [
      "results"
@@ -447,9 +449,90 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "009406c9",
+   "metadata": {},
+   "source": [
+    "### Where more training stopped helping\n",
+    "\n",
+    "Each line traces one configuration's validation information coefficient as epochs are added to\n",
+    "it. This is the figure the checkpoint dimension exists to produce, and it separates two things a\n",
+    "single end-of-training number cannot.\n",
+    "\n",
+    "A line that rises and then falls has an interior optimum: the model was still learning, then\n",
+    "began fitting the training windows at the expense of the validation folds. That is the evidence about whether alternating\n",
+    "time and feature mixing over two blocks has more capacity than the number of eligible\n",
+    "windows supports.\n",
+    "A line that wanders around zero without trend never had anything to learn, and its highest point\n",
+    "is wherever the noise happened to peak. Both produce a respectable-looking maximum, which is why\n",
+    "the curve rather than the maximum is what to read.\n",
+    "\n",
+    "Nothing here selects a checkpoint. Every one of them is registered as its own candidate, and\n",
+    "which one a strategy would use is decided by validation backtest Sharpe in\n",
+    "[`16_backtest`](16_backtest.ipynb)."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c66fa349",
+   "id": "5d7fe057",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "curves = scored.sort(\"config_name\", \"checkpoint_value\")\n",
+    "config_names = curves.get_column(\"config_name\").unique(maintain_order=True).to_list()\n",
+    "# `ml4t_palette` returns a list of that many colours, so it is called once and indexed.\n",
+    "palette = ml4t_palette(len(config_names), categorical=True)\n",
+    "\n",
+    "fig, ax = plt.subplots(figsize=FIGSIZE[\"single\"])\n",
+    "for index, config_name in enumerate(config_names):\n",
+    "    series = curves.filter(pl.col(\"config_name\") == config_name)\n",
+    "    ax.plot(\n",
+    "        series.get_column(\"checkpoint_value\"),\n",
+    "        series.get_column(\"ic_mean\"),\n",
+    "        marker=\"o\",\n",
+    "        markersize=4,\n",
+    "        lw=1.4,\n",
+    "        color=palette[index],\n",
+    "        label=config_name,\n",
+    "    )\n",
+    "zero_line(ax)\n",
+    "ax.set_xlabel(\"Training epochs\")\n",
+    "ax.set_ylabel(\"Mean validation IC\")\n",
+    "ax.legend(fontsize=8, frameon=False)\n",
+    "add_message_title(\n",
+    "    ax,\n",
+    "    \"Mean validation IC against training epoch\",\n",
+    "    subtitle=\"One line per configuration, over the epochs the schedule checkpoints at\",\n",
+    ")\n",
+    "# The alt text counts rather than asserts: whether a curve turns over is the question the figure\n",
+    "# exists to answer, and a line described as peaking when it does not is a claim the data refutes.\n",
+    "_peaks = (\n",
+    "    curves.group_by(\"config_name\")\n",
+    "    .agg(\n",
+    "        peak=pl.col(\"checkpoint_value\").sort_by(\"ic_mean\", descending=True).first(),\n",
+    "        first=pl.col(\"checkpoint_value\").min(),\n",
+    "        last=pl.col(\"checkpoint_value\").max(),\n",
+    "    )\n",
+    "    .with_columns(\n",
+    "        interior=pl.col(\"peak\").is_between(pl.col(\"first\"), pl.col(\"last\"), closed=\"none\")\n",
+    "    )\n",
+    ")\n",
+    "_n_interior = int(_peaks.get_column(\"interior\").sum())\n",
+    "show_with_alt(\n",
+    "    fig,\n",
+    "    \"A line chart of mean validation information coefficient against training epoch, one line per \"\n",
+    "    \"configuration, with a dashed line at zero. Counted from the underlying frame, \"\n",
+    "    f\"{_n_interior} of {_peaks.height} configurations reach their highest information coefficient \"\n",
+    "    \"at an epoch that is neither the first nor the last, which is what an interior optimum looks \"\n",
+    "    \"like on this chart.\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a2c4f160",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -485,7 +568,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1a80004a",
+   "id": "d092e682",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -495,7 +578,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e8f654ad",
+   "id": "e406cb7b",
    "metadata": {},
    "source": [
     "## 6. Naming the sets the later notebooks open\n",
@@ -519,7 +602,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3b7208f8",
+   "id": "0accc129",
    "metadata": {
     "tags": [
      "results"
@@ -573,7 +656,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f844f7d2",
+   "id": "9ec68d7b",
    "metadata": {},
    "source": [
     "`15_model_analysis` reopens both names: the full set to confirm the run filled every member it\n",
@@ -584,7 +667,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5c534d68",
+   "id": "ec6483ac",
    "metadata": {},
    "source": [
     "## What to notice\n",

--- a/case_studies/us_equities_panel/11_dl_tsmixer.ipynb
+++ b/case_studies/us_equities_panel/11_dl_tsmixer.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "9d3c9397",
+   "id": "ce933c56",
    "metadata": {},
    "source": [
     "# US equities panel: mixing along time and across features instead of recurring\n",
@@ -80,7 +80,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5ac54cdd",
+   "id": "0418a1f5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -105,7 +105,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "07adbb76",
+   "id": "90375484",
    "metadata": {
     "tags": [
      "parameters"
@@ -131,7 +131,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b870a079",
+   "id": "212b8367",
    "metadata": {},
    "source": [
     "## 1. Which configurations, and on which label\n",
@@ -139,7 +139,7 @@
     "The menu at `config/training/{label}.yaml` lists the sequence configurations declared for a\n",
     "label, and this notebook takes the ones whose architecture is `tsmixer`. Each name resolves to a\n",
     "preset holding the full parameter set - here a 60-session lookback, 100 epochs, a checkpoint\n",
-    "every 5, and a dropout of 0.1.\n",
+    "every 5, and dropout on the hidden units. The frame below prints the resolved values.\n",
     "\n",
     "What each setting a run may pass decides:\n",
     "\n",
@@ -168,7 +168,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "204db82c",
+   "id": "953adce3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -210,7 +210,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f1a1bcfd",
+   "id": "79cdbf92",
    "metadata": {},
    "source": [
     "A run that narrows the selection, overrides a parameter or fits on another device produces a\n",
@@ -223,7 +223,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "43f4bcaa",
+   "id": "6fde65a1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -243,7 +243,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3a065dde",
+   "id": "919effd2",
    "metadata": {},
    "source": [
     "Both tiers resolve the study through `open_study`. It reads the labels and features in place\n",
@@ -255,7 +255,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9e7901c1",
+   "id": "334d4738",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -272,7 +272,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5658e72c",
+   "id": "aa7f3ae6",
    "metadata": {},
    "source": [
     "## 2. Binding the declarations to the data\n",
@@ -283,7 +283,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "06c8b65a",
+   "id": "d2a5178d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -321,7 +321,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "31471ee4",
+   "id": "e2970aac",
    "metadata": {},
    "source": [
     "## 3. Planning, then fitting\n",
@@ -337,7 +337,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4cabddf4",
+   "id": "4fcd2ec8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -358,7 +358,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b8b542ca",
+   "id": "aa4622fe",
    "metadata": {},
    "source": [
     "`run_model_population` takes the plan, writes the population down, fits every member and then\n",
@@ -378,7 +378,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "da473886",
+   "id": "d71e1fec",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -400,7 +400,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5d2599cb",
+   "id": "a3c8eebd",
    "metadata": {},
    "source": [
     "## 4. What was actually fitted\n",
@@ -412,7 +412,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3afdea30",
+   "id": "8b5ff4f8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -442,7 +442,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b3a962b7",
+   "id": "23dc993e",
    "metadata": {},
    "source": [
     "## 5. What came out\n",
@@ -455,7 +455,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1e5440d1",
+   "id": "b91012da",
    "metadata": {
     "tags": [
      "results"
@@ -484,7 +484,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "413eba17",
+   "id": "22f0b5ba",
    "metadata": {},
    "source": [
     "A prediction set can be registered complete and still have scored no dates. Cross-sectional\n",
@@ -497,7 +497,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "71e9fba1",
+   "id": "a7784319",
    "metadata": {
     "tags": [
      "results"
@@ -514,7 +514,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "12ffd312",
+   "id": "7659d163",
    "metadata": {},
    "source": [
     "### Where more training stopped helping\n",
@@ -539,7 +539,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "696cc551",
+   "id": "d8950673",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -596,7 +596,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "875d060c",
+   "id": "3ebe224f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -630,7 +630,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3bf79fff",
+   "id": "9b0fa6ac",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -640,7 +640,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5ffb8e9e",
+   "id": "947cd7d5",
    "metadata": {},
    "source": [
     "## 6. Naming the sets the later notebooks open\n",
@@ -664,7 +664,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "85cc32a9",
+   "id": "7df9e70f",
    "metadata": {
     "tags": [
      "results"
@@ -719,7 +719,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "09e7022d",
+   "id": "49404482",
    "metadata": {},
    "source": [
     "`15_model_analysis` reopens both names: the full set to confirm the run filled every member it\n",
@@ -730,7 +730,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c1c9d4ed",
+   "id": "e657142d",
    "metadata": {},
    "source": [
     "## What to notice\n",

--- a/case_studies/us_equities_panel/11_dl_tsmixer.py
+++ b/case_studies/us_equities_panel/11_dl_tsmixer.py
@@ -91,12 +91,14 @@
 import os
 from pathlib import Path
 
+import matplotlib.pyplot as plt
 import polars as pl
 import yaml
 
 from case_studies.research import open_study, plan_models
 from utils.modeling import load_configs
 from utils.paths import get_case_study_dir
+from utils.style import FIGSIZE, add_message_title, ml4t_palette, show_with_alt, zero_line
 
 # %% tags=["parameters"]
 CASE_STUDY_ID = "us_equities_panel"
@@ -341,6 +343,75 @@ unscored = scored.filter(pl.col("ic_n_days").is_null() | (pl.col("ic_n_days") <=
 if not unscored.is_empty():
     raise RuntimeError(f"prediction sets scored no dates: {unscored.to_dicts()}")
 scored
+
+# %% [markdown]
+# ### Where more training stopped helping
+#
+# Each line traces one configuration's validation information coefficient as epochs are added to
+# it. This is the figure the checkpoint dimension exists to produce, and it separates two things a
+# single end-of-training number cannot.
+#
+# A line that rises and then falls has an interior optimum: the model was still learning, then
+# began fitting the training windows at the expense of the validation folds. That is the evidence about whether alternating
+# time and feature mixing over two blocks has more capacity than the number of eligible
+# windows supports.
+# A line that wanders around zero without trend never had anything to learn, and its highest point
+# is wherever the noise happened to peak. Both produce a respectable-looking maximum, which is why
+# the curve rather than the maximum is what to read.
+#
+# Nothing here selects a checkpoint. Every one of them is registered as its own candidate, and
+# which one a strategy would use is decided by validation backtest Sharpe in
+# [`16_backtest`](16_backtest.ipynb).
+
+# %%
+curves = scored.sort("config_name", "checkpoint_value")
+config_names = curves.get_column("config_name").unique(maintain_order=True).to_list()
+# `ml4t_palette` returns a list of that many colours, so it is called once and indexed.
+palette = ml4t_palette(len(config_names), categorical=True)
+
+fig, ax = plt.subplots(figsize=FIGSIZE["single"])
+for index, config_name in enumerate(config_names):
+    series = curves.filter(pl.col("config_name") == config_name)
+    ax.plot(
+        series.get_column("checkpoint_value"),
+        series.get_column("ic_mean"),
+        marker="o",
+        markersize=4,
+        lw=1.4,
+        color=palette[index],
+        label=config_name,
+    )
+zero_line(ax)
+ax.set_xlabel("Training epochs")
+ax.set_ylabel("Mean validation IC")
+ax.legend(fontsize=8, frameon=False)
+add_message_title(
+    ax,
+    "Mean validation IC against training epoch",
+    subtitle="One line per configuration, over the epochs the schedule checkpoints at",
+)
+# The alt text counts rather than asserts: whether a curve turns over is the question the figure
+# exists to answer, and a line described as peaking when it does not is a claim the data refutes.
+_peaks = (
+    curves.group_by("config_name")
+    .agg(
+        peak=pl.col("checkpoint_value").sort_by("ic_mean", descending=True).first(),
+        first=pl.col("checkpoint_value").min(),
+        last=pl.col("checkpoint_value").max(),
+    )
+    .with_columns(
+        interior=pl.col("peak").is_between(pl.col("first"), pl.col("last"), closed="none")
+    )
+)
+_n_interior = int(_peaks.get_column("interior").sum())
+show_with_alt(
+    fig,
+    "A line chart of mean validation information coefficient against training epoch, one line per "
+    "configuration, with a dashed line at zero. Counted from the underlying frame, "
+    f"{_n_interior} of {_peaks.height} configurations reach their highest information coefficient "
+    "at an epoch that is neither the first nor the last, which is what an interior optimum looks "
+    "like on this chart.",
+)
 
 # %%
 coverage_rows = []

--- a/case_studies/us_equities_panel/11_dl_tsmixer.py
+++ b/case_studies/us_equities_panel/11_dl_tsmixer.py
@@ -115,10 +115,9 @@ SUPERSEDES_SETS: dict = {}
 DEVICE = "cuda"
 EXECUTION_TIER = "canonical"
 WORKSPACE = ""
-MAX_SYMBOLS = 0
-FOLD_IDS = []
-MAX_TRAIN_SEQUENCES = 0
-PREVIEW_N_EPOCHS = 0
+PREVIEW_MAX_SYMBOLS = 0
+PREVIEW_FOLD_IDS = []
+PREVIEW_MAX_TRAIN_SEQUENCES = 0
 
 # %% [markdown]
 # ## 1. Which configurations, and on which label
@@ -141,9 +140,15 @@ PREVIEW_N_EPOCHS = 0
 #   every fold at the published epoch schedule. A preview run has to declare at least one
 #   reduction and carries it in the identity, so its results can never be compared against
 #   canonical ones or reach a holdout decision.
-# - **`PREVIEW_N_EPOCHS`** shortens the schedule for a preview. It is part of the identity rather
-#   than a runtime detail, because a model trained for fewer epochs is a different model rather
-#   than the same one measured sooner.
+#
+# A shortened training schedule is not among the reductions a preview may declare, and
+# deliberately. This family's preview contract - `SEQUENCE_PREVIEW_FIELDS` in
+# `case_studies/utils/preview_fields.py` - accepts a narrower universe, a fold subset and a cap on
+# training sequences, and no epoch count, because a model trained for fewer epochs is a different
+# model rather than the same one measured sooner. To train a short schedule, pass `n_epochs` in
+# `COMMON_OVERRIDES`. It moves the training identity, so the result registers beside the published
+# one, and a run carrying any override publishes neither the canonical population nor the
+# canonical set names.
 
 # %%
 case_dir = get_case_study_dir(CASE_STUDY_ID)
@@ -210,12 +215,12 @@ if EXECUTION_TIER == "canonical" and not is_published_population and not POPULAT
 
 # %%
 preview_reductions = {}
-if MAX_SYMBOLS:
-    preview_reductions["max_symbols"] = int(MAX_SYMBOLS)
-if FOLD_IDS:
-    preview_reductions["folds"] = [int(fold) for fold in FOLD_IDS]
-if MAX_TRAIN_SEQUENCES:
-    preview_reductions["max_train_sequences"] = int(MAX_TRAIN_SEQUENCES)
+if PREVIEW_MAX_SYMBOLS:
+    preview_reductions["max_symbols"] = int(PREVIEW_MAX_SYMBOLS)
+if PREVIEW_FOLD_IDS:
+    preview_reductions["folds"] = [int(fold) for fold in PREVIEW_FOLD_IDS]
+if PREVIEW_MAX_TRAIN_SEQUENCES:
+    preview_reductions["max_train_sequences"] = int(PREVIEW_MAX_TRAIN_SEQUENCES)
 
 study = open_study(CASE_STUDY_ID, execution_tier=EXECUTION_TIER, workspace=WORKSPACE or None)
 
@@ -232,8 +237,6 @@ for config_name in selected_names:
         **COMMON_OVERRIDES,
         **dict(CONFIG_OVERRIDES.get(config_name, {})),
     }
-    if PREVIEW_N_EPOCHS:
-        overrides["n_epochs"] = int(PREVIEW_N_EPOCHS)
     requests.append(
         study.model(
             family="deep_learning",

--- a/case_studies/us_equities_panel/11_dl_tsmixer.py
+++ b/case_studies/us_equities_panel/11_dl_tsmixer.py
@@ -376,11 +376,22 @@ execution_diagnostics = pl.DataFrame(execution.diagnostics)
 execution_diagnostics
 
 # %% [markdown]
-# ## 6. Naming the set the later notebooks open
+# ## 6. Naming the sets the later notebooks open
 #
-# A canonical default CUDA run freezes every returned TSMixer prediction row under a stable name.
-# The same bounded family set supplies raw diagnostics because this notebook has one published
-# configuration. Preview and customized canonical requests do not publish an official set.
+# A canonical default CUDA run freezes what it produced under two stable names, and preview or
+# customized canonical requests publish neither.
+#
+# The first name is the **full set**: every prediction row this run returned, which
+# [`16_backtest`](16_backtest.ipynb) backtests member by member.
+#
+# The second is the **bounded diagnostic set**, and it is bounded hard.
+# [`15_model_analysis`](15_model_analysis.ipynb) loads every diagnostic member's raw prediction
+# frame and holds them all while it joins them pairwise; one frame on this panel is 7.2 million
+# rows and about 225 MB in memory, so a set that grew with the checkpoint count would not fit
+# beside the other seven families'. The bound is the last checkpoint of each published
+# configuration - one member here, because the menu declares one TSMixer configuration. The
+# epoch dimension is still read, in the learning-curve figure above, which is drawn from registry
+# metrics rather than from raw frames.
 
 # %% tags=["results"]
 set_rows = []
@@ -397,12 +408,28 @@ if is_published_population:
         execution.catalog_rows,
         name=f"us-equities-{label_name}-tsmixer-v1",
     )
+    diagnostic_rows = execution.catalog_rows.filter(
+        # `.fill_null(True)` covers a family that publishes no checkpoint value at all, where the
+        # comparison is null rather than false and would otherwise empty the frame.
+        (
+            pl.col("checkpoint_value") == pl.col("checkpoint_value").max().over("config_name")
+        ).fill_null(True)
+    )
+    diagnostic_set = study.predictions.freeze(
+        diagnostic_rows,
+        name=f"us-equities-{label_name}-tsmixer-diagnostics-v1",
+    )
     set_rows = [
         {
-            "role": "backtest and diagnostic population",
+            "role": "backtest population",
             "set_name": full_set.name,
             "members": len(full_set.members),
-        }
+        },
+        {
+            "role": "bounded diagnostics",
+            "set_name": diagnostic_set.name,
+            "members": len(diagnostic_set.members),
+        },
     ]
 compatible_sets = pl.DataFrame(
     set_rows,
@@ -411,9 +438,10 @@ compatible_sets = pl.DataFrame(
 compatible_sets
 
 # %% [markdown]
-# `15_model_analysis.py` reopens the named set for descriptive analysis. `16_backtest.py` passes
-# every catalog row directly to the shared backtest runner. Model metrics do not choose a
-# configuration or checkpoint.
+# `15_model_analysis` reopens both names: the full set to confirm the run filled every member it
+# promised, and the diagnostic set to read raw predictions. `16_backtest` passes every full-set
+# catalog row to the shared backtest runner. Neither the metrics here nor the ones there choose a
+# configuration or a checkpoint; selection is on validation backtest Sharpe in `16_backtest`.
 
 # %% [markdown]
 # ## What to notice

--- a/case_studies/us_equities_panel/11_dl_tsmixer.py
+++ b/case_studies/us_equities_panel/11_dl_tsmixer.py
@@ -88,14 +88,17 @@
 # %%
 """Generate TSMixer validation predictions through the shared research interface."""
 
-import os
-from pathlib import Path
-
 import matplotlib.pyplot as plt
 import polars as pl
 import yaml
 
-from case_studies.research import open_study, plan_models
+from case_studies.research import (
+    candidate_set_supersedes,
+    open_study,
+    plan_models,
+    run_model_population,
+    supersedes_for_run,
+)
 from utils.modeling import load_configs
 from utils.paths import get_case_study_dir
 from utils.style import FIGSIZE, add_message_title, ml4t_palette, show_with_alt, zero_line
@@ -106,9 +109,12 @@ PRIMARY_LABEL = ""
 CONFIG_NAMES = []
 COMMON_OVERRIDES = {}
 CONFIG_OVERRIDES = {}
+POPULATION_NAME = ""
+SUPERSEDES_POPULATION = ""
+SUPERSEDES_SETS: dict = {}
 DEVICE = "cuda"
 EXECUTION_TIER = "canonical"
-WORKSPACE = "experiments"
+WORKSPACE = ""
 MAX_SYMBOLS = 0
 FOLD_IDS = []
 MAX_TRAIN_SEQUENCES = 0
@@ -175,6 +181,33 @@ menu = pl.DataFrame(
 )
 menu
 
+# %% [markdown]
+# A run that narrows the selection, overrides a parameter or fits on another device produces a
+# different set of predictions from the one the canonical name stands for. Publishing it under
+# that name would leave the name meaning two different member sets at two different times, so the
+# guard below requires such a run to say what to call its own population, and the frozen set names
+# in Section 6 are withheld from it for the same reason.
+
+# %%
+is_published_population = (
+    EXECUTION_TIER == "canonical"
+    and selected_names == published_names
+    and not COMMON_OVERRIDES
+    and not CONFIG_OVERRIDES
+    and DEVICE == "cuda"
+)
+if EXECUTION_TIER == "canonical" and not is_published_population and not POPULATION_NAME:
+    raise ValueError(
+        "this run narrows or overrides what the menu declares, so it cannot publish the canonical "
+        "population; pass POPULATION_NAME to give it its own"
+    )
+
+# %% [markdown]
+# Both tiers resolve the study through `open_study`. It reads the labels and features in place
+# and redirects only writes, so a preview run scores the same inputs a canonical one does and
+# cannot publish over it. A preview must be given a workspace to write into; a canonical run
+# leaves `WORKSPACE` empty and regenerates the case study's own artifacts in place.
+
 # %%
 preview_reductions = {}
 if MAX_SYMBOLS:
@@ -184,23 +217,7 @@ if FOLD_IDS:
 if MAX_TRAIN_SEQUENCES:
     preview_reductions["max_train_sequences"] = int(MAX_TRAIN_SEQUENCES)
 
-# Both tiers resolve the study through `open_study`. It reads the labels and features in place and
-# redirects only writes, so a preview run scores the same inputs a canonical one does and cannot
-# publish over it.
-if EXECUTION_TIER == "canonical":
-    if preview_reductions or PREVIEW_N_EPOCHS:
-        raise ValueError("Canonical execution cannot declare preview reductions")
-    study = open_study(CASE_STUDY_ID, execution_tier=EXECUTION_TIER)
-elif EXECUTION_TIER == "preview":
-    if not preview_reductions:
-        raise ValueError("Preview execution requires a data or fold reduction")
-    study = open_study(
-        CASE_STUDY_ID,
-        execution_tier=EXECUTION_TIER,
-        workspace=Path(os.environ.get("ML4T_OUTPUT_DIR") or WORKSPACE),
-    )
-else:
-    raise ValueError("EXECUTION_TIER must be 'canonical' or 'preview'")
+study = open_study(CASE_STUDY_ID, execution_tier=EXECUTION_TIER, workspace=WORKSPACE or None)
 
 # %% [markdown]
 # ## 2. Binding the declarations to the data
@@ -253,11 +270,6 @@ request_table
 
 # %%
 plan = plan_models(study, requests=requests)
-official_population = None
-if EXECUTION_TIER == "canonical":
-    official_population = plan.create_population(
-        name="us-equities-tsmixer-checkpoints-v1",
-    )
 
 planned_population = pl.DataFrame(
     {
@@ -271,8 +283,35 @@ planned_population = pl.DataFrame(
 )
 planned_population
 
+# %% [markdown]
+# `run_model_population` takes the plan, writes the population down, fits every member and then
+# checks that what came out is what was declared. The same call serves both tiers: a canonical run
+# registers an immutable population that the later notebooks bind to, and a preview run gets a
+# declaration that is verified and then discarded with its workspace, so no notebook here has to
+# branch on the tier to decide what to publish.
+#
+# `SUPERSEDES_POPULATION` names the population hash this run replaces. A population is a set of
+# prediction identities, so anything that moves a training identity - a changed preset as much as a
+# changed menu - produces a different population under the same name, and the registry refuses to
+# write it without being told which snapshot it supersedes. Leaving it empty is right for a first
+# run and for a reader's clean clone, and `supersedes_for_run` withholds a declared hash wherever
+# offering it would be refused.
+
 # %%
-execution = plan.run()
+population_name = POPULATION_NAME or "us-equities-tsmixer-checkpoints-v1"
+execution, official_population = run_model_population(
+    study,
+    plan,
+    population_name=population_name,
+    supersedes=supersedes_for_run(
+        study,
+        population_name=population_name,
+        declared=SUPERSEDES_POPULATION,
+        execution_tier=EXECUTION_TIER,
+    ),
+)
+
+print(f"population {official_population.name}: {len(official_population.members)} prediction sets")
 
 # %% [markdown]
 # ## 4. What was actually fitted
@@ -438,8 +477,6 @@ for run in execution.runs:
         )
 
 coverage_table = pl.DataFrame(coverage_rows).sort("config_name", "checkpoint")
-if official_population is not None:
-    official_population.require_complete()
 coverage_table
 
 # %%
@@ -457,8 +494,8 @@ execution_diagnostics
 #
 # The second is the **bounded diagnostic set**, and it is bounded hard.
 # [`15_model_analysis`](15_model_analysis.ipynb) loads every diagnostic member's raw prediction
-# frame and holds them all while it joins them pairwise; one frame on this panel is 7.2 million
-# rows and about 225 MB in memory, so a set that grew with the checkpoint count would not fit
+# frame and holds them all while it joins them pairwise; one frame on this panel is over seven
+# million rows and about 225 MB in memory, so a set that grew with the checkpoint count would not fit
 # beside the other seven families'. The bound is the last checkpoint of each published
 # configuration - one member here, because the menu declares one TSMixer configuration. The
 # epoch dimension is still read, in the learning-curve figure above, which is drawn from registry
@@ -466,18 +503,15 @@ execution_diagnostics
 
 # %% tags=["results"]
 set_rows = []
-is_published_population = (
-    EXECUTION_TIER == "canonical"
-    and selected_names == published_names
-    and not COMMON_OVERRIDES
-    and not CONFIG_OVERRIDES
-    and DEVICE == "cuda"
-)
 if is_published_population:
     label_name = label.replace("_", "-")
+    full_set_name = f"us-equities-{label_name}-tsmixer-v1"
     full_set = study.predictions.freeze(
         execution.catalog_rows,
-        name=f"us-equities-{label_name}-tsmixer-v1",
+        name=full_set_name,
+        supersedes=candidate_set_supersedes(
+            study, name=full_set_name, declared=SUPERSEDES_SETS.get(full_set_name, "")
+        ),
     )
     diagnostic_rows = execution.catalog_rows.filter(
         # `.fill_null(True)` covers a family that publishes no checkpoint value at all, where the
@@ -486,9 +520,13 @@ if is_published_population:
             pl.col("checkpoint_value") == pl.col("checkpoint_value").max().over("config_name")
         ).fill_null(True)
     )
+    diagnostic_set_name = f"us-equities-{label_name}-tsmixer-diagnostics-v1"
     diagnostic_set = study.predictions.freeze(
         diagnostic_rows,
-        name=f"us-equities-{label_name}-tsmixer-diagnostics-v1",
+        name=diagnostic_set_name,
+        supersedes=candidate_set_supersedes(
+            study, name=diagnostic_set_name, declared=SUPERSEDES_SETS.get(diagnostic_set_name, "")
+        ),
     )
     set_rows = [
         {

--- a/case_studies/us_equities_panel/11_dl_tsmixer.py
+++ b/case_studies/us_equities_panel/11_dl_tsmixer.py
@@ -125,7 +125,7 @@ PREVIEW_MAX_TRAIN_SEQUENCES = 0
 # The menu at `config/training/{label}.yaml` lists the sequence configurations declared for a
 # label, and this notebook takes the ones whose architecture is `tsmixer`. Each name resolves to a
 # preset holding the full parameter set - here a 60-session lookback, 100 epochs, a checkpoint
-# every 5, and a dropout of 0.1.
+# every 5, and dropout on the hidden units. The frame below prints the resolved values.
 #
 # What each setting a run may pass decides:
 #

--- a/case_studies/us_equities_panel/12_dl_weekly.ipynb
+++ b/case_studies/us_equities_panel/12_dl_weekly.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "f112a5f9",
+   "id": "50ee53cb",
    "metadata": {},
    "source": [
     "# US equities panel: predicting a week ahead instead of five days ahead\n",
@@ -75,7 +75,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b1bd5be4",
+   "id": "83d99e23",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -85,7 +85,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1ed1ba32",
+   "id": "7a3d8db7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -127,7 +127,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "35582366",
+   "id": "2a81aaa7",
    "metadata": {},
    "source": [
     "## The values a run can be given\n",
@@ -159,7 +159,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e79e1ed5",
+   "id": "f43f4f75",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -176,7 +176,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "73033003",
+   "id": "01cc2ed4",
    "metadata": {
     "tags": [
      "parameters"
@@ -196,7 +196,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4ab5066f",
+   "id": "42d526e8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -216,7 +216,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ffce8d62",
+   "id": "177158bc",
    "metadata": {},
    "source": [
     "## Load and Subsample to Weekly Frequency\n",
@@ -253,7 +253,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "99bbb40d",
+   "id": "f682061a",
    "metadata": {
     "tags": [
      "results"
@@ -306,7 +306,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "63e85287",
+   "id": "1b599354",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -391,7 +391,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c6bbe258",
+   "id": "82bcecf9",
    "metadata": {},
    "source": [
     "## Create Walk-Forward CV Splits\n",
@@ -412,7 +412,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "28633891",
+   "id": "7e12e169",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -460,7 +460,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9899f113",
+   "id": "3f38fbf6",
    "metadata": {},
    "source": [
     "## The identity these runs register under\n",
@@ -481,7 +481,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a32433f0",
+   "id": "7ff92d83",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -506,7 +506,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6c4e1ae2",
+   "id": "6b2c3a5c",
    "metadata": {},
    "source": [
     "## The direct-regression arm\n",
@@ -527,7 +527,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c250af84",
+   "id": "39992c61",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -562,7 +562,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8d9c3269",
+   "id": "8e7ddb26",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -597,7 +597,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "46a0f78d",
+   "id": "7997d38b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -609,7 +609,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0fa03efb",
+   "id": "ffa80733",
    "metadata": {},
    "source": [
     "## The forecasting arm\n",
@@ -630,7 +630,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ffd0e215",
+   "id": "cda54eb3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -662,7 +662,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fd6eb93b",
+   "id": "9fb783c4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -697,7 +697,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b07f0d55",
+   "id": "5c61bd4b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -708,7 +708,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7703ed4d",
+   "id": "4678b991",
    "metadata": {},
    "source": [
     "### What more training does to each formulation\n",
@@ -731,7 +731,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ac2c58d3",
+   "id": "e05ffd77",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -766,7 +766,7 @@
     "ax.legend(frameon=False, fontsize=7)\n",
     "add_message_title(\n",
     "    ax,\n",
-    "    \"Where each weekly model stops learning and starts fitting the window\",\n",
+    "    \"Mean validation IC against training epoch, weekly models\",\n",
     "    subtitle=\"Out-of-sample information coefficient against training epoch, one line per model\",\n",
     ")\n",
     "# The alt text reads the frame rather than asserting a shape, so a panel described as turning\n",
@@ -797,7 +797,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5f0e0df9",
+   "id": "af6bd286",
    "metadata": {},
    "source": [
     "## Reading the summary table\n",
@@ -838,7 +838,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "edbae559",
+   "id": "9d670a30",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -873,7 +873,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4e9abc72",
+   "id": "e153f40a",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/case_studies/us_equities_panel/12_dl_weekly.ipynb
+++ b/case_studies/us_equities_panel/12_dl_weekly.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "ce8f8a7e",
+   "id": "922224cb",
    "metadata": {},
    "source": [
     "# US equities panel: predicting a week ahead instead of five days ahead\n",
@@ -75,7 +75,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fe46a73e",
+   "id": "8726ba41",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -85,7 +85,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9373ac04",
+   "id": "662b38a8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -127,7 +127,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e6ee77f0",
+   "id": "05a8ff0b",
    "metadata": {},
    "source": [
     "## The values a run can be given\n",
@@ -159,7 +159,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bac539d6",
+   "id": "3a2effa4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -176,7 +176,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3a01a447",
+   "id": "9f994717",
    "metadata": {
     "tags": [
      "parameters"
@@ -196,7 +196,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f687c6e6",
+   "id": "23b6ddd9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -216,7 +216,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3db7740a",
+   "id": "22eb62aa",
    "metadata": {},
    "source": [
     "## Subsampling the panel to a Friday grid\n",
@@ -262,7 +262,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e235e96a",
+   "id": "e81e9f5f",
    "metadata": {
     "tags": [
      "results"
@@ -306,7 +306,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cc21eab9",
+   "id": "81738fde",
    "metadata": {},
    "source": [
     "The three parquet files are filtered to Fridays before anything is joined, because the full\n",
@@ -332,7 +332,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8ea6f1b6",
+   "id": "cf6f9ebf",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -398,7 +398,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "44bd19cc",
+   "id": "ada6b4a0",
    "metadata": {},
    "source": [
     "## The walk-forward folds this run is scored on\n",
@@ -419,7 +419,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "45383828",
+   "id": "5b2b22d3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -467,7 +467,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "45936118",
+   "id": "ee60a0ef",
    "metadata": {},
    "source": [
     "## The identity these runs register under\n",
@@ -488,7 +488,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d353ddbc",
+   "id": "5e9952a6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -513,7 +513,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6c8adf74",
+   "id": "25dc227b",
    "metadata": {},
    "source": [
     "## The direct-regression arm\n",
@@ -541,7 +541,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f209b415",
+   "id": "e5928813",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -571,7 +571,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "becbcf8f",
+   "id": "ad206db5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -606,7 +606,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ef6ec858",
+   "id": "55475d24",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -618,7 +618,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a064669e",
+   "id": "a22a5f9a",
    "metadata": {},
    "source": [
     "## The forecasting arm\n",
@@ -639,7 +639,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ee89a741",
+   "id": "3af667d9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -671,7 +671,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4b7a5774",
+   "id": "c761b78b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -706,7 +706,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "baf544d1",
+   "id": "e56f0dcf",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -717,7 +717,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b1ba33bd",
+   "id": "53e42a14",
    "metadata": {},
    "source": [
     "### What more training does to each formulation\n",
@@ -740,7 +740,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d13de525",
+   "id": "186ed10b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -806,7 +806,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ef1ebb1f",
+   "id": "128a78fc",
    "metadata": {},
    "source": [
     "## Reading the summary table\n",
@@ -847,7 +847,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "aed7fb26",
+   "id": "c8e7cc38",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -886,7 +886,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "022e1079",
+   "id": "5ba9ddd7",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/case_studies/us_equities_panel/12_dl_weekly.ipynb
+++ b/case_studies/us_equities_panel/12_dl_weekly.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "50ee53cb",
+   "id": "ce8f8a7e",
    "metadata": {},
    "source": [
     "# US equities panel: predicting a week ahead instead of five days ahead\n",
@@ -75,7 +75,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "83d99e23",
+   "id": "fe46a73e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -85,7 +85,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7a3d8db7",
+   "id": "9373ac04",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -127,7 +127,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2a81aaa7",
+   "id": "e6ee77f0",
    "metadata": {},
    "source": [
     "## The values a run can be given\n",
@@ -159,7 +159,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f43f4f75",
+   "id": "bac539d6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -176,7 +176,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "01cc2ed4",
+   "id": "3a01a447",
    "metadata": {
     "tags": [
      "parameters"
@@ -196,7 +196,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "42d526e8",
+   "id": "f687c6e6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -216,10 +216,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "177158bc",
+   "id": "3db7740a",
    "metadata": {},
    "source": [
-    "## Load and Subsample to Weekly Frequency\n",
+    "## Subsampling the panel to a Friday grid\n",
     "\n",
     "The daily features and labels are subsampled to Fridays, so `fwd_ret_5d` becomes a\n",
     "one-step-ahead target: each row's window runs to about the next row's date.\n",
@@ -237,9 +237,9 @@
     "The printed distribution is what says how far, and it is worth reading rather than assuming,\n",
     "because the length of an overlap is the size of the dependence it introduces.\n",
     "\n",
-    "This is worth describing rather than removing: sampling every fifth session instead would close\n",
-    "the overlap exactly and replace it with a grid that drifts across weekdays and a cadence nobody\n",
-    "trades.\n",
+    "The overlap is described rather than removed because the alternative that closes it exactly -\n",
+    "sampling every fifth session - drifts across weekdays and produces a cadence nobody trades. A\n",
+    "Friday grid is a week as a trader keeps it, and the price of that is the overlap counted above.\n",
     "\n",
     "What it costs is the mechanical autocorrelation an overlapping window induces, on the share of\n",
     "weeks the cell reports. That share is small enough to leave the one-step formulation intact and\n",
@@ -247,13 +247,22 @@
     "\n",
     "Non-overlap would not buy independence in any case. Returns cluster in volatility and share\n",
     "a market factor across the cross-section, so what non-overlap removes is the correlation the\n",
-    "construction itself imposes, not the dependence in the data."
+    "construction itself imposes, not the dependence in the data.\n",
+    "\n",
+    "The cell below counts how often each case occurs. Each Friday's window closes on the fifth\n",
+    "session after that Friday, and the question is where that session falls relative to the next\n",
+    "one. Zero is an exact fit;\n",
+    "a positive distance is an overlap of that many sessions; a negative one means the window closed\n",
+    "before the next Friday, which happens when that Friday is itself a holiday and the label file\n",
+    "carries no row for it. The whole distribution is reported rather than a single count, because\n",
+    "the size of an overlap is the size of the dependence it introduces. The session index comes\n",
+    "from the label file, so this is a statement about the data this notebook reads."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f682061a",
+   "id": "e235e96a",
    "metadata": {
     "tags": [
      "results"
@@ -261,9 +270,6 @@
    },
    "outputs": [],
    "source": [
-    "# Counted rather than asserted. Each Friday's window closes on the fifth session after it, and\n",
-    "# the question is where that session falls relative to the next Friday. Reading the session\n",
-    "# index off the label file is what keeps this a statement about the data the notebook uses.\n",
     "_sessions = (\n",
     "    pl.scan_parquet(CASE_DIR / \"labels\" / f\"{PRIMARY_LABEL}.parquet\")\n",
     "    .select(\"timestamp\")\n",
@@ -275,11 +281,6 @@
     ")\n",
     "_position = {session: index for index, session in enumerate(_sessions)}\n",
     "_fridays = [session for session in _sessions if session.weekday() == 4]\n",
-    "# The distance, in sessions, between where a Friday's window closes and the next Friday. Zero is\n",
-    "# an exact fit; positive is an overlap of that many sessions; negative means the window closed\n",
-    "# before the next Friday, which happens when that Friday is itself a holiday and the label file\n",
-    "# carries no row for it. The distribution is what gets reported, because the size of an overlap\n",
-    "# is the thing that matters and a single count cannot carry it.\n",
     "_gaps: dict[int, int] = {}\n",
     "for _this_friday, _next_friday in zip(_fridays, _fridays[1:]):\n",
     "    _close_index = _position[_this_friday] + LABEL_HORIZON_SESSIONS\n",
@@ -304,13 +305,37 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "cc21eab9",
+   "metadata": {},
+   "source": [
+    "The three parquet files are filtered to Fridays before anything is joined, because the full\n",
+    "daily join does not fit in memory on this panel.\n",
+    "\n",
+    "**`model_based.parquet` is keyed on `(symbol, timestamp)` alone.** Every estimate behind it is\n",
+    "bounded by a refit schedule rather than by a fold, so a stock-session carries one value whichever\n",
+    "fold reads it and the join multiplies nothing. Both properties are asserted rather than assumed:\n",
+    "a repeated key would fan every weekly observation out to one row per duplicate and leave the\n",
+    "sequence builder no fold it could form, which surfaces as \"No valid folds created\" several cells\n",
+    "later, a long way from the join that caused it.\n",
+    "\n",
+    "**The temporal columns are named in `feature_names`.** `prepare_fold_sequence_stores` builds its\n",
+    "`use_cols` from that list, so a column joined here and left out of it would be dropped again and\n",
+    "the model would train on the financial features alone without saying so.\n",
+    "\n",
+    "**A capped universe takes the stocks with the most rows**, ties broken by name. A sequence model\n",
+    "needs history - a stock that lists part-way through a fold contributes no complete lookback\n",
+    "window to it - and this is the rule every reduced notebook in the case study applies, so a capped\n",
+    "run here selects the same universe as a capped run elsewhere."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1b599354",
+   "id": "8ea6f1b6",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Load only weekly rows before materializing joins. The full daily join OOM-kills the kernel.\n",
     "print(\"Loading weekly features...\")\n",
     "weekly_filter = pl.col(\"timestamp\").dt.weekday() == 5\n",
     "\n",
@@ -328,15 +353,6 @@
     ")\n",
     "print(f\"  Weekly model-based features: {mb.shape[0]:,} rows, {mb.shape[1]} cols\")\n",
     "\n",
-    "# model_based.parquet is keyed on (symbol, timestamp): every estimate behind it is bounded by a\n",
-    "# refit schedule rather than by a fold, so a symbol-session carries one value whichever fold reads\n",
-    "# it and the join is a plain left join that multiplies nothing. `temporal_by_fold` is therefore\n",
-    "# None, which is what `load_modeling_dataset` passes on this shape too.\n",
-    "#\n",
-    "# The key's uniqueness is asserted rather than assumed. A repeat would fan every weekly\n",
-    "# observation out to one row per duplicate, leave duplicate timestamps per symbol, and give\n",
-    "# the sequence builder no fold it could form - which surfaces as \"No valid folds created\"\n",
-    "# several cells later, a long way from the join that caused it.\n",
     "assert mb.select(\"symbol\", \"timestamp\").is_duplicated().sum() == 0, (\n",
     "    \"model_based.parquet repeats a symbol and timestamp; the sequence builder would see \"\n",
     "    \"duplicate dates per symbol and create no folds\"\n",
@@ -350,10 +366,6 @@
     "temporal_feature_names = [c for c in mb.columns if c not in (\"symbol\", \"timestamp\")]\n",
     "temporal_by_fold = None\n",
     "features = feat.join(mb, on=[\"symbol\", \"timestamp\"], how=\"left\")\n",
-    "# prepare_fold_sequence_stores builds `use_cols` from feature_names, so a temporal column absent\n",
-    "# from this list is joined and then immediately dropped - the model would train on the financial\n",
-    "# features alone and report nothing about it. load_modeling_dataset carries its temporal names in\n",
-    "# feature_names for the same reason.\n",
     "feature_names = feat_cols + temporal_feature_names\n",
     "print(\n",
     "    f\"  Base features: {features.shape[0]:,} rows, {len(feat_cols)} financial \"\n",
@@ -371,11 +383,6 @@
     "del feat, mb, features, labels\n",
     "gc.collect()\n",
     "\n",
-    "# A capped universe takes the stocks with the most rows, ties broken by name. Taking the\n",
-    "# alphabetically first names instead would select on the spelling of a ticker rather than on how\n",
-    "# much history it carries, and a sequence model needs history: a stock that lists part-way through\n",
-    "# a fold contributes no complete lookback window to it. This is the rule every reduced notebook in\n",
-    "# the case study applies, so a capped run here selects the same universe as a capped run elsewhere.\n",
     "if MAX_SYMBOLS > 0:\n",
     "    dataset = reduce_to_top_entities(dataset, \"symbol\", MAX_SYMBOLS)\n",
     "    print(f\"  Filtered to {MAX_SYMBOLS} symbols: {dataset.shape[0]:,} rows\")\n",
@@ -391,10 +398,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "82bcecf9",
+   "id": "44bd19cc",
    "metadata": {},
    "source": [
-    "## Create Walk-Forward CV Splits\n",
+    "## The walk-forward folds this run is scored on\n",
     "\n",
     "The folds are the case study's own, resolved from the label file through\n",
     "`modeling_fold_boundaries` - the call [`04_model_based_features`](04_model_based_features.ipynb)\n",
@@ -412,7 +419,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7e12e169",
+   "id": "45383828",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -460,7 +467,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3f38fbf6",
+   "id": "45936118",
    "metadata": {},
    "source": [
     "## The identity these runs register under\n",
@@ -481,7 +488,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7ff92d83",
+   "id": "d353ddbc",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -506,7 +513,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6b2c3a5c",
+   "id": "6c8adf74",
    "metadata": {},
    "source": [
     "## The direct-regression arm\n",
@@ -521,21 +528,23 @@
     "the output.\n",
     "\n",
     "What comes out is used as a ranking signal across stocks on a date, not as a return forecast to\n",
-    "be believed at face value, which is why the scoring below is a rank correlation."
+    "be believed at face value, which is why the scoring below is a rank correlation.\n",
+    "\n",
+    "The two architectures are the ones [`09_dl_nlinear`](09_dl_nlinear.ipynb) and\n",
+    "[`10_dl_lstm`](10_dl_lstm.ipynb) fit, under a weekly schedule: twelve weekly observations rather\n",
+    "than sixty daily ones, and fifty epochs rather than a hundred. They keep the daily presets' names\n",
+    "because they are the same architectures, and the registry keeps the two apart anyway - the\n",
+    "lookback, the epoch count and the input lineage all sit inside the training identity, so a weekly\n",
+    "`lstm_h64` and a daily one are different rows."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "39992c61",
+   "id": "f209b415",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# The two architectures are the ones 09_dl_nlinear and 10_dl_lstm fit, under a weekly schedule:\n",
-    "# twelve weekly observations rather than sixty daily ones, and fifty epochs rather than a hundred.\n",
-    "# They keep the daily presets' names because they are the same architectures, and the registry\n",
-    "# keeps the two apart anyway - the lookback, the epoch count and the input lineage are all inside\n",
-    "# the training identity, so a weekly `lstm_h64` and a daily one are different rows.\n",
     "pytorch_configs = []\n",
     "for name, arch in [(\"lstm_h64\", \"lstm\"), (\"nlinear\", \"nlinear\")]:\n",
     "    cfg = {\n",
@@ -562,7 +571,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8e7ddb26",
+   "id": "becbcf8f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -597,7 +606,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7997d38b",
+   "id": "ef6ec858",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -609,7 +618,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ffa80733",
+   "id": "a064669e",
    "metadata": {},
    "source": [
     "## The forecasting arm\n",
@@ -630,7 +639,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cda54eb3",
+   "id": "ee89a741",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -662,7 +671,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9fb783c4",
+   "id": "4b7a5774",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -697,7 +706,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5c61bd4b",
+   "id": "baf544d1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -708,7 +717,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4678b991",
+   "id": "b1ba33bd",
    "metadata": {},
    "source": [
     "### What more training does to each formulation\n",
@@ -731,7 +740,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e05ffd77",
+   "id": "d13de525",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -797,7 +806,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "af6bd286",
+   "id": "ef1ebb1f",
    "metadata": {},
    "source": [
     "## Reading the summary table\n",
@@ -838,7 +847,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9d670a30",
+   "id": "aed7fb26",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -867,20 +876,20 @@
     ")\n",
     "\n",
     "results_df = pl.DataFrame(all_results).sort(\"ic\", descending=True).rename({\"ic\": \"best_ic\"})\n",
-    "display(results_df)"
+    "display(results_df)\n",
+    "\n",
+    "# The daily families are read through the registry's own accessors. The three tables this needs\n",
+    "# are exactly what `load_training_runs`, `load_prediction_sets` and `load_prediction_metrics`\n",
+    "# return, and `ic_mean_daily` is the mean the metrics table already holds."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e153f40a",
+   "id": "022e1079",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# The daily families through the registry's own accessors rather than a hand-written join: the\n",
-    "# three tables this needs are exactly what `load_training_runs`, `load_prediction_sets` and\n",
-    "# `load_prediction_metrics` return, and `ic_mean_daily` is the mean the metrics table already\n",
-    "# holds. A join written here would be a fourth copy of a schema that lives in one place.\n",
     "daily_runs = [\n",
     "    frame\n",
     "    for family in (\"linear\", \"gbm\", \"tabular_dl\")\n",

--- a/case_studies/us_equities_panel/12_dl_weekly.py
+++ b/case_studies/us_equities_panel/12_dl_weekly.py
@@ -437,7 +437,7 @@ for name, record in INPUT_LINEAGE["artifacts"].items():
 #
 # What comes out is used as a ranking signal across stocks on a date, not as a return forecast to
 # be believed at face value, which is why the scoring below is a rank correlation.
-
+#
 # The two architectures are the ones [`09_dl_nlinear`](09_dl_nlinear.ipynb) and
 # [`10_dl_lstm`](10_dl_lstm.ipynb) fit, under a weekly schedule: twelve weekly observations rather
 # than sixty daily ones, and fifty epochs rather than a hundred. They keep the daily presets' names

--- a/case_studies/us_equities_panel/12_dl_weekly.py
+++ b/case_studies/us_equities_panel/12_dl_weekly.py
@@ -179,7 +179,7 @@ PYTORCH_SAVE_DIR.mkdir(parents=True, exist_ok=True)
 DARTS_SAVE_DIR.mkdir(parents=True, exist_ok=True)
 
 # %% [markdown]
-# ## Load and Subsample to Weekly Frequency
+# ## Subsampling the panel to a Friday grid
 #
 # The daily features and labels are subsampled to Fridays, so `fwd_ret_5d` becomes a
 # one-step-ahead target: each row's window runs to about the next row's date.
@@ -197,9 +197,9 @@ DARTS_SAVE_DIR.mkdir(parents=True, exist_ok=True)
 # The printed distribution is what says how far, and it is worth reading rather than assuming,
 # because the length of an overlap is the size of the dependence it introduces.
 #
-# This is worth describing rather than removing: sampling every fifth session instead would close
-# the overlap exactly and replace it with a grid that drifts across weekdays and a cadence nobody
-# trades.
+# The overlap is described rather than removed because the alternative that closes it exactly -
+# sampling every fifth session - drifts across weekdays and produces a cadence nobody trades. A
+# Friday grid is a week as a trader keeps it, and the price of that is the overlap counted above.
 #
 # What it costs is the mechanical autocorrelation an overlapping window induces, on the share of
 # weeks the cell reports. That share is small enough to leave the one-step formulation intact and
@@ -208,11 +208,17 @@ DARTS_SAVE_DIR.mkdir(parents=True, exist_ok=True)
 # Non-overlap would not buy independence in any case. Returns cluster in volatility and share
 # a market factor across the cross-section, so what non-overlap removes is the correlation the
 # construction itself imposes, not the dependence in the data.
+#
+# The cell below counts how often each case occurs. Each Friday's window closes on the fifth
+# session after that Friday, and the question is where that session falls relative to the next
+# one. Zero is an exact fit;
+# a positive distance is an overlap of that many sessions; a negative one means the window closed
+# before the next Friday, which happens when that Friday is itself a holiday and the label file
+# carries no row for it. The whole distribution is reported rather than a single count, because
+# the size of an overlap is the size of the dependence it introduces. The session index comes
+# from the label file, so this is a statement about the data this notebook reads.
 
 # %% tags=["results"]
-# Counted rather than asserted. Each Friday's window closes on the fifth session after it, and
-# the question is where that session falls relative to the next Friday. Reading the session
-# index off the label file is what keeps this a statement about the data the notebook uses.
 _sessions = (
     pl.scan_parquet(CASE_DIR / "labels" / f"{PRIMARY_LABEL}.parquet")
     .select("timestamp")
@@ -224,11 +230,6 @@ _sessions = (
 )
 _position = {session: index for index, session in enumerate(_sessions)}
 _fridays = [session for session in _sessions if session.weekday() == 4]
-# The distance, in sessions, between where a Friday's window closes and the next Friday. Zero is
-# an exact fit; positive is an overlap of that many sessions; negative means the window closed
-# before the next Friday, which happens when that Friday is itself a holiday and the label file
-# carries no row for it. The distribution is what gets reported, because the size of an overlap
-# is the thing that matters and a single count cannot carry it.
 _gaps: dict[int, int] = {}
 for _this_friday, _next_friday in zip(_fridays, _fridays[1:]):
     _close_index = _position[_this_friday] + LABEL_HORIZON_SESSIONS
@@ -251,8 +252,27 @@ print("  distance in sessions from the close to the next Friday, and how often:"
 for _gap in sorted(_gaps):
     print(f"    {_gap:+d}: {_gaps[_gap]:,}")
 
+# %% [markdown]
+# The three parquet files are filtered to Fridays before anything is joined, because the full
+# daily join does not fit in memory on this panel.
+#
+# **`model_based.parquet` is keyed on `(symbol, timestamp)` alone.** Every estimate behind it is
+# bounded by a refit schedule rather than by a fold, so a stock-session carries one value whichever
+# fold reads it and the join multiplies nothing. Both properties are asserted rather than assumed:
+# a repeated key would fan every weekly observation out to one row per duplicate and leave the
+# sequence builder no fold it could form, which surfaces as "No valid folds created" several cells
+# later, a long way from the join that caused it.
+#
+# **The temporal columns are named in `feature_names`.** `prepare_fold_sequence_stores` builds its
+# `use_cols` from that list, so a column joined here and left out of it would be dropped again and
+# the model would train on the financial features alone without saying so.
+#
+# **A capped universe takes the stocks with the most rows**, ties broken by name. A sequence model
+# needs history - a stock that lists part-way through a fold contributes no complete lookback
+# window to it - and this is the rule every reduced notebook in the case study applies, so a capped
+# run here selects the same universe as a capped run elsewhere.
+
 # %%
-# Load only weekly rows before materializing joins. The full daily join OOM-kills the kernel.
 print("Loading weekly features...")
 weekly_filter = pl.col("timestamp").dt.weekday() == 5
 
@@ -270,15 +290,6 @@ mb = (
 )
 print(f"  Weekly model-based features: {mb.shape[0]:,} rows, {mb.shape[1]} cols")
 
-# model_based.parquet is keyed on (symbol, timestamp): every estimate behind it is bounded by a
-# refit schedule rather than by a fold, so a symbol-session carries one value whichever fold reads
-# it and the join is a plain left join that multiplies nothing. `temporal_by_fold` is therefore
-# None, which is what `load_modeling_dataset` passes on this shape too.
-#
-# The key's uniqueness is asserted rather than assumed. A repeat would fan every weekly
-# observation out to one row per duplicate, leave duplicate timestamps per symbol, and give
-# the sequence builder no fold it could form - which surfaces as "No valid folds created"
-# several cells later, a long way from the join that caused it.
 assert mb.select("symbol", "timestamp").is_duplicated().sum() == 0, (
     "model_based.parquet repeats a symbol and timestamp; the sequence builder would see "
     "duplicate dates per symbol and create no folds"
@@ -292,10 +303,6 @@ feat_cols = [c for c in feat.columns if c not in ("symbol", "timestamp")]
 temporal_feature_names = [c for c in mb.columns if c not in ("symbol", "timestamp")]
 temporal_by_fold = None
 features = feat.join(mb, on=["symbol", "timestamp"], how="left")
-# prepare_fold_sequence_stores builds `use_cols` from feature_names, so a temporal column absent
-# from this list is joined and then immediately dropped - the model would train on the financial
-# features alone and report nothing about it. load_modeling_dataset carries its temporal names in
-# feature_names for the same reason.
 feature_names = feat_cols + temporal_feature_names
 print(
     f"  Base features: {features.shape[0]:,} rows, {len(feat_cols)} financial "
@@ -313,11 +320,6 @@ dataset = features.join(labels, on=["symbol", "timestamp"], how="inner")
 del feat, mb, features, labels
 gc.collect()
 
-# A capped universe takes the stocks with the most rows, ties broken by name. Taking the
-# alphabetically first names instead would select on the spelling of a ticker rather than on how
-# much history it carries, and a sequence model needs history: a stock that lists part-way through
-# a fold contributes no complete lookback window to it. This is the rule every reduced notebook in
-# the case study applies, so a capped run here selects the same universe as a capped run elsewhere.
 if MAX_SYMBOLS > 0:
     dataset = reduce_to_top_entities(dataset, "symbol", MAX_SYMBOLS)
     print(f"  Filtered to {MAX_SYMBOLS} symbols: {dataset.shape[0]:,} rows")
@@ -331,7 +333,7 @@ del dataset
 gc.collect()
 
 # %% [markdown]
-# ## Create Walk-Forward CV Splits
+# ## The walk-forward folds this run is scored on
 #
 # The folds are the case study's own, resolved from the label file through
 # `modeling_fold_boundaries` - the call [`04_model_based_features`](04_model_based_features.ipynb)
@@ -436,12 +438,14 @@ for name, record in INPUT_LINEAGE["artifacts"].items():
 # What comes out is used as a ranking signal across stocks on a date, not as a return forecast to
 # be believed at face value, which is why the scoring below is a rank correlation.
 
+# The two architectures are the ones [`09_dl_nlinear`](09_dl_nlinear.ipynb) and
+# [`10_dl_lstm`](10_dl_lstm.ipynb) fit, under a weekly schedule: twelve weekly observations rather
+# than sixty daily ones, and fifty epochs rather than a hundred. They keep the daily presets' names
+# because they are the same architectures, and the registry keeps the two apart anyway - the
+# lookback, the epoch count and the input lineage all sit inside the training identity, so a weekly
+# `lstm_h64` and a daily one are different rows.
+
 # %%
-# The two architectures are the ones 09_dl_nlinear and 10_dl_lstm fit, under a weekly schedule:
-# twelve weekly observations rather than sixty daily ones, and fifty epochs rather than a hundred.
-# They keep the daily presets' names because they are the same architectures, and the registry
-# keeps the two apart anyway - the lookback, the epoch count and the input lineage are all inside
-# the training identity, so a weekly `lstm_h64` and a daily one are different rows.
 pytorch_configs = []
 for name, arch in [("lstm_h64", "lstm"), ("nlinear", "nlinear")]:
     cfg = {
@@ -711,11 +715,11 @@ all_results.append(
 results_df = pl.DataFrame(all_results).sort("ic", descending=True).rename({"ic": "best_ic"})
 display(results_df)
 
+# The daily families are read through the registry's own accessors. The three tables this needs
+# are exactly what `load_training_runs`, `load_prediction_sets` and `load_prediction_metrics`
+# return, and `ic_mean_daily` is the mean the metrics table already holds.
+
 # %%
-# The daily families through the registry's own accessors rather than a hand-written join: the
-# three tables this needs are exactly what `load_training_runs`, `load_prediction_sets` and
-# `load_prediction_metrics` return, and `ic_mean_daily` is the mean the metrics table already
-# holds. A join written here would be a fourth copy of a schema that lives in one place.
 daily_runs = [
     frame
     for family in ("linear", "gbm", "tabular_dl")

--- a/case_studies/us_equities_panel/12_dl_weekly.py
+++ b/case_studies/us_equities_panel/12_dl_weekly.py
@@ -620,7 +620,7 @@ ax.set_ylabel("Mean validation IC")
 ax.legend(frameon=False, fontsize=7)
 add_message_title(
     ax,
-    "Where each weekly model stops learning and starts fitting the window",
+    "Mean validation IC against training epoch, weekly models",
     subtitle="Out-of-sample information coefficient against training epoch, one line per model",
 )
 # The alt text reads the frame rather than asserting a shape, so a panel described as turning

--- a/case_studies/us_equities_panel/13_latent_factors.ipynb
+++ b/case_studies/us_equities_panel/13_latent_factors.ipynb
@@ -2,16 +2,8 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "9611e12a",
-   "metadata": {
-    "papermill": {
-     "duration": 0.003315,
-     "end_time": "2026-08-13T09:09:50.276135+00:00",
-     "exception": false,
-     "start_time": "2026-08-13T09:09:50.272820+00:00",
-     "status": "completed"
-    }
-   },
+   "id": "90e5479b",
+   "metadata": {},
    "source": [
     "# US equities panel: finding the few things three thousand stocks have in common\n",
     "\n",
@@ -65,23 +57,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
-   "id": "78c9c856",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-08-13T09:09:50.281722Z",
-     "iopub.status.busy": "2026-08-13T09:09:50.281458Z",
-     "iopub.status.idle": "2026-08-13T09:09:54.237240Z",
-     "shell.execute_reply": "2026-08-13T09:09:54.236690Z"
-    },
-    "papermill": {
-     "duration": 3.959331,
-     "end_time": "2026-08-13T09:09:54.237787+00:00",
-     "exception": false,
-     "start_time": "2026-08-13T09:09:50.278456+00:00",
-     "status": "completed"
-    }
-   },
+   "execution_count": null,
+   "id": "289b6d04",
+   "metadata": {},
    "outputs": [],
    "source": [
     "\"\"\"Reference index for the latent-factor execution notebooks.\"\"\"\n",
@@ -96,22 +74,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
-   "id": "3eb7a22b",
+   "execution_count": null,
+   "id": "822b5256",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-08-13T09:09:54.239806Z",
-     "iopub.status.busy": "2026-08-13T09:09:54.239554Z",
-     "iopub.status.idle": "2026-08-13T09:09:54.241723Z",
-     "shell.execute_reply": "2026-08-13T09:09:54.241325Z"
-    },
-    "papermill": {
-     "duration": 0.003487,
-     "end_time": "2026-08-13T09:09:54.241973+00:00",
-     "exception": false,
-     "start_time": "2026-08-13T09:09:54.238486+00:00",
-     "status": "completed"
-    },
     "tags": [
      "parameters"
     ]
@@ -125,16 +90,8 @@
   },
   {
    "cell_type": "markdown",
-   "id": "949cb1ed",
-   "metadata": {
-    "papermill": {
-     "duration": 0.000373,
-     "end_time": "2026-08-13T09:09:54.242874+00:00",
-     "exception": false,
-     "start_time": "2026-08-13T09:09:54.242501+00:00",
-     "status": "completed"
-    }
-   },
+   "id": "ea780606",
+   "metadata": {},
    "source": [
     "## What the two notebooks published\n",
     "\n",
@@ -154,32 +111,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
-   "id": "ef2588c9",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-08-13T09:09:54.244283Z",
-     "iopub.status.busy": "2026-08-13T09:09:54.244150Z",
-     "iopub.status.idle": "2026-08-13T09:09:54.268503Z",
-     "shell.execute_reply": "2026-08-13T09:09:54.268178Z"
-    },
-    "papermill": {
-     "duration": 0.025618,
-     "end_time": "2026-08-13T09:09:54.268916+00:00",
-     "exception": false,
-     "start_time": "2026-08-13T09:09:54.243298+00:00",
-     "status": "completed"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Result catalog ready for us_equities_panel: ResultsCatalog\n"
-     ]
-    }
-   ],
+   "execution_count": null,
+   "id": "88e47396",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "if EXECUTION_TIER == \"canonical\":\n",
     "    # `Study.open` with no workspace, not `open_study`: this notebook writes nothing, and that is\n",
@@ -218,16 +153,8 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8cae5575",
-   "metadata": {
-    "papermill": {
-     "duration": 0.000435,
-     "end_time": "2026-08-13T09:09:54.269986+00:00",
-     "exception": false,
-     "start_time": "2026-08-13T09:09:54.269551+00:00",
-     "status": "completed"
-    }
-   },
+   "id": "88c46131",
+   "metadata": {},
    "source": [
     "## What happens next\n",
     "\n",
@@ -243,7 +170,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9968abfc",
+   "id": "155cc214",
    "metadata": {},
    "source": [
     "## What to notice\n",
@@ -274,30 +201,6 @@
    "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.14.3"
-  },
-  "papermill": {
-   "default_parameters": {},
-   "duration": 5.944274,
-   "end_time": "2026-08-13T09:09:55.086461+00:00",
-   "environment_variables": {},
-   "exception": null,
-   "input_path": "case_studies/us_equities_panel/13_latent_factors.ipynb",
-   "output_path": "case_studies/us_equities_panel/13_latent_factors.ipynb",
-   "parameters": {},
-   "start_time": "2026-08-13T09:09:49.142187+00:00",
-   "version": "2.7.0"
   }
  },
  "nbformat": 4,

--- a/case_studies/us_equities_panel/13a_pca.ipynb
+++ b/case_studies/us_equities_panel/13a_pca.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "cd1decdd",
+   "id": "08e31bf5",
    "metadata": {},
    "source": [
     "# US equities panel: the few movements the whole panel shares\n",
@@ -55,7 +55,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ea94c169",
+   "id": "23cf0e0f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -64,18 +64,20 @@
     "import os\n",
     "from pathlib import Path\n",
     "\n",
+    "import matplotlib.pyplot as plt\n",
     "import polars as pl\n",
     "import yaml\n",
     "\n",
     "from case_studies.research import open_study, plan_models\n",
     "from utils.modeling import load_configs\n",
-    "from utils.paths import get_case_study_dir"
+    "from utils.paths import get_case_study_dir\n",
+    "from utils.style import FIGSIZE, add_message_title, ml4t_palette, show_with_alt, zero_line"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "294272a9",
+   "id": "8e03045c",
    "metadata": {
     "tags": [
      "parameters"
@@ -95,7 +97,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b564d23e",
+   "id": "9c817461",
    "metadata": {},
    "source": [
     "## 1. Which labels, and how many factors\n",
@@ -121,7 +123,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0bc1d729",
+   "id": "43550338",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -163,7 +165,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6ad2afe3",
+   "id": "431da7e1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -196,7 +198,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4a46d5d5",
+   "id": "9f6ce99e",
    "metadata": {},
    "source": [
     "## 2. Binding the declarations to the data\n",
@@ -213,7 +215,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5062b162",
+   "id": "c444ece3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -247,7 +249,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3503da5f",
+   "id": "35b20be6",
    "metadata": {},
    "source": [
     "## 3. Planning, then fitting\n",
@@ -266,7 +268,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bd95c633",
+   "id": "779ecb79",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -293,7 +295,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c18595fb",
+   "id": "e1269b27",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -302,7 +304,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5bcacc95",
+   "id": "0f80fd94",
    "metadata": {},
    "source": [
     "## 4. What was actually fitted\n",
@@ -317,7 +319,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9360d8cb",
+   "id": "69ca1aea",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -343,7 +345,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d12dae35",
+   "id": "14ef20bd",
    "metadata": {},
    "source": [
     "## 5. What came out\n",
@@ -361,7 +363,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "11fd3bb9",
+   "id": "58303fc8",
    "metadata": {
     "tags": [
      "results"
@@ -391,7 +393,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b54c729e",
+   "id": "88606e3e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -425,7 +427,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5e9931d2",
+   "id": "70d622de",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -435,7 +437,81 @@
   },
   {
    "cell_type": "markdown",
-   "id": "35e68bbf",
+   "id": "ef27ed33",
+   "metadata": {},
+   "source": [
+    "### How the ranking held across the walk-forward folds\n",
+    "\n",
+    "The headline information coefficient above is an average over the folds, and an average says\n",
+    "nothing about whether the folds agreed. Each fold is a different year of the market with a\n",
+    "different set of names quoting in it, so a factor model can rank the cross-section well in a few\n",
+    "of them and not at all in the rest and still show a respectable mean.\n",
+    "\n",
+    "The per-fold values come from the registry rather than from the raw predictions: each fold's\n",
+    "information coefficient is registered alongside the prediction set, so reading it back costs a\n",
+    "query rather than a 7.2-million-row load. A model built only from what a stock shares with\n",
+    "the panel has no name-specific information to fall back on, so a fold where the panel moved\n",
+    "together for reasons the factors did not capture is where this one has least to say."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4a34ae3a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fold_rows = []\n",
+    "for run in execution.runs:\n",
+    "    run_label = run.training.spec()[\"label\"]\n",
+    "    for prediction in run.predictions:\n",
+    "        fold_rows.append(prediction.folds().with_columns(label=pl.lit(run_label)))\n",
+    "folds_frame = pl.concat(fold_rows, how=\"vertical_relaxed\").sort(\"label\", \"fold_id\")\n",
+    "\n",
+    "fold_labels = folds_frame.get_column(\"label\").unique(maintain_order=True).to_list()\n",
+    "# `ml4t_palette` returns a list of that many colours, so it is called once and indexed.\n",
+    "palette = ml4t_palette(len(fold_labels), categorical=True)\n",
+    "\n",
+    "fig, ax = plt.subplots(figsize=FIGSIZE[\"single\"])\n",
+    "for index, fold_label in enumerate(fold_labels):\n",
+    "    series = folds_frame.filter(pl.col(\"label\") == fold_label)\n",
+    "    ax.plot(\n",
+    "        series.get_column(\"fold_id\"),\n",
+    "        series.get_column(\"ic\"),\n",
+    "        marker=\"o\",\n",
+    "        markersize=4,\n",
+    "        lw=1.4,\n",
+    "        color=palette[index],\n",
+    "        label=fold_label,\n",
+    "    )\n",
+    "zero_line(ax)\n",
+    "ax.set_xlabel(\"Walk-forward fold\")\n",
+    "ax.set_ylabel(\"Mean validation IC\")\n",
+    "ax.legend(fontsize=8, frameon=False)\n",
+    "add_message_title(\n",
+    "    ax,\n",
+    "    \"Mean validation IC by walk-forward fold\",\n",
+    "    subtitle=\"One line per declared label, over the folds the evaluation stage established\",\n",
+    ")\n",
+    "# The alt text counts rather than asserts: how many folds land above zero is a fact about the\n",
+    "# frame, and a line described as steady when it is not is a claim the data refutes.\n",
+    "_signs = (\n",
+    "    folds_frame.group_by(\"label\").agg(above=(pl.col(\"ic\") > 0).sum(), total=pl.len()).sort(\"label\")\n",
+    ")\n",
+    "_sign_text = \" and \".join(\n",
+    "    f\"{row['above']} of {row['total']} for {row['label']}\" for row in _signs.iter_rows(named=True)\n",
+    ")\n",
+    "show_with_alt(\n",
+    "    fig,\n",
+    "    \"A line chart of mean validation information coefficient against walk-forward fold, one line \"\n",
+    "    \"per declared label, with a dashed line at zero. Counted from the underlying frame, the folds \"\n",
+    "    f\"whose information coefficient is above zero are {_sign_text}.\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cb4bc6d7",
    "metadata": {},
    "source": [
     "## 6. Naming the sets the later notebooks open\n",
@@ -457,7 +533,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "27e4732e",
+   "id": "48056258",
    "metadata": {
     "tags": [
      "results"
@@ -504,7 +580,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e3f491bf",
+   "id": "77471319",
    "metadata": {},
    "source": [
     "`15_model_analysis` reopens both names per label: the full set to confirm the run filled every\n",
@@ -516,7 +592,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "87d6b977",
+   "id": "f481a1ec",
    "metadata": {},
    "source": [
     "## What to notice\n",

--- a/case_studies/us_equities_panel/13a_pca.ipynb
+++ b/case_studies/us_equities_panel/13a_pca.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "08e31bf5",
+   "id": "21d1a838",
    "metadata": {},
    "source": [
     "# US equities panel: the few movements the whole panel shares\n",
@@ -55,20 +55,23 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "23cf0e0f",
+   "id": "e15bd2b6",
    "metadata": {},
    "outputs": [],
    "source": [
     "\"\"\"Generate PCA validation predictions through the shared research interface.\"\"\"\n",
     "\n",
-    "import os\n",
-    "from pathlib import Path\n",
-    "\n",
     "import matplotlib.pyplot as plt\n",
     "import polars as pl\n",
     "import yaml\n",
     "\n",
-    "from case_studies.research import open_study, plan_models\n",
+    "from case_studies.research import (\n",
+    "    candidate_set_supersedes,\n",
+    "    open_study,\n",
+    "    plan_models,\n",
+    "    run_model_population,\n",
+    "    supersedes_for_run,\n",
+    ")\n",
     "from utils.modeling import load_configs\n",
     "from utils.paths import get_case_study_dir\n",
     "from utils.style import FIGSIZE, add_message_title, ml4t_palette, show_with_alt, zero_line"
@@ -77,7 +80,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8e03045c",
+   "id": "afbab95b",
    "metadata": {
     "tags": [
      "parameters"
@@ -88,8 +91,11 @@
     "CASE_STUDY_ID = \"us_equities_panel\"\n",
     "LABELS = []\n",
     "OVERRIDES = {}\n",
+    "POPULATION_NAME = \"\"\n",
+    "SUPERSEDES_POPULATION = \"\"\n",
+    "SUPERSEDES_SETS: dict = {}\n",
     "EXECUTION_TIER = \"canonical\"\n",
-    "WORKSPACE = \"experiments\"\n",
+    "WORKSPACE = \"\"\n",
     "MAX_SYMBOLS = 0\n",
     "FOLD_IDS = []\n",
     "PREVIEW_N_FACTORS = 0"
@@ -97,7 +103,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9c817461",
+   "id": "6eb9e24a",
    "metadata": {},
    "source": [
     "## 1. Which labels, and how many factors\n",
@@ -123,7 +129,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "43550338",
+   "id": "63f5aaf2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -163,9 +169,49 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "e7c7ba8c",
+   "metadata": {},
+   "source": [
+    "A run that narrows the labels or overrides a parameter produces a different set of predictions\n",
+    "from the one the canonical name stands for. Publishing it under that name would leave the name\n",
+    "meaning two different member sets at two different times, so the guard below requires such a run\n",
+    "to say what to call its own population, and the frozen set names in Section 6 are withheld from\n",
+    "it for the same reason."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "id": "431da7e1",
+   "id": "2982b06d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "is_published_population = (\n",
+    "    EXECUTION_TIER == \"canonical\" and selected_labels == published_labels and not OVERRIDES\n",
+    ")\n",
+    "if EXECUTION_TIER == \"canonical\" and not is_published_population and not POPULATION_NAME:\n",
+    "    raise ValueError(\n",
+    "        \"this run narrows the declared labels or overrides a parameter, so it cannot publish the \"\n",
+    "        \"canonical population; pass POPULATION_NAME to give it its own\"\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0fb78b78",
+   "metadata": {},
+   "source": [
+    "Both tiers resolve the study through `open_study`. It reads the labels and features in place\n",
+    "and redirects only writes, so a preview run scores the same inputs a canonical one does and\n",
+    "cannot publish over it. A preview must be given a workspace to write into; a canonical run\n",
+    "leaves `WORKSPACE` empty and regenerates the case study's own artifacts in place."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3f8af837",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -177,28 +223,12 @@
     "if PREVIEW_N_FACTORS:\n",
     "    preview_reductions[\"n_factors\"] = int(PREVIEW_N_FACTORS)\n",
     "\n",
-    "# Both tiers resolve the study through `open_study`. It reads the labels and features in place and\n",
-    "# redirects only writes, so a preview run scores the same inputs a canonical one does and cannot\n",
-    "# publish over it.\n",
-    "if EXECUTION_TIER == \"canonical\":\n",
-    "    if preview_reductions:\n",
-    "        raise ValueError(\"Canonical execution cannot declare preview reductions\")\n",
-    "    study = open_study(CASE_STUDY_ID, execution_tier=EXECUTION_TIER)\n",
-    "elif EXECUTION_TIER == \"preview\":\n",
-    "    if not preview_reductions:\n",
-    "        raise ValueError(\"Preview execution requires at least one declared reduction\")\n",
-    "    study = open_study(\n",
-    "        CASE_STUDY_ID,\n",
-    "        execution_tier=EXECUTION_TIER,\n",
-    "        workspace=Path(os.environ.get(\"ML4T_OUTPUT_DIR\") or WORKSPACE),\n",
-    "    )\n",
-    "else:\n",
-    "    raise ValueError(\"EXECUTION_TIER must be 'canonical' or 'preview'\")"
+    "study = open_study(CASE_STUDY_ID, execution_tier=EXECUTION_TIER, workspace=WORKSPACE or None)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "9f6ce99e",
+   "id": "6465520a",
    "metadata": {},
    "source": [
     "## 2. Binding the declarations to the data\n",
@@ -215,7 +245,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c444ece3",
+   "id": "cbac0914",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -249,7 +279,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "35b20be6",
+   "id": "fe5de638",
    "metadata": {},
    "source": [
     "## 3. Planning, then fitting\n",
@@ -268,16 +298,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "779ecb79",
+   "id": "fe887a34",
    "metadata": {},
    "outputs": [],
    "source": [
     "plan = plan_models(study, requests=requests)\n",
-    "official_population = None\n",
-    "if EXECUTION_TIER == \"canonical\":\n",
-    "    official_population = plan.create_population(\n",
-    "        name=\"us-equities-pca-checkpoints-v1\",\n",
-    "    )\n",
     "\n",
     "planned_population = pl.DataFrame(\n",
     "    {\n",
@@ -293,18 +318,50 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "27246f5a",
+   "metadata": {},
+   "source": [
+    "`run_model_population` takes the plan, writes the population down, fits every member and then\n",
+    "checks that what came out is what was declared. The same call serves both tiers: a canonical run\n",
+    "registers an immutable population that the later notebooks bind to, and a preview run gets a\n",
+    "declaration that is verified and then discarded with its workspace, so no notebook here has to\n",
+    "branch on the tier to decide what to publish.\n",
+    "\n",
+    "`SUPERSEDES_POPULATION` names the population hash this run replaces. A population is a set of\n",
+    "prediction identities, so anything that moves a training identity - a changed preset as much as a\n",
+    "changed menu - produces a different population under the same name, and the registry refuses to\n",
+    "write it without being told which snapshot it supersedes. Leaving it empty is right for a first\n",
+    "run and for a reader's clean clone, and `supersedes_for_run` withholds a declared hash wherever\n",
+    "offering it would be refused."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e1269b27",
+   "id": "12cda7b6",
    "metadata": {},
    "outputs": [],
    "source": [
-    "execution = plan.run()"
+    "population_name = POPULATION_NAME or \"us-equities-pca-checkpoints-v1\"\n",
+    "execution, official_population = run_model_population(\n",
+    "    study,\n",
+    "    plan,\n",
+    "    population_name=population_name,\n",
+    "    supersedes=supersedes_for_run(\n",
+    "        study,\n",
+    "        population_name=population_name,\n",
+    "        declared=SUPERSEDES_POPULATION,\n",
+    "        execution_tier=EXECUTION_TIER,\n",
+    "    ),\n",
+    ")\n",
+    "\n",
+    "print(f\"population {official_population.name}: {len(official_population.members)} prediction sets\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "0f80fd94",
+   "id": "5ad9c71a",
    "metadata": {},
    "source": [
     "## 4. What was actually fitted\n",
@@ -319,7 +376,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "69ca1aea",
+   "id": "5da22d9a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -345,7 +402,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "14ef20bd",
+   "id": "eceb17a5",
    "metadata": {},
    "source": [
     "## 5. What came out\n",
@@ -363,7 +420,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "58303fc8",
+   "id": "62a1d55a",
    "metadata": {
     "tags": [
      "results"
@@ -393,7 +450,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "88606e3e",
+   "id": "a7ca3366",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -419,15 +476,13 @@
     "        )\n",
     "\n",
     "coverage_table = pl.DataFrame(coverage_rows).sort(\"label\", \"prediction_hash\")\n",
-    "if official_population is not None:\n",
-    "    official_population.require_complete()\n",
     "coverage_table"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "70d622de",
+   "id": "d33c779b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -437,7 +492,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ef27ed33",
+   "id": "2d6d1b93",
    "metadata": {},
    "source": [
     "### How the ranking held across the walk-forward folds\n",
@@ -449,7 +504,7 @@
     "\n",
     "The per-fold values come from the registry rather than from the raw predictions: each fold's\n",
     "information coefficient is registered alongside the prediction set, so reading it back costs a\n",
-    "query rather than a 7.2-million-row load. A model built only from what a stock shares with\n",
+    "query rather than a seven-million-row load. A model built only from what a stock shares with\n",
     "the panel has no name-specific information to fall back on, so a fold where the panel moved\n",
     "together for reasons the factors did not capture is where this one has least to say."
    ]
@@ -457,7 +512,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4a34ae3a",
+   "id": "f47fabc4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -511,7 +566,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cb4bc6d7",
+   "id": "3322c678",
    "metadata": {},
    "source": [
     "## 6. Naming the sets the later notebooks open\n",
@@ -533,7 +588,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "48056258",
+   "id": "73b177d0",
    "metadata": {
     "tags": [
      "results"
@@ -542,20 +597,27 @@
    "outputs": [],
    "source": [
     "set_rows = []\n",
-    "is_published_population = (\n",
-    "    EXECUTION_TIER == \"canonical\" and selected_labels == published_labels and not OVERRIDES\n",
-    ")\n",
     "if is_published_population:\n",
     "    for selected_label in selected_labels:\n",
     "        label_name = selected_label.replace(\"_\", \"-\")\n",
     "        label_rows = execution.catalog_rows.filter(pl.col(\"label\") == selected_label)\n",
+    "        full_set_name = f\"us-equities-{label_name}-pca-v1\"\n",
     "        full_set = study.predictions.freeze(\n",
     "            label_rows,\n",
-    "            name=f\"us-equities-{label_name}-pca-v1\",\n",
+    "            name=full_set_name,\n",
+    "            supersedes=candidate_set_supersedes(\n",
+    "                study, name=full_set_name, declared=SUPERSEDES_SETS.get(full_set_name, \"\")\n",
+    "            ),\n",
     "        )\n",
+    "        diagnostic_set_name = f\"us-equities-{label_name}-pca-diagnostics-v1\"\n",
     "        diagnostic_set = study.predictions.freeze(\n",
     "            label_rows,\n",
-    "            name=f\"us-equities-{label_name}-pca-diagnostics-v1\",\n",
+    "            name=diagnostic_set_name,\n",
+    "            supersedes=candidate_set_supersedes(\n",
+    "                study,\n",
+    "                name=diagnostic_set_name,\n",
+    "                declared=SUPERSEDES_SETS.get(diagnostic_set_name, \"\"),\n",
+    "            ),\n",
     "        )\n",
     "        set_rows.extend(\n",
     "            [\n",
@@ -580,7 +642,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "77471319",
+   "id": "a7275f50",
    "metadata": {},
    "source": [
     "`15_model_analysis` reopens both names per label: the full set to confirm the run filled every\n",
@@ -592,7 +654,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f481a1ec",
+   "id": "a6bc4243",
    "metadata": {},
    "source": [
     "## What to notice\n",

--- a/case_studies/us_equities_panel/13a_pca.ipynb
+++ b/case_studies/us_equities_panel/13a_pca.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "1567f2ea",
+   "id": "cd1decdd",
    "metadata": {},
    "source": [
     "# US equities panel: the few movements the whole panel shares\n",
@@ -54,16 +54,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
-   "id": "68ed9be7",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-04-28T01:42:39.291996Z",
-     "iopub.status.busy": "2026-04-28T01:42:39.291891Z",
-     "iopub.status.idle": "2026-04-28T01:42:41.783569Z",
-     "shell.execute_reply": "2026-04-28T01:42:41.783003Z"
-    }
-   },
+   "execution_count": null,
+   "id": "ea94c169",
+   "metadata": {},
    "outputs": [],
    "source": [
     "\"\"\"Generate PCA validation predictions through the shared research interface.\"\"\"\n",
@@ -81,15 +74,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
-   "id": "05d61460",
+   "execution_count": null,
+   "id": "294272a9",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-04-28T01:42:41.786709Z",
-     "iopub.status.busy": "2026-04-28T01:42:41.786621Z",
-     "iopub.status.idle": "2026-04-28T01:42:41.788299Z",
-     "shell.execute_reply": "2026-04-28T01:42:41.788082Z"
-    },
     "tags": [
      "parameters"
     ]
@@ -108,7 +95,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cf8aafa6",
+   "id": "b564d23e",
    "metadata": {},
    "source": [
     "## 1. Which labels, and how many factors\n",
@@ -133,31 +120,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
-   "id": "c223d192",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-04-28T01:42:41.792681Z",
-     "iopub.status.busy": "2026-04-28T01:42:41.792622Z",
-     "iopub.status.idle": "2026-04-28T01:42:47.846485Z",
-     "shell.execute_reply": "2026-04-28T01:42:47.846013Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Case study: us_equities_panel\n",
-      "Model: pca\n",
-      "Primary label: fwd_ret_1d\n",
-      "Variant labels: ['fwd_ret_5d', 'fwd_ret_21d']\n",
-      "Dataset rows: 9,205,450\n",
-      "Features: 72\n",
-      "Splits: 16\n"
-     ]
-    }
-   ],
+   "execution_count": null,
+   "id": "0bc1d729",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "case_dir = get_case_study_dir(CASE_STUDY_ID)\n",
     "setup = yaml.safe_load((case_dir / \"config\" / \"setup.yaml\").read_text())\n",
@@ -197,7 +163,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9a0cdf58",
+   "id": "6ad2afe3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -230,7 +196,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "93ae98f2",
+   "id": "4a46d5d5",
    "metadata": {},
    "source": [
     "## 2. Binding the declarations to the data\n",
@@ -246,285 +212,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
-   "id": "b5c679c6",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-04-28T01:42:47.850165Z",
-     "iopub.status.busy": "2026-04-28T01:42:47.850089Z",
-     "iopub.status.idle": "2026-04-28T01:57:03.243423Z",
-     "shell.execute_reply": "2026-04-28T01:57:03.242928Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Latent factor CV: 1 models × 16 folds\n",
-      "Log file: case_studies/us_equities_panel/run_log/latent_factors.log\n",
-      "Scoring: dates=rebalance cadence=daily_close step=1 checkpoint_selection=fixed reporting_epoch=last\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  pca (K=5):\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    Fold 0: ragged train=2519, val=252, max_N=2684\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 0: reported_epoch=0, IC=-0.0226, 15.5s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    Fold 1: ragged train=2519, val=252, max_N=2684\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 1: reported_epoch=0, IC=-0.0080, 15.4s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    Fold 2: ragged train=2519, val=252, max_N=2534\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 2: reported_epoch=0, IC=+0.0040, 14.5s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    Fold 3: ragged train=2519, val=252, max_N=2184\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 3: reported_epoch=0, IC=+0.0057, 12.8s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    Fold 4: ragged train=2519, val=252, max_N=2140\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 4: reported_epoch=0, IC=+0.0084, 10.7s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    Fold 5: ragged train=2519, val=252, max_N=2026\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 5: reported_epoch=0, IC=-0.0012, 9.8s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    Fold 6: ragged train=2519, val=252, max_N=1991\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 6: reported_epoch=0, IC=+0.0049, 8.7s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    Fold 7: ragged train=2519, val=252, max_N=1991\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 7: reported_epoch=0, IC=-0.0132, 6.9s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    Fold 8: ragged train=2519, val=252, max_N=1991\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 8: reported_epoch=0, IC=+0.0044, 5.4s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    Fold 9: ragged train=2519, val=252, max_N=1832\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 9: reported_epoch=0, IC=+0.0002, 4.4s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    Fold 10: ragged train=2519, val=252, max_N=1652\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 10: reported_epoch=0, IC=-0.0075, 3.1s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    Fold 11: ragged train=2519, val=252, max_N=1486\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 11: reported_epoch=0, IC=-0.0353, 2.4s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    Fold 12: ragged train=2519, val=252, max_N=1323\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 12: reported_epoch=0, IC=+0.0081, 1.8s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    Fold 13: ragged train=2519, val=252, max_N=1127\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 13: reported_epoch=0, IC=+0.0043, 1.3s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    Fold 14: ragged train=2519, val=252, max_N=1084\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 14: reported_epoch=0, IC=-0.0212, 0.9s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    Fold 15: ragged train=2493, val=252, max_N=987\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 15: reported_epoch=0, IC=-0.0082, 0.6s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    -> best epoch=0, IC=-0.0048 (853.7s)\n",
-      "  Best: pca (IC=-0.0048)\n",
-      "[{'model_name': 'pca', 'mean_ic': -0.0048, 'best_epoch': 0, 'n_folds': 16, 'elapsed_s': 853.7, 'started_at': '2026-04-28T01:42:48.132794+00:00'}]\n",
-      "shape: (16, 6)\n",
-      "┌─────────┬───────┬─────────┬─────────┬────────┬────────────────┐\n",
-      "│ fold_id ┆ epoch ┆ ic_mean ┆ n_train ┆ n_test ┆ n_scored_dates │\n",
-      "│ ---     ┆ ---   ┆ ---     ┆ ---     ┆ ---    ┆ ---            │\n",
-      "│ i64     ┆ i64   ┆ f64     ┆ i64     ┆ i64    ┆ i64            │\n",
-      "╞═════════╪═══════╪═════════╪═════════╪════════╪════════════════╡\n",
-      "│ 0       ┆ 0     ┆ -0.0226 ┆ 2506    ┆ 252    ┆ 252            │\n",
-      "│ 1       ┆ 0     ┆ -0.008  ┆ 2510    ┆ 248    ┆ 248            │\n",
-      "│ 2       ┆ 0     ┆ 0.004   ┆ 2513    ┆ 249    ┆ 249            │\n",
-      "│ 3       ┆ 0     ┆ 0.0057  ┆ 2519    ┆ 246    ┆ 246            │\n",
-      "│ 4       ┆ 0     ┆ 0.0084  ┆ 2519    ┆ 252    ┆ 252            │\n",
-      "│ …       ┆ …     ┆ …       ┆ …       ┆ …      ┆ …              │\n",
-      "│ 11      ┆ 0     ┆ -0.0353 ┆ 2519    ┆ 252    ┆ 252            │\n",
-      "│ 12      ┆ 0     ┆ 0.0081  ┆ 2519    ┆ 252    ┆ 252            │\n",
-      "│ 13      ┆ 0     ┆ 0.0043  ┆ 2519    ┆ 252    ┆ 252            │\n",
-      "│ 14      ┆ 0     ┆ -0.0212 ┆ 2519    ┆ 252    ┆ 251            │\n",
-      "│ 15      ┆ 0     ┆ -0.0082 ┆ 2493    ┆ 252    ┆ 252            │\n",
-      "└─────────┴───────┴─────────┴─────────┴────────┴────────────────┘\n"
-     ]
-    }
-   ],
+   "execution_count": null,
+   "id": "5062b162",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "requests = tuple(\n",
     "    study.model(\n",
@@ -556,7 +247,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c012ce7f",
+   "id": "3503da5f",
    "metadata": {},
    "source": [
     "## 3. Planning, then fitting\n",
@@ -574,504 +265,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
-   "id": "0bbb8f9c",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-04-28T01:57:03.246715Z",
-     "iopub.status.busy": "2026-04-28T01:57:03.246612Z",
-     "iopub.status.idle": "2026-04-28T02:25:42.157439Z",
-     "shell.execute_reply": "2026-04-28T02:25:42.156752Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Latent factor CV: 1 models × 16 folds\n",
-      "Log file: case_studies/us_equities_panel/run_log/latent_factors.log\n",
-      "Scoring: dates=rebalance cadence=daily_close step=5 checkpoint_selection=fixed reporting_epoch=last\n",
-      "  pca (K=5):\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    Fold 0: ragged train=2515, val=252, max_N=2678\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 0: reported_epoch=0, IC=+0.0506, 15.3s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    Fold 1: ragged train=2515, val=252, max_N=2678\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 1: reported_epoch=0, IC=+0.0257, 14.1s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    Fold 2: ragged train=2515, val=252, max_N=2534\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 2: reported_epoch=0, IC=-0.0124, 13.4s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    Fold 3: ragged train=2515, val=252, max_N=2184\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 3: reported_epoch=0, IC=-0.0003, 12.3s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    Fold 4: ragged train=2515, val=252, max_N=2140\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 4: reported_epoch=0, IC=+0.0016, 10.7s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    Fold 5: ragged train=2515, val=252, max_N=2026\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 5: reported_epoch=0, IC=+0.0104, 9.6s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    Fold 6: ragged train=2515, val=252, max_N=1990\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 6: reported_epoch=0, IC=-0.0024, 8.7s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    Fold 7: ragged train=2515, val=252, max_N=1990\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 7: reported_epoch=0, IC=+0.0184, 6.9s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    Fold 8: ragged train=2515, val=252, max_N=1990\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 8: reported_epoch=0, IC=-0.0411, 5.7s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    Fold 9: ragged train=2515, val=252, max_N=1832\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 9: reported_epoch=0, IC=-0.0160, 4.1s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    Fold 10: ragged train=2515, val=252, max_N=1652\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 10: reported_epoch=0, IC=+0.0073, 3.1s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    Fold 11: ragged train=2515, val=252, max_N=1486\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 11: reported_epoch=0, IC=+0.0113, 2.6s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    Fold 12: ragged train=2515, val=252, max_N=1323\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 12: reported_epoch=0, IC=-0.0483, 1.8s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    Fold 13: ragged train=2515, val=252, max_N=1127\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 13: reported_epoch=0, IC=+0.0000, 1.2s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    Fold 14: ragged train=2515, val=252, max_N=1084\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 14: reported_epoch=0, IC=+0.0167, 0.8s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    Fold 15: ragged train=2489, val=252, max_N=987\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 15: reported_epoch=0, IC=+0.0090, 0.6s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    -> best epoch=0, IC=+0.0019 (850.8s)\n",
-      "  Best: pca (IC=+0.0019)\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Latent factor CV: 1 models × 16 folds\n",
-      "Log file: case_studies/us_equities_panel/run_log/latent_factors.log\n",
-      "Scoring: dates=rebalance cadence=daily_close step=21 checkpoint_selection=fixed reporting_epoch=last\n",
-      "  pca (K=5):\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    Fold 0: ragged train=2499, val=252, max_N=2654\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 0: reported_epoch=0, IC=+0.0417, 15.3s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    Fold 1: ragged train=2499, val=252, max_N=2654\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 1: reported_epoch=0, IC=+0.0182, 14.7s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    Fold 2: ragged train=2497, val=252, max_N=2524\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 2: reported_epoch=0, IC=-0.0079, 13.6s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    Fold 3: ragged train=2499, val=252, max_N=2184\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 3: reported_epoch=0, IC=+0.0453, 12.1s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    Fold 4: ragged train=2499, val=252, max_N=2139\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 4: reported_epoch=0, IC=-0.0075, 10.5s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    Fold 5: ragged train=2499, val=252, max_N=2026\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 5: reported_epoch=0, IC=+0.0222, 8.8s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    Fold 6: ragged train=2499, val=252, max_N=1990\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 6: reported_epoch=0, IC=+0.0987, 8.5s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    Fold 7: ragged train=2499, val=252, max_N=1990\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 7: reported_epoch=0, IC=-0.0036, 6.8s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    Fold 8: ragged train=2499, val=252, max_N=1990\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 8: reported_epoch=0, IC=-0.0902, 5.8s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    Fold 9: ragged train=2499, val=252, max_N=1832\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 9: reported_epoch=0, IC=+0.0314, 4.1s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    Fold 10: ragged train=2499, val=252, max_N=1649\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 10: reported_epoch=0, IC=+0.0149, 3.0s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    Fold 11: ragged train=2499, val=252, max_N=1486\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 11: reported_epoch=0, IC=-0.0095, 2.4s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    Fold 12: ragged train=2499, val=252, max_N=1323\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 12: reported_epoch=0, IC=+0.0042, 1.7s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    Fold 13: ragged train=2499, val=252, max_N=1127\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 13: reported_epoch=0, IC=+0.0372, 1.2s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    Fold 14: ragged train=2499, val=252, max_N=1083\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 14: reported_epoch=0, IC=+0.0073, 0.9s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    Fold 15: ragged train=2472, val=252, max_N=987\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 15: reported_epoch=0, IC=-0.0470, 0.5s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    -> best epoch=0, IC=+0.0097 (853.0s)\n",
-      "  Best: pca (IC=+0.0097)\n",
-      "fwd_ret_5d [{'model_name': 'pca', 'mean_ic': 0.0019, 'best_epoch': 0, 'n_folds': 16, 'elapsed_s': 850.8, 'started_at': '2026-04-28T01:57:08.933915+00:00'}]\n",
-      "fwd_ret_21d [{'model_name': 'pca', 'mean_ic': 0.0097, 'best_epoch': 0, 'n_folds': 16, 'elapsed_s': 853.0, 'started_at': '2026-04-28T02:11:27.487289+00:00'}]\n"
-     ]
-    }
-   ],
+   "execution_count": null,
+   "id": "bd95c633",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "plan = plan_models(study, requests=requests)\n",
     "official_population = None\n",
@@ -1096,7 +293,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "40907d5b",
+   "id": "c18595fb",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1105,7 +302,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4c8b2807",
+   "id": "5bcacc95",
    "metadata": {},
    "source": [
     "## 4. What was actually fitted\n",
@@ -1120,7 +317,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4013bb15",
+   "id": "9360d8cb",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1146,7 +343,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "74478d67",
+   "id": "d12dae35",
    "metadata": {},
    "source": [
     "## 5. What came out\n",
@@ -1164,7 +361,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "50ad355d",
+   "id": "11fd3bb9",
    "metadata": {
     "tags": [
      "results"
@@ -1194,7 +391,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d4bbd23d",
+   "id": "b54c729e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1228,7 +425,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "54b69ff6",
+   "id": "5e9931d2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1238,7 +435,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "185f203c",
+   "id": "35e68bbf",
    "metadata": {},
    "source": [
     "## 6. Naming the sets the later notebooks open\n",
@@ -1248,15 +445,19 @@
     "times, so a run that overrode a parameter, narrowed the labels or ran under the preview tier\n",
     "keeps its rows and publishes no name.\n",
     "\n",
-    "These sets are small enough to be compared prediction by prediction, which is why\n",
-    "[`15_model_analysis`](15_model_analysis.ipynb) does not need a separate bounded subset for\n",
-    "them the way it does for the larger grids."
+    "Each label gets two names, the same pair every other model notebook publishes: a **full set**\n",
+    "that [`16_backtest`](16_backtest.ipynb) backtests member by member, and a **bounded diagnostic\n",
+    "set** that [`15_model_analysis`](15_model_analysis.ipynb) loads raw predictions for. Here the\n",
+    "two hold the same single member, because this family declares one configuration and fits it\n",
+    "once rather than checkpointing it, so there is nothing to bound away. The two names still exist\n",
+    "so that every family is opened the same way downstream; the registry stores one set and binds\n",
+    "both names to it."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e4168a6a",
+   "id": "27e4732e",
    "metadata": {
     "tags": [
      "results"
@@ -1271,16 +472,28 @@
     "if is_published_population:\n",
     "    for selected_label in selected_labels:\n",
     "        label_name = selected_label.replace(\"_\", \"-\")\n",
-    "        result_set = study.predictions.freeze(\n",
-    "            execution.catalog_rows.filter(pl.col(\"label\") == selected_label),\n",
+    "        label_rows = execution.catalog_rows.filter(pl.col(\"label\") == selected_label)\n",
+    "        full_set = study.predictions.freeze(\n",
+    "            label_rows,\n",
     "            name=f\"us-equities-{label_name}-pca-v1\",\n",
     "        )\n",
-    "        set_rows.append(\n",
-    "            {\n",
-    "                \"role\": \"backtest and diagnostic population\",\n",
-    "                \"set_name\": result_set.name,\n",
-    "                \"members\": len(result_set.members),\n",
-    "            }\n",
+    "        diagnostic_set = study.predictions.freeze(\n",
+    "            label_rows,\n",
+    "            name=f\"us-equities-{label_name}-pca-diagnostics-v1\",\n",
+    "        )\n",
+    "        set_rows.extend(\n",
+    "            [\n",
+    "                {\n",
+    "                    \"role\": \"backtest population\",\n",
+    "                    \"set_name\": full_set.name,\n",
+    "                    \"members\": len(full_set.members),\n",
+    "                },\n",
+    "                {\n",
+    "                    \"role\": \"bounded diagnostics\",\n",
+    "                    \"set_name\": diagnostic_set.name,\n",
+    "                    \"members\": len(diagnostic_set.members),\n",
+    "                },\n",
+    "            ]\n",
     "        )\n",
     "compatible_sets = pl.DataFrame(\n",
     "    set_rows,\n",
@@ -1291,17 +504,19 @@
   },
   {
    "cell_type": "markdown",
-   "id": "733fe8f2",
+   "id": "e3f491bf",
    "metadata": {},
    "source": [
-    "`15_model_analysis.py` reopens the named label sets for descriptive analysis. `16_backtest.py`\n",
-    "passes every catalog row directly to the shared backtest runner. Predictive metrics do not choose\n",
-    "a configuration or checkpoint."
+    "`15_model_analysis` reopens both names per label: the full set to confirm the run filled every\n",
+    "member it promised, and the diagnostic set to read raw predictions. `16_backtest` passes every\n",
+    "full-set catalog row to the shared backtest runner. Neither the metrics here nor the ones there\n",
+    "choose a configuration or a checkpoint; selection is on validation backtest Sharpe in\n",
+    "`16_backtest`."
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "5984de66",
+   "id": "87d6b977",
    "metadata": {},
    "source": [
     "## What to notice\n",
@@ -1336,33 +551,6 @@
    "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.14.3"
-  },
-  "papermill": {
-   "default_parameters": {},
-   "duration": 2587.131892,
-   "end_time": "2026-04-28T02:25:45.769318+00:00",
-   "environment_variables": {},
-   "exception": null,
-   "input_path": "case_studies/us_equities_panel/12a_pca.ipynb",
-   "output_path": "~/scratch/tmp.09mHAwp5yj.ipynb",
-   "parameters": {
-    "FORCE_RETRAIN": true,
-    "USE_CACHE": false
-   },
-   "start_time": "2026-04-28T01:42:38.637426+00:00",
-   "version": "2.7.0"
   }
  },
  "nbformat": 4,

--- a/case_studies/us_equities_panel/13a_pca.ipynb
+++ b/case_studies/us_equities_panel/13a_pca.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "86e74fcf",
+   "id": "660c5565",
    "metadata": {},
    "source": [
     "# US equities panel: the few movements the whole panel shares\n",
@@ -55,7 +55,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c86eef52",
+   "id": "9ca3f906",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -80,7 +80,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "701c9af6",
+   "id": "3fbeb1eb",
    "metadata": {
     "tags": [
      "parameters"
@@ -103,7 +103,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "de3e34ef",
+   "id": "481cd5b1",
    "metadata": {},
    "source": [
     "## 1. Which labels, and how many factors\n",
@@ -129,7 +129,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "38511202",
+   "id": "2d7aae4b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -170,7 +170,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "84041244",
+   "id": "c856fdfc",
    "metadata": {},
    "source": [
     "A run that narrows the labels or overrides a parameter produces a different set of predictions\n",
@@ -183,7 +183,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "024e8f21",
+   "id": "066bccc8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -199,7 +199,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "57fdde9d",
+   "id": "41da5592",
    "metadata": {},
    "source": [
     "Both tiers resolve the study through `open_study`. It reads the labels and features in place\n",
@@ -211,7 +211,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "43fd5843",
+   "id": "42467f96",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -228,7 +228,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6ef49d44",
+   "id": "c9d775aa",
    "metadata": {},
    "source": [
     "## 2. Binding the declarations to the data\n",
@@ -245,7 +245,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cdc9e6fc",
+   "id": "a466e823",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -279,7 +279,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3ee878e5",
+   "id": "5097bb05",
    "metadata": {},
    "source": [
     "## 3. Planning, then fitting\n",
@@ -298,7 +298,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4a806d70",
+   "id": "53e3b903",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -319,7 +319,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d286d330",
+   "id": "bdacb1d9",
    "metadata": {},
    "source": [
     "`run_model_population` takes the plan, writes the population down, fits every member and then\n",
@@ -339,7 +339,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "59ee7ecc",
+   "id": "233daec3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -361,7 +361,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "97536349",
+   "id": "8191b727",
    "metadata": {},
    "source": [
     "## 4. What was actually fitted\n",
@@ -376,7 +376,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6a5c23e7",
+   "id": "c075ba31",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -402,7 +402,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "efb5bf8d",
+   "id": "db767d9c",
    "metadata": {},
    "source": [
     "## 5. What came out\n",
@@ -420,7 +420,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "df88e2ed",
+   "id": "c8cabb80",
    "metadata": {
     "tags": [
      "results"
@@ -450,7 +450,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "18fcf67a",
+   "id": "0944b3a7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -482,7 +482,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "74212669",
+   "id": "9f57a1fd",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -492,7 +492,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c6dd176c",
+   "id": "22e9f7c2",
    "metadata": {},
    "source": [
     "### How the ranking held across the walk-forward folds\n",
@@ -512,7 +512,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3b68fcca",
+   "id": "5938e371",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -566,7 +566,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e98e84e3",
+   "id": "a90b5fbb",
    "metadata": {},
    "source": [
     "## 6. Naming the sets the later notebooks open\n",
@@ -588,7 +588,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4abf7cb5",
+   "id": "5375f4d0",
    "metadata": {
     "tags": [
      "results"
@@ -642,7 +642,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5001419a",
+   "id": "8ef00936",
    "metadata": {},
    "source": [
     "`15_model_analysis` reopens both names per label: the full set to confirm the run filled every\n",
@@ -654,7 +654,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b21f5753",
+   "id": "3c7ba193",
    "metadata": {},
    "source": [
     "## What to notice\n",
@@ -668,9 +668,9 @@
     "what a stock shares with the panel, so where it ranks the cross-section well, the ranking is\n",
     "coming from common movement rather than from anything specific to a name.\n",
     "\n",
-    "**The loadings belong to the stocks that were there.** A loading is fitted per stock, so a stock\n",
-    "with no training history in a fold has none, and a stock whose character changes over a decade\n",
-    "keeps the one it was fitted with. [`13b_ipca`](13b_ipca.ipynb) is the answer to both, and the\n",
+    "**A loading is fitted per stock, on the stocks a fold had.** A stock with no training history in\n",
+    "a fold gets none, and a stock whose character changes over a decade keeps the loading it was\n",
+    "fitted with. [`13b_ipca`](13b_ipca.ipynb) is the answer to both, and the\n",
     "comparison between the two is what the pair is for.\n",
     "\n",
     "**Known limitations.** The factor count is declared rather than searched, so nothing here says\n",

--- a/case_studies/us_equities_panel/13a_pca.ipynb
+++ b/case_studies/us_equities_panel/13a_pca.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "21d1a838",
+   "id": "86e74fcf",
    "metadata": {},
    "source": [
     "# US equities panel: the few movements the whole panel shares\n",
@@ -55,7 +55,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e15bd2b6",
+   "id": "c86eef52",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -80,7 +80,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "afbab95b",
+   "id": "701c9af6",
    "metadata": {
     "tags": [
      "parameters"
@@ -96,14 +96,14 @@
     "SUPERSEDES_SETS: dict = {}\n",
     "EXECUTION_TIER = \"canonical\"\n",
     "WORKSPACE = \"\"\n",
-    "MAX_SYMBOLS = 0\n",
-    "FOLD_IDS = []\n",
+    "PREVIEW_MAX_SYMBOLS = 0\n",
+    "PREVIEW_FOLD_IDS = []\n",
     "PREVIEW_N_FACTORS = 0"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "6eb9e24a",
+   "id": "de3e34ef",
    "metadata": {},
    "source": [
     "## 1. Which labels, and how many factors\n",
@@ -123,13 +123,13 @@
     "- **`EXECUTION_TIER`** is `canonical` or `preview`. A canonical run fits the whole panel on every\n",
     "  fold. A preview run declares its reductions and carries them in the identity, so its results\n",
     "  can never be compared against canonical ones or reach a holdout decision.\n",
-    "- **`FOLD_IDS`** and **`MAX_SYMBOLS`** are the reductions a preview declares."
+    "- **`PREVIEW_FOLD_IDS`** and **`PREVIEW_MAX_SYMBOLS`** are the reductions a preview declares."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "63f5aaf2",
+   "id": "38511202",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -170,7 +170,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e7c7ba8c",
+   "id": "84041244",
    "metadata": {},
    "source": [
     "A run that narrows the labels or overrides a parameter produces a different set of predictions\n",
@@ -183,7 +183,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2982b06d",
+   "id": "024e8f21",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -199,7 +199,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0fb78b78",
+   "id": "57fdde9d",
    "metadata": {},
    "source": [
     "Both tiers resolve the study through `open_study`. It reads the labels and features in place\n",
@@ -211,15 +211,15 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3f8af837",
+   "id": "43fd5843",
    "metadata": {},
    "outputs": [],
    "source": [
     "preview_reductions = {}\n",
-    "if MAX_SYMBOLS:\n",
-    "    preview_reductions[\"max_symbols\"] = int(MAX_SYMBOLS)\n",
-    "if FOLD_IDS:\n",
-    "    preview_reductions[\"folds\"] = [int(fold) for fold in FOLD_IDS]\n",
+    "if PREVIEW_MAX_SYMBOLS:\n",
+    "    preview_reductions[\"max_symbols\"] = int(PREVIEW_MAX_SYMBOLS)\n",
+    "if PREVIEW_FOLD_IDS:\n",
+    "    preview_reductions[\"folds\"] = [int(fold) for fold in PREVIEW_FOLD_IDS]\n",
     "if PREVIEW_N_FACTORS:\n",
     "    preview_reductions[\"n_factors\"] = int(PREVIEW_N_FACTORS)\n",
     "\n",
@@ -228,7 +228,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6465520a",
+   "id": "6ef49d44",
    "metadata": {},
    "source": [
     "## 2. Binding the declarations to the data\n",
@@ -245,7 +245,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cbac0914",
+   "id": "cdc9e6fc",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -279,7 +279,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fe5de638",
+   "id": "3ee878e5",
    "metadata": {},
    "source": [
     "## 3. Planning, then fitting\n",
@@ -298,7 +298,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fe887a34",
+   "id": "4a806d70",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -319,7 +319,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "27246f5a",
+   "id": "d286d330",
    "metadata": {},
    "source": [
     "`run_model_population` takes the plan, writes the population down, fits every member and then\n",
@@ -339,7 +339,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "12cda7b6",
+   "id": "59ee7ecc",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -361,7 +361,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5ad9c71a",
+   "id": "97536349",
    "metadata": {},
    "source": [
     "## 4. What was actually fitted\n",
@@ -376,7 +376,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5da22d9a",
+   "id": "6a5c23e7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -402,7 +402,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "eceb17a5",
+   "id": "efb5bf8d",
    "metadata": {},
    "source": [
     "## 5. What came out\n",
@@ -420,7 +420,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "62a1d55a",
+   "id": "df88e2ed",
    "metadata": {
     "tags": [
      "results"
@@ -450,7 +450,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a7ca3366",
+   "id": "18fcf67a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -482,7 +482,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d33c779b",
+   "id": "74212669",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -492,7 +492,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2d6d1b93",
+   "id": "c6dd176c",
    "metadata": {},
    "source": [
     "### How the ranking held across the walk-forward folds\n",
@@ -512,7 +512,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f47fabc4",
+   "id": "3b68fcca",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -566,7 +566,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3322c678",
+   "id": "e98e84e3",
    "metadata": {},
    "source": [
     "## 6. Naming the sets the later notebooks open\n",
@@ -588,7 +588,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "73b177d0",
+   "id": "4abf7cb5",
    "metadata": {
     "tags": [
      "results"
@@ -642,7 +642,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a7275f50",
+   "id": "5001419a",
    "metadata": {},
    "source": [
     "`15_model_analysis` reopens both names per label: the full set to confirm the run filled every\n",
@@ -654,7 +654,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a6bc4243",
+   "id": "b21f5753",
    "metadata": {},
    "source": [
     "## What to notice\n",

--- a/case_studies/us_equities_panel/13a_pca.py
+++ b/case_studies/us_equities_panel/13a_pca.py
@@ -87,8 +87,8 @@ SUPERSEDES_POPULATION = ""
 SUPERSEDES_SETS: dict = {}
 EXECUTION_TIER = "canonical"
 WORKSPACE = ""
-MAX_SYMBOLS = 0
-FOLD_IDS = []
+PREVIEW_MAX_SYMBOLS = 0
+PREVIEW_FOLD_IDS = []
 PREVIEW_N_FACTORS = 0
 
 # %% [markdown]
@@ -109,7 +109,7 @@ PREVIEW_N_FACTORS = 0
 # - **`EXECUTION_TIER`** is `canonical` or `preview`. A canonical run fits the whole panel on every
 #   fold. A preview run declares its reductions and carries them in the identity, so its results
 #   can never be compared against canonical ones or reach a holdout decision.
-# - **`FOLD_IDS`** and **`MAX_SYMBOLS`** are the reductions a preview declares.
+# - **`PREVIEW_FOLD_IDS`** and **`PREVIEW_MAX_SYMBOLS`** are the reductions a preview declares.
 
 # %%
 case_dir = get_case_study_dir(CASE_STUDY_ID)
@@ -171,10 +171,10 @@ if EXECUTION_TIER == "canonical" and not is_published_population and not POPULAT
 
 # %%
 preview_reductions = {}
-if MAX_SYMBOLS:
-    preview_reductions["max_symbols"] = int(MAX_SYMBOLS)
-if FOLD_IDS:
-    preview_reductions["folds"] = [int(fold) for fold in FOLD_IDS]
+if PREVIEW_MAX_SYMBOLS:
+    preview_reductions["max_symbols"] = int(PREVIEW_MAX_SYMBOLS)
+if PREVIEW_FOLD_IDS:
+    preview_reductions["folds"] = [int(fold) for fold in PREVIEW_FOLD_IDS]
 if PREVIEW_N_FACTORS:
     preview_reductions["n_factors"] = int(PREVIEW_N_FACTORS)
 

--- a/case_studies/us_equities_panel/13a_pca.py
+++ b/case_studies/us_equities_panel/13a_pca.py
@@ -63,14 +63,17 @@
 # %%
 """Generate PCA validation predictions through the shared research interface."""
 
-import os
-from pathlib import Path
-
 import matplotlib.pyplot as plt
 import polars as pl
 import yaml
 
-from case_studies.research import open_study, plan_models
+from case_studies.research import (
+    candidate_set_supersedes,
+    open_study,
+    plan_models,
+    run_model_population,
+    supersedes_for_run,
+)
 from utils.modeling import load_configs
 from utils.paths import get_case_study_dir
 from utils.style import FIGSIZE, add_message_title, ml4t_palette, show_with_alt, zero_line
@@ -79,8 +82,11 @@ from utils.style import FIGSIZE, add_message_title, ml4t_palette, show_with_alt,
 CASE_STUDY_ID = "us_equities_panel"
 LABELS = []
 OVERRIDES = {}
+POPULATION_NAME = ""
+SUPERSEDES_POPULATION = ""
+SUPERSEDES_SETS: dict = {}
 EXECUTION_TIER = "canonical"
-WORKSPACE = "experiments"
+WORKSPACE = ""
 MAX_SYMBOLS = 0
 FOLD_IDS = []
 PREVIEW_N_FACTORS = 0
@@ -140,6 +146,29 @@ label_menu = pl.DataFrame(
 )
 label_menu
 
+# %% [markdown]
+# A run that narrows the labels or overrides a parameter produces a different set of predictions
+# from the one the canonical name stands for. Publishing it under that name would leave the name
+# meaning two different member sets at two different times, so the guard below requires such a run
+# to say what to call its own population, and the frozen set names in Section 6 are withheld from
+# it for the same reason.
+
+# %%
+is_published_population = (
+    EXECUTION_TIER == "canonical" and selected_labels == published_labels and not OVERRIDES
+)
+if EXECUTION_TIER == "canonical" and not is_published_population and not POPULATION_NAME:
+    raise ValueError(
+        "this run narrows the declared labels or overrides a parameter, so it cannot publish the "
+        "canonical population; pass POPULATION_NAME to give it its own"
+    )
+
+# %% [markdown]
+# Both tiers resolve the study through `open_study`. It reads the labels and features in place
+# and redirects only writes, so a preview run scores the same inputs a canonical one does and
+# cannot publish over it. A preview must be given a workspace to write into; a canonical run
+# leaves `WORKSPACE` empty and regenerates the case study's own artifacts in place.
+
 # %%
 preview_reductions = {}
 if MAX_SYMBOLS:
@@ -149,23 +178,7 @@ if FOLD_IDS:
 if PREVIEW_N_FACTORS:
     preview_reductions["n_factors"] = int(PREVIEW_N_FACTORS)
 
-# Both tiers resolve the study through `open_study`. It reads the labels and features in place and
-# redirects only writes, so a preview run scores the same inputs a canonical one does and cannot
-# publish over it.
-if EXECUTION_TIER == "canonical":
-    if preview_reductions:
-        raise ValueError("Canonical execution cannot declare preview reductions")
-    study = open_study(CASE_STUDY_ID, execution_tier=EXECUTION_TIER)
-elif EXECUTION_TIER == "preview":
-    if not preview_reductions:
-        raise ValueError("Preview execution requires at least one declared reduction")
-    study = open_study(
-        CASE_STUDY_ID,
-        execution_tier=EXECUTION_TIER,
-        workspace=Path(os.environ.get("ML4T_OUTPUT_DIR") or WORKSPACE),
-    )
-else:
-    raise ValueError("EXECUTION_TIER must be 'canonical' or 'preview'")
+study = open_study(CASE_STUDY_ID, execution_tier=EXECUTION_TIER, workspace=WORKSPACE or None)
 
 # %% [markdown]
 # ## 2. Binding the declarations to the data
@@ -221,11 +234,6 @@ request_table
 
 # %%
 plan = plan_models(study, requests=requests)
-official_population = None
-if EXECUTION_TIER == "canonical":
-    official_population = plan.create_population(
-        name="us-equities-pca-checkpoints-v1",
-    )
 
 planned_population = pl.DataFrame(
     {
@@ -239,8 +247,35 @@ planned_population = pl.DataFrame(
 )
 planned_population
 
+# %% [markdown]
+# `run_model_population` takes the plan, writes the population down, fits every member and then
+# checks that what came out is what was declared. The same call serves both tiers: a canonical run
+# registers an immutable population that the later notebooks bind to, and a preview run gets a
+# declaration that is verified and then discarded with its workspace, so no notebook here has to
+# branch on the tier to decide what to publish.
+#
+# `SUPERSEDES_POPULATION` names the population hash this run replaces. A population is a set of
+# prediction identities, so anything that moves a training identity - a changed preset as much as a
+# changed menu - produces a different population under the same name, and the registry refuses to
+# write it without being told which snapshot it supersedes. Leaving it empty is right for a first
+# run and for a reader's clean clone, and `supersedes_for_run` withholds a declared hash wherever
+# offering it would be refused.
+
 # %%
-execution = plan.run()
+population_name = POPULATION_NAME or "us-equities-pca-checkpoints-v1"
+execution, official_population = run_model_population(
+    study,
+    plan,
+    population_name=population_name,
+    supersedes=supersedes_for_run(
+        study,
+        population_name=population_name,
+        declared=SUPERSEDES_POPULATION,
+        execution_tier=EXECUTION_TIER,
+    ),
+)
+
+print(f"population {official_population.name}: {len(official_population.members)} prediction sets")
 
 # %% [markdown]
 # ## 4. What was actually fitted
@@ -325,8 +360,6 @@ for run in execution.runs:
         )
 
 coverage_table = pl.DataFrame(coverage_rows).sort("label", "prediction_hash")
-if official_population is not None:
-    official_population.require_complete()
 coverage_table
 
 # %%
@@ -343,7 +376,7 @@ execution_diagnostics
 #
 # The per-fold values come from the registry rather than from the raw predictions: each fold's
 # information coefficient is registered alongside the prediction set, so reading it back costs a
-# query rather than a 7.2-million-row load. A model built only from what a stock shares with
+# query rather than a seven-million-row load. A model built only from what a stock shares with
 # the panel has no name-specific information to fall back on, so a fold where the panel moved
 # together for reasons the factors did not capture is where this one has least to say.
 
@@ -413,20 +446,27 @@ show_with_alt(
 
 # %% tags=["results"]
 set_rows = []
-is_published_population = (
-    EXECUTION_TIER == "canonical" and selected_labels == published_labels and not OVERRIDES
-)
 if is_published_population:
     for selected_label in selected_labels:
         label_name = selected_label.replace("_", "-")
         label_rows = execution.catalog_rows.filter(pl.col("label") == selected_label)
+        full_set_name = f"us-equities-{label_name}-pca-v1"
         full_set = study.predictions.freeze(
             label_rows,
-            name=f"us-equities-{label_name}-pca-v1",
+            name=full_set_name,
+            supersedes=candidate_set_supersedes(
+                study, name=full_set_name, declared=SUPERSEDES_SETS.get(full_set_name, "")
+            ),
         )
+        diagnostic_set_name = f"us-equities-{label_name}-pca-diagnostics-v1"
         diagnostic_set = study.predictions.freeze(
             label_rows,
-            name=f"us-equities-{label_name}-pca-diagnostics-v1",
+            name=diagnostic_set_name,
+            supersedes=candidate_set_supersedes(
+                study,
+                name=diagnostic_set_name,
+                declared=SUPERSEDES_SETS.get(diagnostic_set_name, ""),
+            ),
         )
         set_rows.extend(
             [

--- a/case_studies/us_equities_panel/13a_pca.py
+++ b/case_studies/us_equities_panel/13a_pca.py
@@ -66,12 +66,14 @@
 import os
 from pathlib import Path
 
+import matplotlib.pyplot as plt
 import polars as pl
 import yaml
 
 from case_studies.research import open_study, plan_models
 from utils.modeling import load_configs
 from utils.paths import get_case_study_dir
+from utils.style import FIGSIZE, add_message_title, ml4t_palette, show_with_alt, zero_line
 
 # %% tags=["parameters"]
 CASE_STUDY_ID = "us_equities_panel"
@@ -330,6 +332,68 @@ coverage_table
 # %%
 execution_diagnostics = pl.DataFrame(execution.diagnostics)
 execution_diagnostics
+
+# %% [markdown]
+# ### How the ranking held across the walk-forward folds
+#
+# The headline information coefficient above is an average over the folds, and an average says
+# nothing about whether the folds agreed. Each fold is a different year of the market with a
+# different set of names quoting in it, so a factor model can rank the cross-section well in a few
+# of them and not at all in the rest and still show a respectable mean.
+#
+# The per-fold values come from the registry rather than from the raw predictions: each fold's
+# information coefficient is registered alongside the prediction set, so reading it back costs a
+# query rather than a 7.2-million-row load. A model built only from what a stock shares with
+# the panel has no name-specific information to fall back on, so a fold where the panel moved
+# together for reasons the factors did not capture is where this one has least to say.
+
+# %%
+fold_rows = []
+for run in execution.runs:
+    run_label = run.training.spec()["label"]
+    for prediction in run.predictions:
+        fold_rows.append(prediction.folds().with_columns(label=pl.lit(run_label)))
+folds_frame = pl.concat(fold_rows, how="vertical_relaxed").sort("label", "fold_id")
+
+fold_labels = folds_frame.get_column("label").unique(maintain_order=True).to_list()
+# `ml4t_palette` returns a list of that many colours, so it is called once and indexed.
+palette = ml4t_palette(len(fold_labels), categorical=True)
+
+fig, ax = plt.subplots(figsize=FIGSIZE["single"])
+for index, fold_label in enumerate(fold_labels):
+    series = folds_frame.filter(pl.col("label") == fold_label)
+    ax.plot(
+        series.get_column("fold_id"),
+        series.get_column("ic"),
+        marker="o",
+        markersize=4,
+        lw=1.4,
+        color=palette[index],
+        label=fold_label,
+    )
+zero_line(ax)
+ax.set_xlabel("Walk-forward fold")
+ax.set_ylabel("Mean validation IC")
+ax.legend(fontsize=8, frameon=False)
+add_message_title(
+    ax,
+    "Mean validation IC by walk-forward fold",
+    subtitle="One line per declared label, over the folds the evaluation stage established",
+)
+# The alt text counts rather than asserts: how many folds land above zero is a fact about the
+# frame, and a line described as steady when it is not is a claim the data refutes.
+_signs = (
+    folds_frame.group_by("label").agg(above=(pl.col("ic") > 0).sum(), total=pl.len()).sort("label")
+)
+_sign_text = " and ".join(
+    f"{row['above']} of {row['total']} for {row['label']}" for row in _signs.iter_rows(named=True)
+)
+show_with_alt(
+    fig,
+    "A line chart of mean validation information coefficient against walk-forward fold, one line "
+    "per declared label, with a dashed line at zero. Counted from the underlying frame, the folds "
+    f"whose information coefficient is above zero are {_sign_text}.",
+)
 
 # %% [markdown]
 # ## 6. Naming the sets the later notebooks open

--- a/case_studies/us_equities_panel/13a_pca.py
+++ b/case_studies/us_equities_panel/13a_pca.py
@@ -339,9 +339,13 @@ execution_diagnostics
 # times, so a run that overrode a parameter, narrowed the labels or ran under the preview tier
 # keeps its rows and publishes no name.
 #
-# These sets are small enough to be compared prediction by prediction, which is why
-# [`15_model_analysis`](15_model_analysis.ipynb) does not need a separate bounded subset for
-# them the way it does for the larger grids.
+# Each label gets two names, the same pair every other model notebook publishes: a **full set**
+# that [`16_backtest`](16_backtest.ipynb) backtests member by member, and a **bounded diagnostic
+# set** that [`15_model_analysis`](15_model_analysis.ipynb) loads raw predictions for. Here the
+# two hold the same single member, because this family declares one configuration and fits it
+# once rather than checkpointing it, so there is nothing to bound away. The two names still exist
+# so that every family is opened the same way downstream; the registry stores one set and binds
+# both names to it.
 
 # %% tags=["results"]
 set_rows = []
@@ -351,16 +355,28 @@ is_published_population = (
 if is_published_population:
     for selected_label in selected_labels:
         label_name = selected_label.replace("_", "-")
-        result_set = study.predictions.freeze(
-            execution.catalog_rows.filter(pl.col("label") == selected_label),
+        label_rows = execution.catalog_rows.filter(pl.col("label") == selected_label)
+        full_set = study.predictions.freeze(
+            label_rows,
             name=f"us-equities-{label_name}-pca-v1",
         )
-        set_rows.append(
-            {
-                "role": "backtest and diagnostic population",
-                "set_name": result_set.name,
-                "members": len(result_set.members),
-            }
+        diagnostic_set = study.predictions.freeze(
+            label_rows,
+            name=f"us-equities-{label_name}-pca-diagnostics-v1",
+        )
+        set_rows.extend(
+            [
+                {
+                    "role": "backtest population",
+                    "set_name": full_set.name,
+                    "members": len(full_set.members),
+                },
+                {
+                    "role": "bounded diagnostics",
+                    "set_name": diagnostic_set.name,
+                    "members": len(diagnostic_set.members),
+                },
+            ]
         )
 compatible_sets = pl.DataFrame(
     set_rows,
@@ -369,9 +385,11 @@ compatible_sets = pl.DataFrame(
 compatible_sets
 
 # %% [markdown]
-# `15_model_analysis.py` reopens the named label sets for descriptive analysis. `16_backtest.py`
-# passes every catalog row directly to the shared backtest runner. Predictive metrics do not choose
-# a configuration or checkpoint.
+# `15_model_analysis` reopens both names per label: the full set to confirm the run filled every
+# member it promised, and the diagnostic set to read raw predictions. `16_backtest` passes every
+# full-set catalog row to the shared backtest runner. Neither the metrics here nor the ones there
+# choose a configuration or a checkpoint; selection is on validation backtest Sharpe in
+# `16_backtest`.
 
 # %% [markdown]
 # ## What to notice

--- a/case_studies/us_equities_panel/13a_pca.py
+++ b/case_studies/us_equities_panel/13a_pca.py
@@ -507,9 +507,9 @@ compatible_sets
 # what a stock shares with the panel, so where it ranks the cross-section well, the ranking is
 # coming from common movement rather than from anything specific to a name.
 #
-# **The loadings belong to the stocks that were there.** A loading is fitted per stock, so a stock
-# with no training history in a fold has none, and a stock whose character changes over a decade
-# keeps the one it was fitted with. [`13b_ipca`](13b_ipca.ipynb) is the answer to both, and the
+# **A loading is fitted per stock, on the stocks a fold had.** A stock with no training history in
+# a fold gets none, and a stock whose character changes over a decade keeps the loading it was
+# fitted with. [`13b_ipca`](13b_ipca.ipynb) is the answer to both, and the
 # comparison between the two is what the pair is for.
 #
 # **Known limitations.** The factor count is declared rather than searched, so nothing here says

--- a/case_studies/us_equities_panel/13b_ipca.ipynb
+++ b/case_studies/us_equities_panel/13b_ipca.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "1c4c27a6",
+   "id": "af7fc6a1",
    "metadata": {},
    "source": [
     "# US equities panel: loadings that depend on what a stock is\n",
@@ -61,20 +61,23 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2de410e1",
+   "id": "6310e547",
    "metadata": {},
    "outputs": [],
    "source": [
     "\"\"\"Generate IPCA validation predictions through the shared research interface.\"\"\"\n",
     "\n",
-    "import os\n",
-    "from pathlib import Path\n",
-    "\n",
     "import matplotlib.pyplot as plt\n",
     "import polars as pl\n",
     "import yaml\n",
     "\n",
-    "from case_studies.research import open_study, plan_models\n",
+    "from case_studies.research import (\n",
+    "    candidate_set_supersedes,\n",
+    "    open_study,\n",
+    "    plan_models,\n",
+    "    run_model_population,\n",
+    "    supersedes_for_run,\n",
+    ")\n",
     "from utils.modeling import load_configs\n",
     "from utils.paths import get_case_study_dir\n",
     "from utils.style import FIGSIZE, add_message_title, ml4t_palette, show_with_alt, zero_line"
@@ -83,7 +86,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "769f035a",
+   "id": "9545bb8a",
    "metadata": {
     "tags": [
      "parameters"
@@ -94,8 +97,11 @@
     "CASE_STUDY_ID = \"us_equities_panel\"\n",
     "LABELS = []\n",
     "OVERRIDES = {}\n",
+    "POPULATION_NAME = \"\"\n",
+    "SUPERSEDES_POPULATION = \"\"\n",
+    "SUPERSEDES_SETS: dict = {}\n",
     "EXECUTION_TIER = \"canonical\"\n",
-    "WORKSPACE = \"experiments\"\n",
+    "WORKSPACE = \"\"\n",
     "MAX_SYMBOLS = 0\n",
     "FOLD_IDS = []\n",
     "PREVIEW_N_FACTORS = 0\n",
@@ -104,7 +110,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bd4037c4",
+   "id": "114b4c37",
    "metadata": {},
    "source": [
     "## 1. Which labels, and how many factors\n",
@@ -130,7 +136,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c0bfa90f",
+   "id": "be322d11",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -170,9 +176,49 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "240e1292",
+   "metadata": {},
+   "source": [
+    "A run that narrows the labels or overrides a parameter produces a different set of predictions\n",
+    "from the one the canonical name stands for. Publishing it under that name would leave the name\n",
+    "meaning two different member sets at two different times, so the guard below requires such a run\n",
+    "to say what to call its own population, and the frozen set names in Section 6 are withheld from\n",
+    "it for the same reason."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fb6dd121",
+   "id": "1c3bda52",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "is_published_population = (\n",
+    "    EXECUTION_TIER == \"canonical\" and selected_labels == published_labels and not OVERRIDES\n",
+    ")\n",
+    "if EXECUTION_TIER == \"canonical\" and not is_published_population and not POPULATION_NAME:\n",
+    "    raise ValueError(\n",
+    "        \"this run narrows the declared labels or overrides a parameter, so it cannot publish the \"\n",
+    "        \"canonical population; pass POPULATION_NAME to give it its own\"\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "89ddc616",
+   "metadata": {},
+   "source": [
+    "Both tiers resolve the study through `open_study`. It reads the labels and features in place\n",
+    "and redirects only writes, so a preview run scores the same inputs a canonical one does and\n",
+    "cannot publish over it. A preview must be given a workspace to write into; a canonical run\n",
+    "leaves `WORKSPACE` empty and regenerates the case study's own artifacts in place."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b531f452",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -186,28 +232,12 @@
     "if PREVIEW_MAX_ITER:\n",
     "    preview_reductions[\"max_iter\"] = int(PREVIEW_MAX_ITER)\n",
     "\n",
-    "# Both tiers resolve the study through `open_study`. It reads the labels and features in place and\n",
-    "# redirects only writes, so a preview run scores the same inputs a canonical one does and cannot\n",
-    "# publish over it.\n",
-    "if EXECUTION_TIER == \"canonical\":\n",
-    "    if preview_reductions:\n",
-    "        raise ValueError(\"Canonical execution cannot declare preview reductions\")\n",
-    "    study = open_study(CASE_STUDY_ID, execution_tier=EXECUTION_TIER)\n",
-    "elif EXECUTION_TIER == \"preview\":\n",
-    "    if not preview_reductions:\n",
-    "        raise ValueError(\"Preview execution requires at least one declared reduction\")\n",
-    "    study = open_study(\n",
-    "        CASE_STUDY_ID,\n",
-    "        execution_tier=EXECUTION_TIER,\n",
-    "        workspace=Path(os.environ.get(\"ML4T_OUTPUT_DIR\") or WORKSPACE),\n",
-    "    )\n",
-    "else:\n",
-    "    raise ValueError(\"EXECUTION_TIER must be 'canonical' or 'preview'\")"
+    "study = open_study(CASE_STUDY_ID, execution_tier=EXECUTION_TIER, workspace=WORKSPACE or None)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "9c7a4c11",
+   "id": "05297d40",
    "metadata": {},
    "source": [
     "## 2. Binding the declarations to the data\n",
@@ -224,7 +254,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2654d7d4",
+   "id": "6c221cef",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -258,7 +288,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "80f09d8c",
+   "id": "1841a5c5",
    "metadata": {},
    "source": [
     "## 3. Planning, then fitting\n",
@@ -281,16 +311,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ea0c68c0",
+   "id": "f1104809",
    "metadata": {},
    "outputs": [],
    "source": [
     "plan = plan_models(study, requests=requests)\n",
-    "official_population = None\n",
-    "if EXECUTION_TIER == \"canonical\":\n",
-    "    official_population = plan.create_population(\n",
-    "        name=\"us-equities-ipca-checkpoints-v1\",\n",
-    "    )\n",
     "\n",
     "planned_population = pl.DataFrame(\n",
     "    {\n",
@@ -306,18 +331,50 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "87a0c398",
+   "metadata": {},
+   "source": [
+    "`run_model_population` takes the plan, writes the population down, fits every member and then\n",
+    "checks that what came out is what was declared. The same call serves both tiers: a canonical run\n",
+    "registers an immutable population that the later notebooks bind to, and a preview run gets a\n",
+    "declaration that is verified and then discarded with its workspace, so no notebook here has to\n",
+    "branch on the tier to decide what to publish.\n",
+    "\n",
+    "`SUPERSEDES_POPULATION` names the population hash this run replaces. A population is a set of\n",
+    "prediction identities, so anything that moves a training identity - a changed preset as much as a\n",
+    "changed menu - produces a different population under the same name, and the registry refuses to\n",
+    "write it without being told which snapshot it supersedes. Leaving it empty is right for a first\n",
+    "run and for a reader's clean clone, and `supersedes_for_run` withholds a declared hash wherever\n",
+    "offering it would be refused."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a371a218",
+   "id": "1ecdd074",
    "metadata": {},
    "outputs": [],
    "source": [
-    "execution = plan.run()"
+    "population_name = POPULATION_NAME or \"us-equities-ipca-checkpoints-v1\"\n",
+    "execution, official_population = run_model_population(\n",
+    "    study,\n",
+    "    plan,\n",
+    "    population_name=population_name,\n",
+    "    supersedes=supersedes_for_run(\n",
+    "        study,\n",
+    "        population_name=population_name,\n",
+    "        declared=SUPERSEDES_POPULATION,\n",
+    "        execution_tier=EXECUTION_TIER,\n",
+    "    ),\n",
+    ")\n",
+    "\n",
+    "print(f\"population {official_population.name}: {len(official_population.members)} prediction sets\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "ec96aac8",
+   "id": "7ef82ee6",
    "metadata": {},
    "source": [
     "## 4. What was actually fitted\n",
@@ -332,7 +389,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "96fabf56",
+   "id": "0ffe2873",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -359,7 +416,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1609f85c",
+   "id": "e27e97cf",
    "metadata": {},
    "source": [
     "## 5. What came out\n",
@@ -377,7 +434,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6c867675",
+   "id": "d1a2aa80",
    "metadata": {
     "tags": [
      "results"
@@ -407,7 +464,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "82a02973",
+   "id": "d5662796",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -433,15 +490,13 @@
     "        )\n",
     "\n",
     "coverage_table = pl.DataFrame(coverage_rows).sort(\"label\", \"prediction_hash\")\n",
-    "if official_population is not None:\n",
-    "    official_population.require_complete()\n",
     "coverage_table"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5e0ae699",
+   "id": "0304e951",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -451,7 +506,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d2f43cae",
+   "id": "75fb55a2",
    "metadata": {},
    "source": [
     "### How the ranking held across the walk-forward folds\n",
@@ -463,7 +518,7 @@
     "\n",
     "The per-fold values come from the registry rather than from the raw predictions: each fold's\n",
     "information coefficient is registered alongside the prediction set, so reading it back costs a\n",
-    "query rather than a 7.2-million-row load. Loadings here are a function of a stock's own\n",
+    "query rather than a seven-million-row load. Loadings here are a function of a stock's own\n",
     "characteristics rather than fitted per name, so a fold whose cross-section is unlike the\n",
     "training window's is the one to look at first."
    ]
@@ -471,7 +526,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "db209f63",
+   "id": "780b88d3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -525,7 +580,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d7e117cb",
+   "id": "01f4727c",
    "metadata": {},
    "source": [
     "## 6. Naming the sets the later notebooks open\n",
@@ -547,7 +602,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "84dd9a95",
+   "id": "97a20e8e",
    "metadata": {
     "tags": [
      "results"
@@ -556,20 +611,27 @@
    "outputs": [],
    "source": [
     "set_rows = []\n",
-    "is_published_population = (\n",
-    "    EXECUTION_TIER == \"canonical\" and selected_labels == published_labels and not OVERRIDES\n",
-    ")\n",
     "if is_published_population:\n",
     "    for selected_label in selected_labels:\n",
     "        label_name = selected_label.replace(\"_\", \"-\")\n",
     "        label_rows = execution.catalog_rows.filter(pl.col(\"label\") == selected_label)\n",
+    "        full_set_name = f\"us-equities-{label_name}-ipca-v1\"\n",
     "        full_set = study.predictions.freeze(\n",
     "            label_rows,\n",
-    "            name=f\"us-equities-{label_name}-ipca-v1\",\n",
+    "            name=full_set_name,\n",
+    "            supersedes=candidate_set_supersedes(\n",
+    "                study, name=full_set_name, declared=SUPERSEDES_SETS.get(full_set_name, \"\")\n",
+    "            ),\n",
     "        )\n",
+    "        diagnostic_set_name = f\"us-equities-{label_name}-ipca-diagnostics-v1\"\n",
     "        diagnostic_set = study.predictions.freeze(\n",
     "            label_rows,\n",
-    "            name=f\"us-equities-{label_name}-ipca-diagnostics-v1\",\n",
+    "            name=diagnostic_set_name,\n",
+    "            supersedes=candidate_set_supersedes(\n",
+    "                study,\n",
+    "                name=diagnostic_set_name,\n",
+    "                declared=SUPERSEDES_SETS.get(diagnostic_set_name, \"\"),\n",
+    "            ),\n",
     "        )\n",
     "        set_rows.extend(\n",
     "            [\n",
@@ -594,7 +656,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b2f17fa7",
+   "id": "dce31009",
    "metadata": {},
    "source": [
     "`15_model_analysis` reopens both names per label: the full set to confirm the run filled every\n",
@@ -606,7 +668,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3b82fd80",
+   "id": "c601a6f6",
    "metadata": {},
    "source": [
     "## What to notice\n",

--- a/case_studies/us_equities_panel/13b_ipca.ipynb
+++ b/case_studies/us_equities_panel/13b_ipca.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "69212913",
+   "id": "8b179ad1",
    "metadata": {},
    "source": [
     "# US equities panel: loadings that depend on what a stock is\n",
@@ -60,16 +60,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
-   "id": "6c1be035",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-04-28T02:32:10.753293Z",
-     "iopub.status.busy": "2026-04-28T02:32:10.752743Z",
-     "iopub.status.idle": "2026-04-28T02:32:13.313501Z",
-     "shell.execute_reply": "2026-04-28T02:32:13.312977Z"
-    }
-   },
+   "execution_count": null,
+   "id": "7b9a8b10",
+   "metadata": {},
    "outputs": [],
    "source": [
     "\"\"\"Generate IPCA validation predictions through the shared research interface.\"\"\"\n",
@@ -87,15 +80,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
-   "id": "ad229215",
+   "execution_count": null,
+   "id": "6850faa1",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-04-28T02:32:13.316741Z",
-     "iopub.status.busy": "2026-04-28T02:32:13.316638Z",
-     "iopub.status.idle": "2026-04-28T02:32:13.318610Z",
-     "shell.execute_reply": "2026-04-28T02:32:13.318345Z"
-    },
     "tags": [
      "parameters"
     ]
@@ -115,7 +102,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f0c0e946",
+   "id": "14a612c1",
    "metadata": {},
    "source": [
     "## 1. Which labels, and how many factors\n",
@@ -140,31 +127,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
-   "id": "015b459c",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-04-28T02:32:13.325322Z",
-     "iopub.status.busy": "2026-04-28T02:32:13.325256Z",
-     "iopub.status.idle": "2026-04-28T02:32:19.530299Z",
-     "shell.execute_reply": "2026-04-28T02:32:19.529864Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Case study: us_equities_panel\n",
-      "Model: ipca\n",
-      "Primary label: fwd_ret_1d\n",
-      "Variant labels: ['fwd_ret_5d', 'fwd_ret_21d']\n",
-      "Dataset rows: 9,205,450\n",
-      "Features: 72\n",
-      "Splits: 16\n"
-     ]
-    }
-   ],
+   "execution_count": null,
+   "id": "753d8e1e",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "case_dir = get_case_study_dir(CASE_STUDY_ID)\n",
     "setup = yaml.safe_load((case_dir / \"config\" / \"setup.yaml\").read_text())\n",
@@ -204,7 +170,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e5c41959",
+   "id": "cfa4d235",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -239,7 +205,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fd437ac8",
+   "id": "50c65f8c",
    "metadata": {},
    "source": [
     "## 2. Binding the declarations to the data\n",
@@ -255,285 +221,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
-   "id": "9ee1f23a",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-04-28T02:32:19.533556Z",
-     "iopub.status.busy": "2026-04-28T02:32:19.533474Z",
-     "iopub.status.idle": "2026-04-28T02:53:47.166461Z",
-     "shell.execute_reply": "2026-04-28T02:53:47.165844Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Latent factor CV: 1 models × 16 folds\n",
-      "Log file: case_studies/us_equities_panel/run_log/latent_factors.log\n",
-      "Scoring: dates=rebalance cadence=daily_close step=1 checkpoint_selection=fixed reporting_epoch=last\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  ipca (K=5):\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    Fold 0: ragged train=2519, val=252, max_N=2684\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 0: reported_epoch=0, IC=-0.0008, 92.3s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    Fold 1: ragged train=2519, val=252, max_N=2684\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 1: reported_epoch=0, IC=-0.0105, 87.2s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    Fold 2: ragged train=2519, val=252, max_N=2534\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 2: reported_epoch=0, IC=+0.0028, 82.3s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    Fold 3: ragged train=2519, val=252, max_N=2184\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 3: reported_epoch=0, IC=+0.0008, 77.4s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    Fold 4: ragged train=2519, val=252, max_N=2140\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 4: reported_epoch=0, IC=-0.0095, 73.5s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    Fold 5: ragged train=2519, val=252, max_N=2026\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 5: reported_epoch=0, IC=+0.0034, 69.6s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    Fold 6: ragged train=2519, val=252, max_N=1991\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 6: reported_epoch=0, IC=+0.0097, 66.9s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    Fold 7: ragged train=2519, val=252, max_N=1991\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 7: reported_epoch=0, IC=+0.0171, 62.1s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    Fold 8: ragged train=2519, val=252, max_N=1991\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 8: reported_epoch=0, IC=-0.0084, 56.4s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    Fold 9: ragged train=2519, val=252, max_N=1832\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 9: reported_epoch=0, IC=+0.0023, 51.4s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    Fold 10: ragged train=2519, val=252, max_N=1652\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 10: reported_epoch=0, IC=-0.0012, 46.8s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    Fold 11: ragged train=2519, val=252, max_N=1486\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 11: reported_epoch=0, IC=+0.0145, 41.4s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    Fold 12: ragged train=2519, val=252, max_N=1323\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 12: reported_epoch=0, IC=+0.0063, 37.9s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    Fold 13: ragged train=2519, val=252, max_N=1127\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 13: reported_epoch=0, IC=+0.0288, 34.4s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    Fold 14: ragged train=2519, val=252, max_N=1084\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 14: reported_epoch=0, IC=+0.0276, 31.2s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    Fold 15: ragged train=2493, val=252, max_N=987\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 15: reported_epoch=0, IC=-0.0040, 27.4s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    -> best epoch=0, IC=+0.0049 (1285.5s)\n",
-      "  Best: ipca (IC=+0.0049)\n",
-      "[{'model_name': 'ipca', 'mean_ic': 0.0049, 'best_epoch': 0, 'n_folds': 16, 'elapsed_s': 1285.5, 'started_at': '2026-04-28T02:32:19.742134+00:00'}]\n",
-      "shape: (16, 6)\n",
-      "┌─────────┬───────┬─────────┬─────────┬────────┬────────────────┐\n",
-      "│ fold_id ┆ epoch ┆ ic_mean ┆ n_train ┆ n_test ┆ n_scored_dates │\n",
-      "│ ---     ┆ ---   ┆ ---     ┆ ---     ┆ ---    ┆ ---            │\n",
-      "│ i64     ┆ i64   ┆ f64     ┆ i64     ┆ i64    ┆ i64            │\n",
-      "╞═════════╪═══════╪═════════╪═════════╪════════╪════════════════╡\n",
-      "│ 0       ┆ 0     ┆ -0.0008 ┆ 2519    ┆ 252    ┆ 252            │\n",
-      "│ 1       ┆ 0     ┆ -0.0105 ┆ 2519    ┆ 252    ┆ 248            │\n",
-      "│ 2       ┆ 0     ┆ 0.0028  ┆ 2519    ┆ 252    ┆ 249            │\n",
-      "│ 3       ┆ 0     ┆ 0.0008  ┆ 2519    ┆ 252    ┆ 246            │\n",
-      "│ 4       ┆ 0     ┆ -0.0095 ┆ 2519    ┆ 252    ┆ 252            │\n",
-      "│ …       ┆ …     ┆ …       ┆ …       ┆ …      ┆ …              │\n",
-      "│ 11      ┆ 0     ┆ 0.0145  ┆ 2519    ┆ 252    ┆ 252            │\n",
-      "│ 12      ┆ 0     ┆ 0.0063  ┆ 2519    ┆ 252    ┆ 252            │\n",
-      "│ 13      ┆ 0     ┆ 0.0288  ┆ 2519    ┆ 252    ┆ 252            │\n",
-      "│ 14      ┆ 0     ┆ 0.0276  ┆ 2519    ┆ 252    ┆ 251            │\n",
-      "│ 15      ┆ 0     ┆ -0.004  ┆ 2493    ┆ 252    ┆ 252            │\n",
-      "└─────────┴───────┴─────────┴─────────┴────────┴────────────────┘\n"
-     ]
-    }
-   ],
+   "execution_count": null,
+   "id": "62a99952",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "requests = tuple(\n",
     "    study.model(\n",
@@ -565,7 +256,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "85d85b2e",
+   "id": "5b9af7db",
    "metadata": {},
    "source": [
     "## 3. Planning, then fitting\n",
@@ -587,504 +278,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
-   "id": "cf2e67ef",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-04-28T02:53:47.169994Z",
-     "iopub.status.busy": "2026-04-28T02:53:47.169909Z",
-     "iopub.status.idle": "2026-04-28T03:36:16.263798Z",
-     "shell.execute_reply": "2026-04-28T03:36:16.262933Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Latent factor CV: 1 models × 16 folds\n",
-      "Log file: case_studies/us_equities_panel/run_log/latent_factors.log\n",
-      "Scoring: dates=rebalance cadence=daily_close step=5 checkpoint_selection=fixed reporting_epoch=last\n",
-      "  ipca (K=5):\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    Fold 0: ragged train=2515, val=252, max_N=2678\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 0: reported_epoch=0, IC=+0.0075, 92.6s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    Fold 1: ragged train=2515, val=252, max_N=2678\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 1: reported_epoch=0, IC=-0.0206, 87.8s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    Fold 2: ragged train=2515, val=252, max_N=2534\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 2: reported_epoch=0, IC=+0.0218, 82.8s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    Fold 3: ragged train=2515, val=252, max_N=2184\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 3: reported_epoch=0, IC=+0.0087, 78.6s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    Fold 4: ragged train=2515, val=252, max_N=2140\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 4: reported_epoch=0, IC=+0.0264, 72.6s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    Fold 5: ragged train=2515, val=252, max_N=2026\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 5: reported_epoch=0, IC=+0.0373, 68.9s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    Fold 6: ragged train=2515, val=252, max_N=1990\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 6: reported_epoch=0, IC=+0.0302, 67.8s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    Fold 7: ragged train=2515, val=252, max_N=1990\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 7: reported_epoch=0, IC=+0.0313, 61.1s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    Fold 8: ragged train=2515, val=252, max_N=1990\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 8: reported_epoch=0, IC=+0.0027, 55.6s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    Fold 9: ragged train=2515, val=252, max_N=1832\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 9: reported_epoch=0, IC=+0.0040, 50.3s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    Fold 10: ragged train=2515, val=252, max_N=1652\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 10: reported_epoch=0, IC=+0.0201, 45.5s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    Fold 11: ragged train=2515, val=252, max_N=1486\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 11: reported_epoch=0, IC=+0.0043, 42.0s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    Fold 12: ragged train=2515, val=252, max_N=1323\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 12: reported_epoch=0, IC=+0.0261, 37.4s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    Fold 13: ragged train=2515, val=252, max_N=1127\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 13: reported_epoch=0, IC=+0.0109, 33.5s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    Fold 14: ragged train=2515, val=252, max_N=1084\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 14: reported_epoch=0, IC=+0.0283, 29.9s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    Fold 15: ragged train=2489, val=252, max_N=987\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 15: reported_epoch=0, IC=-0.0177, 26.8s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    -> best epoch=0, IC=+0.0138 (1282.2s)\n",
-      "  Best: ipca (IC=+0.0138)\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Latent factor CV: 1 models × 16 folds\n",
-      "Log file: case_studies/us_equities_panel/run_log/latent_factors.log\n",
-      "Scoring: dates=rebalance cadence=daily_close step=21 checkpoint_selection=fixed reporting_epoch=last\n",
-      "  ipca (K=5):\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    Fold 0: ragged train=2499, val=252, max_N=2654\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 0: reported_epoch=0, IC=-0.0404, 89.2s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    Fold 1: ragged train=2499, val=252, max_N=2654\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 1: reported_epoch=0, IC=-0.0170, 85.3s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    Fold 2: ragged train=2497, val=252, max_N=2524\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 2: reported_epoch=0, IC=+0.0054, 81.0s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    Fold 3: ragged train=2499, val=252, max_N=2184\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 3: reported_epoch=0, IC=+0.0127, 76.6s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    Fold 4: ragged train=2499, val=252, max_N=2139\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 4: reported_epoch=0, IC=-0.0156, 71.8s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    Fold 5: ragged train=2499, val=252, max_N=2026\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 5: reported_epoch=0, IC=+0.0636, 68.1s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    Fold 6: ragged train=2499, val=252, max_N=1990\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 6: reported_epoch=0, IC=+0.1349, 64.3s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    Fold 7: ragged train=2499, val=252, max_N=1990\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 7: reported_epoch=0, IC=+0.0311, 59.4s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    Fold 8: ragged train=2499, val=252, max_N=1990\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 8: reported_epoch=0, IC=-0.0283, 54.8s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    Fold 9: ragged train=2499, val=252, max_N=1832\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 9: reported_epoch=0, IC=+0.0277, 49.4s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    Fold 10: ragged train=2499, val=252, max_N=1649\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 10: reported_epoch=0, IC=+0.0229, 44.7s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    Fold 11: ragged train=2499, val=252, max_N=1486\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 11: reported_epoch=0, IC=+0.0093, 39.9s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    Fold 12: ragged train=2499, val=252, max_N=1323\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 12: reported_epoch=0, IC=+0.0491, 36.9s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    Fold 13: ragged train=2499, val=252, max_N=1127\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 13: reported_epoch=0, IC=+0.0124, 33.3s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    Fold 14: ragged train=2499, val=252, max_N=1083\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 14: reported_epoch=0, IC=-0.0071, 29.6s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    Fold 15: ragged train=2472, val=252, max_N=987\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      fold 15: reported_epoch=0, IC=+0.0288, 26.4s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    -> best epoch=0, IC=+0.0181 (1251.4s)\n",
-      "  Best: ipca (IC=+0.0181)\n",
-      "fwd_ret_5d [{'model_name': 'ipca', 'mean_ic': 0.0138, 'best_epoch': 0, 'n_folds': 16, 'elapsed_s': 1282.2, 'started_at': '2026-04-28T02:53:52.727272+00:00'}]\n",
-      "fwd_ret_21d [{'model_name': 'ipca', 'mean_ic': 0.0181, 'best_epoch': 0, 'n_folds': 16, 'elapsed_s': 1251.4, 'started_at': '2026-04-28T03:15:22.750315+00:00'}]\n"
-     ]
-    }
-   ],
+   "execution_count": null,
+   "id": "86f4ebda",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "plan = plan_models(study, requests=requests)\n",
     "official_population = None\n",
@@ -1109,7 +306,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7a41d71b",
+   "id": "00af5127",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1118,7 +315,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "82cd3755",
+   "id": "aa70639f",
    "metadata": {},
    "source": [
     "## 4. What was actually fitted\n",
@@ -1133,7 +330,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a5496f65",
+   "id": "2f4feb07",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1160,7 +357,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b4d3fcc8",
+   "id": "cb3030cb",
    "metadata": {},
    "source": [
     "## 5. What came out\n",
@@ -1178,7 +375,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "38c5d878",
+   "id": "539d6f4a",
    "metadata": {
     "tags": [
      "results"
@@ -1208,7 +405,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ef8224e0",
+   "id": "c99e235b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1242,7 +439,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fb7dc51e",
+   "id": "264255ac",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1252,7 +449,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ab97f6e1",
+   "id": "71d49c5d",
    "metadata": {},
    "source": [
     "## 6. Naming the sets the later notebooks open\n",
@@ -1262,15 +459,19 @@
     "times, so a run that overrode a parameter, narrowed the labels or ran under the preview tier\n",
     "keeps its rows and publishes no name.\n",
     "\n",
-    "These sets are small enough to be compared prediction by prediction, which is why\n",
-    "[`15_model_analysis`](15_model_analysis.ipynb) does not need a separate bounded subset for\n",
-    "them the way it does for the larger grids."
+    "Each label gets two names, the same pair every other model notebook publishes: a **full set**\n",
+    "that [`16_backtest`](16_backtest.ipynb) backtests member by member, and a **bounded diagnostic\n",
+    "set** that [`15_model_analysis`](15_model_analysis.ipynb) loads raw predictions for. Here the\n",
+    "two hold the same single member, because this family declares one configuration and fits it\n",
+    "once rather than checkpointing it, so there is nothing to bound away. The two names still exist\n",
+    "so that every family is opened the same way downstream; the registry stores one set and binds\n",
+    "both names to it."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "951f5349",
+   "id": "856aaab3",
    "metadata": {
     "tags": [
      "results"
@@ -1285,16 +486,28 @@
     "if is_published_population:\n",
     "    for selected_label in selected_labels:\n",
     "        label_name = selected_label.replace(\"_\", \"-\")\n",
-    "        result_set = study.predictions.freeze(\n",
-    "            execution.catalog_rows.filter(pl.col(\"label\") == selected_label),\n",
+    "        label_rows = execution.catalog_rows.filter(pl.col(\"label\") == selected_label)\n",
+    "        full_set = study.predictions.freeze(\n",
+    "            label_rows,\n",
     "            name=f\"us-equities-{label_name}-ipca-v1\",\n",
     "        )\n",
-    "        set_rows.append(\n",
-    "            {\n",
-    "                \"role\": \"backtest and diagnostic population\",\n",
-    "                \"set_name\": result_set.name,\n",
-    "                \"members\": len(result_set.members),\n",
-    "            }\n",
+    "        diagnostic_set = study.predictions.freeze(\n",
+    "            label_rows,\n",
+    "            name=f\"us-equities-{label_name}-ipca-diagnostics-v1\",\n",
+    "        )\n",
+    "        set_rows.extend(\n",
+    "            [\n",
+    "                {\n",
+    "                    \"role\": \"backtest population\",\n",
+    "                    \"set_name\": full_set.name,\n",
+    "                    \"members\": len(full_set.members),\n",
+    "                },\n",
+    "                {\n",
+    "                    \"role\": \"bounded diagnostics\",\n",
+    "                    \"set_name\": diagnostic_set.name,\n",
+    "                    \"members\": len(diagnostic_set.members),\n",
+    "                },\n",
+    "            ]\n",
     "        )\n",
     "compatible_sets = pl.DataFrame(\n",
     "    set_rows,\n",
@@ -1305,17 +518,19 @@
   },
   {
    "cell_type": "markdown",
-   "id": "eaaf5c52",
+   "id": "a223a52c",
    "metadata": {},
    "source": [
-    "`15_model_analysis.py` reopens the named label sets for descriptive analysis. `16_backtest.py`\n",
-    "passes every catalog row directly to the shared backtest runner. Predictive metrics do not choose\n",
-    "a configuration or checkpoint."
+    "`15_model_analysis` reopens both names per label: the full set to confirm the run filled every\n",
+    "member it promised, and the diagnostic set to read raw predictions. `16_backtest` passes every\n",
+    "full-set catalog row to the shared backtest runner. Neither the metrics here nor the ones there\n",
+    "choose a configuration or a checkpoint; selection is on validation backtest Sharpe in\n",
+    "`16_backtest`."
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "cc4ff3ad",
+   "id": "ea516a68",
    "metadata": {},
    "source": [
     "## What to notice\n",
@@ -1349,33 +564,6 @@
    "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.14.3"
-  },
-  "papermill": {
-   "default_parameters": {},
-   "duration": 3850.309763,
-   "end_time": "2026-04-28T03:36:20.407748+00:00",
-   "environment_variables": {},
-   "exception": null,
-   "input_path": "case_studies/us_equities_panel/12b_ipca.ipynb",
-   "output_path": "~/scratch/tmp.m7LypxozL5.ipynb",
-   "parameters": {
-    "FORCE_RETRAIN": true,
-    "USE_CACHE": false
-   },
-   "start_time": "2026-04-28T02:32:10.097985+00:00",
-   "version": "2.7.0"
   }
  },
  "nbformat": 4,

--- a/case_studies/us_equities_panel/13b_ipca.ipynb
+++ b/case_studies/us_equities_panel/13b_ipca.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "8b179ad1",
+   "id": "1c4c27a6",
    "metadata": {},
    "source": [
     "# US equities panel: loadings that depend on what a stock is\n",
@@ -61,7 +61,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7b9a8b10",
+   "id": "2de410e1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -70,18 +70,20 @@
     "import os\n",
     "from pathlib import Path\n",
     "\n",
+    "import matplotlib.pyplot as plt\n",
     "import polars as pl\n",
     "import yaml\n",
     "\n",
     "from case_studies.research import open_study, plan_models\n",
     "from utils.modeling import load_configs\n",
-    "from utils.paths import get_case_study_dir"
+    "from utils.paths import get_case_study_dir\n",
+    "from utils.style import FIGSIZE, add_message_title, ml4t_palette, show_with_alt, zero_line"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6850faa1",
+   "id": "769f035a",
    "metadata": {
     "tags": [
      "parameters"
@@ -102,7 +104,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "14a612c1",
+   "id": "bd4037c4",
    "metadata": {},
    "source": [
     "## 1. Which labels, and how many factors\n",
@@ -128,7 +130,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "753d8e1e",
+   "id": "c0bfa90f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -170,7 +172,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cfa4d235",
+   "id": "fb6dd121",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -205,7 +207,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "50c65f8c",
+   "id": "9c7a4c11",
    "metadata": {},
    "source": [
     "## 2. Binding the declarations to the data\n",
@@ -222,7 +224,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "62a99952",
+   "id": "2654d7d4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -256,7 +258,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5b9af7db",
+   "id": "80f09d8c",
    "metadata": {},
    "source": [
     "## 3. Planning, then fitting\n",
@@ -279,7 +281,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "86f4ebda",
+   "id": "ea0c68c0",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -306,7 +308,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "00af5127",
+   "id": "a371a218",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -315,7 +317,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "aa70639f",
+   "id": "ec96aac8",
    "metadata": {},
    "source": [
     "## 4. What was actually fitted\n",
@@ -330,7 +332,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2f4feb07",
+   "id": "96fabf56",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -357,7 +359,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cb3030cb",
+   "id": "1609f85c",
    "metadata": {},
    "source": [
     "## 5. What came out\n",
@@ -375,7 +377,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "539d6f4a",
+   "id": "6c867675",
    "metadata": {
     "tags": [
      "results"
@@ -405,7 +407,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c99e235b",
+   "id": "82a02973",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -439,7 +441,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "264255ac",
+   "id": "5e0ae699",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -449,7 +451,81 @@
   },
   {
    "cell_type": "markdown",
-   "id": "71d49c5d",
+   "id": "d2f43cae",
+   "metadata": {},
+   "source": [
+    "### How the ranking held across the walk-forward folds\n",
+    "\n",
+    "The headline information coefficient above is an average over the folds, and an average says\n",
+    "nothing about whether the folds agreed. Each fold is a different year of the market with a\n",
+    "different set of names quoting in it, so a factor model can rank the cross-section well in a few\n",
+    "of them and not at all in the rest and still show a respectable mean.\n",
+    "\n",
+    "The per-fold values come from the registry rather than from the raw predictions: each fold's\n",
+    "information coefficient is registered alongside the prediction set, so reading it back costs a\n",
+    "query rather than a 7.2-million-row load. Loadings here are a function of a stock's own\n",
+    "characteristics rather than fitted per name, so a fold whose cross-section is unlike the\n",
+    "training window's is the one to look at first."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "db209f63",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fold_rows = []\n",
+    "for run in execution.runs:\n",
+    "    run_label = run.training.spec()[\"label\"]\n",
+    "    for prediction in run.predictions:\n",
+    "        fold_rows.append(prediction.folds().with_columns(label=pl.lit(run_label)))\n",
+    "folds_frame = pl.concat(fold_rows, how=\"vertical_relaxed\").sort(\"label\", \"fold_id\")\n",
+    "\n",
+    "fold_labels = folds_frame.get_column(\"label\").unique(maintain_order=True).to_list()\n",
+    "# `ml4t_palette` returns a list of that many colours, so it is called once and indexed.\n",
+    "palette = ml4t_palette(len(fold_labels), categorical=True)\n",
+    "\n",
+    "fig, ax = plt.subplots(figsize=FIGSIZE[\"single\"])\n",
+    "for index, fold_label in enumerate(fold_labels):\n",
+    "    series = folds_frame.filter(pl.col(\"label\") == fold_label)\n",
+    "    ax.plot(\n",
+    "        series.get_column(\"fold_id\"),\n",
+    "        series.get_column(\"ic\"),\n",
+    "        marker=\"o\",\n",
+    "        markersize=4,\n",
+    "        lw=1.4,\n",
+    "        color=palette[index],\n",
+    "        label=fold_label,\n",
+    "    )\n",
+    "zero_line(ax)\n",
+    "ax.set_xlabel(\"Walk-forward fold\")\n",
+    "ax.set_ylabel(\"Mean validation IC\")\n",
+    "ax.legend(fontsize=8, frameon=False)\n",
+    "add_message_title(\n",
+    "    ax,\n",
+    "    \"Mean validation IC by walk-forward fold\",\n",
+    "    subtitle=\"One line per declared label, over the folds the evaluation stage established\",\n",
+    ")\n",
+    "# The alt text counts rather than asserts: how many folds land above zero is a fact about the\n",
+    "# frame, and a line described as steady when it is not is a claim the data refutes.\n",
+    "_signs = (\n",
+    "    folds_frame.group_by(\"label\").agg(above=(pl.col(\"ic\") > 0).sum(), total=pl.len()).sort(\"label\")\n",
+    ")\n",
+    "_sign_text = \" and \".join(\n",
+    "    f\"{row['above']} of {row['total']} for {row['label']}\" for row in _signs.iter_rows(named=True)\n",
+    ")\n",
+    "show_with_alt(\n",
+    "    fig,\n",
+    "    \"A line chart of mean validation information coefficient against walk-forward fold, one line \"\n",
+    "    \"per declared label, with a dashed line at zero. Counted from the underlying frame, the folds \"\n",
+    "    f\"whose information coefficient is above zero are {_sign_text}.\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d7e117cb",
    "metadata": {},
    "source": [
     "## 6. Naming the sets the later notebooks open\n",
@@ -471,7 +547,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "856aaab3",
+   "id": "84dd9a95",
    "metadata": {
     "tags": [
      "results"
@@ -518,7 +594,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a223a52c",
+   "id": "b2f17fa7",
    "metadata": {},
    "source": [
     "`15_model_analysis` reopens both names per label: the full set to confirm the run filled every\n",
@@ -530,7 +606,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ea516a68",
+   "id": "3b82fd80",
    "metadata": {},
    "source": [
     "## What to notice\n",

--- a/case_studies/us_equities_panel/13b_ipca.ipynb
+++ b/case_studies/us_equities_panel/13b_ipca.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "af7fc6a1",
+   "id": "f8a09178",
    "metadata": {},
    "source": [
     "# US equities panel: loadings that depend on what a stock is\n",
@@ -61,7 +61,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6310e547",
+   "id": "eae25661",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -86,7 +86,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9545bb8a",
+   "id": "b2053bd9",
    "metadata": {
     "tags": [
      "parameters"
@@ -102,15 +102,15 @@
     "SUPERSEDES_SETS: dict = {}\n",
     "EXECUTION_TIER = \"canonical\"\n",
     "WORKSPACE = \"\"\n",
-    "MAX_SYMBOLS = 0\n",
-    "FOLD_IDS = []\n",
+    "PREVIEW_MAX_SYMBOLS = 0\n",
+    "PREVIEW_FOLD_IDS = []\n",
     "PREVIEW_N_FACTORS = 0\n",
     "PREVIEW_MAX_ITER = 0"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "114b4c37",
+   "id": "1888369f",
    "metadata": {},
    "source": [
     "## 1. Which labels, and how many factors\n",
@@ -130,13 +130,13 @@
     "- **`EXECUTION_TIER`** is `canonical` or `preview`. A canonical run fits the whole panel on every\n",
     "  fold. A preview run declares its reductions and carries them in the identity, so its results\n",
     "  can never be compared against canonical ones or reach a holdout decision.\n",
-    "- **`FOLD_IDS`** and **`MAX_SYMBOLS`** are the reductions a preview declares."
+    "- **`PREVIEW_FOLD_IDS`** and **`PREVIEW_MAX_SYMBOLS`** are the reductions a preview declares."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "be322d11",
+   "id": "a51b7012",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -177,7 +177,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "240e1292",
+   "id": "61c825e2",
    "metadata": {},
    "source": [
     "A run that narrows the labels or overrides a parameter produces a different set of predictions\n",
@@ -190,7 +190,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1c3bda52",
+   "id": "740976de",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -206,7 +206,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "89ddc616",
+   "id": "2bb42452",
    "metadata": {},
    "source": [
     "Both tiers resolve the study through `open_study`. It reads the labels and features in place\n",
@@ -218,15 +218,15 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b531f452",
+   "id": "ab1e739c",
    "metadata": {},
    "outputs": [],
    "source": [
     "preview_reductions = {}\n",
-    "if MAX_SYMBOLS:\n",
-    "    preview_reductions[\"max_symbols\"] = int(MAX_SYMBOLS)\n",
-    "if FOLD_IDS:\n",
-    "    preview_reductions[\"folds\"] = [int(fold) for fold in FOLD_IDS]\n",
+    "if PREVIEW_MAX_SYMBOLS:\n",
+    "    preview_reductions[\"max_symbols\"] = int(PREVIEW_MAX_SYMBOLS)\n",
+    "if PREVIEW_FOLD_IDS:\n",
+    "    preview_reductions[\"folds\"] = [int(fold) for fold in PREVIEW_FOLD_IDS]\n",
     "if PREVIEW_N_FACTORS:\n",
     "    preview_reductions[\"n_factors\"] = int(PREVIEW_N_FACTORS)\n",
     "if PREVIEW_MAX_ITER:\n",
@@ -237,7 +237,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "05297d40",
+   "id": "4da04c91",
    "metadata": {},
    "source": [
     "## 2. Binding the declarations to the data\n",
@@ -254,7 +254,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6c221cef",
+   "id": "ec58dc8f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -288,7 +288,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1841a5c5",
+   "id": "8d75effb",
    "metadata": {},
    "source": [
     "## 3. Planning, then fitting\n",
@@ -311,7 +311,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f1104809",
+   "id": "874ae220",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -332,7 +332,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "87a0c398",
+   "id": "b4399a4f",
    "metadata": {},
    "source": [
     "`run_model_population` takes the plan, writes the population down, fits every member and then\n",
@@ -352,7 +352,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1ecdd074",
+   "id": "288d7f6d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -374,7 +374,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7ef82ee6",
+   "id": "9c13dddf",
    "metadata": {},
    "source": [
     "## 4. What was actually fitted\n",
@@ -389,7 +389,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0ffe2873",
+   "id": "5e35356b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -416,7 +416,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e27e97cf",
+   "id": "32aa5f8d",
    "metadata": {},
    "source": [
     "## 5. What came out\n",
@@ -434,7 +434,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d1a2aa80",
+   "id": "e5ffa942",
    "metadata": {
     "tags": [
      "results"
@@ -464,7 +464,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d5662796",
+   "id": "92a39e22",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -496,7 +496,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0304e951",
+   "id": "60591441",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -506,7 +506,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "75fb55a2",
+   "id": "9d0d3252",
    "metadata": {},
    "source": [
     "### How the ranking held across the walk-forward folds\n",
@@ -526,7 +526,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "780b88d3",
+   "id": "fdfc011f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -580,7 +580,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "01f4727c",
+   "id": "17838df5",
    "metadata": {},
    "source": [
     "## 6. Naming the sets the later notebooks open\n",
@@ -602,7 +602,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "97a20e8e",
+   "id": "e985d8f7",
    "metadata": {
     "tags": [
      "results"
@@ -656,7 +656,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dce31009",
+   "id": "287e4664",
    "metadata": {},
    "source": [
     "`15_model_analysis` reopens both names per label: the full set to confirm the run filled every\n",
@@ -668,7 +668,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c601a6f6",
+   "id": "ff38a72f",
    "metadata": {},
    "source": [
     "## What to notice\n",

--- a/case_studies/us_equities_panel/13b_ipca.ipynb
+++ b/case_studies/us_equities_panel/13b_ipca.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "f8a09178",
+   "id": "78f794ce",
    "metadata": {},
    "source": [
     "# US equities panel: loadings that depend on what a stock is\n",
@@ -61,7 +61,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "eae25661",
+   "id": "bc0688f5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -86,7 +86,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b2053bd9",
+   "id": "eb278e3a",
    "metadata": {
     "tags": [
      "parameters"
@@ -110,7 +110,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1888369f",
+   "id": "0448b033",
    "metadata": {},
    "source": [
     "## 1. Which labels, and how many factors\n",
@@ -136,7 +136,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a51b7012",
+   "id": "4c6fbf4e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -177,7 +177,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "61c825e2",
+   "id": "f896d91a",
    "metadata": {},
    "source": [
     "A run that narrows the labels or overrides a parameter produces a different set of predictions\n",
@@ -190,7 +190,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "740976de",
+   "id": "59924abf",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -206,7 +206,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2bb42452",
+   "id": "536ef911",
    "metadata": {},
    "source": [
     "Both tiers resolve the study through `open_study`. It reads the labels and features in place\n",
@@ -218,7 +218,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ab1e739c",
+   "id": "6331f0ca",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -237,7 +237,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4da04c91",
+   "id": "aef822cd",
    "metadata": {},
    "source": [
     "## 2. Binding the declarations to the data\n",
@@ -254,7 +254,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ec58dc8f",
+   "id": "60e79c64",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -288,7 +288,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8d75effb",
+   "id": "2bb6b502",
    "metadata": {},
    "source": [
     "## 3. Planning, then fitting\n",
@@ -311,7 +311,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "874ae220",
+   "id": "fe75c5d0",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -332,7 +332,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b4399a4f",
+   "id": "4ba797ea",
    "metadata": {},
    "source": [
     "`run_model_population` takes the plan, writes the population down, fits every member and then\n",
@@ -352,7 +352,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "288d7f6d",
+   "id": "c40bede1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -374,7 +374,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9c13dddf",
+   "id": "f061756a",
    "metadata": {},
    "source": [
     "## 4. What was actually fitted\n",
@@ -389,7 +389,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5e35356b",
+   "id": "19dfa072",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -416,7 +416,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "32aa5f8d",
+   "id": "7a275593",
    "metadata": {},
    "source": [
     "## 5. What came out\n",
@@ -434,7 +434,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e5ffa942",
+   "id": "d2da35a8",
    "metadata": {
     "tags": [
      "results"
@@ -464,7 +464,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "92a39e22",
+   "id": "9e948632",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -496,7 +496,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "60591441",
+   "id": "24d4cd3a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -506,7 +506,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9d0d3252",
+   "id": "3a91ed7d",
    "metadata": {},
    "source": [
     "### How the ranking held across the walk-forward folds\n",
@@ -526,7 +526,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fdfc011f",
+   "id": "c7138153",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -580,7 +580,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "17838df5",
+   "id": "875b3593",
    "metadata": {},
    "source": [
     "## 6. Naming the sets the later notebooks open\n",
@@ -602,7 +602,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e985d8f7",
+   "id": "e1660276",
    "metadata": {
     "tags": [
      "results"
@@ -656,7 +656,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "287e4664",
+   "id": "a4f498aa",
    "metadata": {},
    "source": [
     "`15_model_analysis` reopens both names per label: the full set to confirm the run filled every\n",
@@ -668,7 +668,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ff38a72f",
+   "id": "5b211e05",
    "metadata": {},
    "source": [
     "## What to notice\n",

--- a/case_studies/us_equities_panel/13b_ipca.py
+++ b/case_studies/us_equities_panel/13b_ipca.py
@@ -69,14 +69,17 @@
 # %%
 """Generate IPCA validation predictions through the shared research interface."""
 
-import os
-from pathlib import Path
-
 import matplotlib.pyplot as plt
 import polars as pl
 import yaml
 
-from case_studies.research import open_study, plan_models
+from case_studies.research import (
+    candidate_set_supersedes,
+    open_study,
+    plan_models,
+    run_model_population,
+    supersedes_for_run,
+)
 from utils.modeling import load_configs
 from utils.paths import get_case_study_dir
 from utils.style import FIGSIZE, add_message_title, ml4t_palette, show_with_alt, zero_line
@@ -85,8 +88,11 @@ from utils.style import FIGSIZE, add_message_title, ml4t_palette, show_with_alt,
 CASE_STUDY_ID = "us_equities_panel"
 LABELS = []
 OVERRIDES = {}
+POPULATION_NAME = ""
+SUPERSEDES_POPULATION = ""
+SUPERSEDES_SETS: dict = {}
 EXECUTION_TIER = "canonical"
-WORKSPACE = "experiments"
+WORKSPACE = ""
 MAX_SYMBOLS = 0
 FOLD_IDS = []
 PREVIEW_N_FACTORS = 0
@@ -147,6 +153,29 @@ label_menu = pl.DataFrame(
 )
 label_menu
 
+# %% [markdown]
+# A run that narrows the labels or overrides a parameter produces a different set of predictions
+# from the one the canonical name stands for. Publishing it under that name would leave the name
+# meaning two different member sets at two different times, so the guard below requires such a run
+# to say what to call its own population, and the frozen set names in Section 6 are withheld from
+# it for the same reason.
+
+# %%
+is_published_population = (
+    EXECUTION_TIER == "canonical" and selected_labels == published_labels and not OVERRIDES
+)
+if EXECUTION_TIER == "canonical" and not is_published_population and not POPULATION_NAME:
+    raise ValueError(
+        "this run narrows the declared labels or overrides a parameter, so it cannot publish the "
+        "canonical population; pass POPULATION_NAME to give it its own"
+    )
+
+# %% [markdown]
+# Both tiers resolve the study through `open_study`. It reads the labels and features in place
+# and redirects only writes, so a preview run scores the same inputs a canonical one does and
+# cannot publish over it. A preview must be given a workspace to write into; a canonical run
+# leaves `WORKSPACE` empty and regenerates the case study's own artifacts in place.
+
 # %%
 preview_reductions = {}
 if MAX_SYMBOLS:
@@ -158,23 +187,7 @@ if PREVIEW_N_FACTORS:
 if PREVIEW_MAX_ITER:
     preview_reductions["max_iter"] = int(PREVIEW_MAX_ITER)
 
-# Both tiers resolve the study through `open_study`. It reads the labels and features in place and
-# redirects only writes, so a preview run scores the same inputs a canonical one does and cannot
-# publish over it.
-if EXECUTION_TIER == "canonical":
-    if preview_reductions:
-        raise ValueError("Canonical execution cannot declare preview reductions")
-    study = open_study(CASE_STUDY_ID, execution_tier=EXECUTION_TIER)
-elif EXECUTION_TIER == "preview":
-    if not preview_reductions:
-        raise ValueError("Preview execution requires at least one declared reduction")
-    study = open_study(
-        CASE_STUDY_ID,
-        execution_tier=EXECUTION_TIER,
-        workspace=Path(os.environ.get("ML4T_OUTPUT_DIR") or WORKSPACE),
-    )
-else:
-    raise ValueError("EXECUTION_TIER must be 'canonical' or 'preview'")
+study = open_study(CASE_STUDY_ID, execution_tier=EXECUTION_TIER, workspace=WORKSPACE or None)
 
 # %% [markdown]
 # ## 2. Binding the declarations to the data
@@ -234,11 +247,6 @@ request_table
 
 # %%
 plan = plan_models(study, requests=requests)
-official_population = None
-if EXECUTION_TIER == "canonical":
-    official_population = plan.create_population(
-        name="us-equities-ipca-checkpoints-v1",
-    )
 
 planned_population = pl.DataFrame(
     {
@@ -252,8 +260,35 @@ planned_population = pl.DataFrame(
 )
 planned_population
 
+# %% [markdown]
+# `run_model_population` takes the plan, writes the population down, fits every member and then
+# checks that what came out is what was declared. The same call serves both tiers: a canonical run
+# registers an immutable population that the later notebooks bind to, and a preview run gets a
+# declaration that is verified and then discarded with its workspace, so no notebook here has to
+# branch on the tier to decide what to publish.
+#
+# `SUPERSEDES_POPULATION` names the population hash this run replaces. A population is a set of
+# prediction identities, so anything that moves a training identity - a changed preset as much as a
+# changed menu - produces a different population under the same name, and the registry refuses to
+# write it without being told which snapshot it supersedes. Leaving it empty is right for a first
+# run and for a reader's clean clone, and `supersedes_for_run` withholds a declared hash wherever
+# offering it would be refused.
+
 # %%
-execution = plan.run()
+population_name = POPULATION_NAME or "us-equities-ipca-checkpoints-v1"
+execution, official_population = run_model_population(
+    study,
+    plan,
+    population_name=population_name,
+    supersedes=supersedes_for_run(
+        study,
+        population_name=population_name,
+        declared=SUPERSEDES_POPULATION,
+        execution_tier=EXECUTION_TIER,
+    ),
+)
+
+print(f"population {official_population.name}: {len(official_population.members)} prediction sets")
 
 # %% [markdown]
 # ## 4. What was actually fitted
@@ -339,8 +374,6 @@ for run in execution.runs:
         )
 
 coverage_table = pl.DataFrame(coverage_rows).sort("label", "prediction_hash")
-if official_population is not None:
-    official_population.require_complete()
 coverage_table
 
 # %%
@@ -357,7 +390,7 @@ execution_diagnostics
 #
 # The per-fold values come from the registry rather than from the raw predictions: each fold's
 # information coefficient is registered alongside the prediction set, so reading it back costs a
-# query rather than a 7.2-million-row load. Loadings here are a function of a stock's own
+# query rather than a seven-million-row load. Loadings here are a function of a stock's own
 # characteristics rather than fitted per name, so a fold whose cross-section is unlike the
 # training window's is the one to look at first.
 
@@ -427,20 +460,27 @@ show_with_alt(
 
 # %% tags=["results"]
 set_rows = []
-is_published_population = (
-    EXECUTION_TIER == "canonical" and selected_labels == published_labels and not OVERRIDES
-)
 if is_published_population:
     for selected_label in selected_labels:
         label_name = selected_label.replace("_", "-")
         label_rows = execution.catalog_rows.filter(pl.col("label") == selected_label)
+        full_set_name = f"us-equities-{label_name}-ipca-v1"
         full_set = study.predictions.freeze(
             label_rows,
-            name=f"us-equities-{label_name}-ipca-v1",
+            name=full_set_name,
+            supersedes=candidate_set_supersedes(
+                study, name=full_set_name, declared=SUPERSEDES_SETS.get(full_set_name, "")
+            ),
         )
+        diagnostic_set_name = f"us-equities-{label_name}-ipca-diagnostics-v1"
         diagnostic_set = study.predictions.freeze(
             label_rows,
-            name=f"us-equities-{label_name}-ipca-diagnostics-v1",
+            name=diagnostic_set_name,
+            supersedes=candidate_set_supersedes(
+                study,
+                name=diagnostic_set_name,
+                declared=SUPERSEDES_SETS.get(diagnostic_set_name, ""),
+            ),
         )
         set_rows.extend(
             [

--- a/case_studies/us_equities_panel/13b_ipca.py
+++ b/case_studies/us_equities_panel/13b_ipca.py
@@ -72,12 +72,14 @@
 import os
 from pathlib import Path
 
+import matplotlib.pyplot as plt
 import polars as pl
 import yaml
 
 from case_studies.research import open_study, plan_models
 from utils.modeling import load_configs
 from utils.paths import get_case_study_dir
+from utils.style import FIGSIZE, add_message_title, ml4t_palette, show_with_alt, zero_line
 
 # %% tags=["parameters"]
 CASE_STUDY_ID = "us_equities_panel"
@@ -344,6 +346,68 @@ coverage_table
 # %%
 execution_diagnostics = pl.DataFrame(execution.diagnostics)
 execution_diagnostics
+
+# %% [markdown]
+# ### How the ranking held across the walk-forward folds
+#
+# The headline information coefficient above is an average over the folds, and an average says
+# nothing about whether the folds agreed. Each fold is a different year of the market with a
+# different set of names quoting in it, so a factor model can rank the cross-section well in a few
+# of them and not at all in the rest and still show a respectable mean.
+#
+# The per-fold values come from the registry rather than from the raw predictions: each fold's
+# information coefficient is registered alongside the prediction set, so reading it back costs a
+# query rather than a 7.2-million-row load. Loadings here are a function of a stock's own
+# characteristics rather than fitted per name, so a fold whose cross-section is unlike the
+# training window's is the one to look at first.
+
+# %%
+fold_rows = []
+for run in execution.runs:
+    run_label = run.training.spec()["label"]
+    for prediction in run.predictions:
+        fold_rows.append(prediction.folds().with_columns(label=pl.lit(run_label)))
+folds_frame = pl.concat(fold_rows, how="vertical_relaxed").sort("label", "fold_id")
+
+fold_labels = folds_frame.get_column("label").unique(maintain_order=True).to_list()
+# `ml4t_palette` returns a list of that many colours, so it is called once and indexed.
+palette = ml4t_palette(len(fold_labels), categorical=True)
+
+fig, ax = plt.subplots(figsize=FIGSIZE["single"])
+for index, fold_label in enumerate(fold_labels):
+    series = folds_frame.filter(pl.col("label") == fold_label)
+    ax.plot(
+        series.get_column("fold_id"),
+        series.get_column("ic"),
+        marker="o",
+        markersize=4,
+        lw=1.4,
+        color=palette[index],
+        label=fold_label,
+    )
+zero_line(ax)
+ax.set_xlabel("Walk-forward fold")
+ax.set_ylabel("Mean validation IC")
+ax.legend(fontsize=8, frameon=False)
+add_message_title(
+    ax,
+    "Mean validation IC by walk-forward fold",
+    subtitle="One line per declared label, over the folds the evaluation stage established",
+)
+# The alt text counts rather than asserts: how many folds land above zero is a fact about the
+# frame, and a line described as steady when it is not is a claim the data refutes.
+_signs = (
+    folds_frame.group_by("label").agg(above=(pl.col("ic") > 0).sum(), total=pl.len()).sort("label")
+)
+_sign_text = " and ".join(
+    f"{row['above']} of {row['total']} for {row['label']}" for row in _signs.iter_rows(named=True)
+)
+show_with_alt(
+    fig,
+    "A line chart of mean validation information coefficient against walk-forward fold, one line "
+    "per declared label, with a dashed line at zero. Counted from the underlying frame, the folds "
+    f"whose information coefficient is above zero are {_sign_text}.",
+)
 
 # %% [markdown]
 # ## 6. Naming the sets the later notebooks open

--- a/case_studies/us_equities_panel/13b_ipca.py
+++ b/case_studies/us_equities_panel/13b_ipca.py
@@ -93,8 +93,8 @@ SUPERSEDES_POPULATION = ""
 SUPERSEDES_SETS: dict = {}
 EXECUTION_TIER = "canonical"
 WORKSPACE = ""
-MAX_SYMBOLS = 0
-FOLD_IDS = []
+PREVIEW_MAX_SYMBOLS = 0
+PREVIEW_FOLD_IDS = []
 PREVIEW_N_FACTORS = 0
 PREVIEW_MAX_ITER = 0
 
@@ -116,7 +116,7 @@ PREVIEW_MAX_ITER = 0
 # - **`EXECUTION_TIER`** is `canonical` or `preview`. A canonical run fits the whole panel on every
 #   fold. A preview run declares its reductions and carries them in the identity, so its results
 #   can never be compared against canonical ones or reach a holdout decision.
-# - **`FOLD_IDS`** and **`MAX_SYMBOLS`** are the reductions a preview declares.
+# - **`PREVIEW_FOLD_IDS`** and **`PREVIEW_MAX_SYMBOLS`** are the reductions a preview declares.
 
 # %%
 case_dir = get_case_study_dir(CASE_STUDY_ID)
@@ -178,10 +178,10 @@ if EXECUTION_TIER == "canonical" and not is_published_population and not POPULAT
 
 # %%
 preview_reductions = {}
-if MAX_SYMBOLS:
-    preview_reductions["max_symbols"] = int(MAX_SYMBOLS)
-if FOLD_IDS:
-    preview_reductions["folds"] = [int(fold) for fold in FOLD_IDS]
+if PREVIEW_MAX_SYMBOLS:
+    preview_reductions["max_symbols"] = int(PREVIEW_MAX_SYMBOLS)
+if PREVIEW_FOLD_IDS:
+    preview_reductions["folds"] = [int(fold) for fold in PREVIEW_FOLD_IDS]
 if PREVIEW_N_FACTORS:
     preview_reductions["n_factors"] = int(PREVIEW_N_FACTORS)
 if PREVIEW_MAX_ITER:

--- a/case_studies/us_equities_panel/13b_ipca.py
+++ b/case_studies/us_equities_panel/13b_ipca.py
@@ -353,9 +353,13 @@ execution_diagnostics
 # times, so a run that overrode a parameter, narrowed the labels or ran under the preview tier
 # keeps its rows and publishes no name.
 #
-# These sets are small enough to be compared prediction by prediction, which is why
-# [`15_model_analysis`](15_model_analysis.ipynb) does not need a separate bounded subset for
-# them the way it does for the larger grids.
+# Each label gets two names, the same pair every other model notebook publishes: a **full set**
+# that [`16_backtest`](16_backtest.ipynb) backtests member by member, and a **bounded diagnostic
+# set** that [`15_model_analysis`](15_model_analysis.ipynb) loads raw predictions for. Here the
+# two hold the same single member, because this family declares one configuration and fits it
+# once rather than checkpointing it, so there is nothing to bound away. The two names still exist
+# so that every family is opened the same way downstream; the registry stores one set and binds
+# both names to it.
 
 # %% tags=["results"]
 set_rows = []
@@ -365,16 +369,28 @@ is_published_population = (
 if is_published_population:
     for selected_label in selected_labels:
         label_name = selected_label.replace("_", "-")
-        result_set = study.predictions.freeze(
-            execution.catalog_rows.filter(pl.col("label") == selected_label),
+        label_rows = execution.catalog_rows.filter(pl.col("label") == selected_label)
+        full_set = study.predictions.freeze(
+            label_rows,
             name=f"us-equities-{label_name}-ipca-v1",
         )
-        set_rows.append(
-            {
-                "role": "backtest and diagnostic population",
-                "set_name": result_set.name,
-                "members": len(result_set.members),
-            }
+        diagnostic_set = study.predictions.freeze(
+            label_rows,
+            name=f"us-equities-{label_name}-ipca-diagnostics-v1",
+        )
+        set_rows.extend(
+            [
+                {
+                    "role": "backtest population",
+                    "set_name": full_set.name,
+                    "members": len(full_set.members),
+                },
+                {
+                    "role": "bounded diagnostics",
+                    "set_name": diagnostic_set.name,
+                    "members": len(diagnostic_set.members),
+                },
+            ]
         )
 compatible_sets = pl.DataFrame(
     set_rows,
@@ -383,9 +399,11 @@ compatible_sets = pl.DataFrame(
 compatible_sets
 
 # %% [markdown]
-# `15_model_analysis.py` reopens the named label sets for descriptive analysis. `16_backtest.py`
-# passes every catalog row directly to the shared backtest runner. Predictive metrics do not choose
-# a configuration or checkpoint.
+# `15_model_analysis` reopens both names per label: the full set to confirm the run filled every
+# member it promised, and the diagnostic set to read raw predictions. `16_backtest` passes every
+# full-set catalog row to the shared backtest runner. Neither the metrics here nor the ones there
+# choose a configuration or a checkpoint; selection is on validation backtest Sharpe in
+# `16_backtest`.
 
 # %% [markdown]
 # ## What to notice

--- a/case_studies/us_equities_panel/14_causal_dml.ipynb
+++ b/case_studies/us_equities_panel/14_causal_dml.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "be87e46d",
+   "id": "4e51db55",
    "metadata": {},
    "source": [
     "# US equities panel: a different question - does momentum cause the return, or predict it?\n",
@@ -67,7 +67,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5c2f0e13",
+   "id": "500c65fd",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -88,7 +88,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "df17ecc1",
+   "id": "a3bde233",
    "metadata": {},
    "source": [
     "## What this estimate rests on, and what it cannot establish\n",
@@ -122,7 +122,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c57e92d1",
+   "id": "6307d210",
    "metadata": {
     "tags": [
      "parameters"
@@ -136,7 +136,7 @@
     "NUISANCE_OVERRIDES = {}\n",
     "EXECUTION_TIER = \"canonical\"\n",
     "WORKSPACE = \"experiments\"\n",
-    "MAX_SYMBOLS = 0\n",
+    "PREVIEW_MAX_SYMBOLS = 0\n",
     "PREVIEW_MAX_SAMPLES = 0\n",
     "PREVIEW_N_FOLDS = 0\n",
     "PREVIEW_N_PLACEBO = 0\n",
@@ -145,7 +145,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c119872f",
+   "id": "807ba58f",
    "metadata": {},
    "source": [
     "## Configure the estimand and execution\n",
@@ -162,7 +162,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3e8e0068",
+   "id": "a741d2a9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -197,13 +197,13 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4d72be99",
+   "id": "7fe1341f",
    "metadata": {},
    "outputs": [],
    "source": [
     "preview_reductions = {}\n",
-    "if MAX_SYMBOLS:\n",
-    "    preview_reductions[\"max_symbols\"] = int(MAX_SYMBOLS)\n",
+    "if PREVIEW_MAX_SYMBOLS:\n",
+    "    preview_reductions[\"max_symbols\"] = int(PREVIEW_MAX_SYMBOLS)\n",
     "if PREVIEW_MAX_SAMPLES:\n",
     "    preview_reductions[\"max_samples\"] = int(PREVIEW_MAX_SAMPLES)\n",
     "if PREVIEW_N_FOLDS:\n",
@@ -243,7 +243,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a240f98f",
+   "id": "d4beed7d",
    "metadata": {},
    "source": [
     "## Inspect the resolved request\n",
@@ -258,7 +258,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "57b9bf71",
+   "id": "a01230f1",
    "metadata": {
     "tags": [
      "results"
@@ -299,7 +299,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9ccdad8f",
+   "id": "6d5e3476",
    "metadata": {},
    "source": [
     "## Execute and validate the result\n",
@@ -321,7 +321,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a9c59ac4",
+   "id": "c105fe07",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -337,7 +337,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d0210f95",
+   "id": "01f6d69f",
    "metadata": {
     "tags": [
      "results"
@@ -366,7 +366,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3a53c484",
+   "id": "f6062e37",
    "metadata": {},
    "source": [
     "### What the permuted treatments produced\n",
@@ -386,7 +386,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "31cf3a12",
+   "id": "abd8cdfb",
    "metadata": {
     "tags": [
      "results"
@@ -426,7 +426,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6cdb23e2",
+   "id": "13a5da8a",
    "metadata": {},
    "source": [
     "## Downstream handoff\n",
@@ -437,7 +437,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9271ae69",
+   "id": "78376921",
    "metadata": {},
    "source": [
     "## What to notice\n",

--- a/case_studies/us_equities_panel/14_causal_dml.ipynb
+++ b/case_studies/us_equities_panel/14_causal_dml.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "84b40606",
+   "id": "be87e46d",
    "metadata": {},
    "source": [
     "# US equities panel: a different question - does momentum cause the return, or predict it?\n",
@@ -31,10 +31,10 @@
     "not explain, regressed on the part of the treatment they do not explain. Whatever the confounders\n",
     "accounted for has been taken out of both sides before the effect is estimated.\n",
     "\n",
-    "**\"Double\" is why machine learning is safe here.** Using a flexible model to remove a confounder\n",
-    "would normally bias the estimate, because the model's own error leaks into what is left.\n",
-    "Residualising *both* sides and estimating from the two residual series is what cancels that\n",
-    "leakage to first order.\n",
+    "**\"Double\" is why machine learning is safe here.** A flexible model fitted to a confounder makes\n",
+    "its own error, and that error is left behind in whatever the model does not explain. Residualising\n",
+    "*both* sides and estimating the effect from the two residual series cancels that leakage to first\n",
+    "order; residualising one side and regressing on the raw other does not.\n",
     "\n",
     "**The nuisance models are fitted walk-forward with an embargo**, the same way every predictive\n",
     "model in this case study is. A confounder model fitted on the whole sample would have removed\n",
@@ -67,7 +67,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "428fa288",
+   "id": "5c2f0e13",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -88,7 +88,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f68ee884",
+   "id": "df17ecc1",
    "metadata": {},
    "source": [
     "## What this estimate rests on, and what it cannot establish\n",
@@ -122,7 +122,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3cb9c1f9",
+   "id": "c57e92d1",
    "metadata": {
     "tags": [
      "parameters"
@@ -145,7 +145,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "11948697",
+   "id": "c119872f",
    "metadata": {},
    "source": [
     "## Configure the estimand and execution\n",
@@ -162,7 +162,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "859e3b34",
+   "id": "3e8e0068",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -197,7 +197,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "af483007",
+   "id": "4d72be99",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -243,7 +243,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d9a4225b",
+   "id": "a240f98f",
    "metadata": {},
    "source": [
     "## Inspect the resolved request\n",
@@ -258,7 +258,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "42d7b03f",
+   "id": "57b9bf71",
    "metadata": {
     "tags": [
      "results"
@@ -299,7 +299,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "66bbd6e6",
+   "id": "9ccdad8f",
    "metadata": {},
    "source": [
     "## Execute and validate the result\n",
@@ -313,14 +313,15 @@
     "made on the same sample rather than on samples that differ. **`confounding_bias_pct`** is the\n",
     "gap between the two, `naive_effect` minus `dml_effect`, as a percentage of the adjusted\n",
     "estimate's magnitude. It is the size of what the three declared confounders were accounting for,\n",
-    "measured against what survives them. A large value says the confounders mattered; it says\n",
+    "measured against what remains once they are taken out. A large value says the confounders\n",
+    "mattered; it says\n",
     "nothing about whether a fourth one is missing."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fde96f0e",
+   "id": "a9c59ac4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -336,7 +337,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4791f906",
+   "id": "d0210f95",
    "metadata": {
     "tags": [
      "results"
@@ -365,7 +366,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ae19e5e5",
+   "id": "3a53c484",
    "metadata": {},
    "source": [
     "### What the permuted treatments produced\n",
@@ -385,7 +386,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b550e2f7",
+   "id": "31cf3a12",
    "metadata": {
     "tags": [
      "results"
@@ -425,7 +426,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "762deb12",
+   "id": "6cdb23e2",
    "metadata": {},
    "source": [
     "## Downstream handoff\n",
@@ -436,7 +437,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "85454e7e",
+   "id": "9271ae69",
    "metadata": {},
    "source": [
     "## What to notice\n",
@@ -451,8 +452,8 @@
     "own in [`15_model_analysis`](15_model_analysis.ipynb) rather than placed beside the predictive\n",
     "results.\n",
     "\n",
-    "**The interesting outcome is not necessarily a large effect.** A predictive relation that\n",
-    "survives conditioning on the confounders and a causal estimate near zero are both informative:\n",
+    "**The interesting outcome is not necessarily a large effect.** A predictive relation that persists\n",
+    "after conditioning on the confounders and a causal estimate near zero are both informative:\n",
     "the first says momentum carries something the three confounders do not, the second says the\n",
     "association may be something they do carry.\n",
     "\n",

--- a/case_studies/us_equities_panel/14_causal_dml.ipynb
+++ b/case_studies/us_equities_panel/14_causal_dml.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "c5de10b4",
+   "id": "84b40606",
    "metadata": {},
    "source": [
     "# US equities panel: a different question - does momentum cause the return, or predict it?\n",
@@ -67,7 +67,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "41a7c9dc",
+   "id": "428fa288",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -88,7 +88,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "be888fcb",
+   "id": "f68ee884",
    "metadata": {},
    "source": [
     "## What this estimate rests on, and what it cannot establish\n",
@@ -122,7 +122,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c1166bf1",
+   "id": "3cb9c1f9",
    "metadata": {
     "tags": [
      "parameters"
@@ -145,7 +145,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4f4be634",
+   "id": "11948697",
    "metadata": {},
    "source": [
     "## Configure the estimand and execution\n",
@@ -162,7 +162,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "302f5a01",
+   "id": "859e3b34",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -197,7 +197,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "31c1b021",
+   "id": "af483007",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -243,7 +243,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ac4b27e4",
+   "id": "d9a4225b",
    "metadata": {},
    "source": [
     "## Inspect the resolved request\n",
@@ -258,7 +258,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5e20031e",
+   "id": "42d7b03f",
    "metadata": {
     "tags": [
      "results"
@@ -299,7 +299,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d294cfde",
+   "id": "66bbd6e6",
    "metadata": {},
    "source": [
     "## Execute and validate the result\n",
@@ -320,7 +320,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "359317d9",
+   "id": "fde96f0e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -336,7 +336,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a749532c",
+   "id": "4791f906",
    "metadata": {
     "tags": [
      "results"
@@ -365,7 +365,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8798f470",
+   "id": "ae19e5e5",
    "metadata": {},
    "source": [
     "### What the permuted treatments produced\n",
@@ -385,7 +385,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0f499bd8",
+   "id": "b550e2f7",
    "metadata": {
     "tags": [
      "results"
@@ -408,10 +408,9 @@
     "ax.set_ylabel(\"Permuted draws\")\n",
     "add_message_title(\n",
     "    ax,\n",
-    "    \"Where the estimate sits once the treatment's timing is destroyed\",\n",
+    "    \"Effect estimated from block-permuted treatments\",\n",
     "    subtitle=\"Block-permuted refits, with the observed effect marked\",\n",
     ")\n",
-    "fig.tight_layout()\n",
     "# The alt text counts rather than asserts. Whether the observed effect is extreme is the whole\n",
     "# question, so it is read off the draws instead of being described.\n",
     "_more_extreme = sum(abs(value) >= abs(observed_effect) for value in placebo_effects)\n",
@@ -426,7 +425,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a4ab70c3",
+   "id": "762deb12",
    "metadata": {},
    "source": [
     "## Downstream handoff\n",
@@ -437,7 +436,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ff6be651",
+   "id": "85454e7e",
    "metadata": {},
    "source": [
     "## What to notice\n",
@@ -473,18 +472,6 @@
    "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.14.3"
   }
  },
  "nbformat": 4,

--- a/case_studies/us_equities_panel/14_causal_dml.py
+++ b/case_studies/us_equities_panel/14_causal_dml.py
@@ -122,7 +122,7 @@ CONFIG_NAME = "dml"
 NUISANCE_OVERRIDES = {}
 EXECUTION_TIER = "canonical"
 WORKSPACE = "experiments"
-MAX_SYMBOLS = 0
+PREVIEW_MAX_SYMBOLS = 0
 PREVIEW_MAX_SAMPLES = 0
 PREVIEW_N_FOLDS = 0
 PREVIEW_N_PLACEBO = 0
@@ -169,8 +169,8 @@ config_menu
 
 # %%
 preview_reductions = {}
-if MAX_SYMBOLS:
-    preview_reductions["max_symbols"] = int(MAX_SYMBOLS)
+if PREVIEW_MAX_SYMBOLS:
+    preview_reductions["max_symbols"] = int(PREVIEW_MAX_SYMBOLS)
 if PREVIEW_MAX_SAMPLES:
     preview_reductions["max_samples"] = int(PREVIEW_MAX_SAMPLES)
 if PREVIEW_N_FOLDS:

--- a/case_studies/us_equities_panel/14_causal_dml.py
+++ b/case_studies/us_equities_panel/14_causal_dml.py
@@ -40,10 +40,10 @@
 # not explain, regressed on the part of the treatment they do not explain. Whatever the confounders
 # accounted for has been taken out of both sides before the effect is estimated.
 #
-# **"Double" is why machine learning is safe here.** Using a flexible model to remove a confounder
-# would normally bias the estimate, because the model's own error leaks into what is left.
-# Residualising *both* sides and estimating from the two residual series is what cancels that
-# leakage to first order.
+# **"Double" is why machine learning is safe here.** A flexible model fitted to a confounder makes
+# its own error, and that error is left behind in whatever the model does not explain. Residualising
+# *both* sides and estimating the effect from the two residual series cancels that leakage to first
+# order; residualising one side and regressing on the raw other does not.
 #
 # **The nuisance models are fitted walk-forward with an embargo**, the same way every predictive
 # model in this case study is. A confounder model fitted on the whole sample would have removed
@@ -259,7 +259,8 @@ resolved_table
 # made on the same sample rather than on samples that differ. **`confounding_bias_pct`** is the
 # gap between the two, `naive_effect` minus `dml_effect`, as a percentage of the adjusted
 # estimate's magnitude. It is the size of what the three declared confounders were accounting for,
-# measured against what survives them. A large value says the confounders mattered; it says
+# measured against what remains once they are taken out. A large value says the confounders
+# mattered; it says
 # nothing about whether a fourth one is missing.
 
 # %%
@@ -353,8 +354,8 @@ show_with_alt(
 # own in [`15_model_analysis`](15_model_analysis.ipynb) rather than placed beside the predictive
 # results.
 #
-# **The interesting outcome is not necessarily a large effect.** A predictive relation that
-# survives conditioning on the confounders and a causal estimate near zero are both informative:
+# **The interesting outcome is not necessarily a large effect.** A predictive relation that persists
+# after conditioning on the confounders and a causal estimate near zero are both informative:
 # the first says momentum carries something the three confounders do not, the second says the
 # association may be something they do carry.
 #

--- a/case_studies/us_equities_panel/14_causal_dml.py
+++ b/case_studies/us_equities_panel/14_causal_dml.py
@@ -320,10 +320,9 @@ ax.set_xlabel("Estimated effect")
 ax.set_ylabel("Permuted draws")
 add_message_title(
     ax,
-    "Where the estimate sits once the treatment's timing is destroyed",
+    "Effect estimated from block-permuted treatments",
     subtitle="Block-permuted refits, with the observed effect marked",
 )
-fig.tight_layout()
 # The alt text counts rather than asserts. Whether the observed effect is extreme is the whole
 # question, so it is read off the draws instead of being described.
 _more_extreme = sum(abs(value) >= abs(observed_effect) for value in placebo_effects)

--- a/case_studies/us_equities_panel/15_model_analysis.ipynb
+++ b/case_studies/us_equities_panel/15_model_analysis.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "e5578992",
+   "id": "e61b268c",
    "metadata": {},
    "source": [
     "# US equities panel: what the fitted models are worth before any of them is traded\n",
@@ -64,7 +64,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bf6ef06a",
+   "id": "93d94d87",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -96,7 +96,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "22047172",
+   "id": "d0abb50f",
    "metadata": {
     "tags": [
      "parameters"
@@ -135,7 +135,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8e9baed2",
+   "id": "efe70255",
    "metadata": {
     "tags": [
      "parameters"
@@ -158,7 +158,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "994ba11f",
+   "id": "359ceaca",
    "metadata": {
     "tags": [
      "parameters"
@@ -189,7 +189,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d232e220",
+   "id": "f73289b3",
    "metadata": {},
    "source": [
     "## 1. Opening the named sets, and checking each is whole\n",
@@ -203,7 +203,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2999a71b",
+   "id": "6691160e",
    "metadata": {
     "tags": [
      "results"
@@ -222,10 +222,9 @@
     "    ):\n",
     "        if not names or len(names) != len(set(names)):\n",
     "            raise ValueError(f\"{field} must contain unique names\")\n",
-    "    # A diagnostic name that is also a prediction name is a family with no bounded set, filled in\n",
-    "    # with the full one. Sections 4 to 6 then load the whole population's raw prediction frames\n",
-    "    # while the prose says they read a bounded subset. Checked here rather than after the sets are\n",
-    "    # opened, because it is a statement about the two lists and needs nothing from the registry.\n",
+    "    # A name in both lists is a family with no bounded set, filled in with the full one, so\n",
+    "    # Sections 4 to 6 would load the whole population. Checked here because it is a statement\n",
+    "    # about the two lists and needs nothing from the registry.\n",
     "    shared_names = sorted(set(DIAGNOSTIC_SET_NAMES) & set(PREDICTION_SET_NAMES))\n",
     "    if shared_names:\n",
     "        raise ValueError(\n",
@@ -260,7 +259,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7a6c8fa1",
+   "id": "da6bb709",
    "metadata": {
     "tags": [
      "results"
@@ -283,7 +282,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "41f30494",
+   "id": "ee988b0a",
    "metadata": {
     "tags": [
      "results"
@@ -320,7 +319,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7331e1ab",
+   "id": "83c5cd41",
    "metadata": {
     "tags": [
      "results"
@@ -358,7 +357,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "138da54d",
+   "id": "21b61396",
    "metadata": {
     "tags": [
      "results"
@@ -379,11 +378,9 @@
     "            raise ValueError(\n",
     "                f\"{diagnostic_set.hash} resolved {len(matching_full_sets)} matching full sets\"\n",
     "            )\n",
-    "        # `<=` above finds the full set this bounded one came from; it does not establish that\n",
-    "        # any bounding happened, because a set is a subset of itself. Where the full set holds\n",
-    "        # more than one member, the bounded one has to be strictly smaller. Where it holds one -\n",
-    "        # a family that declares one configuration and does not checkpoint it - there is nothing\n",
-    "        # to bound and the two coincide, which is why this is not a flat proper-subset test.\n",
+    "        # `<=` above finds which full set this one came from and establishes no bounding, since\n",
+    "        # a set is a subset of itself. A family publishing one member has nothing to bound, so\n",
+    "        # the strict test applies only where the full set holds more than one.\n",
     "        full_members = set(matching_full_sets[0].members)\n",
     "        if len(full_members) > 1 and set(diagnostic_set.members) == full_members:\n",
     "            raise ValueError(\n",
@@ -395,7 +392,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "97e70bdc",
+   "id": "dc9edb7b",
    "metadata": {
     "tags": [
      "results"
@@ -441,7 +438,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a24e5456",
+   "id": "74806cb0",
    "metadata": {
     "tags": [
      "results"
@@ -476,7 +473,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "37845e46",
+   "id": "3b8ae15c",
    "metadata": {},
    "source": [
     "## 2. Every result complete, and scored where it said it would be\n",
@@ -491,7 +488,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "56f174fd",
+   "id": "7bac8783",
    "metadata": {
     "tags": [
      "results"
@@ -507,7 +504,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2e99a734",
+   "id": "aaeaa0fd",
    "metadata": {
     "tags": [
      "results"
@@ -561,7 +558,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c692579e",
+   "id": "612cdde6",
    "metadata": {
     "tags": [
      "results"
@@ -577,7 +574,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ce006d40",
+   "id": "90771397",
    "metadata": {},
    "source": [
     "## 3. How well each model ranks the cross-section\n",
@@ -598,7 +595,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d80682ed",
+   "id": "818e234b",
    "metadata": {
     "tags": [
      "results"
@@ -649,7 +646,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b6e896ed",
+   "id": "dce5547a",
    "metadata": {},
    "source": [
     "The population is several hundred candidates, because a checkpoint is one of them, so a chart\n",
@@ -673,7 +670,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fff42fe6",
+   "id": "59ddba79",
    "metadata": {
     "tags": [
      "results"
@@ -749,7 +746,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8de1fb67",
+   "id": "3a04def3",
    "metadata": {},
    "source": [
     "## 4. Whether that ranking ability holds across windows\n",
@@ -770,7 +767,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "66052ff8",
+   "id": "82c2c213",
    "metadata": {
     "tags": [
      "results"
@@ -822,7 +819,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2aef65e8",
+   "id": "c74f4776",
    "metadata": {
     "tags": [
      "results"
@@ -847,7 +844,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d892e6ed",
+   "id": "f82f07f9",
    "metadata": {},
    "source": [
     "## 5. Whether two models carry the same information\n",
@@ -877,7 +874,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "94885728",
+   "id": "cf94ff50",
    "metadata": {
     "tags": [
      "results"
@@ -901,7 +898,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "45f13850",
+   "id": "9bf09060",
    "metadata": {
     "tags": [
      "results"
@@ -948,7 +945,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4075ee62",
+   "id": "1a5e939a",
    "metadata": {
     "tags": [
      "results"
@@ -956,8 +953,7 @@
    },
    "outputs": [],
    "source": [
-    "# `left_index + 1` rather than `left_index`: a result against itself correlates at one on every\n",
-    "# date and answers nothing.\n",
+    "# `left_index + 1`: a result against itself correlates at one on every date.\n",
     "for left_index, left_hash in enumerate(diagnostic_hashes):\n",
     "    for right_hash in diagnostic_hashes[left_index + 1 :]:\n",
     "        if label_by_member[left_hash] != label_by_member[right_hash]:\n",
@@ -982,10 +978,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0bdb2214",
+   "id": "814fa5ee",
    "metadata": {},
    "source": [
-    "## 6. How wide the uncertainty is, and whether the width holds up\n",
+    "## 6. How wide the uncertainty is, and whether the width is calibrated\n",
     "\n",
     "The width measured here is the one the `conformal_weighted` allocator sizes positions with:\n",
     "calibrated per symbol on every absolute residual known at `t - h`, where `h` is that label's\n",
@@ -1002,7 +998,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1b49ca23",
+   "id": "8e2db1d8",
    "metadata": {
     "tags": [
      "results"
@@ -1045,7 +1041,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5c873db7",
+   "id": "5ed27f1d",
    "metadata": {},
    "source": [
     "## 7. The causal estimate, read on its own terms\n",
@@ -1060,7 +1056,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c14d8b99",
+   "id": "cbf68ee2",
    "metadata": {
     "tags": [
      "results"
@@ -1112,7 +1108,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "82be044a",
+   "id": "ff8ad054",
    "metadata": {},
    "source": [
     "## What goes on to the backtest\n",
@@ -1127,7 +1123,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "29604be3",
+   "id": "76729c71",
    "metadata": {
     "tags": [
      "results"
@@ -1145,7 +1141,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "df370c9c",
+   "id": "d7c7e2da",
    "metadata": {},
    "source": [
     "## What to notice\n",
@@ -1158,7 +1154,7 @@
     "**An average over dates needs an interval that knows the dates are not independent.** A\n",
     "five-session forward return measured every session shares four of its five days with the next\n",
     "one. Treating those as independent observations makes an interval too narrow and a t-statistic\n",
-    "too large, on every model equally, so the ranking survives and the significance does not.\n",
+    "too large, on every model equally, so the ordering is unaffected and the significance is not.\n",
     "\n",
     "**A mean IC and a stable IC are different claims.** Averaging across folds hides which folds\n",
     "contributed, and a configuration that ranks well in one window and not at all in the others has\n",

--- a/case_studies/us_equities_panel/15_model_analysis.ipynb
+++ b/case_studies/us_equities_panel/15_model_analysis.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "d24f040f",
+   "id": "0cd52ee8",
    "metadata": {},
    "source": [
     "# US equities panel: what the fitted models are worth before any of them is traded\n",
@@ -64,7 +64,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ab1612fa",
+   "id": "e42b14f0",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -96,7 +96,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5fa0b89d",
+   "id": "cd0e0e7f",
    "metadata": {
     "tags": [
      "parameters"
@@ -135,7 +135,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e15c5a55",
+   "id": "93ba19cd",
    "metadata": {
     "tags": [
      "parameters"
@@ -158,7 +158,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "43d49a2a",
+   "id": "9fae14fb",
    "metadata": {
     "tags": [
      "parameters"
@@ -189,7 +189,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "12a90dd4",
+   "id": "83373cc1",
    "metadata": {},
    "source": [
     "## 1. Opening the named sets, and checking each is whole\n",
@@ -203,7 +203,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "aa4f921c",
+   "id": "12f9e28a",
    "metadata": {
     "tags": [
      "results"
@@ -260,7 +260,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f5aa36b0",
+   "id": "1b04c599",
    "metadata": {
     "tags": [
      "results"
@@ -283,7 +283,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e986c0d2",
+   "id": "6d44aadc",
    "metadata": {
     "tags": [
      "results"
@@ -320,7 +320,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d5e5b6a7",
+   "id": "db611df2",
    "metadata": {
     "tags": [
      "results"
@@ -358,7 +358,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1938d6f9",
+   "id": "e737066a",
    "metadata": {
     "tags": [
      "results"
@@ -395,7 +395,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ced2ba36",
+   "id": "3655514d",
    "metadata": {
     "tags": [
      "results"
@@ -441,7 +441,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fab0eb42",
+   "id": "7a7c8bd2",
    "metadata": {
     "tags": [
      "results"
@@ -476,7 +476,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8bf48c3f",
+   "id": "a35e0585",
    "metadata": {},
    "source": [
     "## 2. Every result complete, and scored where it said it would be\n",
@@ -491,7 +491,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4fdcbe76",
+   "id": "9f97b0a9",
    "metadata": {
     "tags": [
      "results"
@@ -507,7 +507,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0cc6157b",
+   "id": "4c22e870",
    "metadata": {
     "tags": [
      "results"
@@ -561,7 +561,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c31d5fe5",
+   "id": "a181d123",
    "metadata": {
     "tags": [
      "results"
@@ -577,7 +577,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "aee64aa6",
+   "id": "d1a7faed",
    "metadata": {},
    "source": [
     "## 3. How well each model ranks the cross-section\n",
@@ -598,7 +598,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0914c605",
+   "id": "99130422",
    "metadata": {
     "tags": [
      "results"
@@ -649,7 +649,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "af806726",
+   "id": "be6a8fb5",
    "metadata": {},
    "source": [
     "The population is several hundred candidates, because a checkpoint is one of them, so a chart\n",
@@ -673,7 +673,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "122dc142",
+   "id": "c620d67f",
    "metadata": {
     "tags": [
      "results"
@@ -723,8 +723,10 @@
     "axes[1].set_ylim(bottom=0)\n",
     "add_message_title(\n",
     "    axes[0],\n",
-    "    \"Read the cloud, not the point: several hundred candidates per column\",\n",
-    "    subtitle=\"Left, each candidate's mean daily IC; right, the half-width of its HAC interval\",\n",
+    "    \"Mean daily IC and interval half-width, by label and family\",\n",
+    "    subtitle=(\n",
+    "        \"One point per candidate; read the height of a column's cloud rather than any single point\"\n",
+    "    ),\n",
     ")\n",
     "# The alt text counts rather than asserts: whether any family's cloud clears zero is a fact about\n",
     "# the frame, and a panel described as separating the families when it does not is a claim the data\n",
@@ -747,7 +749,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "29444f4b",
+   "id": "aa08520f",
    "metadata": {},
    "source": [
     "## 4. Whether that ranking ability holds across windows\n",
@@ -768,7 +770,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9802014a",
+   "id": "c069b7ab",
    "metadata": {
     "tags": [
      "results"
@@ -820,7 +822,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f412709b",
+   "id": "39d6f5d5",
    "metadata": {
     "tags": [
      "results"
@@ -845,7 +847,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7ace145c",
+   "id": "7533bf39",
    "metadata": {},
    "source": [
     "## 5. Whether two models carry the same information\n",
@@ -875,7 +877,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6f65db9c",
+   "id": "f4f37ff9",
    "metadata": {
     "tags": [
      "results"
@@ -899,7 +901,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3844c865",
+   "id": "5ea34912",
    "metadata": {
     "tags": [
      "results"
@@ -946,7 +948,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "feeac640",
+   "id": "a9df1c8a",
    "metadata": {
     "tags": [
      "results"
@@ -980,7 +982,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9bf74f42",
+   "id": "a1300dc4",
    "metadata": {},
    "source": [
     "## 6. How wide the uncertainty is, and whether the width holds up\n",
@@ -1000,7 +1002,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a3af2f3a",
+   "id": "42cd11fa",
    "metadata": {
     "tags": [
      "results"
@@ -1043,7 +1045,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6b9009ad",
+   "id": "b5d12aa0",
    "metadata": {},
    "source": [
     "## 7. The causal estimate, read on its own terms\n",
@@ -1058,7 +1060,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1153a8e9",
+   "id": "b5e2b3fc",
    "metadata": {
     "tags": [
      "results"
@@ -1110,7 +1112,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7562e14b",
+   "id": "24920d67",
    "metadata": {},
    "source": [
     "## What goes on to the backtest\n",
@@ -1125,7 +1127,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fb923a78",
+   "id": "c64bcfe1",
    "metadata": {
     "tags": [
      "results"
@@ -1143,7 +1145,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e4f817fa",
+   "id": "1535c4b4",
    "metadata": {},
    "source": [
     "## What to notice\n",

--- a/case_studies/us_equities_panel/15_model_analysis.ipynb
+++ b/case_studies/us_equities_panel/15_model_analysis.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "57a326ad",
+   "id": "d24f040f",
    "metadata": {},
    "source": [
     "# US equities panel: what the fitted models are worth before any of them is traded\n",
@@ -64,7 +64,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "25334a84",
+   "id": "ab1612fa",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -96,7 +96,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cf205f70",
+   "id": "5fa0b89d",
    "metadata": {
     "tags": [
      "parameters"
@@ -135,7 +135,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f63f6aa0",
+   "id": "e15c5a55",
    "metadata": {
     "tags": [
      "parameters"
@@ -158,7 +158,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "391fdbcb",
+   "id": "43d49a2a",
    "metadata": {
     "tags": [
      "parameters"
@@ -174,22 +174,22 @@
     "    \"us-equities-fwd-ret-5d-gbm-diagnostics-v1\",\n",
     "    \"us-equities-fwd-ret-21d-gbm-diagnostics-v1\",\n",
     "    \"us-equities-fwd-ret-1d-tabular-dl-diagnostics-v1\",\n",
-    "    \"us-equities-fwd-ret-1d-nlinear-v1\",\n",
-    "    \"us-equities-fwd-ret-1d-lstm-v1\",\n",
-    "    \"us-equities-fwd-ret-1d-tsmixer-v1\",\n",
-    "    \"us-equities-fwd-ret-1d-pca-v1\",\n",
-    "    \"us-equities-fwd-ret-1d-ipca-v1\",\n",
-    "    \"us-equities-fwd-ret-5d-pca-v1\",\n",
-    "    \"us-equities-fwd-ret-5d-ipca-v1\",\n",
-    "    \"us-equities-fwd-ret-21d-pca-v1\",\n",
-    "    \"us-equities-fwd-ret-21d-ipca-v1\",\n",
+    "    \"us-equities-fwd-ret-1d-nlinear-diagnostics-v1\",\n",
+    "    \"us-equities-fwd-ret-1d-lstm-diagnostics-v1\",\n",
+    "    \"us-equities-fwd-ret-1d-tsmixer-diagnostics-v1\",\n",
+    "    \"us-equities-fwd-ret-1d-pca-diagnostics-v1\",\n",
+    "    \"us-equities-fwd-ret-1d-ipca-diagnostics-v1\",\n",
+    "    \"us-equities-fwd-ret-5d-pca-diagnostics-v1\",\n",
+    "    \"us-equities-fwd-ret-5d-ipca-diagnostics-v1\",\n",
+    "    \"us-equities-fwd-ret-21d-pca-diagnostics-v1\",\n",
+    "    \"us-equities-fwd-ret-21d-ipca-diagnostics-v1\",\n",
     "]\n",
     "CAUSAL_LABELS = [\"fwd_ret_1d\"]"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "18763954",
+   "id": "12a90dd4",
    "metadata": {},
    "source": [
     "## 1. Opening the named sets, and checking each is whole\n",
@@ -203,7 +203,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "787df4a9",
+   "id": "aa4f921c",
    "metadata": {
     "tags": [
      "results"
@@ -222,6 +222,15 @@
     "    ):\n",
     "        if not names or len(names) != len(set(names)):\n",
     "            raise ValueError(f\"{field} must contain unique names\")\n",
+    "    # A diagnostic name that is also a prediction name is a family with no bounded set, filled in\n",
+    "    # with the full one. Sections 4 to 6 then load the whole population's raw prediction frames\n",
+    "    # while the prose says they read a bounded subset. Checked here rather than after the sets are\n",
+    "    # opened, because it is a statement about the two lists and needs nothing from the registry.\n",
+    "    shared_names = sorted(set(DIAGNOSTIC_SET_NAMES) & set(PREDICTION_SET_NAMES))\n",
+    "    if shared_names:\n",
+    "        raise ValueError(\n",
+    "            f\"these names are declared as both the full and the bounded set: {shared_names}\"\n",
+    "        )\n",
     "    study = Study.open(CASE_STUDY_ID)\n",
     "elif EXECUTION_TIER == \"preview\":\n",
     "    if not preview_filters or PREVIEW_MAX_PREDICTIONS < 1 or PREVIEW_MAX_DIAGNOSTICS < 1:\n",
@@ -251,7 +260,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "73785123",
+   "id": "f5aa36b0",
    "metadata": {
     "tags": [
      "results"
@@ -274,7 +283,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7f9026e8",
+   "id": "e986c0d2",
    "metadata": {
     "tags": [
      "results"
@@ -311,7 +320,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "803b471d",
+   "id": "d5e5b6a7",
    "metadata": {
     "tags": [
      "results"
@@ -329,11 +338,6 @@
     "    prediction_set_by_member = {\n",
     "        member: declared_set.name\n",
     "        for declared_set in prediction_sets\n",
-    "        for member in declared_set.members\n",
-    "    }\n",
-    "    diagnostic_set_by_member = {\n",
-    "        member: declared_set.name\n",
-    "        for declared_set in diagnostic_sets\n",
     "        for member in declared_set.members\n",
     "    }\n",
     "    if len(prediction_members) != len(set(prediction_members)):\n",
@@ -354,7 +358,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fd7b06aa",
+   "id": "1938d6f9",
    "metadata": {
     "tags": [
      "results"
@@ -374,13 +378,24 @@
     "        if len(matching_full_sets) != 1:\n",
     "            raise ValueError(\n",
     "                f\"{diagnostic_set.hash} resolved {len(matching_full_sets)} matching full sets\"\n",
+    "            )\n",
+    "        # `<=` above finds the full set this bounded one came from; it does not establish that\n",
+    "        # any bounding happened, because a set is a subset of itself. Where the full set holds\n",
+    "        # more than one member, the bounded one has to be strictly smaller. Where it holds one -\n",
+    "        # a family that declares one configuration and does not checkpoint it - there is nothing\n",
+    "        # to bound and the two coincide, which is why this is not a flat proper-subset test.\n",
+    "        full_members = set(matching_full_sets[0].members)\n",
+    "        if len(full_members) > 1 and set(diagnostic_set.members) == full_members:\n",
+    "            raise ValueError(\n",
+    "                f\"{diagnostic_set.name} bounds nothing: it is all {len(full_members)} members of \"\n",
+    "                f\"{matching_full_sets[0].name}\"\n",
     "            )"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "53ada031",
+   "id": "ced2ba36",
    "metadata": {
     "tags": [
      "results"
@@ -426,7 +441,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b65db672",
+   "id": "fab0eb42",
    "metadata": {
     "tags": [
      "results"
@@ -442,9 +457,6 @@
     "        for row in preview_selection.iter_rows(named=True)\n",
     "    }\n",
     "    prediction_set_by_member = dict(preview_group_by_member)\n",
-    "    diagnostic_set_by_member = {\n",
-    "        member: preview_group_by_member[member] for member in diagnostic_members\n",
-    "    }\n",
     "    set_rows = [\n",
     "        {\n",
     "            \"role\": role,\n",
@@ -464,7 +476,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fcff8ca3",
+   "id": "8bf48c3f",
    "metadata": {},
    "source": [
     "## 2. Every result complete, and scored where it said it would be\n",
@@ -479,7 +491,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0b371828",
+   "id": "4fdcbe76",
    "metadata": {
     "tags": [
      "results"
@@ -495,7 +507,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5d61869c",
+   "id": "0cc6157b",
    "metadata": {
     "tags": [
      "results"
@@ -549,7 +561,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d7891c31",
+   "id": "c31d5fe5",
    "metadata": {
     "tags": [
      "results"
@@ -565,7 +577,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0779cd48",
+   "id": "aee64aa6",
    "metadata": {},
    "source": [
     "## 3. How well each model ranks the cross-section\n",
@@ -586,7 +598,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "497e950f",
+   "id": "0914c605",
    "metadata": {
     "tags": [
      "results"
@@ -637,7 +649,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f29ad3b0",
+   "id": "af806726",
    "metadata": {},
    "source": [
     "The population is several hundred candidates, because a checkpoint is one of them, so a chart\n",
@@ -661,7 +673,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "27fc6334",
+   "id": "122dc142",
    "metadata": {
     "tags": [
      "results"
@@ -714,7 +726,6 @@
     "    \"Read the cloud, not the point: several hundred candidates per column\",\n",
     "    subtitle=\"Left, each candidate's mean daily IC; right, the half-width of its HAC interval\",\n",
     ")\n",
-    "fig.tight_layout()\n",
     "# The alt text counts rather than asserts: whether any family's cloud clears zero is a fact about\n",
     "# the frame, and a panel described as separating the families when it does not is a claim the data\n",
     "# refutes.\n",
@@ -736,7 +747,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bbfe5ff7",
+   "id": "29444f4b",
    "metadata": {},
    "source": [
     "## 4. Whether that ranking ability holds across windows\n",
@@ -747,13 +758,17 @@
     "The fold summaries below separate them.\n",
     "\n",
     "This is where raw predictions are read rather than registry metrics, which is why it runs over\n",
-    "the bounded diagnostic subset rather than the whole population."
+    "the bounded diagnostic subset rather than the whole population. Each model notebook publishes\n",
+    "that subset as one member per label and family - its diagnostic configuration at its last\n",
+    "checkpoint - and the bound is arithmetic rather than taste. One prediction frame on this panel\n",
+    "is 7.2 million rows and about 225 MB held in memory, every diagnostic frame is resident at once\n",
+    "because Section 5 joins them pairwise, and the full population is several hundred members."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "29ed9f13",
+   "id": "9802014a",
    "metadata": {
     "tags": [
      "results"
@@ -805,7 +820,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ef22e5e3",
+   "id": "f412709b",
    "metadata": {
     "tags": [
      "results"
@@ -830,7 +845,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ccc8739f",
+   "id": "7ace145c",
    "metadata": {},
    "source": [
     "## 5. Whether two models carry the same information\n",
@@ -839,17 +854,28 @@
     "names in the same order. A portfolio holding both would then be taking one bet at twice the\n",
     "size, which is the failure this section exists to catch.\n",
     "\n",
+    "Every pair drawn from the same label is compared, which pairs the families against each other:\n",
+    "a label fixes what the models were predicting and which folds they were scored on, so two\n",
+    "results under it are answering the same question and their orderings can be set side by side.\n",
+    "Pairs that cross labels are not compared, because a one-day and a twenty-one-day forward return\n",
+    "are different questions and a correlation between them measures nothing.\n",
+    "\n",
     "The comparison is made only on the observations both results actually cover, one date at a time,\n",
     "and averaged over dates. Two things are checked before any correlation is computed: that the\n",
     "join is one-to-one, because a join that quietly multiplies rows makes two models look more alike\n",
     "than they are, and that both artifacts carry the same realized return for every shared\n",
-    "observation, because if they disagree about what happened they are not comparable at all."
+    "observation, because if they disagree about what happened they are not comparable at all.\n",
+    "\n",
+    "Coverage differs between families and the frame says by how much. A sequence model scores only\n",
+    "the stock-dates where sixty consecutive sessions were available, so it covers fewer rows than a\n",
+    "model on the flat table, and `n_shared_rows` is what a reader checks before reading a\n",
+    "correlation as a statement about the whole panel."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9d6413c8",
+   "id": "6f65db9c",
    "metadata": {
     "tags": [
      "results"
@@ -859,6 +885,10 @@
    "source": [
     "correlation_rows = []\n",
     "diagnostic_hashes = list(diagnostic_members)\n",
+    "label_by_member = {\n",
+    "    row[\"prediction_hash\"]: row[\"label\"]\n",
+    "    for row in catalog.select(\"prediction_hash\", \"label\").iter_rows(named=True)\n",
+    "}\n",
     "\n",
     "\n",
     "def prediction_display_id(prediction_hash):\n",
@@ -869,7 +899,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "eef87a0a",
+   "id": "3844c865",
    "metadata": {
     "tags": [
      "results"
@@ -916,7 +946,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c2840677",
+   "id": "feeac640",
    "metadata": {
     "tags": [
      "results"
@@ -924,19 +954,33 @@
    },
    "outputs": [],
    "source": [
+    "# `left_index + 1` rather than `left_index`: a result against itself correlates at one on every\n",
+    "# date and answers nothing.\n",
     "for left_index, left_hash in enumerate(diagnostic_hashes):\n",
-    "    for right_hash in diagnostic_hashes[left_index:]:\n",
-    "        if diagnostic_set_by_member[left_hash] != diagnostic_set_by_member[right_hash]:\n",
+    "    for right_hash in diagnostic_hashes[left_index + 1 :]:\n",
+    "        if label_by_member[left_hash] != label_by_member[right_hash]:\n",
     "            continue\n",
     "        correlation_rows.append(summarize_prediction_pair(left_hash, right_hash))\n",
     "\n",
-    "correlations = pl.DataFrame(correlation_rows).sort(\"left\", \"right\")\n",
+    "# The schema is declared so that a run whose diagnostic members share no label - a preview holding\n",
+    "# one - produces an empty frame with columns rather than a frame with none, which `sort` would\n",
+    "# raise on.\n",
+    "correlations = pl.DataFrame(\n",
+    "    correlation_rows,\n",
+    "    schema={\n",
+    "        \"left\": pl.String,\n",
+    "        \"right\": pl.String,\n",
+    "        \"mean_daily_correlation\": pl.Float64,\n",
+    "        \"n_shared_rows\": pl.Int64,\n",
+    "        \"n_decision_dates\": pl.Int64,\n",
+    "    },\n",
+    ").sort(\"left\", \"right\")\n",
     "correlations"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "9718b292",
+   "id": "9bf74f42",
    "metadata": {},
    "source": [
     "## 6. How wide the uncertainty is, and whether the width holds up\n",
@@ -956,7 +1000,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3f06dc3b",
+   "id": "a3af2f3a",
    "metadata": {
     "tags": [
      "results"
@@ -999,7 +1043,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c02f1c20",
+   "id": "6b9009ad",
    "metadata": {},
    "source": [
     "## 7. The causal estimate, read on its own terms\n",
@@ -1014,7 +1058,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c23fcdc1",
+   "id": "1153a8e9",
    "metadata": {
     "tags": [
      "results"
@@ -1066,7 +1110,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "14805c99",
+   "id": "7562e14b",
    "metadata": {},
    "source": [
     "## What goes on to the backtest\n",
@@ -1081,7 +1125,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f80bc3c9",
+   "id": "fb923a78",
    "metadata": {
     "tags": [
      "results"
@@ -1099,7 +1143,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "014c098e",
+   "id": "e4f817fa",
    "metadata": {},
    "source": [
     "## What to notice\n",
@@ -1152,18 +1196,6 @@
    "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.14.3"
   }
  },
  "nbformat": 4,

--- a/case_studies/us_equities_panel/15_model_analysis.ipynb
+++ b/case_studies/us_equities_panel/15_model_analysis.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "0cd52ee8",
+   "id": "e5578992",
    "metadata": {},
    "source": [
     "# US equities panel: what the fitted models are worth before any of them is traded\n",
@@ -64,7 +64,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e42b14f0",
+   "id": "bf6ef06a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -96,7 +96,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cd0e0e7f",
+   "id": "22047172",
    "metadata": {
     "tags": [
      "parameters"
@@ -135,7 +135,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "93ba19cd",
+   "id": "8e9baed2",
    "metadata": {
     "tags": [
      "parameters"
@@ -158,7 +158,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9fae14fb",
+   "id": "994ba11f",
    "metadata": {
     "tags": [
      "parameters"
@@ -189,7 +189,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "83373cc1",
+   "id": "d232e220",
    "metadata": {},
    "source": [
     "## 1. Opening the named sets, and checking each is whole\n",
@@ -203,7 +203,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "12f9e28a",
+   "id": "2999a71b",
    "metadata": {
     "tags": [
      "results"
@@ -260,7 +260,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1b04c599",
+   "id": "7a6c8fa1",
    "metadata": {
     "tags": [
      "results"
@@ -283,7 +283,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6d44aadc",
+   "id": "41f30494",
    "metadata": {
     "tags": [
      "results"
@@ -320,7 +320,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "db611df2",
+   "id": "7331e1ab",
    "metadata": {
     "tags": [
      "results"
@@ -358,7 +358,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e737066a",
+   "id": "138da54d",
    "metadata": {
     "tags": [
      "results"
@@ -395,7 +395,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3655514d",
+   "id": "97e70bdc",
    "metadata": {
     "tags": [
      "results"
@@ -441,7 +441,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7a7c8bd2",
+   "id": "a24e5456",
    "metadata": {
     "tags": [
      "results"
@@ -476,7 +476,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a35e0585",
+   "id": "37845e46",
    "metadata": {},
    "source": [
     "## 2. Every result complete, and scored where it said it would be\n",
@@ -491,7 +491,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9f97b0a9",
+   "id": "56f174fd",
    "metadata": {
     "tags": [
      "results"
@@ -507,7 +507,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4c22e870",
+   "id": "2e99a734",
    "metadata": {
     "tags": [
      "results"
@@ -561,7 +561,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a181d123",
+   "id": "c692579e",
    "metadata": {
     "tags": [
      "results"
@@ -577,7 +577,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d1a7faed",
+   "id": "ce006d40",
    "metadata": {},
    "source": [
     "## 3. How well each model ranks the cross-section\n",
@@ -598,7 +598,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "99130422",
+   "id": "d80682ed",
    "metadata": {
     "tags": [
      "results"
@@ -649,7 +649,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "be6a8fb5",
+   "id": "b6e896ed",
    "metadata": {},
    "source": [
     "The population is several hundred candidates, because a checkpoint is one of them, so a chart\n",
@@ -673,7 +673,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c620d67f",
+   "id": "fff42fe6",
    "metadata": {
     "tags": [
      "results"
@@ -749,7 +749,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "aa08520f",
+   "id": "8de1fb67",
    "metadata": {},
    "source": [
     "## 4. Whether that ranking ability holds across windows\n",
@@ -763,14 +763,14 @@
     "the bounded diagnostic subset rather than the whole population. Each model notebook publishes\n",
     "that subset as one member per label and family - its diagnostic configuration at its last\n",
     "checkpoint - and the bound is arithmetic rather than taste. One prediction frame on this panel\n",
-    "is 7.2 million rows and about 225 MB held in memory, every diagnostic frame is resident at once\n",
+    "is over seven million rows and about 225 MB held in memory, every diagnostic frame is resident at once\n",
     "because Section 5 joins them pairwise, and the full population is several hundred members."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c069b7ab",
+   "id": "66052ff8",
    "metadata": {
     "tags": [
      "results"
@@ -822,7 +822,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "39d6f5d5",
+   "id": "2aef65e8",
    "metadata": {
     "tags": [
      "results"
@@ -847,7 +847,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7533bf39",
+   "id": "d892e6ed",
    "metadata": {},
    "source": [
     "## 5. Whether two models carry the same information\n",
@@ -877,7 +877,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f4f37ff9",
+   "id": "94885728",
    "metadata": {
     "tags": [
      "results"
@@ -901,7 +901,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5ea34912",
+   "id": "45f13850",
    "metadata": {
     "tags": [
      "results"
@@ -948,7 +948,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a9df1c8a",
+   "id": "4075ee62",
    "metadata": {
     "tags": [
      "results"
@@ -982,7 +982,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a1300dc4",
+   "id": "0bdb2214",
    "metadata": {},
    "source": [
     "## 6. How wide the uncertainty is, and whether the width holds up\n",
@@ -1002,7 +1002,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "42cd11fa",
+   "id": "1b49ca23",
    "metadata": {
     "tags": [
      "results"
@@ -1045,7 +1045,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b5d12aa0",
+   "id": "5c873db7",
    "metadata": {},
    "source": [
     "## 7. The causal estimate, read on its own terms\n",
@@ -1060,7 +1060,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b5e2b3fc",
+   "id": "c14d8b99",
    "metadata": {
     "tags": [
      "results"
@@ -1112,7 +1112,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "24920d67",
+   "id": "82be044a",
    "metadata": {},
    "source": [
     "## What goes on to the backtest\n",
@@ -1127,7 +1127,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c64bcfe1",
+   "id": "29604be3",
    "metadata": {
     "tags": [
      "results"
@@ -1145,7 +1145,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1535c4b4",
+   "id": "df370c9c",
    "metadata": {},
    "source": [
     "## What to notice\n",

--- a/case_studies/us_equities_panel/15_model_analysis.py
+++ b/case_studies/us_equities_panel/15_model_analysis.py
@@ -143,15 +143,15 @@ DIAGNOSTIC_SET_NAMES = [
     "us-equities-fwd-ret-5d-gbm-diagnostics-v1",
     "us-equities-fwd-ret-21d-gbm-diagnostics-v1",
     "us-equities-fwd-ret-1d-tabular-dl-diagnostics-v1",
-    "us-equities-fwd-ret-1d-nlinear-v1",
-    "us-equities-fwd-ret-1d-lstm-v1",
-    "us-equities-fwd-ret-1d-tsmixer-v1",
-    "us-equities-fwd-ret-1d-pca-v1",
-    "us-equities-fwd-ret-1d-ipca-v1",
-    "us-equities-fwd-ret-5d-pca-v1",
-    "us-equities-fwd-ret-5d-ipca-v1",
-    "us-equities-fwd-ret-21d-pca-v1",
-    "us-equities-fwd-ret-21d-ipca-v1",
+    "us-equities-fwd-ret-1d-nlinear-diagnostics-v1",
+    "us-equities-fwd-ret-1d-lstm-diagnostics-v1",
+    "us-equities-fwd-ret-1d-tsmixer-diagnostics-v1",
+    "us-equities-fwd-ret-1d-pca-diagnostics-v1",
+    "us-equities-fwd-ret-1d-ipca-diagnostics-v1",
+    "us-equities-fwd-ret-5d-pca-diagnostics-v1",
+    "us-equities-fwd-ret-5d-ipca-diagnostics-v1",
+    "us-equities-fwd-ret-21d-pca-diagnostics-v1",
+    "us-equities-fwd-ret-21d-ipca-diagnostics-v1",
 ]
 CAUSAL_LABELS = ["fwd_ret_1d"]
 
@@ -175,6 +175,15 @@ if EXECUTION_TIER == "canonical":
     ):
         if not names or len(names) != len(set(names)):
             raise ValueError(f"{field} must contain unique names")
+    # A diagnostic name that is also a prediction name is a family with no bounded set, filled in
+    # with the full one. Sections 4 to 6 then load the whole population's raw prediction frames
+    # while the prose says they read a bounded subset. Checked here rather than after the sets are
+    # opened, because it is a statement about the two lists and needs nothing from the registry.
+    shared_names = sorted(set(DIAGNOSTIC_SET_NAMES) & set(PREDICTION_SET_NAMES))
+    if shared_names:
+        raise ValueError(
+            f"these names are declared as both the full and the bounded set: {shared_names}"
+        )
     study = Study.open(CASE_STUDY_ID)
 elif EXECUTION_TIER == "preview":
     if not preview_filters or PREVIEW_MAX_PREDICTIONS < 1 or PREVIEW_MAX_DIAGNOSTICS < 1:
@@ -251,11 +260,6 @@ if EXECUTION_TIER == "canonical":
         for declared_set in prediction_sets
         for member in declared_set.members
     }
-    diagnostic_set_by_member = {
-        member: declared_set.name
-        for declared_set in diagnostic_sets
-        for member in declared_set.members
-    }
     if len(prediction_members) != len(set(prediction_members)):
         raise ValueError("full prediction sets overlap")
     if len(diagnostic_members) != len(set(diagnostic_members)):
@@ -283,6 +287,17 @@ if EXECUTION_TIER == "canonical":
         if len(matching_full_sets) != 1:
             raise ValueError(
                 f"{diagnostic_set.hash} resolved {len(matching_full_sets)} matching full sets"
+            )
+        # `<=` above finds the full set this bounded one came from; it does not establish that
+        # any bounding happened, because a set is a subset of itself. Where the full set holds
+        # more than one member, the bounded one has to be strictly smaller. Where it holds one -
+        # a family that declares one configuration and does not checkpoint it - there is nothing
+        # to bound and the two coincide, which is why this is not a flat proper-subset test.
+        full_members = set(matching_full_sets[0].members)
+        if len(full_members) > 1 and set(diagnostic_set.members) == full_members:
+            raise ValueError(
+                f"{diagnostic_set.name} bounds nothing: it is all {len(full_members)} members of "
+                f"{matching_full_sets[0].name}"
             )
 
 # %% tags=["results"]
@@ -329,9 +344,6 @@ if EXECUTION_TIER == "preview":
         for row in preview_selection.iter_rows(named=True)
     }
     prediction_set_by_member = dict(preview_group_by_member)
-    diagnostic_set_by_member = {
-        member: preview_group_by_member[member] for member in diagnostic_members
-    }
     set_rows = [
         {
             "role": role,
@@ -531,7 +543,6 @@ add_message_title(
     "Read the cloud, not the point: several hundred candidates per column",
     subtitle="Left, each candidate's mean daily IC; right, the half-width of its HAC interval",
 )
-fig.tight_layout()
 # The alt text counts rather than asserts: whether any family's cloud clears zero is a fact about
 # the frame, and a panel described as separating the families when it does not is a claim the data
 # refutes.
@@ -559,7 +570,11 @@ show_with_alt(
 # The fold summaries below separate them.
 #
 # This is where raw predictions are read rather than registry metrics, which is why it runs over
-# the bounded diagnostic subset rather than the whole population.
+# the bounded diagnostic subset rather than the whole population. Each model notebook publishes
+# that subset as one member per label and family - its diagnostic configuration at its last
+# checkpoint - and the bound is arithmetic rather than taste. One prediction frame on this panel
+# is 7.2 million rows and about 225 MB held in memory, every diagnostic frame is resident at once
+# because Section 5 joins them pairwise, and the full population is several hundred members.
 
 # %% tags=["results"]
 KEYS = ["symbol", "timestamp", "fold_id"]
@@ -624,15 +639,30 @@ fold_ic
 # names in the same order. A portfolio holding both would then be taking one bet at twice the
 # size, which is the failure this section exists to catch.
 #
+# Every pair drawn from the same label is compared, which pairs the families against each other:
+# a label fixes what the models were predicting and which folds they were scored on, so two
+# results under it are answering the same question and their orderings can be set side by side.
+# Pairs that cross labels are not compared, because a one-day and a twenty-one-day forward return
+# are different questions and a correlation between them measures nothing.
+#
 # The comparison is made only on the observations both results actually cover, one date at a time,
 # and averaged over dates. Two things are checked before any correlation is computed: that the
 # join is one-to-one, because a join that quietly multiplies rows makes two models look more alike
 # than they are, and that both artifacts carry the same realized return for every shared
 # observation, because if they disagree about what happened they are not comparable at all.
+#
+# Coverage differs between families and the frame says by how much. A sequence model scores only
+# the stock-dates where sixty consecutive sessions were available, so it covers fewer rows than a
+# model on the flat table, and `n_shared_rows` is what a reader checks before reading a
+# correlation as a statement about the whole panel.
 
 # %% tags=["results"]
 correlation_rows = []
 diagnostic_hashes = list(diagnostic_members)
+label_by_member = {
+    row["prediction_hash"]: row["label"]
+    for row in catalog.select("prediction_hash", "label").iter_rows(named=True)
+}
 
 
 def prediction_display_id(prediction_hash):
@@ -678,13 +708,27 @@ def summarize_prediction_pair(left_hash, right_hash):
 
 
 # %% tags=["results"]
+# `left_index + 1` rather than `left_index`: a result against itself correlates at one on every
+# date and answers nothing.
 for left_index, left_hash in enumerate(diagnostic_hashes):
-    for right_hash in diagnostic_hashes[left_index:]:
-        if diagnostic_set_by_member[left_hash] != diagnostic_set_by_member[right_hash]:
+    for right_hash in diagnostic_hashes[left_index + 1 :]:
+        if label_by_member[left_hash] != label_by_member[right_hash]:
             continue
         correlation_rows.append(summarize_prediction_pair(left_hash, right_hash))
 
-correlations = pl.DataFrame(correlation_rows).sort("left", "right")
+# The schema is declared so that a run whose diagnostic members share no label - a preview holding
+# one - produces an empty frame with columns rather than a frame with none, which `sort` would
+# raise on.
+correlations = pl.DataFrame(
+    correlation_rows,
+    schema={
+        "left": pl.String,
+        "right": pl.String,
+        "mean_daily_correlation": pl.Float64,
+        "n_shared_rows": pl.Int64,
+        "n_decision_dates": pl.Int64,
+    },
+).sort("left", "right")
 correlations
 
 # %% [markdown]

--- a/case_studies/us_equities_panel/15_model_analysis.py
+++ b/case_studies/us_equities_panel/15_model_analysis.py
@@ -575,7 +575,7 @@ show_with_alt(
 # the bounded diagnostic subset rather than the whole population. Each model notebook publishes
 # that subset as one member per label and family - its diagnostic configuration at its last
 # checkpoint - and the bound is arithmetic rather than taste. One prediction frame on this panel
-# is 7.2 million rows and about 225 MB held in memory, every diagnostic frame is resident at once
+# is over seven million rows and about 225 MB held in memory, every diagnostic frame is resident at once
 # because Section 5 joins them pairwise, and the full population is several hundred members.
 
 # %% tags=["results"]

--- a/case_studies/us_equities_panel/15_model_analysis.py
+++ b/case_studies/us_equities_panel/15_model_analysis.py
@@ -540,8 +540,10 @@ zero_line(axes[0])
 axes[1].set_ylim(bottom=0)
 add_message_title(
     axes[0],
-    "Read the cloud, not the point: several hundred candidates per column",
-    subtitle="Left, each candidate's mean daily IC; right, the half-width of its HAC interval",
+    "Mean daily IC and interval half-width, by label and family",
+    subtitle=(
+        "One point per candidate; read the height of a column's cloud rather than any single point"
+    ),
 )
 # The alt text counts rather than asserts: whether any family's cloud clears zero is a fact about
 # the frame, and a panel described as separating the families when it does not is a claim the data

--- a/case_studies/us_equities_panel/15_model_analysis.py
+++ b/case_studies/us_equities_panel/15_model_analysis.py
@@ -175,10 +175,9 @@ if EXECUTION_TIER == "canonical":
     ):
         if not names or len(names) != len(set(names)):
             raise ValueError(f"{field} must contain unique names")
-    # A diagnostic name that is also a prediction name is a family with no bounded set, filled in
-    # with the full one. Sections 4 to 6 then load the whole population's raw prediction frames
-    # while the prose says they read a bounded subset. Checked here rather than after the sets are
-    # opened, because it is a statement about the two lists and needs nothing from the registry.
+    # A name in both lists is a family with no bounded set, filled in with the full one, so
+    # Sections 4 to 6 would load the whole population. Checked here because it is a statement
+    # about the two lists and needs nothing from the registry.
     shared_names = sorted(set(DIAGNOSTIC_SET_NAMES) & set(PREDICTION_SET_NAMES))
     if shared_names:
         raise ValueError(
@@ -288,11 +287,9 @@ if EXECUTION_TIER == "canonical":
             raise ValueError(
                 f"{diagnostic_set.hash} resolved {len(matching_full_sets)} matching full sets"
             )
-        # `<=` above finds the full set this bounded one came from; it does not establish that
-        # any bounding happened, because a set is a subset of itself. Where the full set holds
-        # more than one member, the bounded one has to be strictly smaller. Where it holds one -
-        # a family that declares one configuration and does not checkpoint it - there is nothing
-        # to bound and the two coincide, which is why this is not a flat proper-subset test.
+        # `<=` above finds which full set this one came from and establishes no bounding, since
+        # a set is a subset of itself. A family publishing one member has nothing to bound, so
+        # the strict test applies only where the full set holds more than one.
         full_members = set(matching_full_sets[0].members)
         if len(full_members) > 1 and set(diagnostic_set.members) == full_members:
             raise ValueError(
@@ -710,8 +707,7 @@ def summarize_prediction_pair(left_hash, right_hash):
 
 
 # %% tags=["results"]
-# `left_index + 1` rather than `left_index`: a result against itself correlates at one on every
-# date and answers nothing.
+# `left_index + 1`: a result against itself correlates at one on every date.
 for left_index, left_hash in enumerate(diagnostic_hashes):
     for right_hash in diagnostic_hashes[left_index + 1 :]:
         if label_by_member[left_hash] != label_by_member[right_hash]:
@@ -734,7 +730,7 @@ correlations = pl.DataFrame(
 correlations
 
 # %% [markdown]
-# ## 6. How wide the uncertainty is, and whether the width holds up
+# ## 6. How wide the uncertainty is, and whether the width is calibrated
 #
 # The width measured here is the one the `conformal_weighted` allocator sizes positions with:
 # calibrated per symbol on every absolute residual known at `t - h`, where `h` is that label's
@@ -859,7 +855,7 @@ set_table.filter(pl.col("role") == "strategy handoff")
 # **An average over dates needs an interval that knows the dates are not independent.** A
 # five-session forward return measured every session shares four of its five days with the next
 # one. Treating those as independent observations makes an interval too narrow and a t-statistic
-# too large, on every model equally, so the ranking survives and the significance does not.
+# too large, on every model equally, so the ordering is unaffected and the significance is not.
 #
 # **A mean IC and a stable IC are different claims.** Averaging across folds hides which folds
 # contributed, and a configuration that ranks well in one window and not at all in the others has

--- a/case_studies/us_equities_panel/16_backtest.ipynb
+++ b/case_studies/us_equities_panel/16_backtest.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "596aa62e",
+   "id": "d3425c99",
    "metadata": {},
    "source": [
     "# US equities panel: from a ranking to a book, at equal weight\n",
@@ -27,9 +27,8 @@
     "poorly on information coefficient is still run, because ranking accuracy and strategy\n",
     "performance are different questions - a model can order the cross-section well and trade so much\n",
     "that turnover consumes the whole of it, or rank indifferently and hold a book that does not.\n",
-    "Selecting on\n",
-    "the ranking measure before backtesting would decide the second question with the answer to the\n",
-    "first.\n",
+    "Selecting on the ranking measure before backtesting would decide the second question with the\n",
+    "answer to the first.\n",
     "\n",
     "**This is where selection genuinely begins.** Every notebook so far has said \"selection happens\n",
     "in `16_backtest`\". This notebook produces the validation backtests it happens on; the choice\n",
@@ -62,7 +61,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a5e92d5c",
+   "id": "aca353bd",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -77,8 +76,10 @@
     "from case_studies.research import (\n",
     "    CandidateSet,\n",
     "    OfficialPopulation,\n",
+    "    candidate_set_supersedes,\n",
     "    open_study,\n",
     "    plan_backtests,\n",
+    "    population_supersedes,\n",
     "    run_backtests,\n",
     ")\n",
     "from case_studies.utils.backtest_loaders import get_backtest_config, load_backtest_prices_for\n",
@@ -88,7 +89,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a599326e",
+   "id": "f42fa955",
    "metadata": {},
    "source": [
     "### Which prediction sets enter the pool\n",
@@ -107,7 +108,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7e1b5609",
+   "id": "1b904c35",
    "metadata": {
     "tags": [
      "parameters"
@@ -135,6 +136,9 @@
     "    \"us-equities-fwd-ret-21d-ipca-v1\",\n",
     "]\n",
     "EXECUTION_TIER = \"canonical\"\n",
+    "POPULATION_NAME = \"\"\n",
+    "SUPERSEDES_POPULATION = \"\"\n",
+    "SUPERSEDES_SETS: dict = {}\n",
     "WORKSPACE = \"experiments\"\n",
     "PREVIEW_LABELS = []\n",
     "PREVIEW_FAMILIES = []\n",
@@ -145,29 +149,30 @@
   },
   {
    "cell_type": "markdown",
-   "id": "52941889",
+   "id": "d7c72eb0",
    "metadata": {},
    "source": [
     "## 2. Every model, no shortlist\n",
     "\n",
     "The named sets above are opened and their membership checked, and every member goes on to be\n",
-    "backtested. Nothing here filters on a predictive metric, for the reason the preamble gives: a\n",
-    "model that ranks the cross-section well can still trade too much to survive turnover, and one\n",
-    "that ranks indifferently can hold a book that works. Deciding the second question with the answer\n",
-    "to the first is the mistake the whole design avoids."
+    "backtested. Both tiers resolve the study through `open_study`, which reads the labels and\n",
+    "features in place and redirects only writes, so a preview run scores the same inputs a canonical\n",
+    "one does and cannot publish over it.\n",
+    "\n",
+    "Nothing here filters on a predictive metric, for the reason the preamble gives: a\n",
+    "model that ranks the cross-section well can still trade too much for anything to be left after\n",
+    "turnover, and one that ranks indifferently can hold a book that works. Deciding the second\n",
+    "question with the answer to the first is the mistake the whole design avoids."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5656a01f",
+   "id": "4e20669b",
    "metadata": {},
    "outputs": [],
    "source": [
     "preview_filters = bool(PREVIEW_LABELS or PREVIEW_FAMILIES or PREVIEW_CONFIG_NAMES)\n",
-    "# Both tiers resolve the study through `open_study`. It reads the labels and features in place and\n",
-    "# redirects only writes, so a preview run scores the same inputs a canonical one does and cannot\n",
-    "# publish over it.\n",
     "if EXECUTION_TIER == \"canonical\":\n",
     "    if preview_filters or PREVIEW_MAX_PREDICTIONS or MAX_SYMBOLS:\n",
     "        raise ValueError(\"Canonical execution cannot declare preview reductions\")\n",
@@ -190,7 +195,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b04d4c13",
+   "id": "8c37c9e6",
    "metadata": {},
    "source": [
     "## 3. Which rows can be backtested at all\n",
@@ -204,7 +209,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e08732e3",
+   "id": "922fe4b1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -244,7 +249,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "214e4a8c",
+   "id": "5cb958ba",
    "metadata": {},
    "source": [
     "The selected rows expose the model family, configuration, label, checkpoint, and exact result\n",
@@ -254,7 +259,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "225dd209",
+   "id": "b8220ff8",
    "metadata": {
     "tags": [
      "results"
@@ -276,7 +281,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1f77e31e",
+   "id": "a67d6f76",
    "metadata": {},
    "source": [
     "## 4. Planning the backtests before running any\n",
@@ -288,13 +293,18 @@
     "\n",
     "**The top-*k* grid is a strategy decision, not a tuning knob.** Holding 20 names a side and\n",
     "holding 50 are different strategies with different concentration and different turnover, and\n",
-    "both are backtested rather than one being chosen in advance."
+    "both are backtested rather than one being chosen in advance.#\n",
+    "`SUPERSEDES_POPULATION` and `SUPERSEDES_SETS` name the generation this run replaces. A population\n",
+    "and a candidate set are both immutable, so a re-run that admits different members has to say\n",
+    "which snapshot it supersedes or the registry refuses the write. Both default to empty, which is\n",
+    "right for a first run and for a reader's clean clone; `population_supersedes` and\n",
+    "`candidate_set_supersedes` withhold a declared hash wherever offering it would be refused."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8d96f852",
+   "id": "747193a5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -342,7 +352,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ff1ce096",
+   "id": "56e09a21",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -374,7 +384,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "345a1875",
+   "id": "860dedc6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -386,9 +396,13 @@
     "\n",
     "official_population = None\n",
     "if EXECUTION_TIER == \"canonical\":\n",
+    "    population_name = POPULATION_NAME or \"us-equities-baseline-v1\"\n",
     "    official_population = OfficialPopulation.create(\n",
     "        study,\n",
-    "        name=\"us-equities-baseline-v1\",\n",
+    "        name=population_name,\n",
+    "        supersedes=population_supersedes(\n",
+    "            study, name=population_name, declared=SUPERSEDES_POPULATION\n",
+    "        ),\n",
     "        member_kind=\"backtest\",\n",
     "        members=tuple(planned_population.get_column(\"backtest_hash\")),\n",
     "    )\n",
@@ -398,7 +412,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1d053982",
+   "id": "8e26c088",
    "metadata": {},
    "source": [
     "## 5. Running them\n",
@@ -410,7 +424,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "13aa0c8d",
+   "id": "db985434",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -440,7 +454,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3c3554e9",
+   "id": "4482cb3a",
    "metadata": {
     "tags": [
      "results"
@@ -475,7 +489,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "364c6396",
+   "id": "d29d920e",
    "metadata": {
     "tags": [
      "results"
@@ -515,7 +529,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "93b96bfb",
+   "id": "0cb6d703",
    "metadata": {},
    "source": [
     "## 6. Naming the baseline sets\n",
@@ -532,7 +546,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d1807f74",
+   "id": "d97422fe",
    "metadata": {
     "tags": [
      "results"
@@ -555,9 +569,13 @@
     "if EXECUTION_TIER == \"canonical\":\n",
     "    for label in completed.get_column(\"label\").unique().sort().to_list():\n",
     "        label_name = label.replace(\"_\", \"-\")\n",
+    "        result_set_name = f\"us-equities-{label_name}-baseline-v1\"\n",
     "        result_set = study.backtests.freeze(\n",
     "            completed.filter(pl.col(\"label\") == label),\n",
-    "            name=f\"us-equities-{label_name}-baseline-v1\",\n",
+    "            name=result_set_name,\n",
+    "            supersedes=candidate_set_supersedes(\n",
+    "                study, name=result_set_name, declared=SUPERSEDES_SETS.get(result_set_name, \"\")\n",
+    "            ),\n",
     "        )\n",
     "        set_rows.append(\n",
     "            {\"label\": label, \"set_name\": result_set.name, \"members\": len(result_set.members)}\n",
@@ -572,7 +590,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "66f51ae4",
+   "id": "8c87c54f",
    "metadata": {},
    "source": [
     "## 7. What came out\n",
@@ -589,7 +607,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e04d1b05",
+   "id": "10853eca",
    "metadata": {
     "tags": [
      "results"
@@ -635,7 +653,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e3217f2f",
+   "id": "eb487f65",
    "metadata": {},
    "source": [
     "## What to notice\n",

--- a/case_studies/us_equities_panel/16_backtest.ipynb
+++ b/case_studies/us_equities_panel/16_backtest.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "1c741fc8",
+   "id": "eebc2ae8",
    "metadata": {},
    "source": [
     "# US equities panel: from a ranking to a book, at equal weight\n",
@@ -61,7 +61,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "433416e6",
+   "id": "306976ea",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -87,7 +87,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "04b0d497",
+   "id": "2b7906a5",
    "metadata": {},
    "source": [
     "### Which prediction sets enter the pool\n",
@@ -106,7 +106,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "41850def",
+   "id": "64dfd7cd",
    "metadata": {
     "tags": [
      "parameters"
@@ -144,7 +144,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1c6f255f",
+   "id": "fe77619e",
    "metadata": {},
    "source": [
     "## 2. Every model, no shortlist\n",
@@ -159,7 +159,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4053669b",
+   "id": "01e56ef8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -189,7 +189,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0fd0c04c",
+   "id": "a36a46b8",
    "metadata": {},
    "source": [
     "## 3. Which rows can be backtested at all\n",
@@ -203,7 +203,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3b8bff58",
+   "id": "f986d07f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -243,7 +243,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "54e8171c",
+   "id": "b40078e0",
    "metadata": {},
    "source": [
     "The selected rows expose the model family, configuration, label, checkpoint, and exact result\n",
@@ -253,7 +253,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "902c6a26",
+   "id": "7edd29b0",
    "metadata": {
     "tags": [
      "results"
@@ -275,7 +275,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e4ce6b33",
+   "id": "6b7e375d",
    "metadata": {},
    "source": [
     "## 4. Planning the backtests before running any\n",
@@ -293,7 +293,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "df03f417",
+   "id": "ce0a47cb",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -341,7 +341,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c4fa82fc",
+   "id": "7d982453",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -373,7 +373,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "51bb3414",
+   "id": "3366b8fe",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -397,7 +397,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "12d1d7af",
+   "id": "c2d1c9c4",
    "metadata": {},
    "source": [
     "## 5. Running them\n",
@@ -409,7 +409,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "416da363",
+   "id": "ff0c6026",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -439,7 +439,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8e304414",
+   "id": "b3b7d871",
    "metadata": {
     "tags": [
      "results"
@@ -474,7 +474,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "362a0b25",
+   "id": "0f60d4f0",
    "metadata": {
     "tags": [
      "results"
@@ -514,7 +514,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d3a0b899",
+   "id": "e3f3f525",
    "metadata": {},
    "source": [
     "## 6. Naming the baseline sets\n",
@@ -526,7 +526,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "96475d37",
+   "id": "7bec604f",
    "metadata": {
     "tags": [
      "results"
@@ -570,7 +570,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dce57f78",
+   "id": "fc13fc8f",
    "metadata": {},
    "source": [
     "## 7. What came out\n",
@@ -587,7 +587,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "81584aeb",
+   "id": "d24b83f2",
    "metadata": {
     "tags": [
      "results"
@@ -619,10 +619,9 @@
     "ax.set_ylabel(\"Validation Sharpe\")\n",
     "add_message_title(\n",
     "    ax,\n",
-    "    \"What the plainest sizing rule was worth, before any cost\",\n",
-    "    subtitle=\"One point per complete equal-weight validation backtest\",\n",
+    "    \"Validation Sharpe of the equal-weight backtests, by label and family\",\n",
+    "    subtitle=\"One point per complete equal-weight validation backtest, gross of costs\",\n",
     ")\n",
-    "fig.tight_layout()\n",
     "show_with_alt(\n",
     "    fig,\n",
     "    \"A strip plot with one column per label and model family. Each point is one complete \"\n",
@@ -634,7 +633,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "38d9fa5a",
+   "id": "8faeaa76",
    "metadata": {},
    "source": [
     "## What to notice\n",
@@ -676,18 +675,6 @@
    "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.14.3"
   }
  },
  "nbformat": 4,

--- a/case_studies/us_equities_panel/16_backtest.ipynb
+++ b/case_studies/us_equities_panel/16_backtest.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "eebc2ae8",
+   "id": "596aa62e",
    "metadata": {},
    "source": [
     "# US equities panel: from a ranking to a book, at equal weight\n",
@@ -26,7 +26,8 @@
     "**Every member of every model population is backtested, not a shortlist.** A model that ranked\n",
     "poorly on information coefficient is still run, because ranking accuracy and strategy\n",
     "performance are different questions - a model can order the cross-section well and trade so much\n",
-    "that nothing survives turnover, or rank indifferently and hold a book that does. Selecting on\n",
+    "that turnover consumes the whole of it, or rank indifferently and hold a book that does not.\n",
+    "Selecting on\n",
     "the ranking measure before backtesting would decide the second question with the answer to the\n",
     "first.\n",
     "\n",
@@ -61,7 +62,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "306976ea",
+   "id": "a5e92d5c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -87,7 +88,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2b7906a5",
+   "id": "a599326e",
    "metadata": {},
    "source": [
     "### Which prediction sets enter the pool\n",
@@ -106,7 +107,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "64dfd7cd",
+   "id": "7e1b5609",
    "metadata": {
     "tags": [
      "parameters"
@@ -144,7 +145,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fe77619e",
+   "id": "52941889",
    "metadata": {},
    "source": [
     "## 2. Every model, no shortlist\n",
@@ -159,7 +160,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "01e56ef8",
+   "id": "5656a01f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -189,7 +190,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a36a46b8",
+   "id": "b04d4c13",
    "metadata": {},
    "source": [
     "## 3. Which rows can be backtested at all\n",
@@ -203,7 +204,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f986d07f",
+   "id": "e08732e3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -243,7 +244,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b40078e0",
+   "id": "214e4a8c",
    "metadata": {},
    "source": [
     "The selected rows expose the model family, configuration, label, checkpoint, and exact result\n",
@@ -253,7 +254,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7edd29b0",
+   "id": "225dd209",
    "metadata": {
     "tags": [
      "results"
@@ -275,7 +276,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6b7e375d",
+   "id": "1f77e31e",
    "metadata": {},
    "source": [
     "## 4. Planning the backtests before running any\n",
@@ -293,7 +294,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ce0a47cb",
+   "id": "8d96f852",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -341,7 +342,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7d982453",
+   "id": "ff1ce096",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -373,7 +374,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3366b8fe",
+   "id": "345a1875",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -397,7 +398,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c2d1c9c4",
+   "id": "1d053982",
    "metadata": {},
    "source": [
     "## 5. Running them\n",
@@ -409,7 +410,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ff0c6026",
+   "id": "13aa0c8d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -439,7 +440,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b3b7d871",
+   "id": "3c3554e9",
    "metadata": {
     "tags": [
      "results"
@@ -474,7 +475,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0f60d4f0",
+   "id": "364c6396",
    "metadata": {
     "tags": [
      "results"
@@ -514,19 +515,24 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e3f3f525",
+   "id": "93b96bfb",
    "metadata": {},
    "source": [
     "## 6. Naming the baseline sets\n",
     "\n",
     "One frozen set per label, under a name the later notebooks open by. Only an unnarrowed canonical\n",
-    "run publishes one, because a name must not mean two different member sets at two different times."
+    "run publishes one, because a name must not mean two different member sets at two different times.\n",
+    "\n",
+    "**The freeze is also the comparability check.** Nothing is declared comparable, so\n",
+    "`CandidateSet.create` requires every field of the protocol to be identical across the members:\n",
+    "two rows that measured their Sharpe on different folds are not two rankings of one thing, and\n",
+    "this is what refuses to freeze them together."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7bec604f",
+   "id": "d1807f74",
    "metadata": {
     "tags": [
      "results"
@@ -549,10 +555,6 @@
     "if EXECUTION_TIER == \"canonical\":\n",
     "    for label in completed.get_column(\"label\").unique().sort().to_list():\n",
     "        label_name = label.replace(\"_\", \"-\")\n",
-    "        # Nothing is declared comparable, so every field of the protocol has to be identical\n",
-    "        # across the members. That is the guard: two rows that measured their Sharpe on different\n",
-    "        # folds are not two rankings of one thing, and this is what refuses to freeze them\n",
-    "        # together.\n",
     "        result_set = study.backtests.freeze(\n",
     "            completed.filter(pl.col(\"label\") == label),\n",
     "            name=f\"us-equities-{label_name}-baseline-v1\",\n",
@@ -570,7 +572,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fc13fc8f",
+   "id": "66f51ae4",
    "metadata": {},
    "source": [
     "## 7. What came out\n",
@@ -587,7 +589,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d24b83f2",
+   "id": "e04d1b05",
    "metadata": {
     "tags": [
      "results"
@@ -633,7 +635,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8faeaa76",
+   "id": "e3217f2f",
    "metadata": {},
    "source": [
     "## What to notice\n",
@@ -641,7 +643,8 @@
     "**A ranking and a strategy are not the same thing, and this is where they separate.** Every model\n",
     "was scored on how well it ordered the cross-section. What it earns depends on that order *and*\n",
     "on how often the order changes, because every change is a trade. A model can rank well and turn\n",
-    "its book over so fast that nothing survives, and the previous notebooks had no way to see it.\n",
+    "its book over so fast that turnover consumes what the ranking earned, and the previous notebooks\n",
+    "had no way to see it.\n",
     "\n",
     "**Equal weight is what makes the comparison about the models.** Nothing here estimates anything\n",
     "from the data beyond the predictions themselves, so a difference between two rows is a difference\n",

--- a/case_studies/us_equities_panel/16_backtest.py
+++ b/case_studies/us_equities_panel/16_backtest.py
@@ -35,7 +35,8 @@
 # **Every member of every model population is backtested, not a shortlist.** A model that ranked
 # poorly on information coefficient is still run, because ranking accuracy and strategy
 # performance are different questions - a model can order the cross-section well and trade so much
-# that nothing survives turnover, or rank indifferently and hold a book that does. Selecting on
+# that turnover consumes the whole of it, or rank indifferently and hold a book that does not.
+# Selecting on
 # the ranking measure before backtesting would decide the second question with the answer to the
 # first.
 #
@@ -404,6 +405,11 @@ execution_diagnostics
 #
 # One frozen set per label, under a name the later notebooks open by. Only an unnarrowed canonical
 # run publishes one, because a name must not mean two different member sets at two different times.
+#
+# **The freeze is also the comparability check.** Nothing is declared comparable, so
+# `CandidateSet.create` requires every field of the protocol to be identical across the members:
+# two rows that measured their Sharpe on different folds are not two rankings of one thing, and
+# this is what refuses to freeze them together.
 
 # %% tags=["results"]
 set_rows = []
@@ -421,10 +427,6 @@ if (
 if EXECUTION_TIER == "canonical":
     for label in completed.get_column("label").unique().sort().to_list():
         label_name = label.replace("_", "-")
-        # Nothing is declared comparable, so every field of the protocol has to be identical
-        # across the members. That is the guard: two rows that measured their Sharpe on different
-        # folds are not two rankings of one thing, and this is what refuses to freeze them
-        # together.
         result_set = study.backtests.freeze(
             completed.filter(pl.col("label") == label),
             name=f"us-equities-{label_name}-baseline-v1",
@@ -492,7 +494,8 @@ show_with_alt(
 # **A ranking and a strategy are not the same thing, and this is where they separate.** Every model
 # was scored on how well it ordered the cross-section. What it earns depends on that order *and*
 # on how often the order changes, because every change is a trade. A model can rank well and turn
-# its book over so fast that nothing survives, and the previous notebooks had no way to see it.
+# its book over so fast that turnover consumes what the ranking earned, and the previous notebooks
+# had no way to see it.
 #
 # **Equal weight is what makes the comparison about the models.** Nothing here estimates anything
 # from the data beyond the predictions themselves, so a difference between two rows is a difference

--- a/case_studies/us_equities_panel/16_backtest.py
+++ b/case_studies/us_equities_panel/16_backtest.py
@@ -475,10 +475,9 @@ ax.set_xlim(-0.5, len(groups) - 0.5)
 ax.set_ylabel("Validation Sharpe")
 add_message_title(
     ax,
-    "What the plainest sizing rule was worth, before any cost",
-    subtitle="One point per complete equal-weight validation backtest",
+    "Validation Sharpe of the equal-weight backtests, by label and family",
+    subtitle="One point per complete equal-weight validation backtest, gross of costs",
 )
-fig.tight_layout()
 show_with_alt(
     fig,
     "A strip plot with one column per label and model family. Each point is one complete "

--- a/case_studies/us_equities_panel/16_backtest.py
+++ b/case_studies/us_equities_panel/16_backtest.py
@@ -36,9 +36,8 @@
 # poorly on information coefficient is still run, because ranking accuracy and strategy
 # performance are different questions - a model can order the cross-section well and trade so much
 # that turnover consumes the whole of it, or rank indifferently and hold a book that does not.
-# Selecting on
-# the ranking measure before backtesting would decide the second question with the answer to the
-# first.
+# Selecting on the ranking measure before backtesting would decide the second question with the
+# answer to the first.
 #
 # **This is where selection genuinely begins.** Every notebook so far has said "selection happens
 # in `16_backtest`". This notebook produces the validation backtests it happens on; the choice
@@ -79,8 +78,10 @@ import polars as pl
 from case_studies.research import (
     CandidateSet,
     OfficialPopulation,
+    candidate_set_supersedes,
     open_study,
     plan_backtests,
+    population_supersedes,
     run_backtests,
 )
 from case_studies.utils.backtest_loaders import get_backtest_config, load_backtest_prices_for
@@ -121,6 +122,9 @@ PREDICTION_SET_NAMES = [
     "us-equities-fwd-ret-21d-ipca-v1",
 ]
 EXECUTION_TIER = "canonical"
+POPULATION_NAME = ""
+SUPERSEDES_POPULATION = ""
+SUPERSEDES_SETS: dict = {}
 WORKSPACE = "experiments"
 PREVIEW_LABELS = []
 PREVIEW_FAMILIES = []
@@ -132,16 +136,17 @@ MAX_SYMBOLS = 0
 # ## 2. Every model, no shortlist
 #
 # The named sets above are opened and their membership checked, and every member goes on to be
-# backtested. Nothing here filters on a predictive metric, for the reason the preamble gives: a
-# model that ranks the cross-section well can still trade too much to survive turnover, and one
-# that ranks indifferently can hold a book that works. Deciding the second question with the answer
-# to the first is the mistake the whole design avoids.
+# backtested. Both tiers resolve the study through `open_study`, which reads the labels and
+# features in place and redirects only writes, so a preview run scores the same inputs a canonical
+# one does and cannot publish over it.
+#
+# Nothing here filters on a predictive metric, for the reason the preamble gives: a
+# model that ranks the cross-section well can still trade too much for anything to be left after
+# turnover, and one that ranks indifferently can hold a book that works. Deciding the second
+# question with the answer to the first is the mistake the whole design avoids.
 
 # %%
 preview_filters = bool(PREVIEW_LABELS or PREVIEW_FAMILIES or PREVIEW_CONFIG_NAMES)
-# Both tiers resolve the study through `open_study`. It reads the labels and features in place and
-# redirects only writes, so a preview run scores the same inputs a canonical one does and cannot
-# publish over it.
 if EXECUTION_TIER == "canonical":
     if preview_filters or PREVIEW_MAX_PREDICTIONS or MAX_SYMBOLS:
         raise ValueError("Canonical execution cannot declare preview reductions")
@@ -229,7 +234,12 @@ prediction_population
 #
 # **The top-*k* grid is a strategy decision, not a tuning knob.** Holding 20 names a side and
 # holding 50 are different strategies with different concentration and different turnover, and
-# both are backtested rather than one being chosen in advance.
+# both are backtested rather than one being chosen in advance.#
+# `SUPERSEDES_POPULATION` and `SUPERSEDES_SETS` name the generation this run replaces. A population
+# and a candidate set are both immutable, so a re-run that admits different members has to say
+# which snapshot it supersedes or the registry refuses the write. Both default to empty, which is
+# right for a first run and for a reader's clean clone; `population_supersedes` and
+# `candidate_set_supersedes` withhold a declared hash wherever offering it would be refused.
 
 # %%
 backtest_config = get_backtest_config(CASE_STUDY_ID)
@@ -307,9 +317,13 @@ if planned_population.get_column("backtest_hash").n_unique() != planned_populati
 
 official_population = None
 if EXECUTION_TIER == "canonical":
+    population_name = POPULATION_NAME or "us-equities-baseline-v1"
     official_population = OfficialPopulation.create(
         study,
-        name="us-equities-baseline-v1",
+        name=population_name,
+        supersedes=population_supersedes(
+            study, name=population_name, declared=SUPERSEDES_POPULATION
+        ),
         member_kind="backtest",
         members=tuple(planned_population.get_column("backtest_hash")),
     )
@@ -427,9 +441,13 @@ if (
 if EXECUTION_TIER == "canonical":
     for label in completed.get_column("label").unique().sort().to_list():
         label_name = label.replace("_", "-")
+        result_set_name = f"us-equities-{label_name}-baseline-v1"
         result_set = study.backtests.freeze(
             completed.filter(pl.col("label") == label),
-            name=f"us-equities-{label_name}-baseline-v1",
+            name=result_set_name,
+            supersedes=candidate_set_supersedes(
+                study, name=result_set_name, declared=SUPERSEDES_SETS.get(result_set_name, "")
+            ),
         )
         set_rows.append(
             {"label": label, "set_name": result_set.name, "members": len(result_set.members)}

--- a/case_studies/us_equities_panel/17_portfolio_management.ipynb
+++ b/case_studies/us_equities_panel/17_portfolio_management.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "c3f15efa",
+   "id": "865cfa0e",
    "metadata": {},
    "source": [
     "# US equities panel: the same names, sized differently\n",
@@ -67,7 +67,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b1665d7b",
+   "id": "efc9a938",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -83,8 +83,10 @@
     "from case_studies.research import (\n",
     "    CandidateSet,\n",
     "    OfficialPopulation,\n",
+    "    candidate_set_supersedes,\n",
     "    open_study,\n",
     "    plan_backtests,\n",
+    "    population_supersedes,\n",
     "    run_backtests,\n",
     ")\n",
     "from case_studies.research.strategy import strategy_warmup_periods\n",
@@ -103,7 +105,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "623eb015",
+   "id": "dace5e51",
    "metadata": {
     "tags": [
      "parameters"
@@ -118,6 +120,9 @@
     "    \"us-equities-fwd-ret-21d-baseline-v1\",\n",
     "]\n",
     "EXECUTION_TIER = \"canonical\"\n",
+    "POPULATION_NAME = \"\"\n",
+    "SUPERSEDES_POPULATION = \"\"\n",
+    "SUPERSEDES_SETS: dict = {}\n",
     "WORKSPACE = \"experiments\"\n",
     "PREVIEW_LABELS = []\n",
     "PREVIEW_MAX_BASELINE_ROWS = 0\n",
@@ -127,7 +132,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b81189a9",
+   "id": "a658c923",
    "metadata": {},
    "source": [
     "## 2. The baseline this notebook varies\n",
@@ -138,7 +143,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0cc1496a",
+   "id": "f99e3c7f",
    "metadata": {},
    "source": [
     "Both tiers resolve the study through `open_study`. It reads the labels and features in place and\n",
@@ -149,7 +154,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7176c85b",
+   "id": "b395087e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -180,7 +185,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0aaaf9f3",
+   "id": "26a38d93",
    "metadata": {},
    "source": [
     "## 3. Which baseline rows can be re-sized\n",
@@ -193,7 +198,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6e1f9867",
+   "id": "9f5afc16",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -235,7 +240,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "17381333",
+   "id": "93ad2702",
    "metadata": {},
    "source": [
     "## 4. The shortlist, and what it costs\n",
@@ -253,7 +258,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9bb97bb1",
+   "id": "2c1d6c61",
    "metadata": {
     "tags": [
      "results"
@@ -299,7 +304,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e6cfe708",
+   "id": "606975c0",
    "metadata": {},
    "source": [
     "## 5. Planning one backtest per allocator\n",
@@ -312,12 +317,18 @@
     "amount differs between them - the mean-variance method here declares a longer window than the\n",
     "others because shrinkage on a matrix estimated from too few observations pulls it all the way to\n",
     "its target and hands back something close to equal weight under a different name. Each allocator\n",
-    "therefore declares the history it needs, and is measured on that."
+    "therefore declares the history it needs, and is measured on that.\n",
+    "\n",
+    "`SUPERSEDES_POPULATION` and `SUPERSEDES_SETS` name the generation this run replaces. A population\n",
+    "and a candidate set are both immutable, so a re-run that admits different members has to say\n",
+    "which snapshot it supersedes or the registry refuses the write. Both default to empty, which is\n",
+    "right for a first run and for a reader's clean clone; `population_supersedes` and\n",
+    "`candidate_set_supersedes` withhold a declared hash wherever offering it would be refused."
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "bedbf911",
+   "id": "7832edf6",
    "metadata": {},
    "source": [
     "**Prices are cached by label and warmup, not once per label.** Each allocator needs a different\n",
@@ -331,7 +342,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cc55e014",
+   "id": "8a560dde",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -368,7 +379,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0041c806",
+   "id": "3ac69cf0",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -415,7 +426,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "16d2e23d",
+   "id": "f7da522e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -433,7 +444,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "13b2b57f",
+   "id": "089dc92c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -445,9 +456,13 @@
     "\n",
     "official_population = None\n",
     "if EXECUTION_TIER == \"canonical\":\n",
+    "    population_name = POPULATION_NAME or \"us-equities-allocation-v1\"\n",
     "    official_population = OfficialPopulation.create(\n",
     "        study,\n",
-    "        name=\"us-equities-allocation-v1\",\n",
+    "        name=population_name,\n",
+    "        supersedes=population_supersedes(\n",
+    "            study, name=population_name, declared=SUPERSEDES_POPULATION\n",
+    "        ),\n",
     "        member_kind=\"backtest\",\n",
     "        members=tuple(planned_population.get_column(\"backtest_hash\")),\n",
     "    )\n",
@@ -457,7 +472,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "30d97cf3",
+   "id": "bb80bfc1",
    "metadata": {},
    "source": [
     "## 6. Running them\n",
@@ -469,7 +484,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e8dd4557",
+   "id": "fba95117",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -500,7 +515,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e2d3491d",
+   "id": "cd82434b",
    "metadata": {
     "tags": [
      "results"
@@ -532,7 +547,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "329c99bc",
+   "id": "921a2b77",
    "metadata": {
     "tags": [
      "results"
@@ -572,7 +587,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7461661b",
+   "id": "5c308ba4",
    "metadata": {},
    "source": [
     "## 7. Naming the allocation sets\n",
@@ -589,7 +604,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "718c03bf",
+   "id": "1f624a67",
    "metadata": {
     "tags": [
      "results"
@@ -612,9 +627,13 @@
     "if EXECUTION_TIER == \"canonical\":\n",
     "    for label in completed.get_column(\"label\").unique().sort().to_list():\n",
     "        label_name = label.replace(\"_\", \"-\")\n",
+    "        result_set_name = f\"us-equities-{label_name}-allocation-v1\"\n",
     "        result_set = study.backtests.freeze(\n",
     "            completed.filter(pl.col(\"label\") == label),\n",
-    "            name=f\"us-equities-{label_name}-allocation-v1\",\n",
+    "            name=result_set_name,\n",
+    "            supersedes=candidate_set_supersedes(\n",
+    "                study, name=result_set_name, declared=SUPERSEDES_SETS.get(result_set_name, \"\")\n",
+    "            ),\n",
     "        )\n",
     "        set_rows.append(\n",
     "            {\"label\": label, \"set_name\": result_set.name, \"members\": len(result_set.members)}\n",
@@ -629,7 +648,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "48256ee3",
+   "id": "ed5f07ed",
    "metadata": {},
    "source": [
     "## 8. What came out\n",
@@ -650,7 +669,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4c2b72ec",
+   "id": "5e3eae42",
    "metadata": {
     "tags": [
      "results"
@@ -714,7 +733,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f06c701d",
+   "id": "6a799bc7",
    "metadata": {},
    "source": [
     "## What to notice\n",

--- a/case_studies/us_equities_panel/17_portfolio_management.ipynb
+++ b/case_studies/us_equities_panel/17_portfolio_management.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "30c1a82c",
+   "id": "c3f15efa",
    "metadata": {},
    "source": [
     "# US equities panel: the same names, sized differently\n",
@@ -26,17 +26,16 @@
     "  here.\n",
     "- **From each stock's own volatility.** `inverse_vol` puts less into a stock that moves more, so\n",
     "  each position contributes a similar amount of variation rather than a similar amount of money.\n",
-    "  `risk_parity` as implemented here is the same idea with a steeper exponent - weight\n",
-    "  proportional to one over volatility raised to 1.5 - which approximates equal risk contribution\n",
-    "  without estimating how the stocks move together.\n",
+    "  `risk_parity` as implemented here is the same idea with a steeper exponent on volatility,\n",
+    "  which approximates equal risk contribution without estimating how the stocks move together.\n",
     "- **From how the stocks move together.** `mvo_ledoit_wolf` and `hrp` read a covariance matrix, so\n",
     "  they alone can tell that two names which always move together are one bet held twice. That is\n",
     "  the property none of the rules above can see, and it is the one that has to be estimated. These\n",
     "  two need history before they can decide anything, and how much is declared per allocator rather\n",
     "  than assumed.\n",
     "\n",
-    "**Equal weight is excluded here, and not because it lost.** It is the baseline every row is\n",
-    "measured against, and re-running it would produce the identical backtest under a new name.\n",
+    "**Equal weight is excluded here because its backtest already exists.** It is the baseline every\n",
+    "row is measured against, and [`16_backtest`](16_backtest.ipynb) ran it.\n",
     "\n",
     "**A shortlist is taken first, and that is a real decision.** Applying every allocator to every\n",
     "member of the whole model population would multiply an already large grid by seven. So the\n",
@@ -68,7 +67,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b7749fe4",
+   "id": "b1665d7b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -104,7 +103,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "453f4c5d",
+   "id": "623eb015",
    "metadata": {
     "tags": [
      "parameters"
@@ -128,7 +127,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8cc32c9c",
+   "id": "b81189a9",
    "metadata": {},
    "source": [
     "## 2. The baseline this notebook varies\n",
@@ -138,15 +137,22 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "0cc1496a",
+   "metadata": {},
+   "source": [
+    "Both tiers resolve the study through `open_study`. It reads the labels and features in place and\n",
+    "redirects only writes, so a preview run scores the same inputs a canonical one does and cannot\n",
+    "publish over it."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "id": "18ef1f1d",
+   "id": "7176c85b",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Both tiers resolve the study through `open_study`. It reads the labels and features in place and\n",
-    "# redirects only writes, so a preview run scores the same inputs a canonical one does and cannot\n",
-    "# publish over it.\n",
     "if EXECUTION_TIER == \"canonical\":\n",
     "    if PREVIEW_LABELS or PREVIEW_MAX_BASELINE_ROWS or PREVIEW_MAX_ALLOCATORS or MAX_SYMBOLS:\n",
     "        raise ValueError(\"Canonical execution cannot declare preview reductions\")\n",
@@ -174,7 +180,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "77686b84",
+   "id": "0aaaf9f3",
    "metadata": {},
    "source": [
     "## 3. Which baseline rows can be re-sized\n",
@@ -187,7 +193,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f8bc0650",
+   "id": "6e1f9867",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -229,7 +235,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e30072f3",
+   "id": "17381333",
    "metadata": {},
    "source": [
     "## 4. The shortlist, and what it costs\n",
@@ -247,7 +253,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "375a30bd",
+   "id": "9bb97bb1",
    "metadata": {
     "tags": [
      "results"
@@ -293,7 +299,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a6e233d3",
+   "id": "e6cfe708",
    "metadata": {},
    "source": [
     "## 5. Planning one backtest per allocator\n",
@@ -304,24 +310,31 @@
     "**The history each allocator needs is declared per allocator, not shared.** The methods that read\n",
     "a covariance matrix cannot decide anything until they have enough bars to estimate one, and the\n",
     "amount differs between them - the mean-variance method here declares a longer window than the\n",
-    "others because shrinkage on a matrix estimated from too few observations collapses toward its\n",
-    "target and hands back something close to equal weight under a different name. Giving every\n",
-    "allocator the longest window instead would change what the cheap ones are measured on."
+    "others because shrinkage on a matrix estimated from too few observations pulls it all the way to\n",
+    "its target and hands back something close to equal weight under a different name. Each allocator\n",
+    "therefore declares the history it needs, and is measured on that."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bedbf911",
+   "metadata": {},
+   "source": [
+    "**Prices are cached by label and warmup, not once per label.** Each allocator needs a different\n",
+    "amount of history before it can decide anything - none for the ones that read only the\n",
+    "predictions, a volatility window for the per-stock ones, a longer lookback for the ones that\n",
+    "estimate a covariance matrix - and the price frame a member was handed is digested into that\n",
+    "member's identity. So the frame has to be the one that member's own warmup implies, and the\n",
+    "cache key is what keeps it that way while still loading each distinct frame once."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1b3af5bc",
+   "id": "cc55e014",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Prices are cached by (label, warmup), not once per label. Each allocator needs a different\n",
-    "# amount of history before it can decide anything - none for the ones that read only the\n",
-    "# predictions, a volatility window for the per-stock ones, a longer lookback for the ones that\n",
-    "# estimate a covariance matrix - and the frame a member was handed is digested into its identity.\n",
-    "# So the frame has to be the one that member's own warmup implies, and the cache key is what keeps\n",
-    "# it that way while still loading each distinct frame once.\n",
     "_price_cache: dict[tuple[str, int], object] = {}\n",
     "\n",
     "\n",
@@ -355,7 +368,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7c0c0ad1",
+   "id": "0041c806",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -402,7 +415,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a9d1c9b1",
+   "id": "16d2e23d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -420,7 +433,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b231a966",
+   "id": "13b2b57f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -444,7 +457,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8849c0b5",
+   "id": "30d97cf3",
    "metadata": {},
    "source": [
     "## 6. Running them\n",
@@ -456,7 +469,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0420ebaa",
+   "id": "e8dd4557",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -487,7 +500,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bee78fab",
+   "id": "e2d3491d",
    "metadata": {
     "tags": [
      "results"
@@ -519,7 +532,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "19253110",
+   "id": "329c99bc",
    "metadata": {
     "tags": [
      "results"
@@ -559,19 +572,24 @@
   },
   {
    "cell_type": "markdown",
-   "id": "28e464ed",
+   "id": "7461661b",
    "metadata": {},
    "source": [
     "## 7. Naming the allocation sets\n",
     "\n",
     "One frozen set per label, published only by an unnarrowed canonical run, for the reason\n",
-    "[`16_backtest`](16_backtest.ipynb) gives."
+    "[`16_backtest`](16_backtest.ipynb) gives.\n",
+    "\n",
+    "**The freeze is also the comparability check.** Nothing is declared comparable, so\n",
+    "`CandidateSet.create` requires every field of the protocol to be identical across the members:\n",
+    "two rows that measured their Sharpe on different folds are not two rankings of one thing, and\n",
+    "this is what refuses to freeze them together."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "849d531d",
+   "id": "718c03bf",
    "metadata": {
     "tags": [
      "results"
@@ -594,10 +612,6 @@
     "if EXECUTION_TIER == \"canonical\":\n",
     "    for label in completed.get_column(\"label\").unique().sort().to_list():\n",
     "        label_name = label.replace(\"_\", \"-\")\n",
-    "        # Nothing is declared comparable, so every field of the protocol has to be identical\n",
-    "        # across the members. That is the guard: two rows that measured their Sharpe on different\n",
-    "        # folds are not two rankings of one thing, and this is what refuses to freeze them\n",
-    "        # together.\n",
     "        result_set = study.backtests.freeze(\n",
     "            completed.filter(pl.col(\"label\") == label),\n",
     "            name=f\"us-equities-{label_name}-allocation-v1\",\n",
@@ -615,7 +629,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "eeac20ac",
+   "id": "48256ee3",
    "metadata": {},
    "source": [
     "## 8. What came out\n",
@@ -636,7 +650,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a1bd3c9f",
+   "id": "4c2b72ec",
    "metadata": {
     "tags": [
      "results"
@@ -700,7 +714,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d3a55f34",
+   "id": "f06c701d",
    "metadata": {},
    "source": [
     "## What to notice\n",

--- a/case_studies/us_equities_panel/17_portfolio_management.ipynb
+++ b/case_studies/us_equities_panel/17_portfolio_management.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "865cfa0e",
+   "id": "e5d424c1",
    "metadata": {},
    "source": [
     "# US equities panel: the same names, sized differently\n",
@@ -21,9 +21,11 @@
     "  confident about, so it trusts the magnitude of a prediction and not only its order.\n",
     "  `conformal_weighted` reads the prediction's uncertainty rather than its size: it weights each\n",
     "  name by one over the width of its prediction interval, so a name the model is less sure about\n",
-    "  gets less capital. That is the same width whose calibration\n",
-    "  [`15_model_analysis`](15_model_analysis.ipynb) checked, which is why the check there matters\n",
-    "  here.\n",
+    "  gets less capital. The width is floored at the first percentile of that date's own\n",
+    "  cross-section before the reciprocal is taken, which keeps an unusually confident name from\n",
+    "  taking the whole leg and uses no width from a later date to do it. That is the same width whose\n",
+    "  calibration [`15_model_analysis`](15_model_analysis.ipynb) checked, which is why the check\n",
+    "  there matters here.\n",
     "- **From each stock's own volatility.** `inverse_vol` puts less into a stock that moves more, so\n",
     "  each position contributes a similar amount of variation rather than a similar amount of money.\n",
     "  `risk_parity` as implemented here is the same idea with a steeper exponent on volatility,\n",
@@ -67,7 +69,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "efc9a938",
+   "id": "a9302db8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -105,7 +107,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "dace5e51",
+   "id": "9bbb210b",
    "metadata": {
     "tags": [
      "parameters"
@@ -132,7 +134,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a658c923",
+   "id": "a35c21b7",
    "metadata": {},
    "source": [
     "## 2. The baseline this notebook varies\n",
@@ -143,7 +145,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f99e3c7f",
+   "id": "fbd7a25e",
    "metadata": {},
    "source": [
     "Both tiers resolve the study through `open_study`. It reads the labels and features in place and\n",
@@ -154,7 +156,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b395087e",
+   "id": "56629a11",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -185,7 +187,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "26a38d93",
+   "id": "cef0ff53",
    "metadata": {},
    "source": [
     "## 3. Which baseline rows can be re-sized\n",
@@ -198,7 +200,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9f5afc16",
+   "id": "6a7c6be4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -240,7 +242,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "93ad2702",
+   "id": "495f17aa",
    "metadata": {},
    "source": [
     "## 4. The shortlist, and what it costs\n",
@@ -258,7 +260,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2c1d6c61",
+   "id": "9bdb8c1c",
    "metadata": {
     "tags": [
      "results"
@@ -304,7 +306,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "606975c0",
+   "id": "44198859",
    "metadata": {},
    "source": [
     "## 5. Planning one backtest per allocator\n",
@@ -328,7 +330,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7832edf6",
+   "id": "2e8a8076",
    "metadata": {},
    "source": [
     "**Prices are cached by label and warmup, not once per label.** Each allocator needs a different\n",
@@ -342,7 +344,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8a560dde",
+   "id": "dc2757ef",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -379,7 +381,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3ac69cf0",
+   "id": "2dfe66c0",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -426,7 +428,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f7da522e",
+   "id": "0be987d4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -444,7 +446,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "089dc92c",
+   "id": "b2bccde9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -472,7 +474,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bb80bfc1",
+   "id": "755afcf7",
    "metadata": {},
    "source": [
     "## 6. Running them\n",
@@ -484,7 +486,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fba95117",
+   "id": "a89e31a7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -515,7 +517,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cd82434b",
+   "id": "187fbbe2",
    "metadata": {
     "tags": [
      "results"
@@ -547,7 +549,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "921a2b77",
+   "id": "1f1714bd",
    "metadata": {
     "tags": [
      "results"
@@ -587,7 +589,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5c308ba4",
+   "id": "87b69b69",
    "metadata": {},
    "source": [
     "## 7. Naming the allocation sets\n",
@@ -604,7 +606,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1f624a67",
+   "id": "c2eb8056",
    "metadata": {
     "tags": [
      "results"
@@ -648,7 +650,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ed5f07ed",
+   "id": "5763153e",
    "metadata": {},
    "source": [
     "## 8. What came out\n",
@@ -669,7 +671,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5e3eae42",
+   "id": "8eb193f6",
    "metadata": {
     "tags": [
      "results"
@@ -733,7 +735,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6a799bc7",
+   "id": "146da44b",
    "metadata": {},
    "source": [
     "## What to notice\n",

--- a/case_studies/us_equities_panel/17_portfolio_management.ipynb
+++ b/case_studies/us_equities_panel/17_portfolio_management.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "63c5cbe3",
+   "id": "30c1a82c",
    "metadata": {},
    "source": [
     "# US equities panel: the same names, sized differently\n",
@@ -68,7 +68,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7b2ddb74",
+   "id": "b7749fe4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -104,7 +104,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "dfeb6501",
+   "id": "453f4c5d",
    "metadata": {
     "tags": [
      "parameters"
@@ -128,7 +128,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e7761772",
+   "id": "8cc32c9c",
    "metadata": {},
    "source": [
     "## 2. The baseline this notebook varies\n",
@@ -140,7 +140,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "783ac593",
+   "id": "18ef1f1d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -174,7 +174,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "31247da3",
+   "id": "77686b84",
    "metadata": {},
    "source": [
     "## 3. Which baseline rows can be re-sized\n",
@@ -187,7 +187,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f8606c76",
+   "id": "f8bc0650",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -229,7 +229,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "aef958e1",
+   "id": "e30072f3",
    "metadata": {},
    "source": [
     "## 4. The shortlist, and what it costs\n",
@@ -247,7 +247,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c8ad4e00",
+   "id": "375a30bd",
    "metadata": {
     "tags": [
      "results"
@@ -293,7 +293,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0a0e4b54",
+   "id": "a6e233d3",
    "metadata": {},
    "source": [
     "## 5. Planning one backtest per allocator\n",
@@ -312,7 +312,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6b9b0965",
+   "id": "1b3af5bc",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -355,7 +355,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "727d456e",
+   "id": "7c0c0ad1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -402,7 +402,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cad85e9e",
+   "id": "a9d1c9b1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -420,7 +420,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "28e46b62",
+   "id": "b231a966",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -444,7 +444,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bf4566ac",
+   "id": "8849c0b5",
    "metadata": {},
    "source": [
     "## 6. Running them\n",
@@ -456,7 +456,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1f6e6b9a",
+   "id": "0420ebaa",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -487,7 +487,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "40b8b308",
+   "id": "bee78fab",
    "metadata": {
     "tags": [
      "results"
@@ -519,7 +519,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1d3fb441",
+   "id": "19253110",
    "metadata": {
     "tags": [
      "results"
@@ -559,7 +559,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f492aa47",
+   "id": "28e464ed",
    "metadata": {},
    "source": [
     "## 7. Naming the allocation sets\n",
@@ -571,7 +571,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6326bef9",
+   "id": "849d531d",
    "metadata": {
     "tags": [
      "results"
@@ -615,7 +615,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ed5ce174",
+   "id": "eeac20ac",
    "metadata": {},
    "source": [
     "## 8. What came out\n",
@@ -636,7 +636,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f0448cda",
+   "id": "a1bd3c9f",
    "metadata": {
     "tags": [
      "results"
@@ -679,11 +679,10 @@
     "ax.set_ylabel(\"Validation Sharpe\")\n",
     "add_message_title(\n",
     "    ax,\n",
-    "    \"What sizing was worth, on the strategies equal weight already liked\",\n",
+    "    \"Validation Sharpe by allocator, for the shortlisted configurations\",\n",
     "    subtitle=\"One point per shortlisted configuration and allocator, coloured by label\",\n",
     ")\n",
     "ax.legend(fontsize=8, frameon=False)\n",
-    "fig.tight_layout()\n",
     "# The alt text counts rather than asserts: how many allocators clear zero anywhere is a fact about\n",
     "# the frame, and a panel described as beating the baseline when it does not is a claim the data\n",
     "# refutes.\n",
@@ -701,7 +700,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7c19fc22",
+   "id": "d3a55f34",
    "metadata": {},
    "source": [
     "## What to notice\n",

--- a/case_studies/us_equities_panel/17_portfolio_management.py
+++ b/case_studies/us_equities_panel/17_portfolio_management.py
@@ -35,17 +35,16 @@
 #   here.
 # - **From each stock's own volatility.** `inverse_vol` puts less into a stock that moves more, so
 #   each position contributes a similar amount of variation rather than a similar amount of money.
-#   `risk_parity` as implemented here is the same idea with a steeper exponent - weight
-#   proportional to one over volatility raised to 1.5 - which approximates equal risk contribution
-#   without estimating how the stocks move together.
+#   `risk_parity` as implemented here is the same idea with a steeper exponent on volatility,
+#   which approximates equal risk contribution without estimating how the stocks move together.
 # - **From how the stocks move together.** `mvo_ledoit_wolf` and `hrp` read a covariance matrix, so
 #   they alone can tell that two names which always move together are one bet held twice. That is
 #   the property none of the rules above can see, and it is the one that has to be estimated. These
 #   two need history before they can decide anything, and how much is declared per allocator rather
 #   than assumed.
 #
-# **Equal weight is excluded here, and not because it lost.** It is the baseline every row is
-# measured against, and re-running it would produce the identical backtest under a new name.
+# **Equal weight is excluded here because its backtest already exists.** It is the baseline every
+# row is measured against, and [`16_backtest`](16_backtest.ipynb) ran it.
 #
 # **A shortlist is taken first, and that is a real decision.** Applying every allocator to every
 # member of the whole model population would multiply an already large grid by seven. So the
@@ -122,10 +121,12 @@ MAX_SYMBOLS = 0
 # The equal-weight sets are opened and checked complete. Everything below changes one thing about
 # them, so a gap here would silently narrow what the allocator comparison is made over.
 
-# %%
+# %% [markdown]
 # Both tiers resolve the study through `open_study`. It reads the labels and features in place and
 # redirects only writes, so a preview run scores the same inputs a canonical one does and cannot
 # publish over it.
+
+# %%
 if EXECUTION_TIER == "canonical":
     if PREVIEW_LABELS or PREVIEW_MAX_BASELINE_ROWS or PREVIEW_MAX_ALLOCATORS or MAX_SYMBOLS:
         raise ValueError("Canonical execution cannot declare preview reductions")
@@ -250,17 +251,19 @@ shortlist.select(
 # **The history each allocator needs is declared per allocator, not shared.** The methods that read
 # a covariance matrix cannot decide anything until they have enough bars to estimate one, and the
 # amount differs between them - the mean-variance method here declares a longer window than the
-# others because shrinkage on a matrix estimated from too few observations collapses toward its
-# target and hands back something close to equal weight under a different name. Giving every
-# allocator the longest window instead would change what the cheap ones are measured on.
+# others because shrinkage on a matrix estimated from too few observations pulls it all the way to
+# its target and hands back something close to equal weight under a different name. Each allocator
+# therefore declares the history it needs, and is measured on that.
 
-# %%
-# Prices are cached by (label, warmup), not once per label. Each allocator needs a different
+# %% [markdown]
+# **Prices are cached by label and warmup, not once per label.** Each allocator needs a different
 # amount of history before it can decide anything - none for the ones that read only the
 # predictions, a volatility window for the per-stock ones, a longer lookback for the ones that
-# estimate a covariance matrix - and the frame a member was handed is digested into its identity.
-# So the frame has to be the one that member's own warmup implies, and the cache key is what keeps
-# it that way while still loading each distinct frame once.
+# estimate a covariance matrix - and the price frame a member was handed is digested into that
+# member's identity. So the frame has to be the one that member's own warmup implies, and the
+# cache key is what keeps it that way while still loading each distinct frame once.
+
+# %%
 _price_cache: dict[tuple[str, int], object] = {}
 
 
@@ -448,6 +451,11 @@ execution_diagnostics
 #
 # One frozen set per label, published only by an unnarrowed canonical run, for the reason
 # [`16_backtest`](16_backtest.ipynb) gives.
+#
+# **The freeze is also the comparability check.** Nothing is declared comparable, so
+# `CandidateSet.create` requires every field of the protocol to be identical across the members:
+# two rows that measured their Sharpe on different folds are not two rankings of one thing, and
+# this is what refuses to freeze them together.
 
 # %% tags=["results"]
 set_rows = []
@@ -465,10 +473,6 @@ if (
 if EXECUTION_TIER == "canonical":
     for label in completed.get_column("label").unique().sort().to_list():
         label_name = label.replace("_", "-")
-        # Nothing is declared comparable, so every field of the protocol has to be identical
-        # across the members. That is the guard: two rows that measured their Sharpe on different
-        # folds are not two rankings of one thing, and this is what refuses to freeze them
-        # together.
         result_set = study.backtests.freeze(
             completed.filter(pl.col("label") == label),
             name=f"us-equities-{label_name}-allocation-v1",

--- a/case_studies/us_equities_panel/17_portfolio_management.py
+++ b/case_studies/us_equities_panel/17_portfolio_management.py
@@ -534,11 +534,10 @@ ax.set_xlim(-0.5, len(allocator_order) - 0.5)
 ax.set_ylabel("Validation Sharpe")
 add_message_title(
     ax,
-    "What sizing was worth, on the strategies equal weight already liked",
+    "Validation Sharpe by allocator, for the shortlisted configurations",
     subtitle="One point per shortlisted configuration and allocator, coloured by label",
 )
 ax.legend(fontsize=8, frameon=False)
-fig.tight_layout()
 # The alt text counts rather than asserts: how many allocators clear zero anywhere is a fact about
 # the frame, and a panel described as beating the baseline when it does not is a claim the data
 # refutes.

--- a/case_studies/us_equities_panel/17_portfolio_management.py
+++ b/case_studies/us_equities_panel/17_portfolio_management.py
@@ -85,8 +85,10 @@ import polars as pl
 from case_studies.research import (
     CandidateSet,
     OfficialPopulation,
+    candidate_set_supersedes,
     open_study,
     plan_backtests,
+    population_supersedes,
     run_backtests,
 )
 from case_studies.research.strategy import strategy_warmup_periods
@@ -109,6 +111,9 @@ BASELINE_SET_NAMES = [
     "us-equities-fwd-ret-21d-baseline-v1",
 ]
 EXECUTION_TIER = "canonical"
+POPULATION_NAME = ""
+SUPERSEDES_POPULATION = ""
+SUPERSEDES_SETS: dict = {}
 WORKSPACE = "experiments"
 PREVIEW_LABELS = []
 PREVIEW_MAX_BASELINE_ROWS = 0
@@ -254,6 +259,12 @@ shortlist.select(
 # others because shrinkage on a matrix estimated from too few observations pulls it all the way to
 # its target and hands back something close to equal weight under a different name. Each allocator
 # therefore declares the history it needs, and is measured on that.
+#
+# `SUPERSEDES_POPULATION` and `SUPERSEDES_SETS` name the generation this run replaces. A population
+# and a candidate set are both immutable, so a re-run that admits different members has to say
+# which snapshot it supersedes or the registry refuses the write. Both default to empty, which is
+# right for a first run and for a reader's clean clone; `population_supersedes` and
+# `candidate_set_supersedes` withhold a declared hash wherever offering it would be refused.
 
 # %% [markdown]
 # **Prices are cached by label and warmup, not once per label.** Each allocator needs a different
@@ -355,9 +366,13 @@ if planned_population.get_column("backtest_hash").n_unique() != planned_populati
 
 official_population = None
 if EXECUTION_TIER == "canonical":
+    population_name = POPULATION_NAME or "us-equities-allocation-v1"
     official_population = OfficialPopulation.create(
         study,
-        name="us-equities-allocation-v1",
+        name=population_name,
+        supersedes=population_supersedes(
+            study, name=population_name, declared=SUPERSEDES_POPULATION
+        ),
         member_kind="backtest",
         members=tuple(planned_population.get_column("backtest_hash")),
     )
@@ -473,9 +488,13 @@ if (
 if EXECUTION_TIER == "canonical":
     for label in completed.get_column("label").unique().sort().to_list():
         label_name = label.replace("_", "-")
+        result_set_name = f"us-equities-{label_name}-allocation-v1"
         result_set = study.backtests.freeze(
             completed.filter(pl.col("label") == label),
-            name=f"us-equities-{label_name}-allocation-v1",
+            name=result_set_name,
+            supersedes=candidate_set_supersedes(
+                study, name=result_set_name, declared=SUPERSEDES_SETS.get(result_set_name, "")
+            ),
         )
         set_rows.append(
             {"label": label, "set_name": result_set.name, "members": len(result_set.members)}

--- a/case_studies/us_equities_panel/17_portfolio_management.py
+++ b/case_studies/us_equities_panel/17_portfolio_management.py
@@ -30,9 +30,11 @@
 #   confident about, so it trusts the magnitude of a prediction and not only its order.
 #   `conformal_weighted` reads the prediction's uncertainty rather than its size: it weights each
 #   name by one over the width of its prediction interval, so a name the model is less sure about
-#   gets less capital. That is the same width whose calibration
-#   [`15_model_analysis`](15_model_analysis.ipynb) checked, which is why the check there matters
-#   here.
+#   gets less capital. The width is floored at the first percentile of that date's own
+#   cross-section before the reciprocal is taken, which keeps an unusually confident name from
+#   taking the whole leg and uses no width from a later date to do it. That is the same width whose
+#   calibration [`15_model_analysis`](15_model_analysis.ipynb) checked, which is why the check
+#   there matters here.
 # - **From each stock's own volatility.** `inverse_vol` puts less into a stock that moves more, so
 #   each position contributes a similar amount of variation rather than a similar amount of money.
 #   `risk_parity` as implemented here is the same idea with a steeper exponent on volatility,

--- a/case_studies/us_equities_panel/18_risk_management.ipynb
+++ b/case_studies/us_equities_panel/18_risk_management.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "6676b229",
+   "id": "6814efc9",
    "metadata": {},
    "source": [
     "# US equities panel: rules that close a position early\n",
@@ -67,7 +67,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1f733ed2",
+   "id": "8be29a3f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -103,7 +103,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9c9a2c4a",
+   "id": "d6682355",
    "metadata": {
     "tags": [
      "parameters"
@@ -136,7 +136,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "49152226",
+   "id": "21f8a138",
    "metadata": {},
    "source": [
     "## 2. The strategies an overlay may be laid on\n",
@@ -149,7 +149,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0376b9b2",
+   "id": "d7d288b1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -184,7 +184,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3b54f4b7",
+   "id": "e7afc5b8",
    "metadata": {},
    "source": [
     "## 3. Which rows can carry an overlay\n",
@@ -196,7 +196,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d21cd2f5",
+   "id": "989b0629",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -236,7 +236,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7b28dece",
+   "id": "e3c6d2fc",
    "metadata": {},
    "source": [
     "## 4. Fixing the strategy the overlays are applied to\n",
@@ -261,7 +261,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "19a53d28",
+   "id": "430676c5",
    "metadata": {
     "tags": [
      "results"
@@ -312,7 +312,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2d09917d",
+   "id": "9d0f2d33",
    "metadata": {},
    "source": [
     "## 5. The controls, and the check that they bound\n",
@@ -335,7 +335,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8ffca49d",
+   "id": "98fdf017",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -374,7 +374,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "33c98990",
+   "id": "95636a02",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -406,7 +406,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2a27d13e",
+   "id": "31177931",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -444,7 +444,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "be2bde62",
+   "id": "5d1d272b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -466,7 +466,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b77fbb8a",
+   "id": "9137fe6a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -494,7 +494,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "adab5907",
+   "id": "dd7cb03e",
    "metadata": {},
    "source": [
     "## 6. Running them\n",
@@ -505,7 +505,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8f2b28c1",
+   "id": "53b20c7a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -537,7 +537,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "11cc196a",
+   "id": "d7b1bf1a",
    "metadata": {
     "tags": [
      "results"
@@ -569,7 +569,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3edad856",
+   "id": "deacbba5",
    "metadata": {
     "tags": [
      "results"
@@ -609,7 +609,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0c249d80",
+   "id": "8c2db4cf",
    "metadata": {},
    "source": [
     "## 7. Naming the overlay sets, and the population selection is made over\n",
@@ -631,7 +631,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "308ab6e9",
+   "id": "d91d58ba",
    "metadata": {
     "tags": [
      "results"
@@ -654,32 +654,40 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d11b73c0",
+   "id": "40b2381c",
    "metadata": {},
    "source": [
-    "**Did the overlay change anything?** Each result is compared against the strategy it was laid on,\n",
-    "on the two axes the catalog carries: the trade count and the Sharpe. A row that differs on either\n",
-    "acted, because there is no other way for those numbers to move.\n",
+    "**Did the control fire, and did anything move?** Those are two questions and the catalog answers\n",
+    "both.\n",
     "\n",
-    "A row identical on both moved neither of the two statistics compared here, and that is a weaker\n",
-    "statement than it looks. It is weaker than \"changed nothing\", because two different return paths\n",
-    "can share a Sharpe and a trade count while differing in total return or in drawdown. It is weaker\n",
-    "still than \"never fired\", because a stop can close a position the next rebalance would have\n",
-    "closed anyway, replacing one exit with an earlier one and leaving the count where it was. What\n",
-    "would settle whether a control fired is a per-control trigger count, and the backtest does not\n",
-    "surface one into the catalog today.\n",
+    "`risk_triggers` counts how many times the declared control acted during the backtest, recorded by\n",
+    "the engine as it installs each rule. It is what separates a control that fired and changed\n",
+    "nothing measurable from a control that was never installed at all: a positive count is the first,\n",
+    "a zero count the second, and a null means no control of that kind was declared for this row.\n",
+    "Reading it is what this stage owes, because a sweep of fourteen settings that all report the same\n",
+    "numbers is a finding about risk control if they fired and a defect in the wiring if they did not,\n",
+    "and nothing else on this page tells the two apart.\n",
     "\n",
-    "**So there are three outcomes here, not two.** A row is CHANGED when either comparison is true,\n",
-    "because one difference is enough to establish the control acted. It is UNCHANGED only when both\n",
-    "are false and both were comparable. Anything else is UNKNOWN: a comparison that could not be made\n",
-    "is not evidence of sameness, and collapsing it into one would manufacture the signature this\n",
+    "The second question is whether the numbers moved, and each result is compared against the\n",
+    "strategy it was laid on across the two axes the catalog carries: the trade count and the Sharpe.\n",
+    "A row that differs on either acted; a row identical on both moved neither of those two\n",
+    "statistics, which is weaker than \"changed nothing\", because two different return paths can share\n",
+    "a Sharpe and a trade count while differing in total return or in drawdown. It is weaker still\n",
+    "than \"never fired\" - a stop can close a position the next rebalance would have closed anyway,\n",
+    "replacing one exit with an earlier one and leaving the count where it was - and that is exactly\n",
+    "the gap the trigger count fills.\n",
+    "\n",
+    "**So the movement check has three outcomes, not two.** A row is CHANGED when either comparison is\n",
+    "true, because one difference is enough to establish the control acted. It is UNCHANGED only when\n",
+    "both are false and both were comparable. Anything else is UNKNOWN: a comparison that could not be\n",
+    "made is not evidence of sameness, and collapsing it into one would manufacture the signature this\n",
     "check exists to detect."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "45ec96ca",
+   "id": "53db9d50",
    "metadata": {
     "tags": [
      "results"
@@ -688,7 +696,7 @@
    "outputs": [],
    "source": [
     "overlay_effect = (\n",
-    "    completed_risk.select(\"label\", \"backtest_hash\", \"sharpe\", \"num_trades\")\n",
+    "    completed_risk.select(\"label\", \"backtest_hash\", \"sharpe\", \"num_trades\", \"risk_triggers\")\n",
     "    .join(\n",
     "        planned_population.select(\"backtest_hash\", \"risk\", \"source_backtest_hash\"),\n",
     "        on=\"backtest_hash\",\n",
@@ -714,7 +722,15 @@
     "        .then(None)\n",
     "        .otherwise(pl.col(\"sharpe\") != pl.col(\"source_sharpe\")),\n",
     "    )\n",
-    "    .select(\"label\", \"risk\", \"num_trades\", \"source_num_trades\", \"trades_moved\", \"sharpe_moved\")\n",
+    "    .select(\n",
+    "        \"label\",\n",
+    "        \"risk\",\n",
+    "        \"risk_triggers\",\n",
+    "        \"num_trades\",\n",
+    "        \"source_num_trades\",\n",
+    "        \"trades_moved\",\n",
+    "        \"sharpe_moved\",\n",
+    "    )\n",
     "    .sort(\"label\", \"risk\")\n",
     ")\n",
     "_changed = overlay_effect.get_column(\"trades_moved\").fill_null(False) | overlay_effect.get_column(\n",
@@ -732,6 +748,22 @@
     "    f\"laid on; {n_unchanged} match it on both compared statistics; {n_unknown} could not be \"\n",
     "    \"fully compared\"\n",
     ")\n",
+    "_triggers = overlay_effect.get_column(\"risk_triggers\")\n",
+    "n_fired = int((_triggers.fill_null(0) > 0).sum())\n",
+    "n_silent = int((_triggers == 0).sum())\n",
+    "n_undeclared = int(_triggers.is_null().sum())\n",
+    "print(\n",
+    "    f\"{n_fired} of {overlay_effect.height} controls fired at least once; {n_silent} were installed \"\n",
+    "    f\"and never fired; {n_undeclared} registered no trigger count\"\n",
+    ")\n",
+    "# A control that never fires is what C17 calls a failure rather than a finding, and it is only\n",
+    "# visible here.\n",
+    "if n_silent == overlay_effect.height:\n",
+    "    raise RuntimeError(\n",
+    "        \"every declared control was installed and fired zero times, so this sweep measured \"\n",
+    "        \"nothing about risk control; check that the declared thresholds can be reached on this \"\n",
+    "        \"book before reading any row below\"\n",
+    "    )\n",
     "if n_unchanged and not n_changed and not n_unknown:\n",
     "    print(\n",
     "        \"  No declared control moved either the trade count or the Sharpe. Neither statistic \"\n",
@@ -798,7 +830,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1e80904e",
+   "id": "fb0d65d6",
    "metadata": {},
    "source": [
     "### What the threshold does\n",
@@ -818,15 +850,14 @@
     "sample, one strategy per label, and no correction for having looked at fourteen. A flat line\n",
     "means the measured Sharpe did not move across the declared settings, which is weaker than it\n",
     "sounds in two directions: two different thresholds can produce the same exits, and two different\n",
-    "return paths can share a Sharpe. It is not evidence that the controls never fired. Nothing on\n",
-    "this page can settle that, and the trigger count that would is not something the backtest\n",
-    "records."
+    "return paths can share a Sharpe. It is not evidence that the controls never fired, and the\n",
+    "`risk_triggers` column above is what settles that rather than the shape of any line here."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b0644f82",
+   "id": "10334c15",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -938,7 +969,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "27629b33",
+   "id": "28941146",
    "metadata": {},
    "source": [
     "`20_strategy_analysis.py` reopens one of these per-label sets -\n",
@@ -951,7 +982,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b5d58f2e",
+   "id": "b6794303",
    "metadata": {},
    "source": [
     "## What to notice\n",
@@ -959,8 +990,9 @@
     "**Check that the overlays moved something before reading what they did.** A result matching the\n",
     "unprotected book on both compared statistics has not been shown to change anything, and matching\n",
     "across every declared setting is a reason to confirm the controls reach the engine rather than a\n",
-    "finding about risk control. Neither question is settled by these two columns; a per-control\n",
-    "trigger count would settle the first, and the backtest does not surface one today.\n",
+    "finding about risk control. The two compared columns do not settle it on their own; the\n",
+    "`risk_triggers` count does, and a sweep where every control was installed and fired zero times\n",
+    "stops the notebook rather than being reported as a result.\n",
     "\n",
     "**An overlay can only remove, so it reshapes a return distribution rather than shifting it.** It\n",
     "truncates the left tail by closing losing positions early and truncates the right by closing\n",

--- a/case_studies/us_equities_panel/18_risk_management.ipynb
+++ b/case_studies/us_equities_panel/18_risk_management.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "d9993084",
+   "id": "6676b229",
    "metadata": {},
    "source": [
     "# US equities panel: rules that close a position early\n",
@@ -67,7 +67,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "dabd4d0e",
+   "id": "1f733ed2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -84,8 +84,10 @@
     "from case_studies.research import (\n",
     "    CandidateSet,\n",
     "    OfficialPopulation,\n",
+    "    candidate_set_supersedes,\n",
     "    open_study,\n",
     "    plan_backtests,\n",
+    "    population_supersedes,\n",
     "    run_backtests,\n",
     ")\n",
     "from case_studies.research.strategy import strategy_warmup_periods\n",
@@ -101,7 +103,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3df82129",
+   "id": "9c9a2c4a",
    "metadata": {
     "tags": [
      "parameters"
@@ -122,6 +124,9 @@
     "]\n",
     "VALIDATION_SET_NAME_TEMPLATE = \"us-equities-{label}-validation-strategies-v1\"\n",
     "EXECUTION_TIER = \"canonical\"\n",
+    "POPULATION_NAME = \"\"\n",
+    "SUPERSEDES_POPULATION = \"\"\n",
+    "SUPERSEDES_SETS: dict = {}\n",
     "WORKSPACE = \"experiments\"\n",
     "PREVIEW_LABELS = []\n",
     "PREVIEW_MAX_SOURCE_ROWS = 0\n",
@@ -131,7 +136,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "430d4eae",
+   "id": "49152226",
    "metadata": {},
    "source": [
     "## 2. The strategies an overlay may be laid on\n",
@@ -144,7 +149,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "84781fd2",
+   "id": "0376b9b2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -179,7 +184,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "70365690",
+   "id": "3b54f4b7",
    "metadata": {},
    "source": [
     "## 3. Which rows can carry an overlay\n",
@@ -191,7 +196,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5d3eafda",
+   "id": "d21cd2f5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -231,7 +236,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4967e7cd",
+   "id": "7b28dece",
    "metadata": {},
    "source": [
     "## 4. Fixing the strategy the overlays are applied to\n",
@@ -256,7 +261,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e174ec64",
+   "id": "19a53d28",
    "metadata": {
     "tags": [
      "results"
@@ -307,7 +312,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4e47eabd",
+   "id": "2d09917d",
    "metadata": {},
    "source": [
     "## 5. The controls, and the check that they bound\n",
@@ -318,13 +323,19 @@
     "**Whether the overlays changed anything is checked after execution**, in the section that reports\n",
     "results: each one against the strategy it was laid on, on the trade count and the Sharpe. A\n",
     "difference establishes that the control acted. Matching values establish only that those two\n",
-    "statistics did not move, and leave every other outcome undetermined."
+    "statistics did not move, and leave every other outcome undetermined.\n",
+    "\n",
+    "`SUPERSEDES_POPULATION` and `SUPERSEDES_SETS` name the generation this run replaces. A population\n",
+    "and a candidate set are both immutable, so a re-run that admits different members has to say\n",
+    "which snapshot it supersedes or the registry refuses the write. Both default to empty, which is\n",
+    "right for a first run and for a reader's clean clone; `population_supersedes` and\n",
+    "`candidate_set_supersedes` withhold a declared hash wherever offering it would be refused."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9de57e9c",
+   "id": "8ffca49d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -363,7 +374,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4af742c0",
+   "id": "33c98990",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -395,7 +406,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ceb3be3a",
+   "id": "2a27d13e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -433,7 +444,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "183628ec",
+   "id": "be2bde62",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -455,7 +466,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "904a13e8",
+   "id": "b77fbb8a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -467,9 +478,13 @@
     "\n",
     "official_population = None\n",
     "if EXECUTION_TIER == \"canonical\":\n",
+    "    population_name = POPULATION_NAME or \"us-equities-risk-overlay-v1\"\n",
     "    official_population = OfficialPopulation.create(\n",
     "        study,\n",
-    "        name=\"us-equities-risk-overlay-v1\",\n",
+    "        name=population_name,\n",
+    "        supersedes=population_supersedes(\n",
+    "            study, name=population_name, declared=SUPERSEDES_POPULATION\n",
+    "        ),\n",
     "        member_kind=\"backtest\",\n",
     "        members=tuple(planned_population.get_column(\"backtest_hash\")),\n",
     "    )\n",
@@ -479,7 +494,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b842252b",
+   "id": "adab5907",
    "metadata": {},
    "source": [
     "## 6. Running them\n",
@@ -490,7 +505,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f8f1c7e9",
+   "id": "8f2b28c1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -522,7 +537,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d87461d4",
+   "id": "11cc196a",
    "metadata": {
     "tags": [
      "results"
@@ -554,7 +569,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "70a75df2",
+   "id": "3edad856",
    "metadata": {
     "tags": [
      "results"
@@ -594,7 +609,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "880793c8",
+   "id": "0c249d80",
    "metadata": {},
    "source": [
     "## 7. Naming the overlay sets, and the population selection is made over\n",
@@ -616,7 +631,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "43d52f36",
+   "id": "308ab6e9",
    "metadata": {
     "tags": [
      "results"
@@ -639,7 +654,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b71b3df6",
+   "id": "d11b73c0",
    "metadata": {},
    "source": [
     "**Did the overlay change anything?** Each result is compared against the strategy it was laid on,\n",
@@ -664,7 +679,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ae5db488",
+   "id": "45ec96ca",
    "metadata": {
     "tags": [
      "results"
@@ -729,9 +744,13 @@
     "if EXECUTION_TIER == \"canonical\":\n",
     "    for label in completed_risk.get_column(\"label\").unique().sort().to_list():\n",
     "        label_name = label.replace(\"_\", \"-\")\n",
+    "        result_set_name = f\"us-equities-{label_name}-risk-overlay-v1\"\n",
     "        result_set = study.backtests.freeze(\n",
     "            completed_risk.filter(pl.col(\"label\") == label),\n",
-    "            name=f\"us-equities-{label_name}-risk-overlay-v1\",\n",
+    "            name=result_set_name,\n",
+    "            supersedes=candidate_set_supersedes(\n",
+    "                study, name=result_set_name, declared=SUPERSEDES_SETS.get(result_set_name, \"\")\n",
+    "            ),\n",
     "        )\n",
     "        set_rows.append(\n",
     "            {\"label\": label, \"set_name\": result_set.name, \"members\": len(result_set.members)}\n",
@@ -751,9 +770,15 @@
     "            != validation_candidates.height\n",
     "        ):\n",
     "            raise ValueError(f\"Selection-eligible strategy sets overlap for {label}\")\n",
+    "        validation_set_name = VALIDATION_SET_NAME_TEMPLATE.format(label=label_name)\n",
     "        validation_set = study.backtests.freeze(\n",
     "            validation_candidates,\n",
-    "            name=VALIDATION_SET_NAME_TEMPLATE.format(label=label_name),\n",
+    "            name=validation_set_name,\n",
+    "            supersedes=candidate_set_supersedes(\n",
+    "                study,\n",
+    "                name=validation_set_name,\n",
+    "                declared=SUPERSEDES_SETS.get(validation_set_name, \"\"),\n",
+    "            ),\n",
     "        )\n",
     "        set_rows.append(\n",
     "            {\n",
@@ -773,7 +798,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b46dd4ca",
+   "id": "1e80904e",
    "metadata": {},
    "source": [
     "### What the threshold does\n",
@@ -801,7 +826,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5b9280cb",
+   "id": "b0644f82",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -913,7 +938,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "424304da",
+   "id": "27629b33",
    "metadata": {},
    "source": [
     "`20_strategy_analysis.py` reopens one of these per-label sets -\n",
@@ -926,7 +951,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "19bcaec9",
+   "id": "b5d58f2e",
    "metadata": {},
    "source": [
     "## What to notice\n",

--- a/case_studies/us_equities_panel/18_risk_management.ipynb
+++ b/case_studies/us_equities_panel/18_risk_management.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "6814efc9",
+   "id": "a83c3708",
    "metadata": {},
    "source": [
     "# US equities panel: rules that close a position early\n",
@@ -67,7 +67,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8be29a3f",
+   "id": "feaa69b3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -103,7 +103,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d6682355",
+   "id": "a582a5e0",
    "metadata": {
     "tags": [
      "parameters"
@@ -136,7 +136,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "21f8a138",
+   "id": "974d5910",
    "metadata": {},
    "source": [
     "## 2. The strategies an overlay may be laid on\n",
@@ -149,7 +149,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d7d288b1",
+   "id": "10975f6e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -184,7 +184,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e7afc5b8",
+   "id": "308ba1ab",
    "metadata": {},
    "source": [
     "## 3. Which rows can carry an overlay\n",
@@ -196,7 +196,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "989b0629",
+   "id": "fdaddb8b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -236,7 +236,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e3c6d2fc",
+   "id": "f25f734b",
    "metadata": {},
    "source": [
     "## 4. Fixing the strategy the overlays are applied to\n",
@@ -261,7 +261,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "430676c5",
+   "id": "aea07a62",
    "metadata": {
     "tags": [
      "results"
@@ -312,7 +312,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9d0f2d33",
+   "id": "77fd4234",
    "metadata": {},
    "source": [
     "## 5. The controls, and the check that they bound\n",
@@ -335,7 +335,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "98fdf017",
+   "id": "5b99b68a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -374,7 +374,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "95636a02",
+   "id": "230213d6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -406,7 +406,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "31177931",
+   "id": "254e5894",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -444,7 +444,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5d1d272b",
+   "id": "05e66e02",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -466,7 +466,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9137fe6a",
+   "id": "840c771e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -494,7 +494,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dd7cb03e",
+   "id": "e157c892",
    "metadata": {},
    "source": [
     "## 6. Running them\n",
@@ -505,7 +505,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "53b20c7a",
+   "id": "333049a9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -537,7 +537,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d7b1bf1a",
+   "id": "ff16a439",
    "metadata": {
     "tags": [
      "results"
@@ -569,7 +569,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "deacbba5",
+   "id": "53126036",
    "metadata": {
     "tags": [
      "results"
@@ -609,7 +609,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8c2db4cf",
+   "id": "2a2d4335",
    "metadata": {},
    "source": [
     "## 7. Naming the overlay sets, and the population selection is made over\n",
@@ -631,7 +631,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d91d58ba",
+   "id": "0c5dada7",
    "metadata": {
     "tags": [
      "results"
@@ -654,19 +654,26 @@
   },
   {
    "cell_type": "markdown",
-   "id": "40b2381c",
+   "id": "0a400593",
    "metadata": {},
    "source": [
     "**Did the control fire, and did anything move?** Those are two questions and the catalog answers\n",
     "both.\n",
     "\n",
-    "`risk_triggers` counts how many times the declared control acted during the backtest, recorded by\n",
-    "the engine as it installs each rule. It is what separates a control that fired and changed\n",
-    "nothing measurable from a control that was never installed at all: a positive count is the first,\n",
-    "a zero count the second, and a null means no control of that kind was declared for this row.\n",
+    "`risk_triggers` counts how many times the installed control acted during the backtest, recorded\n",
+    "by the engine as it installs each rule. Its three states are what separate the cases nothing else\n",
+    "on this page can tell apart:\n",
+    "\n",
+    "- **A positive count** is a control that fired. Whether that changed anything measurable is the\n",
+    "  second question below.\n",
+    "- **Zero** is a control that was installed and never reached its threshold. That is a result:\n",
+    "  a wide stop on a book that never drew down that far has nothing to do.\n",
+    "- **Null** is no control installed at all - the engine records a count for every rule it builds,\n",
+    "  so a null where a control was declared means the declaration did not reach the engine.\n",
+    "\n",
     "Reading it is what this stage owes, because a sweep of fourteen settings that all report the same\n",
-    "numbers is a finding about risk control if they fired and a defect in the wiring if they did not,\n",
-    "and nothing else on this page tells the two apart.\n",
+    "numbers is a finding about risk control if they were installed and a defect in the wiring if they\n",
+    "were not.\n",
     "\n",
     "The second question is whether the numbers moved, and each result is compared against the\n",
     "strategy it was laid on across the two axes the catalog carries: the trade count and the Sharpe.\n",
@@ -687,7 +694,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "53db9d50",
+   "id": "3c41bb67",
    "metadata": {
     "tags": [
      "results"
@@ -751,18 +758,19 @@
     "_triggers = overlay_effect.get_column(\"risk_triggers\")\n",
     "n_fired = int((_triggers.fill_null(0) > 0).sum())\n",
     "n_silent = int((_triggers == 0).sum())\n",
-    "n_undeclared = int(_triggers.is_null().sum())\n",
+    "n_uninstalled = int(_triggers.is_null().sum())\n",
     "print(\n",
     "    f\"{n_fired} of {overlay_effect.height} controls fired at least once; {n_silent} were installed \"\n",
-    "    f\"and never fired; {n_undeclared} registered no trigger count\"\n",
+    "    f\"and never reached their threshold; {n_uninstalled} installed no rule at all\"\n",
     ")\n",
-    "# A control that never fires is what C17 calls a failure rather than a finding, and it is only\n",
-    "# visible here.\n",
-    "if n_silent == overlay_effect.height:\n",
+    "# The engine records a count for every rule it builds, so a row that declared a control and\n",
+    "# registered no count is one whose declaration never reached it. That is the failure C17 names,\n",
+    "# and it is the only one of the three states that is not a result.\n",
+    "if n_uninstalled:\n",
     "    raise RuntimeError(\n",
-    "        \"every declared control was installed and fired zero times, so this sweep measured \"\n",
-    "        \"nothing about risk control; check that the declared thresholds can be reached on this \"\n",
-    "        \"book before reading any row below\"\n",
+    "        f\"{n_uninstalled} of {overlay_effect.height} overlay results registered no trigger count, \"\n",
+    "        \"so their declared control was never installed and the row is named for behaviour that \"\n",
+    "        \"did not run\"\n",
     "    )\n",
     "if n_unchanged and not n_changed and not n_unknown:\n",
     "    print(\n",
@@ -830,7 +838,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fb0d65d6",
+   "id": "4976a7da",
    "metadata": {},
    "source": [
     "### What the threshold does\n",
@@ -850,14 +858,15 @@
     "sample, one strategy per label, and no correction for having looked at fourteen. A flat line\n",
     "means the measured Sharpe did not move across the declared settings, which is weaker than it\n",
     "sounds in two directions: two different thresholds can produce the same exits, and two different\n",
-    "return paths can share a Sharpe. It is not evidence that the controls never fired, and the\n",
-    "`risk_triggers` column above is what settles that rather than the shape of any line here."
+    "return paths can share a Sharpe. It is not evidence that the controls never fired; the\n",
+    "`risk_triggers` column above is what settles that, and it is read there rather than inferred\n",
+    "from the shape of any line here."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "10334c15",
+   "id": "e81b449a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -969,7 +978,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "28941146",
+   "id": "7e6d1c8b",
    "metadata": {},
    "source": [
     "`20_strategy_analysis.py` reopens one of these per-label sets -\n",
@@ -982,17 +991,18 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b6794303",
+   "id": "dceb998c",
    "metadata": {},
    "source": [
     "## What to notice\n",
     "\n",
     "**Check that the overlays moved something before reading what they did.** A result matching the\n",
     "unprotected book on both compared statistics has not been shown to change anything, and matching\n",
-    "across every declared setting is a reason to confirm the controls reach the engine rather than a\n",
-    "finding about risk control. The two compared columns do not settle it on their own; the\n",
-    "`risk_triggers` count does, and a sweep where every control was installed and fired zero times\n",
-    "stops the notebook rather than being reported as a result.\n",
+    "across every declared setting is a reason to check that the controls reached the engine rather\n",
+    "than a finding about risk control. The two compared columns do not settle it on their own; the\n",
+    "`risk_triggers` count does, and a row that declared a control and installed none stops the\n",
+    "notebook rather than being reported as a result. A row installed and never triggered is a\n",
+    "result: it says the threshold was never reached on this book.\n",
     "\n",
     "**An overlay can only remove, so it reshapes a return distribution rather than shifting it.** It\n",
     "truncates the left tail by closing losing positions early and truncates the right by closing\n",

--- a/case_studies/us_equities_panel/18_risk_management.ipynb
+++ b/case_studies/us_equities_panel/18_risk_management.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "d2ee008e",
+   "id": "d9993084",
    "metadata": {},
    "source": [
     "# US equities panel: rules that close a position early\n",
@@ -24,16 +24,17 @@
     "\n",
     "**An overlay only ever removes.** It cannot enter a position the strategy did not take, so it\n",
     "can only cut a loss short or cut a gain short, and which of the two it does more of is exactly\n",
-    "what the sweep measures. Fourteen controls are declared across the three kinds, spanning stops\n",
-    "from 3% to 15% and trailing stops from 1% to 20%, so the sweep says how the effect moves with the\n",
-    "threshold rather than whether one chosen threshold helped.\n",
+    "what the sweep measures. Fourteen controls are declared across the three kinds, each kind swept\n",
+    "from its tightest declared threshold to its loosest, so the sweep says how the effect moves with\n",
+    "the threshold rather than whether one chosen threshold helped.\n",
     "\n",
     "**The thing to check first is whether the overlays changed anything at all.** A control that\n",
     "never fires returns the unprotected book unchanged in every digit, and so does a control that was\n",
     "declared in one shape and read by the engine in another. One result cannot tell those apart: both\n",
-    "produce a row identical to the book it was laid on. Fourteen different rules, spanning a 3% stop\n",
-    "to a 40-bar time exit, all declining to act on one book and agreeing to the last digit would be\n",
-    "the second and not the first, and it would read on the page as a finding about risk control.\n",
+    "produce a row identical to the book it was laid on. Fourteen different rules, spanning the\n",
+    "tightest declared stop to the longest declared time exit, all declining to act on one book and\n",
+    "agreeing to the last digit would be the second and not the first, and it would read on the page\n",
+    "as a finding about risk control.\n",
     "\n",
     "So the results section compares each overlay against the strategy it was laid on rather than\n",
     "reporting its performance alone. **A difference proves the control acted; matching statistics\n",
@@ -66,7 +67,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "070fbb8a",
+   "id": "dabd4d0e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -100,7 +101,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b2f8398d",
+   "id": "3df82129",
    "metadata": {
     "tags": [
      "parameters"
@@ -130,7 +131,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "88919b6a",
+   "id": "430d4eae",
    "metadata": {},
    "source": [
     "## 2. The strategies an overlay may be laid on\n",
@@ -143,7 +144,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cfe7d8d3",
+   "id": "84781fd2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -178,7 +179,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1702554c",
+   "id": "70365690",
    "metadata": {},
    "source": [
     "## 3. Which rows can carry an overlay\n",
@@ -190,7 +191,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e83febd4",
+   "id": "5d3eafda",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -230,7 +231,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2b2733d4",
+   "id": "4967e7cd",
    "metadata": {},
    "source": [
     "## 4. Fixing the strategy the overlays are applied to\n",
@@ -241,13 +242,21 @@
     "\n",
     "**Sweeping overlays across several strategies at once would confound the two.** A table in which\n",
     "both the strategy and the control vary cannot say whether a difference came from the rule or from\n",
-    "the book it was applied to."
+    "the book it was applied to.\n",
+    "\n",
+    "\n",
+    "**Prices are cached by label and warmup, not once per label.** A strategy's identity digests the\n",
+    "price frame it was handed, and the allocator underneath each overlay needs a different amount of\n",
+    "history before it can decide anything - none for the ones reading only the predictions, a\n",
+    "volatility window for the per-stock ones, a longer lookback for the ones estimating a covariance\n",
+    "matrix. So each member has to receive the frame its own warmup implies, and the cache key is\n",
+    "what keeps that true while loading each distinct frame once."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3d38397c",
+   "id": "e174ec64",
    "metadata": {
     "tags": [
      "results"
@@ -255,12 +264,6 @@
    },
    "outputs": [],
    "source": [
-    "# Prices are cached by (label, warmup), not once per label. A strategy's identity digests the\n",
-    "# price frame it was handed, and the allocator underneath each overlay needs a different amount of\n",
-    "# history before it can decide anything - none for the ones reading only the predictions, a\n",
-    "# volatility window for the per-stock ones, a longer lookback for the ones estimating a covariance\n",
-    "# matrix. So each member has to receive the frame its own warmup implies, and the cache key is\n",
-    "# what keeps that true while loading each distinct frame once.\n",
     "_price_cache: dict[tuple[str, int], object] = {}\n",
     "\n",
     "\n",
@@ -304,7 +307,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bd32cb12",
+   "id": "4e47eabd",
    "metadata": {},
    "source": [
     "## 5. The controls, and the check that they bound\n",
@@ -321,7 +324,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4401e74a",
+   "id": "9de57e9c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -360,7 +363,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d3107bc8",
+   "id": "4af742c0",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -392,7 +395,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a77718c3",
+   "id": "ceb3be3a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -430,7 +433,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6f4a2f04",
+   "id": "183628ec",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -452,7 +455,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7cdffdba",
+   "id": "904a13e8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -476,7 +479,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8c9906c0",
+   "id": "b842252b",
    "metadata": {},
    "source": [
     "## 6. Running them\n",
@@ -487,7 +490,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4a68e603",
+   "id": "f8f1c7e9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -519,7 +522,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a208ea49",
+   "id": "d87461d4",
    "metadata": {
     "tags": [
      "results"
@@ -551,7 +554,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5ab495e3",
+   "id": "70a75df2",
    "metadata": {
     "tags": [
      "results"
@@ -591,7 +594,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9e9ad8da",
+   "id": "880793c8",
    "metadata": {},
    "source": [
     "## 7. Naming the overlay sets, and the population selection is made over\n",
@@ -602,13 +605,18 @@
     "**The union is the point.** A strategy may legitimately come from any of the three stages, so\n",
     "ranking only the last of them would exclude an un-overlaid book that was better than every\n",
     "overlaid one. [`19_costs`](19_costs.ipynb) derives its pool from the same stage sequence for the\n",
-    "same reason."
+    "same reason.\n",
+    "\n",
+    "**The freeze is also the comparability check.** Nothing is declared comparable, so\n",
+    "`CandidateSet.create` requires every field of the protocol to be identical across the members:\n",
+    "two rows that measured their Sharpe on different folds are not two rankings of one thing, and\n",
+    "this is what refuses to freeze them together."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "38b43ba8",
+   "id": "43d52f36",
    "metadata": {
     "tags": [
      "results"
@@ -626,16 +634,44 @@
     "    or completed_risk.filter(pl.col(\"execution_tier\") != EXECUTION_TIER).height\n",
     "    or completed_risk.filter(pl.col(\"sharpe\").is_null() | ~pl.col(\"sharpe\").is_finite()).height\n",
     "):\n",
-    "    raise RuntimeError(\"The risk catalog is incomplete or mis-staged\")\n",
-    "# Did the overlay change anything? Each result is compared against the strategy it was laid on, on\n",
-    "# the two axes the catalog carries: the trade count and the Sharpe. A row that differs on either\n",
-    "# acted - there is no other way for the numbers to move. A row identical on both moved neither of\n",
-    "# the two statistics compared here - which is weaker than \"changed nothing\", since two\n",
-    "# different return paths can share a Sharpe and a trade count while differing in total return or in\n",
-    "# drawdown, and weaker still than \"never fired\": a stop can close a position the next rebalance\n",
-    "# would have closed anyway, replacing one exit with an earlier one and leaving the count where it\n",
-    "# was. What would settle whether a control fired is a per-control trigger count, which the backtest\n",
-    "# does not surface into the catalog today.\n",
+    "    raise RuntimeError(\"The risk catalog is incomplete or mis-staged\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b71b3df6",
+   "metadata": {},
+   "source": [
+    "**Did the overlay change anything?** Each result is compared against the strategy it was laid on,\n",
+    "on the two axes the catalog carries: the trade count and the Sharpe. A row that differs on either\n",
+    "acted, because there is no other way for those numbers to move.\n",
+    "\n",
+    "A row identical on both moved neither of the two statistics compared here, and that is a weaker\n",
+    "statement than it looks. It is weaker than \"changed nothing\", because two different return paths\n",
+    "can share a Sharpe and a trade count while differing in total return or in drawdown. It is weaker\n",
+    "still than \"never fired\", because a stop can close a position the next rebalance would have\n",
+    "closed anyway, replacing one exit with an earlier one and leaving the count where it was. What\n",
+    "would settle whether a control fired is a per-control trigger count, and the backtest does not\n",
+    "surface one into the catalog today.\n",
+    "\n",
+    "**So there are three outcomes here, not two.** A row is CHANGED when either comparison is true,\n",
+    "because one difference is enough to establish the control acted. It is UNCHANGED only when both\n",
+    "are false and both were comparable. Anything else is UNKNOWN: a comparison that could not be made\n",
+    "is not evidence of sameness, and collapsing it into one would manufacture the signature this\n",
+    "check exists to detect."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ae5db488",
+   "metadata": {
+    "tags": [
+     "results"
+    ]
+   },
+   "outputs": [],
+   "source": [
     "overlay_effect = (\n",
     "    completed_risk.select(\"label\", \"backtest_hash\", \"sharpe\", \"num_trades\")\n",
     "    .join(\n",
@@ -666,10 +702,6 @@
     "    .select(\"label\", \"risk\", \"num_trades\", \"source_num_trades\", \"trades_moved\", \"sharpe_moved\")\n",
     "    .sort(\"label\", \"risk\")\n",
     ")\n",
-    "# Three outcomes, not two. A row is CHANGED when either comparison is true, because one difference\n",
-    "# is enough to establish the control acted. It is UNCHANGED only when both are false and both were\n",
-    "# comparable. Anything else is UNKNOWN - a comparison that could not be made is not evidence of\n",
-    "# sameness, and collapsing it into one would manufacture the signature this check exists to detect.\n",
     "_changed = overlay_effect.get_column(\"trades_moved\").fill_null(False) | overlay_effect.get_column(\n",
     "    \"sharpe_moved\"\n",
     ").fill_null(False)\n",
@@ -697,10 +729,6 @@
     "if EXECUTION_TIER == \"canonical\":\n",
     "    for label in completed_risk.get_column(\"label\").unique().sort().to_list():\n",
     "        label_name = label.replace(\"_\", \"-\")\n",
-    "        # Nothing is declared comparable, so every field of the protocol has to be identical\n",
-    "        # across the members. That is the guard: two rows that measured their Sharpe on different\n",
-    "        # folds are not two rankings of one thing, and this is what refuses to freeze them\n",
-    "        # together.\n",
     "        result_set = study.backtests.freeze(\n",
     "            completed_risk.filter(pl.col(\"label\") == label),\n",
     "            name=f\"us-equities-{label_name}-risk-overlay-v1\",\n",
@@ -745,7 +773,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "af2d7484",
+   "id": "b46dd4ca",
    "metadata": {},
    "source": [
     "### What the threshold does\n",
@@ -773,7 +801,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e53b8e8e",
+   "id": "5b9280cb",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -781,10 +809,8 @@
     "    control[\"name\"]: (control[\"type\"], float(control.get(\"threshold\", control.get(\"bars\"))))\n",
     "    for control in get_position_risk_controls(CASE_STUDY_ID)\n",
     "}\n",
-    "# The Sharpe of the strategy each label's overlays were laid on, which is the line they have to\n",
-    "# clear. Asserted rather than assumed to be one per label: `top_n` is read from the sweep\n",
-    "# configuration, and a label carrying two sources would need two reference lines, not one drawn\n",
-    "# from whichever row a dict happened to keep.\n",
+    "# One source per label is asserted rather than assumed: `top_n` comes from the sweep\n",
+    "# configuration, and a label with two sources needs two reference lines.\n",
     "_sources_per_label = selected_sources.group_by(\"label\").len()\n",
     "if (_sources_per_label.get_column(\"len\") != 1).any():\n",
     "    raise ValueError(\n",
@@ -887,7 +913,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6ae737f1",
+   "id": "424304da",
    "metadata": {},
    "source": [
     "`20_strategy_analysis.py` reopens one of these per-label sets -\n",
@@ -900,7 +926,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "18168d51",
+   "id": "19bcaec9",
    "metadata": {},
    "source": [
     "## What to notice\n",
@@ -912,7 +938,8 @@
     "trigger count would settle the first, and the backtest does not surface one today.\n",
     "\n",
     "**An overlay can only remove, so it reshapes a return distribution rather than shifting it.** It\n",
-    "truncates the left tail by closing losers early and truncates the right by closing winners early,\n",
+    "truncates the left tail by closing losing positions early and truncates the right by closing\n",
+    "profitable ones early,\n",
     "and which effect dominates is a property of how the strategy's returns actually arrive. A book\n",
     "whose gains come from a few positions running a long way is one an early exit hurts.\n",
     "\n",

--- a/case_studies/us_equities_panel/18_risk_management.ipynb
+++ b/case_studies/us_equities_panel/18_risk_management.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "08f0cb0a",
+   "id": "d2ee008e",
    "metadata": {},
    "source": [
     "# US equities panel: rules that close a position early\n",
@@ -65,16 +65,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
-   "id": "e7af0af7",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-05-17T21:41:25.425722Z",
-     "iopub.status.busy": "2026-05-17T21:41:25.424699Z",
-     "iopub.status.idle": "2026-05-17T21:41:27.088103Z",
-     "shell.execute_reply": "2026-05-17T21:41:27.087574Z"
-    }
-   },
+   "execution_count": null,
+   "id": "070fbb8a",
+   "metadata": {},
    "outputs": [],
    "source": [
     "\"\"\"Generate risk overlays and freeze the official US-equities validation set.\"\"\"\n",
@@ -106,15 +99,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
-   "id": "5e3f1e71",
+   "execution_count": null,
+   "id": "b2f8398d",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-05-17T21:41:27.092253Z",
-     "iopub.status.busy": "2026-05-17T21:41:27.092077Z",
-     "iopub.status.idle": "2026-05-17T21:41:27.093830Z",
-     "shell.execute_reply": "2026-05-17T21:41:27.093558Z"
-    },
     "tags": [
      "parameters"
     ]
@@ -143,7 +130,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0caead82",
+   "id": "88919b6a",
    "metadata": {},
    "source": [
     "## 2. The strategies an overlay may be laid on\n",
@@ -156,7 +143,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "216b5aa7",
+   "id": "cfe7d8d3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -191,7 +178,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fea9d745",
+   "id": "1702554c",
    "metadata": {},
    "source": [
     "## 3. Which rows can carry an overlay\n",
@@ -202,25 +189,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
-   "id": "0ed8727c",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-05-17T21:41:27.097663Z",
-     "iopub.status.busy": "2026-05-17T21:41:27.097594Z",
-     "iopub.status.idle": "2026-05-17T21:41:27.111154Z",
-     "shell.execute_reply": "2026-05-17T21:41:27.110699Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Case study: us_equities_panel, label: fwd_ret_1d, mode: engine\n"
-     ]
-    }
-   ],
+   "execution_count": null,
+   "id": "e83febd4",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "backtest_catalog = study.backtests.table(include_preview=True)\n",
     "if EXECUTION_TIER == \"canonical\":\n",
@@ -258,7 +230,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ebe7cbdc",
+   "id": "2b2733d4",
    "metadata": {},
    "source": [
     "## 4. Fixing the strategy the overlays are applied to\n",
@@ -274,28 +246,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
-   "id": "6f91799a",
+   "execution_count": null,
+   "id": "3d38397c",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-05-17T21:41:27.115475Z",
-     "iopub.status.busy": "2026-05-17T21:41:27.115389Z",
-     "iopub.status.idle": "2026-05-17T21:41:27.143400Z",
-     "shell.execute_reply": "2026-05-17T21:41:27.142987Z"
-    },
     "tags": [
      "results"
     ]
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Sharpe=1.642  alloc=equal_weight  bt_hash=4d4fdf29\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Prices are cached by (label, warmup), not once per label. A strategy's identity digests the\n",
     "# price frame it was handed, and the allocator underneath each overlay needs a different amount of\n",
@@ -346,7 +304,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b866d0e4",
+   "id": "bd32cb12",
    "metadata": {},
    "source": [
     "## 5. The controls, and the check that they bound\n",
@@ -363,7 +321,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4c34d478",
+   "id": "4401e74a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -402,7 +360,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bc353ade",
+   "id": "d3107bc8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -434,7 +392,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a6c3f4bd",
+   "id": "a77718c3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -472,7 +430,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cfdccf36",
+   "id": "6f4a2f04",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -493,16 +451,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
-   "id": "83a5368d",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-05-17T21:41:27.146378Z",
-     "iopub.status.busy": "2026-05-17T21:41:27.146289Z",
-     "iopub.status.idle": "2026-05-17T21:41:29.656373Z",
-     "shell.execute_reply": "2026-05-17T21:41:29.655551Z"
-    }
-   },
+   "execution_count": null,
+   "id": "7cdffdba",
+   "metadata": {},
    "outputs": [],
    "source": [
     "planned_population = pl.DataFrame(plan_rows).sort(\n",
@@ -525,7 +476,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6132ec59",
+   "id": "8c9906c0",
    "metadata": {},
    "source": [
     "## 6. Running them\n",
@@ -536,7 +487,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8c5f0f62",
+   "id": "4a68e603",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -568,7 +519,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "16116681",
+   "id": "a208ea49",
    "metadata": {
     "tags": [
      "results"
@@ -599,28 +550,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
-   "id": "850ec048",
+   "execution_count": null,
+   "id": "5ab495e3",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-05-17T21:41:29.663387Z",
-     "iopub.status.busy": "2026-05-17T21:41:29.663218Z",
-     "iopub.status.idle": "2026-05-17T21:42:13.548030Z",
-     "shell.execute_reply": "2026-05-17T21:42:13.547407Z"
-    },
     "tags": [
      "results"
     ]
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "MAE/MFE calibration added 6 thresholds\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "execution_diagnostics = pl.DataFrame(\n",
     "    execution_rows,\n",
@@ -654,7 +591,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "42448f7e",
+   "id": "9e9ad8da",
    "metadata": {},
    "source": [
     "## 7. Naming the overlay sets, and the population selection is made over\n",
@@ -670,33 +607,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
-   "id": "7d71c6d4",
+   "execution_count": null,
+   "id": "38b43ba8",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-05-17T21:42:13.557722Z",
-     "iopub.status.busy": "2026-05-17T21:42:13.557485Z"
-    },
     "tags": [
      "results"
     ]
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Combo 1/1: equal_weight — weights precomputed in 1s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    stop_loss_3pct: Sharpe=-0.209, MaxDD=-99.88%\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "completed_risk = study.backtests.table(include_preview=True).filter(\n",
     "    pl.col(\"backtest_hash\").is_in(planned_population.get_column(\"backtest_hash\"))\n",
@@ -827,7 +745,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9f9b9fc1",
+   "id": "af2d7484",
    "metadata": {},
    "source": [
     "### What the threshold does\n",
@@ -855,7 +773,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c013cdb3",
+   "id": "e53b8e8e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -929,13 +847,12 @@
     "axes[-1].legend(fontsize=8, frameon=False)\n",
     "add_message_title(\n",
     "    axes[0],\n",
-    "    \"Loosening the control, against the book it was laid on\",\n",
+    "    \"Validation Sharpe against each risk control's threshold\",\n",
     "    subtitle=(\n",
     "        \"Validation Sharpe against each control's own threshold, one line per label, with the \"\n",
     "        \"unprotected strategy dashed\"\n",
     "    ),\n",
     ")\n",
-    "fig.tight_layout()\n",
     "# The alt text counts rather than asserts: whether any line turns over is the question the sweep\n",
     "# exists to answer, and a panel described as peaking when it does not is a claim the data refutes.\n",
     "_peaks = (\n",
@@ -970,7 +887,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "638d45f6",
+   "id": "6ae737f1",
    "metadata": {},
    "source": [
     "`20_strategy_analysis.py` reopens one of these per-label sets -\n",
@@ -983,7 +900,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c865e598",
+   "id": "18168d51",
    "metadata": {},
    "source": [
     "## What to notice\n",
@@ -1026,18 +943,6 @@
    "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
-  },
-  "papermill": {
-   "default_parameters": {},
-   "duration": null,
-   "end_time": null,
-   "environment_variables": {},
-   "exception": null,
-   "input_path": "case_studies/us_equities_panel/19_risk_management.ipynb",
-   "output_path": "case_studies/us_equities_panel/19_risk_management.ipynb",
-   "parameters": {},
-   "start_time": "2026-05-17T21:41:24.762396+00:00",
-   "version": "2.7.0"
   }
  },
  "nbformat": 4,

--- a/case_studies/us_equities_panel/18_risk_management.ipynb
+++ b/case_studies/us_equities_panel/18_risk_management.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "a83c3708",
+   "id": "d0e00389",
    "metadata": {},
    "source": [
     "# US equities panel: rules that close a position early\n",
@@ -67,7 +67,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "feaa69b3",
+   "id": "37681c2d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -103,7 +103,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a582a5e0",
+   "id": "dae94cb7",
    "metadata": {
     "tags": [
      "parameters"
@@ -136,7 +136,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "974d5910",
+   "id": "259afc7b",
    "metadata": {},
    "source": [
     "## 2. The strategies an overlay may be laid on\n",
@@ -149,7 +149,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "10975f6e",
+   "id": "7c8cdf1e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -184,7 +184,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "308ba1ab",
+   "id": "a353edff",
    "metadata": {},
    "source": [
     "## 3. Which rows can carry an overlay\n",
@@ -196,7 +196,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fdaddb8b",
+   "id": "5eb9ae7c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -236,7 +236,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f25f734b",
+   "id": "18260bd8",
    "metadata": {},
    "source": [
     "## 4. Fixing the strategy the overlays are applied to\n",
@@ -261,7 +261,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "aea07a62",
+   "id": "e0315eb2",
    "metadata": {
     "tags": [
      "results"
@@ -312,7 +312,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "77fd4234",
+   "id": "95b7c736",
    "metadata": {},
    "source": [
     "## 5. The controls, and the check that they bound\n",
@@ -335,7 +335,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5b99b68a",
+   "id": "c79a95a7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -374,7 +374,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "230213d6",
+   "id": "99add262",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -406,7 +406,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "254e5894",
+   "id": "8d03fa93",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -444,7 +444,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "05e66e02",
+   "id": "373d794e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -466,7 +466,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "840c771e",
+   "id": "c55b8438",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -494,7 +494,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e157c892",
+   "id": "01805180",
    "metadata": {},
    "source": [
     "## 6. Running them\n",
@@ -505,7 +505,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "333049a9",
+   "id": "5c1e5e36",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -537,7 +537,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ff16a439",
+   "id": "d1f0ac8d",
    "metadata": {
     "tags": [
      "results"
@@ -569,7 +569,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "53126036",
+   "id": "24496441",
    "metadata": {
     "tags": [
      "results"
@@ -609,7 +609,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2a2d4335",
+   "id": "b4c6a397",
    "metadata": {},
    "source": [
     "## 7. Naming the overlay sets, and the population selection is made over\n",
@@ -631,7 +631,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0c5dada7",
+   "id": "101b2820",
    "metadata": {
     "tags": [
      "results"
@@ -654,7 +654,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0a400593",
+   "id": "d36fc51d",
    "metadata": {},
    "source": [
     "**Did the control fire, and did anything move?** Those are two questions and the catalog answers\n",
@@ -694,7 +694,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3c41bb67",
+   "id": "9ebd7bda",
    "metadata": {
     "tags": [
      "results"
@@ -838,7 +838,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4976a7da",
+   "id": "97b08eeb",
    "metadata": {},
    "source": [
     "### What the threshold does\n",
@@ -866,7 +866,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e81b449a",
+   "id": "ab03cebb",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -978,7 +978,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7e6d1c8b",
+   "id": "ab92e83c",
    "metadata": {},
    "source": [
     "`20_strategy_analysis.py` reopens one of these per-label sets -\n",
@@ -991,7 +991,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dceb998c",
+   "id": "802e0573",
    "metadata": {},
    "source": [
     "## What to notice\n",

--- a/case_studies/us_equities_panel/18_risk_management.ipynb
+++ b/case_studies/us_equities_panel/18_risk_management.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "d0e00389",
+   "id": "0f28ca02",
    "metadata": {},
    "source": [
     "# US equities panel: rules that close a position early\n",
@@ -67,7 +67,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "37681c2d",
+   "id": "6ce7c681",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -103,7 +103,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "dae94cb7",
+   "id": "da8f3418",
    "metadata": {
     "tags": [
      "parameters"
@@ -136,7 +136,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "259afc7b",
+   "id": "8643bd71",
    "metadata": {},
    "source": [
     "## 2. The strategies an overlay may be laid on\n",
@@ -149,7 +149,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7c8cdf1e",
+   "id": "2f458f41",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -184,7 +184,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a353edff",
+   "id": "62220ac7",
    "metadata": {},
    "source": [
     "## 3. Which rows can carry an overlay\n",
@@ -196,7 +196,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5eb9ae7c",
+   "id": "c00b50b6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -236,7 +236,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "18260bd8",
+   "id": "5dc5b7d2",
    "metadata": {},
    "source": [
     "## 4. Fixing the strategy the overlays are applied to\n",
@@ -261,7 +261,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e0315eb2",
+   "id": "2e3904df",
    "metadata": {
     "tags": [
      "results"
@@ -312,7 +312,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "95b7c736",
+   "id": "da9c5188",
    "metadata": {},
    "source": [
     "## 5. The controls, and the check that they bound\n",
@@ -335,7 +335,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c79a95a7",
+   "id": "705a1f02",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -374,7 +374,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "99add262",
+   "id": "589aaeae",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -406,7 +406,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8d03fa93",
+   "id": "f35ccdef",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -444,7 +444,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "373d794e",
+   "id": "cd33ea8a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -466,7 +466,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c55b8438",
+   "id": "ee7614cd",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -494,7 +494,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "01805180",
+   "id": "413c65e6",
    "metadata": {},
    "source": [
     "## 6. Running them\n",
@@ -505,7 +505,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5c1e5e36",
+   "id": "0ec0168e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -537,7 +537,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d1f0ac8d",
+   "id": "4fb43206",
    "metadata": {
     "tags": [
      "results"
@@ -569,7 +569,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "24496441",
+   "id": "c429370a",
    "metadata": {
     "tags": [
      "results"
@@ -609,7 +609,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b4c6a397",
+   "id": "1f2ac375",
    "metadata": {},
    "source": [
     "## 7. Naming the overlay sets, and the population selection is made over\n",
@@ -631,12 +631,8 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "101b2820",
-   "metadata": {
-    "tags": [
-     "results"
-    ]
-   },
+   "id": "3dd339a9",
+   "metadata": {},
    "outputs": [],
    "source": [
     "completed_risk = study.backtests.table(include_preview=True).filter(\n",
@@ -654,7 +650,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d36fc51d",
+   "id": "9c93568b",
    "metadata": {},
    "source": [
     "**Did the control fire, and did anything move?** Those are two questions and the catalog answers\n",
@@ -694,7 +690,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9ebd7bda",
+   "id": "36035078",
    "metadata": {
     "tags": [
      "results"
@@ -838,7 +834,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "97b08eeb",
+   "id": "48b3070a",
    "metadata": {},
    "source": [
     "### What the threshold does\n",
@@ -866,7 +862,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ab03cebb",
+   "id": "aaad2ddf",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -978,7 +974,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ab92e83c",
+   "id": "8df10412",
    "metadata": {},
    "source": [
     "`20_strategy_analysis.py` reopens one of these per-label sets -\n",
@@ -991,7 +987,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "802e0573",
+   "id": "68592d7e",
    "metadata": {},
    "source": [
     "## What to notice\n",

--- a/case_studies/us_equities_panel/18_risk_management.py
+++ b/case_studies/us_equities_panel/18_risk_management.py
@@ -517,27 +517,35 @@ if (
     raise RuntimeError("The risk catalog is incomplete or mis-staged")
 
 # %% [markdown]
-# **Did the overlay change anything?** Each result is compared against the strategy it was laid on,
-# on the two axes the catalog carries: the trade count and the Sharpe. A row that differs on either
-# acted, because there is no other way for those numbers to move.
+# **Did the control fire, and did anything move?** Those are two questions and the catalog answers
+# both.
 #
-# A row identical on both moved neither of the two statistics compared here, and that is a weaker
-# statement than it looks. It is weaker than "changed nothing", because two different return paths
-# can share a Sharpe and a trade count while differing in total return or in drawdown. It is weaker
-# still than "never fired", because a stop can close a position the next rebalance would have
-# closed anyway, replacing one exit with an earlier one and leaving the count where it was. What
-# would settle whether a control fired is a per-control trigger count, and the backtest does not
-# surface one into the catalog today.
+# `risk_triggers` counts how many times the declared control acted during the backtest, recorded by
+# the engine as it installs each rule. It is what separates a control that fired and changed
+# nothing measurable from a control that was never installed at all: a positive count is the first,
+# a zero count the second, and a null means no control of that kind was declared for this row.
+# Reading it is what this stage owes, because a sweep of fourteen settings that all report the same
+# numbers is a finding about risk control if they fired and a defect in the wiring if they did not,
+# and nothing else on this page tells the two apart.
 #
-# **So there are three outcomes here, not two.** A row is CHANGED when either comparison is true,
-# because one difference is enough to establish the control acted. It is UNCHANGED only when both
-# are false and both were comparable. Anything else is UNKNOWN: a comparison that could not be made
-# is not evidence of sameness, and collapsing it into one would manufacture the signature this
+# The second question is whether the numbers moved, and each result is compared against the
+# strategy it was laid on across the two axes the catalog carries: the trade count and the Sharpe.
+# A row that differs on either acted; a row identical on both moved neither of those two
+# statistics, which is weaker than "changed nothing", because two different return paths can share
+# a Sharpe and a trade count while differing in total return or in drawdown. It is weaker still
+# than "never fired" - a stop can close a position the next rebalance would have closed anyway,
+# replacing one exit with an earlier one and leaving the count where it was - and that is exactly
+# the gap the trigger count fills.
+#
+# **So the movement check has three outcomes, not two.** A row is CHANGED when either comparison is
+# true, because one difference is enough to establish the control acted. It is UNCHANGED only when
+# both are false and both were comparable. Anything else is UNKNOWN: a comparison that could not be
+# made is not evidence of sameness, and collapsing it into one would manufacture the signature this
 # check exists to detect.
 
 # %% tags=["results"]
 overlay_effect = (
-    completed_risk.select("label", "backtest_hash", "sharpe", "num_trades")
+    completed_risk.select("label", "backtest_hash", "sharpe", "num_trades", "risk_triggers")
     .join(
         planned_population.select("backtest_hash", "risk", "source_backtest_hash"),
         on="backtest_hash",
@@ -563,7 +571,15 @@ overlay_effect = (
         .then(None)
         .otherwise(pl.col("sharpe") != pl.col("source_sharpe")),
     )
-    .select("label", "risk", "num_trades", "source_num_trades", "trades_moved", "sharpe_moved")
+    .select(
+        "label",
+        "risk",
+        "risk_triggers",
+        "num_trades",
+        "source_num_trades",
+        "trades_moved",
+        "sharpe_moved",
+    )
     .sort("label", "risk")
 )
 _changed = overlay_effect.get_column("trades_moved").fill_null(False) | overlay_effect.get_column(
@@ -581,6 +597,22 @@ print(
     f"laid on; {n_unchanged} match it on both compared statistics; {n_unknown} could not be "
     "fully compared"
 )
+_triggers = overlay_effect.get_column("risk_triggers")
+n_fired = int((_triggers.fill_null(0) > 0).sum())
+n_silent = int((_triggers == 0).sum())
+n_undeclared = int(_triggers.is_null().sum())
+print(
+    f"{n_fired} of {overlay_effect.height} controls fired at least once; {n_silent} were installed "
+    f"and never fired; {n_undeclared} registered no trigger count"
+)
+# A control that never fires is what C17 calls a failure rather than a finding, and it is only
+# visible here.
+if n_silent == overlay_effect.height:
+    raise RuntimeError(
+        "every declared control was installed and fired zero times, so this sweep measured "
+        "nothing about risk control; check that the declared thresholds can be reached on this "
+        "book before reading any row below"
+    )
 if n_unchanged and not n_changed and not n_unknown:
     print(
         "  No declared control moved either the trade count or the Sharpe. Neither statistic "
@@ -662,9 +694,8 @@ compatible_sets
 # sample, one strategy per label, and no correction for having looked at fourteen. A flat line
 # means the measured Sharpe did not move across the declared settings, which is weaker than it
 # sounds in two directions: two different thresholds can produce the same exits, and two different
-# return paths can share a Sharpe. It is not evidence that the controls never fired. Nothing on
-# this page can settle that, and the trigger count that would is not something the backtest
-# records.
+# return paths can share a Sharpe. It is not evidence that the controls never fired, and the
+# `risk_triggers` column above is what settles that rather than the shape of any line here.
 
 # %%
 control_axes = {
@@ -786,8 +817,9 @@ show_with_alt(
 # **Check that the overlays moved something before reading what they did.** A result matching the
 # unprotected book on both compared statistics has not been shown to change anything, and matching
 # across every declared setting is a reason to confirm the controls reach the engine rather than a
-# finding about risk control. Neither question is settled by these two columns; a per-control
-# trigger count would settle the first, and the backtest does not surface one today.
+# finding about risk control. The two compared columns do not settle it on their own; the
+# `risk_triggers` count does, and a sweep where every control was installed and fired zero times
+# stops the notebook rather than being reported as a result.
 #
 # **An overlay can only remove, so it reshapes a return distribution rather than shifting it.** It
 # truncates the left tail by closing losing positions early and truncates the right by closing

--- a/case_studies/us_equities_panel/18_risk_management.py
+++ b/case_studies/us_equities_panel/18_risk_management.py
@@ -33,16 +33,17 @@
 #
 # **An overlay only ever removes.** It cannot enter a position the strategy did not take, so it
 # can only cut a loss short or cut a gain short, and which of the two it does more of is exactly
-# what the sweep measures. Fourteen controls are declared across the three kinds, spanning stops
-# from 3% to 15% and trailing stops from 1% to 20%, so the sweep says how the effect moves with the
-# threshold rather than whether one chosen threshold helped.
+# what the sweep measures. Fourteen controls are declared across the three kinds, each kind swept
+# from its tightest declared threshold to its loosest, so the sweep says how the effect moves with
+# the threshold rather than whether one chosen threshold helped.
 #
 # **The thing to check first is whether the overlays changed anything at all.** A control that
 # never fires returns the unprotected book unchanged in every digit, and so does a control that was
 # declared in one shape and read by the engine in another. One result cannot tell those apart: both
-# produce a row identical to the book it was laid on. Fourteen different rules, spanning a 3% stop
-# to a 40-bar time exit, all declining to act on one book and agreeing to the last digit would be
-# the second and not the first, and it would read on the page as a finding about risk control.
+# produce a row identical to the book it was laid on. Fourteen different rules, spanning the
+# tightest declared stop to the longest declared time exit, all declining to act on one book and
+# agreeing to the last digit would be the second and not the first, and it would read on the page
+# as a finding about risk control.
 #
 # So the results section compares each overlay against the strategy it was laid on rather than
 # reporting its performance alone. **A difference proves the control acted; matching statistics
@@ -205,13 +206,15 @@ if eligible.is_empty() or not ineligible.is_empty():
 # both the strategy and the control vary cannot say whether a difference came from the rule or from
 # the book it was applied to.
 
-# %% tags=["results"]
-# Prices are cached by (label, warmup), not once per label. A strategy's identity digests the
+#
+# **Prices are cached by label and warmup, not once per label.** A strategy's identity digests the
 # price frame it was handed, and the allocator underneath each overlay needs a different amount of
 # history before it can decide anything - none for the ones reading only the predictions, a
 # volatility window for the per-stock ones, a longer lookback for the ones estimating a covariance
 # matrix. So each member has to receive the frame its own warmup implies, and the cache key is
 # what keeps that true while loading each distinct frame once.
+
+# %% tags=["results"]
 _price_cache: dict[tuple[str, int], object] = {}
 
 
@@ -479,6 +482,11 @@ execution_diagnostics
 # ranking only the last of them would exclude an un-overlaid book that was better than every
 # overlaid one. [`19_costs`](19_costs.ipynb) derives its pool from the same stage sequence for the
 # same reason.
+#
+# **The freeze is also the comparability check.** Nothing is declared comparable, so
+# `CandidateSet.create` requires every field of the protocol to be identical across the members:
+# two rows that measured their Sharpe on different folds are not two rankings of one thing, and
+# this is what refuses to freeze them together.
 
 # %% tags=["results"]
 completed_risk = study.backtests.table(include_preview=True).filter(
@@ -492,15 +500,27 @@ if (
     or completed_risk.filter(pl.col("sharpe").is_null() | ~pl.col("sharpe").is_finite()).height
 ):
     raise RuntimeError("The risk catalog is incomplete or mis-staged")
-# Did the overlay change anything? Each result is compared against the strategy it was laid on, on
-# the two axes the catalog carries: the trade count and the Sharpe. A row that differs on either
-# acted - there is no other way for the numbers to move. A row identical on both moved neither of
-# the two statistics compared here - which is weaker than "changed nothing", since two
-# different return paths can share a Sharpe and a trade count while differing in total return or in
-# drawdown, and weaker still than "never fired": a stop can close a position the next rebalance
-# would have closed anyway, replacing one exit with an earlier one and leaving the count where it
-# was. What would settle whether a control fired is a per-control trigger count, which the backtest
-# does not surface into the catalog today.
+
+# %% [markdown]
+# **Did the overlay change anything?** Each result is compared against the strategy it was laid on,
+# on the two axes the catalog carries: the trade count and the Sharpe. A row that differs on either
+# acted, because there is no other way for those numbers to move.
+#
+# A row identical on both moved neither of the two statistics compared here, and that is a weaker
+# statement than it looks. It is weaker than "changed nothing", because two different return paths
+# can share a Sharpe and a trade count while differing in total return or in drawdown. It is weaker
+# still than "never fired", because a stop can close a position the next rebalance would have
+# closed anyway, replacing one exit with an earlier one and leaving the count where it was. What
+# would settle whether a control fired is a per-control trigger count, and the backtest does not
+# surface one into the catalog today.
+#
+# **So there are three outcomes here, not two.** A row is CHANGED when either comparison is true,
+# because one difference is enough to establish the control acted. It is UNCHANGED only when both
+# are false and both were comparable. Anything else is UNKNOWN: a comparison that could not be made
+# is not evidence of sameness, and collapsing it into one would manufacture the signature this
+# check exists to detect.
+
+# %% tags=["results"]
 overlay_effect = (
     completed_risk.select("label", "backtest_hash", "sharpe", "num_trades")
     .join(
@@ -531,10 +551,6 @@ overlay_effect = (
     .select("label", "risk", "num_trades", "source_num_trades", "trades_moved", "sharpe_moved")
     .sort("label", "risk")
 )
-# Three outcomes, not two. A row is CHANGED when either comparison is true, because one difference
-# is enough to establish the control acted. It is UNCHANGED only when both are false and both were
-# comparable. Anything else is UNKNOWN - a comparison that could not be made is not evidence of
-# sameness, and collapsing it into one would manufacture the signature this check exists to detect.
 _changed = overlay_effect.get_column("trades_moved").fill_null(False) | overlay_effect.get_column(
     "sharpe_moved"
 ).fill_null(False)
@@ -562,10 +578,6 @@ set_rows = []
 if EXECUTION_TIER == "canonical":
     for label in completed_risk.get_column("label").unique().sort().to_list():
         label_name = label.replace("_", "-")
-        # Nothing is declared comparable, so every field of the protocol has to be identical
-        # across the members. That is the guard: two rows that measured their Sharpe on different
-        # folds are not two rankings of one thing, and this is what refuses to freeze them
-        # together.
         result_set = study.backtests.freeze(
             completed_risk.filter(pl.col("label") == label),
             name=f"us-equities-{label_name}-risk-overlay-v1",
@@ -634,10 +646,8 @@ control_axes = {
     control["name"]: (control["type"], float(control.get("threshold", control.get("bars"))))
     for control in get_position_risk_controls(CASE_STUDY_ID)
 }
-# The Sharpe of the strategy each label's overlays were laid on, which is the line they have to
-# clear. Asserted rather than assumed to be one per label: `top_n` is read from the sweep
-# configuration, and a label carrying two sources would need two reference lines, not one drawn
-# from whichever row a dict happened to keep.
+# One source per label is asserted rather than assumed: `top_n` comes from the sweep
+# configuration, and a label with two sources needs two reference lines.
 _sources_per_label = selected_sources.group_by("label").len()
 if (_sources_per_label.get_column("len") != 1).any():
     raise ValueError(
@@ -755,7 +765,8 @@ show_with_alt(
 # trigger count would settle the first, and the backtest does not surface one today.
 #
 # **An overlay can only remove, so it reshapes a return distribution rather than shifting it.** It
-# truncates the left tail by closing losers early and truncates the right by closing winners early,
+# truncates the left tail by closing losing positions early and truncates the right by closing
+# profitable ones early,
 # and which effect dominates is a property of how the strategy's returns actually arrive. A book
 # whose gains come from a few positions running a long way is one an early exit hurts.
 #

--- a/case_studies/us_equities_panel/18_risk_management.py
+++ b/case_studies/us_equities_panel/18_risk_management.py
@@ -520,13 +520,20 @@ if (
 # **Did the control fire, and did anything move?** Those are two questions and the catalog answers
 # both.
 #
-# `risk_triggers` counts how many times the declared control acted during the backtest, recorded by
-# the engine as it installs each rule. It is what separates a control that fired and changed
-# nothing measurable from a control that was never installed at all: a positive count is the first,
-# a zero count the second, and a null means no control of that kind was declared for this row.
+# `risk_triggers` counts how many times the installed control acted during the backtest, recorded
+# by the engine as it installs each rule. Its three states are what separate the cases nothing else
+# on this page can tell apart:
+#
+# - **A positive count** is a control that fired. Whether that changed anything measurable is the
+#   second question below.
+# - **Zero** is a control that was installed and never reached its threshold. That is a result:
+#   a wide stop on a book that never drew down that far has nothing to do.
+# - **Null** is no control installed at all - the engine records a count for every rule it builds,
+#   so a null where a control was declared means the declaration did not reach the engine.
+#
 # Reading it is what this stage owes, because a sweep of fourteen settings that all report the same
-# numbers is a finding about risk control if they fired and a defect in the wiring if they did not,
-# and nothing else on this page tells the two apart.
+# numbers is a finding about risk control if they were installed and a defect in the wiring if they
+# were not.
 #
 # The second question is whether the numbers moved, and each result is compared against the
 # strategy it was laid on across the two axes the catalog carries: the trade count and the Sharpe.
@@ -600,18 +607,19 @@ print(
 _triggers = overlay_effect.get_column("risk_triggers")
 n_fired = int((_triggers.fill_null(0) > 0).sum())
 n_silent = int((_triggers == 0).sum())
-n_undeclared = int(_triggers.is_null().sum())
+n_uninstalled = int(_triggers.is_null().sum())
 print(
     f"{n_fired} of {overlay_effect.height} controls fired at least once; {n_silent} were installed "
-    f"and never fired; {n_undeclared} registered no trigger count"
+    f"and never reached their threshold; {n_uninstalled} installed no rule at all"
 )
-# A control that never fires is what C17 calls a failure rather than a finding, and it is only
-# visible here.
-if n_silent == overlay_effect.height:
+# The engine records a count for every rule it builds, so a row that declared a control and
+# registered no count is one whose declaration never reached it. That is the failure C17 names,
+# and it is the only one of the three states that is not a result.
+if n_uninstalled:
     raise RuntimeError(
-        "every declared control was installed and fired zero times, so this sweep measured "
-        "nothing about risk control; check that the declared thresholds can be reached on this "
-        "book before reading any row below"
+        f"{n_uninstalled} of {overlay_effect.height} overlay results registered no trigger count, "
+        "so their declared control was never installed and the row is named for behaviour that "
+        "did not run"
     )
 if n_unchanged and not n_changed and not n_unknown:
     print(
@@ -694,8 +702,9 @@ compatible_sets
 # sample, one strategy per label, and no correction for having looked at fourteen. A flat line
 # means the measured Sharpe did not move across the declared settings, which is weaker than it
 # sounds in two directions: two different thresholds can produce the same exits, and two different
-# return paths can share a Sharpe. It is not evidence that the controls never fired, and the
-# `risk_triggers` column above is what settles that rather than the shape of any line here.
+# return paths can share a Sharpe. It is not evidence that the controls never fired; the
+# `risk_triggers` column above is what settles that, and it is read there rather than inferred
+# from the shape of any line here.
 
 # %%
 control_axes = {
@@ -816,10 +825,11 @@ show_with_alt(
 #
 # **Check that the overlays moved something before reading what they did.** A result matching the
 # unprotected book on both compared statistics has not been shown to change anything, and matching
-# across every declared setting is a reason to confirm the controls reach the engine rather than a
-# finding about risk control. The two compared columns do not settle it on their own; the
-# `risk_triggers` count does, and a sweep where every control was installed and fired zero times
-# stops the notebook rather than being reported as a result.
+# across every declared setting is a reason to check that the controls reached the engine rather
+# than a finding about risk control. The two compared columns do not settle it on their own; the
+# `risk_triggers` count does, and a row that declared a control and installed none stops the
+# notebook rather than being reported as a result. A row installed and never triggered is a
+# result: it says the threshold was never reached on this book.
 #
 # **An overlay can only remove, so it reshapes a return distribution rather than shifting it.** It
 # truncates the left tail by closing losing positions early and truncates the right by closing

--- a/case_studies/us_equities_panel/18_risk_management.py
+++ b/case_studies/us_equities_panel/18_risk_management.py
@@ -700,13 +700,12 @@ axes[0].set_ylabel("Validation Sharpe")
 axes[-1].legend(fontsize=8, frameon=False)
 add_message_title(
     axes[0],
-    "Loosening the control, against the book it was laid on",
+    "Validation Sharpe against each risk control's threshold",
     subtitle=(
         "Validation Sharpe against each control's own threshold, one line per label, with the "
         "unprotected strategy dashed"
     ),
 )
-fig.tight_layout()
 # The alt text counts rather than asserts: whether any line turns over is the question the sweep
 # exists to answer, and a panel described as peaking when it does not is a claim the data refutes.
 _peaks = (

--- a/case_studies/us_equities_panel/18_risk_management.py
+++ b/case_studies/us_equities_panel/18_risk_management.py
@@ -86,8 +86,10 @@ import polars as pl
 from case_studies.research import (
     CandidateSet,
     OfficialPopulation,
+    candidate_set_supersedes,
     open_study,
     plan_backtests,
+    population_supersedes,
     run_backtests,
 )
 from case_studies.research.strategy import strategy_warmup_periods
@@ -113,6 +115,9 @@ ALLOCATION_SET_NAMES = [
 ]
 VALIDATION_SET_NAME_TEMPLATE = "us-equities-{label}-validation-strategies-v1"
 EXECUTION_TIER = "canonical"
+POPULATION_NAME = ""
+SUPERSEDES_POPULATION = ""
+SUPERSEDES_SETS: dict = {}
 WORKSPACE = "experiments"
 PREVIEW_LABELS = []
 PREVIEW_MAX_SOURCE_ROWS = 0
@@ -265,6 +270,12 @@ selected_sources.select(
 # results: each one against the strategy it was laid on, on the trade count and the Sharpe. A
 # difference establishes that the control acted. Matching values establish only that those two
 # statistics did not move, and leave every other outcome undetermined.
+#
+# `SUPERSEDES_POPULATION` and `SUPERSEDES_SETS` name the generation this run replaces. A population
+# and a candidate set are both immutable, so a re-run that admits different members has to say
+# which snapshot it supersedes or the registry refuses the write. Both default to empty, which is
+# right for a first run and for a reader's clean clone; `population_supersedes` and
+# `candidate_set_supersedes` withhold a declared hash wherever offering it would be refused.
 
 # %%
 risk_requests = []
@@ -381,9 +392,13 @@ if planned_population.get_column("backtest_hash").n_unique() != planned_populati
 
 official_population = None
 if EXECUTION_TIER == "canonical":
+    population_name = POPULATION_NAME or "us-equities-risk-overlay-v1"
     official_population = OfficialPopulation.create(
         study,
-        name="us-equities-risk-overlay-v1",
+        name=population_name,
+        supersedes=population_supersedes(
+            study, name=population_name, declared=SUPERSEDES_POPULATION
+        ),
         member_kind="backtest",
         members=tuple(planned_population.get_column("backtest_hash")),
     )
@@ -578,9 +593,13 @@ set_rows = []
 if EXECUTION_TIER == "canonical":
     for label in completed_risk.get_column("label").unique().sort().to_list():
         label_name = label.replace("_", "-")
+        result_set_name = f"us-equities-{label_name}-risk-overlay-v1"
         result_set = study.backtests.freeze(
             completed_risk.filter(pl.col("label") == label),
-            name=f"us-equities-{label_name}-risk-overlay-v1",
+            name=result_set_name,
+            supersedes=candidate_set_supersedes(
+                study, name=result_set_name, declared=SUPERSEDES_SETS.get(result_set_name, "")
+            ),
         )
         set_rows.append(
             {"label": label, "set_name": result_set.name, "members": len(result_set.members)}
@@ -600,9 +619,15 @@ if EXECUTION_TIER == "canonical":
             != validation_candidates.height
         ):
             raise ValueError(f"Selection-eligible strategy sets overlap for {label}")
+        validation_set_name = VALIDATION_SET_NAME_TEMPLATE.format(label=label_name)
         validation_set = study.backtests.freeze(
             validation_candidates,
-            name=VALIDATION_SET_NAME_TEMPLATE.format(label=label_name),
+            name=validation_set_name,
+            supersedes=candidate_set_supersedes(
+                study,
+                name=validation_set_name,
+                declared=SUPERSEDES_SETS.get(validation_set_name, ""),
+            ),
         )
         set_rows.append(
             {

--- a/case_studies/us_equities_panel/18_risk_management.py
+++ b/case_studies/us_equities_panel/18_risk_management.py
@@ -210,7 +210,7 @@ if eligible.is_empty() or not ineligible.is_empty():
 # **Sweeping overlays across several strategies at once would confound the two.** A table in which
 # both the strategy and the control vary cannot say whether a difference came from the rule or from
 # the book it was applied to.
-
+#
 #
 # **Prices are cached by label and warmup, not once per label.** A strategy's identity digests the
 # price frame it was handed, and the allocator underneath each overlay needs a different amount of

--- a/case_studies/us_equities_panel/18_risk_management.py
+++ b/case_studies/us_equities_panel/18_risk_management.py
@@ -503,7 +503,7 @@ execution_diagnostics
 # two rows that measured their Sharpe on different folds are not two rankings of one thing, and
 # this is what refuses to freeze them together.
 
-# %% tags=["results"]
+# %%
 completed_risk = study.backtests.table(include_preview=True).filter(
     pl.col("backtest_hash").is_in(planned_population.get_column("backtest_hash"))
 )

--- a/case_studies/us_equities_panel/19_costs.ipynb
+++ b/case_studies/us_equities_panel/19_costs.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "2aecf36d",
+   "id": "f57fcdf4",
    "metadata": {},
    "source": [
     "# US equities panel: how much friction the strategy can absorb\n",
@@ -55,16 +55,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
-   "id": "0a085369",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-05-18T17:57:57.928350Z",
-     "iopub.status.busy": "2026-05-18T17:57:57.928207Z",
-     "iopub.status.idle": "2026-05-18T17:57:58.842438Z",
-     "shell.execute_reply": "2026-05-18T17:57:58.841760Z"
-    }
-   },
+   "execution_count": null,
+   "id": "d5fd1e74",
+   "metadata": {},
    "outputs": [],
    "source": [
     "\"\"\"Generate the US-equities cost-sensitivity validation population.\"\"\"\n",
@@ -97,15 +90,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
-   "id": "6ab70cfd",
+   "execution_count": null,
+   "id": "fae286c0",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-05-18T17:57:58.846332Z",
-     "iopub.status.busy": "2026-05-18T17:57:58.846184Z",
-     "iopub.status.idle": "2026-05-18T17:57:58.848227Z",
-     "shell.execute_reply": "2026-05-18T17:57:58.847843Z"
-    },
     "tags": [
      "parameters"
     ]
@@ -138,7 +125,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e6f57439",
+   "id": "1b93a460",
    "metadata": {},
    "source": [
     "## 1. Which strategies get re-priced\n",
@@ -161,7 +148,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "129fe367",
+   "id": "ec2c3a10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -201,7 +188,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "10ef8ac3",
+   "id": "2f35294a",
    "metadata": {},
    "source": [
     "## 2. The rows this run will sweep\n",
@@ -214,7 +201,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "93e3163e",
+   "id": "16fce956",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -254,7 +241,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "00cf77a5",
+   "id": "5c9b51ed",
    "metadata": {},
    "source": [
     "## 3. Fixing the strategy that will be re-priced\n",
@@ -282,28 +269,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
-   "id": "da83aa7c",
+   "execution_count": null,
+   "id": "d9c8c1e4",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-05-18T17:57:58.850616Z",
-     "iopub.status.busy": "2026-05-18T17:57:58.850541Z",
-     "iopub.status.idle": "2026-05-18T17:57:58.880149Z",
-     "shell.execute_reply": "2026-05-18T17:57:58.879664Z"
-    },
     "tags": [
      "results"
     ]
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Case study: us_equities_panel, label: fwd_ret_1d\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Prices are cached per label AND per warmup, not once per label. A strategy records the digest of\n",
     "# exactly the price frame it was handed, and allocators need different amounts of history before\n",
@@ -355,7 +328,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3575af12",
+   "id": "1f68c862",
    "metadata": {},
    "source": [
     "## 4. The two cost grids\n",
@@ -376,7 +349,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a1b6d648",
+   "id": "9beb13e7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -394,7 +367,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ac06b36d",
+   "id": "439c2165",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -433,7 +406,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "376f02ff",
+   "id": "d19fab53",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -468,7 +441,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e302e93b",
+   "id": "61537a9a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -520,7 +493,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "54abcd85",
+   "id": "9c98456e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -541,25 +514,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
-   "id": "551e9c38",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-05-18T17:57:58.884174Z",
-     "iopub.status.busy": "2026-05-18T17:57:58.884093Z",
-     "iopub.status.idle": "2026-05-18T17:57:58.905413Z",
-     "shell.execute_reply": "2026-05-18T17:57:58.904873Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Sharpe=1.642  alloc=equal_weight  bt_hash=4d4fdf29\n"
-     ]
-    }
-   ],
+   "execution_count": null,
+   "id": "5c5edc0a",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "planned_population = pl.DataFrame(plan_rows).sort(\n",
     "    \"label\", \"regime\", \"cost_value\", \"source_backtest_hash\", \"backtest_hash\"\n",
@@ -581,7 +539,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "51be673b",
+   "id": "f46d566a",
    "metadata": {},
    "source": [
     "## 5. Running the sweep\n",
@@ -594,7 +552,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "657c9023",
+   "id": "cb3f1e3f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -628,7 +586,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ab0d5e57",
+   "id": "c3fe7316",
    "metadata": {
     "tags": [
      "results"
@@ -660,28 +618,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
-   "id": "4616d299",
+   "execution_count": null,
+   "id": "d709a0eb",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-05-18T17:57:58.908074Z",
-     "iopub.status.busy": "2026-05-18T17:57:58.907999Z",
-     "iopub.status.idle": "2026-05-18T17:58:01.177495Z",
-     "shell.execute_reply": "2026-05-18T17:58:01.176838Z"
-    },
     "tags": [
      "results"
     ]
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Prices: 9,853,066 rows, 3175 assets\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "execution_diagnostics = pl.DataFrame(\n",
     "    execution_rows,\n",
@@ -717,7 +661,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b236364e",
+   "id": "6eb3e2db",
    "metadata": {},
    "source": [
     "## 6. Naming the curves\n",
@@ -730,58 +674,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
-   "id": "fc44ff40",
+   "execution_count": null,
+   "id": "18e77616",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-05-18T17:58:01.183152Z",
-     "iopub.status.busy": "2026-05-18T17:58:01.183004Z",
-     "iopub.status.idle": "2026-05-18T18:03:38.844658Z",
-     "shell.execute_reply": "2026-05-18T18:03:38.844120Z"
-    },
     "tags": [
      "results"
     ]
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [1/11] bps  equal_weight @ 0.0bps: Sharpe=4.011\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [7/11] bps  equal_weight @ 10.0bps: Sharpe=2.117\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [9/11] bps  equal_weight @ 20.0bps: Sharpe=0.212\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [10/11] bps  equal_weight @ 30.0bps: Sharpe=-1.237\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [11/11] bps  equal_weight @ 50.0bps: Sharpe=-1.754\n",
-      "\n",
-      "Bps sweep complete: 11 backtests in 338s\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "set_rows = []\n",
     "completed = study.backtests.table(include_preview=True).filter(\n",
@@ -819,7 +719,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9c81993a",
+   "id": "f7d4957e",
    "metadata": {},
    "source": [
     "## 7. Reading the curves\n",
@@ -836,7 +736,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "701d5811",
+   "id": "897f56a4",
    "metadata": {
     "tags": [
      "results"
@@ -880,10 +780,9 @@
     "axes[1].legend(fontsize=8, frameon=False)\n",
     "add_message_title(\n",
     "    axes[0],\n",
-    "    \"Where each fixed strategy stops paying for itself\",\n",
+    "    \"Validation Sharpe against trading cost, by cost regime\",\n",
     "    subtitle=\"Validation Sharpe against cost, under a proportional and a per-share schedule\",\n",
     ")\n",
-    "fig.tight_layout()\n",
     "# The alt text reads the crossing from the frame rather than asserting one: a curve described as\n",
     "# crossing zero when it never does is a claim the data refutes, and where it crosses is the whole\n",
     "# question this notebook asks.\n",
@@ -917,7 +816,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c204070d",
+   "id": "a134d813",
    "metadata": {},
    "source": [
     "## What to notice\n",
@@ -957,30 +856,6 @@
    "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.14.3"
-  },
-  "papermill": {
-   "default_parameters": {},
-   "duration": 523.267971,
-   "end_time": "2026-05-18T18:06:40.543128+00:00",
-   "environment_variables": {},
-   "exception": null,
-   "input_path": "case_studies/us_equities_panel/18_costs.ipynb",
-   "output_path": "case_studies/us_equities_panel/18_costs.ipynb",
-   "parameters": {},
-   "start_time": "2026-05-18T17:57:57.275157+00:00",
-   "version": "2.7.0"
   }
  },
  "nbformat": 4,

--- a/case_studies/us_equities_panel/19_costs.ipynb
+++ b/case_studies/us_equities_panel/19_costs.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "30b348d7",
+   "id": "7b81bdf8",
    "metadata": {},
    "source": [
     "# US equities panel: how much friction the strategy can absorb\n",
@@ -56,7 +56,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4973d77f",
+   "id": "3ca1ac44",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -72,8 +72,10 @@
     "from case_studies.research import (\n",
     "    CandidateSet,\n",
     "    OfficialPopulation,\n",
+    "    candidate_set_supersedes,\n",
     "    open_study,\n",
     "    plan_backtests,\n",
+    "    population_supersedes,\n",
     "    run_backtests,\n",
     ")\n",
     "from case_studies.research.strategy import strategy_warmup_periods\n",
@@ -91,7 +93,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e180e58a",
+   "id": "8591921c",
    "metadata": {
     "tags": [
      "parameters"
@@ -116,6 +118,9 @@
     "    \"us-equities-fwd-ret-21d-risk-overlay-v1\",\n",
     "]\n",
     "EXECUTION_TIER = \"canonical\"\n",
+    "POPULATION_NAME = \"\"\n",
+    "SUPERSEDES_POPULATION = \"\"\n",
+    "SUPERSEDES_SETS: dict = {}\n",
     "WORKSPACE = \"experiments\"\n",
     "PREVIEW_LABELS = []\n",
     "PREVIEW_MAX_SOURCE_ROWS = 0\n",
@@ -125,7 +130,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "96391aa6",
+   "id": "63813aba",
    "metadata": {},
    "source": [
     "## 1. Which strategies get re-priced\n",
@@ -147,7 +152,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bc2be153",
+   "id": "172fb173",
    "metadata": {},
    "source": [
     "**The pool is every stage a strategy can be carried forward from**, which is the backtest\n",
@@ -162,7 +167,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5f998ef6",
+   "id": "6490af86",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -196,7 +201,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e2ffa2a4",
+   "id": "3fcfaa76",
    "metadata": {},
    "source": [
     "## 2. The rows this run will sweep\n",
@@ -209,7 +214,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "064023d7",
+   "id": "3733a104",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -249,7 +254,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3ed8cc04",
+   "id": "3930913f",
    "metadata": {},
    "source": [
     "## 3. Fixing the strategy that will be re-priced\n",
@@ -287,7 +292,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "42702009",
+   "id": "ba0e272e",
    "metadata": {
     "tags": [
      "results"
@@ -338,7 +343,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "04f99346",
+   "id": "898c0da4",
    "metadata": {},
    "source": [
     "## 4. The two cost grids\n",
@@ -353,13 +358,19 @@
     "\n",
     "Every identity is written down before the first backtest runs, for the same reason the model\n",
     "populations were: a sweep that came out short would otherwise look like a smaller sweep rather\n",
-    "than a failed one."
+    "than a failed one.\n",
+    "\n",
+    "`SUPERSEDES_POPULATION` and `SUPERSEDES_SETS` name the generation this run replaces. A population\n",
+    "and a candidate set are both immutable, so a re-run that admits different members has to say\n",
+    "which snapshot it supersedes or the registry refuses the write. Both default to empty, which is\n",
+    "right for a first run and for a reader's clean clone; `population_supersedes` and\n",
+    "`candidate_set_supersedes` withhold a declared hash wherever offering it would be refused."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0e7cfb73",
+   "id": "2905ee1c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -377,7 +388,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "afdeb122",
+   "id": "fc00a7e2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -416,7 +427,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "914a1dc0",
+   "id": "3f0d4301",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -451,7 +462,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9ea48c5e",
+   "id": "c858f3d9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -499,7 +510,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5503ab1d",
+   "id": "cf21f504",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -521,7 +532,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "52f4922a",
+   "id": "06f65694",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -533,9 +544,13 @@
     "\n",
     "official_population = None\n",
     "if EXECUTION_TIER == \"canonical\":\n",
+    "    population_name = POPULATION_NAME or \"us-equities-cost-sensitivity-v1\"\n",
     "    official_population = OfficialPopulation.create(\n",
     "        study,\n",
-    "        name=\"us-equities-cost-sensitivity-v1\",\n",
+    "        name=population_name,\n",
+    "        supersedes=population_supersedes(\n",
+    "            study, name=population_name, declared=SUPERSEDES_POPULATION\n",
+    "        ),\n",
     "        member_kind=\"backtest\",\n",
     "        members=tuple(planned_population.get_column(\"backtest_hash\")),\n",
     "    )\n",
@@ -545,7 +560,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d7b404ae",
+   "id": "f462302d",
    "metadata": {},
    "source": [
     "## 5. Running the sweep\n",
@@ -558,7 +573,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "50ec44fa",
+   "id": "6ea90726",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -592,7 +607,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a39cd7f8",
+   "id": "89e1d7bb",
    "metadata": {
     "tags": [
      "results"
@@ -625,7 +640,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "815b71ec",
+   "id": "c9057b95",
    "metadata": {
     "tags": [
      "results"
@@ -667,7 +682,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "25a16058",
+   "id": "f47460fd",
    "metadata": {},
    "source": [
     "## 6. Naming the curves\n",
@@ -686,7 +701,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "044595b0",
+   "id": "dec9a4d0",
    "metadata": {
     "tags": [
      "results"
@@ -709,9 +724,13 @@
     "if EXECUTION_TIER == \"canonical\":\n",
     "    for label in completed.get_column(\"label\").unique().sort().to_list():\n",
     "        label_name = label.replace(\"_\", \"-\")\n",
+    "        result_set_name = f\"us-equities-{label_name}-cost-sensitivity-v1\"\n",
     "        result_set = study.backtests.freeze(\n",
     "            completed.filter(pl.col(\"label\") == label),\n",
-    "            name=f\"us-equities-{label_name}-cost-sensitivity-v1\",\n",
+    "            name=result_set_name,\n",
+    "            supersedes=candidate_set_supersedes(\n",
+    "                study, name=result_set_name, declared=SUPERSEDES_SETS.get(result_set_name, \"\")\n",
+    "            ),\n",
     "        )\n",
     "        set_rows.append(\n",
     "            {\"label\": label, \"set_name\": result_set.name, \"members\": len(result_set.members)}\n",
@@ -726,7 +745,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1773a8f9",
+   "id": "d23b92da",
    "metadata": {},
    "source": [
     "## 7. Reading the curves\n",
@@ -743,7 +762,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "02fbc8fe",
+   "id": "1c2ecf48",
    "metadata": {
     "tags": [
      "results"
@@ -823,7 +842,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "360649b0",
+   "id": "16eb63f7",
    "metadata": {},
    "source": [
     "## What to notice\n",

--- a/case_studies/us_equities_panel/19_costs.ipynb
+++ b/case_studies/us_equities_panel/19_costs.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "7b81bdf8",
+   "id": "b716c3f8",
    "metadata": {},
    "source": [
     "# US equities panel: how much friction the strategy can absorb\n",
@@ -56,7 +56,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3ca1ac44",
+   "id": "41aa2f4c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -93,7 +93,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8591921c",
+   "id": "d1deda78",
    "metadata": {
     "tags": [
      "parameters"
@@ -130,7 +130,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "63813aba",
+   "id": "ea3beaf5",
    "metadata": {},
    "source": [
     "## 1. Which strategies get re-priced\n",
@@ -142,22 +142,13 @@
     "\n",
     "`STAGE_SEQUENCE` is the order the backtest stages run in: signal, allocation, risk overlay, then\n",
     "cost sensitivity. Everything before the last one is a stage a strategy can come from, so the pool\n",
-    "is the sequence minus the terminal stage. Naming the stages by hand instead is how\n",
-    "`risk_overlay` came to be missing from this notebook while four of the seven completed case\n",
-    "studies carry a risk overlay as their leading validation strategy - and a risk overlay shares its\n",
-    "allocation parent's prediction hash, so the omission does not raise. It silently joins the\n",
-    "un-overlaid cost curve to a strategy that has an overlay, and Chapter 20 then describes a\n",
-    "different strategy from the one it names."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "172fb173",
-   "metadata": {},
-   "source": [
-    "**The pool is every stage a strategy can be carried forward from**, which is the backtest\n",
-    "sequence without its own terminal stage. It is derived from `STAGE_SEQUENCE` rather than listed,\n",
-    "so a stage added there reaches this pool without anyone remembering to come here.\n",
+    "is the sequence minus the terminal stage.\n",
+    "\n",
+    "**A stage left out of that pool does not raise.** A risk overlay shares its allocation parent's\n",
+    "prediction hash, so a pool missing `risk_overlay` still resolves a source for every label - the\n",
+    "un-overlaid one - and the cost curve it draws is then a curve for a different strategy from the\n",
+    "one it is named after. Deriving the pool is what makes a stage added later reach it without\n",
+    "anyone remembering to come here.\n",
     "\n",
     "Both tiers resolve the study through `open_study`. It reads the labels, features and earlier\n",
     "results in place and redirects only writes, so a preview run sweeps the same inputs a canonical\n",
@@ -167,7 +158,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6490af86",
+   "id": "48413223",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -201,7 +192,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3fcfaa76",
+   "id": "e25378b7",
    "metadata": {},
    "source": [
     "## 2. The rows this run will sweep\n",
@@ -214,7 +205,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3733a104",
+   "id": "9bc8a57c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -254,7 +245,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3930913f",
+   "id": "3583a33b",
    "metadata": {},
    "source": [
     "## 3. Fixing the strategy that will be re-priced\n",
@@ -292,7 +283,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ba0e272e",
+   "id": "5c3b2f53",
    "metadata": {
     "tags": [
      "results"
@@ -343,7 +334,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "898c0da4",
+   "id": "2cab1901",
    "metadata": {},
    "source": [
     "## 4. The two cost grids\n",
@@ -370,7 +361,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2905ee1c",
+   "id": "8359b25f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -388,7 +379,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fc00a7e2",
+   "id": "13aacbfa",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -427,7 +418,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3f0d4301",
+   "id": "4e22175a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -462,7 +453,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c858f3d9",
+   "id": "5f1db105",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -510,7 +501,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cf21f504",
+   "id": "6127057e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -532,7 +523,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "06f65694",
+   "id": "67861495",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -560,7 +551,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f462302d",
+   "id": "52b0ef16",
    "metadata": {},
    "source": [
     "## 5. Running the sweep\n",
@@ -573,7 +564,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6ea90726",
+   "id": "6638cada",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -607,7 +598,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "89e1d7bb",
+   "id": "53ceaa38",
    "metadata": {
     "tags": [
      "results"
@@ -640,7 +631,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c9057b95",
+   "id": "2cf31f8a",
    "metadata": {
     "tags": [
      "results"
@@ -682,7 +673,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f47460fd",
+   "id": "0389cfbc",
    "metadata": {},
    "source": [
     "## 6. Naming the curves\n",
@@ -701,7 +692,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "dec9a4d0",
+   "id": "0f50b88d",
    "metadata": {
     "tags": [
      "results"
@@ -745,7 +736,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d23b92da",
+   "id": "fef4085d",
    "metadata": {},
    "source": [
     "## 7. Reading the curves\n",
@@ -762,7 +753,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1c2ecf48",
+   "id": "15fc5440",
    "metadata": {
     "tags": [
      "results"
@@ -842,7 +833,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "16eb63f7",
+   "id": "1534d978",
    "metadata": {},
    "source": [
     "## What to notice\n",

--- a/case_studies/us_equities_panel/19_costs.ipynb
+++ b/case_studies/us_equities_panel/19_costs.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "b716c3f8",
+   "id": "95a3e1ba",
    "metadata": {},
    "source": [
     "# US equities panel: how much friction the strategy can absorb\n",
@@ -56,7 +56,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "41aa2f4c",
+   "id": "f9e5ad61",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -93,7 +93,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d1deda78",
+   "id": "6a0baeee",
    "metadata": {
     "tags": [
      "parameters"
@@ -130,7 +130,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ea3beaf5",
+   "id": "4fd4bbae",
    "metadata": {},
    "source": [
     "## 1. Which strategies get re-priced\n",
@@ -158,7 +158,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "48413223",
+   "id": "52e759f7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -192,7 +192,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e25378b7",
+   "id": "ae4fccbb",
    "metadata": {},
    "source": [
     "## 2. The rows this run will sweep\n",
@@ -205,7 +205,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9bc8a57c",
+   "id": "03a747c6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -245,7 +245,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3583a33b",
+   "id": "31bc5a52",
    "metadata": {},
    "source": [
     "## 3. Fixing the strategy that will be re-priced\n",
@@ -283,7 +283,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5c3b2f53",
+   "id": "93db56e4",
    "metadata": {
     "tags": [
      "results"
@@ -334,7 +334,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2cab1901",
+   "id": "d0d023d5",
    "metadata": {},
    "source": [
     "## 4. The two cost grids\n",
@@ -361,7 +361,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8359b25f",
+   "id": "97f77983",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -379,7 +379,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "13aacbfa",
+   "id": "f669d81d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -418,7 +418,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4e22175a",
+   "id": "fe032cbd",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -453,7 +453,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5f1db105",
+   "id": "0b9a9b4a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -501,7 +501,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6127057e",
+   "id": "29ca3675",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -523,7 +523,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "67861495",
+   "id": "4bfe8f76",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -551,7 +551,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "52b0ef16",
+   "id": "5594c445",
    "metadata": {},
    "source": [
     "## 5. Running the sweep\n",
@@ -564,7 +564,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6638cada",
+   "id": "6c5498ec",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -598,7 +598,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "53ceaa38",
+   "id": "291250a8",
    "metadata": {
     "tags": [
      "results"
@@ -631,7 +631,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2cf31f8a",
+   "id": "5e87a75b",
    "metadata": {
     "tags": [
      "results"
@@ -673,7 +673,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0389cfbc",
+   "id": "5c324ce6",
    "metadata": {},
    "source": [
     "## 6. Naming the curves\n",
@@ -692,7 +692,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0f50b88d",
+   "id": "93500fe6",
    "metadata": {
     "tags": [
      "results"
@@ -736,7 +736,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fef4085d",
+   "id": "d3a0f23c",
    "metadata": {},
    "source": [
     "## 7. Reading the curves\n",
@@ -753,7 +753,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "15fc5440",
+   "id": "42d67db1",
    "metadata": {
     "tags": [
      "results"
@@ -833,7 +833,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1534d978",
+   "id": "8a2f943a",
    "metadata": {},
    "source": [
     "## What to notice\n",

--- a/case_studies/us_equities_panel/19_costs.ipynb
+++ b/case_studies/us_equities_panel/19_costs.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "f57fcdf4",
+   "id": "30b348d7",
    "metadata": {},
    "source": [
     "# US equities panel: how much friction the strategy can absorb\n",
@@ -56,7 +56,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d5fd1e74",
+   "id": "4973d77f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -91,7 +91,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fae286c0",
+   "id": "e180e58a",
    "metadata": {
     "tags": [
      "parameters"
@@ -125,7 +125,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1b93a460",
+   "id": "96391aa6",
    "metadata": {},
    "source": [
     "## 1. Which strategies get re-priced\n",
@@ -146,21 +146,29 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "bc2be153",
+   "metadata": {},
+   "source": [
+    "**The pool is every stage a strategy can be carried forward from**, which is the backtest\n",
+    "sequence without its own terminal stage. It is derived from `STAGE_SEQUENCE` rather than listed,\n",
+    "so a stage added there reaches this pool without anyone remembering to come here.\n",
+    "\n",
+    "Both tiers resolve the study through `open_study`. It reads the labels, features and earlier\n",
+    "results in place and redirects only writes, so a preview run sweeps the same inputs a canonical\n",
+    "one does and cannot publish over it."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ec2c3a10",
+   "id": "5f998ef6",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Every stage a strategy can be carried forward from: the backtest sequence without its\n",
-    "# terminal stage. Derived from `STAGE_SEQUENCE` so a stage added there reaches this pool\n",
-    "# without anyone remembering to come here.\n",
     "PRE_COST_STAGES = tuple(stage for stage in STAGE_SEQUENCE if stage != \"cost_sensitivity\")\n",
     "\n",
     "declared_set_names = [*BASELINE_SET_NAMES, *ALLOCATION_SET_NAMES, *RISK_SET_NAMES]\n",
-    "# Both tiers resolve the study through `open_study`. It reads the labels, features and earlier\n",
-    "# results in place and redirects only writes, so a preview run sweeps the same inputs a canonical\n",
-    "# one does and cannot publish over it.\n",
     "if EXECUTION_TIER == \"canonical\":\n",
     "    if PREVIEW_LABELS or PREVIEW_MAX_SOURCE_ROWS or PREVIEW_MAX_COST_VALUES or MAX_SYMBOLS:\n",
     "        raise ValueError(\"Canonical execution cannot declare preview reductions\")\n",
@@ -188,7 +196,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2f35294a",
+   "id": "e2ffa2a4",
    "metadata": {},
    "source": [
     "## 2. The rows this run will sweep\n",
@@ -201,7 +209,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "16fce956",
+   "id": "064023d7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -241,7 +249,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5c9b51ed",
+   "id": "3ed8cc04",
    "metadata": {},
    "source": [
     "## 3. Fixing the strategy that will be re-priced\n",
@@ -264,13 +272,22 @@
     "\n",
     "**Because one configuration is kept per label, some summaries have no width.** A median, a range\n",
     "or a confidence band across configurations is computed over a single row, so all three coincide.\n",
-    "That is a property of the shortlist size rather than a finding about stability."
+    "That is a property of the shortlist size rather than a finding about stability.\n",
+    "\n",
+    "\n",
+    "**Prices are cached per label and per warmup, not once per label.** A strategy records the digest\n",
+    "of exactly the price frame it was handed, and allocators need different amounts of history before\n",
+    "their first decision: none for the simple weighting methods, a volatility window for\n",
+    "inverse-volatility and risk parity, a longer lookback for the mean-variance ones. A single frame\n",
+    "long enough for the greediest of them would record a digest that nothing recomputing at a\n",
+    "member's own warmup can reproduce, and the later notebooks and the holdout evaluation both check\n",
+    "exactly that."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d9c8c1e4",
+   "id": "42702009",
    "metadata": {
     "tags": [
      "results"
@@ -278,13 +295,6 @@
    },
    "outputs": [],
    "source": [
-    "# Prices are cached per label AND per warmup, not once per label. A strategy records the digest of\n",
-    "# exactly the price frame it was handed, and allocators need different amounts of history before\n",
-    "# their first decision: none for the simple weighting methods, a volatility window for\n",
-    "# inverse-volatility and risk parity, a longer lookback for the mean-variance ones. Handing every\n",
-    "# member of a label one frame long enough for the greediest of them would record a digest that\n",
-    "# nothing recomputing at a member's own warmup can reproduce, and the later notebooks and the\n",
-    "# holdout evaluation both check exactly that.\n",
     "_price_cache: dict[tuple[str, int], object] = {}\n",
     "\n",
     "\n",
@@ -328,7 +338,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1f68c862",
+   "id": "04f99346",
    "metadata": {},
    "source": [
     "## 4. The two cost grids\n",
@@ -349,7 +359,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9beb13e7",
+   "id": "0e7cfb73",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -367,7 +377,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "439c2165",
+   "id": "afdeb122",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -406,7 +416,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d19fab53",
+   "id": "914a1dc0",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -441,7 +451,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "61537a9a",
+   "id": "9ea48c5e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -454,12 +464,8 @@
     "    source_spec = json.loads(source_row[\"spec_json\"])\n",
     "    signal = dict(source_spec[\"strategy\"][\"signal\"])\n",
     "    allocation = source_spec[\"strategy\"].get(\"allocation\")\n",
-    "    # Every block the source strategy carries has to be carried into the re-priced one, and the\n",
-    "    # risk block is the one that is easy to lose: it is absent from a signal-stage or an\n",
-    "    # allocation-stage source, `plan_backtests` and `run_backtests` both default it to None, and\n",
-    "    # a strategy re-priced without its overlay produces a cost curve for a different strategy\n",
-    "    # under the overlaid one's name. That is the same defect as excluding risk_overlay from the\n",
-    "    # pool, arriving from the other side, so it is asserted rather than assumed below.\n",
+    "    # A risk block is absent from a signal- or allocation-stage source and defaults to None in\n",
+    "    # both planners, so a re-priced overlay could silently lose it. Asserted below.\n",
     "    risk = source_spec[\"strategy\"].get(\"risk\")\n",
     "    if source_row[\"stage\"] == \"risk_overlay\" and not risk:\n",
     "        raise ValueError(\n",
@@ -493,7 +499,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9c98456e",
+   "id": "5503ab1d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -515,7 +521,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5c5edc0a",
+   "id": "52f4922a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -539,7 +545,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f46d566a",
+   "id": "d7b404ae",
    "metadata": {},
    "source": [
     "## 5. Running the sweep\n",
@@ -552,7 +558,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cb3f1e3f",
+   "id": "50ec44fa",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -586,7 +592,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c3fe7316",
+   "id": "a39cd7f8",
    "metadata": {
     "tags": [
      "results"
@@ -619,7 +625,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d709a0eb",
+   "id": "815b71ec",
    "metadata": {
     "tags": [
      "results"
@@ -661,7 +667,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6eb3e2db",
+   "id": "25a16058",
    "metadata": {},
    "source": [
     "## 6. Naming the curves\n",
@@ -669,13 +675,18 @@
     "One set per label, holding both regimes, under a name\n",
     "[`20_strategy_analysis`](20_strategy_analysis.ipynb) opens. These rows describe a strategy that\n",
     "was already chosen, so they stay out of the pool anything selects from - a cost row winning a\n",
-    "selection would mean the cost assumption picked the strategy."
+    "selection would mean the cost assumption picked the strategy.\n",
+    "\n",
+    "**The freeze is also the comparability check.** No comparison contract is declared, which makes\n",
+    "every field of the protocol required-constant: two members that disagree on their\n",
+    "cross-validation design measured their Sharpe on different folds, so ranking them is not a\n",
+    "comparison, and this is the only thing that checks it."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "18e77616",
+   "id": "044595b0",
    "metadata": {
     "tags": [
      "results"
@@ -698,10 +709,6 @@
     "if EXECUTION_TIER == \"canonical\":\n",
     "    for label in completed.get_column(\"label\").unique().sort().to_list():\n",
     "        label_name = label.replace(\"_\", \"-\")\n",
-    "        # No comparison contract is declared, which makes every protocol field\n",
-    "        # required-constant. That is the guard rather than an omission: two members that disagree\n",
-    "        # on their cross-validation design measured their Sharpe on different folds, so ranking\n",
-    "        # them is not a comparison, and this is the only thing that checks it.\n",
     "        result_set = study.backtests.freeze(\n",
     "            completed.filter(pl.col(\"label\") == label),\n",
     "            name=f\"us-equities-{label_name}-cost-sensitivity-v1\",\n",
@@ -719,7 +726,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f7d4957e",
+   "id": "1773a8f9",
    "metadata": {},
    "source": [
     "## 7. Reading the curves\n",
@@ -736,7 +743,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "897f56a4",
+   "id": "02fbc8fe",
    "metadata": {
     "tags": [
      "results"
@@ -816,7 +823,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a134d813",
+   "id": "360649b0",
    "metadata": {},
    "source": [
     "## What to notice\n",
@@ -833,7 +840,8 @@
     "panel, which is where a broad long-short book holds a large share of its names, so an ordering\n",
     "that holds under one is not thereby established under the other.\n",
     "\n",
-    "**Where a curve crosses zero is a break-even, not a verdict on tradability.** It says what\n",
+    "**Where a curve crosses zero is a break-even, and it does not say the strategy is tradable.**\n",
+    "It says what\n",
     "uniform friction this strategy could absorb before the validation Sharpe went negative. Real\n",
     "friction is not uniform: it varies by name, by size, by time of day, and it grows with the\n",
     "position relative to what the stock trades. A strategy whose break-even sits far above any\n",

--- a/case_studies/us_equities_panel/19_costs.py
+++ b/case_studies/us_equities_panel/19_costs.py
@@ -231,7 +231,7 @@ if eligible.is_empty() or not ineligible.is_empty():
 # **Because one configuration is kept per label, some summaries have no width.** A median, a range
 # or a confidence band across configurations is computed over a single row, so all three coincide.
 # That is a property of the shortlist size rather than a finding about stability.
-
+#
 #
 # **Prices are cached per label and per warmup, not once per label.** A strategy records the digest
 # of exactly the price frame it was handed, and allocators need different amounts of history before

--- a/case_studies/us_equities_panel/19_costs.py
+++ b/case_studies/us_equities_panel/19_costs.py
@@ -130,16 +130,19 @@ MAX_SYMBOLS = 0
 # un-overlaid cost curve to a strategy that has an overlay, and Chapter 20 then describes a
 # different strategy from the one it names.
 
-# %%
-# Every stage a strategy can be carried forward from: the backtest sequence without its
-# terminal stage. Derived from `STAGE_SEQUENCE` so a stage added there reaches this pool
-# without anyone remembering to come here.
-PRE_COST_STAGES = tuple(stage for stage in STAGE_SEQUENCE if stage != "cost_sensitivity")
-
-declared_set_names = [*BASELINE_SET_NAMES, *ALLOCATION_SET_NAMES, *RISK_SET_NAMES]
+# %% [markdown]
+# **The pool is every stage a strategy can be carried forward from**, which is the backtest
+# sequence without its own terminal stage. It is derived from `STAGE_SEQUENCE` rather than listed,
+# so a stage added there reaches this pool without anyone remembering to come here.
+#
 # Both tiers resolve the study through `open_study`. It reads the labels, features and earlier
 # results in place and redirects only writes, so a preview run sweeps the same inputs a canonical
 # one does and cannot publish over it.
+
+# %%
+PRE_COST_STAGES = tuple(stage for stage in STAGE_SEQUENCE if stage != "cost_sensitivity")
+
+declared_set_names = [*BASELINE_SET_NAMES, *ALLOCATION_SET_NAMES, *RISK_SET_NAMES]
 if EXECUTION_TIER == "canonical":
     if PREVIEW_LABELS or PREVIEW_MAX_SOURCE_ROWS or PREVIEW_MAX_COST_VALUES or MAX_SYMBOLS:
         raise ValueError("Canonical execution cannot declare preview reductions")
@@ -228,14 +231,16 @@ if eligible.is_empty() or not ineligible.is_empty():
 # or a confidence band across configurations is computed over a single row, so all three coincide.
 # That is a property of the shortlist size rather than a finding about stability.
 
-# %% tags=["results"]
-# Prices are cached per label AND per warmup, not once per label. A strategy records the digest of
-# exactly the price frame it was handed, and allocators need different amounts of history before
+#
+# **Prices are cached per label and per warmup, not once per label.** A strategy records the digest
+# of exactly the price frame it was handed, and allocators need different amounts of history before
 # their first decision: none for the simple weighting methods, a volatility window for
-# inverse-volatility and risk parity, a longer lookback for the mean-variance ones. Handing every
-# member of a label one frame long enough for the greediest of them would record a digest that
-# nothing recomputing at a member's own warmup can reproduce, and the later notebooks and the
-# holdout evaluation both check exactly that.
+# inverse-volatility and risk parity, a longer lookback for the mean-variance ones. A single frame
+# long enough for the greediest of them would record a digest that nothing recomputing at a
+# member's own warmup can reproduce, and the later notebooks and the holdout evaluation both check
+# exactly that.
+
+# %% tags=["results"]
 _price_cache: dict[tuple[str, int], object] = {}
 
 
@@ -374,12 +379,8 @@ def plan_cost_member(label, prices, cost_request, source_row):
     source_spec = json.loads(source_row["spec_json"])
     signal = dict(source_spec["strategy"]["signal"])
     allocation = source_spec["strategy"].get("allocation")
-    # Every block the source strategy carries has to be carried into the re-priced one, and the
-    # risk block is the one that is easy to lose: it is absent from a signal-stage or an
-    # allocation-stage source, `plan_backtests` and `run_backtests` both default it to None, and
-    # a strategy re-priced without its overlay produces a cost curve for a different strategy
-    # under the overlaid one's name. That is the same defect as excluding risk_overlay from the
-    # pool, arriving from the other side, so it is asserted rather than assumed below.
+    # A risk block is absent from a signal- or allocation-stage source and defaults to None in
+    # both planners, so a re-priced overlay could silently lose it. Asserted below.
     risk = source_spec["strategy"].get("risk")
     if source_row["stage"] == "risk_overlay" and not risk:
         raise ValueError(
@@ -539,6 +540,11 @@ execution_diagnostics
 # [`20_strategy_analysis`](20_strategy_analysis.ipynb) opens. These rows describe a strategy that
 # was already chosen, so they stay out of the pool anything selects from - a cost row winning a
 # selection would mean the cost assumption picked the strategy.
+#
+# **The freeze is also the comparability check.** No comparison contract is declared, which makes
+# every field of the protocol required-constant: two members that disagree on their
+# cross-validation design measured their Sharpe on different folds, so ranking them is not a
+# comparison, and this is the only thing that checks it.
 
 # %% tags=["results"]
 set_rows = []
@@ -556,10 +562,6 @@ if (
 if EXECUTION_TIER == "canonical":
     for label in completed.get_column("label").unique().sort().to_list():
         label_name = label.replace("_", "-")
-        # No comparison contract is declared, which makes every protocol field
-        # required-constant. That is the guard rather than an omission: two members that disagree
-        # on their cross-validation design measured their Sharpe on different folds, so ranking
-        # them is not a comparison, and this is the only thing that checks it.
         result_set = study.backtests.freeze(
             completed.filter(pl.col("label") == label),
             name=f"us-equities-{label_name}-cost-sensitivity-v1",
@@ -670,7 +672,8 @@ show_with_alt(
 # panel, which is where a broad long-short book holds a large share of its names, so an ordering
 # that holds under one is not thereby established under the other.
 #
-# **Where a curve crosses zero is a break-even, not a verdict on tradability.** It says what
+# **Where a curve crosses zero is a break-even, and it does not say the strategy is tradable.**
+# It says what
 # uniform friction this strategy could absorb before the validation Sharpe went negative. Real
 # friction is not uniform: it varies by name, by size, by time of day, and it grows with the
 # position relative to what the stock trades. A strategy whose break-even sits far above any

--- a/case_studies/us_equities_panel/19_costs.py
+++ b/case_studies/us_equities_panel/19_costs.py
@@ -128,17 +128,13 @@ MAX_SYMBOLS = 0
 #
 # `STAGE_SEQUENCE` is the order the backtest stages run in: signal, allocation, risk overlay, then
 # cost sensitivity. Everything before the last one is a stage a strategy can come from, so the pool
-# is the sequence minus the terminal stage. Naming the stages by hand instead is how
-# `risk_overlay` came to be missing from this notebook while four of the seven completed case
-# studies carry a risk overlay as their leading validation strategy - and a risk overlay shares its
-# allocation parent's prediction hash, so the omission does not raise. It silently joins the
-# un-overlaid cost curve to a strategy that has an overlay, and Chapter 20 then describes a
-# different strategy from the one it names.
-
-# %% [markdown]
-# **The pool is every stage a strategy can be carried forward from**, which is the backtest
-# sequence without its own terminal stage. It is derived from `STAGE_SEQUENCE` rather than listed,
-# so a stage added there reaches this pool without anyone remembering to come here.
+# is the sequence minus the terminal stage.
+#
+# **A stage left out of that pool does not raise.** A risk overlay shares its allocation parent's
+# prediction hash, so a pool missing `risk_overlay` still resolves a source for every label - the
+# un-overlaid one - and the cost curve it draws is then a curve for a different strategy from the
+# one it is named after. Deriving the pool is what makes a stage added later reach it without
+# anyone remembering to come here.
 #
 # Both tiers resolve the study through `open_study`. It reads the labels, features and earlier
 # results in place and redirects only writes, so a preview run sweeps the same inputs a canonical

--- a/case_studies/us_equities_panel/19_costs.py
+++ b/case_studies/us_equities_panel/19_costs.py
@@ -622,10 +622,9 @@ axes[0].set_ylabel("Validation Sharpe")
 axes[1].legend(fontsize=8, frameon=False)
 add_message_title(
     axes[0],
-    "Where each fixed strategy stops paying for itself",
+    "Validation Sharpe against trading cost, by cost regime",
     subtitle="Validation Sharpe against cost, under a proportional and a per-share schedule",
 )
-fig.tight_layout()
 # The alt text reads the crossing from the frame rather than asserting one: a curve described as
 # crossing zero when it never does is a claim the data refutes, and where it crosses is the whole
 # question this notebook asks.

--- a/case_studies/us_equities_panel/19_costs.py
+++ b/case_studies/us_equities_panel/19_costs.py
@@ -74,8 +74,10 @@ import polars as pl
 from case_studies.research import (
     CandidateSet,
     OfficialPopulation,
+    candidate_set_supersedes,
     open_study,
     plan_backtests,
+    population_supersedes,
     run_backtests,
 )
 from case_studies.research.strategy import strategy_warmup_periods
@@ -107,6 +109,9 @@ RISK_SET_NAMES = [
     "us-equities-fwd-ret-21d-risk-overlay-v1",
 ]
 EXECUTION_TIER = "canonical"
+POPULATION_NAME = ""
+SUPERSEDES_POPULATION = ""
+SUPERSEDES_SETS: dict = {}
 WORKSPACE = "experiments"
 PREVIEW_LABELS = []
 PREVIEW_MAX_SOURCE_ROWS = 0
@@ -295,6 +300,12 @@ selected_sources.select(
 # Every identity is written down before the first backtest runs, for the same reason the model
 # populations were: a sweep that came out short would otherwise look like a smaller sweep rather
 # than a failed one.
+#
+# `SUPERSEDES_POPULATION` and `SUPERSEDES_SETS` name the generation this run replaces. A population
+# and a candidate set are both immutable, so a re-run that admits different members has to say
+# which snapshot it supersedes or the registry refuses the write. Both default to empty, which is
+# right for a first run and for a reader's clean clone; `population_supersedes` and
+# `candidate_set_supersedes` withhold a declared hash wherever offering it would be refused.
 
 # %%
 bps_values = get_cost_grid_bps(CASE_STUDY_ID)
@@ -435,9 +446,13 @@ if planned_population.get_column("backtest_hash").n_unique() != planned_populati
 
 official_population = None
 if EXECUTION_TIER == "canonical":
+    population_name = POPULATION_NAME or "us-equities-cost-sensitivity-v1"
     official_population = OfficialPopulation.create(
         study,
-        name="us-equities-cost-sensitivity-v1",
+        name=population_name,
+        supersedes=population_supersedes(
+            study, name=population_name, declared=SUPERSEDES_POPULATION
+        ),
         member_kind="backtest",
         members=tuple(planned_population.get_column("backtest_hash")),
     )
@@ -562,9 +577,13 @@ if (
 if EXECUTION_TIER == "canonical":
     for label in completed.get_column("label").unique().sort().to_list():
         label_name = label.replace("_", "-")
+        result_set_name = f"us-equities-{label_name}-cost-sensitivity-v1"
         result_set = study.backtests.freeze(
             completed.filter(pl.col("label") == label),
-            name=f"us-equities-{label_name}-cost-sensitivity-v1",
+            name=result_set_name,
+            supersedes=candidate_set_supersedes(
+                study, name=result_set_name, declared=SUPERSEDES_SETS.get(result_set_name, "")
+            ),
         )
         set_rows.append(
             {"label": label, "set_name": result_set.name, "members": len(result_set.members)}

--- a/case_studies/us_equities_panel/20_strategy_analysis.ipynb
+++ b/case_studies/us_equities_panel/20_strategy_analysis.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "484f786e",
+   "id": "b091492c",
    "metadata": {},
    "source": [
     "# Strategy Analysis for the US Equities Panel\n",
@@ -31,7 +31,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "276b801f",
+   "id": "15aa9457",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -64,7 +64,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b1c6e27e",
+   "id": "6194612a",
    "metadata": {
     "tags": [
      "parameters"
@@ -78,7 +78,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5d10ccbe",
+   "id": "0984637c",
    "metadata": {},
    "source": [
     "## Reopen the validation set\n",
@@ -92,7 +92,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5584a21d",
+   "id": "c0241732",
    "metadata": {
     "tags": [
      "results"
@@ -115,7 +115,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "95bd4616",
+   "id": "71c4db59",
    "metadata": {},
    "source": [
     "## Validate the comparison protocol\n",
@@ -132,13 +132,20 @@
     "notebook is held to the same rule. Requiring `label_artifact` to be constant across the set is how\n",
     "that is enforced, and it is why the set this notebook opens is one of the per-label sets rather\n",
     "than a union of them. `feature_artifacts` and `cv` are allowed to vary: within a label the funnel\n",
-    "ranks model families against each other, and they do not share a feature lineage."
+    "ranks model families against each other, and they do not share a feature lineage.\n",
+    "\n",
+    "\n",
+    "One label, many families. `label_artifact` has to be constant across the set - that is what makes\n",
+    "the ranking a within-label one - while `feature_artifacts` and `cv` may vary, because the funnel\n",
+    "ranks model families against each other and they do not share a feature lineage: `latent_factors`\n",
+    "builds `feature_artifacts` from `input_lineage[\"files\"]` and the rest from `[\"artifacts\"]`.\n",
+    "Requiring all three constant would reject every set the funnel actually produces."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "576e9740",
+   "id": "9f9e4980",
    "metadata": {
     "tags": [
      "results"
@@ -146,11 +153,6 @@
    },
    "outputs": [],
    "source": [
-    "# One label, many families. `label_artifact` must be constant across the set - that is what makes\n",
-    "# the ranking a within-label one - while `feature_artifacts` and `cv` may vary, because the funnel\n",
-    "# ranks model families against each other and they do not share a feature lineage: latent_factors\n",
-    "# builds feature_artifacts from input_lineage[\"files\"] and the rest from [\"artifacts\"]. Requiring\n",
-    "# all three constant would reject every set the funnel actually produces.\n",
     "CONSTANT_IDENTITY_FIELDS = {\"label_artifact\"}\n",
     "comparable_fields = set(validation_set.comparison_contract.get(\"comparable_fields\", ()))\n",
     "varying_identity_fields = CONSTANT_IDENTITY_FIELDS & comparable_fields\n",
@@ -174,7 +176,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ef1e33cf",
+   "id": "4214e079",
    "metadata": {},
    "source": [
     "Every member must reproduce the canonical validation price identity for its own label and warmup\n",
@@ -184,7 +186,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3587b87b",
+   "id": "873b218b",
    "metadata": {
     "tags": [
      "results"
@@ -233,7 +235,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5f22712c",
+   "id": "37db11e7",
    "metadata": {},
    "source": [
     "Apply the selection rule only after every member has passed the protocol checks. The\n",
@@ -245,7 +247,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "880efa19",
+   "id": "fed58476",
    "metadata": {
     "tags": [
      "results"
@@ -266,7 +268,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c17e403f",
+   "id": "4f5d4219",
    "metadata": {},
    "source": [
     "The selected result is reconstructed through the catalog, so the prediction set, training run\n",
@@ -277,7 +279,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2d605143",
+   "id": "0d15377d",
    "metadata": {
     "tags": [
      "results"
@@ -299,7 +301,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "999074a6",
+   "id": "7153edd7",
    "metadata": {},
    "source": [
     "## Validation selection evidence\n",
@@ -312,7 +314,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0edf5e9e",
+   "id": "0117775c",
    "metadata": {
     "tags": [
      "results"
@@ -349,7 +351,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3e7ba000",
+   "id": "d8c1649f",
    "metadata": {},
    "source": [
     "The joined rows must reproduce exact set membership. Canonical tier, validation split, complete\n",
@@ -360,7 +362,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1cd91c82",
+   "id": "ab6c28f1",
    "metadata": {
     "tags": [
      "results"
@@ -388,10 +390,8 @@
     "selection_evidence = selection_evidence.sort([\"sharpe\", \"backtest_hash\"], descending=[True, False])\n",
     "if selected_validation.hash not in selection_evidence[\"backtest_hash\"].to_list():\n",
     "    raise ValueError(\"the selected configuration is not among the candidates this table describes\")\n",
-    "# The table is ordered by the stored Sharpe, which is descriptive. Where its first row is not the\n",
-    "# selected configuration, the two orderings disagree and saying so is the point of showing the\n",
-    "# table: the stored column compares configurations over whatever span each one priced, and the\n",
-    "# selection compares them over the span they share.\n",
+    "# The stored Sharpe orders the table; the selection ordered over the shared span. Where the two\n",
+    "# disagree the line below says so.\n",
     "if selection_evidence[\"backtest_hash\"][0] != selected_validation.hash:\n",
     "    print(\n",
     "        f\"stored-Sharpe order leads with {selection_evidence['backtest_hash'][0]}; the selected configuration \"\n",
@@ -402,7 +402,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bb7c4ce8",
+   "id": "606dce83",
    "metadata": {},
    "source": [
     "## Resolve the exact holdout evaluation\n",
@@ -417,7 +417,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7a27cdd0",
+   "id": "b932e8ae",
    "metadata": {
     "tags": [
      "results"
@@ -447,7 +447,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c946d881",
+   "id": "293c271d",
    "metadata": {},
    "source": [
     "The holdout lineage must be the selected configuration refitted, differing from the validation\n",
@@ -460,7 +460,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4157c79c",
+   "id": "d5766503",
    "metadata": {
     "tags": [
      "results"
@@ -486,16 +486,38 @@
     "if holdout_training.hash == selected_training.hash:\n",
     "    raise ValueError(\n",
     "        \"the holdout carries the validation training identity, which means it was not refitted\"\n",
-    "    )\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7e6fef27",
+   "metadata": {},
+   "source": [
+    "**Finding the holdout replay is not the same as proving it is the same configuration.** The\n",
+    "resolver matches on the declared configuration - family, configuration name, label, checkpoint -\n",
+    "and on the strategy specification, and a refit under changed feature artifacts or changed model\n",
+    "parameters keeps its configuration name and would match all of that.\n",
     "\n",
-    "# The resolver matches on the declared configuration - family, config name, label, checkpoint -\n",
-    "# and on the strategy specification. That is enough to find the replay and not enough to prove it\n",
-    "# is the SAME configuration: a refit under changed feature artifacts or changed model parameters\n",
-    "# keeps its config_name and would match. So the derived specification is rebuilt here from the\n",
-    "# selected validation spec and its identity compared against the one the holdout registered\n",
-    "# under. The training hash covers the feature lineage, the model parameters and the CV interval,\n",
-    "# so agreement is the whole claim rather than a sample of it. Disagreement means the holdout on\n",
-    "# file answers a different question from the one the validation selection asked.\n",
+    "So the specification the holdout should have been fitted under is rebuilt here from the selected\n",
+    "validation specification, and its identity is compared against the one the holdout actually\n",
+    "registered under. That hash covers the feature lineage, the model parameters and the\n",
+    "cross-validation interval, so agreement is the whole claim rather than a sample of it.\n",
+    "Disagreement means the holdout on file answers a different question from the one the validation\n",
+    "selection asked."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "061e8523",
+   "metadata": {
+    "tags": [
+     "results"
+    ]
+   },
+   "outputs": [],
+   "source": [
     "expected_holdout_spec = build_holdout_training_spec(\n",
     "    study,\n",
     "    selected_training.spec(),\n",
@@ -525,7 +547,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "936dd365",
+   "id": "0ea90280",
    "metadata": {},
    "source": [
     "### Two kinds of check, and why they differ\n",
@@ -550,7 +572,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d8b5c6dd",
+   "id": "f0839e32",
    "metadata": {
     "tags": [
      "results"
@@ -574,7 +596,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c450c1a8",
+   "id": "cee43770",
    "metadata": {},
    "source": [
     "## Validation and holdout performance\n",
@@ -587,7 +609,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fe9c43dc",
+   "id": "2f2dbf80",
    "metadata": {
     "tags": [
      "results"
@@ -640,7 +662,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fd3e7622",
+   "id": "961c58d1",
    "metadata": {},
    "source": [
     "## Required paired comparisons\n",
@@ -657,7 +679,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7f90391f",
+   "id": "b1f9c553",
    "metadata": {
     "tags": [
      "results"
@@ -695,7 +717,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a78bf395",
+   "id": "82d81e18",
    "metadata": {},
    "source": [
     "Each named comparison must resolve to one finite row. The equal-weight benchmark identifiers also\n",
@@ -705,7 +727,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4a14f27e",
+   "id": "e506eaf3",
    "metadata": {
     "tags": [
      "results"
@@ -758,7 +780,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b52219bb",
+   "id": "20f7f31f",
    "metadata": {},
    "source": [
     "## Return and drawdown paths\n",
@@ -770,7 +792,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "90292467",
+   "id": "d1bb2177",
    "metadata": {
     "tags": [
      "results"
@@ -807,7 +829,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "eff2a25f",
+   "id": "3ed3f96e",
    "metadata": {},
    "source": [
     "The two columns below retain separate time axes for validation and holdout. The top row compounds\n",
@@ -817,7 +839,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "957800aa",
+   "id": "71b5ae43",
    "metadata": {
     "tags": [
      "results"
@@ -868,7 +890,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3c5bfcbd",
+   "id": "52f5c291",
    "metadata": {},
    "source": [
     "## Computed assessment\n",
@@ -881,7 +903,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "581f2094",
+   "id": "0174c1ef",
    "metadata": {
     "tags": [
      "results"
@@ -907,7 +929,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6c1694c3",
+   "id": "b478ad64",
    "metadata": {},
    "source": [
     "## Key takeaways and limitations\n",

--- a/case_studies/us_equities_panel/20_strategy_analysis.ipynb
+++ b/case_studies/us_equities_panel/20_strategy_analysis.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "0124042f",
+   "id": "484f786e",
    "metadata": {},
    "source": [
     "# Strategy Analysis for the US Equities Panel\n",
@@ -31,7 +31,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9b8c9a1c",
+   "id": "276b801f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -58,13 +58,13 @@
     "    resolve_solvent_carrier,\n",
     "    select_holdout_self_backtest,\n",
     ")\n",
-    "from utils.style import COLORS, show_with_alt"
+    "from utils.style import COLORS, add_message_title, show_with_alt"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "be7d493b",
+   "id": "b1c6e27e",
    "metadata": {
     "tags": [
      "parameters"
@@ -78,7 +78,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "31b392e5",
+   "id": "5d10ccbe",
    "metadata": {},
    "source": [
     "## Reopen the validation set\n",
@@ -92,7 +92,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9badafdf",
+   "id": "5584a21d",
    "metadata": {
     "tags": [
      "results"
@@ -115,7 +115,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "410dcfbd",
+   "id": "95bd4616",
    "metadata": {},
    "source": [
     "## Validate the comparison protocol\n",
@@ -138,7 +138,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8ad11cf2",
+   "id": "576e9740",
    "metadata": {
     "tags": [
      "results"
@@ -174,7 +174,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b2be941d",
+   "id": "ef1e33cf",
    "metadata": {},
    "source": [
     "Every member must reproduce the canonical validation price identity for its own label and warmup\n",
@@ -184,7 +184,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f99f3a1d",
+   "id": "3587b87b",
    "metadata": {
     "tags": [
      "results"
@@ -233,7 +233,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "399960d7",
+   "id": "5f22712c",
    "metadata": {},
    "source": [
     "Apply the selection rule only after every member has passed the protocol checks. The\n",
@@ -245,7 +245,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "05fc18d1",
+   "id": "880efa19",
    "metadata": {
     "tags": [
      "results"
@@ -266,7 +266,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7fdfedcc",
+   "id": "c17e403f",
    "metadata": {},
    "source": [
     "The selected result is reconstructed through the catalog, so the prediction set, training run\n",
@@ -277,7 +277,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e8bc763f",
+   "id": "2d605143",
    "metadata": {
     "tags": [
      "results"
@@ -299,7 +299,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "10975f56",
+   "id": "999074a6",
    "metadata": {},
    "source": [
     "## Validation selection evidence\n",
@@ -312,7 +312,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "410926d0",
+   "id": "0edf5e9e",
    "metadata": {
     "tags": [
      "results"
@@ -349,7 +349,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9c3b2d76",
+   "id": "3e7ba000",
    "metadata": {},
    "source": [
     "The joined rows must reproduce exact set membership. Canonical tier, validation split, complete\n",
@@ -360,7 +360,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2e673b8c",
+   "id": "1cd91c82",
    "metadata": {
     "tags": [
      "results"
@@ -402,7 +402,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3d5fb459",
+   "id": "bb7c4ce8",
    "metadata": {},
    "source": [
     "## Resolve the exact holdout evaluation\n",
@@ -417,7 +417,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7c9c412e",
+   "id": "7a27cdd0",
    "metadata": {
     "tags": [
      "results"
@@ -447,7 +447,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "41d0ca47",
+   "id": "c946d881",
    "metadata": {},
    "source": [
     "The holdout lineage must be the selected configuration refitted, differing from the validation\n",
@@ -460,7 +460,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f77c8396",
+   "id": "4157c79c",
    "metadata": {
     "tags": [
      "results"
@@ -525,7 +525,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "37e14bca",
+   "id": "936dd365",
    "metadata": {},
    "source": [
     "### Two kinds of check, and why they differ\n",
@@ -550,7 +550,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f6e07bcd",
+   "id": "d8b5c6dd",
    "metadata": {
     "tags": [
      "results"
@@ -574,7 +574,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bf3549cc",
+   "id": "c450c1a8",
    "metadata": {},
    "source": [
     "## Validation and holdout performance\n",
@@ -587,7 +587,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7dfffef6",
+   "id": "fe9c43dc",
    "metadata": {
     "tags": [
      "results"
@@ -640,7 +640,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "167e63e2",
+   "id": "fd3e7622",
    "metadata": {},
    "source": [
     "## Required paired comparisons\n",
@@ -657,7 +657,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d1a52fda",
+   "id": "7f90391f",
    "metadata": {
     "tags": [
      "results"
@@ -695,7 +695,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "46929c2e",
+   "id": "a78bf395",
    "metadata": {},
    "source": [
     "Each named comparison must resolve to one finite row. The equal-weight benchmark identifiers also\n",
@@ -705,7 +705,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f82098d0",
+   "id": "4a14f27e",
    "metadata": {
     "tags": [
      "results"
@@ -758,7 +758,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6634cf3a",
+   "id": "b52219bb",
    "metadata": {},
    "source": [
     "## Return and drawdown paths\n",
@@ -770,7 +770,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "57a72e61",
+   "id": "90292467",
    "metadata": {
     "tags": [
      "results"
@@ -807,7 +807,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "27d3d5fb",
+   "id": "eff2a25f",
    "metadata": {},
    "source": [
     "The two columns below retain separate time axes for validation and holdout. The top row compounds\n",
@@ -817,7 +817,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7beed992",
+   "id": "957800aa",
    "metadata": {
     "tags": [
      "results"
@@ -836,7 +836,7 @@
     "    summary[period] = (float(wealth[-1] - 1.0), float(drawdown.min()))\n",
     "    axes[0, column].plot(returns[\"timestamp\"], wealth - 1.0, color=COLORS[\"blue\"])\n",
     "    axes[0, column].axhline(0, color=COLORS[\"neutral\"], linewidth=0.8, linestyle=\"--\")\n",
-    "    axes[0, column].set_title(f\"{period.title()} Cumulative Return\")\n",
+    "    axes[0, column].set_title(f\"{period} cumulative return\")\n",
     "    axes[1, column].fill_between(\n",
     "        returns[\"timestamp\"],\n",
     "        drawdown,\n",
@@ -844,11 +844,14 @@
     "        color=COLORS[\"negative\"],\n",
     "        alpha=0.35,\n",
     "    )\n",
-    "    axes[1, column].set_title(f\"{period.title()} Drawdown\")\n",
+    "    axes[1, column].set_title(f\"{period} drawdown\")\n",
     "axes[0, 0].set_ylabel(\"Cumulative return\")\n",
     "axes[1, 0].set_ylabel(\"Drawdown\")\n",
-    "fig.suptitle(\"Locked Strategy Across Validation and Holdout Windows\")\n",
-    "fig.tight_layout()\n",
+    "add_message_title(\n",
+    "    axes[0, 0],\n",
+    "    \"Cumulative return and drawdown, validation and holdout\",\n",
+    "    subtitle=\"Each column keeps its own dates; drawdown is measured from that window's own peak\",\n",
+    ")\n",
     "# The alt text reads the two end points and the two troughs from the frames rather than describing\n",
     "# a shape, so a window described as ending ahead when it does not is a claim the data refutes.\n",
     "_read = \"; \".join(\n",
@@ -865,7 +868,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "15228530",
+   "id": "3c5bfcbd",
    "metadata": {},
    "source": [
     "## Computed assessment\n",
@@ -878,7 +881,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9326e636",
+   "id": "581f2094",
    "metadata": {
     "tags": [
      "results"
@@ -904,7 +907,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "abe29317",
+   "id": "6c1694c3",
    "metadata": {},
    "source": [
     "## Key takeaways and limitations\n",

--- a/case_studies/us_equities_panel/20_strategy_analysis.ipynb
+++ b/case_studies/us_equities_panel/20_strategy_analysis.ipynb
@@ -2,10 +2,10 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "b091492c",
+   "id": "539a9d01",
    "metadata": {},
    "source": [
-    "# Strategy Analysis for the US Equities Panel\n",
+    "# US equities panel: what the one holdout was spent on, and what it bought\n",
     "\n",
     "This notebook reads the immutable validation backtest set, applies the selection rule to it, and\n",
     "resolves the holdout evaluation of whatever that rule chose. The selection rule is one sentence:\n",
@@ -24,14 +24,17 @@
     "**Book reference**: Chapters 16-20 for signal evaluation, allocation, trading costs, risk, and\n",
     "strategy assessment.\n",
     "\n",
-    "**Prerequisites**: the strategy execution notebooks must have published the canonical validation\n",
-    "set, and the holdout notebooks must have registered the refit and its backtest."
+    "**Prerequisites**: [`18_risk_management`](18_risk_management.ipynb) has frozen the per-label\n",
+    "validation strategy set this notebook opens, and the holdout notebooks have registered the refit\n",
+    "and its backtest.\n",
+    "\n",
+    "**What it writes**: nothing. It reads the registry, applies the selection rule and reports."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "15aa9457",
+   "id": "39c778c5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -64,7 +67,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6194612a",
+   "id": "a802901b",
    "metadata": {
     "tags": [
      "parameters"
@@ -78,7 +81,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0984637c",
+   "id": "2c178435",
    "metadata": {},
    "source": [
     "## Reopen the validation set\n",
@@ -92,7 +95,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c0241732",
+   "id": "0da67583",
    "metadata": {
     "tags": [
      "results"
@@ -115,7 +118,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "71c4db59",
+   "id": "6db438a3",
    "metadata": {},
    "source": [
     "## Validate the comparison protocol\n",
@@ -127,25 +130,20 @@
     "once, and the holdout it leads to is used once - so what the ranking is taken over decides what\n",
     "that single use buys. A set spanning `fwd_ret_1d`, `fwd_ret_5d` and `fwd_ret_21d` would rank a\n",
     "one-day-horizon Sharpe against a twenty-one-day one and spend the holdout on a cross-horizon\n",
-    "comparison, which is not the question the funnel asks. `reference/CASE_STUDY_PIPELINE.md`\n",
-    "section 4 runs the funnel per label and every other case study compares within one label; this\n",
-    "notebook is held to the same rule. Requiring `label_artifact` to be constant across the set is how\n",
+    "comparison, which is not the question the funnel asks. Every case study in the book runs the\n",
+    "funnel once per label for that reason. Requiring `label_artifact` to be constant across the set\n",
+    "is how\n",
     "that is enforced, and it is why the set this notebook opens is one of the per-label sets rather\n",
     "than a union of them. `feature_artifacts` and `cv` are allowed to vary: within a label the funnel\n",
-    "ranks model families against each other, and they do not share a feature lineage.\n",
-    "\n",
-    "\n",
-    "One label, many families. `label_artifact` has to be constant across the set - that is what makes\n",
-    "the ranking a within-label one - while `feature_artifacts` and `cv` may vary, because the funnel\n",
-    "ranks model families against each other and they do not share a feature lineage: `latent_factors`\n",
-    "builds `feature_artifacts` from `input_lineage[\"files\"]` and the rest from `[\"artifacts\"]`.\n",
-    "Requiring all three constant would reject every set the funnel actually produces."
+    "ranks model families against each other, and they do not share a feature lineage -\n",
+    "`latent_factors` builds `feature_artifacts` from `input_lineage[\"files\"]` and the rest from\n",
+    "`[\"artifacts\"]`. Requiring all three constant would reject every set the funnel produces."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9f9e4980",
+   "id": "8f31f010",
    "metadata": {
     "tags": [
      "results"
@@ -176,7 +174,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4214e079",
+   "id": "70be5d29",
    "metadata": {},
    "source": [
     "Every member must reproduce the canonical validation price identity for its own label and warmup\n",
@@ -186,7 +184,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "873b218b",
+   "id": "53165ef6",
    "metadata": {
     "tags": [
      "results"
@@ -235,7 +233,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "37db11e7",
+   "id": "07af02b3",
    "metadata": {},
    "source": [
     "Apply the selection rule only after every member has passed the protocol checks. The\n",
@@ -247,7 +245,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fed58476",
+   "id": "c0469df5",
    "metadata": {
     "tags": [
      "results"
@@ -268,7 +266,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4f5d4219",
+   "id": "49b240a1",
    "metadata": {},
    "source": [
     "The selected result is reconstructed through the catalog, so the prediction set, training run\n",
@@ -279,7 +277,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0d15377d",
+   "id": "4f8a42e3",
    "metadata": {
     "tags": [
      "results"
@@ -301,7 +299,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7153edd7",
+   "id": "2eaa9b53",
    "metadata": {},
    "source": [
     "## Validation selection evidence\n",
@@ -314,7 +312,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0117775c",
+   "id": "415fc553",
    "metadata": {
     "tags": [
      "results"
@@ -351,7 +349,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d8c1649f",
+   "id": "deb47e5b",
    "metadata": {},
    "source": [
     "The joined rows must reproduce exact set membership. Canonical tier, validation split, complete\n",
@@ -362,7 +360,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ab6c28f1",
+   "id": "270923bb",
    "metadata": {
     "tags": [
      "results"
@@ -402,7 +400,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "606dce83",
+   "id": "2bb543d4",
    "metadata": {},
    "source": [
     "## Resolve the exact holdout evaluation\n",
@@ -417,7 +415,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b932e8ae",
+   "id": "c8d07a42",
    "metadata": {
     "tags": [
      "results"
@@ -447,7 +445,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "293c271d",
+   "id": "0f43dd9b",
    "metadata": {},
    "source": [
     "The holdout lineage must be the selected configuration refitted, differing from the validation\n",
@@ -460,7 +458,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d5766503",
+   "id": "bf299d28",
    "metadata": {
     "tags": [
      "results"
@@ -491,7 +489,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7e6fef27",
+   "id": "df61249d",
    "metadata": {},
    "source": [
     "**Finding the holdout replay is not the same as proving it is the same configuration.** The\n",
@@ -510,7 +508,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "061e8523",
+   "id": "1c188f46",
    "metadata": {
     "tags": [
      "results"
@@ -547,7 +545,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0ea90280",
+   "id": "80da9be3",
    "metadata": {},
    "source": [
     "### Two kinds of check, and why they differ\n",
@@ -572,7 +570,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f0839e32",
+   "id": "ef09fb83",
    "metadata": {
     "tags": [
      "results"
@@ -596,7 +594,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cee43770",
+   "id": "b091b0e9",
    "metadata": {},
    "source": [
     "## Validation and holdout performance\n",
@@ -609,7 +607,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2f2dbf80",
+   "id": "9e4003e6",
    "metadata": {
     "tags": [
      "results"
@@ -662,7 +660,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "961c58d1",
+   "id": "9b3cc6fe",
    "metadata": {},
    "source": [
     "## Required paired comparisons\n",
@@ -679,7 +677,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b1f9c553",
+   "id": "1444ac4f",
    "metadata": {
     "tags": [
      "results"
@@ -717,7 +715,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "82d81e18",
+   "id": "60f7594d",
    "metadata": {},
    "source": [
     "Each named comparison must resolve to one finite row. The equal-weight benchmark identifiers also\n",
@@ -727,7 +725,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e506eaf3",
+   "id": "d936af77",
    "metadata": {
     "tags": [
      "results"
@@ -780,7 +778,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "20f7f31f",
+   "id": "c50f3d60",
    "metadata": {},
    "source": [
     "## Return and drawdown paths\n",
@@ -792,7 +790,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d1bb2177",
+   "id": "56fd315f",
    "metadata": {
     "tags": [
      "results"
@@ -829,7 +827,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3ed3f96e",
+   "id": "8b30f79d",
    "metadata": {},
    "source": [
     "The two columns below retain separate time axes for validation and holdout. The top row compounds\n",
@@ -839,7 +837,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "71b5ae43",
+   "id": "01e7da15",
    "metadata": {
     "tags": [
      "results"
@@ -890,7 +888,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "52f5c291",
+   "id": "46ecde5c",
    "metadata": {},
    "source": [
     "## Computed assessment\n",
@@ -903,7 +901,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0174c1ef",
+   "id": "0a797eda",
    "metadata": {
     "tags": [
      "results"
@@ -929,7 +927,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b478ad64",
+   "id": "1a8c11f2",
    "metadata": {},
    "source": [
     "## Key takeaways and limitations\n",

--- a/case_studies/us_equities_panel/20_strategy_analysis.py
+++ b/case_studies/us_equities_panel/20_strategy_analysis.py
@@ -14,7 +14,7 @@
 # ---
 
 # %% [markdown]
-# # Strategy Analysis for the US Equities Panel
+# # US equities panel: what the one holdout was spent on, and what it bought
 #
 # This notebook reads the immutable validation backtest set, applies the selection rule to it, and
 # resolves the holdout evaluation of whatever that rule chose. The selection rule is one sentence:
@@ -33,8 +33,11 @@
 # **Book reference**: Chapters 16-20 for signal evaluation, allocation, trading costs, risk, and
 # strategy assessment.
 #
-# **Prerequisites**: the strategy execution notebooks must have published the canonical validation
-# set, and the holdout notebooks must have registered the refit and its backtest.
+# **Prerequisites**: [`18_risk_management`](18_risk_management.ipynb) has frozen the per-label
+# validation strategy set this notebook opens, and the holdout notebooks have registered the refit
+# and its backtest.
+#
+# **What it writes**: nothing. It reads the registry, applies the selection rule and reports.
 
 # %%
 """Read-only assessment of one validation and holdout lineage."""
@@ -97,19 +100,14 @@ if validation_set.member_kind != "backtest":
 # once, and the holdout it leads to is used once - so what the ranking is taken over decides what
 # that single use buys. A set spanning `fwd_ret_1d`, `fwd_ret_5d` and `fwd_ret_21d` would rank a
 # one-day-horizon Sharpe against a twenty-one-day one and spend the holdout on a cross-horizon
-# comparison, which is not the question the funnel asks. `reference/CASE_STUDY_PIPELINE.md`
-# section 4 runs the funnel per label and every other case study compares within one label; this
-# notebook is held to the same rule. Requiring `label_artifact` to be constant across the set is how
+# comparison, which is not the question the funnel asks. Every case study in the book runs the
+# funnel once per label for that reason. Requiring `label_artifact` to be constant across the set
+# is how
 # that is enforced, and it is why the set this notebook opens is one of the per-label sets rather
 # than a union of them. `feature_artifacts` and `cv` are allowed to vary: within a label the funnel
-# ranks model families against each other, and they do not share a feature lineage.
-
-#
-# One label, many families. `label_artifact` has to be constant across the set - that is what makes
-# the ranking a within-label one - while `feature_artifacts` and `cv` may vary, because the funnel
-# ranks model families against each other and they do not share a feature lineage: `latent_factors`
-# builds `feature_artifacts` from `input_lineage["files"]` and the rest from `["artifacts"]`.
-# Requiring all three constant would reject every set the funnel actually produces.
+# ranks model families against each other, and they do not share a feature lineage -
+# `latent_factors` builds `feature_artifacts` from `input_lineage["files"]` and the rest from
+# `["artifacts"]`. Requiring all three constant would reject every set the funnel produces.
 
 # %% tags=["results"]
 CONSTANT_IDENTITY_FIELDS = {"label_artifact"}

--- a/case_studies/us_equities_panel/20_strategy_analysis.py
+++ b/case_studies/us_equities_panel/20_strategy_analysis.py
@@ -104,12 +104,14 @@ if validation_set.member_kind != "backtest":
 # than a union of them. `feature_artifacts` and `cv` are allowed to vary: within a label the funnel
 # ranks model families against each other, and they do not share a feature lineage.
 
-# %% tags=["results"]
-# One label, many families. `label_artifact` must be constant across the set - that is what makes
+#
+# One label, many families. `label_artifact` has to be constant across the set - that is what makes
 # the ranking a within-label one - while `feature_artifacts` and `cv` may vary, because the funnel
-# ranks model families against each other and they do not share a feature lineage: latent_factors
-# builds feature_artifacts from input_lineage["files"] and the rest from ["artifacts"]. Requiring
-# all three constant would reject every set the funnel actually produces.
+# ranks model families against each other and they do not share a feature lineage: `latent_factors`
+# builds `feature_artifacts` from `input_lineage["files"]` and the rest from `["artifacts"]`.
+# Requiring all three constant would reject every set the funnel actually produces.
+
+# %% tags=["results"]
 CONSTANT_IDENTITY_FIELDS = {"label_artifact"}
 comparable_fields = set(validation_set.comparison_contract.get("comparable_fields", ()))
 varying_identity_fields = CONSTANT_IDENTITY_FIELDS & comparable_fields
@@ -267,10 +269,8 @@ if not required_selection_metrics <= set(selection_evidence.columns) or any(
 selection_evidence = selection_evidence.sort(["sharpe", "backtest_hash"], descending=[True, False])
 if selected_validation.hash not in selection_evidence["backtest_hash"].to_list():
     raise ValueError("the selected configuration is not among the candidates this table describes")
-# The table is ordered by the stored Sharpe, which is descriptive. Where its first row is not the
-# selected configuration, the two orderings disagree and saying so is the point of showing the
-# table: the stored column compares configurations over whatever span each one priced, and the
-# selection compares them over the span they share.
+# The stored Sharpe orders the table; the selection ordered over the shared span. Where the two
+# disagree the line below says so.
 if selection_evidence["backtest_hash"][0] != selected_validation.hash:
     print(
         f"stored-Sharpe order leads with {selection_evidence['backtest_hash'][0]}; the selected configuration "
@@ -335,14 +335,20 @@ if holdout_training.hash == selected_training.hash:
         "the holdout carries the validation training identity, which means it was not refitted"
     )
 
-# The resolver matches on the declared configuration - family, config name, label, checkpoint -
-# and on the strategy specification. That is enough to find the replay and not enough to prove it
-# is the SAME configuration: a refit under changed feature artifacts or changed model parameters
-# keeps its config_name and would match. So the derived specification is rebuilt here from the
-# selected validation spec and its identity compared against the one the holdout registered
-# under. The training hash covers the feature lineage, the model parameters and the CV interval,
-# so agreement is the whole claim rather than a sample of it. Disagreement means the holdout on
-# file answers a different question from the one the validation selection asked.
+# %% [markdown]
+# **Finding the holdout replay is not the same as proving it is the same configuration.** The
+# resolver matches on the declared configuration - family, configuration name, label, checkpoint -
+# and on the strategy specification, and a refit under changed feature artifacts or changed model
+# parameters keeps its configuration name and would match all of that.
+#
+# So the specification the holdout should have been fitted under is rebuilt here from the selected
+# validation specification, and its identity is compared against the one the holdout actually
+# registered under. That hash covers the feature lineage, the model parameters and the
+# cross-validation interval, so agreement is the whole claim rather than a sample of it.
+# Disagreement means the holdout on file answers a different question from the one the validation
+# selection asked.
+
+# %% tags=["results"]
 expected_holdout_spec = build_holdout_training_spec(
     study,
     selected_training.spec(),

--- a/case_studies/us_equities_panel/20_strategy_analysis.py
+++ b/case_studies/us_equities_panel/20_strategy_analysis.py
@@ -60,7 +60,7 @@ from case_studies.utils.strategy_analysis import (
     resolve_solvent_carrier,
     select_holdout_self_backtest,
 )
-from utils.style import COLORS, show_with_alt
+from utils.style import COLORS, add_message_title, show_with_alt
 
 # %% tags=["parameters"]
 CASE_STUDY_ID = "us_equities_panel"
@@ -587,7 +587,7 @@ for column, period in enumerate(("validation", "holdout")):
     summary[period] = (float(wealth[-1] - 1.0), float(drawdown.min()))
     axes[0, column].plot(returns["timestamp"], wealth - 1.0, color=COLORS["blue"])
     axes[0, column].axhline(0, color=COLORS["neutral"], linewidth=0.8, linestyle="--")
-    axes[0, column].set_title(f"{period.title()} Cumulative Return")
+    axes[0, column].set_title(f"{period} cumulative return")
     axes[1, column].fill_between(
         returns["timestamp"],
         drawdown,
@@ -595,11 +595,14 @@ for column, period in enumerate(("validation", "holdout")):
         color=COLORS["negative"],
         alpha=0.35,
     )
-    axes[1, column].set_title(f"{period.title()} Drawdown")
+    axes[1, column].set_title(f"{period} drawdown")
 axes[0, 0].set_ylabel("Cumulative return")
 axes[1, 0].set_ylabel("Drawdown")
-fig.suptitle("Locked Strategy Across Validation and Holdout Windows")
-fig.tight_layout()
+add_message_title(
+    axes[0, 0],
+    "Cumulative return and drawdown, validation and holdout",
+    subtitle="Each column keeps its own dates; drawdown is measured from that window's own peak",
+)
 # The alt text reads the two end points and the two troughs from the frames rather than describing
 # a shape, so a window described as ending ahead when it does not is a claim the data refutes.
 _read = "; ".join(

--- a/tests/overrides.yaml
+++ b/tests/overrides.yaml
@@ -3592,6 +3592,11 @@ case_studies/us_equities_panel/13b_ipca:
     PREVIEW_N_FACTORS: 2
   timeout: 300
 case_studies/us_equities_panel/14_causal_dml:
+  # MAX_SYMBOLS carries the PREVIEW_ prefix here. Without it, injected_parameters strips it on
+  # neither path: canonically_refused_parameters reads the notebook's canonical guard, whose test
+  # is the local `preview_reductions` aggregate rather than a declared parameter name, so the
+  # intersection with the parameters cell is empty. It reached a canonical run and raised
+  # "Canonical execution cannot declare preview reductions".
   # CV_FOLDS, MAX_SAMPLES and N_PLACEBO became PREVIEW_N_FOLDS,
   # PREVIEW_MAX_SAMPLES and PREVIEW_N_PLACEBO: the reduced fold count, sample
   # cap and placebo count are part of the preview identity now, not free knobs.
@@ -3600,7 +3605,7 @@ case_studies/us_equities_panel/14_causal_dml:
   # any n below 20 and the draws are spent on a verdict that cannot be reached. 20 is
   # the first reachable count; 24 leaves margin for draws that fail.
   parameters:
-    MAX_SYMBOLS: 5
+    PREVIEW_MAX_SYMBOLS: 5
     PREVIEW_N_FOLDS: 2
     PREVIEW_MAX_SAMPLES: 5000
     PREVIEW_N_PLACEBO: 25

--- a/tests/overrides.yaml
+++ b/tests/overrides.yaml
@@ -3519,29 +3519,32 @@ case_studies/us_equities_panel/08_tabular_dl:
     DEVICE: cpu
     CONFIG_NAMES: [tabm_s]
     DIAGNOSTIC_CONFIG_NAMES: [tabm_s]
-    MAX_FOLDS: 2
-    MAX_SYMBOLS: 20
+    PREVIEW_MAX_FOLDS: 2
+    PREVIEW_MAX_SYMBOLS: 20
     PREVIEW_N_EPOCHS: 1
   timeout: 180
 case_studies/us_equities_panel/09_dl_nlinear:
+  # n_epochs rides in COMMON_OVERRIDES rather than in a PREVIEW_N_EPOCHS parameter of its own.
+  # SEQUENCE_PREVIEW_FIELDS does not accept an epoch count, so the notebook's old parameter fed
+  # `overrides` while its name promised a preview-tier restriction the shared validation could
+  # not enforce - a canonical run carrying it would have trained one epoch and published it.
+  # An override is refused a canonical population by the notebook's own publish guard.
   # MAX_FOLDS became FOLD_IDS: the sequence runner takes the fold ids it should
   # keep, not a count to slice to.
   parameters:
     DEVICE: cpu
     CONFIG_NAMES: [nlinear]
-    COMMON_OVERRIDES: {batch_size: 32, lookback: 5}
-    FOLD_IDS: [0, 1]
-    MAX_SYMBOLS: 5
-    PREVIEW_N_EPOCHS: 1
+    COMMON_OVERRIDES: {batch_size: 32, lookback: 5, n_epochs: 1}
+    PREVIEW_FOLD_IDS: [0, 1]
+    PREVIEW_MAX_SYMBOLS: 5
   timeout: 600
 case_studies/us_equities_panel/10_dl_lstm:
   parameters:
     DEVICE: cpu
     CONFIG_NAMES: [lstm_h64]
-    COMMON_OVERRIDES: {batch_size: 32, lookback: 5}
-    FOLD_IDS: [0, 1]
-    MAX_SYMBOLS: 5
-    PREVIEW_N_EPOCHS: 1
+    COMMON_OVERRIDES: {batch_size: 32, lookback: 5, n_epochs: 1}
+    PREVIEW_FOLD_IDS: [0, 1]
+    PREVIEW_MAX_SYMBOLS: 5
   timeout: 600
 case_studies/us_equities_panel/11_dl_tsmixer:
   # The pinned SYMBOLS whitelist this entry used to carry has no parameter to
@@ -3555,10 +3558,9 @@ case_studies/us_equities_panel/11_dl_tsmixer:
   parameters:
     DEVICE: cpu
     CONFIG_NAMES: [tsmixer]
-    COMMON_OVERRIDES: {batch_size: 32, lookback: 5}
-    FOLD_IDS: [0, 1]
-    MAX_SYMBOLS: 8
-    PREVIEW_N_EPOCHS: 1
+    COMMON_OVERRIDES: {batch_size: 32, lookback: 5, n_epochs: 1}
+    PREVIEW_FOLD_IDS: [0, 1]
+    PREVIEW_MAX_SYMBOLS: 8
   timeout: 600
 case_studies/us_equities_panel/12_dl_weekly:
   parameters:
@@ -3577,16 +3579,16 @@ case_studies/us_equities_panel/13a_pca:
   # 11b_ipca run under.
   parameters:
     LABELS: [fwd_ret_1d]
-    MAX_SYMBOLS: 5
-    FOLD_IDS: [0, 1]
+    PREVIEW_MAX_SYMBOLS: 5
+    PREVIEW_FOLD_IDS: [0, 1]
     PREVIEW_N_FACTORS: 2
   timeout: 300
 case_studies/us_equities_panel/13b_ipca:
   # See 13a_pca on why this is no longer skipped.
   parameters:
     LABELS: [fwd_ret_1d]
-    MAX_SYMBOLS: 5
-    FOLD_IDS: [0, 1]
+    PREVIEW_MAX_SYMBOLS: 5
+    PREVIEW_FOLD_IDS: [0, 1]
     PREVIEW_N_FACTORS: 2
   timeout: 300
 case_studies/us_equities_panel/14_causal_dml:

--- a/tests/test_us_equities_panel_named_sets.py
+++ b/tests/test_us_equities_panel_named_sets.py
@@ -85,11 +85,49 @@ def _frozen_names(path: Path) -> set[str]:
     `label_name` is a label with underscores replaced by dashes. Expanding that against
     the three declared labels is the point: a producer that fits one label while the
     consumer names three is exactly the defect, and it has to be visible here.
+
+    A producer may bind that f-string to a local first and pass the local, which is what
+    happens where the same name is also handed to `candidate_set_supersedes` - repeating
+    the literal at both call sites is how the two drift apart. So a bare `ast.Name` is
+    resolved against the module's assignments before it is given up on.
+
+    **Anything still unresolved fails the test rather than contributing nothing.** Returning
+    an empty set for a form the parser does not recognise makes every consumer name look
+    unfrozen, which reads as sixteen missing producers rather than as one unparsed call -
+    and that is exactly what a `name=<local>` call produced before this branch.
     """
     labels = ["fwd-ret-1d", "fwd-ret-5d", "fwd-ret-21d"]
     source = path.read_text()
     names: set[str] = set()
     tree = ast.parse(source)
+
+    bindings: dict[str, ast.expr] = {}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name):
+                    bindings[target.id] = node.value
+
+    def resolve(value: ast.expr, origin: str) -> None:
+        if isinstance(value, ast.Name):
+            bound = bindings.get(value.id)
+            if bound is None:
+                pytest.fail(f"{path.name}: freeze name {value.id!r} is never assigned")
+            resolve(bound, f"{origin} via {value.id}")
+            return
+        if isinstance(value, ast.Constant) and isinstance(value.value, str):
+            names.add(value.value)
+            return
+        if isinstance(value, ast.JoinedStr):
+            template = "".join(
+                part.value if isinstance(part, ast.Constant) else "{}" for part in value.values
+            )
+            if template.count("{}") != 1:
+                pytest.fail(f"{path.name}: cannot resolve freeze name {template!r}")
+            names.update(template.format(label) for label in labels)
+            return
+        pytest.fail(f"{path.name}: cannot resolve the freeze name at {origin}")
+
     for node in ast.walk(tree):
         if not isinstance(node, ast.Call):
             continue
@@ -97,19 +135,8 @@ def _frozen_names(path: Path) -> set[str]:
         if not (isinstance(func, ast.Attribute) and func.attr == "freeze"):
             continue
         for keyword in node.keywords:
-            if keyword.arg != "name":
-                continue
-            value = keyword.value
-            if isinstance(value, ast.Constant):
-                names.add(value.value)
-            elif isinstance(value, ast.JoinedStr):
-                template = "".join(
-                    part.value if isinstance(part, ast.Constant) else "{}" for part in value.values
-                )
-                if template.count("{}") == 1:
-                    names.update(template.format(label) for label in labels)
-                else:
-                    pytest.fail(f"{path.name}: cannot resolve freeze name {template!r}")
+            if keyword.arg == "name":
+                resolve(keyword.value, f"line {keyword.value.lineno}")
     return names
 
 


### PR DESCRIPTION
One review-and-fix pass over the seventeen `us_equities_panel` notebooks at stage 06 and later,
before any of them is executed. Nothing in this case study has run at stage 06 or later, so no
committed value moves anywhere in this branch, and every register row goes to `ready` rather than
`done`.

## What it found

**Five model-execution notebooks imported no plotting library.** `08_tabular_dl`, `09_dl_nlinear`,
`11_dl_tsmixer`, `13a_pca` and `13b_ipca`. That is the first item on
`rules/stages/06-model-execution.md`'s failure list, and it is invisible to every gate, because a
synced notebook and one whose figure was deleted look identical. Each gains a figure sourced from
the catalog or the registry: a learning curve for the three that checkpoint, and mean validation IC
by walk-forward fold for the two that fit once per label. Both blocks were executed against frames
of the registered schema before committing.

**`18_risk_management` said three times that no per-control trigger count exists, and the registry
carries one.** The notebook's whole question is whether the declared controls bound or were never
installed. `backtest_runner.py` builds a `RiskTriggerLog`, wraps every rule in it, and folds the
counts into the registered metrics on all three execution paths; `registry/store.py` registers
`risk_triggers` and one column per control type, and `research/catalog.py` carries them on every
backtest row. The notebook now reads them, reports the three states, and stops on the one that is a
failure - a row that declared a control and installed none.

**Nine of sixteen "bounded diagnostic" sets were the whole population.** One prediction artifact
here is 7,170,323 rows and about 225 MB as a frame, `15_model_analysis` holds every diagnostic
frame at once and joins them pairwise, and the declared membership came to 107 results: 23.5 GB
resident and 840 joins. Every diagnostic set is now one member per label and family - 16 results,
3.5 GB, 40 joins - and two guards replace the one that passed degenerately.
(ml4t/agent-workspace#1060.)

**Eight notebooks called `fig.tight_layout()`.** `matplotlibrc` sets
`figure.constrained_layout.use: True`, so the call overrides the house layout and can emit
`UserWarning: The figure layout has changed to tight` into the committed render. `M2` bans it for
that reason. (An earlier version of this description also said the warning would block stamping,
which is wrong: `sanitize_notebook_paths.py` excludes `/tmp/ipykernel_` by name and
`test_an_ipython_cell_path_is_not_rewritten` pins that, so nothing refuses the stamp. The layout
override and the stderr in a committed render are the whole of it.)

**Nothing had a supersession path.** No `freeze` and no `OfficialPopulation.create` in this case
study passed `supersedes`, so a re-run admitting different members was refused with nothing the
notebook could offer. The registry holds four candidate sets already, one of them a set this branch
re-bounds. Every producer now routes through `candidate_set_supersedes` and `population_supersedes`.

**A narrowed canonical run could publish the canonical population** in six notebooks. The guard is
now computed from the menu before anything is planned.

**Two preview parameters could reach a canonical run.** `PREVIEW_N_EPOCHS` in the three sequence
notebooks fed `overrides` rather than `preview_reductions`, so the shared validation could not see
it; and `14_causal_dml`'s `MAX_SYMBOLS` was stripped by neither the `PREVIEW_` prefix nor the
harness's guard read, and raised on the canonical path. Both verified with `injected_parameters` on
both paths for every affected entry.

**`06_linear` described an `alpha_frac` parameterisation this case study never declares** - all
four of its L1 and ElasticNet presets are raw `alpha`.

## The rest

Six notebooks stop branching on `EXECUTION_TIER` and call `run_model_population` like `06` and
`07`. Eighteen figure titles now describe rather than assert, following the 2026-09-09 ruling.
Thirty-one comment blocks moved into markdown or were tightened, nine verdict words replaced, six
choices restated positively. `18_risk_management` and `19_costs` were carrying a partial render
from an interrupted run and are cleared, as is `13_latent_factors`.

`check_notebook_prose.py` goes from 76 violations in this case study to 15, all of them in stages
01 to 05 except one: the checker's result-vocabulary pattern matches `beats` inside **N-BEATS**, the
Darts model `12_dl_weekly` fits. All seven stage-06 notebooks now pass
`check_notebook_conformance.py --stage 06 --pre-run`; none did before.

## Not in this PR

No notebook is executed: the machine is running another case study's production chain. And one
input has to be regenerated before this case study's sweep can be, for a reason measured on the way
through - `features/model_based.parquet` on disk carries a `fold` column at 6.88x whose values
genuinely differ between folds, from an estimation design `04_model_based_features` no longer has.
Detail in ml4t/agent-workspace#1020.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P1tBf8pMZ74NrdVfCzz76s

