### PR TITLE
Stop the model plan from carrying one panel per label to the last fit

### DIFF
--- a/case_studies/utils/gbm.py
+++ b/case_studies/utils/gbm.py
@@ -2742,18 +2742,24 @@ def plan_model_requests(
 
     ordered: list[dict[str, Any] | None] = [None] * len(requests)
     planned_groups = []
-    input_cache: dict[tuple[str, str, int], tuple[Any, Any]] = {}
+    # One entry, not a growing dict. The cache is here so two compatibility groups over the same
+    # inputs read the panel once; keeping every group's panel instead is what made a multi-label
+    # plan carry one modeling dataset per label to the end of the run. Measured 2026-09-10 on
+    # nasdaq100_microstructure, one `load_modeling_dataset` per label with nothing released:
+    # 6.71, 12.65, 18.41, 22.53 GiB resident and a 35.79 GiB peak, before a single fit.
+    cached_input_key: tuple[str, str, int] | None = None
+    cached_inputs: tuple[Any, Any] | None = None
     for key, indexed_requests in groups.items():
         input_key = _gbm_input_compatibility_key(indexed_requests[0][1])
+        if cached_input_key != input_key:
+            # Released before the next panel is read, so the two are never alive together.
+            cached_input_key, cached_inputs = None, None
         base = _load_gbm_batch_base(
             study,
             indexed_requests[0][1],
-            inputs=input_cache.get(input_key),
+            inputs=cached_inputs,
         )
-        input_cache.setdefault(
-            input_key,
-            (base["label_ref"], base["mds"]),
-        )
+        cached_input_key, cached_inputs = input_key, (base["label_ref"], base["mds"])
         mds = base["mds"]
         placeholder_folds = tuple({"fold": int(split["fold"])} for split in base["splits"])
         planned_candidates = {}
@@ -2787,6 +2793,14 @@ def plan_model_requests(
             ordered[index] = spec
             planned_candidates[index] = (config, effective, device, max_bin, num_threads)
         planned_groups.append((key, indexed_requests, base, planned_candidates))
+        # The payload outlives planning by the whole length of the run, and `mds` is by far the
+        # largest thing in `base`. `run_model_plan` reloads this group's panel when it reaches
+        # the group and drops it again afterwards, so one is alive at a time instead of one per
+        # group. Nothing else planning derived is rebuilt - the splits, the expected keys and
+        # the provenance in `base` are the planned ones - so no identity can move.
+        mds = None
+        base["mds"] = None
+    cached_input_key, cached_inputs = None, None
     if any(spec is None for spec in ordered):
         raise RuntimeError("GBM batch planner did not resolve every request")
     return tuple(spec for spec in ordered if spec is not None), tuple(planned_groups)
@@ -2798,6 +2812,21 @@ def run_model_plan(study: Study, payload: tuple[Any, ...]) -> tuple[ModelRun, ..
     ]
     failures = []
     for key, indexed_requests, base, planned_candidates in payload:
+        if base.get("mds") is None:
+            # Planning dropped it rather than carry every group's panel to the end of the run.
+            # One reload per group - a scan - against one modeling dataset per label held for
+            # the length of a multi-label call.
+            from utils.modeling import load_modeling_dataset
+
+            request = indexed_requests[0][1]
+            tier = ExecutionTier(request["execution_tier"])
+            study.require_writable()
+            study.activate(tier)
+            base["mds"] = load_modeling_dataset(
+                study.case_study,
+                base["label_ref"].name,
+                max_symbols=int(dict(request["preview_reductions"]).get("max_symbols", 0)),
+            )
         try:
             candidates = _run_gbm_batch_group(
                 study,
@@ -2810,6 +2839,9 @@ def run_model_plan(study: Study, payload: tuple[Any, ...]) -> tuple[ModelRun, ..
         except Exception as error:
             failures.append(error)
             continue
+        finally:
+            # Whatever the group did, its panel goes now: the next group loads its own.
+            base["mds"] = None
         for candidate in candidates:
             if candidate.error is not None:
                 failures.append(candidate.error)
@@ -2831,18 +2863,21 @@ def run_model_requests(study: Study, requests: list[dict[str, Any]]) -> tuple[Mo
 
     ordered: list[ModelRun | None] = [None] * len(requests)
     failures = []
-    input_cache: dict[tuple[str, str, int], tuple[Any, Any]] = {}
+    # One entry, not a growing dict - see `plan_model_requests`. A dict keyed by input holds
+    # every label's panel to the end of the call; measured at 22.53 GiB over four labels on
+    # nasdaq100_microstructure, before a single fit.
+    cached_input_key: tuple[str, str, int] | None = None
+    cached_inputs: tuple[Any, Any] | None = None
     for key, indexed_requests in groups.items():
         input_key = _gbm_input_compatibility_key(indexed_requests[0][1])
+        if cached_input_key != input_key:
+            cached_input_key, cached_inputs = None, None
         base = _load_gbm_batch_base(
             study,
             indexed_requests[0][1],
-            inputs=input_cache.get(input_key),
+            inputs=cached_inputs,
         )
-        input_cache.setdefault(
-            input_key,
-            (base["label_ref"], base["mds"]),
-        )
+        cached_input_key, cached_inputs = input_key, (base["label_ref"], base["mds"])
         candidates = _run_gbm_batch_group(
             study,
             indexed_requests,

--- a/case_studies/utils/linear.py
+++ b/case_studies/utils/linear.py
@@ -1514,15 +1514,25 @@ def plan_model_requests(
 
     ordered: list[dict[str, Any] | None] = [None] * len(requests)
     planned_groups = []
-    input_cache: dict[tuple[str, str, int], tuple[Any, Any]] = {}
+    # One entry, not a growing dict. The cache is here so two compatibility groups over the same
+    # inputs read the panel once; keeping every group's panel instead is what made a multi-label
+    # plan carry one modeling dataset per label to the end of the run. Measured 2026-09-10 on
+    # nasdaq100_microstructure, one `load_modeling_dataset` per label with nothing released:
+    # 6.71, 12.65, 18.41, 22.53 GiB resident and a 35.79 GiB peak, before a single fit. Its
+    # 06_linear fits four labels in one call and died at 48.6 GB on the third of them.
+    cached_input_key: tuple[str, str, int] | None = None
+    cached_inputs: tuple[Any, Any] | None = None
     for key, indexed_requests in groups.items():
         input_key = _input_compatibility_key(indexed_requests[0][1])
+        if cached_input_key != input_key:
+            # Released before the next panel is read, so the two are never alive together.
+            cached_input_key, cached_inputs = None, None
         base = _load_batch_base(
             study,
             indexed_requests[0][1],
-            inputs=input_cache.get(input_key),
+            inputs=cached_inputs,
         )
-        input_cache.setdefault(input_key, (base["label_ref"], base["mds"]))
+        cached_input_key, cached_inputs = input_key, (base["label_ref"], base["mds"])
         fold_ids = tuple(int(split["fold"]) for split in base["splits"])
         candidates = []
         dependent = []
@@ -1578,6 +1588,16 @@ def plan_model_requests(
                 {candidate.index: candidate.effective_params for candidate in candidates},
             )
         )
+        # The payload outlives planning by the whole length of the run, and `mds` is by far the
+        # largest thing in `base`. `run_model_plan` reloads this group's panel when it reaches
+        # the group and drops it again afterwards, so one is alive at a time instead of one per
+        # group. Nothing else planning derived is rebuilt - the splits, the expected keys and
+        # the provenance in `base` are the planned ones - so no identity can move.
+        base["mds"] = None
+    cached_input_key, cached_inputs = None, None
+    # `_INPUT_MEMO` is left holding the last group's panel rather than cleared. It is a
+    # one-entry memo that clears itself on the next miss, so it costs one panel and not one per
+    # group, and it is what lets a single-group plan reach execution without a second read.
     if any(spec is None for spec in ordered):
         raise RuntimeError("linear batch planner did not resolve every request")
     return tuple(spec for spec in ordered if spec is not None), tuple(planned_groups)
@@ -1589,6 +1609,20 @@ def run_model_plan(study: Study, payload: tuple[Any, ...]) -> tuple[ModelRun, ..
     ]
     failures = []
     for key, indexed_requests, base, planned_effective in payload:
+        if base.get("mds") is None:
+            # Planning dropped it rather than carry every group's panel to the end of the run.
+            # One reload per group - a scan, ~18 s on the nasdaq100_microstructure minute panel -
+            # against 22.53 GiB held for the length of a four-label call.
+            request = indexed_requests[0][1]
+            tier = ExecutionTier(request["execution_tier"])
+            study.require_writable()
+            study.activate(tier)
+            _, base["mds"] = _load_inputs(
+                study,
+                request,
+                tier,
+                int(dict(request["preview_reductions"]).get("max_symbols", 0)),
+            )
         try:
             candidates = _run_batch_group(
                 study,
@@ -1601,6 +1635,10 @@ def run_model_plan(study: Study, payload: tuple[Any, ...]) -> tuple[ModelRun, ..
         except Exception as error:
             failures.append(error)
             continue
+        finally:
+            # Whatever the group did, its panel goes now: the next group loads its own.
+            base["mds"] = None
+            clear_input_memo()
         for candidate in candidates:
             if candidate.error is not None:
                 failures.append(candidate.error)
@@ -1622,15 +1660,21 @@ def run_model_requests(study: Study, requests: list[dict[str, Any]]) -> tuple[Mo
 
     ordered: list[ModelRun | None] = [None] * len(requests)
     failures: list[Exception] = []
-    input_cache: dict[tuple[str, str, int], tuple[Any, Any]] = {}
+    # One entry, not a growing dict - see `plan_model_requests`. A dict keyed by input holds
+    # every label's panel to the end of the call; measured at 22.53 GiB over four labels on
+    # nasdaq100_microstructure, before a single fit.
+    cached_input_key: tuple[str, str, int] | None = None
+    cached_inputs: tuple[Any, Any] | None = None
     for key, indexed_requests in groups.items():
         input_key = _input_compatibility_key(indexed_requests[0][1])
+        if cached_input_key != input_key:
+            cached_input_key, cached_inputs = None, None
         base = _load_batch_base(
             study,
             indexed_requests[0][1],
-            inputs=input_cache.get(input_key),
+            inputs=cached_inputs,
         )
-        input_cache.setdefault(input_key, (base["label_ref"], base["mds"]))
+        cached_input_key, cached_inputs = input_key, (base["label_ref"], base["mds"])
         candidates = _run_batch_group(
             study,
             indexed_requests,

--- a/tests/test_research_model_planning.py
+++ b/tests/test_research_model_planning.py
@@ -147,15 +147,87 @@ def test_planned_fold_major_runner_attempts_later_group_after_failure(
         return [SimpleNamespace(index=1, error=None, result=object())]
 
     monkeypatch.setattr(module, batch_name, observed_batch)
+    # `base` is the dict the planner builds. A panel is already in it, so the runner's reload
+    # branch stays out of a test about failure ordering.
     payload = (
-        ("first", [(0, {})], object(), {}),
-        ("second", [(1, {})], object(), {}),
+        ("first", [(0, {})], {"mds": object()}, {}),
+        ("second", [(1, {})], {"mds": object()}, {}),
     )
 
     with pytest.raises(RuntimeError, match="injected compatibility-group failure"):
         module.run_model_plan(SimpleNamespace(), payload)
 
     assert calls == ["first", "second"]
+
+
+@pytest.mark.parametrize(
+    ("module", "batch_name"),
+    [(linear, "_run_batch_group"), (gbm, "_run_gbm_batch_group")],
+)
+def test_planned_runner_holds_one_panel_at_a_time(monkeypatch, module, batch_name) -> None:
+    """The plan payload carries no modeling dataset, and the runner keeps one alive.
+
+    The planner used to leave `base["mds"]` in every payload entry, so a call spanning four
+    labels held four modeling datasets from planning to the last fit - 22.53 GiB resident on
+    `nasdaq100_microstructure` before a single fit, measured 2026-09-10, and the third label is
+    where its `06_linear` died at 48.6 GB. What is pinned here is the shape that fixes it: the
+    panel is absent from the payload, loaded when its group is reached, and gone afterwards.
+    """
+    panels = {"first": object(), "second": object()}
+    loaded: list[str] = []
+    alive_when_each_group_ran: list[list[str]] = []
+    payload = (
+        (
+            "first",
+            [(0, {"label": "first", "execution_tier": "canonical", "preview_reductions": {}})],
+            {"mds": None, "label_ref": None},
+            {},
+        ),
+        (
+            "second",
+            [(1, {"label": "second", "execution_tier": "canonical", "preview_reductions": {}})],
+            {"mds": None, "label_ref": None},
+            {},
+        ),
+    )
+
+    def fake_load(study, request, *args, **kwargs):
+        label = request["label"]
+        loaded.append(label)
+        return None, panels[label]
+
+    def fake_load_gbm(case_study, label, **kwargs):
+        loaded.append(label)
+        return panels[label]
+
+    if module is linear:
+        monkeypatch.setattr(module, "_load_inputs", fake_load)
+    else:
+        monkeypatch.setattr(
+            "utils.modeling.load_modeling_dataset",
+            lambda case_study, label, **kwargs: fake_load_gbm(case_study, label, **kwargs),
+        )
+        for _, indexed, base, _ in payload:
+            base["label_ref"] = SimpleNamespace(name=indexed[0][1]["label"])
+
+    def observed_batch(study, indexed_requests, key, base, **kwargs):
+        alive_when_each_group_ran.append(
+            [name for name, _, entry, _ in payload if entry["mds"] is not None]
+        )
+        return [SimpleNamespace(index=indexed_requests[0][0], error=None, result=object())]
+
+    monkeypatch.setattr(module, batch_name, observed_batch)
+    study = SimpleNamespace(
+        case_study="cs",
+        require_writable=lambda: None,
+        activate=lambda tier: None,
+    )
+
+    module.run_model_plan(study, payload)
+
+    assert loaded == ["first", "second"]
+    assert alive_when_each_group_ran == [["first"], ["second"]]
+    assert [entry["mds"] for _, _, entry, _ in payload] == [None, None]
 
 
 def test_planned_tabm_runner_attempts_later_group_after_failure(monkeypatch) -> None:


### PR DESCRIPTION
## What was wrong

`plan_model_requests` builds a `base` per compatibility group and put the whole
dict, `base["mds"]` included, into the payload `run_model_plan` walks. A
compatibility group is one label, so a call spanning four labels held four
modeling datasets from planning until the last fit returned - and a
model-execution notebook keeps the plan alive across every cell after it, so
nothing released them.

Measured on `nasdaq100_microstructure`, one `load_modeling_dataset` per declared
label with nothing released:

| held | label | resident | peak | frame |
|---|---|---|---|---|
| 1 | fwd_ret_15m | 6.71 GiB | 19.86 GiB | 5.56 GiB |
| 2 | fwd_ret_5m | 12.65 GiB | 26.07 GiB | 5.74 GiB |
| 3 | fwd_dir_15m | 18.41 GiB | 31.56 GiB | 5.58 GiB |
| 4 | fwd_ret_60m | 22.53 GiB | 35.79 GiB | 4.75 GiB |

22.53 GiB resident and a 35.79 GiB peak before a single fit. That case study's
`06_linear` fits all four labels in one call and has never completed at full
scale: 51.5 GB on 2026-09-05 and 48.6 GB on 2026-09-10, both killed on memory,
the second on the third label - which is where the third panel lands.

The two `input_cache` dicts had the same shape for the same reason: keyed by
input, one entry per label, never evicted.

## What changed

The payload carries no panel. `run_model_plan` loads the group's panel when it
reaches the group and drops it in a `finally` afterwards, so one is alive at a
time. Both `input_cache` dicts are one-entry caches now, released before the
next panel is read.

Nothing else planning derived is rebuilt. The splits, the expected keys and the
runtime provenance in `base` are the planned ones, so no training or prediction
identity moves and nothing already registered is invalidated.

Same fix in `gbm.py`, which had the shape in all three places.

## Cost

One scan per group at execution, about 18 s on that minute panel. `_INPUT_MEMO`
is deliberately left holding the last planned panel rather than cleared, so a
single-group plan still reaches execution without a second read - which is what
`test_linear_model_plan_reuses_one_materialization_and_one_execution_fold_pass`
pins at one load, and it still passes unchanged.

## Tests

`test_planned_runner_holds_one_panel_at_a_time` is new, parameterized over both
families, and fails without the release: the second group runs with both panels
alive. `test_planned_fold_major_runner_attempts_later_group_after_failure` now
passes the dict `base` the planner actually builds rather than a bare `object()`.

`tests/test_research_models.py tests/test_research_model_planning.py` 87 passed.
The linear and gbm suites plus `test_modeling_input_lineage.py`,
`test_holdout_boundary.py` and `test_sp500_options_linear_fold_alignment.py`:
157 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sy1WqyZZTXcoyFYAjVbyiu
