### PR TITLE
Move the news-features seed to the directory chapter 10 now reads

### DIFF
--- a/tests/fixtures/seed_results.py
+++ b/tests/fixtures/seed_results.py
@@ -1934,8 +1934,18 @@ def _seed_demo_predictions(cs_dir: Path, cs_id: str, primary_label: str) -> None
 def _seed_news_features(output_dir: Path) -> None:
     """Seed a minimal news_features.parquet for Ch10/08_text_feature_evaluation.
 
-    The notebook loads from get_output_dir(8, "fnspid") / "news_features.parquet".
-    In test mode that becomes {ML4T_OUTPUT_DIR}/ch08_fnspid/news_features.parquet.
+    The panel is produced by 10/07_news_return_signals, which declares `gpu: true` and so
+    skips on a CI runner. 08 is the only chapter-10 notebook that runs there, so without this
+    seed it fails on a missing input rather than exercising anything. The notebook is right to
+    raise on the missing file - a notebook that tolerates absent input reports success for a
+    run that computed nothing - which is why the fixture supplies it instead.
+
+    The notebook loads from get_output_dir(10, "fnspid") / "news_features.parquet"; in test
+    mode that is {ML4T_OUTPUT_DIR}/ch10_fnspid/news_features.parquet. This directory name is
+    the notebook's chapter number, so it moves whenever the notebook's does - it read
+    get_output_dir(8, ...) until #902 corrected chapter 10's artifacts out of chapter 8's
+    output tree, and this seed did not move with it.
+
     Required columns: symbol, timestamp, fwd_ret_1d, fwd_ret_5d, fwd_ret_20d,
     weighted_surprise, sentiment_mean, sentiment_momentum, coverage_count.
     """
@@ -1945,7 +1955,7 @@ def _seed_news_features(output_dir: Path) -> None:
     except ImportError:
         return
 
-    out_dir = output_dir / "ch08_fnspid"
+    out_dir = output_dir / "ch10_fnspid"
     path = out_dir / "news_features.parquet"
     if path.exists():
         return


### PR DESCRIPTION
The ch10 CI job has been red on `main` since #902 merged. One directory name.

## What broke

#902 corrected two chapter-10 notebooks out of chapter 8's output tree: `07_news_return_signals` and `08_text_feature_evaluation` called `get_output_dir(8, "fnspid")` and now call `get_output_dir(10, ...)`. The CI fixture that seeds the panel they share did not move with them.

`tests/fixtures/seed_results.py::_seed_news_features` writes `news_features.parquet` into `{ML4T_OUTPUT_DIR}/ch08_fnspid/`. The notebook now looks in `ch10_fnspid/` and fails at its first cell:

    Cell 6: FileNotFoundError
    Missing input: /tmp/ml4t-test-output/ch10_fnspid/news_features.parquet

## Why it takes the whole job down

`08` is the only chapter-10 notebook that runs on a CI runner. The other eight carry `gpu: true` or a `docker_env` in `tests/overrides.yaml` and skip there - including `07_news_return_signals`, the notebook that would otherwise produce this panel. That is exactly what the seed is for: it lets `08` run without its producer. With the seed pointing elsewhere, chapter 10 has no coverage at all and the job is red on `main` and on every branch cut from it.

## Why not gate 08 instead

Gating `08` behind a skip would trade the only chapter-10 coverage CI has for a one-line mismatch, and `gpu: true` would mislabel it besides - `08` does no GPU work. Making the notebook tolerate a missing input is worse: `rules/notebook-standards.md` forbids a silent skip inside a notebook, and a notebook that carries on without its input reports success for a run that computed nothing. The raise is correct and stays.

## Verification

Against the job's own test rather than by inspection:

    pytest "tests/test_chapter_notebooks.py::test_chapter_notebook[10_text_feature_engineering::08_text_feature_evaluation.py]"

fails on `main` with the missing-input error above, and passes on this branch in 51 seconds.

The seeder's docstring now records why the seed exists, why the notebook's raise is right, and that this directory name tracks the notebook's chapter number - so the next person moving a notebook between chapters can see what else has to move with it.

Closes ml4t/agent-workspace#1110

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014qWNpT7VKxFHxJefsWHJVu
