### PR TITLE
nasdaq: the executed 04 and 06 renders

### DIFF
--- a/case_studies/nasdaq100_microstructure/04_model_based_features.ipynb
+++ b/case_studies/nasdaq100_microstructure/04_model_based_features.ipynb
@@ -2,13 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "2f4d3ce2",
+   "id": "d80eb802",
    "metadata": {
     "papermill": {
-     "duration": 0.013587,
-     "end_time": "2026-09-04T03:04:03.013655+00:00",
+     "duration": 0.016799,
+     "end_time": "2026-09-09T20:51:00.234495+00:00",
      "exception": false,
-     "start_time": "2026-09-04T03:04:03.000068+00:00",
+     "start_time": "2026-09-09T20:51:00.217696+00:00",
      "status": "completed"
     }
    },
@@ -65,9 +65,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "bcb94d08",
-   "metadata": {},
+   "execution_count": 1,
+   "id": "421933f1",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-09T20:51:00.274017Z",
+     "iopub.status.busy": "2026-09-09T20:51:00.272862Z",
+     "iopub.status.idle": "2026-09-09T20:51:03.112817Z",
+     "shell.execute_reply": "2026-09-09T20:51:03.112247Z"
+    },
+    "papermill": {
+     "duration": 2.862289,
+     "end_time": "2026-09-09T20:51:03.113581+00:00",
+     "exception": false,
+     "start_time": "2026-09-09T20:51:00.251292+00:00",
+     "status": "completed"
+    }
+   },
    "outputs": [],
    "source": [
     "\"\"\"NASDAQ-100 Microstructure: Model-Based Features (Ch9).\"\"\"\n",
@@ -99,9 +113,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "57f22a9d",
+   "execution_count": 2,
+   "id": "a89c79f2",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-09T20:51:03.120123Z",
+     "iopub.status.busy": "2026-09-09T20:51:03.119944Z",
+     "iopub.status.idle": "2026-09-09T20:51:03.122994Z",
+     "shell.execute_reply": "2026-09-09T20:51:03.122405Z"
+    },
+    "papermill": {
+     "duration": 0.006919,
+     "end_time": "2026-09-09T20:51:03.123427+00:00",
+     "exception": false,
+     "start_time": "2026-09-09T20:51:03.116508+00:00",
+     "status": "completed"
+    },
     "tags": [
      "parameters"
     ]
@@ -122,13 +149,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d93fbfb4",
+   "id": "51b04922",
    "metadata": {
     "papermill": {
-     "duration": 0.004046,
-     "end_time": "2026-09-04T03:04:05.069949+00:00",
+     "duration": 0.002745,
+     "end_time": "2026-09-09T20:51:03.130558+00:00",
      "exception": false,
-     "start_time": "2026-09-04T03:04:05.065903+00:00",
+     "start_time": "2026-09-09T20:51:03.127813+00:00",
      "status": "completed"
     }
    },
@@ -144,10 +171,35 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "5da020c2",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 3,
+   "id": "81dfeaa7",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-09T20:51:03.138495Z",
+     "iopub.status.busy": "2026-09-09T20:51:03.138340Z",
+     "iopub.status.idle": "2026-09-09T20:51:03.170851Z",
+     "shell.execute_reply": "2026-09-09T20:51:03.170559Z"
+    },
+    "papermill": {
+     "duration": 0.037681,
+     "end_time": "2026-09-09T20:51:03.171464+00:00",
+     "exception": false,
+     "start_time": "2026-09-09T20:51:03.133783+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "polars.config.Config"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "CASE_DIR = get_case_study_dir(CASE_STUDY_ID)\n",
     "FEATURES_DIR = CASE_DIR / \"features\"\n",
@@ -203,10 +255,36 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "13a913c8",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 4,
+   "id": "c1339ea8",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-09T20:51:03.179293Z",
+     "iopub.status.busy": "2026-09-09T20:51:03.179201Z",
+     "iopub.status.idle": "2026-09-09T20:51:03.181946Z",
+     "shell.execute_reply": "2026-09-09T20:51:03.181694Z"
+    },
+    "papermill": {
+     "duration": 0.006338,
+     "end_time": "2026-09-09T20:51:03.182222+00:00",
+     "exception": false,
+     "start_time": "2026-09-09T20:51:03.175884+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Sample: 2020-01-01 to 2021-12-31, minute bars on the NYSE calendar.\n",
+      "The holdout runs 2021-07-01 to 2021-12-31. Nothing is fitted on it and no number printed below is measured over it; features are still written for it, from windows that end before it, so that a model scored there has inputs.\n",
+      "Predictions are made for fwd_ret_15m, the return over the next 15min (15 bars). The case study also configures fwd_ret_5m, fwd_ret_60m, fwd_dir_15m, whose horizons differ, and each of them asks for a different walk-forward split - which is why Section B resolves one per label.\n",
+      "The HAR regression reads 5, 15 and 60 minutes of squared returns and is refitted on the trailing 120 bars: long enough for the four coefficients to be identified, short enough that the fit follows the day rather than the quarter.\n",
+      "Each spectrum spans 60 bars, which resolves periods up to an hour, and each signature path spans 30 bars, which is the horizon over which order flow and price are expected to lead one another.\n"
+     ]
+    }
+   ],
    "source": [
     "print(f\"Sample: {START_DATE} to {END_DATE}, minute bars on the {CALENDAR} calendar.\")\n",
     "print(\n",
@@ -237,13 +315,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7f3b8b46",
+   "id": "55a7ed98",
    "metadata": {
     "papermill": {
-     "duration": 0.002696,
-     "end_time": "2026-09-04T03:04:05.133813+00:00",
+     "duration": 0.002654,
+     "end_time": "2026-09-09T20:51:03.187693+00:00",
      "exception": false,
-     "start_time": "2026-09-04T03:04:05.131117+00:00",
+     "start_time": "2026-09-09T20:51:03.185039+00:00",
      "status": "completed"
     }
    },
@@ -259,9 +337,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "d4963b7b",
-   "metadata": {},
+   "execution_count": 5,
+   "id": "e724730c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-09T20:51:03.193976Z",
+     "iopub.status.busy": "2026-09-09T20:51:03.193884Z",
+     "iopub.status.idle": "2026-09-09T20:51:04.181267Z",
+     "shell.execute_reply": "2026-09-09T20:51:04.180359Z"
+    },
+    "papermill": {
+     "duration": 0.991709,
+     "end_time": "2026-09-09T20:51:04.182118+00:00",
+     "exception": false,
+     "start_time": "2026-09-09T20:51:03.190409+00:00",
+     "status": "completed"
+    }
+   },
    "outputs": [],
    "source": [
     "READ = [\n",
@@ -318,13 +410,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7b079020",
+   "id": "49c43489",
    "metadata": {
     "papermill": {
-     "duration": 0.002792,
-     "end_time": "2026-09-04T03:04:05.701106+00:00",
+     "duration": 0.003539,
+     "end_time": "2026-09-09T20:51:04.189066+00:00",
      "exception": false,
-     "start_time": "2026-09-04T03:04:05.698314+00:00",
+     "start_time": "2026-09-09T20:51:04.185527+00:00",
      "status": "completed"
     }
    },
@@ -339,10 +431,33 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "14ace662",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 6,
+   "id": "d36189f1",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-09T20:51:04.198647Z",
+     "iopub.status.busy": "2026-09-09T20:51:04.198504Z",
+     "iopub.status.idle": "2026-09-09T20:51:07.119805Z",
+     "shell.execute_reply": "2026-09-09T20:51:07.119267Z"
+    },
+    "papermill": {
+     "duration": 2.925838,
+     "end_time": "2026-09-09T20:51:07.120088+00:00",
+     "exception": false,
+     "start_time": "2026-09-09T20:51:04.194250+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "505 scheduled sessions, 3 of them early closes\n",
+      "54,900 padded bars dropped past the scheduled close\n"
+     ]
+    }
+   ],
    "source": [
     "_schedule = TradingCalendar(CALENDAR).calendar.schedule(start_date=START_DATE, end_date=END_DATE)\n",
     "sessions = pl.DataFrame(\n",
@@ -375,13 +490,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8da38207",
+   "id": "2f1e6e76",
    "metadata": {
     "papermill": {
-     "duration": 0.002718,
-     "end_time": "2026-09-04T03:04:08.073747+00:00",
+     "duration": 0.002744,
+     "end_time": "2026-09-09T20:51:07.125787+00:00",
      "exception": false,
-     "start_time": "2026-09-04T03:04:08.071029+00:00",
+     "start_time": "2026-09-09T20:51:07.123043+00:00",
      "status": "completed"
     }
    },
@@ -392,10 +507,57 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "c6ee229a",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 7,
+   "id": "7f402d3a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-09T20:51:07.132021Z",
+     "iopub.status.busy": "2026-09-09T20:51:07.131932Z",
+     "iopub.status.idle": "2026-09-09T20:51:07.464467Z",
+     "shell.execute_reply": "2026-09-09T20:51:07.463707Z"
+    },
+    "papermill": {
+     "duration": 0.336368,
+     "end_time": "2026-09-09T20:51:07.464931+00:00",
+     "exception": false,
+     "start_time": "2026-09-09T20:51:07.128563+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div><style>\n",
+       ".dataframe > thead > tr,\n",
+       ".dataframe > tbody > tr {\n",
+       "  text-align: right;\n",
+       "  white-space: pre-wrap;\n",
+       "}\n",
+       "</style>\n",
+       "<small>shape: (7, 2)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>quantity</th><th>value</th></tr><tr><td>str</td><td>str</td></tr></thead><tbody><tr><td>&quot;symbols&quot;</td><td>&quot;115&quot;</td></tr><tr><td>&quot;sessions&quot;</td><td>&quot;505&quot;</td></tr><tr><td>&quot;minute bars&quot;</td><td>&quot;20,025,030&quot;</td></tr><tr><td>&quot;first bar&quot;</td><td>&quot;2020-01-02 09:30:00&quot;</td></tr><tr><td>&quot;last bar&quot;</td><td>&quot;2021-12-31 15:59:00&quot;</td></tr><tr><td>&quot;median bars a name trades in a…</td><td>&quot;390&quot;</td></tr><tr><td>&quot;median names quoting per sessi…</td><td>&quot;102&quot;</td></tr></tbody></table></div>"
+      ],
+      "text/plain": [
+       "shape: (7, 2)\n",
+       "┌─────────────────────────────────┬─────────────────────┐\n",
+       "│ quantity                        ┆ value               │\n",
+       "│ ---                             ┆ ---                 │\n",
+       "│ str                             ┆ str                 │\n",
+       "╞═════════════════════════════════╪═════════════════════╡\n",
+       "│ symbols                         ┆ 115                 │\n",
+       "│ sessions                        ┆ 505                 │\n",
+       "│ minute bars                     ┆ 20,025,030          │\n",
+       "│ first bar                       ┆ 2020-01-02 09:30:00 │\n",
+       "│ last bar                        ┆ 2021-12-31 15:59:00 │\n",
+       "│ median bars a name trades in a… ┆ 390                 │\n",
+       "│ median names quoting per sessi… ┆ 102                 │\n",
+       "└─────────────────────────────────┴─────────────────────┘"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "sessions_seen = df.group_by(\"session_date\").agg(pl.col(\"symbol\").n_unique().alias(\"symbols\"))\n",
     "symbol_sessions = df.group_by(\"session_date\", \"symbol\").agg(pl.len().alias(\"bars\"))\n",
@@ -427,13 +589,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "db4c5490",
+   "id": "c7d48912",
    "metadata": {
     "papermill": {
-     "duration": 0.003509,
-     "end_time": "2026-09-04T03:04:08.664087+00:00",
+     "duration": 0.002834,
+     "end_time": "2026-09-09T20:51:07.470899+00:00",
      "exception": false,
-     "start_time": "2026-09-04T03:04:08.660578+00:00",
+     "start_time": "2026-09-09T20:51:07.468065+00:00",
      "status": "completed"
     }
    },
@@ -461,10 +623,39 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "f0ede1f5",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 8,
+   "id": "c98b0ea9",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-09T20:51:07.478078Z",
+     "iopub.status.busy": "2026-09-09T20:51:07.477911Z",
+     "iopub.status.idle": "2026-09-09T20:51:10.746827Z",
+     "shell.execute_reply": "2026-09-09T20:51:10.746419Z"
+    },
+    "papermill": {
+     "duration": 3.273497,
+     "end_time": "2026-09-09T20:51:10.747277+00:00",
+     "exception": false,
+     "start_time": "2026-09-09T20:51:07.473780+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Signed volume share stays inside [-1, 1]; the largest magnitude is 1.000.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Minute panel digest: ae8fbd77fdbd64f5\n"
+     ]
+    }
+   ],
    "source": [
     "TRADED_VOLUME = (pl.col(\"volume\") + pl.col(\"finra_volume\")).clip(lower_bound=1)\n",
     "signed_vol = (pl.col(\"trade_at_ask\") + pl.col(\"trade_at_mid_ask\")) - (\n",
@@ -497,13 +688,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "238599dd",
+   "id": "13054c13",
    "metadata": {
     "papermill": {
-     "duration": 0.002985,
-     "end_time": "2026-09-04T03:04:11.362467+00:00",
+     "duration": 0.002882,
+     "end_time": "2026-09-09T20:51:10.753312+00:00",
      "exception": false,
-     "start_time": "2026-09-04T03:04:11.359482+00:00",
+     "start_time": "2026-09-09T20:51:10.750430+00:00",
      "status": "completed"
     }
    },
@@ -547,13 +738,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c87b6c57",
+   "id": "ae89ab87",
    "metadata": {
     "papermill": {
-     "duration": 0.002922,
-     "end_time": "2026-09-04T03:04:11.368311+00:00",
+     "duration": 0.00276,
+     "end_time": "2026-09-09T20:51:10.758991+00:00",
      "exception": false,
-     "start_time": "2026-09-04T03:04:11.365389+00:00",
+     "start_time": "2026-09-09T20:51:10.756231+00:00",
      "status": "completed"
     }
    },
@@ -578,10 +769,66 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "2675e7b0",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 9,
+   "id": "4183a3c9",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-09T20:51:10.765651Z",
+     "iopub.status.busy": "2026-09-09T20:51:10.765555Z",
+     "iopub.status.idle": "2026-09-09T20:51:13.438346Z",
+     "shell.execute_reply": "2026-09-09T20:51:13.437880Z"
+    },
+    "papermill": {
+     "duration": 2.676915,
+     "end_time": "2026-09-09T20:51:13.438787+00:00",
+     "exception": false,
+     "start_time": "2026-09-09T20:51:10.761872+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div><style>\n",
+       ".dataframe > thead > tr,\n",
+       ".dataframe > tbody > tr {\n",
+       "  text-align: right;\n",
+       "  white-space: pre-wrap;\n",
+       "}\n",
+       "</style>\n",
+       "<small>shape: (8, 7)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>label</th><th>seals</th><th>fold</th><th>train_start</th><th>train_end</th><th>val_start</th><th>val_end</th></tr><tr><td>str</td><td>str</td><td>i64</td><td>datetime[μs]</td><td>datetime[μs]</td><td>datetime[μs]</td><td>datetime[μs]</td></tr></thead><tbody><tr><td>&quot;fwd_dir_15m&quot;</td><td>&quot;16min&quot;</td><td>0</td><td>2020-01-02 09:30:00</td><td>2020-06-30 10:31:00</td><td>2020-06-30 10:48:00</td><td>2020-12-30 10:01:00</td></tr><tr><td>&quot;fwd_ret_15m&quot;</td><td>&quot;16min&quot;</td><td>0</td><td>2020-01-02 09:30:00</td><td>2020-06-30 10:31:00</td><td>2020-06-30 10:48:00</td><td>2020-12-30 10:01:00</td></tr><tr><td>&quot;fwd_ret_5m&quot;</td><td>&quot;6min&quot;</td><td>0</td><td>2020-01-02 09:30:00</td><td>2020-06-30 10:33:00</td><td>2020-06-30 10:40:00</td><td>2020-12-30 09:52:00</td></tr><tr><td>&quot;fwd_ret_60m&quot;</td><td>&quot;61min&quot;</td><td>0</td><td>2020-01-02 09:30:00</td><td>2020-06-30 09:39:00</td><td>2020-06-30 10:41:00</td><td>2020-12-30 10:20:00</td></tr><tr><td>&quot;fwd_dir_15m&quot;</td><td>&quot;16min&quot;</td><td>1</td><td>2020-06-30 10:48:00</td><td>2020-12-30 09:45:00</td><td>2020-12-30 10:02:00</td><td>2021-06-30 15:43:00</td></tr><tr><td>&quot;fwd_ret_15m&quot;</td><td>&quot;16min&quot;</td><td>1</td><td>2020-06-30 10:48:00</td><td>2020-12-30 09:45:00</td><td>2020-12-30 10:02:00</td><td>2021-06-30 15:43:00</td></tr><tr><td>&quot;fwd_ret_5m&quot;</td><td>&quot;6min&quot;</td><td>1</td><td>2020-06-30 10:40:00</td><td>2020-12-30 09:46:00</td><td>2020-12-30 09:53:00</td><td>2021-06-30 15:53:00</td></tr><tr><td>&quot;fwd_ret_60m&quot;</td><td>&quot;61min&quot;</td><td>1</td><td>2020-06-30 10:41:00</td><td>2020-12-29 14:58:00</td><td>2020-12-30 10:21:00</td><td>2021-06-30 14:58:00</td></tr></tbody></table></div>"
+      ],
+      "text/plain": [
+       "shape: (8, 7)\n",
+       "┌─────────────┬───────┬──────┬─────────────────┬─────────────────┬────────────────┬────────────────┐\n",
+       "│ label       ┆ seals ┆ fold ┆ train_start     ┆ train_end       ┆ val_start      ┆ val_end        │\n",
+       "│ ---         ┆ ---   ┆ ---  ┆ ---             ┆ ---             ┆ ---            ┆ ---            │\n",
+       "│ str         ┆ str   ┆ i64  ┆ datetime[μs]    ┆ datetime[μs]    ┆ datetime[μs]   ┆ datetime[μs]   │\n",
+       "╞═════════════╪═══════╪══════╪═════════════════╪═════════════════╪════════════════╪════════════════╡\n",
+       "│ fwd_dir_15m ┆ 16min ┆ 0    ┆ 2020-01-02      ┆ 2020-06-30      ┆ 2020-06-30     ┆ 2020-12-30     │\n",
+       "│             ┆       ┆      ┆ 09:30:00        ┆ 10:31:00        ┆ 10:48:00       ┆ 10:01:00       │\n",
+       "│ fwd_ret_15m ┆ 16min ┆ 0    ┆ 2020-01-02      ┆ 2020-06-30      ┆ 2020-06-30     ┆ 2020-12-30     │\n",
+       "│             ┆       ┆      ┆ 09:30:00        ┆ 10:31:00        ┆ 10:48:00       ┆ 10:01:00       │\n",
+       "│ fwd_ret_5m  ┆ 6min  ┆ 0    ┆ 2020-01-02      ┆ 2020-06-30      ┆ 2020-06-30     ┆ 2020-12-30     │\n",
+       "│             ┆       ┆      ┆ 09:30:00        ┆ 10:33:00        ┆ 10:40:00       ┆ 09:52:00       │\n",
+       "│ fwd_ret_60m ┆ 61min ┆ 0    ┆ 2020-01-02      ┆ 2020-06-30      ┆ 2020-06-30     ┆ 2020-12-30     │\n",
+       "│             ┆       ┆      ┆ 09:30:00        ┆ 09:39:00        ┆ 10:41:00       ┆ 10:20:00       │\n",
+       "│ fwd_dir_15m ┆ 16min ┆ 1    ┆ 2020-06-30      ┆ 2020-12-30      ┆ 2020-12-30     ┆ 2021-06-30     │\n",
+       "│             ┆       ┆      ┆ 10:48:00        ┆ 09:45:00        ┆ 10:02:00       ┆ 15:43:00       │\n",
+       "│ fwd_ret_15m ┆ 16min ┆ 1    ┆ 2020-06-30      ┆ 2020-12-30      ┆ 2020-12-30     ┆ 2021-06-30     │\n",
+       "│             ┆       ┆      ┆ 10:48:00        ┆ 09:45:00        ┆ 10:02:00       ┆ 15:43:00       │\n",
+       "│ fwd_ret_5m  ┆ 6min  ┆ 1    ┆ 2020-06-30      ┆ 2020-12-30      ┆ 2020-12-30     ┆ 2021-06-30     │\n",
+       "│             ┆       ┆      ┆ 10:40:00        ┆ 09:46:00        ┆ 09:53:00       ┆ 15:53:00       │\n",
+       "│ fwd_ret_60m ┆ 61min ┆ 1    ┆ 2020-06-30      ┆ 2020-12-29      ┆ 2020-12-30     ┆ 2021-06-30     │\n",
+       "│             ┆       ┆      ┆ 10:41:00        ┆ 14:58:00        ┆ 10:21:00       ┆ 14:58:00       │\n",
+       "└─────────────┴───────┴──────┴─────────────────┴─────────────────┴────────────────┴────────────────┘"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "label_splits: dict[str, list[dict]] = {}\n",
     "label_timeline_digest: dict[str, str] = {}\n",
@@ -626,13 +873,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1f99b821",
+   "id": "4822f16b",
    "metadata": {
     "papermill": {
-     "duration": 0.002939,
-     "end_time": "2026-09-04T03:04:13.882931+00:00",
+     "duration": 0.002933,
+     "end_time": "2026-09-09T20:51:13.445638+00:00",
      "exception": false,
-     "start_time": "2026-09-04T03:04:13.879992+00:00",
+     "start_time": "2026-09-09T20:51:13.442705+00:00",
      "status": "completed"
     }
    },
@@ -647,10 +894,32 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "4839dc9e",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 10,
+   "id": "6fe7243e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-09T20:51:13.452245Z",
+     "iopub.status.busy": "2026-09-09T20:51:13.452130Z",
+     "iopub.status.idle": "2026-09-09T20:51:13.454511Z",
+     "shell.execute_reply": "2026-09-09T20:51:13.454262Z"
+    },
+    "papermill": {
+     "duration": 0.006332,
+     "end_time": "2026-09-09T20:51:13.454926+00:00",
+     "exception": false,
+     "start_time": "2026-09-09T20:51:13.448594+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The contract holds for 2 folds on each of 4 targets.\n"
+     ]
+    }
+   ],
    "source": [
     "for label, label_split in label_splits.items():\n",
     "    seal = pd.Timedelta(resolve_label_buffer(CASE_STUDY_ID, label, SETUP))\n",
@@ -666,13 +935,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f76fd67a",
+   "id": "237dbd1a",
    "metadata": {
     "papermill": {
-     "duration": 0.002851,
-     "end_time": "2026-09-04T03:04:13.899179+00:00",
+     "duration": 0.00289,
+     "end_time": "2026-09-09T20:51:13.460794+00:00",
      "exception": false,
-     "start_time": "2026-09-04T03:04:13.896328+00:00",
+     "start_time": "2026-09-09T20:51:13.457904+00:00",
      "status": "completed"
     }
    },
@@ -690,10 +959,34 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "37376955",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 11,
+   "id": "4a740ba5",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-09T20:51:13.467445Z",
+     "iopub.status.busy": "2026-09-09T20:51:13.467359Z",
+     "iopub.status.idle": "2026-09-09T20:51:13.469866Z",
+     "shell.execute_reply": "2026-09-09T20:51:13.469626Z"
+    },
+    "papermill": {
+     "duration": 0.006441,
+     "end_time": "2026-09-09T20:51:13.470186+00:00",
+     "exception": false,
+     "start_time": "2026-09-09T20:51:13.463745+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Fold 0 needs 2020-01-02 09:30:00 .. 2020-12-30 10:20:00\n",
+      "  Fold 1 needs 2020-06-30 10:40:00 .. 2021-06-30 15:53:00\n",
+      "  Fold 2 needs every bar from 2020-01-02 09:30:00 to 2021-12-31, and is trained on everything before the holdout opens.\n"
+     ]
+    }
+   ],
    "source": [
     "fold_window = {\n",
     "    s[\"fold\"]: (\n",
@@ -722,9 +1015,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "8c41876d",
-   "metadata": {},
+   "execution_count": 12,
+   "id": "54a0c876",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-09T20:51:13.476673Z",
+     "iopub.status.busy": "2026-09-09T20:51:13.476597Z",
+     "iopub.status.idle": "2026-09-09T20:51:13.478514Z",
+     "shell.execute_reply": "2026-09-09T20:51:13.478289Z"
+    },
+    "papermill": {
+     "duration": 0.005884,
+     "end_time": "2026-09-09T20:51:13.479055+00:00",
+     "exception": false,
+     "start_time": "2026-09-09T20:51:13.473171+00:00",
+     "status": "completed"
+    }
+   },
    "outputs": [],
    "source": [
     "def validation_rows(frame: pl.DataFrame) -> pl.DataFrame:\n",
@@ -748,13 +1055,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2bdc8ef0",
+   "id": "63fe0bdc",
    "metadata": {
     "papermill": {
-     "duration": 0.002895,
-     "end_time": "2026-09-04T03:04:13.924358+00:00",
+     "duration": 0.002906,
+     "end_time": "2026-09-09T20:51:13.484964+00:00",
      "exception": false,
-     "start_time": "2026-09-04T03:04:13.921463+00:00",
+     "start_time": "2026-09-09T20:51:13.482058+00:00",
      "status": "completed"
     }
    },
@@ -771,10 +1078,277 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "fd6619c9",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 13,
+   "id": "6d1e8422",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-09T20:51:13.491411Z",
+     "iopub.status.busy": "2026-09-09T20:51:13.491327Z",
+     "iopub.status.idle": "2026-09-09T20:51:14.864639Z",
+     "shell.execute_reply": "2026-09-09T20:51:14.862794Z"
+    },
+    "papermill": {
+     "duration": 1.378867,
+     "end_time": "2026-09-09T20:51:14.866778+00:00",
+     "exception": false,
+     "start_time": "2026-09-09T20:51:13.487911+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.plotly.v1+json": {
+       "config": {
+        "plotlyServerURL": "https://plot.ly"
+       },
+       "data": [
+        {
+         "legendgroup": "Training bars",
+         "line": {
+          "color": "#0a1628",
+          "width": 16
+         },
+         "mode": "lines",
+         "name": "Training bars",
+         "showlegend": true,
+         "type": "scatter",
+         "x": [
+          "2020-01-02T09:30:00",
+          "2020-06-30T10:31:00"
+         ],
+         "y": [
+          "Fold 0",
+          "Fold 0"
+         ]
+        },
+        {
+         "legendgroup": "Validation bars",
+         "line": {
+          "color": "#D4A84B",
+          "width": 16
+         },
+         "mode": "lines",
+         "name": "Validation bars",
+         "showlegend": true,
+         "type": "scatter",
+         "x": [
+          "2020-06-30T10:48:00",
+          "2020-12-30T10:01:00"
+         ],
+         "y": [
+          "Fold 0",
+          "Fold 0"
+         ]
+        },
+        {
+         "legendgroup": "Training bars",
+         "line": {
+          "color": "#0a1628",
+          "width": 16
+         },
+         "mode": "lines",
+         "name": "Training bars",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2020-06-30T10:48:00",
+          "2020-12-30T09:45:00"
+         ],
+         "y": [
+          "Fold 1",
+          "Fold 1"
+         ]
+        },
+        {
+         "legendgroup": "Validation bars",
+         "line": {
+          "color": "#D4A84B",
+          "width": 16
+         },
+         "mode": "lines",
+         "name": "Validation bars",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2020-12-30T10:02:00",
+          "2021-06-30T15:43:00"
+         ],
+         "y": [
+          "Fold 1",
+          "Fold 1"
+         ]
+        },
+        {
+         "legendgroup": "Training bars",
+         "line": {
+          "color": "#0a1628",
+          "width": 16
+         },
+         "mode": "lines",
+         "name": "Training bars",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2020-01-02T09:30:00",
+          "2021-07-01T00:00:00"
+         ],
+         "y": [
+          "Fold 2",
+          "Fold 2"
+         ]
+        },
+        {
+         "legendgroup": "Holdout bars",
+         "line": {
+          "color": "#94a3b8",
+          "width": 16
+         },
+         "mode": "lines",
+         "name": "Holdout bars",
+         "showlegend": true,
+         "type": "scatter",
+         "x": [
+          "2021-07-01T00:00:00",
+          "2022-01-01T00:00:00"
+         ],
+         "y": [
+          "Fold 2",
+          "Fold 2"
+         ]
+        }
+       ],
+       "layout": {
+        "height": 460,
+        "margin": {
+         "l": 90,
+         "t": 140
+        },
+        "shapes": [
+         {
+          "fillcolor": "#94a3b8",
+          "layer": "below",
+          "line": {
+           "width": 0
+          },
+          "opacity": 0.12,
+          "type": "rect",
+          "x0": "2021-07-01T00:00:00",
+          "x1": "2022-01-01T00:00:00",
+          "xref": "x",
+          "y0": 0,
+          "y1": 1,
+          "yref": "y domain"
+         },
+         {
+          "line": {
+           "color": "#ef4444",
+           "dash": "dash"
+          },
+          "type": "line",
+          "x0": "2021-07-01T00:00:00",
+          "x1": "2021-07-01T00:00:00",
+          "xref": "x",
+          "y0": 0,
+          "y1": 1,
+          "yref": "y domain"
+         }
+        ],
+        "template": {
+         "layout": {
+          "colorway": [
+           "#0a1628",
+           "#D4A84B",
+           "#C87533",
+           "#10b981",
+           "#ef4444",
+           "#94a3b8"
+          ],
+          "font": {
+           "color": "#334155",
+           "family": "DM Sans, DejaVu Sans, sans-serif",
+           "size": 11
+          },
+          "hoverlabel": {
+           "bgcolor": "white",
+           "font": {
+            "family": "DM Sans, DejaVu Sans, sans-serif",
+            "size": 11
+           }
+          },
+          "legend": {
+           "bgcolor": "rgba(255,255,255,0.8)",
+           "bordercolor": "#e8e8e6",
+           "borderwidth": 1,
+           "font": {
+            "size": 10
+           }
+          },
+          "paper_bgcolor": "#FAFAF9",
+          "plot_bgcolor": "white",
+          "title": {
+           "font": {
+            "color": "#0a1628",
+            "size": 14
+           },
+           "x": 0.5,
+           "xanchor": "center"
+          },
+          "xaxis": {
+           "gridcolor": "#e8e8e6",
+           "gridwidth": 0.5,
+           "linecolor": "#e8e8e6",
+           "showgrid": true,
+           "tickfont": {
+            "size": 10
+           },
+           "title": {
+            "font": {
+             "size": 11
+            }
+           }
+          },
+          "yaxis": {
+           "gridcolor": "#e8e8e6",
+           "gridwidth": 0.5,
+           "linecolor": "#e8e8e6",
+           "showgrid": true,
+           "tickfont": {
+            "size": 10
+           },
+           "title": {
+            "font": {
+             "size": 11
+            }
+           }
+          }
+         }
+        },
+        "title": {
+         "text": "Every fold trains left of the validation span it is scored on<br><sup>The dashed rule is where the holdout opens and the shaded region is the<br>holdout itself. The last fold is the one written so that a model scored on the<br>holdout has features there; its training bars all predate the rule. Spans overlap<br>between folds because the fold tag selects rows rather than changing values.</sup>"
+        },
+        "xaxis": {
+         "title": {
+          "text": "Session"
+         }
+        },
+        "yaxis": {
+         "title": {
+          "text": ""
+         }
+        }
+       }
+      },
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAArwAAAHMCAYAAAA3cHsfAAAQAElEQVR4AeydBWAURxfH/xfBoS1eKFKkWHF3hw93d3d3CQ7B3T24OxRrKe7u7lKgOBTn2zdkj8vlLrmE2N39IbM7O/Pmzczvze69m53dc3n//t0XBjLgGOAY4BjgGOAY4BjgGOAYcNQx4AL+IwESIAESAEAIJEACJEACjkqADq+jWpb9IgESIAESIAESIIHAEHDAMnR4HdCo7BIJkAAJkAAJkAAJkMA3AnR4v7FgjARIwHYClCQBEiABEiABuyFAh9duTMWGkgAJkAAJkAAJhD0CbJE9EKDDaw9WYhtJgARIgARIgARIgAQCTYAOb6DRsSAJ2E6AkiRAAiRAAiRAAqFHgA5v6LFnzSRAAiRAAiTgbATYXxIIFQJ0eEMFOyslARIgARIgARIgARIIKQJ0eEOKNOuxnQAlSYAESIAESIAESCAICdDhDUKYVEUCJEACJEACQUmAukiABIKGAB3eoOFILSRAAiRAAiRAAiRAAmGUAB3eMGoY25tFSRIgARIgARIgARIgAb8I0OH1iw7zSIAESIAE7IcAW0oCJEACVgjQ4bUChskkQAIkQAIkQAIkQAKOQcDZHF7HsBp7QQIkQAIkQAIkQAIkYDMBOrw2o6IgCZAACTgSAfaFBEiABJyHAB1e57E1e0oCJEACJEACJEACTknAT4fXKYmw0yRAAiRAAiRAAiRAAg5FgA6vQ5mTnSEBEggmAlRLAiRAAiRgxwTo8Nqx8dh0EiABEiABEiABEghZAvZZGx1e+7QbW00CJEACJEACJEACJGAjATq8NoKiGAmQgO0EKEkCJEACJEACYYkAHd6wZA22hQRIgARIgARIwJEIsC9hhAAd3jBiCDaDBEiABEiABEiABEggeAjQ4Q0ertRKArYToCQJkAAJkAAJkECwEqDDG6x4qZwESIAESIAESMBWApQjgeAiQIc3uMhSLwmQAAmQAAmQAAmQQJggQIc3TJiBjbCdACVJgARIgARIgARIIGAE6PAGjBelSYAESIAESCBsEGArSIAEbCZAh9dmVBQkARIgARIgARIgARKwRwJ0eO3Rara3mZIkQAIkQAIkQAIk4PQE6PA6/RAgABIgARJwBgLsIwmQgDMToMPrzNZn30mABEiABEiABEjACQjQ4TUxMqMkQAIkQAIkQAIkQAKOR4AOr+PZlD0iARIgge8lwPIkQAIk4FAE6PA6lDnZGRIgARIgARIgARIgAXMCgXd4zTXxmARIgARIgARIgARIgATCIAE6vGHQKGwSCZCAfRFga0mABEiABMI2ATq8Yds+bB0JkAAJkAAJkAAJ2AuBMNtOOrxh1jRsGAmQAAmQAAmQAAmQQFAQoMMbFBSpgwRIwHYClCQBEiABEiCBECZAhzeEgbM6EiABEiABEiABEhACDCFHgA5vyLFmTSRAAiRAAiRAAiRAAqFAgA5vKEBnlSRgOwFKkgAJkAAJkAAJfC8BOrzfS5DlSYAESIAESIAEgp8AayCB7yBAh/c74LEoCZAACZAACZAACZBA2CdAhzfs24gttJ0AJUmABEiABEiABEjAFwE6vL6QMIEESIAESIAE7J0A208CJGBKgA6vKQ3GSYAESIAESIAESIAEHI4AHV6HM6ntHaIkCZAACZAACZAACTgDATq8zmBl9pEESIAESMAvAswjARJwcAJ0eB3cwOweCZAACZAACZAACTg7ATq8to4AypEACZAACZAACZAACdglATq8dmk2NpoESIAEQo8AayYBEiABeyNAh9feLMb2kgAJkAAJkAAJkAAJBIhAMDm8AWoDhUmABEiABEiABEiABEgg2AjQ4Q02tFRMAiRAAgAIgQRIgARIINQJ0OENdROwAWGFwLUbt1CrcXskSZsfCVPltqlZU2ctQv7/VfdTtkV7D7TvPtBPmaDMlDblK14tKFX60pUsfQGs3bjdV7pfCZNnLFCsfvwlPSZOm+eXaIDztv+9F2WqNkbcZNmUDW1VMGrCLJSo2MBW8RCVq9esM3r0G26ss16zTujed5jx2FIkfa6SWLZqo6WsAKUlTZc/wPYNUAVhXDgw/T919gJkbD/+92kY7933Ny+oxtn3t4Qa7I1AaLaXDm9o0nfgum/euqsu/vIBYB4C6iiFFKapsxbizZu3OLJrLW6d3xtS1eL4ybOK1bPnL4Kkzp/jxkaGdKmDRFdQKXn46F/07D8CXdo1xZNbx9G6WV3lmPYaMDJIqug3eCyyZEyLG2d2Y+HMsRZ1ypeYjZt3WMyzh8SUvyXFr4kSBGlT5YtHwVI1fenMkS0jYkT/0Ve6sySY9t/W8zNypIgokDcH3N3dnAUT+0kCdkWADq9dmcv+Gju0fzesXzbTR8iVPVOY7Mjd+/8gberfEP0n+/6gL1eqCMaP6BumGN+990C1J3/e7HBx8euyo8QCvLl15x6yZ8mICBHCB7isvRTo0aklmjX07ZwGR/vlS0OenFmCQ7Vd6AxM/5P+mghrFk/DD9Gi2kUf2UgScDYCQf/J42wE2V8/CaRJlRx5c2X1EWLFjI7rN29DZn7Pnr/so/y8xauQPENBfPjwQaVfuHQNtZt0QMpMRVR6i/YeMJ0J1W9Jy0xVtgLl8FOCDFi0fJ2S13UoRdqmadueqN+8ixbz/ZciY2HI7N/4qV6qXfoShKPHT6N8jWZIlDoPMuUpjd4DR+G//976VuCd8ur1G0jZ3zIWQtocJdSspneWxZ3MhOszbInT5FV1SztFuHLtlpAZ0FYd+yBNtuKqHZI+Y+5iSJ7IZ8lXFoNHTMTHjx8lSwXzJQ0i6zFoFDr0GIRUWYqqdg0YOt5HmXWbtqNizRaqn2KXAiVr4J72BUAptGHjl51mei2B3scEKXOpPjZq2VXxnjR9vjqWOi9evm6xpn8ePYYwkbYn18ZGgxZdcefufSV77sIVVf7Fy1eo3qCNilu6pZ85bxmIjCxZkbpSZy2myusbaWPW/GXVcpbGrbvjwcNHepbab/1rN/5Xob7iI8yHjp6KT58+qTzzjS1jW8bJoOETUKx8XQgT4b1q3WZzVT6OzZc03Lh5B9XqtVbLb7IXrIAlK9f7kJcDv8aKnCcynvUZTOEyd8EKKQbzW/p+2UAK6Ofh9DmL4RdHkdWDMGjfbSByFamk7Bb/t5yQ80/Pl3Er+TUbtVPnvpxP/YaM9TFu/eqf6AlMu6Sc3n+/zk+RMw3mSxr8659pWYmfOX8JsoxFxqbYQs75v3cfkCwVZMmVni/XQ7kunL94VeXJZvGKdZBxJBwLlKiBOfOXS7IxxEycGV6LVqrzXK4dw8ZMU3n+jW1bxplSZLJ5//4DZHzLWJDxXbpKY+w7eNREApD2zF+yGlXqtFRjOE/RKli6coMPGac/IIAgJUCHN0hxUpmtBOTWbPYsGbB6vc8P+VXrtqBCmWLabUF3yG3wctWaIP3vqbF++SxsXTsPP/wQBVW1D/nPnz8bqzpx+hyOnjiDZV6TcPPcHlQq+z98+PgBm7fvMso8f/ESazduQ40qZY1pppGLx//E/4rkQ7sW9fHszkmMHeoBmZUsW60p4saOhaO712PiqP5YrDnTnXsNMS3qI96r/0is15zHuVNH4M/1C/DPw3/x1859PmRMDxIljI8dGxeppBtnd6u6p4//pn+29qGVNEki7N6yFPOmj1JyL16+Qae2jXHqwB8YPqg79h44Bs9Rk1Wetc3CpeuQNVM67N22HKM9e0H0rlz7lf3LV6/RqFV3VK9cGif3b8KJvRtRv2YlGAwGa+p8pPtnp8b1qmObZjspdOfiftXHWZOHo9T/CqJV0zrqWJinSP6riPgIX758QbW6bXBB+2BftXCqpme+csQr1mquvhSlTplMlY8YMQKWzJ2g4lUrlvKhQw7EftGiRlHLHaSuc4e3SrIK167fwobNO9C+VSN0bd9M43kUQ0dNVXmy2bnnINp27o/6tSupcTBlzEAcOnIS/T3HSbavYMvYfv/+PcKHj4Axnh6KeasmdbQvRyOx/e+9vvRZShBnu1r9Nnj6/AV2bV6KuVNHQr7oPHv2woe4X2OlpnYuDPLohIzp0yhuwqV+7co+ysuBfzYQGQlyHsqXpOXzJmPNkmm4duO2D44iYxrGTZ6NG7fuYObEYbh7aT8WzxmH+D/HNhXBwmVrkS1zBhzeuRZjh3lg6aqNGDl+plHGr/7pQgFtl15O9v6dnyJjLdjSP9Oy3TyG4Zf4cbFl9VxcP7MLYhsZ1yIj51ixcnUROVIkrFwwBfv+XIHc2gz8i5cvJRvyhbWFNhlQo3IZnD28BY3qVVVfcBcsXaPy9Y04uQ3qVMaFo9vRonEt+De2bR1nun5933fIGMyYuxTDBnZX41uW45Sr3gyXr97URdR+xpwlaN64tpKpWbUcmrfvDXGwVSY3JBDEBOjwBjFQqvNJQB4kktkK0yCOpEhVLFscK7ydLjmWdLkAVypXQg6VU5bu9xTo0q4JkidNpNYvevbrirPnLqt1r0rIeyMfhokT/QJxasKHD4cqFUr6mPFavnojYseKiaIFc3uX8H8ns81RIkfCmKG9ETPGT8iVPTM8urVRH8KPHj/xpUBmdKRMj04tlGzsWDEg7Xr95o0vWVsTMqZLg46tG6llFtI3KdepTSPkzJZJ+opC+XKhW4dmWpvWSZbVUETrtzg4slyjaME8KFwgNw4fO63k//33qXIe82gfoD/+EA3Csb7m+MhaYCXgz0acZ1vt5I8qX9kyHsRhGT+yL1KlSKraNn5EP1y6cgObtu70JR+YhA/a7Pji2eNQSz5wG9WELBs4eOSEUdWYSbPRpEENVK9URo2DrJnTo2fnFmp8GoXMIv6NbbGDjGu5AyJxGa/1a1XGkhW+Z2lh4d8Obebv4uVrGDesr2IibAb27gj5YmcqHpixYlpe4rba4Kcff0C/nu1Ve9KlSanxLItDR79xFF2m4f6DR/g1cQKk1r60iCOXL3c26Oe+Lifrstu3bAAZl4Xz54J8MZi7cIWeDVv6F9B2GZV/Z8SW/plWcf/BP8iQNjUS/BIPP2ks5Yu/TAqIzBxt5l2WSowf0UedBzJm5HzW82fMXYKSxQuosSus6lSvAPniN332YiluDDWrlEGZEoXV0h+5nvg3tm0dZ8YKtIjcAZvptQyd2zZV1ydp69D+XRDv59iYNW+JJvHtr2HdKhC7Sn9bNqmN2DFj4NjJM98EGCOBICRAhzcIYVKVbwKW1vDGjBFdCVYoU1y7Nf3AeKtr1bqtyrHVL+JXr9/Eth171e1O3WGWJQviQF7XbucqJdomRfIkkA8DLWr8q1O9IjZv2wX9ienFKzZoDkupAK0fvarN/OXNnRX6LIsoF2dR9tdu3JKdj3Dr9j3IbFj+PDmN6VGjRIY4ksaEAEYypEvlq8SBw8dRU7vNmzJzEQiXctWb4sE/j/DmzX++ZPWE+D/H0aNqHyvmT3j0+F8VFwc3d44sKKrNIMmDZTPmLobcylWZNmxstZMNAtRmSgAAEABJREFUqnyJCOe4cWJBHAE9M4U2EyxB6tXTvmcvM+imNk6c8BcjG9ErjuXAYeMVa+EtoUjZOpAvOPcfPBQRX8G/sS0F5BZ0qcqN1O1c0Tl09BTcvnNfsvwNN27eVo6ROLq6sCwdMu2HpAdmrEg502CrDRLE/9m0mPblIIa6S+Mj0eSggvaFd96iVZBlGSPGzcAf2hcYOX9MRJA2zW+mh0ifNpWPsW5L/wLaLh8VfseBLf0zVV+5fAm07zYQslRh3JS5OKbdtdLzr1y7gcwZ08LNzU1P8rG/fPUGimhfYk0T5fj8pavqmqSnZ0ibRo+qvX9j29ZxppR5b27cuqu+QMuXbO8k1e6C+XJC7qboabKPZ3ZdihM7pnbu+Z5MEFn/AyVIwG8CdHj95sPc7yQgM1jyQWwaZAZW1MoMaJECubB6/TY5xKr1m1Gx7NfZXUkwGAxqxkdutZoH+XAQGQkRI0SQnY8g9YrjLLdEZW2crMWtXa2CDxlbDlxdXX2Iubr5PPaR6X3g5ubztLKljHdRX7uIZg9hiZNXpU4rVKtYRrv16YV/bx7DppWzVbn33uue1YHZxsXFYJYih19ko8LKBZPh0a01IoQPD/lykL1QBezZf0Tl+bcxGGyzk396rOW7u7v7yjK3iy+BACS4mdnYYDD4cBIMBgNGDelpvO1vOhatzYL7N7ZlraLcXu7TvQ0O/b1G6e7dtQ38sqF5l8zbLfmuLi6yUyGwY0UVNtvYYgNLDyOaO7CmamVm76+NC5FTu3MiDl2zdj3VFzlTGWtx4WRr/wLaLmt1BjQ9oP3r2bkVZk8ZjoQJ4mPfgSMoXKY2JkydZ3O15ueEm3atEv4Gw7dzP0LE8D70GQz+j23/xpkPhSYH5s65m6tvZ92ybUyUMEoCQUjg29UxCJVSFQnYSkBuYa7ZsAXy8Jo8PFOt0rf1lymSJ8Ve7cIvt8hs1WcqV7t6ecxfvAqLlq2FzC7IejzTfP/iSX9NiFNnLvgQO37inDpOkjih2ptuEiaIp9a9njpz0Zgsa+COn/xaxphoFgmvOZmSZLouWY4thWMnzmozZ9Ehb2KQ/siH3Omz3+qzVMaWtAiaYy237Pt0b4u/NixE5gxpsXm7bUsGAmun8OHC+3AsLbVTOMsDaqYzqTJrL7PvSX9NZKmI1TT5YvT5y2er+dYyUqdIhr927beWbTXdr7F94MgJ5NYcPflSJjPYouT0WZ9jTdKshcSJEkDeTGG6tObi5euQWWe9jC1jJUKEcPjy+dsXH72s6T4obWCqV+Lpf0+F9i0bYNq4wZg7bYSa5TVdlnH67CURM4aTp88jTqyYkNv2tvTPWPA7IgE5P82r8a9/5vLFC+dFtw7NsNRrIjq3bYzV2rVRZJIlSaxmfE0fTpV0PSRPmli7Vvm8Dhw/dRaptbGry1jaS75fY9uWcWauN3HC+JDr0qkzPq97x06eQRLtmmouz2MSCCkCdHhDirST1iOO7O59h2EaxIHRcci6M3FoO/YYBFmXKg/86HkN61RW0SZte+CU5gyIQ3j+4hXIGwZMPxSVkIVNhdLF8OTpc8j6N3mYw4KIn0myDk6WKUh94mTJg0oDh4+HrPWUN02YF5b1vnVrVMSQkZNw/uJVvH37Dh6DRuPps+fmoj6OE/zyM8KHD4cz53x+uPsQ8j5Ik+o33HvwD06f+/rhpr9Zwjs7ULvzGtNRE2ZBt4s8NHL12k38mugXm/QF1k5JEv+iOIldrVUk6zrTa7ex23XtD3HopG0yVhJpXy5KFM1vrZjFdFm6IOPRYqYfifKAoHCWBwOlfmmvrGuVGVo/iqk1ldbGdtrUv6kHLZ88faZu/46eOAtb/9rtlzofeQXyZEeyJAnRrlt/bYw/w/0HD9Gtz1A1jnRBW8bKr9oXN3GcTd98opfX90FpA12n7OUNHVv+3K3ediFfDHftOQRx/mVtqeRLkPXbcntf2vfnzn2YNGM+GtSpIlmwpX9K8Ds3ATk/TauaNH0+/Oufqby8MeOY9zIGeZBU1tj/qn2xEZkGtStDGLTtMkCdMzJu5C0b+lrzJvWrq/Xf8oYSkVu9fgvmLVqNpg1rSHFLQaX5N7ZtGWdKkclGltU0bVAdnqOmqAkLaevwsdNxWvtiLu00EWWUBEKUAB3eEMXtfJXJL0PJg2umYc2Gr0sYhIY8rFL6f4UhF+4KZXy+KuqnH39Qt+0jRYyIOk06InGavOjYYzBkds/dylo20akHufBWKFMc4bRb4vKghp5u6/6X+D9jw/KZOHL8tHolWfP2vVC4QC6MHNzTqorBfTtDHPcKNZohR+GK6sO8bMkiVuUlQ9b5dmjVEGWrNVHrROUVXJJuKcgDPpNGDUDL9h7IXrACRk2ciQG92lsStTlN+O7ccwC/Z/+fqj9zvrIoXiQf5CEqW5QE1k61qpXHzVt3ED1hRsgaVnFozeuTW55L5oxHlChRUL5GUxQtV0fNoq+YPwXhwvle6mBe3vS4TbN6mDR9nqpLXv1kmudXXOy5ftlMHDp6CoVK10KqzEUxasJMvH//zq9i6ol6a2Nb2JYqXgCFS9dGtgIV1JedDq0a+anPNFNuFy+ZOwEf3n9A/hI1ILe/K5cvoRxGXc6WsVIwbw6k+z0l5NwSG+ivJdN1yD4obSD69PDp82e07tQHMRJlUmHjlr8wY4Knsq8u01Bzbk9rX3alfbK+tXql0upBNcm3pX8i970hIOenaV229M9U/p+Hj1GyckM1PuVVXvLFSj+3ZYnMhuWz8fLVK1So2Uy9Pm+Mdu5HihRRqZBrjDxcO3nmAqTJWhzjJs/FgN4dUFs7x5SAlU3ObJng19i2ZZxZUt2/ZweUL10U7bsNQPqcJbFr7yGsXTINAb0rY0k300ggsATo8AaWnKOX+87+ye1207WOpnH5lS1T9VPHDVJrGJs2qGGarOKiR17TdXLfJsivn/2xag68po2EfqHv1KYRJE0JW9iIQ1W1YmkfD55ZEFNJSzQHon+vDiqubzKmT4N1S2eouo/t2YCBvTv50NW8UU3s3LxEF4fM8o4d5oELx7ZDXu81bEB3dbtWXnNmFLIQ6d6xBXRG0l8RWaHW1baVqI8gjs3urctwcMdqtfxAbp1LWbnNK4LSpl1blkpUBUt65GFCr2mjVL4wlj6KDgmyLnjc8D7qtqQSsLC5cvJvtaxCzxId0m5rdpI3G4hu4aOXkdkrYSrpEuRBND3PdC+zfrMnD8P5I9tw+cQOZX9ZPmIqc//yQfVaOdM083iJYvlx+8I+xVl/LZml8SPLRa6e8rmcQ9agr140FddO74S8wk54eXTzbRvzOq2NbXEipfzxvRsgQfrXtX1T7PB+RZ3o8dLGuWe/rhJVwUuzl9hNHWgb4bd8/mScPvAHpD/i3Ah/eTpfy1Z//o0VaYf8WILwlyBv55CC0n/hIHEJ/tnAVo6iSw9tm9dT9pR6JRzeuU69r1vPl30E7c7HzIlDlc2kn317tFOvLJQ8Cf71LzDtEr3m/bd0foqcaZA3U0g/5I0ukm5L/0ROD+LsP7hySPVV9MgYix8vrp6NlL8lwfwZo9UrxSRfeKVNncKYL3b/e9Ni9Yq3v/9YjHo1KxnzJPL4xlFfD7ZJun9j25ZxJnpMg3wZlTXp0kY55zZoEwfylhtTGUvt2aVdt+T6ZSrHOAkEFQE6vEFFknrCHAFZ/7v9773aTKXPC3+YaygbRAIkEKYJsHEkQAL2T4AOr/3bkD2wQCB9rpJo13UAJozsB3ljgwURJpEACZAACZAACTgJATq8QWJoKglrBOTW7pFd6yAPnoW1trE9JEAC/hOwtBTH/1KUIAESIAHLBOjwWubC1DBGoETFBuphDnmwxjT8vfsAshcsr96IEBRNlh9fkDcyBESX/EKctC8gZUxlN2/fBXm4zzQtIPG1G7ej35CxNhcR+b6Dx9gs75dg++4Dbf45XL/0+JV37sIV/LVrn1Hke+oMjK3y/6+6j9d96Q0RhsJSPw7IfqbXErx//yEgRexGdrOV8Szj/PLVm8Z+BOV5K0rlDQXyAyESD0wIqD2lP99z3lpro+gU3dbybU2XsSl9skVe6jO1zfecY7bURxkSCA0CdHhDgzrrDDABeTBNHtSQJ4qLFMhtfLCjQN4cAdbl7AVyZc+EerXsZ13zhUtXsHP3QYcym/wcs/x4gkN1yp/ObN+xF/JjEf6IOX1243rVkTVTuu/mEJDznLb5btxUYAcEQsPhtQMsbKK9EfAcNRkyy1qzUTu8fPVaNf/Bw0do2LKbemVThZrNcenKDZVuupH3pDZv11vJNGrVHe/fvVfZMtshM1AFStZA9QZtIDODkiHvca3XrDOKla+LlJmKQN4xKelv371D/eZdUKh0LZjOqhw5dgrySjZ5bVSL9h7Gtm3bsQd5i1VF5dotrf7Ag8yyyDrkijVbYPqcxaovh4+elOog79osWKqmiptubOnzvoPH4LVwpSo2fOx0CBt5TdeIcTNUmr6Rl9zLWmg5vnHzjpphv3Lt6wxdtgLlIPmSt3nbLpSv0QwFStTA+YtXJEnlyayzpMms+WZt1k8yZBaubtNOqt/SP9FhSU5k9SCvWFq7abuqY4f3D0AEpE5dj763Zit5V7SMIbFh516eFmdgx0yajdxFK6Nq3Va4rjHRdc6Yu1jZXmwye/4ylSwz09Xrt1Fx2fQaMBLyPl/5lTV5v3PNhu0gY0/yTIO1dsh47Nl/BEpVbqRsdvPWXVXMms2Fr/RD7FuyUkOjbayNYaVM28jrsKSOfMWrQWwnD39qyeockP7JOBd7i90kXYJ/41nq3PLnLniOnKzsqP9gRmDPW9Fn6Ty8cu0WKtVqoc4teRettM1afyTPmj2D8ry1Zh85l8pVb6rs6TFoFIS3tElm/w9r1w2J+zUW5DojdhAO+jVPyujB9Dxfp50/1eq1VlzkeqLLyF5YWrLN95xjopeBBMIaATq8Yc0ibE+gCGRIl0a9nixzhnSYv3i10jFo2EQUKZgbf65fgL492qJTz0Eq3XQzf8lqyK9viUztauVw8sx5lR0zxo9Yv2wW5DU/taqWx+ARk1X6lJkL0KR+dWxdMw/7/lyBKJEjq/SrmiModWxbOw8XLl2FvDBfXqYv7w0ePrC7aoP8gML4KXPw4cMH9T7haeOHYMnc8bh+47bSYWljMBiwcuFkWHplmyV5W/qslxMndv+hY5DXbZ09tAV1apTXs9Re3sGZNHEiNSsnH8D582TH4WMnIY5W/Hg/Q/JF0NXVoHR49u+CIZpDI2lLV23Ei5evsW3dPCzV+jh4+ETlpEuelJ83fRTkVW1+yYmshHYt66NcySKQ12fJL+ZJWkDrlDJ6sGSrjx8/olWnvvDs1wXb183HvQcPsHjFOr2I2otjsGTFemxe7YXxI/rh4OETKv3CpWvqC4lwlJ9olp+DtfTlSglrm2qVSkNeq7Zo9jhMHedzTPrXDnln7sYVs6B+4ET7kiB7HR0AABAASURBVKepg182F06rFk7BtHGDjLaxNoZFlwSDwYCxw/pAXhE1ffxgdPUYKskq6OzEFk+fvVDj3JbxLA+OFi+cDz06t1R21H+4JbDnrbU+3P/noXp117plMyDOtDi7BoPl/lizZ1Cft9bsM3DYBFQoXQxiT3kXtgJssvFvLAg7sYO8bk+/5pkU9xH1HDUF8lo7eZ3h5DEDfORZs42MHRnTtp7XPpTygATCIAGXMNgmNokEAkxAfhBCCmXJ+DsuX7shUew9cBQyoyizIP2GjMMps58JFqHjJ8+hZpWyEoU4U0kSJ1Bx+RnaVeu2QGYjZ81bhvPabXXJyJzhd0yc5oVRE2bhwT+PjT9+kDzZr5D3VcpPasq7ey9fuYHbd+7jzr0H6NFvBKQNazZshfw06q079yA/vykvzhensXrl0qLaYihWKK+PF/FbFDJJtKXPunic2DHx9OlzzRGahAVL1yDGTz/qWcZ9tizpNSf3lBZOokXj2jh89DQOabPM2bV0XahAnpyqjdkyp9dm0a+r5P3aLPKxk2dQpW5rNTP9+MlTXLx8TeXlzZ3V+B5lv+SUsJVNQOs0VWPJVjdv30X8n+MgQ7rUkHfT1qtZWevrKdNikP6UL10U8kME8l5a+XEOEZAvAWU1h/yHaFERXWMo76+VNMkLaPCvHUUL5lUq5SdoZRZSDvyyecF8uZRt4seLa7SNtTEsuiQYDAacu3AZLbQ7Eh26D8L9B4+MX1ZS/JZUjXOR+zlubMg4D8h4lnKmIbDnrbU+yLiUd3T/9OMPiBsntnaOPlL9t9Qfa/YM6vPWmn3kS3EN72uPfKk25SJxf8dCoTwihp+1furXPJVgYfN76t/Qa8AoTJ6xQI1vCyK+kr7nHPOljAkkYAuBYJahwxvMgKk+ZAjIr6lJTeKsfPzwUaL4ov1fOneCmlGSmZCb5/aodNPNly9ffPzAQrhw4VT2jLlLtQ/Lhxjavyvkxfdv3rxR6Q3qVMHwgT20D9OYmjPcETJLKhl6/RI3GFzwQZsxlPpTJE9irH/z6rlYNm8StCp91Onu5i7FLIZw4b/lubm5arPRX5Tcx4+f1N58I3X612e9jPwSnczA5sudHXv2H0HP/l9/iELPl704EIc1J1dmLP9XJB8uX72unN8sJmsM3cO5iajq00et33IgXHt3bQ3hLkF+NCJ7lgyShfAmv5Dml5wStrIJaJ2masK5f2Oq20ryha/sJbi7u2p2+spajiVIW11cXCWqgpvJr/2Zxt3d3VRZV1dXyAyjEtY2MnOo7fz9c9PsrAuZt0PaoOfpe79srutycXFRy0ykjLUxLHkSjp88q5a8dGzTGDI7/IvmLL9+/XX8u2l9EhkJBoPh6zjXMElfJU2CX+NZ8k1DOG9bqPYF4Ly11gddn9QhOj9oOq31R1i6uPi2p/AMyvNW9Fk6J+U6ID/QIG2VMSN786DbT9Ld3V3VuJK4BDdvW7iIbbV+Spq1ID9qUbdmBbzS7FhV+xJqOi6tlfmec8yaTqaTQGgScAnNylk3CQQngXy5sqnZS6lDPtzk9r3ETUOmDGnUTLCkifOqz0Jeu3kLeXJlRTxt1m/rX7slW4XnL16q29G1qpaDzOTK7WyVYWGT8Jd4ePL0Kf7YulPlvtacZpnVSZQgHu7cva/d8n+l0mWdnor4s5FyshxAxOSngGVvHmzps15G2mMwGJAnZxZ0aNUIx0+d1bOMe/mFtL0HjkD/FTeZwdy55yByZM1olLEUyZMrizYTPk99wEq+zEZaeiuBLXKRIkXCi6/rskWV1WCLLmuFEyWIr81kPlS36MUZ8Fq4CtmzfnXQ9TKZtNn9fQePqkNx7PV41kzpsW7Tn5CxIWu6123ajmyZM+CX+HFw++4DJS9933/wuIrLJnLkyHihjSWJmwb/2rFo+TolLjPymTOmVfGA2FwKSDtlSYW1MSxrSzOmT4XkSRPh+s3bOHfxihSzGhLZOJ4jR4qAly+/jnmryrQMW/rjXx80NcY/a/2xZs+gPm+t9SdT+jTYtfeQaufOvQfV3nSTyIYxaSrvV1x4pf89FTq2bognz54bz0u9jK22+Z5zTK+LexIILQJ0eEOLPOsNdgIe3drg0eOnkAdt5KGsjVt2+KpT3tN7+849yAMdHoNGI+mvCZVMg9qV0av/CPVw1e0791WabLr09kTyDAW12d1OkHWIhQvklGSLwVWbgZF1uvIQijz8kzlPWcgaSHdtVstTmzlu0ro75CE7U/0WFXknVqlQGqMmzFRtkofqvJN97Gzps17gxs27+CVlLvVg0uiJM9FH46Xn6fsokSMhshbEOZC0LBnTIWLEiJB0ObYWqlcqA5kdlgf2chWpBI9Bll+DZoucOORv3vynHhTTH1qzVK8tuiyVkzSZoR0z1AM9+o5AkbJ1NNvGgOiTPD38nuo3yFtB5EHDus06KS6SJz/52rBOZfUgWaXaLdGsYU38liwxImuOer7cWRXf5u17Q35+WeQltGxcG108PH09tOZfO+7dfwB5EPCPbTvRq3MrUYWA2FwK+DeGZanG33sOqWU446d4QZZ5SDlrwdbxLD/xvWHzX4rTo8dPrKmzqT/+9cFUubX+WLNnUJ+31uwjd0Bmz1/+9Xy+ch0//BDVtNlqjbx/Y9JHAT8OchaupF7f2KKDB9q3rI9oUaP4kLbVNnJO2HJe+1DOg2AiQLUBJUCHN6DEKB+qBPJqs67yQnrTRhzcsQYRIoRXSZIvv64mB+KQygMaOzYugtxSH+TRSZJ9hIgRI2DS6AFY6jVRPewiP1YRM8ZPSJcmJUSv1NWtQzMVl4LTxw/B5RM7IA9dDenbBfJhL+sj5bVpki9B5PV1wRnSpsbKhVOgHmY7th2VypUQERQtmEfVuWjWOKxaNAVD+3dT6aYbeairSIHcxiRxog7uWA1pU/eOzSH9kkxZM9qvZ3uJao5adPjXZ5Hv36uD+gW6B1cOqbZJv/LlzqZ0mG/kgb62zeup5DbN66oH+dSBtjFv49Hd67VUwGAwoEenlqqN+7avVA8Uyu3bqhVLaQ5NW+j/DAbLcnq+7MW5njZusFoOIuusA1qn6NCDX7aSsSN2/GvDQowc3MO4Pnvn5iVGB79Dq4aKv9hNuAhL0d2kfg1IObFJwzpVJUmFYQO6K76zJw9TY6bU/wqq9AplimHhzLGYOm6QOjbdWGuHyPTr0R5//7FYPSSoO9DWxrk1TmLry2ZjWHTrQZwh6ZssRRk3vA/kIT7hJkH46HKm49yW8ZwmVXJ4TRup2i5tlvMrsOetpT6Yjy1pvzCy1h/phzV7BuV5K321dE7GjRNL8ZDzOXGiBMis3UGQNsm1QJYPSdzaWLDGTsroQcamnOdyfO7wVnUNk6UNpuNT8iSY28ba2DEY/D9fRR8DCYRFAnR4w6JV2CYSCAICVEECJBB2CRw9fhoJtDssBUrWwI5dB9C62dcvlWG3xWwZCdg3ATq89m0/tp4ESMBJCJjO6jlJlx26m/Kav9sX9kFefSh3AOTOkkN3OHQ7x9pJAHR4OQhIgARIgARIgARIgAQcmgAdXoc2LztnMwEKkgAJkAAJkAAJOCwBOrwOa1p2jARIgARIgAQCToAlSMARCdDhdUSrsk8kQAIkQAIkQAIkQAJGAnR4jSgYsZ0AJUmABEiABEiABEjAfgjQ4bUfW7GlJEACJEACYY0A20MCJGAXBOjw2oWZ2EgSIAESIAESIAESIIHAEqDDG1hytpejJAmQAAmQAAmQAAmQQCgSoMMbivBZtXUC2QuWx9u376wLmOX06Dccm7fvMkuFSuved5ivdFsSRN/lqzctiopOyZfMmV5L8P79B4kGOOT/X3W8ev1GlVuwdA3K12iGURNmqWPTjbD48Zf0sBQWL1+HgcPGm4oHKG7aBlsLSpu9Fq20Ku5XX/RCAbWZKXNdh7W92MbUdgEdT9b0hlb643+fomi5uqr6cxeu4K9d+1RcNuZ9lbSQDubjYdmqjVbGpOWWmZe3LBVyqcJamFurUfKKlf9qD2syIZned/AYrN24PUirNB9n7bsPxPa/9wZpHVRGAiFJgA5vSNJmXXZFYPuOvbh63bLD27hedWTNlE71Z/b85Xj/IXAOr1LgvRk7aTZWLpiMTm0aead820WIEB7P7pxUoUenlvDo1lbFJc3V1fWbYAjFXr1+jQVL11qtza++WC3kT4Ypc39E4Zft/CsbFvN/iBYFIwZ2V027cOkKdu4+qOKyCQt99W88SDv9Ct9b3i/dzAscAfNxFjgtLEUCYYdAmHN4ww4atiS0CXiOmowSFRugZqN2ePnqtWrO7Tv3UKNhWxQvX0/t7957oNJNN9t27EHeYlVRuXZLbYZ3pzFr977DSl+h0rXQuZcn9FnZ9LlKGmU2bt6BXgNG4uz5y9jy5y54jpysZl0fPX5ilJGIzOoePnYKS1duwK3b91CzYTs0b9cbL16+QruuA1C2WhMkz1DQOBN3RJMtU7UxCpepjRbtPYz9EV0Sunp44o7Wl0pam//Y+q3NkmdLuHLtFirVaqH6vXr9FmORJSvXqzoLlqqJkeNnGtMtRT5//oxSlRshX/FqajZx74EjSsxSn8ZNnoNLl68pNhOmzlNy+sa8L99jM12n7HXmEh8+djoq1GyO1FmLYcS4GZJkDNZsZ2k8PXj4CA1bdlOMRN+lKzeMevTIu3fv0annECUjfPYfOqayZBazXrPOinvJSg2hc//48SP6DRmLAiVqKI4yA6sKmGxGT5yFOdoXJUlq3amvGjsSn7d4FSRPxnWBkjVQr1knNZZkRrGLx1ARwbjJc7F203bFfs78Fb7GqbU+yQydjHvpp7T3/MUrSp/pRthJn2T2MmWmInjy9JnKnjF3MQpp542Mo9nzl6k0042l8WBpTFobY5bK6/qtldHzZS+8pG0NWnRV50C3PkOx/o8/1XgWm91/8FDEYM2W//33VtlAzs9GrbrjvWZzKWCLLUVOD5b4SfvlDoy0L13Okpgyc6ESt3Y9krsRcg2S81nOQWvn8BjtC3LuopVRtW4rXL95R+k031g792wZC6bjbMeu/Ur15m271LiTsa2Pn4AyUoq4IYFQIECHNxSgs0rbCGRIlwZ/rJqDzBnSYf7i1apQ/6HjkT93DmxZ44Vc2bJgwLAJKl3ffNBmWjv2GIxp44dgydzxuH7jtsqSi3IrzbHw7NcF29fNx70HD7B4xTqVZ2mTJlVyFC+cDz06t8SaxdMQK2Z0S2KoVqk0EiaIh0Wzx2HquEHqQzZ+vLhYt3QGzhzcggxpU+PTp0+QNg3XZuj+XL8A6dOmwvgpc3zoGz6wB+LEjqnqKlEsv488Ww7u//MQ82eMxrplMyCOnXzIXrl2E7M1p0pmjbetnQf5gDK9FW6u12AwYOywPti1ZSmmjx+Mrt4OljgO5n1q17IBfkueRLW3TXOft3bN+xJYm5m3Tz++oX24i9O5etFUnD20BXVqlNfKHxynAAAQAElEQVSz1N6a7SyNp0HDJqJIwdwQu/Tt0VZzbAcpHaabhcvW4PG/T9S4GdCrPVp08FA2FRmd+6aVszF+qheE+1Ltdv6Ll6+xbd08LNXG4ODhE/Hs+QsRN4bsWdLj0NFT6viW9iXu4aN/VfywlpYtc3oVP3PuEvr1bK/Gkru7u0qTTbuW9VGuZBHFvkGdyr7GqV99cnU1YNXCKZg2bhCGaF/mRJ9pmDJzAZrUr46ta+Zh358rECVyZFy4dA3T5yyG8JaxNEH7gmP+xaCdhfGgszEdkwaDAZbGmKXyersMBstl9Hx9f1Ub7/01Xtu1c2zfgWPqS+vGFbO0c7SUar/IWbPl/CWr8fnLZzUOalcrh5Nnzos4bLGlEvTeWOK3RPtSfOLUeWxeNRfHdq9DyWIF4N/1KF2alFip2SlO7FgWz2FxrJesWI/Nq70wfkQ/HDx8wrsFPnd+nXv+jYV2JuOsYL6cSrGUkXHg2b+LcfwElJFSxA0JhAIBl1Cok1WSgE0EChfIpeSyZPwdl6/dUPEjx0+jXs2KKt6wbmUcOnJSxfXNLc15SJwwPlKnTAY3NzdUr1xaZd28fRfxf46DDOlSw8XFRdNRGeJcqMwg3KRJmVzNKg8bMw17tBnS6D/9iNt37qvZ2x79RqjZkTUbtuLk6a8fqEFVtThQkSJFxE8//oC4cWLjwT+PcPDICTzWZqbrN++CynVa4dyFy5APXlj5ZzAYlEwLbQa6Q/dBuP/gkXLULPXJigqLyYG1mUVlWmIc7YvB06fPtQ/cSViwdA1iaIy1ZH//LI2nvQeOQmZqZe10vyHjcOrMBV96Dh89rTnVFWAwGJA5Y1rEjhVD2VQEc2bNCOEu8WhRoyju+w8ew7GTZ1Clbms1e/z4yVNc1GbDRUYPmTOk1WRO498nz5Q+0Xlfm4U8euI0smh1iFy631Pi10QJJBqg4FefCubLpfohX2AuXbnuS2/mDL9j4jQvtY78wT+PES6cOw4fO4mymoP9Q7SokPFcrlQRlearsFmCpTFpMFgeY2ZFfRwaDLaVSZ7sV/XlM3z4cEilnf/ZsqRTejKmT2O8fliz5fGT51CzSlklL85dksRfudtiS1XIe2OJ3z5tjDVtWBPSLrkmJdKuT/5dj/5X9OuXXmvn8DFtfJUvXRRRo0TWzvdYKF4kn3cLfO78Ovf8Gws+NX09KpAnpxo/8qVMHz8BZfRVE7ckEFAC3y9Ph/f7GVJDMBEI5z2rJQ7qxw8fVS1fvnzRHFlXFQ8fLpzam260bJiuaXV3czdmu7l9LScJ7u6uEF0SNw0ftdlY0+OAxjNoDrXMgKRNnQLDNad39fqt+KL9T+E9GyqzxZtXz8WyeZMCqtpP+XDerERIeH3QeEn/KpQppmYCpd79f65Ex9a+1wdLGQnHT56F10JNpk1jNQv4izZT/fr1G/UlwbxPIm9rkHbo7ANqM0t1RIwYQc2e5sudHXv2H0HP/qMsiflK0xkJH+N40myzdO4EI6Ob5/b4KicJbq4mY8fNXSv1RZKNY1EODAYDdO69u7Y26jx/ZBuyZ8kgIsYQIUJ4xIgeHZu27tDy0quwZfsuRIsaFZIngpZYSbp/QcabtT7pdlAMPn49p0z1NahTBTJDHzdOTNRt2hEymy754qjJXoK7u5vFc0fyTEM4C2PS2hgzLWcet7WMaX2uLq7Qz32J6/YW3ZZsKWPU1cTG4byvLZLuny1Fpx4s8RMd7u7fxo8u6+bH9Ui3vZS1dA5LuovLN52m9tH1y17k9Hp0nZIuQU93cXFRM86S5l9wD+emRFw1VjJLLQdSR0AYSRkGEggNAi6hUSnrJIHAEpAHxWSdo5SfNW+Z5ij4dCQSJYiHO3fvq7W0IiPr5GSfKEF8bcbyIU6cPge57ey1cBWyZ/1a9pd4P0PWAIrcrr2HZKdC5EgR8PLlKxX3axNZu+374sVLJfJc28tMWMniBVC9Umkc12ZiEv4SD0+ePoW+Nvf1mzeqHaqAhc3LV6+1cmct5AQsKWe2jFi5bgtkaYOUFC66AyPH5kHkMqZPheRJE+H6zds4573G01Kf5Fa33mdzPebHgbWZuR79WPgZDAbkyZkFHVo1wvFTX1np+bK31Xb5cmVTM8VSRj64ZamExE1D1sxp1Uyy5B/XvhQ8evwYYlNTGdN4nlxZtFnSeZA3D0j6kWOnjOvF5VgPObTxJ7Op2bJkQNYs6TFl1gJImp5vbR8pUiS80MaInh/ZbJza0ie9rPlebC1LdGpVLQeZGZXlDFkzpce6TX9C8mRN77pN25Et89dzRy9v63iwNsb8Km+tjF53QPbWbJkpQxrIzLjoknNEn5G31ZZSToIwMueXK0dmzPRaqtYPi4yMC7+uRyKjB2vncCZtJn7fwaNKTBxPPa4STDZZM6WDX9dLE1Ff0Uhm48yXgHdCQBl5F+OOBEKcAB3eEEfOCr+HQN/ubdWrcYqXr4e/9xyAR7fWPtS5a7NKnv27oknr7pCH3WQ5gQi4ublhzFAP9Og7AkXK1kGsmDE0h7SMZKFxvaqQh8VqN+ngY+aqasXS2LD5L/VwlPlDa6qg96Zl49ro4uGpHnpZrTmYPyfPjip1WmL/4eNqPaTMhsia4pleS9RDTJnzlIWsN/Qu7mt35eoNdOo1xFd6QBOS/poIwqtVxz7qgSO5bf/f27dW1cht0b/3HILIjZ/ipWZ2RdhSn6JEjoTS/yuIWo3bQ9Z0ipy1IG3Y/vde9aBhQGxmTd+Nm3fxS8pciuXoiTPRp1sbX6K22s5DK/vo8VPIA0XyANzGLTt86apVtTx+iBZNjZveA0dj3PC+Pu4imBeoXqkM5Ha+PKSYq0gleAwaYy6ijrNqjuQ/D/+F3A1InSKZ9kXtH2TJ+PU2vBKwshFH/82b/9TDSvIwkXlfbemTFdXo0ttTPWxZt2kn7RyJjsIFciLlb0nQsE5ldR7IedJMuz3/W7LEPlTYOh6sjTG/ylsr46MBNh5Ys2Wd6hVw+849VKvXWrPXaCT9NaHSaKstlbC2scSvWsVS+C3pryiqXXfS5iiBabMXa3cGrF+PNDXGv6RWzuHfU/2GAnlzQB7MrdusEyJr56OxkEnEv3PPRNRX1Hyc+RLwTggoI+9i3AUvAWq3QIAOrwUoTAp9Agd3rDHe2s2bKysmjOynGpVAmy1dPHu8emhN9rIWUTI8+3XF/7zXsRUtmAdLvSZi0axxWLVoCob27yYiED3yENxfGxZi5OAean2iZFQoUxwH/lqFBTPGYLRnLwzu01mSIQ8/eU0bqR7WiWX20Jro1OurUKYYFs4cC3lorX7tyrh/+SCWz5+M6eOHQNoryuThNXkIRR4eu3BsOyqVKyHJ2Ll5CeTDXg5O7tskOzWzJm1UBxY23To0Q6c235YmVNU+UOU1ZbqoLF+QdYJyXEHrmzzgJ/qO7FqHVJpjJemmQW9DtKhRIA9vSflxw/tAHu4Tvtb6JHVKv80fWhPdel8kLgzEVtIO2YtOSbfFZiKnB5252OXBlUMQlsI4X+5suohxLzKmtrM2nsSuk8cMwI6NiyBLDwZ5dDLq0COy9nLUkJ6KzcYVs5AzWyaVZY27wWBAj04tlc5921eqBy/DhXNXZUw38nDijbO71Zpyua1899J+lC5RSIkIIxmr6kDbxIzxk+qvFlXjZdq4wWpZjKw3TZMqOUz7aq1PY7UvfEUK5BYVKhzdvV7tTTfC8/KJHZg3fRSG9O0C+QIp+U3q14CMIeHUsE5VSfIVTMeDNTbWxpgoMy0vx3rwq4wuY85rytiB6nyXfFnPv2TuBImqdbSWbCnLZCaNHqCuG/Lwp5wrwtxgsGxLydu6xufbSaQCS/zky7Y8fCgPg54+8Ifx3LV2PTIdq6LT2jncoVVDrFgwWV3n5LyVtdUibxqsnXu2jAW5LpmOM2tlDAbLjEzbwTgJhAUCdHjDghXYBhIIaQKsjwRIgARIgASciAAdXicyNrtKAiRAAiRAAiTgkwCPnIMAHV7nsDN7SQIkQAIkQAIkQAJOS4AOr9Oanh23nQAlSYAESIAESIAE7JkAHV57th7bTgIkQAIkQAIhSYB1kYCdEqDDa6eGY7NJgARIgARIgARIgARsI0CH1zZOlLKdACVJgARIgARIgARIIEwRoMMbpszBxpAACZAACTgOAfaEBEggrBCgwxtWLMF2kAAJkAAJkAAJkAAJBAsBOrzBgtV2pc4o2b77QGz/e6/NXV+7cTv6DRnrS/7V6zfIV7yar3RbEqSs16KVFkWXrdqIgcPGW8wLbOKhIydRtW4rNGrVPcAqzl24gr927QtwucAWMGcTHDz8a5vYVdohwZqdLOkIqLyuQ8ZY38Fj9EOLe1tkLBY0S7x77wFKVGxglhoyhz36Dcfm7btUZfn/Vx3CSx0E00bq6t53mJ/aReby1Zt+yphnzvRagvfvPxiTsxcsj7dv3xmPgyMi9rd0HbKlrpevXqNVxz7IUagiMuUpjer129hSzC5kTMeUXTSYjXRaAnR4ndb0zt3xV69fY8HStSEGYea8pejYpjFmTRoa4DovXLqCnbsPBrhcYAuENBtL7Rw7zAMRI4TXHLKA2Smwbc+VPRPq1apkqSnGNFtkjMKM2Exg+469uHpdObw2l5k9fznef/jm8NpcMJQEZ81bhg8fP2LX5qU4tmcDmjWsGUotYbUk4LwE6PA6r+1Dteebt+1C+RrNUKBEDZy/eEW15d279+jUcwgKl6mNUpUbYf+hYzD/Jx+MUq5kpYYYNmaKMdtaWZkJGjt5jlGuYKmaePb8BcZpaZcuX1NtmDB1njFfj1y5dguVarVA3mJVsXr9FpX8+fNn1S6ZfSxari72Hjii0l+8fIV2XQegbLUmSJ6hoK/ZWJmhFIe198DRGDFuBj5qH3wyUyR9Fz2bvWfcZJZLZqoKlKyB6g3aQGYCpYJxk+di7abtqq07du1Hw5bdcPjoSclSfZE+yYHMxNZt2gmVa7eEzKJbq+fs+cuo16wzipWvi5SZiuDJ02dS3BgssbHEQwosWble2UvaMHL8TElS7ZY+1GvWSTH577//1Ay9eX+lf6mzFlNlzDftuw3Ef9qMnXlbAtp2cybWGO87eAxeC7/O+Au7zr08UaFmc8g408enLTJv3vyHZu16oUjZOspOMov6+N+n5t3T+vZWs0EnCDeZ+dNnJwcMHY/MecuomcBZ2pckvaCMi14DRqoxKeNu+Njpqn3CT8aULqfvZTYybY4S6g6InFOms6G6jKW92ES3nXnbzNtw5NgplKnaWNm/RXsPyCym6Ny2Y486b2Qcbt6+U5JUsNQ3seeWP3fBc+RkNb4fPX4Ca3qVEm2zdOUG3Lp9DzUbtkPzdr21lK9/nqMmq5nzmo3aGdvy4OEjZQe5pog9L1258VXYZCv2lvO3Ys0WmD5nsZK3dH6ZFIEtek3lH//7BNkyp0O4cO4quWC+nGrvF29LvKSQ2EHuRsh1UM5jAABdTQAAEABJREFUnfs67RpRrV5rxV76IrKmwdo1snj5erhz975RNGfhSqp/1vpozstYUIv41eae/Ueo66fY4eatu5o0/0ggZAnYl8MbsmxYWzAScHU1YPWiqfDs3wVDtA87qWrhsjWQD4bt6+ZjQK/2aNHBA58+fZIsYxg4bCLKlyqKTStnazOAEYzptpQ1CmuRdi0b4LfkSbBm8TS0aV5XS/H5d/+fh5g/YzTWLZsB+SAVZ9dgMGDssD7YtWUppo8fjK4eQ1Wh9X/8ifjx4mLd0hk4c3ALMqRNrdL1Tb2alZAjWwaMGNgdXdo1wdJVG/Hi5WtsWzcPS+eOx+DhE5XjGjPGj1i/bBb+3rQYtaqWx+ARk5WKdi3ro1zJIqqt+gelyrCwkQ+SedNHYexQD6v1TJm5AE3qV8fWNfOw788ViBI5sg9N7SywscTjyrWbkJm2lQsmY9vaeeqLi7704sy5S+jXs71ismr9Viv9jY45U4b7qNv8wLwtgWm7KRNrjM3rlfG5auEUTBs3yDg+bZGZv2Q1vnz5AhnDdWtUwMkz582LqeMTp86heaNa+GvDQjx78QLyxUEyqlcui6O712P7+gVYtW6rj5nPdGlSYqXWpvg/x4V8GZTz5+yhLahTo7wU9REypE2FIzvX4u8/FiN8eHdtLGzwke/XgTih/Xt2wI6NixA5ckQfZfU25MiaER17DMZwbUz/qbU1vVbf+Clz8EGbdZX0aeOHYIk2tq/fuG2sylLf0qRKjuKF86FH55ZqfEf/6QeLeo1KtEi1SqWRMEE8LJo9DlM1+2hJ6i9DujT4Y9UcZM6QDvMXr1Zpg7TrRZGCuSFt7NujrfaFepBKN98YDAaN7WQ0bVDDPMvisa169cK1q1XA1FmL1BeW8VO91JdCPc8ab0u89DLSV7l2lSiW39hXz1FT4DVtFHZvXYbJYwboosb9wmWWr69lShTG8jV/KDlZPhUndkzEjR0LfvXRYDBY5OVXm9P9nhIbV8xC3RoVMUT7cqIq5IYEQpCASwjWxapIwEigQJ6cMBgM2qxHely6cl2lHz56WvvwrqDSM2dMi9ixYuD2nW8zDyJ0/NRZ1KhSVqKQDxEV0Ta2lNXEbP7LniU9IkWKiJ9+/AFx48TGg38eqXadu3AZLbTZrA7dB+H+g0fKUU2TMjlkJmvYmGnYo836Rv/pRz/r2a/NJh47eQZV6rZWs0mPnzzFRW22OWKECJqTswUySyu3QM9fuuKnHkuZeXNnVe2WPGv1ZM7wOyZO88KoCbO0fj02zjpJGWvBEo+DR07gsTYjV795F1Su0wrC5sSprw6efLj9migB5J+1doQPHw7Zs2QQEZtDYNpuysRWxgXz5VL2li8y+vg0b6QlGel/Te/xWSBvDiRJnMC8mDpOnTIZcmbLpOqoVaU8pJxkvH79GjITVqdJR218/YMLF69Jsgr/K5pf7cUhefr0OYaMnIQFS9cghoXx5u7uhjGTZqNGg7aQmekLl66qsrZsUqdIhsSJflGiRQrmwdHjZ1RcNnob5Ly8c+8BevQbAZlpXLNhK06ePo9bd+4hccL4kP65ubmheuXSUkwFv/qmBLSNNb1alr9/hQvkUjJZMv6Oy9duqPjeA0chs/zSxn5DxuHUmQsq3XxTrFBeZQvzdGvHturVy6f8LQn2bF2OZo1qqrszMnuu31mxxtsvXkUL5VGqf9auTXpff0/9G3oNGIXJMxbAxcX3R7u1a2S5UkUgs8OiUPZlSxaWKPzqozVefra5YF6lt3jhvGoWXx1wQwIhSMD3WRGClbMq5yXgHs5Ndd7V1VXd4lcH2sZNO9Z26s/dzR1ftP/qwHujTZ4ZHTT5UPdOVjtLZd1c3SCzs0pA23z6+Enb+v8Xzt3dKCQfHh8+fMTxk2fVbW9Ziyuzf79os7qvX79BhnSp1Wx12tQpMFxzeldrM5rGwhYiMgPYu2trNaMlszTnj2xTjt+MuUs1B/QhhvbvipkTh+LNmzcWSgNubq74LCC03I9m/QnvfctUy1IzjZbqaVCnijYz10Nz5GNqznVH3Lh5R8T9DJZ4SD8qlClm7Mf+P1eiY+tGSk/4cOHUXjYiZ6kdkhfQEJi2mzIJCGNpm9j+48ePEvUVxA6SaCojfZUxLekSwplwkGM9yLg0xt1d1Z0MueXcQrurUaV8SSyZMx7FNMfgtckY0JlGjBhB3R3Ilzs79uw/gp79R+mqjPvOvYcgRfJfMUMbRx1aNcLrN/8Z8/yLSB9MZUyP9TbIeZnC+w6JjOHNq+di2bxJ2pgDTPsv57Do8q9vIiPBml7J8y/oY1TZQztfRV70LZ07wThGb57bI8m+Qrjw3853sau180svaKteXV72ESKEhziKcucoU/o0+PPvfZKsMfui9vpGePvHy837Omna1xkTPFG3ZgW80q5JVbUv06bXPV23Xk6OxTbSjwS/xIOwk+ViazduQ8niBSVbu/J+0e5AWWZnyksJaxv/2iz90sT4RwLBQcAmnS42SVGIBEKAQNbMadWMlVwYxbl89PgxEmoXY9Oq5YNi195DKmnn3oNqLxtrZRMmjKdmnURGbm1fuvp1Nllu47948VKSbQ5yCz9j+lRInjQRrt+8jXMXv87APtf0/BAtqvZBUQDVtdutx7XZW7+U5smVRZthnac+mERO1izKGstrN28hT66siPdzHGz9a7dkqRApUiS8ePVaxWWTSLudK32R+M49B2RnMeSxUo+0V24J16paDhm1D94Ll675KG8rm5zZMmLlui0QLqJA1gFacp6ttePFy1eKg5S1Fszb8r1tt8bYWv0BTc+UIY2aGZNywkJm7iVuHs5qdwpkhlzG+qJl67Tb8L/jX22m/8cfoimbuLgY8LeVBxVfa06wwWBAnpxZIM6s3PUw13/12k21VCBa1CjYvsOyk2deRj+21DY9T9/Lefnk6VP8sXWnSpI2nTh9DjI2ZRyIbSVj977DsvOzb5EjRcBLbSyIoDW9kmcaIkeODFvO33y5skFmwqWssJalIBL3K0gf/Du/rOmVvovjaK5fznF9Rvfxv0/VUhW5gyVylnjbOhakvB7k3Ej/eyrtS2dDPHn23Hh90fOtXSMlv2zJIpA7VHHjxIIsZ4D2z1oftSyLf/61edHydaqc3JXIrN3BUwfckEAIEqDDG4KwWZXfBGTd6g/RokEe+JEHvMYN7+tjtkhK9+neRq0blQdiduz65uxZK5s3Z1bIGjm5pTlh2jwk+zWRqEGUyJFQ+n8FUatxe0yw8NCaEjLbFC+SD3/vOQTRNX6Kl5rZFZHVmtP3c/LsqFKnJfYfPq7Wx0q6tVC9UhltRje9euAnV5FK8Bg0Rok2qF0ZvfqPgPRNbu2qRG0jjs0bbYauat1WkIfWqlQojVETZio5eQhLE7H4Z62eLr091cN1snQiVszoKFwgp4/ytrJJqrHs272tet1SodK1FJf/3r71oUsOrLVDHtjZtPVvEbEazNsS6LZ712CNsXf2d+9qVyuvHqiqVq815GFJWe4iTqe54rRpUmDE2OnqAaPIkSJqt/7LqC86yZIkgjzI2Lh1d6ROmdy8mDq+cfMufkmZS8mNnjgTfbq1Uemmm7YtGkBum9du0gERI4Y3zfI3bqlt5oVkFlfW6cpDodLezHnKQpxsd+3OiKd2h6KJ1n55eEwfx/IlzlrfqlYsjQ2b/1IP4T15+hyW9JrX37JxbXTx8PTx0Jq5jBx7aGwePX6qWMgDfhu37JBkP4Mt55c1vWs2bMOcBSt86b9x6y7kHJGH/NLm+B8K5M2F/HmyKzlLvP3ipQpZ2MjDZvJAm9wlaN+yPszHnbVrpKiSZQyy9KNMiUJyqIK1PqpMCxv/2nzv/gMUKFEDf2zbiV6dW1nQwCQSCF4CLsGrntpJwDcBeaCqSIHcxgx5SEcOwocPh1FDekIeMNm4YpZa4yjpssZMHoCSeJLECeE1bSRWLJiMaeMGqwfIJN1aWfkAlgeq5LbryME9sGfbcsgsmpTx6NYWC2eO9fXQWtWKpSB5IiNByiZKGF99gEjb5Hjc8D6QB5NkjWf92pVx//JBLJ8/GdPHD4HcIpRypsFr2ig1cydpBoMBPTq1VA8F7du+Uj1oEy6cO9KlSYmDO9aovnXr0EzFRV6cPumr3DKWh9Z+S5ZYy1ut5Lp3bK70iJx5uw0Gy/VIGy+f2AF5uG1I3y4QRlLeNEj/dTbmeqX/wkPkK5Qpji1rvNTDV0d2rUOqFMnUA3zy8JDkSzAYLLfjyPHTaFS3ioj4CvJgoPRbMkzb8r1tt8ZYxlj/Xh2kOlgbn7bIiB1He/bCUq+J6qG0n376wbgERynXNjJm5MFEGcMyHieNHoAI2u1uLQsTR/WHjFcZL7MnD4Owl3QZF7pMmlTJ8eDKISUnPPLlziYiPoLM3h/csRoLZoxRy1ekTyLg2a8r/qd9cZP4zs1L1Bc/iZsGWedsqW2mbRB5eThTHqKT9l44th2VypWQZBQtmEf1f9GscVi1aAqG9u+m0q31TfrjpZ3T8hCefAGzplcp8d5UKFNMnbv6Q2umbcur3SWZMLKfkhR98gDXjo2LIEuHBnl0UummG2Fjej2ydn6J/fXrkDW9rZvVhaU6KpcvgRN7N2L9spnqWjFiUHdjE6zxtsbLWl/PHd6qXRfWQJY2NKxT1ahfj1i7Rkq+XLOe3TkJ03LW+mjOy3RMWWuz1NGvR3v8/cditfxLv35IOkPIE3DWGunwOqvl2W8SCGUCdapXMDpJodyUIKv+7bv3SJa+gJpR7NxrCAZ6dAwy3VREAiRAAiQQeAJ0eAPPjiVJwEEJsFuBJSCz0ncu7lez7huWz4TMVgZWV2iUk9ln09n50GiDM9XpLLxNZ6Wdyb7sa9giQIc3bNmDrSEBEiABEiABEggrBNgOhyFAh9dhTMmOkAAJkAAJkAAJkAAJWCJAh9cSFaaRgO0EKEkCJEACJEACJBDGCdDhDeMGYvNIgARIgARIwD4IsJUkEHYJ0OENu7Zhy0iABEiABEiABEiABIKAAB3eIIBIFbYToCQJkAAJkAAJkAAJhDQBOrwhTZz1kQAJkAAJkABABiRAAiFIgA5vCMJmVb4JyE9hvn37zneGlZTN23fh8tWbVnJDJvnLly/o2X+E+inULX/utlpp/v9Vx6vXb3zl9x08Bms3bveVbimhffeB2P73XktZYTLN3D4Bta9pp76Xs/zk7eN/n5qqVHH5Odz37z+oeEhuevQbDuET0DrPXbiCv3btC2ixMCNv3v6gHNNyfnktWmnsq/w87sBh443HwRkJibq69x0WqDHzvf0O7Fj93npZngSCkwAd3uCk+726Wd4Xge079uLq9dB1eMXhvnzlOlYvmorihfP6aqMzJwSlfYKL8+z5y/H+Q8g7vIEdFxcuXcHO3QcDWzzUywVn+1+9fo0FS9eGeh+DqwGN61VH1kzpgks99ZKAUxGgw+tU5g6bnR2gzciUqtxIzd/Z3zIAABAASURBVJjevHVXNfLBw0do2LIbCpeprdIvXbmBs+cvY8ufu+A5cjLK12iG+w8eIn2ukkr+xs07+PGX9Lhy7asznK1AOXz8+BGW9EgBa+ky+9S5l6eqs2Slhjh/8YqIG4PMDLbq1Acnz1xQbbh95x527zuMEhUboFDpWpCyImMs4B0ZM2k2chetjKp1W+G61lbvZAwfO13VlTprMYwYN0NP9rFfv+lPlK7SGAVK1sCOXftVnvSt35CxKFCiBmQmc7M28y0Znz9/hsxwFSxVE+lylsSUmQshacI3X/FqSnbvgSMiCpl5q16/jYrLpteAkdi4eYdELbbryLFTKFO1sbJJi/YeePnqtZLVN+b2efT4icryHDVZ8anZqJ2xjDX+qoC2EYYB5fzff2/RvF1v1b5Grbrj/bv3miaff0tXbsCt2/dQs2E7JWuNjZQaPXGWslmVOi1Rt2kni7Py6zZtR7V6rZG3WFVUrNlCilkdcyrTe2ON5YnT59S4EpumylIUwmHc5LlYq9UjY17sb6lOb7VqJzOP0t7KtVtCxrOM0RoN26J4+XqQ/d17D9S54d+5E9B65AuKzOjLOK3eoA2kHmmQefslbfO2XaqfMn71c+yjdr5aGtN6f/T+SHk9jJs8B5cuX1O6Jkydp5KvXLuFSrVaKJusXr9FpVmzs7RRzpX6zbsoHVK/KmC2sWQXEQmqurb+tVu1V++jzOyKfrkbcVg77/xqp7WyUl4PYvs7d+/rh8hZuJIap3KnKW2OEpBrQ6eeQ9R4Mwp5R/RxIodyfZDrhMStncP+jRspy0ACoUGADm9oUGedPgjEiB4dG1fMQuH8uTB45CSVN2jYRBQpmBt/rl+Avj3aolPPQUiTKrk2o5oPPTq3xJrF0/Bz3NhImjiRmvGVD4X8ebLj8LGTEKc5fryf4ebmBkt6pAJr6ZLn6mrAqoVTMG3cIAzRnGtJ00O4cO4YNaQnsmZOZ2xDq0594dmvC7avm497Dx5g8Yp1urjaiyO4ZMV6bF7thfEj+uHg4RMqXZz0/YeOqZnis4e2oE6N8irdfHPv/gOsWzodo4f0QtuuA5QDu3TVRrx4+Rrb1s3D0rnjMXj4RDx7/gJLNIfuxKnz2LxqLo7tXoeSxQrAYDBg7LA+2LVlKaaPH4yuHkPNq/BxbKldnz59QscegzF8YHdlk/RpU2H8lDk+ypnbJ1bM6Co/Q7o0kJ+rzZwhHeYvXq3S/OIvAoHhPH/Janz+8lm1r3a1ctqXkvOiykeoVqk0EiaIh0Wzx2GqZl+DwWCRjdhMnGOx2aTRA40286FMO/AcNQVe00Zh99ZlmDxmgJYCq2NOZWobaywlvUnr7mjXoj62rZ2HTStna2PYFe1a1ke5kkXUeCuYLycs1amp9fEn58C86aMwdqgH+g8dj/y5c2DLGi/kypYFA4ZN0PS6+XvuBLSemDF+xPpls/D3psWoVbU8Bo+YrNpk3n5JlHNstXaHxLN/F+M5Zm1Mi7xpf+RYD+1aNsBvyZMoNm2a11XJ9/95iPkzRmPdshkaq8kQZ9dgMMDaOXBV+5LcV7vGyDXl6bMXEOdWKfLeWLOLZAdFXR+0uw0dug/CtPFDsNRrAq7fuC2qfQVL7bS1bJkShbF8zR9Kp3zRjRM7JuLGjoUM2nl8ZOda/P3HYoQP746lqzYoGVs21s5hW8aNLfopQwJBTcAlqBWGnj7WbK8EalUrq5per1YlHD95RsX3HjgKmdmRWa1+Q8bhlDajqjLMNtmypNec3FNaOIkWjWvj8NHTOHT0JLJr6SJqTY+1dClTMF8u5STGjxcXl65clySr4ebtu4j/cxxkSJcaLi4uqFezstaGUz7kj2l9Kl+6KKJGiYy4cWKheJF8Kl8+dJ4+fa594E/SbsuuQYyfflTp5psaVcoq3Zky/A5xIu/d/wf7Dx6D6K1St7WaCX/85CkuXr6GfRq3pg1rah9e4ZRTkyhhfNWXcxcuo4U2KysfrPcfPFLOsXk9+rGldt2+cx93tJnBHv1GQGyyZsNWnDx9Xi/i575wgVwqP0vG33H52g0V94u/EjDb2ML5+MlzqKmxkqLiGCZJnECifgaDwaDNdPtmc8zEZrFjxTDazFzZ76l/Q68BozB5xgJlI8n3r2/WWEr6T9oYkLaLnl8TJTDqlGM9WKpTz9P3eXNnRaRIEdXhkeOntXFZUcUb1q2MQ0dOqrh/505A64kYIQJWrdsCmV2eNW8Zzl/yeXdEVeq9KZAnpxqX2TKnN55j1sa0FDHtjxz7FeTcl77/9OMP2vkWGw/+eaTqsnYOpPgtKYS16JQv0ZevfB2jcizBL7sERV23tLtEMlZTp0wGV1dXVK9cWqr1FSy109ay5UoVgcy8ilLZly1ZWKJwd3eD3H2q0aAt9mnXlAuXrqp0WzbWxrkt48YW/ZQhgaAmQIc3qIlSX4AJuLm6qTKuLi7abMwXFf+CL1g6d4KauZGZl5vn9qh084184BzWnFxZ8vA/zZG8fPW6cn6zeK97s6bHWrrod3NzlZ1yNuQ2qzrwY6PLi4i7uyvkYSuJ60GOXVy+6pQ0mXmWfcSIEdQMbb7c2bFn/xH07D9Kkn0FV28+kuGuzVp/+vRZ1dG7a2sjn/NHtmlOfgaVLm0QWT0cP3kWXgtXomObxmrm+hfNkX/9+g1ctQ9Xmf3S5WQmS+KW2iW8UnjPpIk9Nq+ei2XzJom4vyGcu7uScdHs+/HDRxUXfbbYVwl7b2zhLH3yFke4cOH0qNW9NTbWbGauaMYET9StWQHy8FRV7cuH8PSvb5JviaWku7t9ZWVej+mxpTpN8yUeXrsTIXsJ0hedXXgTJv6dOwGtZ8bcpZpz+RBD+3fFzIlD8ebNG6neYnAP533Oa2NQP8eknZbGtCgIb9IfOfYrhPMebyIjY+6DNuas2Vlk3LQ2yF6CwWDAh49fx6gcS/DLLkFR1xftkmc6bq2NAUvttLVsgl/iQdoqzz+s3bgNJYsXlK6hc+8hSJH8V8zQ7NWhVSO8fvOfSre2+ajd6dHzhIulc9iWcaPr4J4EQpIAHd6QpM26LBJYtHydSl+wdA0yZ0yr4vlyZVMzn3IgH4Ry61/ikSNFwMuXrySqQlZthmjvgSP48Ydo6ji6NkO2c89B5MiaUR1b02MtXRUKwCZRgvhqLbHcBhVnx2vhKmTPmsGHBpmZ3XfwqEqTD3c9/lpzCAwGA/LkzAL5sDl+6qySMd8sXbVe+yLwGSdOncPjf5/gl/hxkSdXFkycNk85WiJ/5Ngptf4uV47MmOm1FO+816+KIybrmjOmT4XkSRPh+s3bOHfxihTR9MTB7bsPVFzWiu4/eFzFLbUrofaB+eTpU/yxdadRRvqsDkw25vYxyfIRDSh/2zinwV5thlsqkmUZMuMtcfMQOXJkvHjxUiVbY2PNZqqQyea5pif976nQsXVDPHn2XNnDv75ZYynpYl8Zv1KFrEmWMRUpUiS8MFkvbalOkbcW5KGneYtXqWyZec2e5ev49O/cCWg9127e0sZlVsTT7nhs/evb20vM268aYmFjbUxbEDUmRTGxpTHRQsSanS2I+kqyZhdfgt4JAa0rUYJ4uHP3Pl54X9fkmQBvVf7uAlK2bMkiGDZmmjbrHQuynAHaP1kmUbxwPkSLGgXbd+zRUnz//RLvZ+N67F17DxkFrI1zS+NG+ifOtrEwIyQQggT0qujw6iS4DzUC9+4/QIESNfDHtp3o1bmVaodHtzZ49Pgp5IESeaBr45avD1NVrVgaGzb/pR70evT4CaJEjoTIWsik3e6XglkypkPEiBFVuhxb02MtXcoEJLhpM65jhnqgR98RKFK2DmLFjIHqlcr4UPF7qt9QIG8OyAMpdZt1Uu0VgRs37+KXlLnUg2SjJ85EH63Pkm4eYsWIgUKlakEeQBo5uKeamZU6ZIZOHiLLVaQSPAaNUcWqVSyF35L+iqJaW9LmKIFpsxer2/F/7zkEWYowfoqXWn4hwpE1RyqfdutbHpBq3r43ZPmDpFtql8xAyRrDmV5LIPKZ85SFfFiKvGkwt49pnmk8oPxt4VynegXc1m4Py0NkHoNGI+mvCU2rNMZbNq6NLh6e6qE1WV5iiY3YTNaEi83kAbgkvybAD9GiGHXokZyFK0Ee1GrRwQPtW9ZXjoN/fbPGUtInjeqPURNmQh7WTJGpMD5+/KS+EL3RZt6q1m0FeWjNUp16eyzt+3Zvq15tV7x8Pfy95wA8urVWYv6dOwGtp0HtyujVf4Qa57fv3Fd1yEa+0Jm2X9IsBWtj2pKsniZ9KP2/gqjVuD30h9b0PNO9NTubyliLW7OLNfmA1uWuzUgP6dcFsn5b+iF3Wn6IFtWaeh/pASkryxiWrdqIMiUKGXW0bdFAXWNrN+mgXTfDG9NNI43rVUWl2i0hMjL5oOd5aNerRxau0ZbGzZoN2zBnwQq9KPckECoEXEKlVlZKAt4EDu5Yo90C7aYempCHWHSnK1bM6OohoB0bF0Fu1w/y6KRKyINRXtNGqge9REYS5cG2ts3rSRTy4Io8NKMOtI3IyMNE5nqspctDPkUK5NZKfv07unv914jJNl2alFg4c6wxJW+urOqhrL82LMTIwT20W+nuKm/n5iVGx7tDq4ZYsWAyFs0apx6qkjV10pcHVw5BHlCaPn4I8uXOpsqZbqQ944b3UXykX/r6ToPBgB6dWkL6tW/7SlV/OO22rziG/Xq2Vw+onT7wBzq1aaScMGEkSxFElzxcJ+uTpZ5hA7qr+mdPHgZ5yKmU5jykSZUcltqVIW1qrFw4RclfOLYdlcqVEBU+gpQ1tY/YN0KErx+kwmnCyH5K3hp/lem9CSjniBEjYNLoAVjqNVE9tHRk1zrEjPGTt7Zvuwpliin7yUNrMrP15/oFammIOZumDWoom40f0VebWX+KdL+n/KbEO3bu8FZIH+U2bsM6VVWqtb559usKWXYjQtZYylKcdUtnqDFy6/xeNZbEqZs2brBaQiL2t1Sn6NRDVe1Lj0e3tvoh5Hb24tnj1UNrstdtLwIyLqydOwGtR+wlLGScd+vQTHGROszbL2Pa0jlmMFge0+b9EZ2mQfoq56Oc++ayMublmmLNzsJCHqjU9Um79XXgeprsLdklKOvKlT2zGrdeU0eqL7SZMny90zW0fzc1Zvxqp7Wy0m7TIOPg2Z2T0Mep5NWqWk6z02osmDEGwwf2gNhG0k3HaoUyxXHgr1VKZrRnLwzu01lEtC/30S1eoy2Nm9bN6kK/hqvC3JBAKBCgwxsK0FklCZBA2Ccgry7LXbSymhlvWr8GZLlM2G81W2iPBCZO81KvEcxforo2zn5AsUJ5bO7G95S1uRIKOg8BB+4pHV4HNi67RgIkEHgCMtO6d9sKNYteubzv2ezAa2ZJEvBJoHvHFji1fxNkvPXt0U69VQI2/vuesjZWQTEScAgCdHhDyIzu7uHA4BgM5N2Xbm7uzmpPh+y32PPjx4+zMDIRAAAQAElEQVQO2TdnvO687dQZr0uWwtuTZ/D2/ScGB2Jgy0f2kyf/gsHxGdgyFkxl6PCa0mCcBEiABEiABEjA7gnEjh0XwR9YR2gxDswApcMbGGosQwIkQAIkQAIkQAIkYDcE6PDajanYUHskwDaTAAmQAAmQAAmEPgE6vCFkg8hxUoHBMRjE+jULosRNTXs60JgWe8ZMnJk2dRCbHjx8Ql3Z/9h1AvNW72IIGwyCxA7KsNyQQCAI0OENBDQWIQESIAESIAESIAESsB8CdHjtx1aO31L2kARIgASCgEC5a4+wqmk3PIodPwi0UQUJkIAjEHBxhE6wDyRAAiRAAiTgSATYFxIggaAl4FQO74EjJ5GzeG1jKF65uZ80azfvoX5S1Fxo3tL1WLRik3kyjp86j+4DxqJIhSZo3K4fdu476kuGCSRAAiRAAiRAAiRAAiFLwKkcXkGbLVNa7N+yQIUtK6ZKUpCFSBEjoHPr+tiychrqVS+LwaOmB5lu34qYQgIkQAIkQAIkQAIkYAsBp3N4LUGRmdkm7fujXste8BgyES9fvfYlJrO6VRp0QuuuQ3Dx8nVf+ZKQIvmviBn9R7i6uCBPjoyQX+T67+1byWIgARIgARIILgLUSwI2EFi9fguGjJwU4uHchcs2tI4iwU3A6RzeQ8dOG5c0DBw5HR8/fUIfz0lo0bAqvCYPhqurK+YvXe+D+7Wbd7By3TbMGNcPnn3a4dzFaz7yLR2s3vAnkiVJhIgRIljKZhoJkAAJkEAwEvjy5UswaqdqeySwZsPWEHd2xcG25PDWa9kTWQtX8xVWrt9mE9oajbtYXHJpWtgWGVN5a/HH/z6F6LKWby/pzuLwGu1huqTBo3NT3L33EFGjRkamdKmUTNXyxXDqrM9vYyfPXETBvFnxY7SoiBolMgrnz65krW1Onb2EhSs2oU+XZtZEmE4CJEACJEACJOCkBLwmD8HhP5di/hRPpEiWWMXluFKZojYR6dWpGX7QfBK/hG2R8au8o+U5ncNryYDubm7GZDct/gW+ZwZk5lcXcnNz1aO+9o8eP8HEmYsxcXgPJIgf11c+E0iABEggdAk4R+0Gg8E5OspeOgwBmUmtVK89uvUbjWYd++PBw8do3K4PqjToqGZY/95zyNjXwaOm4fmLl2qWt3L9DugxcCwatfXAgBFT8OnzZyVni8ytO/fRtEM/NGjdC0PHzkSJqpYf5n//4QO69B2FWk27qf2Ll69UHZM0f0fKSLuney1XabKRuvsNm4QWnQdi2txl+Gv3QbTuOhhVG3ZCtUadRCTEg9M7vPHjxcaLl69x8uxFBX/52q3IkDaFiuubtKmS4+iJc/isDSK5TXb42Fk9y8deBmuvwRPQs0MT/Bwnlo88HpAACZAACZAACZCAXwSUA1q/CqaN7ou4sWNq/kRTLJ8zGuOH9sC4aQth6bmgew8eomndypg1fiB+/CEadu094qsKazLjpi1A3hyZMGfiYCT85Wf8999bX2UlQdpVrkRBLJw+DPKA/oLlGyQZJYrkxR/Lpmrpw3H63GUcOX5Gpcvm3fsPmDS8F5rVr4pxUxdgxIBOWDZ7FCYO6yXZIR4sOrwh3opQrNDN1VUtPZg4Y4l6aO3t23eoU7WMjxYlS5IQhfJmR5tunujYeyTE6fUh4H0gzrIYvEaTrsZ1wvINzTubOxIgARIggRAgsDZJLFTUPphjPbwbArWxChIIOgLidCZNnMCo8PqtO+g7dBJ6DhqHl69e4c7df4x5eiT+z3Hwa6Jf1GHsmNEhZdSBycaazLkLV1CxzNdlFPrepJgxGidWDOTRHGNJqFq+OM6evyJRvH33DqMmzUW7Hp64c+8BLl+7pdJlkz9XFri4fHUz0/+eAsPHzcachavxOZTW139tibTMCUKOLOkxzrObr55mTJcKM8b2VQ+tDezZGlEiR1IyC6Z6ImaMn1S8bvUymDSiF8YM7oLZEwagZuWSKt1006JhNfW6M/21Z7KXb2imMoyTAAnYFQE2lgRIgARCjEA4d3djXecuXsXC5RtRr3o5TNVmfJMnSYQ3FmZgZeJOL+TiYsDHj5/0Q+Pemoz4nuHDfa1TlmsaDAZjGdOI5OnHsvRT7nh/+PARPQeORZH8OdUMtMz2mrbP3f3bctEBPVqjeqWSkCWjzTsO0Bzl97q6ENs7lcMbYlRZEQmQAAmQAAmQAAl8B4Ebt+4iRfLESJL4F7x48QpntNnY71BnsWiaVMmw79AJlXfwyCmrd7Dv3n+I/Ye/yi1fswW/p06OZ89fIFy4cJDZW3HUdT1Kmdnm5avXSJEsMRrWqgg3Vxe1PtlMJNgP6fAGO2JWQAIkQAIkQAIkQAIBI5AvVxacOXcZ8uCaLBtIkyJpwBTYIN2uWW2s/WMHmnfsjyMnziL6Tz9YLCVLLeQXZqvU74DnL1+ppZ+xYkZHmpTJUKNJF3TsNdzPB/XlYbUyNVqhe/8xKF4oNxIniGexnuBMpMMbnHSpmwScjAC7SwIkQAIkYDuBlL8lwYJpw1QBWUK5eOYIFZeNLK+cP3UoZo4bgEG92qplDTKbKnkiJ/ISJC5pEqqW/x+a1qsiUUi65EuQuErUNqYyMaL/iFEDu3zVneY3NQurifj4k/IrvcZiwrCeWD53DEb074RoUaMomb5dW2DxjBEYM6QbBvZsg0a1K6p0eSVa4Xw5VFw28mDb+sWTMLRvBzSuW1mSQjzQ4Q0h5K//OQ8Gx2Dw6PoRvHpwjvZ0oDEt9nx84yht6iA2zZ41g7qyl8iXAXUr5GNwIAbKsIHclC9dDD07twqpYKwndcrkgWxx8Be7ePk68pSoo2Zp5Ucv2mozvsFfa+jUQIc3dLizVhIgARIgARIggRAkUKFMcaMTGpKOb1h2eDOlT409f8yHzNJOGNbLoV+pSoc3BE82VkUCPgjwgARIgARIgARIIEQI0OENEcyshARIgARIgARIwBoBppNAcBOgwxvchKmfBEiABEggRAlEGjMGhlWrgVSpQrReVkYCJBB2CdDhDbu2Yct8EOABCZAACZAACZAACQSOAB3ewHFjKRIgARIgARIIHQKslQRIIMAE6PAGGBkLkAAJkAAJkAAJkAAJ2BMBOrz2ZC3b20pJEiABEiABEiABEiABbwJ0eL1BcEcCJEACJOCIBNgnEiABEgDo8HIUkAAJkAAJkAAJkAAJODQBOrwAHNrC7BwJkAAJkAAJkAAJODkBOrxOPgDYfRIgARIwIcAoCZAACTgkATq8DmlWdooESIAEnJfAmw4d8KViBeD8eeeFwJ6TAAn4IBBwh9dHcR6QAAmQAAmQAAmQAAmQQNgmQIc3bNuHrSMBEgjDBNg0EiABEiAB+yBAh9c+7MRWkgAJkAAJkAAJkEBYJRDm20WHN8ybiA0kARIgARIgARIgARL4HgJ0eL+HHsuSAAnYToCSJEACJEACJBBKBOjwhhJ4VksCJEACJEACJBByBF7c3oNHZxeFeHj3/KavTjIh5AnQ4Q155qyRBEiABEiABEgghAm8uLNPc3YXh3h4a8HhnTZ3GcZPX+iDwIXL11G+dhsfaaYHIyfOwR/bd6ukGo274PG/T1XcdDN38RosWLbeNMlXfNe+I7hy/ZYxfcSEb3qNiYGISHukXYEoGiJF6PCGCGZWQgIBJUB5EiABEiABRyVQokhebPlzj4/ubd2xDyWK5vORZu2gV6dm+CFaVGvZfqbvO3QC127cMcpULV8c2TKnNR47aoQOr6Nalv0iARIgASclEGnMGBhWrQZSpXJSAg7WbQfsTsJffsaPP0TDqbOXjL0TB7hE4Tz4c9cBFK/cFFUadETvwePx6vUbo4weGTxqGp6/eKkOZVa3Qp12aNFpAC5qs8QqUdtY0nPp6g3s3HsYM7yWo0n7vrh5+x6WrdmCQ0dPayWAYyfPoWEbD9Ru1g29Bo3Dy1evVbrUN2jkNDTv2F/liZzKMNu8//ABXfqOQq2m3dT+xctXSmLSzMUoUbU5KtVrj+la3SpR21Ss2w6jJs1Fi84D8dfugyq07joYVRt2QrVGnTSJoPujwxt0LKmJBEiABEiABEiABGwiULRgTmz7e5+SPX3uEn76MRrEEU6R7FesWzQRy2aPUscLV2xUMpY2V2/cxnLNYZ0zaRCG9++EM+evGMUs6fktaWLkz50VTepVwYyx/ZEoQTyj/MdPn5ST26pxDSyYNgyurq7wWrzWmP9Jy5800gPTxvTD6MlexnTTyK0791GuREEsnD4MkSJGwILlG1S2zGj/sWyqlj4cp89dxpHjZ1S6bBLEj4spmt5CebNj3NQFGDGgk+r7xGG9JDvIAh3eIENJRaFIgFWTAAmQAAmQgF0R+F+hPNi6Yx++fPmi9kUL5lLtDxfOHXMXrUGbbkOwe/9RXLl6U6Vb2pw4fQGF8+fAj9GiImqUyNB1iGxA9Ij83Xv/IFq0KMicPrUcolqF/+HkmYsqLpuc2TLA1cUFkSNFxNNnLyTJV4gTKwby5Mik0mWpxFlvB/ztu3dqJrddD0/cufcAl6/dUjKyKZQvh+xUSP97CgwfNxtzFq7GZ42LSgyiDR3eIAJJNSRAAiRAAiQQ+gTYAnshEDdOTCSM/zOOnjirHN5SxfKrpg8ZPR0/x4mFIR7t0KFFXfz39p1Kt7aRmVg9z83NVY8ioHqkoLubm+xUcNPiX/BFxWXj6vrNZbTmjJrWL+U/f/6MDx8+oufAsSiSPyfGD+0Bme19899bUalCOPdvdQ7o0RrVK5XUav2C5h0H4O2790omKDbfWh8U2qiDBEiABEiABEiABEjAJgKyrGHs1Plq6ULM6D+qMrIsIF/uLIgWNQp2Hzim0qxt0qX+TS0PEMdSZor1tbgib01PxIgR8OLF17W1IqeH+PHi4LmWfuLMBZW0bM1mZEyXSsVt3dy9/xD7D59Q4rLU4vfUyfHs+QuECxcOMnsbzt0d8tCcErCwkTXDKZIlRsNaFeGmOdgPHj62IBW4JDq8geNm16XYeBIgARIgARIggdAnULxQHnV7v2iBnMbGNKxVAfVa9FRLGj5+/GhMtxRJnjQRCufLgZadB6Jdj6FqeYQuZ01PqaL5sE9zSpt17K8eWtPl3Vxd0b97K4yftlA9mPZWm1muV72cnm3TXtYgL1qxCVXqd8Dzl69Qp2oZxIoZHWlSJkONJl3QsddwyJpda8rkYbUyNVqhe/8xKF4oNxKbrDG2VsbWdDq8tpKiHAmQAAmQgKMRYH9IIFQJ/BAtCg5uW4yq5f9nbEfp4gWwduEETBjWE51a1cfE4V8f3urcuoFaDiCCi2eOQMwYP0kU9WuWx9TRfdVyAa/JQ1BbczIlw5qeZEkSYvSgrpimlZGH1rq0+aY3U/rUmD1hoHpobXDvdogSOZKogrwGTRxrdaBt5AE0befjT9qz0musavfyuWMwon8nNUstQn27tsDiGSMwZkg3DOzZBo1qV5RkrJo3zigjCaJ3/eJJg9qx+wAAEABJREFUGNq3AxrXrSxJQRbo8AYZSioiARIgARIgARIIqwSi/ZILsdLUCPEQ4YdEYRWJU7WLDq9/5mY+CZAACZAACZCA3ROIliCP5uzWDPEQng5vmBg7dHjDhBnYCBIgARII+wTspYVvOnTAl4oVgPPn7aXJbCcJkEAwE6DDG8yAqZ4ESIAESIAESIAESCB0CQSxwxu6nWHtJEACJEACJEACJEACJGBOgA6vOREekwAJkEBQEKAOEiABEiCBMEOADm+YMQUbQgIkQAIkQAIkQAKORyAs9IgOb1iwAttAAiRAAiRAAiRAAiQQbATo8AYbWiomARKwnQAlSYAESIAESCD4CNDhDT621EwCJEACJEACJEACASNA6WAhQIc3WLBSKQmQAAmQAAmQAAmQQFghQIc3rFiC7SAB2wlQkgRIwA8CkcaMgWHVaiBVKj+kmEUCJOBMBOjwOpO12VcSIAESIAEScCgC7AwJ2EaADq9tnChFAiRAAiRAAiRAAiRgpwTo8Nqp4dhs2wlQkgRIgARIgARIwLkJ0OF1bvuz9yRAAiRAAs5DgD0lAaclQIfXaU3PjpMACZAACZAACZCAcxCgw+scdra9l5QkARIgARIgARIgAQcjQIfXwQzK7pAACZAACQQNAWohARJwHAJ0eB3HluwJCZAACZAACZCAFQJXb/2Dw6evhnh48vyVlRYxOSQJ0OH9LtosTAIkQAIkENYIvOnQAV8qVgDOnw9rTWN7QpGAcnhPaQ5vCId/n1l2eBu28cDJMxeNRM6cv4J6LXsajy1FXrx8hUr12lvKQtvunrhw6ZrFPP8Sd+07givXb1kU+2P7boyYMMdinj0l0uG1J2uxrSRAAiQQVgmwXSRAAnZLYN+hE7h2447dtt+WhtPhtYUSZUiABEiABEiABEgghAh8+PARQ8fORM2mXVG3RQ/8ueuAr5rfvX8PjyETUKNJF7Tr4YlXr98YZVas3Yo6WjnJmzZ3mTG9WKUmxrjMLnfoNQyXrt7Azr2HMcNrOZq074ubt+8ZZfTIrTv30aLTAFSp3wHjpy/Uk9G4XR9UadARNRp3wd97DhnTK9Zth1GT5qJF54H4a/dBzJy3Ak079EOpai1CbbY4JB1eIwhGSIAESIAESIAESMDZCYjDmLVwNUho0LqXEceaTX/ipuZkzp86FAN6tMbgUdPx/IXPpRGrN2xXaQunDUPTelVw+twlVV5mamfMX4FxQ7pj9oSB2L7zAGQGV2Va2PyWNDHy586KJpqOGWP7I1GCeL6kzl64otoxb6ondu8/igNHTimZnh2aYvmc0Rg/tAfGTVuI/96+VemySRA/LqaM9EDq35Jiz8HjmD6mHzYunYJ6NcpJdogHOrwhjpwVkgAJkAAJkAAJkAAwc9wAHP5zqQpzJg42Ijlx+gIqlS4CVxcXJE4YH2lTJ8eFy9eM+RI5fe4yKpYpAhdNJk3KZJAg6cdPn0ehfNkR/acfEDFCBJQunt/HWmGRCWjIkyMTYsWMbtR35vxlpeL6rTvoO3QSeg4ah5evXuHO3X9UumwK5cshO8SI/iPevXuPCTMWYsmqTYgWNYpKD+kNHd6QJs76SIAESIAESIAESMAfAm7ubkYJNzc3fPliPDRG3Fxdv8XdvsXdNXk9Q2S+4GthV03+8+fPKuvTp09qb8tGyulyok90nLt4FQuXb0S96uUwdXRfJE+SCG/++zbDG867/e7afv60ocidLSOuXLuN3ppzrOtS+xDa0OENIdCshgRIgARIgARIgARsIZAhbUqs3fgXPmnO6Y1bdyEzqqlTJPFRVGZ9Dx07rdKePX+BC5euq3jGtKmwY88hPHn6XC0x2LhtFzKlS6Xy4v8cG7fvPlDxA0e/LkuQg4gRI+CF2ZIJSdfD3oPH8OjxE6O+dGl+g7QrRfLESJL4F1X2zIUruriPvXKCNW89U/rUaNGoGk57zw77EAqBAzq8IQCZVZAACXwXARYmARIgAaciUL5kYcSJHQN1mndHH8+J6Nauka+lABVKF8HTZy/QqssgTWYS4saJqRiJA1qvWjm06zkU8uqz/LmyIEeW9CqvWoX/qQfc2nQbgpevXqs02ZQqmg/7Dp9As479LT60liLZr0pf7WbdlS7Rl0/Te+bcZcg6ZHlALU2KpKLKV7j/zyPkLVlXPYA3csIc1RdfQiGQQIc3BCCzChIgARIgARIgARIwJSAPlKX/PYUx6fdUyeA1eYg6lmUA3ds3xqLpwzFviicK5c2u0qNFjYKVXmNVPHy4cBjYsw0mjeitHhpbMXcMUv72dRa4crlimK+VWzxjBJrVr6rkZVO0QC6sWTABE4b1RLe2jTBmcDdJRrIkCTF6UFdMG93X10NrJYrkVfLSFqm7bdNaqkyUyJEgD9XJOuRBvdqqZQ16f1bNG2d00JMmToD9Wxepvnj26WDsi1ISghs6vCEIm1WRAAmQAAkEP4FIY8bAsGo1kOrrbdzgr5E12AOBpAnjIGu6pCEeYvwYOg9p2YNNQrKNdHhDkjbrIoEQIMAqSIAESIAEfBNQDm9azeEN4RD9Bzq8vq0R8il0eEOeOWskARIgARIgARIIfgKsgQSMBOjwGlEwQgIkQAIkQAIkQAIk4IgE6PA6olXZJ9sJUJIESIAESIAESMDhCdDhdXgTs4MkQAIkQAIk4D8BSpCAIxOgw+vI1mXfSIAESIAESIAESIAEQIeXgyAABChKAiRAAiRAAiRAAvZHgA6v/dmMLSYBEiABEghtAqyfBEjArgjQ4bUrc7GxJEACJEAC/hF406EDvlSsAJw/758o80mABJyEAB3e4DM0NZMACZAACZAACYQCgYcPH4DBcRkEZkjR4Q0MNZYhARIgARIIAAGKkkDIEYgePQYYHJ9BQEcUHd6AEqM8CZAACZAACZAACZCAXREIMw6vXVFjY0mABEiABEiABEiABOyGAB1euzEVG0oCJOAkBNhNEiABEiCBICZAhzeIgVIdCZAACZAACZAACZBAUBAIOh10eIOOJTWRAAmQAAmQAAmQAAmEQQJ0eMOgUdgkEiAB2wlQkgRIgARIgAT8I0CH1z9CzCcBEiABErArApHGjIFh1WogVSq7ajcbSwLfSYDF/SBAh9cPOMwiARIgARIgARIgARKwfwJ0eO3fhuwBCdhOgJIkQAIkQAIk4IQE6PA6odHZZRIgARIgARJwdgLsv3MRoMPrXPZmb0mABEiABEiABEjA6QjQ4XU6k7PDthOgJAmQAAmQAAmQgCMQoMPrCFZkH0iABEiABEggOAlQNwnYOQE6vHZuQDafBEiABEiABEiABEjAbwJ0eP3mw1zbCVCSBEiABEiABEiABMIkATq8YdIsbBQJkAAJkEBgCbzp0AFfKlYAzp8PrIrvLMfiJEACYY0AHd6wZhG2hwRIgARIgARIgARIIEgJ0OENUpy2K6MkCZAACZAACZAACZBAyBCgwxsynFkLCZAACZCAZQJMJQESIIFgJ0CHN9gRswISIAESIAESIAESIIHQJGAfDm9oEmLdJEACJEACJEACJEACdk2ADq9dm4+NJwEScDYC7C8JkAAJkEDACdDhDTgzlnByAuVrNEOUuKkROU4qBgdhsG95J1xbVxVnl5ZmcAAG//3L15E5+WWa3XcOAgHqJR3eAOGiMAmQAAmQAAmQAAmQgL0RoMNrbxZje0mABGwnQEmnJPCobHgYVq4EUqVyyv6z0yRAAr4J0OH1zYQpJEACJEACJEACJOBQBJy9M07l8B44chI5i9c2huKVm/tp/9rNe+Dxv099ycxbuh6LVmzylf702Qt09hiJguUaYfj4Ob7ymUACJEACJEACJEACJBDyBJzK4RW82TKlxf4tC1TYsmKqJAVpKFksH5rUqRSkOqmMBEKGAGshARIgARIgAcck4HQOryUzHj91Hk3a90e9lr3gMWQiXr567UtMZnWrNOiE1l2H4OLl677yJeGnH6OhUN5siBgxvBwykAAJkAAJkAAJ2CMBttnhCDidw3vo2GnjkoaBI6fj46dP6OM5CS0aVoXX5MFwdXXF/KXrfRj62s07WLluG2aM6wfPPu1w7uI1H/m2HHz48B4MjsHgy5cvtpicMnZE4POXz3bUWjbVFgKfP3/C508fGRyMgS22pwwJWCLgdA6v6ZIGj85NcffeQ0SNGhmZ0n19mrdq+WI4dfayD1Ynz1xEwbxZ8WO0qIgaJTIK58/uI58HTkmAnSYBEiABEiABErATAk7n8Fqyi7ubmzHZTYt/ge8ZPJn51YXc3Fz1qM17d/dwYHAMBgaDwWa7U9A+CLgYeCm0D0vZ3koXF1e4uLoxhAiDkONs+wigJAn4JODi89D5juLHi40XL1/j5NmLqvPL125FhrQpVFzfpE2VHEdPnMPnz58ht7MPHzurZ3FPAiRAAiRAAiRAAiQQxgk4vcPr5uqKPl2aYeKMJeqhtbdv36FO1TI+zJYsSUIUypsdbbp5omPvkcrp9SHgfSDrgeW1Z/JKstUb/1Rrha094OZdxGl27CgJkAAJhBSBWOve4UulSsD58yFVJeshARII4wScyuHNkSU9xnl282WSjOlSYcbYvuqhtYE9WyNK5EhKZsFUT8SM8ZOK161eBpNG9MKYwV0we8IA1KxcUqWbbsR51l95pu9TJP/VVIRxEiABEiAB5ybA3pMACYQCAadyeEOBL6skARIgARIgARIgARIIZQJ0eEPZABarZyIJkAAJkAAJkAAJkECQEaDDG2QoqYgESIAESCCoCVAfCZAACQQFATq8QUGROpyKwJrF0/DqwTm8/uc8g4MwyFVlFJKUXYY01TYwOACDiDG+vlfdqS5M7CwJkICfBBzA4fWzf8wkARIgARIgARIgARJwcgJ0eJ18ALD7JEACDkSAXSEBEiABErBIgA6vRSxMJAESIAESIAESIAESsFcC5u2mw2tOhMckQAIkQAJ2TSDSmDEwrFoNpOJaXrs2JBtPAkFIgA5vEMKkKhIgAXsiwLaSAAmQAAk4CwE6vM5iafaTBEiABEiABEiABCwRcII0OrxOYGR2kQRIgARIgARIgAScmQAdXme2PvtOArYToCQJkAAJkAAJ2C0BOrx2azo2nARIgARIgARIIOQJsEZ7JECH1x6txjaTAAmQAAmQAAmQAAnYTIAOr82oKEgCthOgJAmQAAmQAAmQQNghQIc37NiCLSEBEiABEiABRyPA/pBAmCBAhzdMmIGNIAESIAESCCoCbzp0wJeKFYDz54NKJfWQAAnYOQE6vHZuQIdoPjtBAiRAAiRAAiRAAsFIgA5vMMKlahIgARIgARIICAHKkgAJBA8BOrzBw5VaSYAESIAESIAESIAEwggBOrxhxBC2N4OSJEACJEACJEACJEACASFAhzcgtChLAiRAAiQQdgiwJSRAAiRgIwE6vDaCohgJkAAJkAAJkAAJkIB9EnB0h9c+rcJWkwAJkAAJkAAJkAAJBBkBOt/KjoUAABAASURBVLxBhpKKSIAESCAsE2DbSIAESMB5CdDhdV7bs+ckQAIk4JAEIo0ZA8Oq1UCqVA7ZP3aKBEgg4AR8OLwBL84SJEACJEACJEACJEACJBC2CdDhDdv2YetIgARChwBrJQESIAEScCACdHgdyJjsCgmQAAmQAAmQAAkELQHH0EaH1zHsyF6QAAmQAAmQAAmQAAlYIUCH1woYJpMACdhOgJIkQAIkQAIkEJYJ0OENy9Zh20iABEiABEiABOyJANsaRgnQ4Q2jhmGzSIAESIAESIAESIAEgoYAHd6g4UgtJGA7AUqSAAmQAAmQAAmEKAE6vCGKm5WRAAmQAAkEN4E3HTrgS8UKwPnzwV0V9X8nARYngZAiQIc3pEizHhIgARIgARIgARIggVAhQIc3VLCzUtsJUJIESIAESIAESIAEvo8AHd7v48fSJEACJEACJBAyBFgLCZBAoAnQ4Q00OhYkARIgARIgARIgARKwBwJ0eO3BSra3kZIkQAIkQAIkQAIkQAJmBOjwmgHhIQmQAAmQgCMQYB9IgARI4BsBOrzfWDBGAiRAAiRAAiRAAiTggASc2uF1QHuySyRAAiRAAiRAAiRAAmYE6PCaAeEhCZAACTghAYfqcqQxY2BYtRpIlcqh+sXOkAAJBJ4AHd7As2NJEiABEiABEiABEiABOyBgu8NrB51hE0mABEiABEiABEiABEjAnAAdXnMiPCYBEiABfwgwmwRIgARIwL4I0OG1L3uxtSRAAiRAAiRAAiQQVgjYTTvo8NqNqdhQEiABEiABEiABEiCBwBCgwxsYaixDAiRgOwFKkgAJkAAJkEAoE6DDG8oGYPUkQAIkQAIkQALOQYC9DD0CdHhDjz1rJgESIAESIAESIAESCAECdHhDADKrIAHbCVCSBEjgewm86dABXypWAM6f/15VLE8CJOAgBOjwOogh2Q0SIAESIAEScCgC7AwJBCEBOrxBCJOqSIAESIAESIAESIAEwh4BOrxhzyZske0EKEkCJEACJEACJEAC/hKgw+svIgqQAAmQAAmQQFgnwPaRAAn4RYAOr190mEcCJEACJEACJEACJGD3BOjw2r0Jbe8AJUmABEiABEiABEjAGQnQ4XVGq7PPJEACJODcBNh7EiABJyNAh9fJDM7ukgAJkAAJkAAJkICzEaDDa83iTCcBEiABErBLApHGjIFh1WogVSq7bD8bTQIkEPQE6PAGPVNqJAESIAGHIsDOkAAJkIC9E6DDa+8WZPtJgARIgARIgARIgAT8JBBEDq+fdTCTBEiABEiABEiABEiABEKNAB3eUEPPikmABBySADtFAiRAAiQQ5gjQ4Q1zJmGDSIAESIAESIAESMD+CYSlHtDhDUvWYFtIgARIgARIgARIgASCnAAd3iBHSoUkQAK2E6AkCZAACZAACQQ/ATq8wc+YNZAACZAACZAACZCA3wSYG6wE6PAGK14qJwESIAESCGkCbzp0wJeKFYDz50O6atZHAiQQRgnQ4Q2jhmGzSMACASaRAAmQAAmQAAkEggAd3kBAYxESIAESIAESIIHQJMC6SSBgBOjwBowXpUmABEiABEiABEiABOyMAB1eOzMYm2s7AUqSAAmQAAmQAAmQgBCgwysUGEiABEiABEjAcQmwZyTg9ATo8Dr9ECAAEiABEiABEiABEnBsAnR4Hdu+tveOkiRAAiRAAiRAAiTgoATo8DqoYdktEiABEiCBwBFgKRIgAccjQIfX8WzKHpEACZCAUxOINGYMDKtWA6lSOTUHdp4ESOAbATq831gEIEZREiABEiABEiABEiABeyFAh9deLMV2kgAJkEBYJMA2kQAJkIAdEKDDawdGYhNJgARIgARIgARIgAQCTyAkHN7At44lSYAESIAESIAESIAESOA7CdDh/U6ALE4CJEACthOgJAmQAAmQQGgQoMMbGtRZJwmQAAmQAAmQAAk4M4EQ7jsd3hAGzupIgARIgARIgARIgARClgAd3pDlzdpIgARsJ0BJEiABEiABEggSAnR4gwQjlZAACZAACYQVAm86dMCXihWA8+fDSpPYDhL4TgIs/r0E6PB+L0GWJwESIAESIAESIAESCNME6PCGafOwcSRgOwFKkgAJkAAJkAAJWCZAh9cyF6aSAAmQAAmQAAnYJwG2mgR8EaDD6wsJE0iABEiABEiABEiABByJAB1eR7Im+2I7AUqSAAmQAAmQAAk4DQE6vE5janaUBEiABEiABHwTYAoJOAMBOrwhZOXIcVKBwTEYXNzSBeeWlcHZpaUZHITB85s7QuhKwGpIgARIgARCgwAd3tCgbnd1ssEkQAIkQAIkQAIkYL8E6PDar+3YchIgARIgAQsEIo0ZA8Oq1UCqVBZyvzOJxUmABOySAB1euzQbG00CJEACJEACJEACJGArAadyeA8cOYmcxWsbQ/HKzf3kVLt5Dzz+96kvmXlL12PRik2+0iVh2ZotkHJ1W/TCrv3HJImBBEiABEiABEiABEggFAk4lcMrnLNlSov9WxaosGXFVEkKsnDz9n3MW7Ie00b3wfB+HTB41HS8ffc+yPRTEQmQAAnYFwG2lgRIgATCBgGnc3gtYT9+6jyatO+Pei17wWPIRLx89dqXmMzqVmnQCa27DsHFy9d95UvCngPHkD93FkSOFBFx48REyuS/4vCxM+A/EiABEiABEiABEiCB0CMQ6g5vSHf90LHTxiUNA0dOx8dPn9DHcxJaNKwKr8mD4erqivlL1/to1rWbd7By3TbMGNcPnn3a4dzFaz7y9YNH/z5BvLix9EP8Ei8OHj7+13jMiIMQ+PLFQTrCbugEPn36CAkfPrwHg2Mw+Pz5Ez5rdmX46FAc9HOWexIIKAGnc3hNlzR4dG6Ku/ceImrUyMiU7uvTvFXLF8Ops5d9cDx55iIK5s2KH6NFRdQokVE4f3Yf+aYHBpdvSA0Gg2kW4yRAAiTgFwHmkQAJkAAJBBOBb95ZMFVgD2rd3dyMzXTT4l/gewZPZn51ITc3Vz3qYx8rRnQ8e/bcmPbk6TPEjhnDeMyIgxDgFxkHMeS3bri6usFVC+7u4cDgGAxcXFzhotmUwc2hOHw7axlzbAJB3zuXoFdpXxrjx4uNFy9f4+TZi6rhy9duRYa0KVRc36RNlRxHT5zD58+f8UW7nX342Fk9y8c+T45M2H3gGN69f48nT5+rpQ/Zs6T1IcMDEiABEiABEiABEiCBkCXg9A6vm6sr+nRphokzlqiH1t6+fYc6Vcv4sEKyJAlRKG92tOnmiY69Ryqn14eA90GiBD+jQqnCaNS2L9r3HI4OLesinLu7dy53JEACQUmAukjAGoE3HTrgS8UKwPnz1kSYTgIk4GQEnMrhzZElPcZ5dvNl4ozpUmHG2L7qobWBPVsjSuRISmbBVE/EjPGTitetXgaTRvTCmMFdMHvCANSsXFKlm2+qli8OKTdvymDkz5XZPJvHJEACJEACJEACJBCUBKjLBgJO5fDawIMiJEACJEACJEACJEACDkaADq+DGZTdIQGLBJhIAiRAAiRAAk5MgA6vExufXScBEiABEiABZyPA/jonATq8IWT31/+cB4NjMEhRfARSV12PNNU2MDgIgx8SFQyhKwGrIQESIAESCA0CdHhDgzrrDOME2DwSIAESIAESIAFHIkCH15Gsyb6QAAmQAAmQQFASoC4ScBACdHgdxJDsBgmQAAmQAAmQAAmQgGUCdHgtcwny1A8f3sNBg9P1y93dHR8/fnC6fjvy+BV7urm50aYOcp2KMGokIm/aiAjpf0eEcK4MDsQgyD+cqdBpCNDhdRpTs6MkQAIkQALBS4DaSYAEwioBOrxh1TJsFwmQAAmQAAmQAAmQQJAQoMMbJBhtV0LJ0CHQpH1/nDp7yc/KR0/2wpa/9vqS2bh1F6R8kQpN0MljBK7fvGuUWbZmC2o374G6LXph1/5jxvTJs5ageuMuKF29NQaMmIp379+rvI+fPmHw6Bmo36o3mnbojzv3Hqh0bgJGQOzhnz1t0fjg4WN4jpmJElVaKHt5LV5nLPb436do3XUIGrbpg54Dx+G/t29V3vFT59F9wFjIeGjcrh927juq0mUzcqIXSlVvhRpNusohQwAIyLmRr3R9f0vI+Sa2MRcM6Dnnlx3XbPoLNbTzN2fx2nj67IV5VTy2gYCt9rRBFfy6Bp88cxH1W3ugTouemDl/pVGdtfHgl92NhRlxSAJ0eB3SrOxUUBKIEzsGJg7vgfWLJyB50kSYOmepUn/z9n3MW7Ie00b3wfB+HTB41HS8fffVsU2fNiWWzByBeVMG48nT51i94S9VZv3mv7XjZ5g7aRAqly2KoWNnq3RuQoeAi4sLKpcrij+WT8Hg3m2xfO1WXL1+WzVm3LSFyJElPWZPGIBo0aJi4fJNKj1SxAjo3Lo+tqychnrVyyq7qwxtky5Ncgzs2VqL8c8GAkEqEtBzzi87xokVAwM0O8aM8VOQtpHKAkfA2jX4y5cv6OM5CV3b1MeciQPx1+5DEIdWarE2Hvyyu5RjcFwCdHgd17bsmRUCJau1NObILGHnPiONx5YiWTKkQfhw4RAxQgTkzpYR/zx+qsT2HDiG/LmzIHKkiIgbJyZSJv8Vh4+dgfzLnS2D7BD9px+QQXN+Hz7+Vx3vPXAcJYvmVfFC+bLj7MWreP3mP3XMTeAITJm9FGVqtkG1Rp19zPDIzO2Q0TPRqstg1GvZy/hBaFpL7JjRkTxJIsi/pIkTIOmvCXDvwSM5xN6DJ1Cq2FdbldJstufgcZWeQrNzzOg/wtXFBXlyZMSHDx+Ms7/FCuZCjJ9+VHLcBJ7AinVbMd1ruVFBux7DcPHydeOxpUhAzzm/7Jgza3rjuLBUF9MCTqBZxwGQOx+1m/XAzr1HlAKZqZc7Yb0GT1B3vAZpkwafPn9WeaYba9fgi1duIJJ2/U2dIincXF0h59/uA1/vtFkbD37Z3bROxh2PgEuY7hIbRwJhjMDilZuQPdPvqlWP/n2CeHFjqbhsfokXB7pjK8cS5Db4hi07kc1Y5ini/xxHstQFOm7smHj46Ik65iZwBIoXyoP1iybAa/IQnDl/FUdPnDUq+vTpE8YP64HJI3tj7NQFxnRLEZnZPX/pGtJqs7TyJcRgAH76MZoSTRA/Dh499m2n1Rv+RDLNYZYvQ0qQm1AnEJhzjnYMfrN1a9sIi2cMx5jBXTBx5mLjl0T5gtm4dkVMH9MXP/4QFbv3fXVYrbXI9Br8j3btjG9yDZbz9J+HXycX9PLm40FPlz3tLhScJ9DhdR5bs6ffSWDh8o149uIVGtauYNRk0Gb59AODQfOQ9ANtL7fbemszF4XyZlO3xrUk9WcwfJNzMYmrTG4CTODd+3cYM2UeOvYegbv3/8GV63eMOnJmS69mYmUW/tnzl8Z088izFy/RY+BY9O7cDD9Gi6qyZbmDimgbg8H3pVLuDixcsQl9ujTTJIL/jzX4TyCT/pk3AAAOi0lEQVQw5xzt6D/XoJC4cfsu+g+fCg/PSXj56jXu3nuo1Mb/OTZ+TRRfxeWOi8ipAwsby9fgb9dTwOd5am08iGraXSg4V/A5Opyr7+ytkxJw1W59ffa+bSYzgLZgOHTsNI6ePIuxQ7qq5Q1SJlaM6Hj27LlEVXjy9Blix4yh4rKRByhkmUPLRtXlUIVYMX7Ck6cmZZ69QOxY0VUeNwEn8OHDR3gMmYjC+XKomaPihXLjzX9fHy4TbaZO6+cvXyTJV5BbqAOGT0GHFnWRL2cmlS8O8qdPn/H+wwd1/K9m21gxv9lJZntllkrWdieIH1fJcBN0BNQ5amIvW8/TgJ5ztGPQ2cwvTXLnZPHKP1CnahlMGtELyX5NiDfe56mri6uxqIuLAR8/fjIem0YsXYPjaNfOp8++fZF9op2nst5XL2dpPEge7S4U7DoEqvF0eAOFjYXsmYAsQ7h99x/VhYOaI6sifmxOnr2IOYvWYohHe4RzdzdK5smRCbJeTN7A8ERzYs9dvIbsWdKq/KWrt+Dxv8/QpG5ldaxvcmXPgO07D6rDg0dPI4k2syHOlUrgJsAEnj1/AfkhkHRpflO22X/4ZIB0iMPc13MyShbNB1m3aVo4VzbNVn/vV0lbd+xDHs12ciDrDmXNYc8OTfBznG9LWiSPIWgIxIsb2zgD+FT7Unjp6k1/FQf0nKMd/UUaZAI3b9/Db8kSIUni+Hih3SWTZxcCotzaNThFssTadfYpbt99APni+qd2bZXrsui2Nh5od6HjnIEOr3Pa3el6/eHjR21m9quzWrV8MfV6sfY9h2u31t74y2LijCU4cfoCCpZtCHlNUeX6HVWZRAl+RoVShdGobV+Irg4t6yqn6+OnTxg7dT7Wbf5byUuZgSOnqzJlSxSEzGLIa8lmLViFbu0aqXRuAkZAt6fMusoDK/Kqqi59RkHWUStNNm5k1v7PXQfULLHYScKmbbtU6fbNa2H9ll3qtWS3bt9HrSqlVLq8yeH0ucvqARyRlyCvN5PMJu37q9eb3bh1T9l+0YpNksxgAwF5+E//Qpk5Q2rlxMiDTmOnLkDCX372U0Ngzjm/7CgPQopdxTmSh1z9e7DVz8Y5aaapPcUJPXv+CsSeY6bMR+rfkgSIirVrsMFgQP/uLdX5K9fUzBlTI1O6VPBrPPhl9wA1isJ2R8DF7lrMBpNAAAm8ev0G9+4/xM/eDzfI7e8Vc0er5QldWtfHyAGdlcaOLetBbomrA5PNjLF9sX/LAmOQsnp21fLFsWCqp3r9WP5cmVWyPC1sKi9xj85NjXm9OjZRryWThzQS/sLb4QpMADbm9hS2YoORAzurD78GNcspbT06NIasn1YH2kYebNN2Pv7ktWNiH9Mgs70iFDPGT5gysrd6LdkQj3bqLR2S3qJhNeNY0MvFjR1TsmA+VmpWLqnSufGfwKmzl6EvD5FzSF7dJ6/8E4dm5rh+kKfrRYvYWmwjcT2IvG4LfS/jQvIlz9I555cdzfP0a4ToY7CNgKk9o0SOBN2eA3q0Ussa5K6M2HHBNE+jwspli6FxnYrGYz1ifl6ZXoPT/55C6Z4/ZQia1KmkiojN9XGg7/XxYG5bydfPX1XYATfs0lcCdHi/cuDWQQkcOHISVRt2RstG1RAtahQH7aXzdIv2dExby4zquGkL0KlVXcfsoJP1ivZ0MoPbSXfp8NqJodjMwBGQGbxNSyejfMlCgVPgFKXsp5O0p/3YKiAtlVm3RdOH4fdUyQNSjLJhlADtGUYN4+TNosPr5AOA3ScBEiABEiABEvAmwJ3DEqDD67CmZcdIgARIgARIgARIgASEAB1eocBAArYToCQJkAAJkAAJkICdEaDDa2cGY3NJgARIgARIIGwQYCtIwH4I0OG1H1uxpSRAAiRAAiRAAiRAAoEgQIc3ENBYxHYClCQBEiABEiABEiCB0CZAhze0LcD6SYAESIAEnIEA+0gCJBCKBOjwhiJ8Vk0CJEACJEACJEACJBD8BOjwBj9j22ugJAmQAAmQAAmQAAmQQJAToMMb5EipkARIgARI4HsJsDwJkAAJBCUBOrxBSZO6SIAESIAESIAESIAEwhwBO3Z4wxxLNogESIAESIAESIAESCAMEqDDGwaNwiaRAAmQQIAIUJgESIAESMBPAnR4/cTDTBIgARIgARIgARIgAXshYK2ddHitkWE6CZAACZAACZAACZCAQxCgw+sQZmQnSIAEbCdASRIgARIgAWcjQIfX2SzO/pIACZAACZAACZCAEHCiQIfXiYzNrpIACZAACZAACZCAMxKgw+uMVmefScB2ApQkARIgARIgAbsnQIfX7k3IDpAACZAACZAACQQ/AdZgzwTo8Nqz9dh2EiABEiABEiABEiABfwnQ4fUXEQVIwHYClAw5Ag8ePkaPgWNRtWEn1GjSFZXqdcTJsxeDtAGnzl5CwzZ9glQnlZEACZAACYQ8ATq8Ic+cNZIACQQBgeleK+Di4op5UzyxeMZwjB3SFVEiRQoCzd9UJEn8C7q0qf8tgTESIAFbCVCOBMIUATq8YcocbAwJkICtBB7/+wzZMqZBhPDhVJEE8eMi6a8JVPy/t28xatI8bea3G2o17Y6JMxfj8+fPKm/l+m1o080TtZv1QPHKzfH436f48OEjxk6djxadB6Fi3Q5o3mmgkr124w5GTJir4rKZtWA1ajfvgbotemHgyOl49fqNJGO613L0HDgOrTW9jdv1hefYWfj46ZPK44YESIAESCD0CdDhDX0bOG8L2HMS+A4CDWqWw0zNARUndfKsJThz/rJR28z5q/BJczjnTR6MuZMG4Z+H/2LZmq3KQZ05fzXGenbDgmmeWDJzOKJGjYx9h0/i/oNHmDKyN1bNG4N+3VoYdemRv3YfwqZtuzFxWA/MnjgA/z55ijkLV+vZeKDVMbRPO8wc1x8GgwF/7TpozGOEBEiABEggdAnQ4Q1d/qydBEggkAQypkuFlV6jUb9GWfz79AVadRmCVeu3K20Hj5zWHOAraNPdU4XL127i1NmLiBQxAuLEjoFRE70wZ9FaPH32EuHDhUPyJAlw7eZdiOO8eOUfxlljpcx7c+zkeZQsmhc//hANbq6uqFGpJI5qad7ZyKrNNkeJ/HVJRVytjqs3butZ3JOAvwQoQAIkELwE6PAGL19qJwESCEYC4dzdkT1zOnh0bop2zWph9aa/vtZmADq1qoupozxUWDJzBIZ4tIOLiwvmThyIsiUKIJy7G9r18IQ4pvHixsai6cM0XWm1mdrHaNK+v1rm8FXZ1+0XfFGO7tcjqPJfvnzRD+Hq+u1y6qLV8/HjJ2MeIyRAAiRAAqFL4NsVOnTbwdr9JUABEiABUwL7D59USxQk7f2HDzh9/gpix/xJDpE7WwZM81qBl69eq+N/nz7DxSs38Pbde7x7/x4pk/+KWlVKqTW/Fy9fx/MXr+CuOcCZM6RBy0bV8Oz5S23W+Jkqq28yp0+NP/7cjRcvX6n1uYtX/YEs2qyuns89CZAACZBA2CVAhzfs2oYtIwES8IPA+YvXULVhZzTrOAD/q9wCV67fQtumtVWJBrUqaE5tYjTvOFA9ZFa/ZW88ffYcTzTHt1jFZqjSoBN6D56I+PHioFC+HDh49BRy/a8O6rXshQHDp6KhVj5u7JhKl74plDcbiuTPiZadB6Nh6z6IGiUKGtQsr2dzH5IEWBcJkAAJBJAAHd4AAqM4CZBA2CDQsHYFbFo6GdNG98Ffa2di/pQhSJTgZ9W4COHDac5vLSycPhQLpnpi/eKJyJElPWTpws4Nc7B8zigM6tUaXVrXV+t1ixXMhX2b58Nr8mAM7t0WNSqVUHrSpfkNsycMUHHZNK5TEfKw27wpg9UyCn3NbtN6VSAB3v/qViuDNk1qeh9xRwIkQAIkENoEHNXhDW2urJ8ESIAESIAESIAESCCMEKDDG0YMwWaQAAmQQPAQoFYSIAESIAE6vBwDJEACJEACJEACJEACDk1AObwO3UN2jgRIgARIgARIgARIwKkJ0OF1avOz8yRAAmYEeEgCJEACJOCABOjwOqBR2SUSIAESIAESIAES+D4CjlWaDq9j2ZO9IQESIAESIAESIAESMCNAh9cMCA9JgARsJ0BJEiABEiABErAHAnR47cFKbCMJkAAJkAAJkEBYJsC2hXECdHjDuIHYPBIgARIgARIgARIgge8jQIf3+/ixNAnYToCSJEACJEACJEACoUKADm+oYGelJEACJEACJOC8BNhzEghpAnR4Q5o46yMBEiABEiABEiABEghRAnR4QxQ3K7OdACVJgARIgARIgARIIGgI0OENGo7UQgIkQAIkQALBQ4BaSYAEvpsAHd7vRkgFJEACJEACJEACJEACYZkAHd6wbB3b20ZJEiABEiABEiABEiABKwTo8FoBw2QSIAESIAF7JMA2kwAJkIBvAnR4fTNhCgmQAAmQAAmQAAmQgAMRcEqH14Hsx66QAAmQAAmQAAmQAAn4Q4AOrz+AmE0CJEACDkyAXSMBEiABpyBAh9cpzMxOkgAJkAAJkAAJkIDzEvDf4XVeNuw5CZAACZAACZAACZCAAxCgw+sARmQXSIAEQoYAayEBEiABErBPAnR47dNubDUJkAAJkAAJkAAJhBYBu6uXDq/dmYwNJgESIAESIAESIAESCAgBOrwBoUVZEiAB2wlQkgRIgARIgATCCAE6vGHEEGwGCZAACZAACZCAYxJgr0KfAB3e0LcBW0ACJEACJEACJEACJBCMBOjwBiNcqiYB2wlQkgRIgARIgARIILgI0OENLrLUSwIkQAIkQAIkEHACLEECwUCADm8wQKVKEiABEiABEiABEiCBsEOADm/YsQVbYjsBSpIACZAACZAACZCAzQTo8NqMioIkQAIkQAIkENYIsD0kQAK2EKDDawslypAACZAACZAACZAACdgtATq8dms62xtOSRIgARIgARIgARJwZgL/BwAA//8C1MfeAAAABklEQVQDANi0p+NPkDU4AAAAAElFTkSuQmCC"
+     },
+     "metadata": {
+      "image/png": {
+       "alt": "Horizontal timeline with one row per fold on a session axis, lowest-numbered fold at the bottom. Every row below the top is a validation fold: a long dark navy training bar followed by the shorter amber validation bar it is scored on. The validation windows sit at different points along the axis and the training bars overlap between rows, because a fold tag selects rows rather than changing values. A dashed red rule marks where the holdout opens and a shaded band to its right is the holdout itself. The top row is the extra fold written for the holdout and has no validation bar: its training bar runs from the left edge up to the rule and its light grey holdout bar sits inside the band, later than every validation window. No training bar of any row crosses the rule."
+      }
+     },
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "# Sorted by fold id, so the row order is a property of this cell rather than of the order\n",
     "# `generate_cv_splits` happens to return. Plotly lays a categorical axis out in order of first\n",
@@ -856,13 +1430,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9b2ef3bd",
+   "id": "50a479d2",
    "metadata": {
     "papermill": {
-     "duration": 0.004216,
-     "end_time": "2026-09-04T03:04:15.303063+00:00",
+     "duration": 0.003738,
+     "end_time": "2026-09-09T20:51:14.879503+00:00",
      "exception": false,
-     "start_time": "2026-09-04T03:04:15.298847+00:00",
+     "start_time": "2026-09-09T20:51:14.875765+00:00",
      "status": "completed"
     }
    },
@@ -886,10 +1460,54 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "a28f3d33",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 14,
+   "id": "b4959909",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-09T20:51:14.887206Z",
+     "iopub.status.busy": "2026-09-09T20:51:14.887089Z",
+     "iopub.status.idle": "2026-09-09T20:51:15.359410Z",
+     "shell.execute_reply": "2026-09-09T20:51:15.358991Z"
+    },
+    "papermill": {
+     "duration": 0.476896,
+     "end_time": "2026-09-09T20:51:15.359789+00:00",
+     "exception": false,
+     "start_time": "2026-09-09T20:51:14.882893+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div><style>\n",
+       ".dataframe > thead > tr,\n",
+       ".dataframe > tbody > tr {\n",
+       "  text-align: right;\n",
+       "  white-space: pre-wrap;\n",
+       "}\n",
+       "</style>\n",
+       "<small>shape: (4, 3)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>window</th><th>bars</th><th>share of rows reaching across a session gap</th></tr><tr><td>str</td><td>i64</td><td>str</td></tr></thead><tbody><tr><td>&quot;signature path&quot;</td><td>30</td><td>&quot;7.7%&quot;</td></tr><tr><td>&quot;spectrum&quot;</td><td>60</td><td>&quot;15.4%&quot;</td></tr><tr><td>&quot;HAR components&quot;</td><td>60</td><td>&quot;15.4%&quot;</td></tr><tr><td>&quot;HAR fit window&quot;</td><td>120</td><td>&quot;30.8%&quot;</td></tr></tbody></table></div>"
+      ],
+      "text/plain": [
+       "shape: (4, 3)\n",
+       "┌────────────────┬──────┬─────────────────────────────────┐\n",
+       "│ window         ┆ bars ┆ share of rows reaching across … │\n",
+       "│ ---            ┆ ---  ┆ ---                             │\n",
+       "│ str            ┆ i64  ┆ str                             │\n",
+       "╞════════════════╪══════╪═════════════════════════════════╡\n",
+       "│ signature path ┆ 30   ┆ 7.7%                            │\n",
+       "│ spectrum       ┆ 60   ┆ 15.4%                           │\n",
+       "│ HAR components ┆ 60   ┆ 15.4%                           │\n",
+       "│ HAR fit window ┆ 120  ┆ 30.8%                           │\n",
+       "└────────────────┴──────┴─────────────────────────────────┘"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "_bod = validation_rows(df.select(\"timestamp\", \"bar_of_day\"))\n",
     "display(\n",
@@ -909,14 +1527,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7d144dd8",
+   "id": "e96b9c84",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.003534,
-     "end_time": "2026-09-04T03:04:15.632522+00:00",
+     "duration": 0.003426,
+     "end_time": "2026-09-09T20:51:15.366905+00:00",
      "exception": false,
-     "start_time": "2026-09-04T03:04:15.628988+00:00",
+     "start_time": "2026-09-09T20:51:15.363479+00:00",
      "status": "completed"
     }
    },
@@ -947,10 +1565,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "41ce980c",
+   "execution_count": 15,
+   "id": "ea7b7033",
    "metadata": {
-    "lines_to_next_cell": 2
+    "execution": {
+     "iopub.execute_input": "2026-09-09T20:51:15.374434Z",
+     "iopub.status.busy": "2026-09-09T20:51:15.374344Z",
+     "iopub.status.idle": "2026-09-09T20:51:15.376703Z",
+     "shell.execute_reply": "2026-09-09T20:51:15.376398Z"
+    },
+    "lines_to_next_cell": 2,
+    "papermill": {
+     "duration": 0.00667,
+     "end_time": "2026-09-09T20:51:15.376945+00:00",
+     "exception": false,
+     "start_time": "2026-09-09T20:51:15.370275+00:00",
+     "status": "completed"
+    }
    },
    "outputs": [],
    "source": [
@@ -980,14 +1611,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "34cc0be9",
+   "id": "b23ceac8",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.003511,
-     "end_time": "2026-09-04T03:04:15.652020+00:00",
+     "duration": 0.003308,
+     "end_time": "2026-09-09T20:51:15.383690+00:00",
      "exception": false,
-     "start_time": "2026-09-04T03:04:15.648509+00:00",
+     "start_time": "2026-09-09T20:51:15.380382+00:00",
      "status": "completed"
     }
    },
@@ -1016,10 +1647,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "18b40c58",
+   "execution_count": 16,
+   "id": "5c9fa606",
    "metadata": {
-    "lines_to_next_cell": 2
+    "execution": {
+     "iopub.execute_input": "2026-09-09T20:51:15.391103Z",
+     "iopub.status.busy": "2026-09-09T20:51:15.391018Z",
+     "iopub.status.idle": "2026-09-09T20:51:15.393723Z",
+     "shell.execute_reply": "2026-09-09T20:51:15.393406Z"
+    },
+    "lines_to_next_cell": 2,
+    "papermill": {
+     "duration": 0.006955,
+     "end_time": "2026-09-09T20:51:15.394021+00:00",
+     "exception": false,
+     "start_time": "2026-09-09T20:51:15.387066+00:00",
+     "status": "completed"
+    }
    },
    "outputs": [],
    "source": [
@@ -1057,14 +1701,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1248e32b",
+   "id": "ed5c8441",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.003717,
-     "end_time": "2026-09-04T03:04:15.671248+00:00",
+     "duration": 0.0033,
+     "end_time": "2026-09-09T20:51:15.400724+00:00",
      "exception": false,
-     "start_time": "2026-09-04T03:04:15.667531+00:00",
+     "start_time": "2026-09-09T20:51:15.397424+00:00",
      "status": "completed"
     }
    },
@@ -1077,9 +1721,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "462ab4a2",
-   "metadata": {},
+   "execution_count": 17,
+   "id": "63912abb",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-09T20:51:15.408123Z",
+     "iopub.status.busy": "2026-09-09T20:51:15.408043Z",
+     "iopub.status.idle": "2026-09-09T20:51:15.411418Z",
+     "shell.execute_reply": "2026-09-09T20:51:15.411079Z"
+    },
+    "papermill": {
+     "duration": 0.007619,
+     "end_time": "2026-09-09T20:51:15.411693+00:00",
+     "exception": false,
+     "start_time": "2026-09-09T20:51:15.404074+00:00",
+     "status": "completed"
+    }
+   },
    "outputs": [],
    "source": [
     "def compute_har_per_symbol(\n",
@@ -1160,10 +1818,68 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "75d57798",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 18,
+   "id": "d949ae9c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-09T20:51:15.419256Z",
+     "iopub.status.busy": "2026-09-09T20:51:15.419179Z",
+     "iopub.status.idle": "2026-09-09T21:02:45.586327Z",
+     "shell.execute_reply": "2026-09-09T21:02:45.585780Z"
+    },
+    "papermill": {
+     "duration": 690.176552,
+     "end_time": "2026-09-09T21:02:45.591744+00:00",
+     "exception": false,
+     "start_time": "2026-09-09T20:51:15.415192+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  HAR: 20/115 symbols processed\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  HAR: 40/115 symbols processed\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  HAR: 60/115 symbols processed\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  HAR: 80/115 symbols processed\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  HAR: 100/115 symbols processed\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  HAR: 115/115 symbols processed\n",
+      "HAR: 20,011,115 forecasts on 20,025,030 bars, from 51,487 retained fits.\n"
+     ]
+    }
+   ],
    "source": [
     "symbols = df[\"symbol\"].unique().sort().to_list()\n",
     "har_results = []\n",
@@ -1192,13 +1908,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "78ba9f68",
+   "id": "b4cedc51",
    "metadata": {
     "papermill": {
-     "duration": 0.003416,
-     "end_time": "2026-09-04T03:13:34.603884+00:00",
+     "duration": 0.003461,
+     "end_time": "2026-09-09T21:02:45.598796+00:00",
      "exception": false,
-     "start_time": "2026-09-04T03:13:34.600468+00:00",
+     "start_time": "2026-09-09T21:02:45.595335+00:00",
      "status": "completed"
     }
    },
@@ -1212,10 +1928,51 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "20a8fa1f",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 19,
+   "id": "cd071f51",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-09T21:02:45.606569Z",
+     "iopub.status.busy": "2026-09-09T21:02:45.606411Z",
+     "iopub.status.idle": "2026-09-09T21:02:45.618420Z",
+     "shell.execute_reply": "2026-09-09T21:02:45.617988Z"
+    },
+    "papermill": {
+     "duration": 0.016388,
+     "end_time": "2026-09-09T21:02:45.618702+00:00",
+     "exception": false,
+     "start_time": "2026-09-09T21:02:45.602314+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div><style>\n",
+       ".dataframe > thead > tr,\n",
+       ".dataframe > tbody > tr {\n",
+       "  text-align: right;\n",
+       "  white-space: pre-wrap;\n",
+       "}\n",
+       "</style>\n",
+       "<small>shape: (1, 5)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>beta_5_median</th><th>beta_15_median</th><th>beta_60_median</th><th>persistence_median</th><th>fits</th></tr><tr><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>u32</td></tr></thead><tbody><tr><td>0.8261</td><td>-0.0136</td><td>-0.076</td><td>0.769</td><td>25824</td></tr></tbody></table></div>"
+      ],
+      "text/plain": [
+       "shape: (1, 5)\n",
+       "┌───────────────┬────────────────┬────────────────┬────────────────────┬───────┐\n",
+       "│ beta_5_median ┆ beta_15_median ┆ beta_60_median ┆ persistence_median ┆ fits  │\n",
+       "│ ---           ┆ ---            ┆ ---            ┆ ---                ┆ ---   │\n",
+       "│ f64           ┆ f64            ┆ f64            ┆ f64                ┆ u32   │\n",
+       "╞═══════════════╪════════════════╪════════════════╪════════════════════╪═══════╡\n",
+       "│ 0.8261        ┆ -0.0136        ┆ -0.076         ┆ 0.769              ┆ 25824 │\n",
+       "└───────────────┴────────────────┴────────────────┴────────────────────┴───────┘"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "display(\n",
     "    validation_rows(har_beta_df).select(\n",
@@ -1231,13 +1988,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bf5aea40",
+   "id": "5c71e0c7",
    "metadata": {
     "papermill": {
-     "duration": 0.003742,
-     "end_time": "2026-09-04T03:13:34.649528+00:00",
+     "duration": 0.003814,
+     "end_time": "2026-09-09T21:02:45.626323+00:00",
      "exception": false,
-     "start_time": "2026-09-04T03:13:34.645786+00:00",
+     "start_time": "2026-09-09T21:02:45.622509+00:00",
      "status": "completed"
     }
    },
@@ -1254,10 +2011,56 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "e1d78351",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 20,
+   "id": "baab3d83",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-09T21:02:45.634373Z",
+     "iopub.status.busy": "2026-09-09T21:02:45.634268Z",
+     "iopub.status.idle": "2026-09-09T21:02:46.020258Z",
+     "shell.execute_reply": "2026-09-09T21:02:46.019425Z"
+    },
+    "papermill": {
+     "duration": 0.390538,
+     "end_time": "2026-09-09T21:02:46.020618+00:00",
+     "exception": false,
+     "start_time": "2026-09-09T21:02:45.630080+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div><style>\n",
+       ".dataframe > thead > tr,\n",
+       ".dataframe > tbody > tr {\n",
+       "  text-align: right;\n",
+       "  white-space: pre-wrap;\n",
+       "}\n",
+       "</style>\n",
+       "<small>shape: (6, 2)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>statistic</th><th>value</th></tr><tr><td>str</td><td>str</td></tr></thead><tbody><tr><td>&quot;rows&quot;</td><td>&quot;10,063,364&quot;</td></tr><tr><td>&quot;1st percentile&quot;</td><td>&quot;1.938e-08&quot;</td></tr><tr><td>&quot;median&quot;</td><td>&quot;3.748e-07&quot;</td></tr><tr><td>&quot;99th percentile&quot;</td><td>&quot;9.034e-06&quot;</td></tr><tr><td>&quot;minimum&quot;</td><td>&quot;-2.787e+01&quot;</td></tr><tr><td>&quot;share below zero&quot;</td><td>&quot;0.46%&quot;</td></tr></tbody></table></div>"
+      ],
+      "text/plain": [
+       "shape: (6, 2)\n",
+       "┌──────────────────┬────────────┐\n",
+       "│ statistic        ┆ value      │\n",
+       "│ ---              ┆ ---        │\n",
+       "│ str              ┆ str        │\n",
+       "╞══════════════════╪════════════╡\n",
+       "│ rows             ┆ 10,063,364 │\n",
+       "│ 1st percentile   ┆ 1.938e-08  │\n",
+       "│ median           ┆ 3.748e-07  │\n",
+       "│ 99th percentile  ┆ 9.034e-06  │\n",
+       "│ minimum          ┆ -2.787e+01 │\n",
+       "│ share below zero ┆ 0.46%      │\n",
+       "└──────────────────┴────────────┘"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "_fc = validation_rows(har_df.select(\"timestamp\", \"har_rv5_pred\"))[\"har_rv5_pred\"].drop_nulls()\n",
     "display(\n",
@@ -1287,13 +2090,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a2d2c463",
+   "id": "6811b267",
    "metadata": {
     "papermill": {
-     "duration": 0.003556,
-     "end_time": "2026-09-04T03:13:34.928317+00:00",
+     "duration": 0.003646,
+     "end_time": "2026-09-09T21:02:46.028218+00:00",
      "exception": false,
-     "start_time": "2026-09-04T03:13:34.924761+00:00",
+     "start_time": "2026-09-09T21:02:46.024572+00:00",
      "status": "completed"
     }
    },
@@ -1312,10 +2115,32 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "2e819f38",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 21,
+   "id": "c82212d0",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-09T21:02:46.036610Z",
+     "iopub.status.busy": "2026-09-09T21:02:46.036499Z",
+     "iopub.status.idle": "2026-09-09T21:02:47.304683Z",
+     "shell.execute_reply": "2026-09-09T21:02:47.304241Z"
+    },
+    "papermill": {
+     "duration": 1.27307,
+     "end_time": "2026-09-09T21:02:47.305061+00:00",
+     "exception": false,
+     "start_time": "2026-09-09T21:02:46.031991+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Validation sessions drawn: 253\n"
+     ]
+    }
+   ],
    "source": [
     "har_view = (\n",
     "    validation_rows(har_df.select(\"timestamp\", \"symbol\", \"har_rv5_pred\", \"har_residual\"))\n",
@@ -1334,10 +2159,683 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "e8a065bc",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 22,
+   "id": "a992201e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-09T21:02:47.313343Z",
+     "iopub.status.busy": "2026-09-09T21:02:47.313239Z",
+     "iopub.status.idle": "2026-09-09T21:02:48.780261Z",
+     "shell.execute_reply": "2026-09-09T21:02:48.779801Z"
+    },
+    "papermill": {
+     "duration": 1.471781,
+     "end_time": "2026-09-09T21:02:48.780741+00:00",
+     "exception": false,
+     "start_time": "2026-09-09T21:02:47.308960+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.plotly.v1+json": {
+       "config": {
+        "plotlyServerURL": "https://plot.ly"
+       },
+       "data": [
+        {
+         "line": {
+          "color": "#0a1628",
+          "width": 1.5
+         },
+         "mode": "lines",
+         "name": "Realized 5-bar variance",
+         "type": "scatter",
+         "x": [
+          "2020-06-30T00:00:00",
+          "2020-07-01T00:00:00",
+          "2020-07-02T00:00:00",
+          "2020-07-06T00:00:00",
+          "2020-07-07T00:00:00",
+          "2020-07-08T00:00:00",
+          "2020-07-09T00:00:00",
+          "2020-07-10T00:00:00",
+          "2020-07-13T00:00:00",
+          "2020-07-14T00:00:00",
+          "2020-07-15T00:00:00",
+          "2020-07-16T00:00:00",
+          "2020-07-17T00:00:00",
+          "2020-07-20T00:00:00",
+          "2020-07-21T00:00:00",
+          "2020-07-22T00:00:00",
+          "2020-07-23T00:00:00",
+          "2020-07-24T00:00:00",
+          "2020-07-27T00:00:00",
+          "2020-07-28T00:00:00",
+          "2020-07-29T00:00:00",
+          "2020-07-30T00:00:00",
+          "2020-07-31T00:00:00",
+          "2020-08-03T00:00:00",
+          "2020-08-04T00:00:00",
+          "2020-08-05T00:00:00",
+          "2020-08-06T00:00:00",
+          "2020-08-07T00:00:00",
+          "2020-08-10T00:00:00",
+          "2020-08-11T00:00:00",
+          "2020-08-12T00:00:00",
+          "2020-08-13T00:00:00",
+          "2020-08-14T00:00:00",
+          "2020-08-17T00:00:00",
+          "2020-08-18T00:00:00",
+          "2020-08-19T00:00:00",
+          "2020-08-20T00:00:00",
+          "2020-08-21T00:00:00",
+          "2020-08-24T00:00:00",
+          "2020-08-25T00:00:00",
+          "2020-08-26T00:00:00",
+          "2020-08-27T00:00:00",
+          "2020-08-28T00:00:00",
+          "2020-08-31T00:00:00",
+          "2020-09-01T00:00:00",
+          "2020-09-02T00:00:00",
+          "2020-09-03T00:00:00",
+          "2020-09-04T00:00:00",
+          "2020-09-08T00:00:00",
+          "2020-09-09T00:00:00",
+          "2020-09-10T00:00:00",
+          "2020-09-11T00:00:00",
+          "2020-09-14T00:00:00",
+          "2020-09-15T00:00:00",
+          "2020-09-16T00:00:00",
+          "2020-09-17T00:00:00",
+          "2020-09-18T00:00:00",
+          "2020-09-21T00:00:00",
+          "2020-09-22T00:00:00",
+          "2020-09-23T00:00:00",
+          "2020-09-24T00:00:00",
+          "2020-09-25T00:00:00",
+          "2020-09-28T00:00:00",
+          "2020-09-29T00:00:00",
+          "2020-09-30T00:00:00",
+          "2020-10-01T00:00:00",
+          "2020-10-02T00:00:00",
+          "2020-10-05T00:00:00",
+          "2020-10-06T00:00:00",
+          "2020-10-07T00:00:00",
+          "2020-10-08T00:00:00",
+          "2020-10-09T00:00:00",
+          "2020-10-12T00:00:00",
+          "2020-10-13T00:00:00",
+          "2020-10-14T00:00:00",
+          "2020-10-15T00:00:00",
+          "2020-10-16T00:00:00",
+          "2020-10-19T00:00:00",
+          "2020-10-20T00:00:00",
+          "2020-10-21T00:00:00",
+          "2020-10-22T00:00:00",
+          "2020-10-23T00:00:00",
+          "2020-10-26T00:00:00",
+          "2020-10-27T00:00:00",
+          "2020-10-28T00:00:00",
+          "2020-10-29T00:00:00",
+          "2020-10-30T00:00:00",
+          "2020-11-02T00:00:00",
+          "2020-11-03T00:00:00",
+          "2020-11-04T00:00:00",
+          "2020-11-05T00:00:00",
+          "2020-11-06T00:00:00",
+          "2020-11-09T00:00:00",
+          "2020-11-10T00:00:00",
+          "2020-11-11T00:00:00",
+          "2020-11-12T00:00:00",
+          "2020-11-13T00:00:00",
+          "2020-11-16T00:00:00",
+          "2020-11-17T00:00:00",
+          "2020-11-18T00:00:00",
+          "2020-11-19T00:00:00",
+          "2020-11-20T00:00:00",
+          "2020-11-23T00:00:00",
+          "2020-11-24T00:00:00",
+          "2020-11-25T00:00:00",
+          "2020-11-27T00:00:00",
+          "2020-11-30T00:00:00",
+          "2020-12-01T00:00:00",
+          "2020-12-02T00:00:00",
+          "2020-12-03T00:00:00",
+          "2020-12-04T00:00:00",
+          "2020-12-07T00:00:00",
+          "2020-12-08T00:00:00",
+          "2020-12-09T00:00:00",
+          "2020-12-10T00:00:00",
+          "2020-12-11T00:00:00",
+          "2020-12-14T00:00:00",
+          "2020-12-15T00:00:00",
+          "2020-12-16T00:00:00",
+          "2020-12-17T00:00:00",
+          "2020-12-18T00:00:00",
+          "2020-12-21T00:00:00",
+          "2020-12-22T00:00:00",
+          "2020-12-23T00:00:00",
+          "2020-12-24T00:00:00",
+          "2020-12-28T00:00:00",
+          "2020-12-29T00:00:00",
+          "2020-12-30T00:00:00",
+          "2020-12-31T00:00:00",
+          "2021-01-04T00:00:00",
+          "2021-01-05T00:00:00",
+          "2021-01-06T00:00:00",
+          "2021-01-07T00:00:00",
+          "2021-01-08T00:00:00",
+          "2021-01-11T00:00:00",
+          "2021-01-12T00:00:00",
+          "2021-01-13T00:00:00",
+          "2021-01-14T00:00:00",
+          "2021-01-15T00:00:00",
+          "2021-01-19T00:00:00",
+          "2021-01-20T00:00:00",
+          "2021-01-21T00:00:00",
+          "2021-01-22T00:00:00",
+          "2021-01-25T00:00:00",
+          "2021-01-26T00:00:00",
+          "2021-01-27T00:00:00",
+          "2021-01-28T00:00:00",
+          "2021-01-29T00:00:00",
+          "2021-02-01T00:00:00",
+          "2021-02-02T00:00:00",
+          "2021-02-03T00:00:00",
+          "2021-02-04T00:00:00",
+          "2021-02-05T00:00:00",
+          "2021-02-08T00:00:00",
+          "2021-02-09T00:00:00",
+          "2021-02-10T00:00:00",
+          "2021-02-11T00:00:00",
+          "2021-02-12T00:00:00",
+          "2021-02-16T00:00:00",
+          "2021-02-17T00:00:00",
+          "2021-02-18T00:00:00",
+          "2021-02-19T00:00:00",
+          "2021-02-22T00:00:00",
+          "2021-02-23T00:00:00",
+          "2021-02-24T00:00:00",
+          "2021-02-25T00:00:00",
+          "2021-02-26T00:00:00",
+          "2021-03-01T00:00:00",
+          "2021-03-02T00:00:00",
+          "2021-03-03T00:00:00",
+          "2021-03-04T00:00:00",
+          "2021-03-05T00:00:00",
+          "2021-03-08T00:00:00",
+          "2021-03-09T00:00:00",
+          "2021-03-10T00:00:00",
+          "2021-03-11T00:00:00",
+          "2021-03-12T00:00:00",
+          "2021-03-15T00:00:00",
+          "2021-03-16T00:00:00",
+          "2021-03-17T00:00:00",
+          "2021-03-18T00:00:00",
+          "2021-03-19T00:00:00",
+          "2021-03-22T00:00:00",
+          "2021-03-23T00:00:00",
+          "2021-03-24T00:00:00",
+          "2021-03-25T00:00:00",
+          "2021-03-26T00:00:00",
+          "2021-03-29T00:00:00",
+          "2021-03-30T00:00:00",
+          "2021-03-31T00:00:00",
+          "2021-04-01T00:00:00",
+          "2021-04-05T00:00:00",
+          "2021-04-06T00:00:00",
+          "2021-04-07T00:00:00",
+          "2021-04-08T00:00:00",
+          "2021-04-09T00:00:00",
+          "2021-04-12T00:00:00",
+          "2021-04-13T00:00:00",
+          "2021-04-14T00:00:00",
+          "2021-04-15T00:00:00",
+          "2021-04-16T00:00:00",
+          "2021-04-19T00:00:00",
+          "2021-04-20T00:00:00",
+          "2021-04-21T00:00:00",
+          "2021-04-22T00:00:00",
+          "2021-04-23T00:00:00",
+          "2021-04-26T00:00:00",
+          "2021-04-27T00:00:00",
+          "2021-04-28T00:00:00",
+          "2021-04-29T00:00:00",
+          "2021-04-30T00:00:00",
+          "2021-05-03T00:00:00",
+          "2021-05-04T00:00:00",
+          "2021-05-05T00:00:00",
+          "2021-05-06T00:00:00",
+          "2021-05-07T00:00:00",
+          "2021-05-10T00:00:00",
+          "2021-05-11T00:00:00",
+          "2021-05-12T00:00:00",
+          "2021-05-13T00:00:00",
+          "2021-05-14T00:00:00",
+          "2021-05-17T00:00:00",
+          "2021-05-18T00:00:00",
+          "2021-05-19T00:00:00",
+          "2021-05-20T00:00:00",
+          "2021-05-21T00:00:00",
+          "2021-05-24T00:00:00",
+          "2021-05-25T00:00:00",
+          "2021-05-26T00:00:00",
+          "2021-05-27T00:00:00",
+          "2021-05-28T00:00:00",
+          "2021-06-01T00:00:00",
+          "2021-06-02T00:00:00",
+          "2021-06-03T00:00:00",
+          "2021-06-04T00:00:00",
+          "2021-06-07T00:00:00",
+          "2021-06-08T00:00:00",
+          "2021-06-09T00:00:00",
+          "2021-06-10T00:00:00",
+          "2021-06-11T00:00:00",
+          "2021-06-14T00:00:00",
+          "2021-06-15T00:00:00",
+          "2021-06-16T00:00:00",
+          "2021-06-17T00:00:00",
+          "2021-06-18T00:00:00",
+          "2021-06-21T00:00:00",
+          "2021-06-22T00:00:00",
+          "2021-06-23T00:00:00",
+          "2021-06-24T00:00:00",
+          "2021-06-25T00:00:00",
+          "2021-06-28T00:00:00",
+          "2021-06-29T00:00:00",
+          "2021-06-30T00:00:00"
+         ],
+         "y": {
+          "bdata": "Sb/yEFrDkz5pjdID916YPkkyeKhEI5U+uSusp6qElT6+BmYL0tCVPvatViw9epg+oaEU0rQEoT5qDFT8km+TPvDO7cSuxKA+jNM4x+u7qD7a0jEzRdSiPg2l1Hgd3pg+VF6qWDgSkj5c2OyQ5fWRPpogvCzy0ps+QNMUi+OKlD7xLo83JACkPor6etmnw6E+zY0w4z7blD7m/vI5YXeUPpViuNBTy5Y+45tlX/yonD5+jXuzx4+hPmzdwTWGdpQ+IIX7sk/qlD4IV7Jfy1GRPtenlqB7tZE+RP8JV/qQmj7ING+LfWWXPqoVpACmqZ0+nFO3yHdklD6wo7c/pzSVPtP0A+fLOY4+bhjPby7Chz4Nh6BGjmaMPpB2arovKZE+9w/jvAoVjT7CslYXscCLPkrxAd55gpE+W0JNfcY+jD6KrrZK8n+QPsirSPZbopk+qoW68KfKjT5WHEscBWuQPtUrc1xm0JA+GJ7lzDUUmj6sOilUzp+zPo4YDh2TMLc+fS8iLp2Qrj60KHNvuQCePvXs4vVoFa0+aKPwuQ6uqT6YZvWDmSycPvkiClX+eJQ+ygk7LoasoD4a85o6QSenPmR/Sm+CFKc++nrjz80UpD7adYZUN6OZPg62gmiZq6I+2CUzLyjvpz7w4hYd61eaPirzxuIw6pc+VUVsKT6dlT42PVV852eePrCzdSGKNJ4+tQms6HoGpj4WG9/afiOSPsPTCUCYaZs+3yT5ccr+kT4qbvxnyiCPPurNYamJ3Yw+2HBxQvoamD4kKxQ/+p+bPianRE8EPJs+rniZmrPdlz6I42VVEnWSPuRfCnv7Vpw+ePDaUlVRnD4UNBj7IvCaPueIOMHgAJo+oS/1Aj4YkT6CwmE8mlygPkhnauzltpY+tJoTNZBbpT7a5faU2wGiPmJ5l1Q+y6o+ci+LNoGOoz4QMCV9i/KdPtxYkjTpjKk+PPyxGsERoD6HQx6Il9SaPnodPLbGJ7E+nzqWXfW7sD6Zo9w8oIaaPvKIaxTtIqA+4saHIf7elT4wA84Uav6VPnQgXipdY5U+OHL7bArOlT6UWQvT2XqVPphAT2X5Z5E+XHF4jJ1TlD6ipbo9S1SWPgQ+b0fxhJA+qIkcpaNzmj7bn2ffuxeYPjljzY5DfZk+yNoOLa4Jkj4OK6RrZWGSPh6aUpnEE44+HumvtQ62jT5q3E3ZzAWMPoIDAvy38Zs+lhEuK/UilD5S/LfpW1aSPoKUBLooYZQ+yHItq5DYkD4VUsEaMtuPPlx8gmtagYw+KGn+Fj57kD6OTnaczdyVPgIm8nbibZE+GiclQkHOhz4d+TM08RGSPgasCDTcEIs+hGIU6WOlkD5QMg5jHPSGPlazSeY4Foc+YgkFgI4Poz66hiY7TA+UPgpaPDtBXaM+kbszcn6mlD5d4XfbpRebPlnUk48ylZU+PkbDhDPSmD4FfCmfxDiTPs7d3M824ZQ+KzBjascumT4U5Vq9PFqUPjCY5++XspQ+YH+rC9/Mkj6g/Nxxf3SQPm7LE055L6I+MjMijXFhlj7KtL5zMX6xPrvjgfobCqg+nLn3aOE+rz63RgLDtuudPhpZ25HRTpg+NsxpkTFjlj6MU7aU8cWUPh57ISy7tJM+1Dh8qIf5kD58VTEjl7eOPvbX0qT02Zk+imHD5fkJlz6jTTs59hSQPoRc3hvsSpc+XOCFOYs6mD4W1RPbUUGXPj1p4RjLjJc+qi2cn+b8mj4tJuTGLeSvPvyGRKc7AqI+VBGnpt6tsj7Xs6QFu7evPire88Fvx5g+89nz7hCKnz6Rq6UM456nPuiBTIoliL4+vHjMwEzTuD5Mk0hWdSevPpQowNKIzKA+WMkndHFxqD56+hSbKfCYPhJLG5aMEJo+itqKF64vlT7CYKb1fY+aPo75vu2ErqM+Pvex/XeQoD6rG2+cEQyfPkwt4SQZ6ZQ+LuGdzlMNnD5ysBOvhqCgPmhKwl2kEag+0DulTRVpoj5O4U2pLXqjPjx9BYyooJo+Jubt2ym0lz4e4QWvT8+TPrDM305nMpI+62kztmockT4ID2inN/iPPoZVlQWQToo+FNiYNl/shz5QTI27QGGLPjofzr517og+TKQjAs87kj7GB7WWYtiNPsLQAzwx/4c+ftwxINfzkz5K5huf2aWRPioirVDDrYs+vHKkSpxNmD72frn7vteIPiP16+OmcoY+bCCI771/iT7Q/5vx8Z6OPuIE3Uj39JI+emOgLPc+kT40rTTHwFiPPhzljCMmOps+jMYDSLlnkz6QQLZT4dmZPii510oonJI+FFpbSc5+lz6/zeCKyJSiPik3c5ypLKE+UJAks66WoD4kMzKujX2NPiNIJ0xTfpU+dpudgZ9akT4txgI669qgPky8DjBNOpA+GxrXSe6Pjj4s1LNQCn2DPsiyo90CeIo+ANo7fpQGgz463J05lZqGPhzeJg+ZcYM+Vmijkk1Mhz4MtyY6GiiIPsJs1JS5mIw+cNqg/oH0gT5aMENQuyiFPtBdEb5fgYY+ZCXxMnRygj7428ql3jWGPnrH+5VM534+zBVnklUDgz6a4VQ4942EPoiB2bvkS5E+HSmFmG3Ikj5gnb7IHbGRPn0ooXchm4g+RZabYXclhD7vpjG0e86APobuDq97yoI+cnsI5MubgD6jk99qwr2FPvqMQ8TFEIM+4j1jVKGagj4=",
+          "dtype": "f8"
+         }
+        },
+        {
+         "line": {
+          "color": "#D4A84B",
+          "width": 2
+         },
+         "mode": "lines",
+         "name": "HAR forecast",
+         "type": "scatter",
+         "x": [
+          "2020-06-30T00:00:00",
+          "2020-07-01T00:00:00",
+          "2020-07-02T00:00:00",
+          "2020-07-06T00:00:00",
+          "2020-07-07T00:00:00",
+          "2020-07-08T00:00:00",
+          "2020-07-09T00:00:00",
+          "2020-07-10T00:00:00",
+          "2020-07-13T00:00:00",
+          "2020-07-14T00:00:00",
+          "2020-07-15T00:00:00",
+          "2020-07-16T00:00:00",
+          "2020-07-17T00:00:00",
+          "2020-07-20T00:00:00",
+          "2020-07-21T00:00:00",
+          "2020-07-22T00:00:00",
+          "2020-07-23T00:00:00",
+          "2020-07-24T00:00:00",
+          "2020-07-27T00:00:00",
+          "2020-07-28T00:00:00",
+          "2020-07-29T00:00:00",
+          "2020-07-30T00:00:00",
+          "2020-07-31T00:00:00",
+          "2020-08-03T00:00:00",
+          "2020-08-04T00:00:00",
+          "2020-08-05T00:00:00",
+          "2020-08-06T00:00:00",
+          "2020-08-07T00:00:00",
+          "2020-08-10T00:00:00",
+          "2020-08-11T00:00:00",
+          "2020-08-12T00:00:00",
+          "2020-08-13T00:00:00",
+          "2020-08-14T00:00:00",
+          "2020-08-17T00:00:00",
+          "2020-08-18T00:00:00",
+          "2020-08-19T00:00:00",
+          "2020-08-20T00:00:00",
+          "2020-08-21T00:00:00",
+          "2020-08-24T00:00:00",
+          "2020-08-25T00:00:00",
+          "2020-08-26T00:00:00",
+          "2020-08-27T00:00:00",
+          "2020-08-28T00:00:00",
+          "2020-08-31T00:00:00",
+          "2020-09-01T00:00:00",
+          "2020-09-02T00:00:00",
+          "2020-09-03T00:00:00",
+          "2020-09-04T00:00:00",
+          "2020-09-08T00:00:00",
+          "2020-09-09T00:00:00",
+          "2020-09-10T00:00:00",
+          "2020-09-11T00:00:00",
+          "2020-09-14T00:00:00",
+          "2020-09-15T00:00:00",
+          "2020-09-16T00:00:00",
+          "2020-09-17T00:00:00",
+          "2020-09-18T00:00:00",
+          "2020-09-21T00:00:00",
+          "2020-09-22T00:00:00",
+          "2020-09-23T00:00:00",
+          "2020-09-24T00:00:00",
+          "2020-09-25T00:00:00",
+          "2020-09-28T00:00:00",
+          "2020-09-29T00:00:00",
+          "2020-09-30T00:00:00",
+          "2020-10-01T00:00:00",
+          "2020-10-02T00:00:00",
+          "2020-10-05T00:00:00",
+          "2020-10-06T00:00:00",
+          "2020-10-07T00:00:00",
+          "2020-10-08T00:00:00",
+          "2020-10-09T00:00:00",
+          "2020-10-12T00:00:00",
+          "2020-10-13T00:00:00",
+          "2020-10-14T00:00:00",
+          "2020-10-15T00:00:00",
+          "2020-10-16T00:00:00",
+          "2020-10-19T00:00:00",
+          "2020-10-20T00:00:00",
+          "2020-10-21T00:00:00",
+          "2020-10-22T00:00:00",
+          "2020-10-23T00:00:00",
+          "2020-10-26T00:00:00",
+          "2020-10-27T00:00:00",
+          "2020-10-28T00:00:00",
+          "2020-10-29T00:00:00",
+          "2020-10-30T00:00:00",
+          "2020-11-02T00:00:00",
+          "2020-11-03T00:00:00",
+          "2020-11-04T00:00:00",
+          "2020-11-05T00:00:00",
+          "2020-11-06T00:00:00",
+          "2020-11-09T00:00:00",
+          "2020-11-10T00:00:00",
+          "2020-11-11T00:00:00",
+          "2020-11-12T00:00:00",
+          "2020-11-13T00:00:00",
+          "2020-11-16T00:00:00",
+          "2020-11-17T00:00:00",
+          "2020-11-18T00:00:00",
+          "2020-11-19T00:00:00",
+          "2020-11-20T00:00:00",
+          "2020-11-23T00:00:00",
+          "2020-11-24T00:00:00",
+          "2020-11-25T00:00:00",
+          "2020-11-27T00:00:00",
+          "2020-11-30T00:00:00",
+          "2020-12-01T00:00:00",
+          "2020-12-02T00:00:00",
+          "2020-12-03T00:00:00",
+          "2020-12-04T00:00:00",
+          "2020-12-07T00:00:00",
+          "2020-12-08T00:00:00",
+          "2020-12-09T00:00:00",
+          "2020-12-10T00:00:00",
+          "2020-12-11T00:00:00",
+          "2020-12-14T00:00:00",
+          "2020-12-15T00:00:00",
+          "2020-12-16T00:00:00",
+          "2020-12-17T00:00:00",
+          "2020-12-18T00:00:00",
+          "2020-12-21T00:00:00",
+          "2020-12-22T00:00:00",
+          "2020-12-23T00:00:00",
+          "2020-12-24T00:00:00",
+          "2020-12-28T00:00:00",
+          "2020-12-29T00:00:00",
+          "2020-12-30T00:00:00",
+          "2020-12-31T00:00:00",
+          "2021-01-04T00:00:00",
+          "2021-01-05T00:00:00",
+          "2021-01-06T00:00:00",
+          "2021-01-07T00:00:00",
+          "2021-01-08T00:00:00",
+          "2021-01-11T00:00:00",
+          "2021-01-12T00:00:00",
+          "2021-01-13T00:00:00",
+          "2021-01-14T00:00:00",
+          "2021-01-15T00:00:00",
+          "2021-01-19T00:00:00",
+          "2021-01-20T00:00:00",
+          "2021-01-21T00:00:00",
+          "2021-01-22T00:00:00",
+          "2021-01-25T00:00:00",
+          "2021-01-26T00:00:00",
+          "2021-01-27T00:00:00",
+          "2021-01-28T00:00:00",
+          "2021-01-29T00:00:00",
+          "2021-02-01T00:00:00",
+          "2021-02-02T00:00:00",
+          "2021-02-03T00:00:00",
+          "2021-02-04T00:00:00",
+          "2021-02-05T00:00:00",
+          "2021-02-08T00:00:00",
+          "2021-02-09T00:00:00",
+          "2021-02-10T00:00:00",
+          "2021-02-11T00:00:00",
+          "2021-02-12T00:00:00",
+          "2021-02-16T00:00:00",
+          "2021-02-17T00:00:00",
+          "2021-02-18T00:00:00",
+          "2021-02-19T00:00:00",
+          "2021-02-22T00:00:00",
+          "2021-02-23T00:00:00",
+          "2021-02-24T00:00:00",
+          "2021-02-25T00:00:00",
+          "2021-02-26T00:00:00",
+          "2021-03-01T00:00:00",
+          "2021-03-02T00:00:00",
+          "2021-03-03T00:00:00",
+          "2021-03-04T00:00:00",
+          "2021-03-05T00:00:00",
+          "2021-03-08T00:00:00",
+          "2021-03-09T00:00:00",
+          "2021-03-10T00:00:00",
+          "2021-03-11T00:00:00",
+          "2021-03-12T00:00:00",
+          "2021-03-15T00:00:00",
+          "2021-03-16T00:00:00",
+          "2021-03-17T00:00:00",
+          "2021-03-18T00:00:00",
+          "2021-03-19T00:00:00",
+          "2021-03-22T00:00:00",
+          "2021-03-23T00:00:00",
+          "2021-03-24T00:00:00",
+          "2021-03-25T00:00:00",
+          "2021-03-26T00:00:00",
+          "2021-03-29T00:00:00",
+          "2021-03-30T00:00:00",
+          "2021-03-31T00:00:00",
+          "2021-04-01T00:00:00",
+          "2021-04-05T00:00:00",
+          "2021-04-06T00:00:00",
+          "2021-04-07T00:00:00",
+          "2021-04-08T00:00:00",
+          "2021-04-09T00:00:00",
+          "2021-04-12T00:00:00",
+          "2021-04-13T00:00:00",
+          "2021-04-14T00:00:00",
+          "2021-04-15T00:00:00",
+          "2021-04-16T00:00:00",
+          "2021-04-19T00:00:00",
+          "2021-04-20T00:00:00",
+          "2021-04-21T00:00:00",
+          "2021-04-22T00:00:00",
+          "2021-04-23T00:00:00",
+          "2021-04-26T00:00:00",
+          "2021-04-27T00:00:00",
+          "2021-04-28T00:00:00",
+          "2021-04-29T00:00:00",
+          "2021-04-30T00:00:00",
+          "2021-05-03T00:00:00",
+          "2021-05-04T00:00:00",
+          "2021-05-05T00:00:00",
+          "2021-05-06T00:00:00",
+          "2021-05-07T00:00:00",
+          "2021-05-10T00:00:00",
+          "2021-05-11T00:00:00",
+          "2021-05-12T00:00:00",
+          "2021-05-13T00:00:00",
+          "2021-05-14T00:00:00",
+          "2021-05-17T00:00:00",
+          "2021-05-18T00:00:00",
+          "2021-05-19T00:00:00",
+          "2021-05-20T00:00:00",
+          "2021-05-21T00:00:00",
+          "2021-05-24T00:00:00",
+          "2021-05-25T00:00:00",
+          "2021-05-26T00:00:00",
+          "2021-05-27T00:00:00",
+          "2021-05-28T00:00:00",
+          "2021-06-01T00:00:00",
+          "2021-06-02T00:00:00",
+          "2021-06-03T00:00:00",
+          "2021-06-04T00:00:00",
+          "2021-06-07T00:00:00",
+          "2021-06-08T00:00:00",
+          "2021-06-09T00:00:00",
+          "2021-06-10T00:00:00",
+          "2021-06-11T00:00:00",
+          "2021-06-14T00:00:00",
+          "2021-06-15T00:00:00",
+          "2021-06-16T00:00:00",
+          "2021-06-17T00:00:00",
+          "2021-06-18T00:00:00",
+          "2021-06-21T00:00:00",
+          "2021-06-22T00:00:00",
+          "2021-06-23T00:00:00",
+          "2021-06-24T00:00:00",
+          "2021-06-25T00:00:00",
+          "2021-06-28T00:00:00",
+          "2021-06-29T00:00:00",
+          "2021-06-30T00:00:00"
+         ],
+         "y": {
+          "bdata": "ca81EsbylT4j87krX5uaPtQ0CsHskpY+pet3sLSAlz5Wi/TF02SXPkfkE9xdy5o+48drL2cuoj6WpRkVePmVPqJkVchjiaE+mW4kp0ZIqz6qOAuzDWakPmylV6GI0po+4GZYlg/kkz7ELc5fs5OTPhc89DuL+p0++Wi+cDholj5g2DyKzC+lPkeg9X58RaM+LNwhffGHlz56aKxmLPWVPoogThBFjpg+11ZBlj44nz6wMjihBZKiPpaYowgZz5Y+/VRckssClz6/qbs0mdeSPt59UEDKIpM+qnF7tapfnD6SEyKErb+ZPrY5p2zqep8+tlEv8LKblj7I2a65vTuXPqosHpx8kpA+xSJ/vPeZij5suKpwcC+PPpt6vUWlcZI+dtIauKyjjz4pZjtWdOOOPlD2/qKLQpM+Hnv7SUAEjz7+LeMNa6+RPnjxE/hpd5s+iVrBdbprkD4u6J8suciRPsBYQwyVo5I+jM6peJLVnD62f8D4YG60Puz+QdLra7g+UfbQTQ87sD5UA7x7N36gPkKJHiNZYK4+/8NO7hEWrD7YZwYR7S6ePsGkRmFuo5U+aEw7OrupoT5HlRP2YBSpPqcKwdG0xqg+EdQNIDJspT4CvMjxiNibPurj4uifs6M+ztNscUyuqT4GuMbTwqmcPsQqUr+Uupk+1IipiWM8lz4oGvftBkGgPlZ1rZy7X6A+xBHD8HbHpz5aS69BuTiUPsktL/x06pw++N2XXsQBlD5ohrkPJxaRPjjShhkhAZA+5fBX+h6dmT7qcwVd84KePq3oAYYzyZw+sKX7sMbYmT50dF595zOUPj4kGfCbHp4+m+scB3Osnj4+7Sva9gCePpzBEdZJZpw+7T80Zf0ckz7UVZPQFSuhPk4NvJhqmZg+PkWoRiFLpj5Q5waVIomjPjClz6aFDaw+yiVDtyTqpD6Hx3mJtdSfPlZGB2lhSas+cFeVRCpcoT6wcsVj2Z6dPnDM7NzHNLI+1Dj4Ldkcsj7eVMyeksKcPnWLWhdx8KA+To60vpwCmD7Ixo75XfWXPpjPQK2zlZc+Awk0Gpqolz6RDBjsdZuXPt9vs/hfdJM+nhS0vCWdlj7qFaw2PlKYPoYb6xhXLZI+qgAww8/4nD6UDa90TA+aPgwOcTaSNJw+I/AgqK3Zkz41hu3FeNiTPgbEWdkhsZA+0MVW809ikD7sPXKy/fWOPvTCXg/c950+u62TWt0Rlj6IPahpAXGUPtrA5/VhbZY+iurQlO9Mkj4c67xifm2RPiqdb/tsApA+pfbm2OIDkj7uZSLhafSXPlWkuMA4cpM+qDQSu3DOij5IMjRrYWqTPpq5+m/cP40+NOV96GMxkj5Q4HYH6TiJPpjs2PJ+Xok+0hdioVGopD40wsk9OguWPmZnCts0xqQ+aFZGZtMulz6sUy8YvAidPnoxVHDWsJY+IpHOUFExmz6LwjF+NwmVPspQwa7l4pY+oHTXnOmGmz461ICDF6yWPrcXB3Q4l5Y+1vxPYs8SlT7dlt/XySaSPmNRLOTOmqM+NN9gh4RAmD69pc6FFpiyPs8s4lsXe6o+sBkvG8vTsD44SS6ts4egPjBSXRPawpo+9gfnTQCkmD4OIXI1oAuXPj+gEvUEgJU+xlZNUuA7kz4S4aRQNBqRPqbDxp2HqZs+1bSGz+vUmT4i9GkV+eWRPtIQ7V5QgZk+CCA6Y/13mj5oFona4SSZPhXrDetZ9pk+qJ9qGY5QnT7eW/GkEZGxPn9ebCbL3qM+YmNFhpy+sz6yKNZMyzKxPjwkBnZ5wps+WlBJnVQRoT688gDT5G+pPvDoO7WnHcA+VqCiZxwfuz5KSGyRLpOwPnUgdLfLl6I+gn7vMqjeqj6Ic/YXoIqbPp2KjohuLZw+zBE7BGcJlz5SlD0GA5acPjl6EKSQLaU+wFaM7cW6oT6qa+FwI+GgPl4cNCKaXZc+HPgx9BNVnj5cqK5BDBmiPhqzKZGQkKo+p7ctPO4spD4WvWu0y/6kPo1I6rRNjp0+qt1LiQTAmT4Xgf+GQPeVPjTXrBxKi5M+zM1BNErZkj4SigdL+8KRPly9hZUrCI0+HmR7K58aij4rzIEUbdaNPrCEB6jd24s+zBWxnjB7kz4Uc0ZwCVmQPvClso6SWoo+DaFvze+glT6ZirvikTGTPhPE5YZuQI4+2vGvrrtJmj68BZeyokOLPmJ78tmLTIk+ULfof/ksjD6m+UMXG6iQPuiJnwDK+ZQ+xKBeMXXakj6WdWpQsO2QPhadn0T1gZ0+UH6HvB87lT6aBuhAC0ecPl54WA+DR5Q+Oi7ruoDvmD4yzmzd2XmjPgEA8ouoNaI+2jj+5CwMoj47lqGa5zWQPsuGxNP0/JY+F99+MBkBkz4+xmi5DTSiPhYdzcqKSZI+LiTOhmrPkD6c8cQ3C22FPoMkAmr/GY0+Fz+uVDcQhT5C2MaN7diIPrlM/RKiLYY+6Gk+I9Uoij6M1m0e19qKPnb+Nzf6Zo8+pOadgJgehD7iudSTE5CHPryzK5Z10og+nvIOMwV8hD5vglPzrauIPnLKS23VB4E+kHugNfPYhD4qveqk2rmGPi6vP2wIOpQ+J2WCB/julD7LnitTQnmTPtqHhvX4BYs+Mi2Ai8lBhj6sF+Bbtt+CPkKAMiZp4YQ+qcWQ4njPgj6aPLLWGOmHPvKDWbvjJoU+iO1eraC7hD4=",
+          "dtype": "f8"
+         }
+        }
+       ],
+       "layout": {
+        "height": 440,
+        "margin": {
+         "t": 120
+        },
+        "shapes": [
+         {
+          "line": {
+           "color": "#334155",
+           "dash": "dot"
+          },
+          "type": "line",
+          "x0": "2020-12-30T10:02:00",
+          "x1": "2020-12-30T10:02:00",
+          "xref": "x",
+          "y0": 0,
+          "y1": 1,
+          "yref": "y domain"
+         }
+        ],
+        "template": {
+         "layout": {
+          "colorway": [
+           "#0a1628",
+           "#D4A84B",
+           "#C87533",
+           "#10b981",
+           "#ef4444",
+           "#94a3b8"
+          ],
+          "font": {
+           "color": "#334155",
+           "family": "DM Sans, DejaVu Sans, sans-serif",
+           "size": 11
+          },
+          "hoverlabel": {
+           "bgcolor": "white",
+           "font": {
+            "family": "DM Sans, DejaVu Sans, sans-serif",
+            "size": 11
+           }
+          },
+          "legend": {
+           "bgcolor": "rgba(255,255,255,0.8)",
+           "bordercolor": "#e8e8e6",
+           "borderwidth": 1,
+           "font": {
+            "size": 10
+           }
+          },
+          "paper_bgcolor": "#FAFAF9",
+          "plot_bgcolor": "white",
+          "title": {
+           "font": {
+            "color": "#0a1628",
+            "size": 14
+           },
+           "x": 0.5,
+           "xanchor": "center"
+          },
+          "xaxis": {
+           "gridcolor": "#e8e8e6",
+           "gridwidth": 0.5,
+           "linecolor": "#e8e8e6",
+           "showgrid": true,
+           "tickfont": {
+            "size": 10
+           },
+           "title": {
+            "font": {
+             "size": 11
+            }
+           }
+          },
+          "yaxis": {
+           "gridcolor": "#e8e8e6",
+           "gridwidth": 0.5,
+           "linecolor": "#e8e8e6",
+           "showgrid": true,
+           "tickfont": {
+            "size": 10
+           },
+           "title": {
+            "font": {
+             "size": 11
+            }
+           }
+          }
+         }
+        },
+        "title": {
+         "text": "The HAR forecast tracks realized variance closely and overshoots its peaks<br><sup>Cross-sectional median across symbols per session, validation rows only.<br>Each dotted rule is a boundary between consecutive validation windows. Both series<br>are means of squared one-minute log returns.</sup>"
+        },
+        "xaxis": {
+         "title": {
+          "text": "Session"
+         }
+        },
+        "yaxis": {
+         "title": {
+          "text": "Mean squared 1-minute log return"
+         }
+        }
+       }
+      },
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAArwAAAG4CAYAAACnwzTIAAAQAElEQVR4AexdB2AURRf+9ko6vVoRFUQFRIq9AoIoVYqANPVHaSJVmkgXEBBBRJoFBBFEVKwgiqIiKCKiAkrvvZN2Ze+fN7t72bvcJRfS7pKX3MxOedO+md198+bNrMXhSPWwYQx4DPAY4DHAY4DHAI8BHgM8BgrqGLCA/xgBRoARYAQAMAiMACPACDACBRUBZngLas9yuxgBRoARYAQYAUaAEbgUBApgGmZ4C2CncpMYAUaAEWAEGAFGgBFgBNIQYIY3DQt2MQKMQOgIMCUjwAgwAowAIxAxCDDDGzFdxRVlBBgBRoARYAQYgfBDgGsUCQgwwxsJvcR1ZAQYAUaAEWAEGAFGgBG4ZASY4b1k6DghIxA6AkzJCDACjAAjwAgwAvmHADO8+Yc9l8wIMAKMACPACBQ2BLi9jEC+IMAMb77AzoUyAowAI8AIMAKMACPACOQVAszw5hXSXE7oCDAlI8AIMAKMACPACDACOYgAM7w5CCZnxQgwAowAI8AI5CQCnBcjwAjkDALM8OYMjpwLI8AIMAKMACPACDACjECYIsAMb5h2TOjVYkpGgBFgBBgBRoARYAQYgYwQYIY3I3Q4jhFgBBgBRiByEOCaMgKMACMQBAFmeIMAw8GMACPACDACjAAjwAgwAgUDgcLG8BaMXuNWMAKMACPACDACjAAjwAiEjAAzvCFDxYSMACPACBQkBLgtjAAjwAgUHgSY4S08fc0tZQQYAUaAEWAEGAFGoFAikCHDWygR4UYzAowAI8AIMAKMACPACBQoBJjhLVDdyY1hBBiBXEKAs2UEGAFGgBGIYASY4Y3gzuOqMwKMACPACDACjAAjkLcIRGZpzPBGZr9xrRkBRoARYAQYAUaAEWAEQkSAGd4QgWIyRoARCB0BpmQEGAFGgBFgBMIJAWZ4w6k3uC6MACPACDACjAAjUJAQ4LaECQLM8IZJR3A1GAFGgBFgBBgBRoARYARyBwFmeHMHV86VEQgdAaZkBBgBRoARYAQYgVxFgBneXIWXM2cEGAFGgBFgBBiBUBFgOkYgtxBghje3kOV8GQFGgBFgBBgBRoARYATCAgFmeMOiG7gSoSPAlIwAI8AIMAKMACPACGQNAWZ4s4YXUzMCjAAjwAgwAuGBANeCEWAEQkaAGd6QoWJCRoARYAQYAUaAEWAEGIFIRIAZ3kjstdDrzJSMACPACDACjAAjwAgUegSY4S30Q4ABYAQYAUagMCDAbWQEGIHCjAAzvIW597ntjAAjwAgwAowAI8AIFAIEmOE1dTI7GQFGgBFgBBgBRoARYAQKHgLM8Ba8PuUWMQKMACOQXQQ4PSPACDACBQoBZngLVHdyYxgBRoARYAQYAUaAEWAE/BG4dIbXPyf2MwKMACPACDACjAAjwAgwAmGIADO8YdgpXCVGgBGILAS4towAI8AIMALhjQAzvOHdP1w7RoARYAQYAUaAEWAEIgWBsK0nM7xh2zVcMUaAEWAEGAFGgBFgBBiBnECAGd6cQJHzYAQYgdARYEpGgBFgBBgBRiCPEWCGN48B5+IYAUaAEWAEGAFGgBEgBNjkHQLM8OYd1lwSI8AIMAKMACPACDACjEA+IMAMbz6AzkUyAqEjwJSMACPACDACjAAjkF0EmOHNLoKcnhFgBBgBRoARYARyHwEugRHIBgLM8GYDPE7KCDACjAAjwAgwAowAIxD+CDDDG/59xDUMHQGmZAQYAUaAEWAEGAFGIB0CzPCmgyTvA0pfUwurv/857wvOoxKdTif6DB6DW+56BMWvvAV//PlPHpVcOIr55ddNEteUlNSwb3DnZwdgyMhXvPXs/Gx/DB4x0evPDQeNu6XLv8iNrDPN87rq9+PTL1ZnShfOBH9t/VeOr1Onz+ZZNf3HSZ4VHEJB3fsMBz3PQiDNZ5L0xbfq0ANjJk5PHxGGIbPeeh/3NXw8DGuWeZWmvP4WGj32ZOaETJGnCDDDm4twP9Ssk3xREJMXyNxVv2Uulg7UurcJJk6dna4MuhlvqtMgXTgxppVqPIhrbr4XFxOT0sVTfkY7rqpyl7yh3/vg43R0/gGff70GK8RL/9PFc3D24J+49Zab/Ukixj9j9gI8+Gj7TOv7xP/6YNjoyZnSFXaCKpWvQ8UKVxVYGO647VaUKlm8wLaPG8YIBEIgJ55/l5UvixrVb/JmnxN5ejNjR6FEgBneXOz2SWMG47Ol86R549XRsqRXxw+Tfgp/fdJIGZZfln+5X676ATdVqYR776qDD4NIxDq2bSHrP++NiXjwvjvRe+AofCEYWv+8zP5Dh4/i2opX45oKV5qD2c0IYEj/Hnj2qcwnEJEK1aJ5r+GeO2tHavW53oxAviHQ7NH6mD5pRL6VzwUXPASY4c3FPqXZKTGPZG6trkk1q910g2QoKazWrdW8pR87fhKtO/bA1TfejXseao0lH33ujSPHmbPnMGDYeNS8pzFIuvpY++74e9t/FJVjZvGyT/FY04bCPIz3l30WMN8rr7hM1r9hvXvxQp9nULNGVXz1zfcBaSnwqR6D8OKYKdi4aQtIOnz7g80pGA6HE2NfeR117m8q29O49f+wbsPvMo4sY5n+69Vr8cAj7VD++tvw47rf4Ha78fqsBRKjKyrfCZK2rvhyNSXxmt1794OWREmKXaVmffTs9xK2/btLxm/dvhMvDB+P2x9sIbFu1vYZ/Pn3NhlnWJOmzUWD5p1Q7ro6oDo/2f0FGfX+hytkW0glg8LJvLtwmYwzW88NGCknAW/MeU+mJ7p/d+xBsDaFUidVVUFLfHUbPwFqN60ezHlnsblYrzs11YHHO/fCwy264Oy58zI8WJtkpJ8VrJ6ZYU+rAtSnhB2NUeq35Su+9svd12tWaTDKJbzMpnm7Z72JVn33o2xXhZvuQe37mmLCq7PkmDAI9u47KNtO9xH18QcfBR7HBv2efQdkH/2zbYcRJK8LFi8HrXbQqkco7aKlYpLo01i7+baGMOrsr9Iw993FIFpaRaH6j5s0Ay6XS5ZJFq2+0FIo9S3dG9dWux//6zUYR4+foGiv+faHdWjS5n9yDN8u7qmhoyYhKSlZxl/KsyIr44sK+f2Pv2QbqR/omUT3eHJyCkVJQ/ckPaMonvqSxsLhI8dkHFmZ9SPRGIbuJxonhp+uVN/qdz4Cwon8/iaUPvPDGoGwpnxIfaHyrXVR7Y5GIJz9ywrkX7xshXxu0b36QKN2eOe9D71k89//CDfWfshn3FJkt+dfRMeu/cgpTWYYlb6mFigvwpnGE63myfoOGgNaPSTcqfzps+bL/AzL7VbRd8hYWQdq0+gJ033G4LETJ/FM76Eynu4Bev4dPHTESC6vGbWP+ouEIP7Pv1DqJjPXLXreGSoNOZWn0ef0DqAVS8KN3lEnT53RS9UumWGf2X2s5ZJmE350v/cbMg4ej0euoPbJpJ/SUrMrpxBghjenkMxmPtNmvo1bqt2Ima+OQeVK16JbnxdBL28j245d++PCxYuY+/p4bF73JRo3ehCPte8Gkp4aNNm5Hj12At//uAFNH6mPRg/dj/927M6UoSbG78+/tsFiCT6M3p45ESOH9kGdWreA1Bk2rPlEVnPEy1Mx990lmCik4H/+8iVoabtZ22exY9c+GW9YU16fh8ljh+Dg9nVSFeKV12ZjxVerMerFvti6cRUG9emGkS+/BmKMKc3xE6fQoFknxMfF4aOFb2Ldt8twt5Cwnb9wgaJx7vx5VLu5CpbOn4Gfv/kQde+/S+JoMBTfrV0n6rUYY17shz1/rcXalUtwm6g7JW7fuinGDu8v60FtIdOlQyuK8jGvTx6JRx9+ED2f6SjbTHQ3VKropfFvU2Z1ooQTp87CtDffQe9uXbDt92/wyuhBSA6gs3vhYiJaiYmT0+nGx+/PQvFiRZFRmyjvYMa/nplh73A4EB0dg6njh4P6tGfXjoJBmByyfvqdt9X04kWY/f7jCqkOcHvtW2QVf/hpA3oPGIUuHVri9x8/w5tTx+DXjX9i1PhpMp4Y8se7PIczgslf+/USvDtrspwknD2rMf2SyM8idYrba9fAx5/5MubLV6xEiyYNYLfbxeTMgegQ2vW2YGquu7YCfhRjZsGcKX4lad7zF5LQv/f/sGX9V3hl7GD8vH4Txk+ZqUXq9ua/toKYww8XzMQnH8zG7r0HMGHKLD0WIByIaX6o7r3YuHYF3n97msCpJJw649zxEp4VoY4vqgQ9c5o+/gzKly0j+2HGlFFYLCaDA4a9TNHiOZWIp3sORttWjeU42PzzF+jSviUURZHxVP+M+lESmawObZuD1KLMTMnq73/GMTEJeLxlYxNlmjPUsZgZ1sNGTcZnYkL97qxJ+PazhaLMU/hOTDbSSkrvIma/e5/haNeqCf75bSWe7txGMpgLl2jPPnrGnj5zFt+L8WykThH38mdffSuFDRQWKkYTp87Gkx1bYfvvq9H9f0+A3iN79x/EvBkTcei/X7D4nWm44rKylKXXfCCEKS6nC6+IZ2/r5o1ADPFHn2rjn5ixxzs9h+1CQLB80Sx88+l7ciw+9kQ30OQP4i+z9gV7/oVSN5F9wF9O5rlRTNZOnT6HTxbPxufL3pLte6qHJtSgwkPBPpT7mPIiQ8KORi2fQiuBNa3wKooSUj9RWjY5i0BwTiVny4n83HK5BW1bNcWLLzwnGNm6mDN9HIoWScDvm/+Spa79+Ve50esN8WKpJaTCpBP4VMc2Qrp6Mz4SL2ZJFMSilynN9M0m0KaF+e8vRwPxAi1RvBhiYqLRvHEDLAygn2vOj6SrdrsNnds/FqT0wMEkCZo3fykG9H4Gde+7CyVLFMeEUQNxuXgwv7XgA59Eg/t1Q+2a1WGz2WAX5rWZ7whmtC/qCUa1WNEiePih+9D5iVZC0qFJWt8RElcKnz7pJdx4w3Uyb2JUiamhjImp6ti2BSpcfQWuuvJyPN+9C6oKqfuXK9dQNI4cPSHTEJMbFxeL6oI5pheJjMwhy9ymhPg4ZFYnkgBSu4cO6CH65SE5NkgPmupOVVIUhS4gyV4TISkvXaoklsyfjtjYGBl+qW0y1zMU7KkfBz7fFTffWEli2LrFI+gi+uaDIKsFsnJBrPMXLqLD//qhjuj7QX27Saqpb7yNrk+2Q9uWTVC6VAnQJGrogO4gRpMI1vy4Hv+Kidq0iSNA6jPU/zRxOXdem+wQTSBDqxrL9Bc+xRNDRy+9ls0akVe2JZR20SpOv15PS3q6f2ViP6v/c0/L/qZ4GvuD+j6LRUtX+FCVEPcgTRKpDTT+nmjTFL/+vtlLQzi0E8+L3t06o2yZUriuYgVQvjTuL+VZkdn48hasO0j6TeN26oQXZT/cdXstDB/0nGjHpzhx8jROCWkZMUf3iIkmTbioHV06tMJl5cvKHKj+GfWjJDJZdO9Wuu4amMfRB8s+l5NzarOJ1OsMdSyWyABrkkhSW4f07w5qI2H92sThSExK8pYTyDH33Q/wSMMHQKo67VQhtwAAEABJREFU1H563rR57FHMeXuxJKcyH65/P5Z/qjGZFPj519+JZ5xVChvIHypG7Vs3QZNG9eQzm8YU3esVr7kKN1W5Xk7677v7NhjjmPIlU/3mG0AMJKV7aXBv1H/gLjG+tlCUnEzRJGD65BHy+Ul9N33SSPy3cy9I5Y2IMmsf0QQyodQtULqMwi4lT6vVAmI86flf9cbKGD9yIOi+2SaYfCorFOzpfqPnNmEe7D5WFEWuHjZu/ZR4z3TG4H7dKXtpLqXeMiFb2ULAkq3UnDjHELipSiVvXsTcXS2YMUOisWv3PvmQLS2WsMyM69ffrIVZCuzNwOSghy3pC5sNMSEmErnEQtKHx5o+7A0mJuDDj78ESR68gcJh5PfOm5MEg3wPxr3UH8SEi6iQf3v3H5LSgvoP3u1NQ20mneDde/Z7w8hR07TBbY9Yrk4Vy/W0VG/GYcS4qdiz9yCRY+fuvbI+lJ8M8LOSxLIvLYM/IJYZy1SsLZezibk5cFBbsnvowXvES/sUHnykvVS5oCVxYr78ssmW19wmyiizOu3cvR/U7ttq1SDydIakMhTYrG1XVK5UESRVtwvJJIWRudQ2mesZCvZUFi11PtrqabnUTn004dU3YWBL8aEYWq7u8uxASUq64hZ9BYGYWZqsUb6Gqd+0I4gxOXL0uLgXDshJDDG6MrGwSHXIYPyFN+CvRZOGOHjoqFelZvmKVah0XQUQo2UkCKVdNarfaJAHva7/7Q+0f/p5VKlVX469Zm2fAa2u0BgwEl11xWWGU15LlyoFWrmQHmERDrfVqi5c6X+7LuFZsTOT8eVfyq49+3Hv3XW8EyqKpzFG191798vJxt131Aap3ZAKAC3/7hP3PMWTofpn1I9E42+e6tga73/4qQymCcwXK79DO8HsyYAgVih9lhHW+w8cls/G+++501tCkYT4THWyd+zaK5jItGcbJa7/wN3Y9t8umR/5WzZ7GMTkGs/X5WKFgYQMJGyg+FAxqlHtZiL3mhZNG2KBEF6QShOpMX216gdvmQbRjTdcbzjllSb/J0+dlm7qv/LlyqBGtZuknyxanSKza88+8opVuMzbJwn9rFDq5pckU++l5Hm9mCCaJ0rVxARAURTxDjkgywsF+1Du471C0t5ECCCGDeiJ/3VuK/M2rEupt5GWr5eOADO8l45djqa02aw++SmKIh5UWpCiKFKSQ8u8/oZmqhpVYNvQuaUXv2FoZmum/m7tL4IpOYwu3QbIlzAxE/QiPnX6LGiZzUxr5NdCLPe+LZheeqhu2JgmfTLTZub2Z0ptVlu6JLExMd4wRdEkmb98+xH8cVj/3XIvXUaOoWKJcvNf/+D1KSPx3x/fynxIWuxwOmUykuL8uHIp2gupWqJgjsdPeRMPNGrrw3BIwmxY5jZRNpnViWjIKIrWfnKbjaJo4a2aPyolFSSNMcdfapvM9VQUrYyMsCe9c1pifWnwc/j1+08ktrRqYWBrrlNGbtIpJCnTYrFUT5JEg1ZRFEx5eajM17//Demhzep7H1Faq8VCl6CG8KkvpFwff/aNpFkumI/HmjaSbrJCbVesWBkh+mCGGIbWHXvi8ceaYOXH83Fq3yZ8+dHbktyMkcHgywjdMiY1uhfQugP+f4py6c8KRQmSqX8hwm/1w9nq9/z6aOFMIfXthZjoaCwW0tjb67bAT79sFCkBRcm8H+H3R6oLNOmivQCLP/xMPA9L48F70xhRP3K5ByKUsRgK1jab7/jxb6t/2eT3x8cm8KE+VBQNY1IbI7qvvvlersys+vYnkJCBwsgoSmgYxcRGE7nX0LPsuy8W4U4hdafJ/7PPD5UTLC+BcFBdxMX7UxSqk8frN0+WjUD/9vj7KU9z+4x05msodTPTh+LOqTzpXUT1pzIVJWPsQ72PL7+sHO66oyaWLP9CTsopb8PkVL2N/PgaGgK+d3JoaUKgYpKcROCGytdKhot0ZnMyXyMvWiok1QCzFJjcbcXSMcUZdP5XYkae7NAaw0ZP8Y/K0H/N1VeAHphb/t7qQ7fpz7/laQ4+gSbPdRWvklKlb79fZwr1dV5/7TXYtPlvn00YZgraGNX44XqodtMNKCGWM0ly+s923w1L9KB6Riydjx/5An5Z/RH2C+nvxk2aeklMTBQ8atrLwZy32R0dFQ3jAWoOD+TOrE7XX3s1oqOjxLJjxhMLUnEg6T1Jev/dscenqIza5EMYxBMK9us3bsbd4kV7e+0aICkRZfXXP9vpErL55PNvMGPOe3h31iQpKTQnvElIpmhyZg4zu6+pcJXoq8NCQn/aG0w4kATYGxDE0bJZI3zy+UrQ5jW6zx5v+aiXMifaRZlt2vwPSpcqCdp9TlI1ugf++udfisqSuaHStfjtd20J2j/hpTwrQh1fRlnXVbwaW/727dc/Nmv38rXXXC3JYgTzT8+Pl8SS+XefL0KtGtXw9eofZFxm/SiJ/CySyLUSfUTM84LFH4FWmhSFGDU/Qt2bE3129VWXS+Z8y99pfUR64n/8qbVVLyrdhdQvzGmI4I8t/4DaTW4yxFQ+JqS8H3+2Ch9/thJXXlEepH5AcWSINqOxTjTBzC1Vb0SfHk9i9rRxeHf2JJCUl6TiwejN4deK/qMNVrRiYoSfPHUGJNW/TkhGKSyU9gV7/mWnbjmV504hqTbjQfcgqeBUvOYqap7sp4yw3xTifRwlVtkWzH4VcbExoImu/3MoO1jIirKVZQSY4c0yZHmfgHSFaEbYs/9L+G7tOtAyGG2yojNhaWklOzWihxltQniiTXN5+oIhBaYrbYb49od1MC9H+pfV+YnH8Odf2/Dlyu/9o4L6aYn5mSfbgqSnP6/fiNNnzuKV1+aAHjxdu/gu/ZgzoVk46f2+OuMtsby5QqYjfeBln3wFUskg2ic7tAKdTNB74Gh5MgPlTacrGFJoWr4ifS3SW6S2d+87HOaHH30kgM4WNh5Oa3/+TTLPFa/RjlSrKF4I+w8elmVQecHMtYKedMJoeT4YjRGeWZ2o3fQCGzfpDcGUfQNSsSCmbNqb7xpZeK+D+3VDq+aNYGZ6M2uTN3EGDqpDZthXu6kyfheTDcKcXiDUT6u++zGDXH2j6NSR7n1flPrc5pe/QUWbvWj39/gpM0GqPIQtqaOQJI9oHrjndhDz9vygUXJs0Et70EsT5GSB4jMypHNJY6nfkLGg+402sxn02W0X9IxuvrEyDh89BvqQAwVRW2jDELmzYvr2fEqOf0pLqg4kcZry+ltyHFPds/qsoL4NdXxRPYnZpOV+ksTTPUQbB8e8Mh1PtGmGMqVLivtuJ6g+xDgRPfXVrt37UFE/ljCzfqQ0gcwTjzcT7f4UW7fvFGU1DUTiDcuJPqMJfad2j+HlyW+INu2Sz93hY1+VEllvQQEc9AwjQQF97ISeRcTQLnj/YzzzVDsf6pZNH8bKb9fivQ8+QcumDSVzbRBcKkZ0MsLKb3+UJ0AQc772p19Bk0/SNTXyzuhK990t1W7E8y+MAk0Wqe/onqggmH9DKh1K+wI9/94QE9ns1C2n8lQUBf2GjMMB8RynZ86QkZPkZOOmKtdLaDLDPiv3cVSUHYveeg12u82H6c0uFrKibGUZAWZ4swxZ/iSYP2cKaFPZ0JGTcV31B9DuyefF8vUGJCTEZ6tC9FCmpeuH69+XLh+S1JFkcOGSj9PFGQHlypRG25aNMW7yDCMopOuooX3RvPFD6DNoNG658xHRll/x6Qez5QacjDLo1+sp0JI5bVSqdnsj3NuwjWR24+NiZTJanv78w7dx4eJFtGj/rDxqaOqMeaANaETw8oiBIEaJju257+HHQdKyuvenLY0mJMSBHkZX3nAnSLWjW59hmDR2MAy9twfvvQPVq1bBNTffK+MDHUtG5TzxeHMxUTiIklffKuno5UHhgUxmdaI0L/R5FnTqweRpc+RxWaS7SrvUKc6QJBvXscP7o+kj9STTS8xQZm2iPEIxmWFP0uVHGz6Aeo074LYHWuDvrf+hb8+nQ8la0hATT0zngGHjJWaEPxnjiK87b6spz4D+VUg36zZ+AjfWekgwVvPgcKTK9MS4ffDu63A6nLi/UTvUa9IBrQTzX75cGRmfkRUfFweS/NPEiNR1zLTZbZeRF71Q35gyGj36DMftD7bAFDEuRw/rY0SHfL1fMPZLF8wQkrvv5dFste5tih9+Wg/aWEiZXMqzIqPxRXmazZVXXIbPP5wH2u1OR5LRPVLvgbswedxQSRYXGyvrU/X2h2U/1rqvKRqK5wvhSASZ9SPRBDJ31LkVFa66QjwH78EVl5cPROINo7KyMxaNjMaNGACqb4t2z+KOeo9JRrLpI/WN6IBXip864UXMnLcQN9dpiGkz38XoF/uig3gmmBPcfUctuZGPxn0Lwfya46hMWmULNtbNtGa3W1XRSwhGSlWoCTKk60wn+yhKcGm4OT2peHzwznTxXklA83bP4KFmHSUjvuy9N0HMG9GG0r5Az7/s1i2n8iT95Kpicn5H3ZZ4tOVTckIwd8Z4apo0mWEf6n1sPI9jYqJBmFLmJOlNSkpGdrGgvCLV5Ge9meHNI/TpJiG9Q9pZ7l/kyb2/p9vksHblEnR7ur2XlKQNtHObdFUP/fcL1nzxPpYueANVhdTIS+TnoKObaBe4X7Dc0b31t1UyuEfXDtj7z4+wi+UXGeBnEd2wgb1kaLD8aMfvz98skzSBrD5iee2bTxf4RNHDk/Q7f/thBQ5sXydfoLQT2iCihw7hRQ8LI4yuiqKAXmarV7wnj92hY5noeJkWTRpStDRVKl+L9+a+Ko/qoTyojGo33SDjiCGeN2MCfv3+U1DbCB/6OMC4lwbI+Hr33wXCmNKRIWy6dmkn48iiFwKVR3FkaPc5hfubimJ5fdNPn3v1TWnTR7A2ZVYnypuWv3s92wk/ffMhju36DaT/SYwyxQXK95UxQ2T7aRkyszZRHmYTKD+KV5SMsSdshg/qjT9+/lwa2jz3Qp9n5Fil9GTmz56M8SNfIKc082dPERLdQdJNkkPC1N8Q3pJAWLTy8PH7s7D7rx/w7x/fYsWSuaAyRZT8Ee4fvjcTf63/SvYvMRl/rvsStEteEmRgzZo2VvbXM0+m9TeRh9KuZVJntTeR+5hdW36QKgxGYCvBgP+4aik2rPkYtNRPqhTUXtrNTzS0+/ur5e+Q02tIBYLy8QYIB20SI7r9236WdSYc4vRJ36U8KzIaX3TvUB3pdBhRtPzdesvNEnsqn8b5mBf7S3UjiiR1DaoPpSFDY3XaKy9JNSaKJ5NZP873GyeUhhgF2uDXrnXG0l2iDaXPQsGasKSTGbZvWg06Xm3i6MFSVeC1CcOpmKCGxtv3Xy6Wz6jvv1qMzu1bpqNVFEXmSRgFeo5nhlGg9wad3LFj8xpQnmTo2Uf5GIUHGqcTRg3CfHEfGjQ0QaR7d9vGb0B5zRd9QeodRjxdM2sf3Yc0LqgOZOj5l1ndKF+zofcfvQeNsF76aXYAABAASURBVJzI08irr1gloffovq0/gdSnSHBjxNGVMMvoOZPV+5juTbpfyZA7q1hQndhkHwFmeLOPIefACDACOYYAZ8QIBEZg5rxF8vitxg/XDUzAoYwAI8AIZIAAM7wZgMNRjAAjwAgwAvmLAKnlkGoLffCBpHHBVqPyt5ZcOiOQCwhwljmKADO8OQonZ8YIMAKMACOQkwiQWg4ti9MRbqTHm5N5c16FC4FAaiyFC4HC3VpmeAt3/0dk6+mDGPSVN9pYRh+hIH8kNGTe/A/gcGjn/VJ96TvxxmkQ5L8E45OEdsw3aN7JJyynPVRfqjflS6c/0Ec/yM0mMAK0KZQ+shA4Nn1oXvRh+lJzL2TwiIn4evXa3CsghJyHjHzFWwcauzSG/ZPROKbx7B9u9pvvX+on+rCGOb6gue9/uG2682MLWhu5PYULAWZ4C1d/R3xr6ZirsZNm4IXnn8X2Td/i5REDcOz4SUTCH50sYf7AAG2GyexjBeHcrrtur4nOT6TfjBPOdea65S0C9IUp+jx03pYavLTs3HPm+7dY0QRMGjM4eEEckw8IcJGMQMYIMMObMT4cG2YIzHl7MV4c2AuNGtwP2kFds0ZV0OkFVM3bH2yOYaMno+UT3UHn+859dzHo+CqSBr/93lIikWfYPv/CaDR9vKs83ovONaaIV16bgxbtu+GmOg1AX4+jMLOhDxJ0fnYASIJapWZ90FmzFP/BR5/J46+ojMnT51GQNMtXfC1p723QBp2f7S+//ERnl7Z/6nl0e/5FSdNn0Bgkp2hHagWqK0kHqUxqzyMtn5IH1FNCOlbt0VZPg6RVJGWitlJ4MHPo8FFQ/Z7s/gKoPnQ2LX1Bj/Igc+TocZmUznZ+qscg2R7CwvhiG+lQNm/3LKgOE6e+KWnJWrdhE+Yv+oicIOlYtTsayTr1H/qyV5LdZ/AY0DFjlB+l3/bvTklvtnbs2gfquwceaYe2Tz4Hqi/FUztJOkp1r37nI3hz3iIKlrSX0s90fnGgvpeZ6pb/OEhMSsJtDzTzfkTk8JFjEksipzq/NPZVNGzeGU3a/A90vi711e0PtvB+VYzoqH2Pte8OOgqPzs6mMDJzA4xPCjdMsDFnxBNOhBmNL8KoZ7+X5FmxFB9oXJrpm4rxT2clE61h/NtO4Rs3bZFtoyPeuvcZjgsXEykYdHb34517yfFEbaPAQGEkFf1N5EHxP677DY0ee1LekzQmjNWO28V9SxJWGmM03o0yKE0gQ3gbZ/xS/J31WoLGbrAxSDSGMd9zU994G3c/1AptOvUEfcXNoKHzhWvd2wR31H0Mby1YIoPpa3vm+/fc+YsYOHyCjKOP19CYJ4zofqIPyVBEsPuX4gwTqE8CjQs60/qd9z6UyXr1H+F9hixYvBwUF8rYvlT86dzrdxelncLTd8hY0BnSsjJsMQIRhIAlgurKVWUE5Bd/bqt1S1Akqt9cBR8tehOlSpbEnHcWg46Woc+cvj5rAYiBI0aPzvCkY5P+3rASdCbj3n0HQS8pov3n15Xo2K55uvzfnLcQXbu0xapPFmDdt8sEsx2Pnbv34W3xEqL86dg1YuaIgSYGceT46Xhn5iv4cdVS0NemHm/ZGHS0z/tvTwMdf2UuYPt/uwPWlWiOHDsuj1gj/cXps+bLM4QVRcFrE18CHdkzZ/o4vKC/eIk+mKGD/0cN7YPVny3EuvWb5BfFvlj2Fh5v+agsm9KNnTgD9R+8G98KmhFDeqP/0LEUjDEivPmjD4HqQGc2y0A/q0a1G7Hxh09BRzBFR9uxZPnnXgqrVcFy0Sezp43Fy5NnesMNR+lSxfHZ0rdAxzjRB1DGTdJoPvjoc2zesg1fL38Xm35cgUcaPGAkwaX0c6C+92YoHIHGQXxcHGrVqI7v1v4iKACq0+OPNZZusuiYwZWfzMe111yNMROmy0PmF857DWMmvk7R0tB5tXNnjBf4vYN5goEiBjijPpeJhBVozIlgnx8xxaOG9pVHv8XHx0rcg41LSkhnI9PxhjT+7aajCAO1nT5c0G/IOLwiJJk0Jm4RfTz9Te3ItPFT3pRHWdH4njl1NGUtPyQzf/YUOeaNMBkhLJfLhZ6CURs/ciDoSMHDR49i8bIVIkb71ah+M+j4uUZiIvve4o+1wCB2k0b18OEnX8lY+ghFubKlUb5sGWQ0BiWxySLc6OMQX388H9MnjcSG3zZ7Y9u2ago6gpHuleUrVolnzj5xnwS/fxct/QQnT52W7aJzlbv3HS7P66UMA92/FG425j7ZteeAvB/pWUTPlddnLQA9t26vfQvoTF5Kt//gYfnlTXLTF/foeZjZ2M4O/u0EHks++oKKkxOqNeJeaFDvHulnixGIJASY4Y2k3uK6SgQURZHXQNbDD90vg3/b9CeaPlIfxYoWQckSxeVZqBR2c5VK+Hr1D6Cvc/20fqOMoxfmmTPnBDP2hvyIRSlBLzMxWbWEJHnG7PmgL0gdPXZSHsJOHyk4efI0unQbiFYde2Lr9h2SQVsvXp6PNWngPRyfNt0ggz+qV6C6UpI769zq/WgGfS2JziFVFEWW1V1I3PoOHosjR0+AvuhE9MFMpesrSoabPlF8Y5XrcVvt6pKUzlPdsXuvdP+8/neQVIokbSNfnub9fCx9FtU4+7TD4y0krb9lt9tAErN2T/YGSX63/7fLS/LgfXfJw+tpovHfzj3ecMNBTPTyFSvR6Zn+QqK2FNv+2ymj1on6PPNUe/mlNPqoBJ3vKiOEdSn9HKjvRVbeX7BxQJOCJYL5JsIlQqLfstnD5JSGPgJBjltvuQnEEMbERKPSdRVw7MRJCpbmkQYPiglYcdBZu3Sk1qbNfyGjPpeJhBVozIlgnx99gvYa/Qtm9R+8B7//8TeCjUtKWL1qFdB5puQ2m0BtP3DwCA6K1YEhIyeBxsQnn6+SX1WkdFVvqoxho6dg5tyFoDNvg4VROJl9Bw7hisvKoUb1myR95/atfD6P/FDde4gMl5UrC2M8yoAAFp1LTNJkiqIrfWSF3BmNQYo3m01//i0/fFMkIR7ly5WRH8Yw4hMTEzF01CR07NoPR44ew/Z/dxtRAa+//f6XmCS3kGO81q3VQOdqE3ZEHOj+pXCzMfdJsHFRq0Y1bPrzL5w6fVbmT2UcESszv4uxVFuUmdnYDoB/yPjT+KJzmmlSRB+yeLThg0HPbTe3i92MQLghwAxvuPUI1ydDBK6reDU2/rElKE10VJQ3jpgkw0MvQ/ryDb1wSXpS7aYb8MrU2fj4s1XywPxvVizAfXffLpeih46aIpmG28XSNJnvf1yPJzu2FpKuIeLlWFowZv1AD3/Kr0WTBlIyRdKpX779CP16PS2Xv6k8o+xQroHqSulsNitdpFEUBU6nC/RlJlIl6Pfc/6Tk9MrLyyMxMUnSBLOiTNI8q8UKu80uScntEnmSxwMPlrz7urc9dCi7DPdAMvjkDtauAS++DDpcfu6MCejb82kkJiUTuTRGG4gxIkmTDDRZc99dgqNCkj1h1AuYJ9InJWltIXztdquJMs15Kf0cqO/TckTAcUDxxNRu3vIPfvhpA6pUvl5+PpfCyUTpuFqtVthsGqYUTnWnKxmbzUIXaew2m/zKEnlswk1XMoSrOQ2FBRpzFG42/mnITybQuKR0ZtzIb5jY2Bj43wM0HuhLhDS2yXz98bvyYzeUhr7e1al9C1wU465Np15y5SFQGNEaxmYay3bRr1RPb5zAj9xyjOjjkfyBzFVXXo4ogTutpHz6xTd4RDBgRJfRGKR4s6GyLZa0sWX0BakndO87HK2bPwL6OlaDeveKsayNR3N6f7dNrz+F2212cSeJm0Z4zG1WFO3+FcE+P/8+MepCRMa4iBETKVq1+nLVGpC0l8zK1WtRtEgReTZxZmOb8jLXxW63yucUhZOx6fW3WCwwngcUbhia9JEkmzYI02qVEc5XRiCSEEh7EkdSrbmuuY9AmJbQ9cl2GC2Wi1d//7OsIel5fv7Vd9JtturUvAUrvvwW585fkPq2K75cjdtq1ZB+kvo+0vABtG3ZWDCPf8sXmqIouOfO2pJZI4nm7bVryK9h0RexHrj3DpmOVBKeaNMMt95yM2hJ+s7bbsVHQjJJS8hUNukVEiNMRyeRNIz08yicmAK6xsfH47yoD7nNJlhdzTRmN5V36y03Skninn0HsDWAXqyZPlT3fXfdJqXcRE8MAal5kLumaO/an38lJ374eYO8+lukMtGw3n3iBZyA1Wt+8o/O0L97337cc1cdXC4kgLQp0SC+645amDd/CYgJoTADR3IbJhh21O/+/RwozMiHromC0VYU33FA4YqioEWThujR7yW0afEoBWXJrFz9o5TMkRSeJGS1b62OYPU2Z0z19R9z5nhy/yNWFUiiS/31/tIVqCVWIoKNS6IPZgK1/WrBWJ4+cwZfrfpBJiOazX9tlW6q2y1VbxQTvKdw+uw5yfgGCpPEwqpw1RVCWnoclJ7u2fmLluP2OjVETPDf39v+A+nlBqKgFRFapSkvpLOkzkA0WRmDNQVO6zb8TslAkzDDfer0GZAknu5xi0XB9z+mjfeg92+tanJliPqAJqMnTp4EYSczz6KV0bi4Q+A1Q6wy3Va7BurUvgVvvrUQFEZFEPb+453CDXMp+Btp6drs0YdAqzBHxGoSqRPRs44mHBTHhhGIFASY4Y2UnuJ6SgQaCokLbVobN+kNufmlbZfnkJySIuPMFn1e+KmOreRGtJYdeuBZsTRe+fpr8LFgUC+rdDtad+yBX377Q+rl7t13CFdWuQu0AezVGfPw0qDnzFlJ98AXx8tNbrTsXqZ0SdR74E5cV7ECRgzuDdosVLfxE3LZl+py/bUV0L93V3Tp/gLueag1nuw2QObR438dMHD4eO+GExkorGB1FVEBfw3r34fvf/pVljf9zflymTggYRYDh4t2nzh5BrQBijbvfbFyjczhpcHPSV3lVgLHNWvXyzB/q3f3J2W6Dl37CklptH90hv4nO7TCMLGETPkbS8GU4PHHHkXl6yrioaYdUe2ORpj99mIK9jHBsAvUz4HCzJllNA5aNHkYDocDDeppS+/mdJm5q918A1qJ8dbosSfRqV1L0DgMVm9zXoHGnDme3JT3pNfmyM1j8XGxaNuqSdBxSfTBTKC2W4XUb/b0l8Wk4wPQvVHrnqYgppLyuLNeS7l5kKShfXp0kROdQGFES4akllMnDMeQEZNQX/RnmdKlxISzCUUFNRvE/fnXP9sCxpMaA6nfNGlU1xuflTFY9cbKoIksjblOz/ZHfHyczIcmXXT/Unv/12swbqpSSYaTFez+Jb3zYkWLyna9OOZVTHtlBAg7SpNVk9G4IGb42PFToNUpUmU5eOgYaovJE5WR2di+FPwpX8MULZKAmmKSYKg2ffL5N3hnYdpGNoOOr4xAOCPADG849w7XLSACrZo3kpt0vvt8kVxibd3iEUm3Yc0ncnlPeoTVtUs7EM2aL94Ue+koAAAQAElEQVTHUx3biBCgi2CujuzYgA/fm4k54mVOy6M331gJR3f+Ctp4RmH33X2bpDVbFL5j8xosmDMFL48YCLtYUqV4kvyt/GS+LGfj2hW48YbrKVi+zCm/n775UJZFgS2aNMCiea/B2LRGm87opAmKC1TXNoLhGz6oN0VLQ8vKpMdKLx/aRET+aa+8JDfLkH5s6VIl5KY6SWyyKO6r5dpmIwp+87UxuFdIVMl9U5Xr8cG7r5NTLtXTZiPCa9vGbzB2eH8ZThuy5s+ejGULZ2L2tHFysxxFNHu0PkYN60tOkOSbpOEL506Vqh+vCeaGIuha/4G7ySkNbQaSDpNFEiPqO8p/UN9nhWT9ExlLL2naYEU4/bX+K9Ch8RRBtLTES24ygbAL1M+Bwii9YTIaB6ST3Ln9Y95+pzTmenRs2wJUdwon8+e6L+kC6kMaM4QpqbwYJ4pQZKB6m/sw2JijtIYh/WfCjcbZG6+O9o7/FkIi7T8u/ceBkQddg7WdNnXSJlAay9s3rUbLZo2IHFt/WyX7idQYjHsrUNiEUYPwsJigUSIaczQO6Z6cPG6IV03GjCPRvD55JJGDNiwaecsAk0X3LX2MwhwfbAyOH/mCtw40lox7rm/Pp+SYfv+taaD7icYzFTFjyij5LJg/ewrenjlR9iGFtzDdv9RPhAmFk178lJeHyjy+WPYW7rytJgXLdIHuXxmpW4H6pGuA5xaR04a+vf/8KHWgSfXg0H+/oLHO8Gc2tik9YZsV/H/4+gMYWJFU/tDhYzCetTSOjecD5c2GEYgEBJjhzZFe4kwYAUagoCIwavw0jJv0Oro93aGgNjEs20WML0lcw7JyhahS2/7dJVfTSBBQqmTxQtRybmpBQ4AZ3oLWo9weRoARyFEERgx5Hr/9sAIk1cvRjLOZWSDpYDazzJnknEuBQuDGG64DHRk4uF+3AtUubkzhQ4AZ3sLX59xiRoARYAQYAUaAEWAEChUC+cHwFiqAubGMACPACDACjAAjwAgwAvmLADO8+Ys/l84IMAKFGgFuPCPACDACjEBeIMAMb16gzGUwAowAI8AIMAKMACPACARHIJdjmOHNZYA5e0aAEWAEGAFGgBFgBBiB/EWAGd78xZ9LZwQYgdARYEpGgBFgBBgBRuCSEGCG95Jg40SMACPACDACjAAjwAjkFwJcblYRYIY3q4gxPSPACDACjAAjwAgwAoxARCHADG9EdVf4VDYlJRXFr7zFx0x5/a0sV7DP4DFY/f3PWUr3ULNOOHnqTNA0FxOTMP/9j7zx/n5vRCaOzMrJJDnuf7gtqOzM6Iz4+xo+niV6I12w6+0PNgf1U7D4nA7PLl6B6nPo8FE0euzJQFFBw+bN/wAOhzNoPEcAW7fvxHdr13mh+PSL1RgxbqrXn1cO4x4JVj7dP3RfZFSf/GpLsDoHq2sobQmW9lLD6d6h53SpCjXR9PGu+OyrbzPMiupofnYuXf4FxkycnmGa7EZS/1K52c2H0zMCmSHADG9mCHF8UATKlSmNswf/9Jr+zz0dlDYvIy4mJmLhkk+9Rfr7vRFh5nht4nDExkSHWa0irzpvv/chHE5meDPque3/7cQPP27wktx1e010fqKl15/XjuyUn19tyU6d8xLfdas/wvHdv6Ffr6cx8MXxGRadH8/KPHruZdhujiwcCDDDWzj6Oc9aqaoqHm31NGjWThK/n9dv9Ja9fMXXaNC8E+5t0Aadn+3vDf/6m7Vo3u5ZPNCoHbb9u9MbbjiSk1PQ7fkXUa9JBzzdczAcqQ4jCnPfXYy6jZ/Ag4+2x9vvLZXh02a+g/927JZ5vj5rAfz9LpcLI19+TZZHdfx69VqZLqNyJIGwSOL4wCPtZP2bConJn39tR9suz4kY7Tds9GR88fUazWOyP/joM1l/qufk6fNMMWnOPoPGIFlIzs9fuIjnXxgtJTKVajzoI4kj6owwpnizGS2kM9QfLdp3w779h2TUgYOH0e6p3mjYvLO8Upso4qkeg/Db73+SE2fPnZeYkoekPJ2fHYCWT3THIy2fwsefraRgBMMrWP2oHDN2Y1+ZgXcXLZN5kdV3yNiA2CWnpEi8Cbue/V7ySq03btqCJm3+J3Ht3mc4LlxMxJKPPsf+A4fR/qnn5Zh5dcZbeEcwwJR/r/4jZBi5FyxeDoojd6B8MgonyTlJQ2nMEi5ULtGbzfETp/C/XoPleK98a138ulHDNdB4JVyobV26DZRjlsYm5RVsHASr7+a/tsr0NKZvrP0QSModrE+nzXwXn365WtKvWfsL1m3YhPmLPpIYUvuofDLHTpyU9yu5g5VLcWS+WfMTevR9iZzSfPzZKgx6aYJ0j54wHbXubYI76j6GtxYskWFmyyifwnbt2SfrRWNt4tQ3KUiaHbv2gepGY6jtk8+BcKOIYG2huB/X/SZXCOgZMWDYeIkJhVM+mfVhm049sf2/3USOmvc0Bo0Z8tCzaMPGzV7MKIxWqih/us+o3sZzLFhbUsUzrP/Ql+XYpfvzl183UTbIrMx/tu0Q98IAOa6q1KyP02fOynSZWVarFcWKFkH5smW8pIHGov+zkoh37t4v7316bhv3PoUbJqvjlLCn5yQ9T+j9YDz3KL9Az8lg+RM9G0YgKwhYskLMtIyAGQF6GdJymWFoiU9RFLw28SWsXbkEc6aPwwvDtRcePfhHjp+Od2a+gh9XLcVLg3t7s7JaFXz8/iyMHzUQL0+e6Q03HO998DFUj4pvP1uIDo83w59/b5NR9DKa885imfajhTNBzO1/O/fi+R5PonKla/HJ4tl4rlundP4lYpnu/IVEfLNiAZa8Ox3jBON1VjB4wcqRhZmsv7f+h5FD+2DFkrmw222mmMDOnbv3CWb8Q1Adv/l0gWTqzcvJ/qlo2fGKy8vL/P/esBI1qt3kQ6IogTH2IdI9pUqWxBfL3kK9++/CuMlvyNBRgvm4/+47sPKT+bjrttoYPfF1GZ6RdeTYcbw391V8+dHbmD5rPoipDYaXogSvnxm7Do83FwzqF7JYUr0gxqtBvXuk32xt3rIV3Z5+At99vghnz58HvRTdbjf6DRmHV8YMluPilmo3Yvqb7+Dxlo1x9VWX4/23p2HWtLG4vfYt+PX3LTK7/YLRJ0aUPL+JsNtq3YJg+QQLp7RkalS/WY6vRg3ux3uLP6YgHzNGYHpdxaux6pMFWP/dclx/XQXJPAUar5RwlxgjI4b0lnmeOXsexLwGGgfB6kXhXQWD/Xz3LqAxRv1ks1kp64Dm+R5d0OyR+rK8B++700tTJCFe1PUaGAz6Z4IpbtyoXlCcvAmFo67I5ycxwXXq0nWqf+OH64kYoG2rpvj9x8+wWtzDy1esAj0PZEQAa8zEGWj+6EOgNsTGxHgpSpcqjs+WvoXvv1yMJ9o0x7hJM2VcsLa4xMS2p5jkjB85EKtXvIfDR49i8bIVMg1ZmfVhnVo18NumP3Hk6HFcecVl2LjpL0qGTX/+hVo1qkq32aLn2PJFb2L2tLHe51iwtixa+glOnjot6zV6WB907ztcYpxZmW/OW4iuXdrKcbXu22VIiI83VyGg+676LaXqGU2EhgzoIWlCfXYSsXHvr1g6F+OnzJT3PoUbhvrZ/3lF4zHQ/WmkqX5zFXwksLr7jtpGEII9JwPl703EDkYgCwgww5sFsJjUFwF/lYZmj9aHoijYun0HuguJW9/BY8XL4gRIWrj+t814rEkD0IORcrmuYgW6SPPAPXfKdMSA/LdzjwwzW3/8uRXtWzeVQfRyvvaaq6SbXkZNxUubJBclSxQHlU9hMjID6xchzdr0599o3akXSAJ28vQZ/Cskwn8EKcc/q+pVq6BiBa0O/nGB/CQNOnnyNEiC16pjT4nP5i3bEOzv5iqV8PXqHzBx6mwQA0FtM9MqSmCMzTSG+4nHNdxoufoP0WYK3/jHX+jc/jFy4qlOrbzMjQwIYt1Z51bExcXK2KJFEnD02AkEw0tRgtfPjN01Fa4ESZ727juIL1Z+h0cbPigmEHZZhtm6qcr1uPO2mnKMPNG6OQi7AweP4ODhoxgychJI0vrJ56vw51/pMa1Vo5pkUE6dPouyZUpJQwzM75v/Qu1bqyFYPsHCjXo9VPce6bysXFns2L1Xus3WT79sRO/uXWQQ9R8ZGpvBxusNla/zjqnLyos8xcQt0DgIVi8KLyHuAbo/qFAanxbLpT3emwgGd8VXqykbfPbVd6A6U/6Z4U19+eC9d+Cb734GSf8J43vurC3zSUxMxNBRk9Cxaz/xTDiG7f/uluGBrD+2/IN2+v3e4fEWXhJifpevWIlOz/QXUuKl2PbfTm9cIMe+A4dwxWXlUKP6TSAsOrdvJVYwtnhJM+tDmiwRk0vPrhaNG4Dyo7FTTkhJbTabNx/D8eB9d8kxSs844zkWrC2//f4XOrZrIelriXFIY5MwzqzMWoLRnjF7Pqa8/pa4B08iKir9/WLUx7iSSsOZA5vx/VeLpZ42TS4zGouUzmyoTnTvlyheDOXFeKd73xyflXFqpHv4ofsNp/ca7DkZKH9vInYwAllA4NKeiFkogEkLFwJ//PmPXBrt99z/QNKOK4WkMjExCR6PRzAz6V8ShI49SgunFyZJZSjMbCgtxRlhUVFRhhM204uHpK1E640M4iCaF1/oJaVbJAXetvEbIQmsIesYrBxzVtGm8omepJ1GPEk2DLdxpfJaCGafyiLzy7cfoV+v4PrO9IImiXe1m27AK4LppaVhIy+6BsOY4vyNzapjK5gfVfXIaKqPIf0zt4XCVNFPRORyueniNRRneBRFgdPpCopXRvUzl0f5Pd7yUZC068OPv5TSWQrzN0YbKNxmt0pJmAce3KBL8QnTrz9+F0sXvEEkPiYmJhok5f5y1RrRx7dIs3L1WhQtUgQUFyyfYOFG5jarVTqJkXIJLKTHz/JvK0UHG69GfkSjKAJfIZ0MNA6C1YvC7bb0zA/1W7A+pbICmUcb1gWp5Rw9fgIkEb/xhusE2qHh3eSRelghpMJfiwnbw/XvkwwdLd937zscrZs/gg/emY4G9e5FYlJSoKJlGA3BKJ2Ro3taBgpr7rtLBJN3HBNGvYB5MyYgKYM8BLn8UfulQ1h2u1WOWeGUP1smfUgT8F9//1NKeW+rXQOlS5XESjF2iAGUGfhZRllyTIj+o+hgbaE4o3xyU99RH2ZW5pMdW4tVjSEoX660YPz7gSaLlD4zoygKqt5YGWVKl4SxQhZsLPrnFWVPG1fUNrr3zTRZGadGumjTM9QIo+dSoOdkoPyNNHxlBLKCgCUrxEzLCGgIBLdpWerWW25EJbGEu2ffAWz9V5PC3CEkhCSFM/TuLgomOHguvjE1a9yMn9f/LgPpAU/SWPLUqXmLeLl+i3PnL0hdNnrR3larhlzmOy/CiIYMLfuZ/ffcVRszZi+AUYeNm7ZI3b5g5VAewcyVV5TDgUNHZTTpTP6y4Q/pNlt33nYrPhKSKcKGUkhJ/gAAEABJREFUwg8eOpLhi4raQ1LrRxo+gLZiif4PXTJLaclQPoEwpjh/8/6H2hLuwiWfgCRJFF+nZnWvPuJbC5YKJrAGBaPCVZfD0PP94af1MiwjKxheWalfM7F0TVK7I0dPgJY5A5X3j1gxIOkPvRDfX7oCJOW6+srLRZ+fwVerfpBJiIEiNQDyxItlXnN/31Gnhujv+SCmpU7tW/DmWwtBYUQbLJ9g4ZQmFHP3HbUw7c35XlIaa3WCjFcvkZ8j0DgIVi8KpyXyH37aIHMhCauqqkH7NC4uDucvJkpaf4vUGm6+qRJeGjsVLZo0lNGU/+kzgfGWBLpFEt4fft6Ajz9bhSaN6svQU2IFpXixorj1lpuFpFXB96bNcpLAz6op6Nb+/KsMpbykQ1i79+3HPXfVweVCarvqux9FiPYL1pYKV12BI0ePg8YFYTF/0XLcLsaClipzO0ZMloqK1Yxffv0DxPQTo0tjh9QOMk+tUQRrS51a1UD3JI3pP4SQ4MTJkyCMMyuTxgSp7DzRppnEk1QTqKR1G36HS2eyyR/IEBakA0wrc8HGov+zMlA+/mFUJ//nFbUllPFizivYczJQ/uZ07GYEQkWAGd5QkWK6dAj46/DSRoSGQqrz/U+/gpaZp4sXPs3OKeH111ZA/95d0aX7C7jnodZ4stsACg7JdGzbAgcOHsbjnXth+NhXcV3Fq2W6KpWvxVMdW4E2irTs0APPPtUela+/RjC8cWj88IN44n99pF5vQryvv23LJqCXF214Iv224eLFThkGK4figpl4wTjcd3cdkH5ctz4vosLVV6Qjva5iBYwY3Bs9+72Euo2fAGFDG7HSEeoBHwvm+LJKt6N1xx745bc/pM6eHiUvwTCWkX7W4SNH8UCjdvjqmx8wbEBPGUt1Wf39z3LT2veCsR0+qJcMb92isVgqnYdWAkvaICQDM7CC4ZWV+hFDUVMs0xpL2IGKq3bzDZj02hy5eSo+LhZtWzWRqhCzp78MOoKMsK91T1OQHiyl7/G/Dhg4fLx3gxq93I8dPwWSmN90w/U4eOgYat9anUiD5kOS+2D5y4SZWC8KTP/Z9h/qN+2Iq6rchb/+2Y5g4zVYVoHGQbB6UfgbU0bJ/qPNnTfUrCcYIDeC9SmpGiQlJctNUqQ77V+Hxg/XBW1WbNKonoyi/EPBg+ga1L0X68W4JaafEhODSvc/9RNt5LupSiUKDmpeGvyc1Hmncbhm7Xov3ZMdWmHYqElyfB44eMQbHqwtJMGcOmE4hoyYJPuhTOlSYgLZxJsuFMdttauDpKkk2SQVmH937AGdzuCTNgNPsLaQDnKxokVlvV4c8yqmvTJCjkXKKqMy6ZSFSjUeFNLd/lJaW++BOykJ2j35vHcCLwNMVp/Bo+UG2FvvaYxnnmwLUiUKNhb9n5WmbII6szJOg2YiIoI9JwPlL8j5xwhkGQFLllNwAkZAIBAjpB/mI8nIPe6lAWKpOAG0uYyWmae98pLclEE6bSKJfNnQhpqfvvkQH743k4Lwmngh1X/gbukmiza20NVsYmNj8Maro7Fk/gy5cWrj2hViebGEJOnapZ3czLTmi/cF89tGhpE1fFBvLJr3mty05u9XFAVD+vcApSH9tq+WvyN14TIqh/IgQ20henIbZuLowXKj0NszJ2LBnCl4VDDbFPfD1x9I5pvcJClb+cl8WVeq/403XE/BPmbtyiWSvot4sR/ZsUFiNEcwdVcJaaaZkJjEYBib6Tas+UQs/w4C6e6RioTBjFN+i9+eLjet0ZXaROlosrBhzcdYtnAmBvfrJvGh8DaPPQrCk9xkqG8pr2B4BasfleOPHUneDh0+htYtHqGs0xlKQ5uUqE40bmgc0NgjQtrMRxtfaExt37QaLZs1omAhlWwg+542rVFAowb3Y+8/PwrpokWaQ//9gsaN6lKUNMHyCRZOuBp1uFdIHF+fPFLmY7bKly0DGg+0WerA9nVSB5niuwYYr9RGMy6D+j4rddaDjYNg9aotJPe0kZLGxv5tP8sxHaxPibGZPW0cSA2E9H6bPVofo4b1pSpKQ5NCuqdvvOE66ScrWLkUZzZ03//3x3dSncEInyGYceqn+bOnSFxoTFGccY+Yy7/2mqsxf/ZkOQ6pjnRfEG31m6uAsKexQBiRm8Izagv1D2FLGx4njxsiMaE0lDazPiS6MS/2B90j5K4pJmaECUnAyW+uc7DnWLC2REdHYcrLQ+Wz8otlb3nHB+WbUZn0PNixeY18zrw8YiDsurrBvq0/gaTolN5sqO20cZLGxdGdv4r7urs3OtBYpEi6141nJ/UT+SmcjHHvk9swWR2nZuwpD+pf6kNyB3pOBsuf6NkwAllBgBnerKB1abScihFgBAIgsO3fXVLifd/dt6FUyeIBKDiIEWAEGAFGgBHIGQSY4c0ZHDkXRoARyCICJD0k6S1Jk7OYlMkjFgGuOCPACDAC+YMAM7z5gzuXyggwAowAI8AIMAKMACOQRwiEHcObR+3mYhgBRoARYAQYAUaAEWAECgkCzPAWko7mZjICjEDEIcAVZgQYAUaAEcghBJjhzSEgORtGgBFgBBgBRoARYAQYgdxAIPt5MsObfQw5B0aAEWAEGAFGgBFgBBiBMEaAGd4w7hyuGiPACISOAFMyAowAI8AIMALBEGCGNxgyHM4IMAKMACPACDACjEDkIcA1DoAAM7wBQOEgRoARCD8EFi75BM3bPYspr78VfpXzq9GIcVPx6Rer/ULz1zt4xER8vXrtJVVi6/ad+G7tuiylpfaPfPm1LKXJDjG1bceufdnJgtMyAoxAAUaAGd4C3LncNEYgKAIRGPHaG2/jo4Uz0f+5pyOw9vlf5f91bos6NatfUkW2/7cTP/y44ZLS5lWi1Wt+xq49zPDmFd5cDiMQaQgwwxtpPcb1LfQIqKqKR1s9jfsaPo6HmnXCz+s3SkwOHT6KBx5ph87P9kfTx7siOTkZJGF7oFE7SUcSMElosijNg4+2x5PdX8C9Ddpg0EsT8NlX38r8qYwjR49L6qPHT+CpHoNQr0kHtGjfDf/t3CvDSYpX7Y5Gsi79h74Mh8Mpw/sMHoMBw8ZL2kdaPoVt/+6U4f9s2yHqNwANmndClZr1cfrMWRlutua+u1h+cpjq9fZ7S2XUC8PH46BoX8sOPfDVqh9kmGGt+HI1Hu/cS9b/sfbdZXBycgq6Pf+irO/TPQfj/ofb4uSpMyBJZdsuz0kasoaNnowvvl6DUDF1Op344KPPZL5Uv8nT51E20kwVDPndD7VCm049sWffQRnmb/247jc0euxJ2T7Cx8Dr9gebg6TCJMHu/OwAXLiYKJMGw11G6laofThv/gf4bdMWmSpYedTHv/3+p6Q5e+48qI3kmTbzXXwqcKb6rVn7C0KpF6UzzIGDh9Huqd5o2LyzvFKdKW7n7n1o1vYZOd6Gj50ixxGFm83S5V+g0zP90Ur0PY2rQGXTuFr57VqMnzxTrgKcOHlajtdAbfHPj/KkvqBxndWxaq4nuyMXAa554UCAGd7C0c/cygKEgKIoeG3iS1i7cgnmTB+HF4ZP8Lbu763/YeTQPlixZC6Wf7YK5y8k4psVC7Dk3ekY98oMEBPjJdYduwTTMUqkWf3ZQqxbvwnEPHyx7C083vJRzHlnsaQaO3EG6j94N74VNCOG9Eb/oWNleI1qN2LjD5/i+68WIzrajiXLP5fhZFmtCpYvehOzp43Fy4IRobA35y1E1y5tseqTBVj37TIkxMdTsNds/2+3LPPj92dJae7rsxZI5vqVMUNQrmxpfLJ4Nho1uN9LT47xU97E/NlT8OOqpZg5dTQF4b0PPobqUWV9OzzeDH/+vU2GB7MURQkJ030HDuPt9z6Udfvm0wWSkaelfsLsg2Wf4euP52P6pJHY8NvmdEW5XC707D8C40cOxOoV7+Hw0aNYvGyFl65G9Zu97Xtv8ccyPBjuMtJkhdKHJnLpDFSejAhgPd+jC5o9Ul/W78H77kSo9TKyGjVhOu6/+w6s/GQ+7rqtNkZPfF1GjRHXFo0bgMZbXGysDAtk7dt/CAvmTMFrE4YHLPvmGyuhYb37MGRAD1nHMqVLBsrGG2bOjwIvZaxSOjaMACMQOQhYIqeqXFNGIL8QCK9yFUURksod6N5nOPoOHosjR094GdnqVaugYoWrZIV/2bAJm/78G6079ZLSrpOnz+DfHbtlnNmqdH1FXH3V5YJhjcKNVa7HbbWry+hbb7kZO3bvle6f1/8OkoyRhG/ky9Ow5e/tMtxut4Ekm+2e7I11orzt/+2S4WQ9eN9dUBQFV1xeXjCteygItWpUxYzZ86Ue7tFjJxEVZZfhhvXbpj/RVDBWxYoWQckSxdHs0fpCKvmnER3wWvWmyhg2egpmzl0Ii0V7pP3x51a0b91U0hODdu01GiYyIIClKKFhumHjZpwU0sMu3QaiVceesh82b9kmcW7e+CEUSYhH+XJl0LD+ffD/23fgEK64rBxqVL9J1rNz+1b47fctXrKH6t4j3ZeVK5sp7pLQZIXShyZy6QxUnowIwQo2HoIl3fjHX+jc/jEZ/VSnVvh1o9anm//ainZ6Pz3RprmMD2Tde3cdxMVpDHFWy84sP4q/lLFK6dgwAoxA5CCgvR0ip75cU0ag0CPwx5//YP6ij9Dvuf9JCeqVgqFMTEySuERHRckrWR6PBy++0EtKvEgyum3jN7i9dg2K8jFR9jSm02qxwm7T/OR2OV2S1gOPkBK/7s1r39afZPiAF1/GDZUqYu6MCejb82kkJiXLcLJsNitdJHNH0k3yPNmxNUhaW75cabFM3Q97Ayz922w2IpWGGGpqh/QEsea+Ph6d2rfARYFBG8Hck3oCpbFatfIpWZSOC4VRPIWRcbvddEFWMG3RpIEXh1++Ff3Q62lQeRZLWnnmNsgCdMvAhLx2u1WmIzcZm15fi8WCzHC//cEWIGNs4IsKoQ+pDLMJVB7VTxXjhuhcLg0bcvubYOPBn87wEz6UN/l9xyi8kx7qa4oPZKJNE6NQy6bygrXFnB+VR7R0ldgLSTy5QxmrRFfoDDeYEYhQBCwRWm+uNiNQaBEgvcdbb7kRla6rgD37DmCrrh/rD8g9d9UW0tQFkhGkuI2btnh1bMmfFXPfXbfh5clvyCTEvPzy6ybppqV0WkouWiQBq9doTLCMCGKdO39BSpOfaNMMJEEmFQYzaZ2at2DFl9+C6Ei/d8WXq3FbrfRMujkN0d5S9Ub06/UUTp89J9tbs8bNIBUDolv7868wJM9XXlEOBw4dpWCJxS8b/pDuUDG987Zb8dGKlSB6Snjw0BEQ015TSK7XbfidguASDJPhlgG6VeGqK4Q0/jhIqklM9/xFy3F7nYzbFgz3DWs+Bpmc3sBXQUj6abmfqvzDT+vpIk1cXBzO63rFFBCsXhQXyNSpWR0LFi+XUW8tWApj4lVTrCJQ/1DEDz9voEumJljZ8XExuHDhojd9sB46UP0AABAASURBVLZ4CTJx0LiilQ/zWL0gMKDJUSZJOZoRYATCEAFmeMOwUyK8Slz9XEaAlsu//+lXkHrB9DfnyyXyQEW2bdlEMBa3oEmb/+Gu+i0xfOzUQGQhhQ0f9BxOnDwD2sR0U50G+GLlGpmud/cnZViHrn0RGxstwzKyBr44HpVqPCiku/1Bepb1HrjTh7xK5WvxVMdWcrMbbVB79qn2qHz9NT40/p4767UU0s7m6N53OPr06AJivju2bQG3W5Ub2Wa9vQjEEFO6eMG43SeWx2mzX7c+L6LC1VdQsFRBCAXT6ypWwIjBvdGz30uo2/gJ2QfJKSmoemNlPHDvHaCNVZ2e7Y/4+DiZr9kiqe/UCcMxZMQk1G/aUbS/FKiPzDT+7mC4+9PllL91i8aY8vo82Q7zEV/33FkbSUJ636ZTT9CmtazWizBb/f3PctPa94KRHj6ol6wyrUCQTjThtmPnHhQrVkSGZ2QNDzIW2zzWGJ9//Z0cOydOnkawtmSUtzku0FjduWsv+g972UzGbkaAEYgQBJjhjZCO4moyAgYCxNDR5jFSU5j2yktyAxTpyZL5avk7BpnUnx3SvwfWfPE+1q3+CBQXZVoaJkL/NG++Ngb33lWHonBTlevxwbuvSzcxp7QhjPIi1Yixw/vLcJJ+kaRx4dypUlWBNhVRBF3rP3A3OaX5/cfP5HXO9JexY/MauQHp5REDYTctxUsCYXXt0g7ffb5I1vupjm1EiPb7c92XmsPP3vrbKiHt/ASk2mDQx8bGYNa0sXIj2/tvTUNUdJQ31cTRg0Ebzt6eOVHW49GHH5RMciiYUiYtmjSUm6+ojhvXrsCNN1xPwejb8yksWzgTVB7lRfrHMsJkEbbUD5R28rghMPpjw5pPEBOjTRiI5vXJI2WqYLjLSN0KtQ8njBqEh3Xd4mDl0eSC+pPaMbhfN9kHVEyCYOBnTxuHpQveAOlEh1Ivaj9toKT0V115ORa/PV3iRleqM4WXL1cG82dPlrhdU+EqqeNN4WbT5rFHMXxQb29QsLJp4xrl9fH7s8RkoqScKAVqi39+WRmrtCpBfeetTKYOJmAEGIFwQYAZ3nDpCa4HI8AIMAKFDIHf//gLV1W5Cw880k5Ijtej17OdCxkC3FxGgBHIKwSY4c0rpIOUw8GMACOQ+wiQRLd0qRK5XxCXkCUE7r/ndhzYvg7ff7kYJHHnPsoSfEzMCDACWUCAGd4sgMWkjAAjwAgwArmGAGfMCDACjECuIcAMb65ByxkzAowAI8AIMAKMACPACIQDApHF8IYDYlwHRoARYAQYAUaAEWAEGIGIQoAZ3ojqLq4sI8AIMAIaAmwzAowAI8AIhI4AM7yhY8WUjAAjwAgwAowAI8AIMALhhUBItWGGNySYmIgRYAQYAUaAEWAEGAFGIFIRYIbX1HMz3/oAbf83EI3b9sLoSbOQ6nCYYtnJCDACEYsAV5wRYAQYAUagUCPADK+p+2+pVgUfzJuEBW+Ow+kz5/Dx59+ZYtnJCDACjAAjwAgwAoxAZCNQWGvPDK+p5+++rYb0lSxRDDUE83v85CnpX7ZiFebM/1C6yXp+yET8u2MPOWGxWKCqKuz2KDYZYOByuQVWVsYoCEaKosDj8TA+QfCh+8shVlzoysb3WeN0OnncZDBu3G4VimJhjIJghBD+Tp8+BTaMQbiNgRCGrg8JM7w+cGie5JQUfL7yB9xWs6oWwDYjUKgQ4MYyAowAI+CLQNmy5cGGMQiXMeA7OkPzMcPrhxNJ2V4c9zrq3nsb7qh9i19sem9SUhJSBIOcmHgRbIJjkJqagqSkRMYoyDhJTqZxlMz4BMGH7i2S8NKVje995nCk8rjJYNzQs4fuLx43vuPGwCP9W41DfBBgT4FBgBlev66c995HqFKpIno83dYvJs3rdru9ntjYWERHRyMuLp5NBhhERUUjNjaOMQqCUUwMjaMYxscPny+/+Rn3N3kK0+csFkvSdsbHDx967pCKB13ZBH4G07OH7i/GJzA+4D9GoJAgYCkk7QypmUs+XomTp86ia6dW6ej/27kPLsHo0ma2nXv2w62qkkZRFCgKG0UptBhw/+dy38sbTViKwmNMURgDRWEMFCXnMBC3Fv8YgUKBADO8ejcTM/varPew4uvvcWfDDtKMmTxHjwWSUlLRsdtQ9HzhZdSuURWvzlzgjWMHI8AIMAKMACPACDACjED4IsAMr943NqsVv6xc6GOGD3hGjwVqVK2MxXMnSjN2WC/MmzbKG8cORoARyB0EWjVrgI3fLcWQvl1zpwDOlRFgBBgBRqBQIMAMb6Ho5vBpJNeEEWAEGAFGgBFgBBiBvEaAGd4QEG/VtAGe6dw6BEomYQQYAUaAEWAEQkKAiRgBRiAPEWCGNw/B5qIYAUYgawgs+3QVatdtg/FT52YtIVMzAowAI8AIMAImBJjhNYERdk6uECPACDACjAAjwAgwAoxAthFghjfbEHIGjAAjwAgwArmNAOfPCGSEwC+/bcaDTZ9E1z4j0PrJfpg47S3Qh6QyShMsbvKMd/DV6h9ldLv/DcTJU2ekOztWozbdAiav1/xp1Kn3uDT3PtopIA2VT/UIGJkPgd+uXY9xU2bnQ8nZK5IZ3uzhx6kZAUYgFxHgUxqyBu4/S5vinyWNAY92TnjWUjM1IxDZCNxc5XrMfW0U3pkxFhv/+Bs/rNuY7QYN6/8sihUtku18gmVgtVrw27dLpPnxi8g47rRm9ZvwRGvxnAnWqDANL0AMb5gizNViBBgBRiCvENAZXdWVlFclcjmMQNghkBAfhxtvuM4rmd367y4p+W3/zAvoO3QiTp05K+v8xrzFIMlry859MGf+hzLM3yJJ5rnzF/D1tz/JPEiC/PjT/WFIXIPlffDwMTzTdySe7DUsR/YgOJxODBwxBU88M0hez1+4KKsarA2PdXoeU954F90HjMF3P26QtIbVucdQ7Ny93/DKdv29bSdIctuw1TNSQv7iuOm4mJgkaUja/dygl9G9/2hZ9qYtW7How89lXEZpCOueA8dKDBZ/9KWkJ4uw7NR9iCynS89hFCT7ZMjoqWjXdaCkp/rIiBy0mOHNQTA5K0aAEWAEwgEB1e0Mh2pwHQowAsdPnMLan3/Nc7Pt352ZopqUnII9+w/hnttrwq2qeGn8DPTt3gnvz3kFDerehan6h6Ma1b8XXy2dhUUi/K+tO6RUOFjmD9e7R0qP50wdieLFiqLZI3UzzHva7IW467YaQto8DldeXg7Jok6B8lZF/e59pCNademLFV+tCUQiw/YfPIJmjR4UdZ2IuNgYLNQZzozacNUV5fHm5OGoe+/tMg/Dqn//HVj1/TrpPXn6LI4cPYGqN16PG66viBXvz8DSt6fg6isvw6JlX0gasg4ePorJYwZi0qj+5PWajNIcOXYCE0f2kxis/uEXnBUTh30HDmPKG/Px8vA++PCdVzFycE+Z17RZC1Gj2o1YPHcSRg7qieEvvy7Dc9Jihjcn0eS8GAFGIEcR4FMasgCnLt2lFB63gy5sGIFcQ+CHn9bjkZZd8txMnDoraJs2/L5F6sLe37izZODKlystmLnjOCaY86lvLpCSzGUrVoGkspRJSmqqYL7exfNDxoMYuh0mqSfFBzIkCS5VojjaPtYow7z/3rYDrZs1lFm0bv6wvAayiMFb89m76Pbk45gx731s/nt7IDKUK1MK99xRU8a1ad4Q/wiJLHkyakPd++4gknSm0UP34Zs1v8jwr1f/CGKayRMVZce7738Ckub++Mvv2LlrHwVLU/vWqoiPi5Vus5VRmhrVqoCk7URfqmRx7D9wBH9s2YZ6990uJwEUfs1Vl9MFm/7cilVrfpZ9NHbKbJw8fQYnTp6Wcdm1jPTM8BpI8JURYAQYgYhGwOOtvcoSXi8W7MgdBO6/5w58+dG7eW4G9Q28+YtaeXut6vh19Qd4a/oYfPvDel1iq+Dy8mWkdJb0eylu+YJpcDpdGDrmNdS//05MnzBEMn0kGaZ8ghli1n5avwkjB/fQSQLnLSM9HkQLBpLcNpsViqKQM50pU7ok6Euv9YXUtWHde0BL+Zv/2o4WHXtLs/p7jTGlPIzENpsNJBnOrA1RdpuRxOdaWjCfZLb/txvfiPwbPHiXjH/51Tm4rFwZIX19XkrEk1NSZThZUXY7XdKZjNJYrVYvvUWxwOVygTYS2oPUa8rYF7z9RPrMhI03gxxwMMObAyByFowAIxDJCBSMunt8JLxpL6qC0TpuRbghUFZIHO+7+zbktbnxhuszhEJRFFS/uTI6Pd4Uby36WDK7xBiSHirEH7n//PtfnD13HlFRUbil6g0gZm7dr5tFbPAf0Y8TDCExZURPlMRIU37+eVNc1Zsq46cNf5AT63/7UzJ60mOyEpOSpVoEBdFyP220I9UCkox+/N50kKn/wJ0UjUNHjoNOoiDPh5+sRNWbKmW5DZTWMPUEg/3e0s9AusCVrqsgg0lt4r67a6NokQT8uH6TDMvMymqamrfchG/XbhAS9WMya8KAHLfXro6Zb33gxem3P/6m4Bw1zPDmKJycGSPACOQkAnxKQxbQNDO8Kqs0ZAE5Ji2ACJDKwa49+7F3/2FMGNEXX6xaiw7PDsIjbbrhr207QNJDOtWBNkn1G/YKSN81IxjmL/5U6uEOGztNLruPeuVNWCyWgHlTPs8/2wGffvkduvUbhS++WYvo6CgK9jEHDh7BXQ2fkGoY3fqOQvtWj6JG1So+NIaHdGrfX/YlWnfpi3MXLqJjmyZZboORF11JjWHVmnVSsk1+Mk890QKduw+VKg0kjaWwzExW01S46nI817U9Bo18FXR83JO9XpRFPPfME3A4HGjf9QW5kfCjFd/I8Jy0mOHNSTQ5L0aAEWAE8gkBj1hCNYpmlQYDCb4WFgTurFMDM14Z5m0uLfuv+mgurr3mSlS+7hoZt3D2RHzz8Tx00I/UGvFCd7lJaurLgzBm6HN4usNjMv2AXk96GcHF8yahdKkSeL5bR3yx5E3vkjulJeJgedNGtanjBmHWqyMwfngfrFw2h8h9TJXK12LDN4vlkWQfvDUZTR5+wCfe8FD5H81/Da9PHIoP350qN46RFJbiqR6kB+zfBlLbMGiIzt8UK5ogy32mc2tvVOOGD+DTRa/Lcvr37CIxo0hijgc+9yQ5pal33x2g49rIE2oamnSQdJfSUH6L5kyUm9aWvj2FglC8aBHQZjXCmzYSEr2MyEGLGd4cBJOzYgQKAQLcxLBFIE2HlzethW0nccUYAUYgnxBghjefgOdiGQFGIHME+JSGzDHyUnjcXqfKpzR4sWAHI5B7CHDOkYQAM7yR1FtcV0aAEWAEgiBgVmlgCW8QkDiYEWAECi0CzPAW2q7nhucFAlwGI5BnCLAOb55BzQUxAoxA5CHADG/k9RnXmBEoNAjwKQ1Z6WrVS+zhUxq8WLAjbBDgijAC+YoAM7z5Cj8XzggwAoxAziDAKg07WtxSAAAQAElEQVQ5gyPnwggwAgUTgYhieFNSHaADo+lAYsMUzG4ppK3iZjMCjMClI2A6h5c3rV06jJySEWAECiYCEcPwvr3wY7To2AdvvPUB3hJuwxTMbuFWMQKMACHApzQQCqEZj4nh5U1roWEWzlRcN0aAEchZBCKG4f1l4xZ8ueQNzJk6ArOmDPeanIWDc2MEGAFGIFIRSDuHV3U7I7URXG9GgBFgBHIFgYhheEsULwJFUXIFhMjMlGvNCDACjIAJAbOElzetmYBhJyPACDACQMQwvDHR0Xhx3Ax8/9NGGPq7dOVOZAQYgYKLAJ/SEHrfekzHknncqaEnLAiU3IZCj8Avv21GrxfG+eDQe/B4/LR+kzfs3PmLuP2hdlj6ydfeMJfbjTr1HkfXPiPQ7n8D0X/4JBw/edobb3b8vW0neg4cix4DxpiD8829c89+rF23Md/Kj7SCI4bhpQF48vQZfPDxV6zDG2mjjOvLCDACuY+AScKrskpD7uPNJUQcAiu/+wmVrr0a33z/i0/d7XYb5r42CgvnTERcbAwWLv3MJ97wfPjpSrRr+QhmTh5uBOXrdffeg1j36+Z8rUMkFR4RDC/NwBo8cKdXb/cSdHgjqU+4rowAI8AIZBkBXwmvI8vpOQEjUNAR+GbNLxj43FM4fOQ4Tp4+m665VosFtWrcjJOn0sct/3w11m34A2/MW4zXZr0Hp9OFCa/NQ/tnXkCn7kPw7dr1Mr+vVv+I5wa9jO79R2PgiClQVRXT5yzC40/3xxPPDMLnK7+XdHS/zpj7vpQqN27bQ9JQBOXfqE03tOzcB3Pmf0hB0nz34wYpwW7zVH+ZFwW+tfAj/PDzb1I6vWrNOgpikwECEcHw2qxW/LDu9wyawVGMACNQEBHgUxqy0quql9jpSPW60zs4hBHIPgKp5/bhxD/v57k5f+CnoJXf8PsWqZ5AKgpkSM3BID567CROnDqNW6regEb178UXq34worxXYkL/2LIN9R+4wxtmOB5rXF8yw317dEKfbh3xyZffYt/BI3hv1gSMHtIL46bMAalMEP3Bw0cxecxATBrVHyu+/h4nTp6WdLOnjsCST1Zi7/5DInyNVM98e8YYfLb4DTRr9CAllXX7auksLJrzCv7augMb//hbhk+btRCTRvfH0renYMbEYTLs6Q4tcf/ddaR0usGDd8kwtoIjEBEML1X/ysvL4f1lX+L0mXPkZcMIMAKMACNgRsCkw+t2p5hj2M0I5DgCKZLhXSwY3rw1Fw79ErQtt9eqjt++XeI1d9ap4aX9+ruf0LDuPdLf7JG6WPVdmkSUpLXEIN9Wvy127dmPe+6oKekysjb/tR0tBRNstVhwzdVXoNpNlbB9x26ZpPatVREfFyvdv2/+B//u3Ct1f/sOm4hTQrK89d9dgpH9B0+0bozYmBi5Ib/CVZdL+pTUVEx54108P2Q8iHHesXu/DCdG/ZVpb+OdRR9DNd3rMpKtkBAIyPCGlDKPiWg54XUh/n+0bU/c2bCD1+RxNbg4RoARYATCEgGPWYfXmRqWdeRKFRwEYopVQJmb2+W5KXLFnZcEIqkzvL1oOYixfazT8/hv117sFxJayox0eIlR/nTR64iNjcE7739CwZkam93mpbHZbDD40Ci73RuuKAqe6dRKSmFJT/jLJW/ikYfuk/F2kUY6dIsY76FjXkP9++/E9AlDpLQ3KTlFxpIUuW3LR+AR/936jQZ9iEtGsBUyApaQKfOZ8JeVCxHI5HO1uHhGgBHIRQTC4JSGXGxdDmdtZnjdrMObw+hydn4IREuGt71gePPWFL1Kk9L6VSdDLzG2585f8Ep+ibnt3LYZvvrWVz3i8vJl0b9HZ3zw0ZdITtEYzWAZ16hWBZ9+8R3cqipVFP7etgM33XBtOnKSOi9YsgIXLibKODpZ4ey581I94v2PvvCWk5iUDAqPioqSahfENJs3pFH6G66/Bk898RhsVguOHj8pN9idu3BR5stW5ghEDMObeVOYghFgBBiBwoyAx9t4DzO8XizYwQjQRrL6D/hKhsn/1Tdr04FTpfK1IJWEjz5bnS7OHND8kXooV7YUOnYbjJfGz8Cg559G0SIJZhLpfrTBfbj7jpp4ps9ItOrSF8PGToOqetD04QdQ7abK6NJzGGjTGm1gK1O6JG6ucj3adR2IfsNewVVXlJd5kEWb1Zq064nBo6aiYd27cc1Vlwum+SaoblVuZsubTWtUk8g1EcPwmtUYzO7IhZ5rzggwAoxAziHgo9LAx5LlHLCcU0QgcGedGpjxyjCfupJaAOnjPtuljdxoZo6sUqkiPln4upCWWrHu60XmKLnZrEPrxj5h5Jkwoi9uq1mNnCA1iMF9/of357yCBW+OR917b5fhtCFu4HNPSrdhPdu5NRbPm4Rl707FkremoGSJYrBYLOj9zBPS//kHMyXDTPQjXuiOxXMnYerLgzBm6HN4usNjFAzayEab26gO/+vUSoaR/u/Ekf1ku3nTmoQkQytiGF6zOsM3y+egb/eOQrTfPMPGcSQjwAjkLQI5XdqyT1ehdt02GD91bk5nXfDyMxQIqWX8pTVCgQ0jwAgwAl4EIobh9dZYOBLi49CmeUNs37FH+PjHCDACjAAjYJbwelQXA8IIMAL5iwCXHmYIRCTDSxjSuXaHjhwnJxtGgBFgBBgBqF4MFDi9bnYwAowAI8AIABHD8Jr1dsnd5umB6NKuGfchIxC5CHDNM0WAT2nIFKI0ApNKg+JhCW8aMOxiBBgBRiCCGF6zDi+513z6Fh6ul/XjSbjTGQFGgBEoiAh4TAwvtY/VGggFNpGCANeTEchtBCJGwjvljQXpsBgzeU66MA5gBBgBRqBQImA6h5fa73HzxycIBzaMACPACBACEcPw7ti9j+rrY7Zu3+HjZ09BRoDbVhgRWManNITc7R4/hlflo8lCxo4JGQFGoOAjEPYM74qvv0e3/mOwc/d+eSU3mc49huHaa64q+D3ELWQEGAFGICQE0j48QeQePpqMYCiYhlvFCDACWUYg7BnemtVvxNMdWqB82dLySm4y4196HuNe7J3lBnMCRoARYAQKJAJ+El7+2lqB7GVuFCPACFwiAmHP8F55eTnUubUqFs4ej+o3VwadwUt++ub1Jba5MCTjNjICBQIBPqUh9G70+G1aU92O0BMzJSPACDACBRyBsGd4DfzX/boZzZ94HiMmvCGD6KMTfYZOlG62GAFGgBEo9Aj4SXhVZ2Khh0QDgO2cQOD48aNgwxiEyxi4lDEdMQzvjHmLMXfaSJQsUVy2s0qlijhx8ox0s8UIMAKMACOQ9uEJwsLtTKELG0Yg2wiULFkKbBiDcBsDWR3YEcPw2m02kHqDuYEe+G7SMMdlxc20jAAjEJ4I8CkNofdLOpUGV3LoiZmSEWAEGIECjkDkMLx2G06fOeftjk1btnmlvd5AdjACjAAjUFgR8FdpcF2ShLewosftZgQYgQKOQMQwvAN6dcHoSbO048n6jcGE1+ah9zPtC3j3cPMYAUaAEQgVAd8VL5UlvKECx3SMACNQCBDIOsObD6C43G44nS68OnYgRg7qgdbNH8LieZNQ+boK+VAbLpIRYATyCgE+pSF0pFXV7UOssoTXBw/2MAKMQOFGICIYXpvVirkLPoLFYsE9d9yKevfdAaslIqpeuEcXt54RKOAIhFPzPOkYXtbhDaf+4bowAoxA/iIQMVxjdLQd/+7Yk79ocemMACPACIQpAqrqe0oDS3jDtKO4WoxAwUQg7FsVMQzvoSPH0aXXcLT730B06z/Ga8IeYa4gI8AIXDICfEpD6NClV2lgCW/o6DElI8AIFHQEIobh7du9I6ZPGIx+PTv7fGI4lA46c/Y8BgyfjAebPY1Xpr8TNMngUVNxZ8MOXvPP9l1BaTmCEWAEsogAk+cqAh5dwnshWdPlVfkc3lzFmzNnBBiByEIgYhjeOrdWRSATKtyPNLgPXTu2zJR85qRh+GXlQmlurnJdpvRMwAgwAoxAOCBgqDQkJmuqDXxKQzj0CteBEQiMAIfmPQIRw/BmB5oSxYui7r23ITY2+pKyWbZiFebM/9Cb9vkhE1mf2IsGOxiB3EOAT2kIHVvV7ZLEF1O048lYh1fCwRYjwAgwAhKBQsHwypaGaPUfPgWNWnfH5Bnz5VFomSWjrxux8YAxyGkMOD8eU1kbA6pHU2VITEmT8Ho8WcuD6QsfXpm94zieESgoCDDDa+pJ0g/+7tN5mDiyL7bv2IP3ln5uig3sTE1NFYyxAykpyWwywMDlciI1NYUxCoKRw5EKh4PHUUb3kVtIMDOKL6xxLpdL3lepqQ75kEpM0Rhft5OfSTQmnE6HuLdSJUbkZ+M7LuSgCXeL68cI5AACEcPw/vbH3/A3u/YcgKG3lgNYoGzpkjKb6jdXRsc2jbHtv8Cb1txu7YVCxDExMYiKikZsbBybDDCw26MQExPLGAXBKDo6BtHRPI7876MvVv2Eex/tgtdmLYLNZufxE2D82O0aLjarQo8kXNR1eD3uFMZL4BUlns/R4v7yH1vs195ZctCwxQgUAgQskdLGN+Z9gN6DJ2DUxFnSkHvw6NfQvGMf/LFl2yU3g9LSV9wog4uJSXQBSUx+XL8JN1ZO27T23859oC++nT5zDjv37Idb3xEtE7CV3whw+YxAoUeA1BEIhBSX9lhX+UtrBAcbRoARYAQkAtqTUTrD2ypdqjimjBmAzxa/Lg25K1x5GSaN6odX33wvw8oTo0rHjdGRZB9/8a08dsz4iMULI6fi3PkLMn3Lzv1kHF2LFU1Ap7ZNZDhZSSmp6NhtKHq+8DJq16iKV2cuoGA2jAAjwAiEBQIej667C5usDzO8EoZCaHGTGQFGIBACEcPwHjtxGnfdVgOKokhD7sPHTuCG668J1C6fMJvVKo8ZM44bo+sNlSpKmm+Wz0HpUiWke+WyWZLu00XT8VzX9qB0MkJYNapWxuK5E6UZO6wX5k0bJUL5xwgwArmJAJ/SkAV09U8L2+3RSErVmV9XchYyYFJGgBFgBAouAhHD8Ao2F79u+svbExt+3wKrYGQpgOLoyiY0BPKbKvn0DpzZ9RUcFw7md1W4fEagwCBgqFlFRdmR5D2pIbXAtI8bwggwAoxAdhCIGIZ3aL//YdLr76LZE72lmfLGfAzp8zSSklPQqtlD2cEg07StmjbAM51bZ0rHBKEhcGzLfBze+AaSTv0bWgKmYgQYgUwRML60Rpu0kh26hNep7UvINHHhJeCWMwKMQCFBIGIY3iqVKmLp25MxddwgaZa8NRk33XAd4mJj0PThBwpJdxWMZhq6ha6UcwWjQdyKXENg2aerULtuG4yfOjfXyig4GWunx0RHR4FVGgpOr3JLGAFGIGcQiBiG1+Px4N+de7Fpyz/S/Ldrn/zYQc7AkEEuHJXjCHjc2jKrO5UZ3hwHlzMstAi49eMSo6JikJzKX1srtAOBG84IMAIBEYgYhnfiq6pFOgAAEABJREFU9HfQY8A4/LFluzTd+4+VX0ML2CoODGsEvBLe1PNhXU+uHCMQUQjopzRER+feprWIwoMrywgwAoyACYGIYXg3/vE3lr4zGeNe7C3N0rcnYf3GLaamsDNSEDAYXpbwRkqP5V89+ZSG0LE3PsJDDC9LeEPHjSkZAUagcCCQwwxv7oFGO49LlyzuLYCOErPbrV4/OyIHAYPhdbFKQ+R0Gtc07BEwNq1Fx8Qgydi0xseShX2/cQUZAUYgbxCIGIa3VInimPnWB97PC78+ZxHKlSmdNyhxKTmKgMHwulmlIUdx5czCDIE8ro4H2qa12JhY1uHNY+y5OEaAEQh/BCKG4R01uAdOnj6LERNmSnP23EWMeKFb+CPMNfRBwKM6hV/bUONiCa/Agn8ZIcCnNGSEjm+cIeG1Wm1IStWYX5UlvL4gsY8RYATyBYFwKDRiGN6SJYrhpYHd8OWSmdIMH/gsKCwcQOQ6hI6AId2lFKo8I1RjfsnPhhFgBC4dAY+q30v0NUprjMzI7UyRV7YYAUaAESjsCIQ9wztj3mJkZAp7B0Za+80ML9XdlXyaLmwKPQIMQHYR8Hg0qa7FYoGq2GV2LOGVMLDFCDACjADCnuFNiI9DRob7MLIQUF3aGbxGrV2sx2tAwdcACPApDQFACRLkUTWGV1GsUBRNwssMbxCwOJgRCGcEuG65gkDYM7xd2jVDRiZXUOFMcw0Bj9t3idXNery5hjVnXNgQ0FQaFEWBYouWjVddvvebDGSLEWAEGIFCiEDYM7yFsE8KdJP9X8AulvBeSn9zGkYgHQKqqsowxWKF1RYr3SzhlTCwxQgwAowALIwBI5CXCKh+Kg1ulvDmJfwRVxaf0hB6l3n0L60pigJrdDzoT+VNawQDmwKNADeOEQgNAWZ4Q8OJqXIIAdVPpcHFEt4cQpazKewIeHQJLxQL7NFxoD+W8BIKbBgBRoARQGRJeFMdDmz7bzf3WwQjoPrpFLrzQMIbwXBx1RmBLCCgqTRYLFZExySA/vzvNwpjwwgwAoxAYUQgYiS8637djOZPPI8RE96Q/bR9xx70GTpRutmKHARUXaXhXKJLVtrFEl6JA1uBEeBTGgLjEijUq9IgGd4ikoQlvBIGttIQYBcjUGgRiBiGl87inTttJEqWKC47q0qlijhx8ox0sxU5CBinNBw+rTG8bpbwRk7ncU3DGgGPRz+lQSzcxcZrz0nVb0UlrBvAlWMEGAFGIBcRiBiG126z4crLy/lA4YH2gPcJZE/2EMjl1Kou4T162ilLcrGEV+LAFiOQbQT0c3gtViviEorJ7FjCK2FgixFgBBgBIQqIEBDsdhtOnznnre2mLdu80l5vIDvCHgFVlzgdPqVJeF0paX0a9pXnCuY5AnxKQ+iQe4xTGiwKihQpghSHptNr3HOh58SUBgJ8ZQQYgYKDQMRIeAf06oLRk2Zh5+796NZvDCa8Ng+9n2lfcHqikLTEePmeS46SLXannpVXthgBRiC7CGgrXhbFIhjeBCSlMsObXUQ5PSPACBQcBCKG4SWd3VfHDsTIQT3QuvlDWDxvEipfVyGfe4KLzyoCKckXZJL4YiVxIdkt3W6HFiY9bDECjMClIaBLeGGxomhCPJJTNQaY1RouDU5OxQgwAgULgYhheKe8sQAWiwX33HEr6t13B6wWC8ZMnlOweqMQtMaZmiRbWaJ4KZy9qDO8vHFNYsJWegT4lIb0mAQLUY1Na4olfyS8wSrG4YwAI8AIhAECEcPw7ti9Lx1cW7fvSBfGAeGNgMuRLCtYslRpL8PrYoZXYsIWI5AdBBRdwmsVEt4iLOHNDpSclhFgBAogAnnJ8F4SfCu+/h7d+o/RdHfFldxkOvcYhmuvueqS8uRE+YeA26UxvKXLXiYYXk3H0M0nNeRfh3DJBQgB7X5SiOEtkoAkh7aCYujNF6CGclMYAUaAEcgyAmHP8NasfiOe7tAC5cuWlldykxn/0vMY92LvLDeYE+QvAm6nxvCWK3c5TusqDXxSQ/72STiXXnBPach51A2VBlL9YglvzuPLOTICjEBkIxD2DO+Vl5dDnVurYuHs8fJKbjKXly8b2cgX1tqrqbLlRYqVRLLDKt0ulvBKHNhiBLKFgK7Da7HYQEyvw6U93lnCmy1UOTEjwAjkNgJ5lL/2RMyjwrJTDKkxBDLZyZPT5gMCbocsNC6+KFyIkW436/BKHNhiBLKDgAJDpUF7rLs92oRS1VdVspM3p2UEGAFGINIR0J6MEdAKUmMwTLvHGqFE8SK44Xo+liwCus6nih79a1Bx8UWgWuNknIslvBIHttIjoJ/SgCF9u6aP5BAfBNJUGjRG1+2xy3jVnSKvbDECjAAjUJgRiBiGl9QYDHP/3bUxfngf7DtwBPwXWQgYX4OKi4uHLbqorLybJbwSB7YYgewgoOinNFisGsPrsegMr1M7CjA7eXNaRoARCBcEuB6XikDEMLz+DfR4PDhz9rx/MPvDHAFj2TUhPh5RcSVkbV3M8Eoc2GIEsoOAB9qHJhRFe6wr1hiZHevwShjYYgQYgUKOgPZkjAAQ/PV3H396AKrffEME1Jyr6IuA9lK2WG2ISyglo9ys0iBxyCmrIOXDpzRkpTf1e8uiPdYVa7RMzF9akzCwxQgwAoUcAe3JGAEgGPq7xnXU4J7o37NTBNScq+iLgL6xRkihEoqVk1GulDPyyhYjwAhcOgJpKg2aKoPVrunIu52sw3vpqHLKCEeAq88IeBGIGIbX0N81rjdWvtbbCHZEDgKKXlXFYkWpMpfB6RILsaoLvOyqA8MXRiAIAhcOb8A/Sxpj75qhQSg0Ca/Vqj3WbdFxko7vLQkDW4wAI1DIEdCejBEAwoFDR/Hm20vw3KDx8strhopDBFSdq2hCwKJoL2UICW+pUsVx+oJLxubbxjVZOlvhigCf0pDWMx5VWx1xOy6mBZpdnrR7i4Lt0fF0EZNJ7WMv0sMWI8AIMAKFFIGIYXjHTpmDYsWKokObR32+uFZI+y1im63oDC9trClTuhTOGF9bYz3eiO1TrngeIeDRPhXsdgZmeGkjL9XEYtFOaYiKTiAvXA5meCUQbGWKABMwAgUZgYhheIsWiUf7lo1we63qPl9cK8idUxDbZvHqNFhRplRJnE3UpVZ8UkNB7G5uUw4i4FH11ZBgEl5Fu5es+rFkMXH6sX/OxBysBWfFCDACjEBkIhAxDG+U3Y69+w9HJsoFptbZbIh+Tqiqakuv5cuVwdkLmtTKxQxvNsEtmMn5lIa0fvXoEl5Vnqur3UNpsYCiH0tmSHhjDYbXxZvWwH+MACNQ6BGIGIZ3975DaNf1BXTsPpR1eCN02HoMhld/VyuKgiSntvzqZpWGCO1VrnZeIWDo8FJ5bkcAqa1+X1ksNiJBfIJ2zjVcrNIgAclpi/NjBBiBiEIgYhjefj06YvqEwej9THvW4Y2oIWaqrC6hMvbWUIzTo50V6mIJL8HBhhEIjoBHU2kgAncgtQZ9QmnRz+GNK6IzvKqDkrBhBBgBRqBQIxAxDK9xHJn/NYx7j6vmh0CahNdQ5BUEVm1jDZ/SILDgXzoE+JSGNEg8qqb+QyFqgI1rYsGEomCzR8lr0WJF5bF/gAced6oMY4sRYAQYgcKKQNgzvHT82K69B3zUGCjMMIW14yKy3bpo160vvco22IvIi4tVGiQObIUfAse2LMCe7wYj6cQ/+Vq5pOQ01YRAEl5jQqko2mO9SEI8LiZrG9lUV34zvPkKHRfOCDACjAC0J2MYA0FfVitXppSPGgOFGSaMq85V80PA2HTj8aRJeGPiiksqNzO8EoeMrKST/+Di0U0ZkXBcLiCQcna3YHb/hjP5VC7kHnqWqtvpJXYHOHnB2LQGg+EtkoBkh8HwpjHL3kzYwQgwAoxAIUIgbBjeYJiTCkNCfJzPUWQUZphg6Tg8DBEwdHhNVYtJKCV9rpRz8spWcARSzx/Evh9ewr61I0Du4JQFJyYsTmnQdWM9+awW4Hal6eK6Uy8E6GRj6USbUBaJj0dyKjO8AYDiIEaAESiECIQ9w2v0ifzS2jv8pTUDj0i8ejzaC1lVtRcytSGheFm6wMWb1iQOGVmqfrzUxSO/49Cvr2VEynE5iIBHZ3hVk4Q1B7MPlFXAMNWdpsPrDqDDayQyVBri4mJNEl4+mszAh6+MACNQOBGIGIa334uTYLNa0a5lIx/1hsLZbRHaakPCq/G9shHFS14ur2qAJVoZwZYXAYPhlQE6EybdbOUuAsa4VdNUCnK3wMC5u90mCW+AUxrSVBrSJpQOl1Vm5naySoMEgi1GgBGIMARyrroRw/DarBZ07dQKd91Ww0e9Ieeg4JxyGwFjl7kHaS/kMqVL4vQF7bglV8qZ3K5CROevmpgWj/7VrYhuUAiVD4dTGjz66QiefFZpUN3afUKwBdq0pigeioKipN1fLo/2iPeZLEkqthgBRoARKFwIaE/DCGhz5esr4q+tOyKgplzFYAh4l4ZNm9ZKC4b37EVtqdbNag3BoJPhqukDAsYGQBlRyK3cbr533Oa7SkPGDC90lSHom9YIF5dH+wiF6koiLxtGgBFgBAotAhHD8Dasexd6DBiLOxt28DGFtuciseH6Mrwmh9IaUKZUSZy5qG2scfFJDRooQWzVbdLDNJibILQcnIMIGOM2nxje8wd+wvG/F0FNOuhtVCAJL523qxGkSXjdsMsglY8lkziwxQgUcAS4eRkgEDEM7yvT30GPp9ti9cdz8cvKhV6TQds4KswQSJNKpr2Qy5UtjXOJLOENpatUZ4qXzFNIVBrC4ZSGY8ePS9yTks7La15b5/avxYl/FgPJaQxvIJ13Rb+tFJOEF0qUrC5LeCUMbDECjEAhRiBiGN6iRRLkhrX4uNhc665PvvwO7f43UEqQz5zNn5dbrjUuHDLWJWWq6fhnRVGQ6NA21vDRZBl3kpoTKg0ZF8GxARAwNoO5nfnz8QbvRFFN27TmCnAsmVFPiHvKaIZijZZO82RJBrDFCDACjEAhQyBiGN7balXFu4s/xdnzgc6fzJleow9cjB7aC6VLlciZDDkXHwQ8xjK8xycYTk+MDHA7eJIhgQhipSYnpsXok4e0AHblFgIeaCo3qukc3NwqK1C+Hn3TnOJJOyXClcGpJoqiTSApL4tNu7d81GEogg0jwAiAIShcCEQMw7vowy8w+90P0ah1dymBNXR5c7K77qxzCypdWyFdlstWrMKc+R96w58fMhH/7tjj9bMjNAQ8+jK8apLwUkqPRZPas4SX0AhuHClpEwKPzgQFpy4YMeFwSoOiTy6cplMy8hRd/Vg0c5meAHXxSnih6zaIBBabdm+ZT/gQwfxjBBgBRqDQIRAxDK9Zb9fszu8ec7lccLvdoCsbV1AcCCO3fqySxwMfOsVeRHajM+WcT3j+4xm8PTlfN3em48htOhbL4XQUOqxUVc2XNisQA1aMUDXlDM4f2YzEU7vytIc83MQAABAASURBVB7m48hENbSfJ21sut0aLkY9XbqfxqjVrjG8LkdSntaZyg4X4+bnc4Z9rw0othmBgo9AxDC85q5Y/NFXZm++ulUhaSPjFswcG5dg2gIbj5CSqd5d7hYfOltMMdmHdA6vu5DiqArptyrGUkbth+mUBpcjxQfDjNIVlDhiePOjLdBVGiwp+3Bg7Ys4vuWdPMXeI8aGvEH8LGfKWVkP0vElXKCfw6sKevKTsUfHylSOlAuSlsIKm1HFfUWmsLU71PbKARKKxTSMQIQjEJEM7/LPV+cr7G4hMTAqEBUVDbs9CtHRMYhmg+ggGNhsdthsmm6hR1EQbaKLL1pGwqk6ExFtCi9M7qgQxpFZhxNC6lgY8Pns67W4u1EnvDrzPTF+bIjOh/FhSE7lIBWWR0w88rIeosiAP7tVu4/o3qL6GIoM0THxiNZxionV9iO4ncmI1sMK25Wez3R/FbZ2h9regIOLAxmBAoiApQC2KVea9N/OfXAJRvf0mXPYuWc/3GJ5NVcKitxMM6+5kPISkeKnw5ugM7zOZP7SGjL4syJt05LxVa0MyDkqhxBQxOTCnJXqvGj25r7bk/bBCXNhbmeS2Yu0MWGwvkBMfLykcZmOtJMBbDECjAAjUMgQiEiG97HG9XOlm958e4ncEHfy1Bk88ngPDHhpsrecpJRUdOw2FD1feBm1a1QVEqcF3jh2hIiAzvCShNecomiJ8tKrOs7JK1vpEfCY9Hcp1qovX5ObTe4ikMZIauW4Hb6Mphaae7ZHLMkHyt18TB3Fi4UTugjGN43hjYvT9OPdXnUiScJWriPABTACjEC4IRCRDG+7lo1yBcfuTz3u/aAFbYybPHqAt5waVStj8dyJ0owd1gvzpo3yxrEjNARIj1ej9B12pcuURVKq9vEJf8ZOo2dbdaVIEM5c0HCyFBKGNzxOadA2rckOEJY/oymCcvVHOrqBCjDGhBFnDAnj7F0Kj49PoAtUZnglDmwxAoxA4UXAl/OIMByatH8uwmqcVt1C6dKPV/L4qTSULlUSTn3Vll/MgUeGwWQlOXyZr8DUHJqTCPhLeGVf6KsVOVlO0Lz0+8aIv5isTXpkPYxAcTXq6VH1m0mExcVrEl6PmqYOI4L5xwgwAoxAoUMg7Bne3/74G8GM05k3D/FWTRvgmc6tC93gyOkGe3S9Z0VJW3KlMujzwk63xsiZX9YUx0ZDQHWlSofDpcCtSifgxwjpoXzJYQQCSdPdfvqzOVykT3Znz/qq+lxM1gaA/9m6Fv22UkyfFk6ILyrzCvP7StaRLUaAEWAEchOBsGd4ew+egLcWfhzQJCZpy7y5CRDnnXMIGCoNnnQS3hJw6wwvgmzQyblaRGZOhjTP4bJAVY3JgSbpi8wWhVbrZZ+uQu26bTB+6tzQEuQClSE5NWetOk1fvTNH5Ipb9ck12ak9tlVdzcWI9M4jzQxvEU2lASapr0HPV0aAEWAEChMC2pMzjFtcpnRJvNi/K2ZNGZ7OFC+mLdeFcfW5amYEdImkWQJF0YqiQNWZYA+/mAmSdMZgbtwei1fCG0y3M11iDsgWAorfKQ2UWV5KeBX9vqFyyaS6tOP9VJd585yHouChr7pIl2aVKFlKc6DgT470hvKFEWAEGIGACIQ9w9uo3t04dcZ3Sc9oyc1VrjOcfI0ABFwuTQXFozO35iobYczwmlFJc6uuZOlxqjboAl5WaZCI5L5lqAqYS8pLCa+iqOaikeq2S78xCZIendFVoes1yEBAsdhAf4qYUtKVDSPACDAChRWBsGd46eSEW26+IWD/THipT8BwDgxPBIwNaYppydWoqaJoL2ZPkCOYDLrCejWYGxXE8GpMjaETXZAxCYtTGjS4fWB256VKgya89ZavKlHS7XZqkyDyePRNdB7vbIhCIRhejTkOpIcM/mMEGAFGILIRyFLtw57hzVJrmDisEXB7X8bakqy5sh6dCT5/8GccXD8Z5w/8ZI4u9G6D4fUodq9KA1hql2/jwn/DWG5WxF/C67HEyuKMMUEeQ5Kreny5c+OIMpuflJjSsGEEGAFGoDAhwAxvYertfG6r6nJoNQgw6lSPFnjuwM84t+97JJ74W6NlWyJgqDTAGg2PztR4WN9ZYpOhlc1Ij1sfs375uB1597U1i58OsWKPk7Xxjgnh8+gfJvETBosY/jECjAAjwAgQAhqXQS42jEAuI+Byu2QJipJewgud4VWN47cuHJa0bGkIqPqOfMUSI9gfTYpnLGNrFAXTzu9TGoJh7M7DY8lsFt8NZ1a79rlgs5TZW88AHK9LPwHFE4R5L5gjh1vFCDAC/ggUdj8zvIV9BORh+1Wd4YWuvmAu2lBpMBg7x0VmeM34uJ3aEXxWewx0/gUe1nc2Q5Q7br8TEoxC8nLTmlGmcbXYtKPGnKmJRhDg0Thd/ZIWLlwunV/mUz0EGPxjBBiBQotA2DO83fqPQUam0PZcBDbcYNCUQAyvfnKDsUzruHg0AluYe1U2cLGI5WwvUxOEGbv0WnBKfwS8klO/iDzdtOZXtj1GO47R5UhjeI16unV1F3MSl6r5PPy1NQ0IthkBRqBQIhD2DO/THVqAzNVXXAaXy4UH7q6DRx66FzHR0ShdskSh7LRIbbRqSCQDqDR4oKk5eHRdRGqj48IhurARCKQkXRA2YI+KhUefHBgTCBlRQK18P6VBP/3AH141D1Ua/MuOji8mg9w+5/CqMiyQZXyZz8M634Hg4TBGIDACHFrgELCEe4vq3FoVZP7duQezp45A28ceRtOHH8BrL7+AlFRtmTfc28D10xBQ3do5vIEkvIHUHFKZ4dWAE7YhzbNHJ0BVC48Or2h6vv6CqQGkJAc+GzynK+sxTQCNvKNitIm+qqu5yHBd7K8pNsgQr+VWtcc8M7xeSNjBCDAChRAB7UkYAQ1PSU1NV0uHQ9sElS6CA8ISgQwlvAGkvo7w3riWpxg7HdpXtaJjE4SEV2N4wSoNud8HQSS8jmRN4p7bFTBUFczlxBXRGF4zM+wxGN4AKg1eCa+hQ2/OjN2MACPACBQSBCKG4b2tZnV07z8Gy1aswlerf8KAlyajYoUrCkk3FYxmelRVNkSxaOoL0uO10oc5Egu2Hi8dbZV4/C+knN3jRSGYw1hCj4opIhhe7bb1BGHGguURieHhdkrD2YvaDrC80uH1GGpAps6LL1ZO+iwe8wqXJtvV+V4Zb1heCS9PkAxI+JrjCHCGjED4I6C9OcO/nujXoyOaP1oXf2zZjp/Wb0L9++9An24dwH+Rg4BblzBZLOmHnWJNz/C6ks9ETuMuoaZJJ7di75ohoA9tZJZcdWvMTWwcMbyahDcQM5RZPhyfNQSMSZqR6uR5jeE1JiBGeK5dAzCpRRLikerQJo8eQ+VBp9PYXt/aaJSAh48l8wWGfYwAI1CoEEjPeYRp8xVFQb37bkeHNo0x7sXeeLjePVAU7cUfplXmapkQIKdH3zQTUMIbQKXB7ThPyQqsMZiVkDbn6YxNLG1YMpatdSanwAIUDg3zw/jEOU2NSlG1CUhuV9G4Z4xySD0hQTC8Sakaa6vq5zN7vKLd9M9ED7THfDB9ZCNvvjICjAAjUJAR0J6EEdDCdb9uRvMnnseICW/I2m7fsQd9hk6U7ki1Us7sxPG/F+HCoQ2R2oQs1VvVl+CVAMytYrGny8uVWrAZXlX/yAYxNa7kU972p57bJ8eFz+eVVe2LX/FFSsCjT/Q8Op7ehAXQkd+nNHi8jKQGboo7Wjqs0DZgSk8uWh6/PnapHhRNSEBiqipLVXWGV8hvNb8nPcPrVrXVExpnkoit/EaAy2cEGIF8QCBiGN4Z8xZj7rSRKFmiuISpSqWKOHEyspe8k05uw4l/FuPsvjWyTQXd8ugqDUoAHV4lwNm87gLP8KZ4u9yZeMTrThYTIf9xYfEYDG8xeKDdtszAeCHLPYdHk+gaBdCmwQvJhlpD2jm4RnxOX/37mPjv2NgYJOsqDcYX3/xVL3zqYUyQ9FNSfOLYwwgwAoxAIUFAe3NGQGPtNhuuvFzbrGFU1yNe/YY7Eq+qrlOXTh8wEhsTQp2Nl7IlAMNrCSThTYnsCU1mkKi6mgLRpV5I26Dn0RkTjz4+IKR8FkWFKqR7RYqWAIzJgd9yO/gvxxHwl7BCiUKSPk8xmM0cL9ScoV8fu/Uj6VKd2qPb+CAJoOqp0kt4PbDJuL3fD8M/SxqDv2Io4WCLEWAEChkC2lMzAhptt9tw+kza2ZebtmzzSnsjoPoBq2gwNHny4gxYg7wN9OgvbyXQpjWL9lL2r1HaC90/JvL9SYlpKhtO04kUxhexvBMinTGmZez4uDjRcO22TceMiZiC9lv26SrUrtsG46fOzZ+mickGFXzirAtzvzqNwxdLIFnXZsiLzwv797GY81B14HRrY8Cr0qCp9MKIl0S65YFGq3vF/MlXam2Eh3J1p56TTPO2j1qHQp4jNJwJI8AIMAI5gYDvkzAncsylPAb06oLRk2Zh5+796NZvDCa8Ng+9n2mfS6XlTbaqzsiozot5U2A+l+LRj1hSlPTMrWL1DTt1XnspF2S1BmdK2pK482KaSoPB6Hp0Ca+xApCqaTXAo0t4DTzzuVsLdPEefaPl0TNOwfCewRlXWcFsajqxeXE0mVG+AbKqahJcl/4xCWNsGJNJg8589ejjxQjz6CsIhj8rV2MCalyzkpZpGQFGgBHITwQihuElnd1Xxw7EyEE90Lr5Q1g8bxIqX1cBQH7Cl72yPTpD43YmZy+jCEmtqqqsqRJQpSFKxhnWSZ3hdRVgPV6nM8loLpyJh71uY1wYjK8hxUvV5gBQoN+2usQc/JdrCBgSVkNymhAfB6dH22Dp1j8GkmuFi4w9+iRROOXPqIcbWh2MsSHEtjLeY4wN6TMsjUE3fB6diTf8Wbmq+kZLSmMw2+RmwwgwAoxAuCOgvznDu5outxvd+o+BRSyF33PHrah33x2wWiKi6hkC62VoTIxPhgkiPVLfAGS1+UpzqVlWm+9L+fQFlYJxKRJeOtt2z3eDZfpwtlwOXRlUVDL1QpqE12BIjHhV34mf6tLGvKJPGAxmTCQvsL/8PqXBYCRdbg3ieMHwqop2UoPqTJPQa7G5YXt8MlX1UxhURZsgpklaNTqPmA75JCCPxfd+8+j3IUVl1aj6qhSlSyubfGwYAUaAEQhvBLQ3aHjXETarFTbBJCWnpDEIYV7lkKrn0SW8heXFoer6kIriy9wSWIpp05rD6YH3i1ZBzuJ1Jp2gZOkMMYf09bKkE38j3HF1O9Ik+x7BSLhSzsr2nDunXRN1HV9qE0W4VIUuMJgegxmTgWzlCgIeXcLqgfaoJAmvYo2RZbnzYKLq8ZPGGn2vwmB4U2RdjMmPR2eIZaBh+d1vnmyoNHj0ZxZl7S4kK1PUVjaMACMQeQj411h7ivuHhqHfJpje1l0GYOK0tzFn/odeE4ZVDblKqunloebByzPkiuUWoc48KBZpqRl+AAAQAElEQVRfiRMVZ7VpL3By00v9YqrG3LlSL1CQ19BRbluXPYadX3VH4rHN3nDDYZa6ebLxYjfyy82rWzC55vyNjWtup8bEWHSVBYPhdbq1ZWzoDIzLqSv1mjNhdw4joElOLfqKEkl4FSttHISYUKWppORwoWnZ6WPACFA92iPbYtWlzC5t0uTRx5Jb1+016OVV8b3fjE2RMi6LlmpWaXDlQfuzWD8mZwQYAUYgGALa0zNYbBiF33RDRTRtdD9KFC8SRrXKXlVSTZuW3IVi45oqAbPa0kt4LdYoGUeWS5Cpii5F89PhpQ80eMREQRXL/AfWTSRyH+M2TRw8+scafAjCyOPRPxd8LtEta+XUz+J160yFRdGUdg1JtapouFl0lQadB5NpC6qVu6c0ZI6aR5+kGZOMhPh42KITZMKUxHPympuWt3yjEEWbCFrssTKE7gNyqPqYcekMMYUZRrH4Mryqfh62EZ+Vq6qPWUpTKCbp1FA2jAAjUCAQiBiG95nOrRHIRHIvpCSn6QC6HWnuSG5TRnU3zuG1mtQXDHqrLe2l7HIr8FjjZZQr1ZepMJg/inQ7LiD51DZyeo35JayGuYTXo9dv2wFNouu8eEy2w2B4bRbB+YsQo82qvowNRbttU1I06Z4g4V8uIeDRJayGGk5CfByi44rK0lKSNNUT6ckly5/hVXW1FqvO8Lp1tQIvw6um3UdGlRT/+82jTaSM+KxcjXIojTEuyc2GEWAEIhyBQlB97c0ZIQ39Z/suzF+8wqvOQKoNEVL1gNVU9aVrijQzauQviMaj6yMqiialMrfRR6UBCqxRmhTN7SfhVYVkF6a/84d+NfkAt2kjkUdIgn0iw82jpsoaHb+gSbPTJLxpqgqEmbfNFk0KrugMr+rSD4SVubCVKwjoDK/Fqj0q4+JiER2rM7yJecDw+jGnHmj3ji3KmBBqRxqquuTVrTPEZiwsVm1lwAhTs3FfeMeiyMxtWk0RXv4xAowAIxDWCGhP8bCuola5txd9glemv41PvvwOp06fE9c1OHBIk4hpFJFne3S9O6q5mVEjf0E0xsYaizW9FMpm03QSqd1uj4KomBLkhNtv05rxwo0tdaOMv3DYl+H10eFVw5wh1OvntpeVbXHoZ/F6TAwJjRGvJE1X+1B0lQZX3jK8so55beX3KQ0eXaWhTOkySDy2DQ/cewfiEkpKGJypGrMpPblkGasi3uz1yWJUtMbwOlMTZZSqqzS44cvcUqTip9Lg0VcWKC6rhsajkUbVpcuGn6+MACPACIQzApZwrpy5bl9/+yPemj4K5cqUwpC+/8PyBa8hJVWTkJnpIsnt0RkeqrNaCKQlHo+HmgqrTd98JX2aZQ5TPRbEFiklI/w3ram6hLfIZbfCYo9D6rl9MJ/Y4Da9hNUMXuzH/1oovxh17M93ZDn5YSlwyWITSl8nr86Lh+TVXG9yG2222uJkPBRtwuDRJeZaINu5g4A2ZqFL1amMhOLa2MwTNSRdwkzlkvFAe2RH6WoVLv0sYI8+eXZ7tLFBtIax6BMlw2+oaRj+rFxV02TMOxHLSgZMywgUCAS4EZGIgPb0jICax8XFwWazweF0wq2qiImOgkXRlvcioPqBq2jaVOUuBAwv4JY4WC3ppVC2qBgZRxad0lC0RDlywjiqS3qEZTB/P234GyiiS3kPrRcx2k81bf7zmF7OWmyabbysXX4qE2kUue+y6MvVV19bFReT3aC2kUTbYxoXHsHIuHUm3mKPlpWy6PipuvRRBrKVKwh4vBinPWuKFS0ty/K4k+Q1Ny2P36TGo0tw4+KKyWLd+nODxo4M8NfXFYFWvwlmRveFIM/wZ9w3RGSUTW42jAAjwAiEOwIRw/DGx8bA6XShYoUrMXbyHLw+ZxFSHZqELNxBDlo/neGheNWke0r+gmgU/Rxei5i4+LePJjPeMCHhLVaivPS6U331JB0p2jLyhytW44OVOySNWa3BrTOHFGFmHMlvNgaD4Hb4HntmpsmOO5S0UVZN5eLaa6/DgRPaWHZcOAzB+XqTq4JpT0k+L/12Xa9Z0XUys7PbXmYYAdayT1ehdt02GD91br7UNjVV21Co6JMMqkTxkpoKisXjIG+umvTSWI3xjonX9IiNcazqKg0WW9rE0aiYxU+FyJ+JNuhCuRrlEK2Z+SU/G0aAEWAEwhmBiGF4+/fsIqW7fbt3wFWXl0O0kPAO6/e/cMY207op+pI2EboLAcOr6gyv1ZJ+2dVu06SXhIUKK8qULYekVJW8UHUpFnkMhtdijcasD7VzeC8e+xMeIQmlePPEISOG0HhZu/3O+aU88sToWFBZFSteKxhejXlykB6vR2OEKY6kcc4UTZJoi9JUGhRFw8/l0tIQHZvcQcBtqMUoaY/K+KKaSoMFqblTqClXj1jNMnnhgVaPhCLFZbBH36yWquvyWk33kSQQllXcK+Li/TlNHzzxBobo8Oj3GZGb70vys2EEgiDAwYxAWCCgPT3DoioZV+Laa65AfFws6Figpzq0kEeUlSmtbR7JOGX4xlr0JX6qYWF4eSgGk6dLKKndhrFGRRlOeARzUapkiYBfW3Pqx7fVqlUHF1M8uOgR0jaR74UjG2V6hy4BJk9oEl5Nekr0eWlUXRc5xeFBsaJFcOqidiumkoTXLPkXEl5jY1JUjHZyhcWi0WZHUpeXbY3kstzejYEa5tQWq12beNgVTUWHwnLLuP0mNXRvUFlxCdqmTkWXMjv1M72t+nFlRGMYi9VuOOXVkY29DylJ2goLZWReTSE/G0aAEWAEwhmBtKd4ONdS1O3Ohh0QyIioiP1ZFI+37oXh5eHdtOYv4RUo2ExLsapHSHjLlPQyvC6TFNatb9K5pUYNlCtTGuu2JovUwIXDv8mrIzlNRSEjhtBgOPNDpeHEP4ux94cRsr6pmiYDUpVi0q9JeNMYKY/qhCGNjokrImkUHT+3W5X+gmzl9ykNqo6xYlJpgJiQJQvhuqLA2ze51QcuL8OtleCBpv9epKjG8Fr0VSKnfl8YqwAatWZbdd1vzQe4TVJaIyzUqzPAakuoaZmOEWAEGIH8RCBiGN5fVi6EYb5ZPgd9u3fEU080z0/sslW2wcQYmaimzVZGWMG7qrJJVr9NNBQYFZ2m0gDFKpnZc0kavdv08Qm3LhmNjSuKFk0b4t3P/qHkuCDP4/XAYWKOVV2vURL4WRcvnJEh/pviZGAuW8lndns/mEEf2aDi7AmazjLp8FpMkn9aQjbaHBOr6W1adJ1MVTDDlJZN7iFgYOzD8IriUl2C2xVXtyNN4im8Of5zCwm/OVOLYLbJX1SsCtBGR3LT6pBLP9M7OkY7rozCDWPzu9/c2fgktdukDuHKg2PZjDYUpiu3lRFgBHIHgYhheM3NJ7WGNs0bYvuOPebgiHJ7/F5kZslkRDUkC5U1VBqsOsNmTmqW8EJ/qSc7NWmWWQrrcWkS3Vgh7WzRpCF2HnbCgXh5Xm/yqX/FNY0BcWfA8LpSNb1YqoP/5IPCctMQE2vk73BrjFPRUtfIIJLwKiaGVxXjxKPracYIJp+IFEXDxZONT8RSPmwyR8CtY6zoY9JI4XBrfUDMphGWG1e3n4QXet/Hx8UiKdUji/SI8eHSGdGAEl7T6gklcGVwX1B8RkbVJ5xEUxj2HVA72TACjEDBQCAiGV6C/sTJ0zh05Dg5I9LQUrW54i5dN9UcFtgduaGGSoO/xIlaFBOr6UWSG4q2Kcuhanq9LpPU1sAtoWhJ3HNnHZQtUwp/7pWpkHRyKwyGmEKcutSL3P7Go+s+Urg7l6V0VIbZXDifdvKES9UYp8uurCQYGLdg2C8g2qrrOYhEcmKkH1NWxFjG1k+58Hg0CbggK7C//D6lwePWMPbojKYBtNujjU23aYnfiMvJq+p3LJnB8FosFiQ7NIaXmFBVZ2Jp5cO/fJvpyD+Kc/sz0RQYonEbm/gEvVGmcPKPEWAEGIGwRyBiGF5//d02Tw9El3bNwh7gYBVU/TajuDI5peHI729i+ycdcG7/2mBZhn24Ao15sFg1ZsFcYZ8lY53h9Vg1JthtUmkwjoKKL6rtUm/2aANs3qZ9sMHtTIbHrUmAKW9nSpqb/Gaj6Ewkhbnz+CzeCxfOUbHSkL4yOSpWuAIHT6YxuhRGRhUSXkU/tSEuQWuzRcdH1aWPRMcmdxBw62ojFkWbmBilqIo2hnNdwuv0GxMmXeJUp7Y64BESXo+ul2uP0e4Zo550tfqpNKhiTFG4vzn136fY893gDJ8xHpOEF6p2f50/8BOObn4b5vsUefXH5TACjAAjECICEcPwGvq7xnXNp2/h4Xr3hNjM8CNT9RfU0dNOWTmPYNakI4iVcnaveKGclV8WC0ISAcGaRMpqTT/sFNOB+Yq+Kcti0zZpmVUabIpDtrNYcU3nldQaLiZrTIEqXsaKSXKbkYTXom/2oczM+ZM/t41iOoXB7dGwuPaaq3HklDYWzOV7BHNi19tcpFhpGWWxWuXV4/0ogvQWSstx4RASj/8FV8rpXGm/MalQhETVpwD9q3euXF4dUE0SVSpfMTHeTlUbO6SSQ+OE4o0PUpDbMHa7ST9eBKp+k20RJH8pZ/cg6cTfSD6tnW8tA/0t0/1lEe4jm2bjwLoJOPXvchz6bbo/NfsZAUaAEQgbBLQnZthUJ8crErYZGi+oc0malMbi0aQlwSqs6gxyyrn9wUjCPtzQTbXaNOmYucI+DIXO8NpjtZMLXClpElEjTVxcrHTed/dtsOpnj6pCSm41MbIuZ/BzUq2mI6VceSzhVZDG2KrQjowqX64MEgNUN1U/dSLVocJos1WXkKuetNMcJBgF0Ap2SsM/SxqDzPG/F2HvmiE4f2AdcuMvjeHV1GyMMqx2TZJ6/swJIyhXrm4/Kb7Fok12qDCXW6uTnOhBmwjGJWiTRIo3jD3Kj+H1Y6INOsqH3K7k4JMHxU/F4vSOzyiJNLkt7ZaFsMUIMAKMwCUiEDEMr79Kg7//Etufb8lUIbmjwlXYpO6mdAsJJV0DGY9On3p+X6DoiApT/DYAUeUVRXt5k9uiM7wx8aXIK/VayaHqJ1lcTFHJK42iKKharZp0J1/01el2B9HhJYmYTKBbea3DazHp3nr0tlJVLPb0O+wdSdppEilOTTpOdIoh4fVjhiiuMBhX8klvM42+U/UJoTcihxweva8sfmPWHq31VeLF4MxhTlTBOCXCYcxtTBJet3h2UBkq6e/qjGhcvDZJpHDD2KK0ySGghXh0Ws2XZhsMqytFG3NpMWkuY7J2LtElAy22WJSt+oR0k0qRdLDFCDACjEAYImAJwzoFrNLjLRqifatH8P6cidK0b9lI+g0Vh4CJwjjQo7+gLbYYJKV4ZE1VIaGUjgBWcpJ2viwdWxUgOiKCDB1emF7aRsUtusSM/Ip+UH6R4mXIi5RE7QUsX+wixNBdFE75q1a1urwmnvNleFV9kiAjTVZ6hve8KTb3nYpJugxLRG8a7QAAEABJREFUtLfAaF2i7Q0QDmfKWWEDqU55kZbV0MksBBJe2WA/y5msjQcKNtRRPEH6mmiyY1SdOVRMExPKL0rvq9Sk9KsPFJ9Txu3WOF2XW39UmyS8qqKtDpDeukXRBkiJkto9Yy4/yk/CC10v2UxDbuO+cKUEZ+KNlZFnpx3G7vPlce1Dr6JYhfspucg2SV7ZYgQYAUYgHBHQn6Ja1cLZ/mPLdjzXtT1ocw+Z5555Ar/89mc4VznDuqn6C9pqj8aFZE1imZGEJDU1TeUh5ezuDPMO30iNsQ8k4TXX2aozvMVKXCaD3fqmNVWXgKdqwiUZR1ZCUf2Le05f5sMVRFfRyIfSknGbToEgf24bm6L1N5WjmHSX44poEm0KN4xLb7vDlXarWvVj3Qzpo0FbEK/LPl2F2nXbYPzUud7muVLMDG+iDFf1CaT05JBFusGe1NMyN8XEaFJAbLz24YeU5NydLBlHz/2ytzRu670Lx623U/HSePTJkipWMuyKdlMo1rQJlCQSVnR0rLDTfgYTnxaiuZITtbYYqwpaaJrt0TG+mOxGorsYvtlxJaKLXgVDvUN1McObhha7GAFGINwQSHuLhlvN/OqTkpqKs+e0BzJFnTl7Hi6X9pAnf6QZ4+VhsUYjSVO/ExIS7eUdqC1m3dTUc5Gp1qBAY3jhtzzs316LrqNaqtzVWpRL63dVP4PXpR/lpUUC0bEJ0mlVffHz6JMKGWmyVL8NgoaU0ESSq067VZPadX/9EA6mVvKWVaRYGa/bcLgdWtsd+gYlCrfq+KCQSnjNDK9LnxA4TRNCwii7xpl4TOoG2y5slllZrVZ5NSzjxAxXStq5z0ZcTl6NY/jsdk3v3W5I90UhFmuMsOF9bqSa1F5khG7FxWv3h+4FTJsmvWHCkZpyQdgUnYhA946qTzgdLgUJCfE4f15r+6iJs2Q6h55eeiLUSjy+BTu+6CpPq4jQJnC1GQFGIAgCEcPwdnq8KR5/+gWMmDATL41/A+26voAu7SP4S2s6M6bYouDUlyvdGag0KCapYMq5A0G6M9yDNYZX8d/xrlfb4dLiLbqEt3TpkiBpEkWrgtlVSVdRePwZ3pi49Bt1BBmC7UZXdUkV0ZBxJPtKhiksL8zvO1LgsevSaVFgTLx27Jhwen8eh8aEmNtstWn6zqqaJin2JigEDjPDa6gBnTunSWJzqvnmMihPxaJhTm4yRfQTM4zyKSw3jFvX07bpDK/VmvbIttg1htft0MZvMIZX8au7uDECV1VN2zXpStVUacyExn3jFPO1YsWK4JwQQLw5byGmvDFfkllMH0yRARFoOROPgz7+QqdV0DMnApvAVWYEcgGBgpFl2tMzzNvzaIP78M6M0ah20/WofnMlvPvGWDxS/94wr3Xw6nl0htdiiYJL1V6magaH2NstacwNPZCD5xy+MRZFY2iDqTSoWjQs+pJ96VIlcS5RazepNaj6kqlb36xjtDQ+QVteNvxnEz3SaUjHpMdkqbqk6lyieHOL8NSknGWWRJZBf6pg3CkyMUVrV2yMxrRQWGyRNOaX/NK4Nam129Rmi8HABJHUyXQFxAp0SoPLpMNrNNOlf2nM8Gf36vQrQ/GbpCUU1dRPPO7cXcb3qNoYNRheu117VlD7LMbRaLqeN0leKdzfKEpaGopTgqwMmFeRXMnp7wnjvqEJerGiRbDqux8xYNg4ylLcp1o93foETQZGoGXcn1R1kvbSlQ0jwAgUDAQihuEluC8vXxatmjZA7VurYd2vm+Fwahs1KC7STGKiJpWx2KJhHGLvzoDhNbfPmXjM7PW6nUknQMc0ndn1tTcsnBwKNCYPiu/ysFFHt6od0WbVJVdFiyTgXJJHRrtSLwjBVKp0Qz/0X/MACUV8JaNJ+ieJgzO8mj70iXPaS5ryNvLK7asx0Ul2aFjE6cerUblFi2lMFLkNo+hMrQfaBiUKt+vSPugnCFBYfpu8LN+lM3jmMlVd+m8Oy47bX8JrMdRI9ExtUfHSZT73WQbksGUwvFHR2sTIblJpiIrWVBUM5pwY0UDFW6OLYv7qC3j/O1332bxp0pTAagr3bz+RGWPXpVpQvFhRCgIdC5h4bBuS9UexmWGUBBFmpSZrahpU7cRjkbtHhOrPhhFgBHwRiBiGt0uv4biYmISDh4+h79CJWLdhM8ZNSdvI4tus8Pc59a+AEXOnKtrLLNjyqL/k13HxaMAGJp/+Dyf+WSyY3oUB48MlUFGCMbxaDa2ml3qyzryS5EjVJbMeIRXXKDU7wdi0pnnhUKM1V9Dd6Cky/nxKlLx6XJoUVXpy2TKYcKeubxkXp/U9FVtU36RHbn9jbrPFptebGV4vTKq+YuINyKbDn+GzWnzHrEU/Qs6m6JxeNssLllzVpbHGWbo2k4TXFqMx3W4xGaT0xIjSNZB5f20qPvnVLaMUPU/p0S1VX3nQvTCYaMNPV1VXBXJ7rOj1bGc82aE1Pnh3BkUh1anIq+qnHy8DI8hKvKhPCkSdz+z5Die2LhGu9L/k0zvkB0+MZ1J6Cg4pxAhw08MUgYhheOHxICE+Dus3/okmDz+AyWMG4L9de0OGdeknK9Gh2xB06j4Ma3/ZFDDd4FFTYT7f95/tuwLSZTXw3L7v5SH5+38c403q0JdgbUKaqVi1XdTBJLzGi+b4WReSUlW4HeeFtDPZm5fhcCZp55OSBCwcH8QWfdOa//KwUX+3kByR22ZLYwKdahQFwZ16zttmRd+sIyOERUe7iYv351biNLcuHdU8abaqSwNdFo1hsKjpsUyjzlmXt2yPBe1aN8VNVSp7CyhZ5gqv+0KK361pScPEpuvwohAwvMsCnNKQmqiNcy9YwuHRmTHhzJGfP8Or+G1as+oSXrsldzfOGqc0lC9bDkMH9MT111bwti8mVpOyepzaahExot5IP0eU3Y7oGO05YzFWWkw0qt/qkn/7iVTVmVmXYHjvqHMrZkwZjWJFi1AUHC5tQhDsGSaJIsBypmiT31PnVajOizj+13vimpSu5gfXT5abGh0XDqaL4wBGgBEITwT83qrhWUmqlap6kJLqwO9/bsXNVa6jIFiU0Kq/78ARLPjgM8x+9SW8MrKvkAzPkXnJTPysmZOGwTjb1yjHjyTLXre+Gc0sRXE5tIeoPSoWin4Grer30jEK8ujSK4dLxcGTmkQpkJTXmZT21adw1PNVdB3eYCoNqkeTElmNJXsBgKozei4hxXKkai8ji4khFiTyZ6gIkMcSpTECCMrwagxuTGwRnL7goiRiEqFtDpOeXLRU6kuRv90ei3kzJqLSddcIn/ajZeJUXdXBqet1azGAxaZLrUWA1WaoN2gSOxFUqH7u1DQpnNFwQ3Ju+LN79ddhteh65Ua+1iiN0YuL8hhBuXTVxmeZsmUwbGAvVKxwlbecWOMjE/pmMxUa0+klMDnsUYLhjdYmgoppA6xBouqrJ4Y/9Xx6Rs6Q+qa40yZfBj0xweQO9gyjuEgwToem0jDzs5Piuaw9RzyqfoyOqQHGM9m4n01R7GQEGIEwRSA0jjEMKn//3bXxxDODcfDwcdS65UYcO3EKMTFpTEBGVfxp/SZQ+vi4WJQvVxpVKlXEb5v+Rqh/y1aswpz5H3rJnx8yEf/u2OP1Z+Zwp2pHS5lfKk7BwFE6e0wR2KM0XTyDMaZwszEeqh7YcTgjhjcxQhheKObmed1uneG1Cam3N9CmMRZuIeFNTtJeRj7xOqGxpEpeW4ym06vATd50xuiHmLiiOJ+k6dK682izjfdFGUSt42KKR9bXjSh5NSwzk28wvEohkPAa7Teusu8CMCBCDGeQ5Mg1NfGUTz5WP5UGinTqOueyThSQC8bj1saw1U/CTEXRhI2uhlEV381pRjhdo4SE1yomWeS2W7Q8yW0YVVdpOKQ/X84f+FGsqmjPLYPGpX/hzqHGGEHeq9tjl25V31gqPRFoOVM1QQRNoFOdqmyBqq8ISY9uqfoEQQ0Qp5PwJUQEmIwRyCsEIobhfbpDC3w0/1W89+bLsIkl3WghsRjWv2tIOJ04dRqXl0874/TKy8vh+EnfF5qRUf/hU9CodXdMnjEfTqcmXTHiLvXq1qUGqv6QlPmkHJOXqPjLERWrSRKSE9MfBUREHn251mKLwqFThoT3CEX5mMSzh71+x8U0tzcwnx3GYLPY0r8wqWoenRG229OYvagYDRtiSI1zPm36Zh1KYxinO42Jjo7VTm2wBGF4k/UD9u1RcUh2aLUy+sjILzeutKHw9K4vZdYesSwsHX5WslNrhxOauoURbdOX0MkfFxtHF3g8HnktyJb/KQ2ulPTSXWp/Tm8ecyT5nlJgsWoMHZVlGKdbYzBVfQXHCM/Jq0ef1NisafeEkb+/7roH6WkM2qgoO+LjtXGDAH+qzvAeFs+XtVsSJcWZPd/Iq2E5k7VnpkvxHZsUr+p69e4gq1REEwnGeEYnp6o4n5gqq6y6tWeu9OiWqj+TPfqKjR7MF0aAEQhjBLS3fRhXMFjVaPn32gpXBotOF65Y0pqqKBpT4U/Ur2dnfPfpPEwc2RfbhQT3vaWfI7M/p9MpP4DhcDgQzJw/ozG3Z8+c8NLYXNrLwxJbDrZo7QXiSL7gjTfnlZqiSR1Ujw3JqibxTL1wJB2tU9fhpTqnnD+cLt6cZ167XS4XbFaNQQtWtqpLeBXF5q27PVZjXpMvnkJKkiZxstpivfHevEwMr1fCK5gFb7ypf5KTNJ1HRTDeyfqmuFQh0QtEm1NhF0/vlRsKz+75lrpHsOJpbaQyaBzRBCvZqTFRbksCjKPLKAFNEoiOjNOlUhDireex+9tBSDx7KD0epvZSmoJg3ELamXwhbRVDgmBYqitHMYDTl7GmuYU/hm5dqknj0j8up/we0S5qokexpGtflP7coHgybiUqHY1RD7sQEsSKFbFUV+B7MFU/ncDhtuCzX7X77OzeNb756brTTiXON1yMNY8om+rgTAn8DDPqkR9XevbQ/RVK2W5dT7lBg4dw8vQFahIcqYnp26szuoHiQiknnGhkI9liBAoBAmlcYAFubJlSJXH2rMbkUDNPnzmLsqXTHwFVtrR2Dmr1myujY5vG2PZf4E1r9OKlfMh4xPuDDLmDGUeK9gKxwiVJXCmnYYFT6o+WKnsF4hK0JXhXkGV1jyFNEMvg1pjSMg9nYvqTGiyq9oAmgkDxFB7WxqMNR5s92lvNOP1s2tTE02LVWmP8o/Td6V4i4XCrafqLcUU1jCyms4sFifyRaoQr6bh026Pi4PJoZbl0FRMZkQuWM1Er05u16Euv2+vwwC0mNeS1CImZIc0nv3EEFbkVi9ZWm2hf8sl/4NIlbxRXkI1H3Gvu1MCrIOYjtbKLgduh3a/mfCwWbSJiDvPo+uUXzp00B+esWz9RwSIYVv+MixTXxrkR7la0ibPhN1/XrlyKpQvegJgzyGBDois9wjL8xERv2J4sQoDUc76bgum5JSPs2iRUug1Lx8LIxwiOtC2RmGAAABAASURBVKviSZVVbtW8GSDuQfIYz19ykzH781zCSxVgwwgwApeEgMZhXFLSyEl0zx018eP6TUgVkojTZ85h67+7cXvtarIBf2zZ5lVduJioMVQkESD6GytfJ2nI+m/nPrjE24LS79yzH25Vk7LRUqHdbkNUVFRQ49KZKavikjRI1V6QB0+ouPKKy1CseFkqAnClyHj/vGwafwMIyWdMcU2q7RRMm5lO8ZNIpZw7GDAvc5q8dNtML+xg5X74d2Xc1nsXil5W3Vv3EqW1kwsIQ1XXl6MJgn8ebthg/BUrdbl02gVD6E938MfhUC7+J+Nj44tB1V/UihoYe//0l+qHQ5Poy4LJskZ720h52u12kHErMRQLqz0GJ897pJus2IRiJvpoCvIaK1JNccHHIZUTaWbFV9/jroc7yK952ehGcKVN6rwACIeiuHMMA4uqPQdEtt5fdGxMuvw9tgQZn3T+RLq4nMIZxOWLUmLEJM8/z/LlyiJF3+QoSOCxF8u0Hi6VKAG7zeJDaxETcIqJL1oKUUJyfCrRTl6oifthlGusIJUse5U3zIizG2pG7ty9j4zysnKlZ49d3F+hpDFUY0qVuRwxsQkSA6sFPu01Vqoo0qKoPnGhlBFuNNQONoxAYUBA3MoFv5kVrroMLR6th6d7j0Cfoa+gb49OoE0c1PIXRk7FufPaS7Rl537yWDK6FiuagE5tmxCJNEkpqejYbSh6vvAyateoildnLpDhIVkubbOV1aIxMKn6DuhzDo1xSdA/UwrBdAXKz2D0VMWOMpfdIEkcFw7Jq2HpLyP8tSdZBqmpp+U1kiyaPFB9jSu5DYbX47zoPZYsTjCqFGc2KrQXNIUVL1meLgGN23EeHsEcz/7iFOzFK4s5hPZSMzYWBkyUA4GOi5pai5EVqW0Ybp+rVdOztAop98kLabdnXFyRNDI/6bDboelcphEUXJdL/wLayXMun0bS5MYnIBseV4CvjFkD6PBaozVJ58VzR7JRWmZJNQ41SoyHQJSJKVo8xSmC4aVrRsbl1saUR1+SN2hVMdkmt02sejz6cF38/u858iL5zB55JUsV9w5dy5ZPO1mE/GSsuo55cmJ66TjFR4qx6Ce7xCYUFc8Jq6y2WaJLAao+8Sa3fxyFsWEEGIHwREB7+oVn3XxqdeDQUbz59hI8N2g8uvUf4zU+RBl42jRviIWzxmPBm+Nw/121vJTfLJ+D0qW0F9fKZbPkkWSfLpqO57q2h820M7pG1cpYPHeiNGOH9cK8aaO8eWTqcGtMKNHRBpdU/exGh0Urt3gJbWlS0Y8XIjqz8egfUKBl1YrXXImjp50y2pl0Ql7JcgqJL12Pn/PgwAkHOWEw1tITxKLl8ON/L8LpnV8EocjZ4Iz2AZIkhkojfUO6kilTXjt31Oohhlf7YARJZinObFSkMbyly14pJF/a5MJ/iZUYWwUuvLXyLOKKloHVOCFDf5mb87wUtxpk006ykLib81OsUWav170juYaUcl+IvUPIbdOY3OjYYl4axaK9iI0AdxBVGCO+IF1d+qa1k9ocNVeaZpRhztwSQKXBHl9akqRc8J3MyMCcsnSVBqvNFjDHVJfiDbdEFfe6gzlU7baA8Uwx6BzJGqNqtcei6SP1sW2/JuVOObtLkjj1Z82RU05cflk5GWa2omK0sZqqq2+Z4/LPnfWSbWIVjlJZrDHwKNp9pvptWjMzvEkRzuBTW9kwAoUFgYhheMdOmYNixYqiQ5tHQSc2GCYSOsquaIwa1VUVkpTU85p0NqaIpp5QTGd4LWJZlmj8jWpIFCxRuPaaCjh0yiVJHKYvrhkvaUt0cRw8acRnLnlKObtHbqY6sXWpzDO3LI+uh2y8cAOVY0h2Y2KivdGXlS+LC8lu6bcjSV6LGBJx6dMsi1VLk6IfJeTUN7GZX+w02SBql37GbZGEeETHaUyCI1mTaFH8pRrHxSPYvbofDqybkC6LxLO+55pabVHpaCigZAmtPrFxsbDFlqEgaeKLmBhexfe2TUk8I2kKohXslIYkV2y65qpiFSBd4CUEGOfNmpMGYjjji5aXJO6U3FxN0SS4MbHxsix/y2FieIuX0Z4n/jRmv6rryXtU7Z4y4lKTtRmEXUh4G9S9D/uOa4x08umdksSQep8458aVV2jtlhG6FR2rMbyuCF9tsFs1XCz2OCjieUvNM55d5CZj9jtSkymIDSPACEQAAr5vzjCucNEi8WjfshFur1UddW6t6jXZqXKoaVs1bYBnOrcOldyHzl/CqAqGN/nsfklTvFwleS1aJAFnLmgPWpJAykCTlZKSKH2KkApWFBLegyc1Ca4zMU2y5DSWYe1FcdGhMQPEgMmEGViG5Ca3pYQej/bizojhNUt2zVW+kKyJpaIt2svFmCCYaaAzvEn63MI409djks6QHjClOX5Gyyc+Lg4xCdrmxZTEzJmWs3u/xX+fPRmQoXUIqf2ulb2lVP38gZ9w6NepVJTXuFM0vW0jQLHFGE6fq8HwxkRHIb5EGgOTULRkGp3iK+1LvlhwGd60Rmuu5Asajm5rcS3AZKumvjYFZ9np0qXIe45pE0fKwGpLW0EgP5n4YpfTBR5n9idLMqMAlgJt7Ct+kxyD1Kl/nZCO0SpT7iojOOjVe1/oq0YGYWqKpnZli04ATTiLlddUp2hCTDTOZE0H/Yx4FNF9Q2FmExOn9UewFQ4zbbi6PfqkPFVbQAMU7T5T3WnjAOJP1emEEy79A0LkZsMIMALhjUDEMLxRdjv27g+/s2Uz6163fgavQUd+d7LGqF5RsZoRjBT9Ies2LYm7U89hz3eDcW6Xpm5ADC+9bM4ma9JBh+msXUMCY48pBZfODDiExBGZ/BkMr8ftAJlMyC89Wl+aVfWjxwJl9L/ObbHyk/S60UmpvsPUYotJl9wIS9ElXm5Vk1CpJibIYOovpnhw842VEB8fi4TimhTVmXIhXZ7+AUknt4HwIobWX5p44cgmqWMcW7IyLLZY0PFjKWe05WCitXp0TlzP1Gb6cpoeJC+33nKz/IQsfVGrZLnrZBhZpcukSdUUiy8eKTkgnaYysmqIqafx6fDTJ89qPlmhd+rSVHtCGh5GetWl7bA3/Jd6daVoE4izKVHeLKxWm9dtOMpcXlE6bWrmY0cSXoqlTxSVACoVlJ3LbaULTp534bJyZaU7I8ujn//s0Y87M2idqYnSGRWr6bTfUKUaDouVJI9g7qh/SfWJCFJVbSWF3GYTl1BMes3PLxkQQZYhnEg1+Fur1laP2/feNY8zl0ObPEdQM7mqjEChRcD3zRnGMOzedwjtur6Ajt2HevV3SZc3jKssq+b2Y3gNicneYw6fz4SmOHUGzbQs6xIMb9KJv+FOPi7zsuoPYNVWQvodpo1QKYma5CuuWDnY4svp8ZmrNBib3SiBwRCSO6eNR81cwntNhStxz5110hXt/5IlhtKfyCqYTApz6gyAS5d8eUxf5TLa57HE4dfvV4AmD0WLaUyC24Q75RPImCcQZ/et9SFJPr1D+ktc+xBKXt9Iuk/v+kpeHf5HkolQSxCGt/L1FeUnZK+4vDwuu/xKqc97+/O7oeh9L5JC8ZP2ObPJ8Kae348zu76mrLNkEo//BRqfDtNKQ5YyCIF42aerULtuG4yfOldSK86z8lq8lKbbLT265Uw8KiTsB3TfpV9SLmq68S6LJrWknGL1j32Q2zD22NLSGa3kDtPjdpxHnE1jthSxuiML87Ncuu76iXMulNGPVfQj8fEaKg0u/eQYI9Kpf2EsOkZTTahetQr+PaiVnXJ2NwwJr8uiMcRGOuMaV1R75ljcucj8G4Vl40r7Ff5d0VmMd+3eNGfldmrtdegb+yz6JCM5SYi1TYQeMQkwvC5nzkyyjPz4yggwArmHgCXkrPOZsF+Pjpg+YTB6P9M+onR43anaZhADvuQzmk7coVNun80fDl2v1Cwhcfvpw1ntmsQpushlMjszA+a4qDG8RUtegeJlNMlgin4ahCQ2Wef2rxXSXO1BffFMmm6py6+upiTZdyoKziVdWjZupEl0UxzaEq9/TvboOBnkML5+BW1oOxM15oUijb5wK2n5lSyjLUtb3Ik4smm2lKgnn/6PyNMZh0lnmjA0E6To/fr+55uwL1FjxujgfpIaOS6kX5mw2TW1E3Me/u4KV2lHshUt4stkWOwJ+GqTG7/vSJZJ1Gx86YukmTu/6oHDG2fg1L+fyPxCtVSdQXCn5t6Svrkuqj4pOZfoRvkrrjZHSffe71/E7tUDpDs7lkMfM/Y4kxRZ0SSp5nxJzzNZjEfS+1RdGrNkjs+u+9iWBbBZ3PhpazLscWUCZudRNFWLCyk2KIo2aQ5IqAd6LFo7Dv4yESlnTScwuJIkhbEhtGaNqth+IFWGJYuVCmeSptJgjzGp1shYzSpe6nKplmVDKgxpsBYTXnbK2b2yfq6Us+kqRvcqBbpUDSOLPil16h+joDgyqlgNoysZdy70O+XLhhFgBHIeAY0ryPl8czxHs96u2Z3jBeVwhv6SwxTx8qAizut6tuQmo3psdIFqergaL3gZISyDSSpR9lrhAxwmyZrboS3DlrmsIspfdYOMdwmJl3SYrB1fdMXBX17BkU2zZKjT9HU2dy7u9ldF3sUET5qqS09k4SFaij1tw06qrrLgn9QerdF4FG1SsO24Jp07sulNL3Pv1qXtHksas1mqdDmZlQVOXDz6u5RYOk24ykjdMocnn/pXDwWI2Uk9r0kWX3h5Ifq+NBNxZarKcmnTj0OX8O4+6vSmsUen1cEb6Oe4+kqNGU9I0Npmjl74I/DKhxoz79GZFXN8qG6nqa3HtswHLV9fPPK7HCOks5xRPl4GIeVcRmQ5FufSTwA4fcEFkn4HylgVzP/Fo38Eigo5zJgYFdfvM0qo+EnVKYzM2USNycxpJi9FTKBI6u5WFcz5WpvYUHnpjH6OdIqa+XiitB5ozBzdC2d2r6QgaRT9fOMEfcXjuooVsE8bXqAxbLQvRpfkykQmi8bojsOpMiTl3D55DUdL1e+VC2KMkzrOkd/f9FaT7mPyuHW1D6tdmxi7dOk3xZEx6MjtMUl7yc+GEWAEwheBiGF4Ux0OzF+8An2GTowslQa/pcNkfenbbSvtMypc0Bg1M4Ps9pPw2qK0l9oVV12Hi8lukGRNdSULhisZFo8TSakqrriiAipWvDbt6DITQ0MFGlLhM7u/wbl9a6A40zZrGS96orsUQ3WhZW56WfunV/UXTbJDY+z94zPy26KLeqMdriBDtuiN6Db9MDYd1yR/205ejn8OuEFS2SN/zJXp3YLpJodFSEjpSqZE8WIwznQ1JLGuAJJuh64vffCkEweFsMujOmEwvSn6JGbbgRR0e/oJbP5rK85cVCl7UJkOXZf6VHKapNau96UkCmLFxsagbJlSSIgXMwU/GpvNhgtJ2kZHRc2AIfJL5+91JB73BlGbDm54FWd2rwJJsOnqjQzgIHoKdqUX+cuAAAAQAElEQVSepUuuGPMpDapDK+dCigVFimgTmkCFXjj0S6BgHNvyLvb/OFpK+AIS6IEWXd/6igraxFEGB2F4Lzo1CavTNHGU9CaLGCRirPb/NM4UmrHz8MaZkmDz0ctxOjHImBcUuy9chTGLjmP/ucCSV0Hi8zOrB53d+z0MvX2bqq1EJRTXJlmUKKa4NrFOObMbhppHsRLaqgPFm00RMSnbeShVBvl/oU0Ghoml6nskkk9tl5Pbi8c2e2umimcpeVRoz2KD4XX6qS2YmVzVJO2ltGwYgUKIQMQ0OfiTNMyaMPqVWThx6gxOnjqLFo/WRUJcLKpUuibMapm+OsGkHTFFr/QltmrMrJnJdTsTfWjsUZrE4dprrsahU5q00CkYWmPDGunxVbj6CtxQ6VoR75JpDWaLPG4/Ru7g+ikU7DXEnHk9l+BIObsbe9cMwcH1k9OlNsq+FAlvVKyms0yZuvTlRnKbTVyRsti0UzD/tjIyOCoqCq9+chGKNRokKbt4ZCOSLmhqH7aYYpLGsC6mKoZTXpPOa3TSo1vEOJPzkGB4N+qH8ied3EpBQgKm6e9u3+/AyKF9JZP6069aHLU7+Zx2DJ0lXlN1oERRugoGuTMyV191BeIDMLx2wfBec00lmdSmaIyG9GTRovFDSYpXrAeLPV4y8ecP/kxBckIlHQEsg3GgqOSLp+iS68adqjG8Ka4oxManTR78Cz5/cL0MIgkmSfFO7/wSJPk9uW0ZLhz+Fcf+WijjA1m0KZHC6azrCtdoqkHkVyxWuqQzKa4YGWbouEqPn0XL53TONTHiZPyi03nP7lktxtR/sMeXxcq/rKDJTToiPcATVQafbbgAV/RVekjGl99P3Iz+806KvMsLTC7i/MF1op/Pw6q45CS63GVp+VxbuRpOnRcTa8d5uJO0/QAlywd/5h48rcjCU87ulddwtM6f8x2r7tS01QmamFCdDTURu03rW7dp1Y3ik5Mu0EUaY8IgPWwxAoxAWCNgCevamSq3e+8BDOjVGfHxsWhY925MHjMABw8fM1Hkj/Pwr1Nx6KeXkBpkGc/tuCgrligkstKhWyUv05gV3QuL/nA1HroU7vaT8NrtGlNc8ZqrcMh01q5TP5LsfLKFkklzJkl7QfswvLqEc/8JN6LL3ibpzJbLTxptjgvF7U7V2upfb0pLDAddHS6tXuQO1cQVTZOGu2ELmCxeZwqLFSsq46Ojo/Df/vOIu+5x6T+44TUkn9XUDmLi0hhoikxxpuFG/uQAR5QZDO/RsyrOOkoSGbwMr1h+poBEtSRI0kVM7/4jmoqJ23kRyec1Hd7SV1YjMmmiY+LlNTPrh6+W4MeVH6Yj69qlHbo98xRSnapgVtR08aEG/J+984CPovji+O8uvfeETqhKB6migoBiQ2zYQCkqAv5BRLoCKkgRLHQUUao0QUAQBATpRQSkdwiEQHpPLlfz3ze7e7mUgwRCSHn5ZNqb2dnZ7+7tvnkzO6tOi/n97/Oo2Lx/ts3UKQTZhEpCtYZRUrX+UfxeOrOi8Jo07tDaeYmL9m/KiBcKY1rUMWHFS489I1n6ZYWN8hOvbLX7ezUpKzQk6wAfX/k80zb2pjSkW7woW9rPKRHm5Vmka0CVJ0jKrBq3DWmaESnnZFmPPDZfZKX6PIW1f/yNp59sK9J5eV6esuIfEhyYV3YuGf0udh9PQkDtziKPOgXGdNnKfyNe7iSLDMlr1KAOzl7PkGLyP40gVchj7rScCyTq5ZGIolB4dfHnQaNJmQWcUmDbUaN2m5X7M8Wt17SDrOg6KgYGkzJXncqQ0yvLRFJcY/NSLKXZMQEmUHwJZH/SF992SoqufDM1mcxI18k3YaPRfN9bnHxtJ3SSpU+nKD05G5QaJ1v/LkRloU6WhqKrVquTrahW+TSn7cNRXXNULejsKjOgYe7opEwhJkXMpJOtFhlmFyEjT58pWzH1KVkPepNi4Y1LMuCbtSlw9ixHRa1Onx5vjd9JhJQ72s6cwzJNMospnQIYLfIQsEjk0/P2DbaWNGucrXHbiKeHh0j6+sgKSPc3X4FGo0GvUWvgEdJIsmIlwpwkW109fAJEWdXTm7PXmZEmK6tqPoVqxyHTyR9mtyokQnqc/HKbTpmm4hpQU8h7dH0F1Ws+KOKkNGoMssW4Yq1WQkaek6vceaH4nbh3ur+GN1/tjHS9vLVZnyhHCugblSkNqzcexJDJG+Fd6RFrDWaDPMxtFdhELCb5N0giQ/qd7Zu2vZ1bZbNKgzlD3o/W2Qca5aMAObfffUIeFUm+vh96Zbk0ky7WGlfLRx5boEazhSadfO7TjU7QOsnKpCigyfr9irTiJVhki2iynWkUVMxs03FNiTgopiCRXHUZ0r2DFN30mJNi7rRZnwTP8k3x8cQ18JQ6cmOGD1SL5gqpg0XCciHyyAbFb+WcneVrvV7HkaIYKY1p0cdFPEnnKELVa9KwHs5fN6hJRCWYUKGcPOfdKrSJBFWqJ1LqfHaRuEfetT0TxGiSPo8XQm+1SwdkV+qprNrJyUhLoiQ0DrLC66SMwphzTGkw2ii8mcqniMWG7JV0Atz+Uk4g77t4MTxoTw8PJCan4JEWjdGr/yjJjUa54OyKC+7jnz5Jth7aNoGGu8yp8ioIUWk+1qxrUQbUqCYrTarQ2UVW1FKT41URMtLlB7wqcFJuwJQ2aGRLplB4JYsWySxauQ6Ka5WvdBmUuackUxWYpDQzFi3fgBiPF7Bgjyd+3izv824/YGBWrCV03LQ/W2dWHvqZytQN27zbxX0DsuYVQuOUZ/EqlSsgLeoM3u/VVeTTOrtzvhuPf/79D3M26YVM9bx8sj+0LZqsjgKVMUkKB4W2zpByXSQ9/EMRWEFRZqWOhlnqRBgUxapq7SyFtlx5+fymxctr8Yoh8soVkaKTOypurjbKlKj5zjzVOm26Q+t8RorcIfIJqoZfVq7Fgj0eSKvxJRJS5c4kHV9eLbMo8x0pz2K0rxhTfmE5s3JenNz8JaVEVtyoboONDrNil6y0JEtD9eqcbGN6HNR4lLm2pMi6I/XmIckqe5I2z+ZMym/JkJm9Q6LR5D0y4eBRETfijFKHKhlkSc5WmZIwG2UlXEmC2qPGKcw5V9rBxReHY+ri0OFjGDNiIG613JiHpBBTHeWC86fwurrI3FJ0Fuw7L09BiDktjyDoM7Nfk3UeqIkrUfJ1QPuIT7EgwN/+3OnmzZohTLq30dxug/J7oe3uhbMoTG2vw/zsx1Frc7EoG6jXVYbytTkH5WU19X5rsVnLmzYx2ay9q81DgaYy7JgAEyh+BEqMwjt1wjD4envhnbdewieDeuODd1/HsIHvFBuieVk1MpLCRPuuROrh7Jb1oAiLNqFihezWVWdXRYG1+QCCXpddkXBxk62YVKmDm6y0GdIirQ9QR5u5rp7+ValYtqFcs6KQBkvKWO2a1dBn+Eys3xeDsxHyQ82gixfb3KmXkZq1vfoQUevKNMkPfUebF9DUvNuFgSFZ851V68vttqH8115+TrxENnPBH9BlZnUGfP2zs4eDOxW3OovCySqQIqkxZwEpDK7SBDWrh+J6rEFKAapl78w1PR5qXF/IyHN196cAGYr1l6ZC+Pp4QydtlpBihk/ONojSBfd0Rtkqp57bgtZgSpMV3l693hOsJn07Bz36DkFCiqwYmBQlM2e9FpuPPGgt6Tmz70lalyIPvXsoKwXoTXLnIUOZJhObbEKVOu1AIygGqRNiUZRyQ3qsZOGVp5XMXb4byW6tRfsi//tJhLaeUfkNZDrK10tqhrwPe3N4/Xx9sONYqqhCZ7NyhxAonlnqFClREZj1shWZEpnSkHzi1R0UBa3hTJHyLYdi+Lg5oN/o/97vTiK7jubst27ZFNWryb93uwWVjE7PdMC7PV4Xaz0v3CR34szKVCeNc9Y9SikOjUdWvWmGvDubatmWzZuA7nWUvtfTGtRza8kxv5b2bc9ZlBfWcubTHGuSWdvsJHNwVlZSoXNE+aozKdcVpVnhJQrsmEDJIFBiFF7CefzUeaxcuxmN6j+AalUqIvx6JImLhdMnX8vVjoyEy0J2WlKGQsplWSl1FvlhKjIVz81DtgAbbSx16oNIKQJXtywLjGeArASShTclVh5ad/YsrxZFUIXaIm475Kc+eB2dPTHr23G4HHZNYngDfoHym9f5+dqYqNSOl27ziVtzjgeROlzoqFiy7VSRp9g/SB42pkyt8oEJiufHfTNhFFo2b4zfd8kPd9rGPzjrXFBa65z9fGjMsnJOeeSM6dHINKaI1Rzq1H8ItWqG4macrBCqL0idizCgYT3Z8kvbuKvTJszplESq0UWEEzb44alPw+DkIXdYhPAuPBOcxNY3/p0l1hC+uuszRPwzDdEnFiH+wnokh++RrI9JoozqXdk+HOc3vAt6mYtkpCiGVqsBYtXmkRa4Fh6BRGkUgPLUa4bitk5VOEhGw8Q5lQKS23NG0UmLsZedTd7lhY74d/tKjJQ6uWqHzEex+BtNsoXSoKy9HClZWgf264VdJ2TmUP8sBqjTTsJjTPj4m90S/2AhS5b4qMUoNGXIyqijizzP+89jjli2K0OyCmd1Nqmc6sqXC8bWo/L1EnN6hXXVAzWfQrNRVogpTs5ks4wbWaJJEUs0+qH3V//Bu/4HmLNsH27cjMLXEz6l4rd0rSQlc93yH0AjGrcsqGRWD62C6ZM/x8f938OVWGckKF9tpGyXHFOcSFYptB7SdHKH2KTxIJFd17hBXetSZhlJV+2Wu9sM2/uiRZkqlZ86LTaKqm15k9QhMesTYY47JMRmjwYidFXm2WdK148QKJ7ZmKHEAC1kNlZBGYrwoTKBkkagxCi8tCTZxKk/Yd3GvwXjzMxMjP/2RxEvDp4hVbaU0QMz6eoO3Dg0A/QApLbdSHRE1dDqFBXO4px7+NHdS37Amg3yw5MK0oOQQtW5uGQpvMEVZOWKLFmG+DOiiEewPIeOEtWq10I8WeksRiRLD3V6qS4tJZay4ODsA7IKvf3GSyJdqXINEWaasj+YhbAAXobNy16WHA95vU6enuHuIR9nAaoVRVOUqQAOyot7QphP75d503AyXLbU0SbevtmVTUdXubNBeeS0mXoKrE6nzNU9GZYBmtdIFt6oRPlBR0PjVDA9M/v0Gm+beceUb3KQj9vHxwvu7m4kKhRnhqxI65PCxBB96s3DoJeyYk6vxM0jPyB83ySxxJi6M1Kw0mNOwZgWBYqTnBRF+sodxZf+PB11pKFsU6YrJWHSJ4kwp2exmcNLefbKUV5OF75vMs6v74XYMytzZt0ynalYIgNCZKujyaIR5c0aua0pBidhZb8Ul/U7EQUkz6AMsZerUhf/nTiNKxmNJCmQcy5vumJFdveWf6P7Lvtg5T4z7HW02rRugbAYB8TqPMUSdIlXd4p6bb3U5DjbpMQ0a+Qm/tJmkffThjDs2H0AL/WbgynTfsBzT7dHh7ZZ86lFlr4k9wAAEABJREFUoUL0XF1d8Jb0+1+6LevFX5/A0Fx7aNKoHs6q83idsv9OchWWBI4ecueZrkcpeU/+Lcp0BqrcVvmk9K2c2WY723JmfZLU+dskROsPJsNNOffOVoXXKPJUz2IzuuHkYFHFHDIBJlDMCZQYhffPbbuxaPZ4eHl5CKRBgf5IS08X8eLi0UP83Lq3xbJc8tvPshXLI6A2XGyssx5+8vxO23Z7ePmLZKaNFSLTrBMy1XNzl4+d0tVCK+Ofc1nHfz5Cj4qVZMWV8kmBoSW0KE5KT3LEQehS5Qevs7v84Bo3egimfjUGr7/+OhWDsyURZ1a/avcNdlHoFl5263SW4k6bqFYtN0WxJ1lBnM4gKzeOyst9BdmWrHBVHmyLHzfFY/GOLOuMWodrDiXcSZv9AadaBxMNMjcvTw+k6p3VzUXoLp1jEVE834Ds0yac3INFjr+vL1xdZCVVCO7SOxRTH12nxKFGx6mo2uYzVGg+AMEN3oZ/zefgHlhX1K5PzppfHvnfz0JGnjoEH5/mIF6OIpmfrw92/bkSWmXqCSkDJM/pLDbXKeWZMhIpuK0zStZyXbw8ImE7+nDbDaUCjpCv93IV5c6jyayRpECiubw4t/9dlxXdOs06CXlOL11vxoD+A0BK3EeT1sPNv5ak+EfKv9dLf4rieqVT6OUnj5Z4erjDwcFB5OXlkeJIqygs3S7/tuLOr81VTJ8udxpiEk0iz6yXWRlSb4hOigUO+H1vHPq80w1nzl0EWW2njPtElL2X3ns93sC6vYnQGbW4eMOAkEryqBBs/milhkkrYtB3+g0karLuL7Dz5xUkl7mnFl5j1n3RUiALb0aerTamxyLuwh8i79edSWhYXzYmuHt4CZkmU+7cGtNjpFGTDdCa4oWcPSbABEoWgRKj8Lq4usLJSZ6vqCLWQKNG72tI8zepAXRDpNDFuzL8qj8Ft5o98PqEa6hW73G4Kkom5QdUqENBNuejWgTNWTdl1dKYKg0pXok0Qmtj3aweWgWrdidb6zh8XofqNi/C+fv5IirJmg1SevRp8oPWzUu2RlKngZa3atKkGfaeThOFLZIiY7D5hK4Q5tOztU7ntKaoeV7Kl5zyWaW1WIbZScSdXWWlRiQK4D3etq2kFCVgx9nc23vaLHumVqkqJZRWFTQnH/lhTjKNqx8FVlf1gVbWOEUCQ7Jbyzx85U7OsEF98Ovi2VSkUJyPtxcuhicixeyPSF0QLidVgCakI8o37Scpvm+JfdC5p0jc+XVCwaM4OTrXFOpzvKzkLlmgNQ4yJ5M03EtlcjpLTguvMkxvkCypFzf1RbSdtW6Tru22VqW+SGYV5BFZpazSMOHrWSKXpl9QB4YSpkz59mVyqSbObYJZti6+3uVlLNyagLX7knBKsspTWXJnw/WgNaonfTEc18IjsPdaJRJDjMj8OxP0+zUryqh/kHy+PCSFt0K5YFHOnvdip45Ysvk6zHCDPumqUGJtyxp08g8xOkUrxCaFVcKlLSK976wFtWs/iG8njsL5o3/jj1XzQXNzReY99GrVCEXjh1qg7eAL6DopHFVCa+Xam5imEG3EkYs6BIbITHIVshFUCG0kUnRuCzLNRWyUT8/WwqtLle9p+dlUvQflLJtwZSvovJ8IM6DJw0/DT+r0URkPT28KgEy5A5wcvlsaNfkeLpnytBc5E2I9YzVuN+QMJsAE7jsB+Q5835tx+wb4+Xjj9Dn5jXeazvDTkjWoWf32N+Db13x3JQ5f0EmKZxI2n3BElcdGw7Xp1zivfQ1L97vg8x/2gxTVxx9rBQ9pmIzK/nU0FTXyeMHExy9QNMRBYxAhec6KpbHrN2noOzsJDs7KDVjKrFa1MnYcT4O6FFmCOQS+EiMpy/p/JNwbf5yULcek9JgU5cVTaou1kBIZtSgZ5xMqiJRJeVNdJArgaSyy0kyb5JyOkWmRFXkfv2DKLrAzK0P3zm5eBd6WNmjX5mEKEBDgJ0JbLy8l3KRPtRZJiz0n4hVrNBMheR7e5SkQ7vTVDDwkDf2KhOJ5e3mC1i1VkggsX1NEaTpEq+ZNRLwwPPWch9Z7BI0efgZtnn5Ncq9i2OiJ6PTWSLELffJ1abg9FdEnl4r0vzcri9DqueRm4qS8RGmWhnut5WwiqcnZH/oZiZeEMn1l+0ipc3UdMaeXQ+0o2GwGW4U3IyXCNuuWcYtZL/JTdFmd3KPX/SRFNx5uPvK5UBXhCuVDcCqxNiYsj8XpiKxb3NajBlCZRx9ujmefaodPv16F4Jaj4BHSWNRNHyhxsMidyJAK1YRs0dxvsW2DzE0I8vCe7dgOgdJ1teWYWeTGnlsnQtUzKS9B6szytWvKSBRZ6pq8P28MB1lbSZjzZVaS3Uun7pf2YW/fpPTK+SEU3NLVe7AWyFpMhWLP/kZBoTtbxTVDsZ7nZydqBy9nWbNyX1z2dzze7S6PdlEZrYMzBdBmypb5lBuHRDqnZzHLCnFOeVGlc3Y+i2q/vB8mUNIIZD0NinnLPxveF79t2IZTZy+hzXM9ER4RiUH93rrvre43QxqWdG2A0T+eQ9VW76PhIy/h1e4f4LPx34mXwvr36QFScrz8K4PKfjI/Ki+FF54+QeJYHDXyzVVVGGnuKi0qT0OnooCNR0rv5C3l0eLDS6hQu51Njhy1uIVi4z+yYkIKb6YyR9fbT96XXEr2/fx8cPZylEgYlTfVRaIAnjYzw1ranOONaK1FVlj8/G//0LRWYhM5mfiAGFZ1DZQtSDZZ+YqSJXT2d19i7Kcf5yrvG5h9+gEVMCtr0JLFDhYDrkUb0KhxlsLrX04eVqey52+YUFd60FPc1qUq845pKL1S1dzDxbZl7zTeulVTfDLkf9lceroOs+Yuwo1YHVKk0QFTRgIi/5sHsox5BDfA5MUnsu3Ow0e2jNoKXTzkjlJacqyt2BrX6+QOwamr8nmNv/gnrvw9CrQvtZA+6ZoaFSGNHNCasyazRuoMmGGRlGlqk8i8jWdR5k2mG5ysJc/Hl5MU3gR4+8vtJ0VXzRw9/EPBpFKoPDxtlPZ5Q5d1nr8cPQRx8YmYtXQ/yjXqKTaLu7BBhElpZlSpmt1CLzLsePTbHDqwD2b8KneM6GtqCZe3WkurCprWTe7spSXHICXigLAqxqe74HK0Fq+90slavigjLz3/FIKDAkD3Env7baJ05ircYg1eddsHH6iJFTtlhT765C+glynVvLsJqa5TKzrh2p5xMNu8H6DPkK/D/NSt3lPVslejshTVxLRMhKeG4OEWD6nZ0GgVhVcjXavGNPGhC2umTUS9Nm1ERRa1SCzoJVSdMk2oyHbMO2ICJZCAtqS02Vcauh01+H1sXDELa5ZMw+fD++WyaN6vY3mp81OgodIXpaFNGi7dvmGZWBN2z5ZV+GrsCNEsH6n9IiJ5VSrLllQpmu0/XZ8p0nRjVhWuDKMGIcGBcM1j3idNa9iwaZvY5sl2j4rQ1qOH2KH/LoKGgTMlC5lrZrzI9gvIvf8AP18cP3dT5JvuUOF1USzSVElajhd1nLSy5TogxwoJVDY/zsW7ihhW9faTrXn52SZnGfogRNMmDXKKERBc1SoLj5OjZmW1DJ2yrNi5CBPq181SWitVlRUpKp2hyd2BILnOKP+8aEWHezVETda3T4f2h60jiyRde/SVtquRMnf6XC21KULzMMKux0Gnt1BSON/gLOVdCCTPU+mA6dMUIJLM9t+gWMCPhbvgeqwRJl2ssPCStTSo3puiKHWyRETxkq7tErE9p9IRFikrG/rbWHnVVRo+7NZCbGuEmwjJc3GVFRJfX29KwlYhIys6MfEIqi8pxfGYsioB1arJVnYqTL/Xd3u8junfL8Azb41GRKKL6BBQXlJ6JgUFcu/1eAMOLv5Y9Y+L2O7GoWlIjTwq4hqLPOfUK7CGSJOFl+b4U+KXvyLxRpfnrXOoSVbUbuvvS7B/+xq7u31Curf07NYFNWvcvhPg5emBI+FeWHtc7lwkXNqEa7vHge4/dneQKyO3ID32tBCmRR2TOgrJIk6e0Y7CG3t2Nc793kN09KgcObUTvv6QQRgJFu73IbFwZN2lcygSiqdxkDtXDppMpNw8rEizgnSD/Pu+22PLqrFgMYukhIftGI2MhEuIvUfW9IK1iEszgeJNQP7FFuM2Hjp6Erbu7IUruHL1ulV2v5seKA1ldn21M47s+QM/z56CAX17imWw7LWL1ta0l0fKLeXRG/aJV3dQFHqTFhM+H4YF338t0rbe1Mlj8FjrFiBlukUzeVjWNr9aaGUx1GpryaD8gCDZIkZx1b0gKevpRkeRTEuKFGFBPFLSbctnpMtWHpJZjLIVJiktS8kieUHcG688j02/LYS9zkJB6spZ1l9S9g+cTQdNOUkxuItskzLMqVMsJzRHVmQoXs1aDyApzSxSnkEPiDCnpy6XFZOsKVKFhqbMkFWuXEgQwuOymPuGdsC4aatFM2OT5bZTomIe1mcvvxDKgjn9Bkh5EAkbz6QM03t4B4gpPZTlVaEFXOsOxCeTl1ES+hxL9dEcSMrYdCgJ4TGywktzPUl2O6dajjOVucVU3t3NTax40ah+HdHBJMWR5LYuoGIdSeFNwNq9cSBrpm0eKcRarVZ8nGTP8SxLdppB/h3Ylr1dnKy8wwb1xeQlp5Hu3lQUD987HhmJV6BRRjcqhNYT8kxDAtTh8d/3J1qnM4jM++CJEShJUbW3a+rI0zKG6vQZe+VUOU1rWLsnGtXaTwStbpFy4yBoqovaiVfLFSRMjz0riltMGUiKyFI+VSVWZNp41Nkw6eKsK5FQVkqS3HlT36cIrV4HNP0iOd2Cjf9moOtrL1Axq6O2U8LJwWw9XzTSQzJyGUYHCmAxG0RY1F7UiSXQKR3y5PA9osNZ1G3g/TGBkkRAW9wb++GIScjpbNP3u/29e76R7yb4+frkOZ1BrcAgDbtSPPbsKutLP6ZMJ7FMVLOHGlJWNlc9tAr+XLMQq3/5PptcTbR77GEc3bsRMSlZD3CDMRMaZW6aWo7C4dLD+uPBQyiKjNSsh78Q5MMzS9YG22KGjCwrjEmxBqYrKy3YlstvnOZe0hqx+S1f0HJjV2SIKScZDrKilx4jf4UrXVmSzM0/+ws99MLPkyPDhKUoNMcLa+q+DZkuIqqzyEq0SBSxl54pWz81Wif8ecIdu/f9gyEfvo8UvXxNJKaas1k+1eYFBMqdIq05BVHH5mezqlEZo/K1qTp16mD9gRREG6vCuXY/PPVCd+w+fJWKID1BDilhSLkOUv4MJg3CErxgVJZpo5UKzIYUkUfl7DmTTp6a42jzcRUaPYm5csTeJkJeuaI8IlBJCmnerhAqXkhQIFYv+R6/Lf0BRy5kzT83WFyVEgUL+r7bDXSdfrEoHF4VmoOUs6s7x8BFK0/1qVJT7pRqYRQVH7iQiRq16oIUdiEoJR4ta3f67AW8NXAmnOsMhqOrr6SYncflv4YJJrc7TJM0WmK/9Y8AABAASURBVEDXhVpOJ3U6M6URKms65j81KtWXbo3bRmjeOqWNadHQJ4VRFBnKfF9Pb3m6Tp26DcTLek+MuIIOHZ7CrRT6lBv/gP5+2Z5EgXAZJtkCnHmfFF6TMhLn6BYg2hN3/ncRsscEmEDeBIq9wtu2dVM8UKsaPnj3DWxYPhP7Ny/J5vI+rKKTjhz8Qb53Rg9Xstba22D9cX+s2O+IgNovwLN8U0TEW5Cfh6/tvDPbumlpMrJeWpyzhtyTdbYlssdDystD2xZD1k09e4ncqQt/vI8LG98Hrf9qm2s71KhaeA1m2SJiW664xAP8/YQVNt2ptmhScsQB6WGqk4YLL4p0aO2WIrT1yJJK6Yca16cgl0s0+AircbI5MFdeUQnizDUxZ4sZjtV7YujY2ahftza++HQQdGZX0YSb8SahpImEjRdUPhQ/bopHmllWmNNzfEXMoiy+X6vmg6hUpTqGzwvHk53fwo3IKHTv2UfUZNZFW4eyk5TVGbYfTcaLzz8HR/cQUUYnWajOrnkTlzYPkKy0x4TM1lulrNIw9RfZqufmmXUt25azF69auSLeefs12Pudtn20JZ7q0AZhsVnXpkXrYa+628pnfjMWf+/aj+X/+MHVt5p1TjNNVyoXHIS4ZJO1jl+23CwM6661vuISGfpRH/R77y1s3rYLDdv1wuawJnD2qgjq9Nw8Mge3+qOpHud+74nrB76xFlM7n5HxckfBmiFFLCa95Gf/t0hWYFKaVakuVu68GvXySFPVqtXFaFGnpzuA7o9U7t0er1OQy2UoxluL1KGPiDXCwV/utFBBY6Y8pcZio4yTvKic2SAbFYLqdBG7TAzbLkL2mAATyJuANm9x8ZFO+mwQpk0YDhdnJwz/fCoGjvwKm/7agwy9ofg0Mp8tadm8MW41pSHRFIS1BzJQrklvVG3zBXp9F4cD0Q3yWbv9Yj5BNUUmKbtbTrqJeF5ehcpyOcfM1FzZ+qSr4qUNszLUTwXiL6wHWWJoWDo54iCJrE61+NKDgobeKMNglq2KFC9ujh58tIKDq3cF0KoL1O64c2tEM2mN48ZNsh50Qih5dC493N1B1l4pmev/qq62sBrrXOrkyisqQeVqD2D+hjC89+kv0Eu/mflz5KkxmQ5eogmpRvmhLRI2np9/kKTwJmDzv3LnR5dD4VXXiHb39BZDwafOXMDNqGisW/4j+vfpAWJG1amfa028upOS2Ho0Fa93eR7e/vJKEepQNWVG/jePgjyd2ST31Lz8cs8/z3MDReju7oYZX38BmoOqiPIMWrV+HJGJ8jQPRxsrcp6FbyF8+om24hPNX0yegzjP56wl0xW9LDVDI2RJOgexgsRrL2WVERmlwPPx9sLX4z/FPzt+xyOtmmHkhHn4YPpVZGqckHhlG5KuyddCXodqTIsSYvUrlZRIizlFAVbukq9FkVA8bY6PxJDYkGNeeNzJBUgO3wWDMt+XVsSh0SKajvbow81BFnaa803b5nRGS5Zk98k09H7vPdBLwj1nS49OadSEcm2tz5QuKmdS7sWPvzoKqUY3mA2pUqcxy/pdVO3g/TCB4kPg1i2RfrW3LlAccn28PfHai09h3rTP0aXzk/hm1kIsW72pODStUNvgIz0oLl25Co+QOsIlJiUjQLI83u1OqtRsgmlrY/HcqEs4nxBstzpvL09E51gcXy18be9EhP09EvHKAv10k48+tULNRnrsGRFPSJeV2kxTuphTdmnrYMn6+y8S0yw4GFEwZUVUWERe755vYtD/3kVQgD/+kpQy2m3s2TUU4OJNM2pWDxVxW2/VkjmIviJbHm3lapwUaIrfqxfWqO7buboPyFMxDh89gYmfD7OuJpGirSYptPE4Hxtot4qKFcphz7GbIl8Xf06EVs8idzjdPXxB86tdXJyxavEc8QU/cR1HO4iiN4/OlYaUrwrrHlnLovXl0KDuAwipVEPkmw0pIiQvI/GKpBD9RVGYdHG4sn0E4i/8IdIWZdjYL7iSSBe2R0uL/b4vCev2J8PiLnf87nQf48cMFdOQun84BY4eIaIavVm+1epM8u9j5Y4YvPnqC3BzcxX5pdGrV6cWtqxbjJ9mTcal62n4bm2iOEz6CqUxPUbEc3pJcdeEKNNitI6upMfI95b950xISsuykFNBbaZ8HVJcdeqLkFsOp2DRzkwhvvnPt3DMuCzirtI1KyKSt2z+dOzb9psUy/vfbJHPG+XSOtekIFOcOlJG5QVKmi9MsqJ2Zr3820lKM2Pl9gix+6TwPSJkjwkwgdwEsn7NufOKjSQpORUr127GOwPGYO6iVfjg3dfx+ktPFZv2FVZDPuzXEysXzhIPiGmTP8OXY4ag3WOt7rr6eg2bg+ae6Y245fJDtKNUvayoGJU5kyQj5cOQcp2ikpVXHnamtUbN+kQYLc5CblFeTFOHwJ0zk3Fpy0dC0XH1q4H+3ydBr5Uf/mKDYua9/konkNL7aOvm2H1afohaFKtihtZ+J+FWh0FWY8qvIg2rU3g/XH1JufSQrNBkafuwXy9rE9wD6kgKbwKM7g9YZTkjxKPlY52FOE1Zi1gkJE+jKLweXr6oUD4Ee7euxuM21+qxmBqIiM8EWYav7h4nbQFs+y8Zb3SR66tWs4GQqV6M0tGKOr4ImdIQsS7+oviAwyOVL+GfLYvQ/RG9KFqugrw+rkjcgWdvkyfbP4Z5fyZg/LIY2HsJ0d62OeX0AtviH79DdEws9p6W221UPpyy5J/yeG38NSzfkVQqpzPkZEHpNySL/oqFM7F8WySuJQeAphykRBygrFxOlygrbpSRHnce+uRwyXKZDLo+Xu7STaxrTnmqc9BmV4BJTttQeDXaiJmrLyPWvSMl4ZiZLkIPTz8R5sczKQovrWpStW57sclDjeujYb0HcdNQXaRpPWWyropEEXqmjHixt/79P8S+s/LoRPL1fULGHhNgArkJFHuFd8QX3+HFtwfi3IUwDOr3NhbPmYCXOz0B91JoGaE5oc893V5SCp4XD0OyODZv2ij3WSugpHKlCsLytnz+DEweN/KWW+vMLiJffSGCEqlR/1EgHC0LRDfa2DO/ivTg7+UXQkRC8tKcZAXKUWOQHlSp8KrYCon+b+P81XjrfDmpWLH9Jyt3q0c64MIN+QFCDfUMvLMpCc90fBw0p5MejlTP/XBVKlcQVuilP0/PtvsKFeTOR/XQKtnktomhA99Hp04vIjbJBLLYX9k2FDcOTUf8hQ1w1MiKnJuHj9iEXlQSEcWrU6cuJi+/KVLGNHnVj7+OpEIdwq9WrToSUrIY/7Y3SbKkmyCurbO/QZcgz52mCgypN6X9GSiK8hVzW9pFxl16tJxWh7aPiFpslzcTgjvwiActUfj14uOYtCIGu6+WF7XQEoNhUUbUqdcQZAEVwjLg0X2s22svYsHvsrWWlFnk8WfRy0ocZdGoQroyneHoJR369+mZS+F10trMOaCNJKe+TxBaqykeqFUdz743B2d0raUcIFVnhqdvOeT3z5LpIIrSCi7PPPm4iO/e/KuYJmN2CgZNc8iURh8SLm8ReUXlUaeB9pWWYUGvt15Fy8eeQ3isEWZ9smSUOE5Z7JjA7QiUufxir/Du3HcYFcsFIyIyGrN+Wo6+g8dlc2XujN3hAW/9fQmef/aJ226dbvYRZeIvykPJlEiNzFJ4KR2+d6JkpdHhcpwnDpzViXVYSU5WEMeAxjhyUVZOAuu8hvm7PdHmubfFcmKdnulAxYq9o6Fm6wc7DBbUqNf6jtocEhQoHkblQoLuaPvC3CgwILtVi+Yt0gcrbK2yee2vgWTJOnU1Q2TRtBV6sN888j1cHIxCpnV0EWFOr0fXV3D6hiNuJMq3mDSpCqNkTaYXKamsp4c74mwU3poPNsaUlVGUhRipM6UqLSTQxZ+nANHKHFuRuAdej26vgNpdvZr9TkBBdvt+r65w8qyI3/YmQwd5lCAkWL4WbL/oVZA6S3LZcWMG42qsPIdZF38hz0NxQppVnhJ1Bur83QRDgFhi0aD1t+arEYtRttyqaV2yfB1VqN4YO/9ciY6S9b7H8MV4Z1oC2g8PQ0jlumrR24aWTPn6PXZVg6Y51vB2k4wuNHJGlSRd/ZuCInPqVKCkNLPg8qY0crLlX3mKAy1RVmQN4R0xgRJEQP41F+MGT580AgP7dsO7b72UpyvGTS+RTbtpqQd6k5yW4aEvRtFBpEYeoQB7TskPI1J8SPDJD6cxfFBfhEWbKCkpv+l4pPUjmLjWgpEr3PDiR2sweeoPQonYJT14GkjD66JgMffoIx5HrjhhwV/JmLo2Dk0bNyjmLS5482j5LFqHliyRdreWMuihvmCvN77ZEoRq7SehYstBcAuQrfhSNrROnhTkcjT/d/qUz/HdqghEpJfH5F+j8PrLnbKVSzW4WNP1GrRA00dfxN/HUkEWM52i5G4/5Ygn3/sJC3ZJqpBBnv9q3aiQI6+88Azoa3z+fr6FVnOvt18Vdfn6eIuwl2SNm/LlJ3il89MiXZY86gC+1q03MqROJE2RyqmoZiReEThik+XOlDn9hvXjHd7lG4o89eMdlEhKl5VndeoRyQypNwBTkvjYTq16reDl6YFl86eDRitOXooHTTehcvl1Gy/WwesTrsEpqHmuTZ5+oi3O39SApoFR28W+c5W6tSDu3FrQvfbWpXLnmvVJQphu0IqQXog+EyX/FpN4Hq9gwh4TyElA/rXklBajdPMm9XErV4yaWiqaEhRSCdPXxYljuXH4B5DiQTfXqAQj1h6RLLrn5IfRP1dckCZZg2lN171h5TB+WTQORwQiwN8Xvt7e2Lb3pFiiil5kIiWCLHqi0hLiPfPci5j9ewx2nXUEKW8lpNn3pJlNGtbHn7tO4bsFOzDr1zNYe7w8Dl7UYO5fuYeTbRvQ5cVncfamO14asQebDqWCFErbfKPGw5r0D6mKMSMGYtF2eaqENcMmolfmi9uIin20mzSMTyMr7dvKowRk4f6g99ul+mW1W52UFzt1xPnr8giQLuGStWjC5a2gpelIEJvihDPX5OvArE8U0xCatHqSshBauwmS0824cNMCnclByMxGnQjJS4uWP5t95IIOD9aSX4wk+ahhA7Bm2Vzs3LSSkvl2zm6eYhpFhw65R8cqlA/BpLEjsPmQPA0jOXxvvuulgjSKEfnfPFzbPVaMmJEsv86kl625BmVuOG33yOPP42q0QUxrSI+ROZCcXeEQ4FpKPoFir/CWfMQl6who2sGuUxZcT3KHSRcrbsZ0BIcvGfBG1574cNY1rD1XH2Pnn8Nnn3wkvnRVvmoDrNufgloN2lFR0FA5LQP1764NoHmsQljCPPWrS82ayJalEtb8Qm1uxw6PIbRKJfyyci3mzFuC0V/9hAHTL+LItSyF1d4Ou3d9WWQ98fgjCAr0F3Gr5+RnjZarVEt0lt7vNxArdsrWK2umEjHbKMiKqNgHdMzL588Arfdb7BtbBA2sHloFV+NJlTYBAAAQAElEQVTkx446UhRzegVuHJpm3bsenohOd7emj17KwMPNHxLphk1a44kRYZi83hXmTCchs5iypjSkKQpvtM4/V6eiY/vHxDrUYqN8eu3aPAy6J7ZX5nfn3Iws9ieuuwixalklay+1w2yQlVKRmYdna9k1psflUcK+SK3bBHnfVPLNVztj6+FUiiLp2h4RsscEmEAWAfnOk5XmWBknUC44CJ9LiuzHM88KEqYMeSmhFEsFdH72CTxYuwYmzFqHoPLVxVQFKtResl7Rcj1kyaI0PSDoU6T0sKd0SXQ01E/znr8aNyKfzS+9xcgyS0s3nT70F66fO4AdG5eLgyUlWERu4fXo1kVYdod/3C9XKTfvYCGjeYjlK1QW8fd6vIE9lwPRd/oNfL0qBu3rmbCwTzp6tjFC4yRPCxAF2SuxBDKcQkXb6eXHG//ORPSJxSKtehZHX2g9qqlJJBr8RceaBPQSGk1T8PX1hgXOJIJFsfDS6h4pNw8LWWDVZiK8W4+U5BULZuJWI1R1mj4rrM4ZksXakBqJ6we+Fks43m7FhGwKb5o87zi/7aWX00RZR3kaA8XppedIfUWK4nb7FoXYYwJljAArvGXshOfncGnI1SugOn7/N2vIOjC0Ffx8ffDnmkUgZXDiF8OtVT3VoQ02r10k1le1CktBpHXLprf8FHQpOMQ7OgR64/7Mv9tAS2/droJqVStj0dxvxSohOct6+soP53jZKGXNnvTlZ7gY5YDQ+vIwtprh5J7DQqxmcFiiCFR8oJ0YeqcVORIu/Sna/sNWoN+MCPxvZgRiHVugXGhTISfPq1wDCqxu4+oFmPLlp8jUytbNsB2f4vr+KYj87ydYJKvqySs6NH84+7Vj3fgeRF57uRN2npDfb6CX1/RJV8Ve1FAkbDyjpNyG750Ao81axLZxtSgp8Go8Z6haeJ1cs3cC2z7xIsKiDDBlJEBd4SLntkWS5p0wgWJIgBXeYnhSikOT6IWjKcuuYM1hZwycfQOtHn5MNIustn9LFj51CSchZK/MEaDlzu72oIOqthBfrfp2S/aXxFo0a4ybFw9h2LBR2XbhoViEswk5UeII0IjQ0u3KtBWNI8YuT8Nvu2Nx7oYWh85noGL5EDRs1hY/booXrkGLZ2H791Dj+mJJt/O6RtbpL0nXdiL+4kZRbMmOVNCX1ESiCLz6dWvjYqyseMYqX2ek3SZFZy2tR2lyNG/34uYPhQWWPmpxPdZAYkn5jRah6iVc2oSbR39Uk7nC1OQYIXNxz/7bodGYrUfkHqQ6xUIUzOEZUiJySDjJBEo/AVZ4S/85vqMjJKXjjVdfwcSFZ3DsGkBptSIaUlTjdxjyZkwAtD40YbC37i2tELHhiBY9fnAXqzR4+xffL/XRcbDLHwEaeg+s8QQiYo0Y9EMUwhK9cWD7GnwypD8qVSyPBx+oieqhVbD6QKak8CaghZ21yF09AvHN6lhsDG8D/1rPi51fiTLBt3JrES9Kr07zF5Cut8Bis0SaMek8rmwfgcijc0VTYk4txdVdn0ll0uAeVA/DlzmJ44P0lxgr3WSlkP7jzv2GG//OQkrEP0i8shXRJ3+BIeUGZVmdLjlWxN29s38pkQwSeld53XB7L9FRG8N2jrmj1SHETtljAiWUACu8JfTEFUWzx44aDFpK6I0u8sOkKPbJ+yg7BMqXCxaWOPoKnL2jPnbNSWTRKg9BVeUXl4SAvRJNYOTwQXhnahT8KjfF9j+WCUV34Ae9cO7IduvUqPGfDQV9cdLeUmJvv/EyPu7/Hj6fMh/P9F+LRf81wOeLb+J/73cvcjb0QZU9J9Oy7VeTaUJ6zEnEnf8d9NGW6JNLRb5H6AsYuTgduw6eRtXq9QAAuuRIkUfKbdSJJSJuyohHxD/TEHNqGdSlIUWG5Ol1iZIPePuGiNDWa//Uy7gSSdMa4pEee9o2S8SvH/wWNK0i5vRKkWaPCZQVAqzwlpUzfQfHGRjgh8snd2PGlC/uYGvehAncnsCm3xai33tv2S2YbA4QeTqDRXS+RIK9Ek+AOtKrly4AvRDm4e6e5/F0f/Nl8cXJPDMlobu7G8aNHoz/9m1ClUoVMfPntfAIfBCtmjeRcov2n0YrburK2d1peuwZOLj44rrLi3isx8/4e+c+sebzgP6D5G0yIhG+d7xQbmkd6rDoTFmu+PrkLAuwqEsfLnL8g3KPenR6ugN2ndSL/OTwPUiLOibm9JIg7vw6yXJ8gKLQxZ2VFOJTIs4eEygLBFjhLQFnmZvIBMoqgRlTRmPZj5NxYt+Gsoqg1B43fSyhMA6uVo1Q/L5ynvjAxCdD/lcYVd5RHXWbd0ZSmhmXbuhx9LJR1HH4gg46QyacA+pj2rYAvNznG/HS76Gd68UqN6G1G4lyjshA8vX9gIMrvvzVhMkrsk9hSIg6J8rRi3A0LcIBRuw4loryNi/3QfmjqUAOfrLSnxS+FxGHZuDmkbmSgnsGkUd/FKX+PS8v5Ra+b4pIs8cEygIBVnjLwlnmY2QCJZQArfJACg1Z80roIXCzC5eA3do6P/skaMUYuwXuccYLnTvhyZFheHPSdVwxPSyW1pu0Kgn9Z0Wgcbd1WLRyCyZ+Pgxb1i2G7UufcSmyNdfk4Ie3v7qGXccT8OiTXXHgbBqOXtSJVptSroNWcgjb8SloDu6p61p8tUZvXa5NFLLxnnzuNXlagy4OxrRIJIfvRtiOMaLE7PVx+GR+FCITTLCYZcVcZLDHBEo5AVZ4S/kJ5sNjAkyACTCBe0/Az9cHgwf0xqdD+6NOgxY4Iimrw4eNRFSqJxo3qIsje/7Ah/165WrIrO3+mL4+FU8NOQx3vyo4+Pda0PzlUYtT0Wf6DSSmmuEAvXgBjtZFv3BTg+HzIrF2mWytzVWhJGjftjX2n8taVlISwWLS4dBFMw5eC8TKpQvR+bOr+Gxl9jJUjh0TKK0ESp/CW1rPFB8XEyiDBFat24Jm7V/DxO/sP9zLIBY+5GJKYOyoj0HTKrq8+CzSos6IaQvL5s/A3r9Wgz6akVeza9dpjCVbo/DmG29iz5ZV4gU+Kjf1q8/w1dgRiExyoKRkqY3CpahMDJsfh3WrFuGhxvWF3J7nXOFxfLY4Cl8ujcaFCAPiUjX44pcoLF8wA/SiKLUzPCrD3uYsZwKljgArvKXulPIBMQEmwARkAuzffwK3e4mOXrw7e3gbvps0OltjX3+lE/r36YEEs7wSw9VoM0YtSsH6VUvQsN6D2crmlXjppS6g1U3OxQVhnKToDpp9Dd9NnoSa1UNFcbJE79++RsTZYwJlgQArvGXhLPMxMgEmwASYQLElQKs82Gucyb892g+7jNFLM7BWUnbtWYpzbk9K8aXju7DxtwV4tVtfPPHcm3ixU8ecxTjNBMoKAbDCW2ZONR8oEyh5BLq80BH/bl+JkYN6l7zGc4uZQCEQ6PLisxj3+Sj8vnqZ+CBHQaosFxKEcsFBGPFxPzE9oiDbclkmUNoIsMJb2s4oHw8TYAJ3RoC3YgLFkACth/5+r66oWMH+Or/FsNncJCZQ7AiwwlvsTgk3iAkwASbABJgAE2AC949AadwzK7yl8azyMTGBUkKAV2koJSeSD4MJMAEmcJ8JsMJ7n08A754JlEwC3GomwASYABNgAiWHACu8JedccUuZABNgAkyACTCB4kaA21MiCLDCWyJOEzeSCZRNArxKQ9k873zUTIAJMIHCJsAKb2ET5fqYQG4CLGECTIAJMAEmwATuIwFWeO8jfN41E2ACTIAJMIGyRYCPlgncHwKs8N4f7rxXJsAE8kGAV2nIByQuwgSYABNgArclwArvbRFxgaImwPtjAkyACTABJsAEmEBhEmCFtzBpcl1MgAkwASbABAqPANfEBJhAIRFghfcuQVosFmi1WhiNBna3YODo6ACLxcyM7DDKzMyERqNhPjn4vPDs49i/eQmG9O8BZ2dn5pODD913nJycmEseXIgNOQcHLTIzLczIDqO7fATy5kygxBBghbfEnCo7DWUxE2ACTIAJMAEmwASYwC0JsMJ7SzycyQSYABNgAiWFALeTCTABJmCPQJlUeA/8ewwDR35lj4lV/lbfkYiNS7CmKRIZHYuJ383DM6/2wxvvDcXCZb+TWDiT2Yzx3/6Inv8bhfcHfYHrNyKF/OjxMxgxdiqeeKk33hv4OXbuOyzk5FH9/YdNwDsDxuCTcdOgy8gg8X1zPy1Zg7f6jBTupe4f4dTZS3fdlsJmduzkOfTsPxpv9/sE8xavvuv25bcCOr8PP/UWvpuz2LrJohXrMXfhr9b0nUZudY3YO94/tuxC74++ENfV4NFTcOVqhHX3K9duBl2/3ft9il37j1jlRRWZ8/MKzF+67q53V9jXztqN2/Gm9Lul85iQmHzX7ctvBXTPoX2u37zDusl/J86CZKt+32KVFTRSmNcN8Rgy+mu0e+FdTJ4+v6BNuavydB2/0O3DbHX0Hz4Rz77+QTbZnSQK+xr6euZCPPfG//Bm72F30hzehgkwgftEoIwpvHdPWavVossLT2LTr3MwftSH+HXdFly6Ei4qXv/nDsQnJGLBrC/RpfOTmDT1ZyF3d3PFkP49sXn1D+jxRmeM/2aukJM37Ydf0KpZI/w8Yyy8vb3wy68bSXxfHCm3a//Yhm/HD8WSHyZizpRRcHN1veu2FCazzMxMjJk4C8MG9MT8meOwffc/oIf+XTcynxW4ujhjt6RAJiYVrrJk7xq51fGGBAdg5uSRWL9sBmrVqIrv568QR3E1/CYWLV+PH74dg8mfDxLXW4beIPJKmleY1w4de0hQAMZ+0h+BAX6ULDKn0WgQWqUitu08aN3nX1K8WtWKYu62VVjASGFeN7TrZzu2Qe+3X6FokToJDzw83Kwd7KTkVCQkJN0VG/UACvsaalivFsZJ15BaP4dMgAmUDAJlXuFdJVlXbC10ZPk9d+GK3bMXHOiPWtWrgv5qhFZGjWqVcSMyhpLYe+Aonn3yMRFv36YlTp27hLR0HR6oVQ2B/r5w0GrxaKsmMBqNVkvu3oP/4bmO8jbPSdvuOXhUbH8/vDjpAVNdOiY6Rtp/uZBAVA+tSFGcOX8ZfQePE1ZVsgLFSYo9ZUyUrN1fTP4eZKV+/d0h2LpjP4mzOaqvsJiduxgGd3c31H2gBhwdHNCxXWvsPlA0FkyNRgNHR0e88Ew7LF/zZ7ZjpARZksjSShb+/w0dLzpCqWnp6CxZrkhxpTKkeD7z2gcwmUyUtDp718itjrdZ43pwcXYWnZJHWjRBVGyCqG+PxKPtI83gIXGic/igdP0dOnJS5N0PjzolqkWMOivEhNpB186Eb+eBWPX44NM8Oy6Fee3QPh9u3sj6+6V0UbpKFYKRmJQCOn66Hg4dPYEmDetYm0BW8ee7DgD9jmxHLojT2CnSb0yyeP64aJW1PEXu6rqROrO2142frzfaP9YCbm4uVHWRuw5tWuGvnfL9Y8vf+0D3ULUR1Il7SIVUwQAAEABJREFUtddgdHt/BPp+PA6XwyJE1vcLVmLpqo0iTh4xXLZ6E0WtrrCvIbrnBPj5WuvnCBNgAiWDgLZkNLN4tpIsu6QINpB6/NTCmLgEVCwfQlGhjJULDkR0TLxIq96aDdtQU1KYyXJKyrCkQ4EeNJRfuWIIYmKzlyd5UbkWD9VHhl4vpldMmbEANORK+zZbLPhi8hwM7NMNi+dMwJPtHsa073+hLOEMkgI/fdII/PDdZ5gtDWXTA11k5OHdLbMoiWfFckHWmolZVHScNV0UEbLwb96+T3RmbPc3Y+5S1KldQ1j4n3niUUyc+hM8PdxRu3oV/KMonDv3HkLrFo2F4my7rW3c9hrJ7/EuW70RLaXzR/XExMWjgg2jShVCEB1btIyoHaqrLVmff1v0HZbO/QpVKpXDst+yFBKz2YzpX43E7K9HYer3S9RN8gzv9trJs9IiFrZ/rKVk5T2AQ0dP4qGGdaHV0AoCmaIVT7V/FOuXzsDC2RNw8swlHP7vlJCTpzcYMX3icPTu3oWSebq7vW7yrLQIha2aNcSBQ8fEHskS3kEyGoiE5Pn5emGOdI38MncS3n37JXw9a4EkBTp1bIt1m7aLOHUitvy9H52eaiPSeXml4RrK67hYxgSYwO0J3Erhvf3WZbhEYnIKRo6bilFD+sDX28tKQqPRWONamzgJj586j18ka8SYoX0oKRwNt4mI5Gmkh58U3Ld/Gq7//pvRGPZhLzg4aPDxqK+xcesu3IyMBileNP2ir2TlXb3+L5y9cNnazkdaNgYdB3GoJSl3Fy9fs+bZRgqLmUabxRgo+kuYLKfPdHgEq9ZttT08HD99AaQMk/C5jm0Qdi1CWHKfeLyVpOQcJLGwgD/5eEsRz8vL6xq53fH+8usfSJSGgN956yVrlRppNEFNaDQaNXpfQmdnJyxa/js++mQy9kijIJdsro+HWzSCg1YrrNFk/bTXwMK6duzVX1Tyju0elqyYB8X18ETb7NeB3qDHd3MWSb+7KYi4GYWLV65bm9W2dVPQb8wqyBEprOsmR7VFmqSlC+s+UBN/7zkErYMW/n7eICWWGuHq6iK4Dfv8W9B7BlfDb5AY1JkL9PcTI1D7/jkmdTirwcvTQ+Tl9ErLNZTzuDjNBJhA/ggUvbaQv3YVWSkHBwdYMmULC+2ULE4U3sqRxXOsZPEc1K872jz8kLVoUIAf4hOSrOn4xGQEB/mLdIxkuZ05b5mYc1m5YjkhI8XJbLaALKQkoGkCQYFyeUrfD6fRaEBD4B9/0AND+nfHxr/2Ss3QoHxIIEgZJjdXsuSu/PkbSa782/AjifqQorjqCotZiMQzITFFrVbinQiay2oV3MMIHRc52sUbLz+D3zb8JSm0Zmg0WQqlk6MjZQuZRqMBKZ6PP9oC+w/9h+SUVJw6exnNH2ogyuT08rpGbne8/xw5gcPHTmHqhGFiegPVGRTgj8REm+swIRHBgQGUdV/cV9N+kq6fIIz75H9ilECXkTWfWCspu2qjbH+HqozCwrp2qK47d3e3JV035GiKCf3eT565iIca1bVWajSaMHrCTNCw/nfjh+Kp9o8gXZf1AitNpbEWzhEprOsmR7VFmhS3EMnrIHUCpsyYjydsrLvUkJVrtiD8RiQ+lu65s6d8Cp1OD/Xv+afbYsOWXZLbgeeeaquKs4Wl4RrKdkCcYAJMoMAEyrzCW6FcMCJuRAtwCZKCev7SVRG359GD6bOJs/Hsk21A8wFty7Vu2VhYIUh28PAJVK9aUViuaCWGT8fPwCeDeosHP+Wrjoa3/1LmvW75ex8elepQ84o6vHY90jo3jh4QJ6Vh1QA/HzE8TnNON2/fK5pEDMiiJBKSt2HLbpikoemw8Js4ceoCakpWXkls/afyhcXsgZqhYuWM8IhIUBtp6PPRVlmdDutO73HE28sT9HAmCzgpMrS7hnVrgazfFKdzGVqlorBeuro4o37dmvhq+nwxR9JBq6Ui2Zy9a+RWx3vs1DmxEsKE0R/B2cnJWh/xoHnNeoNB6hAk4fS5y2jZrIE1v6gjdK4elTqGxKygc9QL89op6uO2t793ur0EchqNxlokMSkZ9AGJhvVqi3O5XxnatxawEynM68bOLopU3LJZQ7z4bDu0lxRf2x1fu34TDzWoA+ow7D90XLrfZM2Bb/dYCxyQZOcuXEXr5o1sNxPx0ngNiQNjjwncLwIldL+5n7wl9EAK0myj0Sw9XBzEJk0b1wU9kPt8PFbMIaxSqbyQ2/PImrZt1wFhjaElhciR0kPlOz/TDlppuJ1eWvppyW8YPvBdEouVHE5Iw920jA2VJ0cvOFHmR327Yf3mXWLe7DVJYez26nMkvi+OhlQ/+XIqevUfjeff7I+jJ86iT88u0jFpxYoUG7fuAb1c1LnrAJy0Wa4sJCgA3ft9ghFffIuP/9c915BiYTLTaDT4YsQHgj9xbtqkLh6yefGnKMG9/drzYqqHus8B73fFsZNnxbJ06zb+jREfvaNm4Ym2rbB910EpbGmV2UZotY+8rhGNxv7xzvxxOWiedbvO74jlrbr0/FhUWbVyebz0XAe8++FnYhrBoA+6CyVKZBaRZzSZJIuzrIT3fPMFvDtAbgt1nArShMK8dmi/9FIT/f5IUaQlr4aM+ZrERepaNm0gOku2O6WRHXoRk5aSGzrmG9BQvW2+vXhhXjfUaSU2tCTZmj+2iWvqVi/w2mvT3cgdtFq83+NV0PQo23poqtCc+SvwwdDxOHL8NHxsppG5ODujqWQtf7pDazGyYrsdxQv7Gur90RdiScqwazcEI9uX5mh/7JgAEyieBLTFs1n3tlWnzl1EVUWxpTf9F8z6ErSEEylS86Z9DnrzmVqw5PuJCAzwo6jVtWrWSHzqlD53qjqy9lIBquvTj3uD6qNh/yqV5KkL/d55Pdc29EIbbUP108sYtCzZhNEDQS+zkfx+uFrVq2L5vCliua+NK2Zj2Y9fSdbdYNEUyps2cTgWzh4vlmTr+sozQk7eY5L1jl5Iom2ffPxhEmVzhc2sUf0HBGN6ga4ol1Ci8/vXmh+tx+bn643dfywQD2gS0jn9ZtxQ0bZZ0rBrjdDKJBauQ5tW4hqwfStfZCjera4Re8f749TPRJ3qdbhqwbdKbcBrLz4Fun4XzRkPmv9pzSiCiMViwemzl1FF+Y3R72P1wm/FtAuaBkTXETVj5KD3hMWb4uTohS0KbV1hXzs5OX89dojt7u5ZnI4jr30NljqIXTp3FPsdPeR9cc6+HjdEdOp6dX1ByHNyEkLFy3k8dC3QdUjZBb1u6Pqm7W2dei+k+u6lo2s5575oRIDuQ7Tf2jWqgq5vms4woHdX8XIfycnRCMuVaxHo/HQ7SuZyxN72mChO1yQVpGMu6D2b2kp1qK5rl2epKnZMgAkUcwJlTuHtO3gczpy7gm6vdirmp4abxwRKHgGyEnZ4qTdofVl6mbHkHQG3uCQRoI+t0Ado6j5QTUx3KElt57aWFQJ8nMWFQJlTeOmlK7Iw+fv5FJdzUKLbcSvrU4k+MG78HREgi9nf637C8IHv5Dm8fEeV8kZMwA4B6ljRSAaNHNgpwmImwASYgCBQ5hRecdTsMYFiRICbwgSYABNgAkyACdxbAqzw3lu+XDsTYAJMgAkwASaQPwJcigncMwKs8N4ztFwxE2ACTIAJMAEmwASYQHEgwApvcTgL3Ib8E+CSTIAJMAEmwASYABMoIAFWeAsIjIszASbABJgAEygOBLgNTIAJ5J8AK7z5Z8UlmQATYAJMgAkwASbABEogAVZ4S+BJy3+TuSQTYAJMgAkwASbABJgAK7x8DTABJsAEmEDpJ8BHyASYQJkmwApvmT79fPBMgAkwASbABJgAEyj9BFjhzTrHHGMCTIAJMAEmwASYABMohQRY4S2FJ5UPiQkwASZwdwR4aybABJhA6SLACm/pOp98NEyACTABJsAEmAATYAI5CNyxwpujHk4yASbABJgAE2ACTIAJMIFiSYAV3mJ5WrhRTIAJlCAC3FQmwASYABMo5gRY4S3mJ4ibxwSYABNgAkyACTCBkkGg+LaSFd7ie264ZUyACTABJsAEmAATYAKFQIAV3kKAyFUwASaQfwJckgkwASbABJhAURNghbeoifP+mAATYAJMgAkwASYAMIMiJMAKbxHC5l0xASbABJgAE2ACTIAJFD0BVniLnjnvkQnknwCXZAJMgAkwASbABO6aACu8d42QK2ACTIAJMAEmwATuNQGunwncDQFWeO+GHm/LBJhANgKR0bEYOW4qXntnMN7sPQyv9PgYx06dy1bmbhPHT53HOwPG3G01vD0TYAJMgAmUIQKs8Jahk136D5WP8H4TmLtwFbRaByyaMxHLfpyMqROGwdPdvVCbVT20EoYO6FmodXJlTIAJMAEmULoJsMJbus8vHx0TKFICsXGJaNGkHlxdnMV+K1cshxrVKou4LiMD38xaJFl+h6Pb+yMwc94yWCwWkbd6/VYMGD4Rb/UZiae69EVsXAKMRhOmfr8Y/YZ8iZe7D0LfweNE2cth1zFlxgIRJ++nJWvwVt+R6N7vU4z7ei5S09JJjLkLf8Un46ahv1TvewM/w8SpP8FkNos89phAqSfAB8gEmEA2AqzwZsPBCSbABO6GQK+uL2CepICSkjr7p+U4eeaCtbp5i3+DWVI4F80ejwWzvkRUdBxWrt0iFNR5i9dg6sThWPLDRCyfNxleXh7Yd+gYbkbGYM7Xo/Dbou/w+fB+1rrUyPbd/2Dj1t2Y+dVI/DxzLOLiEzD/lzVqNiKlfUwaMxDzpn0BjUaD7bsOWvM4wgSYABNgAmWHACu8Zedc5zxSTjOBQifQpGEdrF74LXq+2RlxCcn439AJ+G39X2I/B/89ISnAFzFgxEThLly+iuOnzsHdzRUhwQH4ZuZCzF+6DgmJKXBxdkat6pVx+WoESHFetnqT1WosKlO8I8fO4NknH4OvjzccHRzw5ivP4rAkU7LRXLI2e3rIUyrKSfu4FBauZnHIBJgAE2ACZYgAK7xl6GTzoTKBoiDg7OSElk0bYvSQ9zGwTzes2bhd3q0GGPy/7vj+m9HCLZ83BRNGD4RWq8WCmePQ+ZnH4ezkiIEjJ4IU0wrlgrF07ldSXQ0kS20sen/0hZjmIFcm+5nIFIqunILYPjMzU03CwSHrFqeV9mMyma15HGECWQQ4xgSYQGknkPU0KO1HysfHBJjAPSew/9AxMUWBdmQwGnHizEUEB/pREo+0aIwfFq5CSmqaSMclJOLcxTBk6A3QGwx4sFY1dHv1OTHn99yFK0hKToWTpAA3bVwPH7z7OhKTUiSrcaLYVvWaNqqLTdt2IzklVczPXfbbJjSTrLpqPodMgAkwASbABIgAK7xEIR+OizABJnB7AmfOXcZr7wxBn4/H4uku/XDxyjV8+P5bYsNe3V6SlNpQ9P14nHjJrOcHo5CQmIR4SfHt+HIfvNprMEaNn4mKFXVfd7QAAAQ4SURBVELQvk0rHDx8HK2ffhs9PvgUYyd/j3ek7csFB4q6VK/9Yy3wRNuH8cGQ8Xin/xh4eXqiV9cX1WwOmQATYAJMgAkIAqzwCgzsMQEmUBgE3nnrJWxcMRs/fDsG29fNw+I5E1C1cnlRtauLs6T8dsMvcydhyfcTsX7ZTLRq1gg0dWHnhvn4df43+PLT/hjav6eYr9uxXWvs+3MxFs4ej/GjPsSbrzwj6mlYrzZ+njFWxMl77+2XQS+7LZozXkyjUOfsvt/jVZCD8tf99ecxoHdXJcXBXRDgTZkAE2ACJY4AK7wl7pRxg5kAE2ACTIAJMAEmwAQKQuDeKLwFaQGXZQJMgAkwASbABJgAE2AC95AAK7z3EC5XzQSYABNgAkyACTABJnD/CbDCe//PAbeACTABJsAEmAATYAKlncB9PT5WeO8rft45E2ACTIAJMAEmwASYwL0mwArvvSbM9TMBJpB/AlySCTABJsAEmMA9IMAK7z2AylUyASbABJgAE2ACTOBuCPC2hUuAFd7C5cm1MQEmwASYABNgAkyACRQzAqzwFrMTws1hAvknwCWZABNgAkyACTCB/BBghTc/lLgME2ACTIAJMAEmUHwJcMuYwG0IsMJ7G0CczQSYABNgAkyACTABJlCyCbDCW7LPH7c+/wS4JBNgAkyACTABJlBGCbDCW0ZPPB82E2ACTIAJlFUCfNxMoOwRYIW37J1zPmImwASYABNgAkyACZQpAqzwlqnTnf+D5ZJMgAkwASbABJgAEygtBFjhLS1nko+DCTABJsAE7gUBrpMJMIFSQIAV3lJwEvkQmAATYAJMgAkwASbABOwTYIXXPpv853BJJsAEmAATYAJMgAkwgWJLgBXeYntquGFMgAkwgZJHgFvMBJgAEyiOBFjhLY5nhdvEBJgAE2ACTIAJMAEmUGgE7oPCW2ht54qYABNgAkyACTABJsAEmMBtCbDCe1tEXIAJMAEmcI8IcLVMgAkwASZQJARY4S0SzLwTJsAEmAATYAJMgAkwAXsE7rWcFd57TZjrZwJMgAkwASbABJgAE7ivBFjhva/4eedMgAnknwCXZAJMgAkwASZwZwRY4b0zbrwVE2ACTIAJMAEmwATuDwHea4EJsMJbYGS8ARNgAkyACTABJsAEmEBJIsAKb0k6W9xWJpB/AlySCTABJsAEmAATUAiwwquA4IAJMAEmwASYABMojQT4mJgAwAovXwVMgAkwASbABJgAE2ACpZoAK7yl+vTyweWXAJdjAkyACTABJsAESi8BVnhL77nlI2MCTIAJMAEmUFACXJ4JlEoCrPCWytPKB8UEmAATYAJMgAkwASagEmCFVyXBYf4JcEkmwASYABNgAkyACZQgAqzwlqCTxU1lAkyACTCB4kWAW8MEmEDJIMAKb8k4T9xKJsAEmAATYAJMgAkwgTsk8H8AAAD//43Nv6EAAAAGSURBVAMApqZTXYfbL7sAAAAASUVORK5CYII="
+     },
+     "metadata": {
+      "image/png": {
+       "alt": "Two lines over validation sessions on a shared axis of mean squared one-minute log return. A thin dark navy line is realized 5-bar variance, spiky, with occasional tall isolated peaks. A thicker amber line is the HAR forecast, tracking the same path closely and rising above the navy line at every peak. A single dotted vertical rule near the middle is the boundary between the two consecutive validation windows."
+      }
+     },
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "fig = go.Figure()\n",
     "fig.add_trace(\n",
@@ -1388,14 +2886,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4fdfd2f7",
+   "id": "da450957",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.00595,
-     "end_time": "2026-09-04T03:13:37.178416+00:00",
+     "duration": 0.004925,
+     "end_time": "2026-09-09T21:02:48.794538+00:00",
      "exception": false,
-     "start_time": "2026-09-04T03:13:37.172466+00:00",
+     "start_time": "2026-09-09T21:02:48.789613+00:00",
      "status": "completed"
     }
    },
@@ -1421,10 +2919,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "750f3e7a",
+   "execution_count": 23,
+   "id": "4d65ec0b",
    "metadata": {
-    "lines_to_next_cell": 2
+    "execution": {
+     "iopub.execute_input": "2026-09-09T21:02:48.804355Z",
+     "iopub.status.busy": "2026-09-09T21:02:48.804185Z",
+     "iopub.status.idle": "2026-09-09T21:02:48.808894Z",
+     "shell.execute_reply": "2026-09-09T21:02:48.808322Z"
+    },
+    "lines_to_next_cell": 2,
+    "papermill": {
+     "duration": 0.010593,
+     "end_time": "2026-09-09T21:02:48.809385+00:00",
+     "exception": false,
+     "start_time": "2026-09-09T21:02:48.798792+00:00",
+     "status": "completed"
+    }
    },
    "outputs": [],
    "source": [
@@ -1481,14 +2992,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1e34b3fc",
+   "id": "1ab3f094",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.004094,
-     "end_time": "2026-09-04T03:13:37.199316+00:00",
+     "duration": 0.00837,
+     "end_time": "2026-09-09T21:02:48.826453+00:00",
      "exception": false,
-     "start_time": "2026-09-04T03:13:37.195222+00:00",
+     "start_time": "2026-09-09T21:02:48.818083+00:00",
      "status": "completed"
     }
    },
@@ -1501,9 +3012,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "d3041217",
-   "metadata": {},
+   "execution_count": 24,
+   "id": "b91221b7",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-09T21:02:48.836961Z",
+     "iopub.status.busy": "2026-09-09T21:02:48.836781Z",
+     "iopub.status.idle": "2026-09-09T21:02:48.840596Z",
+     "shell.execute_reply": "2026-09-09T21:02:48.840016Z"
+    },
+    "papermill": {
+     "duration": 0.009937,
+     "end_time": "2026-09-09T21:02:48.840899+00:00",
+     "exception": false,
+     "start_time": "2026-09-09T21:02:48.830962+00:00",
+     "status": "completed"
+    }
+   },
    "outputs": [],
    "source": [
     "def compute_fft_per_symbol(\n",
@@ -1538,10 +3063,74 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "746e76b1",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 25,
+   "id": "c85b2232",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-09T21:02:48.851298Z",
+     "iopub.status.busy": "2026-09-09T21:02:48.851077Z",
+     "iopub.status.idle": "2026-09-09T21:35:16.266285Z",
+     "shell.execute_reply": "2026-09-09T21:35:16.248489Z"
+    },
+    "papermill": {
+     "duration": 1947.434232,
+     "end_time": "2026-09-09T21:35:16.279861+00:00",
+     "exception": false,
+     "start_time": "2026-09-09T21:02:48.845629+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  FFT: 20/115 symbols processed\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  FFT: 40/115 symbols processed\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  FFT: 60/115 symbols processed\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  FFT: 80/115 symbols processed\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  FFT: 100/115 symbols processed\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  FFT: 115/115 symbols processed\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "FFT: 20,018,024 of 20,025,030 bars.\n"
+     ]
+    }
+   ],
    "source": [
     "fft_results = []\n",
     "\n",
@@ -1563,14 +3152,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "881dcf2b",
+   "id": "0b846fa8",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.004366,
-     "end_time": "2026-09-04T03:49:33.920410+00:00",
+     "duration": 0.007395,
+     "end_time": "2026-09-09T21:35:16.299948+00:00",
      "exception": false,
-     "start_time": "2026-09-04T03:49:33.916044+00:00",
+     "start_time": "2026-09-09T21:35:16.292553+00:00",
      "status": "completed"
     }
    },
@@ -1600,9 +3189,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "2db7a270",
-   "metadata": {},
+   "execution_count": 26,
+   "id": "3923a7d4",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-09T21:35:16.334414Z",
+     "iopub.status.busy": "2026-09-09T21:35:16.332291Z",
+     "iopub.status.idle": "2026-09-09T21:35:16.370104Z",
+     "shell.execute_reply": "2026-09-09T21:35:16.369030Z"
+    },
+    "papermill": {
+     "duration": 0.065475,
+     "end_time": "2026-09-09T21:35:16.370770+00:00",
+     "exception": false,
+     "start_time": "2026-09-09T21:35:16.305295+00:00",
+     "status": "completed"
+    }
+   },
    "outputs": [],
    "source": [
     "def compute_depth2_signature(path: np.ndarray) -> np.ndarray:\n",
@@ -1634,13 +3237,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "84fad83d",
+   "id": "5ce775f4",
    "metadata": {
     "papermill": {
-     "duration": 0.004447,
-     "end_time": "2026-09-04T03:49:33.942529+00:00",
+     "duration": 0.004309,
+     "end_time": "2026-09-09T21:35:16.380161+00:00",
      "exception": false,
-     "start_time": "2026-09-04T03:49:33.938082+00:00",
+     "start_time": "2026-09-09T21:35:16.375852+00:00",
      "status": "completed"
     }
    },
@@ -1655,10 +3258,32 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "f4511a99",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 27,
+   "id": "627b7962",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-09T21:35:16.391193Z",
+     "iopub.status.busy": "2026-09-09T21:35:16.391015Z",
+     "iopub.status.idle": "2026-09-09T21:35:16.424711Z",
+     "shell.execute_reply": "2026-09-09T21:35:16.424068Z"
+    },
+    "papermill": {
+     "duration": 0.040688,
+     "end_time": "2026-09-09T21:35:16.425373+00:00",
+     "exception": false,
+     "start_time": "2026-09-09T21:35:16.384685+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Depth-2 signature identities hold on 20 random 3-dimensional paths.\n"
+     ]
+    }
+   ],
    "source": [
     "_rng = np.random.default_rng(0)\n",
     "for _trial in range(20):\n",
@@ -1674,10 +3299,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "594d63a9",
+   "execution_count": 28,
+   "id": "386f99f8",
    "metadata": {
-    "lines_to_next_cell": 2
+    "execution": {
+     "iopub.execute_input": "2026-09-09T21:35:16.435460Z",
+     "iopub.status.busy": "2026-09-09T21:35:16.435353Z",
+     "iopub.status.idle": "2026-09-09T21:35:16.439740Z",
+     "shell.execute_reply": "2026-09-09T21:35:16.439185Z"
+    },
+    "lines_to_next_cell": 2,
+    "papermill": {
+     "duration": 0.010034,
+     "end_time": "2026-09-09T21:35:16.440304+00:00",
+     "exception": false,
+     "start_time": "2026-09-09T21:35:16.430270+00:00",
+     "status": "completed"
+    }
    },
    "outputs": [],
    "source": [
@@ -1691,14 +3329,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f1db2b3a",
+   "id": "6ca00051",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.004331,
-     "end_time": "2026-09-04T03:49:33.981164+00:00",
+     "duration": 0.004403,
+     "end_time": "2026-09-09T21:35:16.449298+00:00",
      "exception": false,
-     "start_time": "2026-09-04T03:49:33.976833+00:00",
+     "start_time": "2026-09-09T21:35:16.444895+00:00",
      "status": "completed"
     }
    },
@@ -1714,9 +3352,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "abe5420c",
-   "metadata": {},
+   "execution_count": 29,
+   "id": "5bfa38a1",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-09T21:35:16.459380Z",
+     "iopub.status.busy": "2026-09-09T21:35:16.459270Z",
+     "iopub.status.idle": "2026-09-09T21:35:16.475475Z",
+     "shell.execute_reply": "2026-09-09T21:35:16.474701Z"
+    },
+    "papermill": {
+     "duration": 0.022212,
+     "end_time": "2026-09-09T21:35:16.476053+00:00",
+     "exception": false,
+     "start_time": "2026-09-09T21:35:16.453841+00:00",
+     "status": "completed"
+    }
+   },
    "outputs": [],
    "source": [
     "def compute_signatures_per_symbol(\n",
@@ -1766,10 +3418,68 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "b15fe713",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 30,
+   "id": "78b2097f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-09T21:35:16.896317Z",
+     "iopub.status.busy": "2026-09-09T21:35:16.896209Z",
+     "iopub.status.idle": "2026-09-09T22:25:34.612491Z",
+     "shell.execute_reply": "2026-09-09T22:25:34.611536Z"
+    },
+    "papermill": {
+     "duration": 3018.140368,
+     "end_time": "2026-09-09T22:25:34.621607+00:00",
+     "exception": false,
+     "start_time": "2026-09-09T21:35:16.481239+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Signatures: 20/115 symbols processed\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Signatures: 40/115 symbols processed\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Signatures: 60/115 symbols processed\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Signatures: 80/115 symbols processed\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Signatures: 100/115 symbols processed\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Signatures: 115/115 symbols processed\n",
+      "Signatures: 20,021,511 of 20,025,030 bars.\n"
+     ]
+    }
+   ],
    "source": [
     "sig_results = []\n",
     "\n",
@@ -1791,13 +3501,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b0722e06",
+   "id": "1d48c005",
    "metadata": {
     "papermill": {
-     "duration": 0.00653,
-     "end_time": "2026-09-04T04:41:37.730698+00:00",
+     "duration": 0.004647,
+     "end_time": "2026-09-09T22:25:34.632890+00:00",
      "exception": false,
-     "start_time": "2026-09-04T04:41:37.724168+00:00",
+     "start_time": "2026-09-09T22:25:34.628243+00:00",
      "status": "completed"
     }
    },
@@ -1818,10 +3528,32 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "99eca798",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 31,
+   "id": "0779492f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-09T22:25:34.643075Z",
+     "iopub.status.busy": "2026-09-09T22:25:34.642915Z",
+     "iopub.status.idle": "2026-09-09T22:27:03.688650Z",
+     "shell.execute_reply": "2026-09-09T22:27:03.688136Z"
+    },
+    "papermill": {
+     "duration": 89.05214,
+     "end_time": "2026-09-09T22:27:03.689600+00:00",
+     "exception": false,
+     "start_time": "2026-09-09T22:25:34.637460+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "326,100 rows on 3 symbols recomputed from a panel ending 2021-07-01; every value identical.\n"
+     ]
+    }
+   ],
    "source": [
     "_check_symbols = symbols[:3]\n",
     "_full = (\n",
@@ -1867,13 +3599,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2433b03e",
+   "id": "d7ddf42f",
    "metadata": {
     "papermill": {
-     "duration": 0.005622,
-     "end_time": "2026-09-04T04:43:24.494581+00:00",
+     "duration": 0.004512,
+     "end_time": "2026-09-09T22:27:03.700503+00:00",
      "exception": false,
-     "start_time": "2026-09-04T04:43:24.488959+00:00",
+     "start_time": "2026-09-09T22:27:03.695991+00:00",
      "status": "completed"
     }
    },
@@ -1900,10 +3632,32 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "4de63d59",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 32,
+   "id": "3ed6955f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-09T22:27:03.710818Z",
+     "iopub.status.busy": "2026-09-09T22:27:03.710711Z",
+     "iopub.status.idle": "2026-09-09T22:27:03.749248Z",
+     "shell.execute_reply": "2026-09-09T22:27:03.748846Z"
+    },
+    "papermill": {
+     "duration": 0.044586,
+     "end_time": "2026-09-09T22:27:03.749752+00:00",
+     "exception": false,
+     "start_time": "2026-09-09T22:27:03.705166+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "77,472 retained fits across 2 folds, summarised in the figure below.\n"
+     ]
+    }
+   ],
    "source": [
     "beta_long = validation_rows(\n",
     "    har_beta_df.select(\"timestamp\", \"symbol\", \"beta_5\", \"beta_15\", \"beta_60\")\n",
@@ -1934,10 +3688,241 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "d5332c85",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 33,
+   "id": "ae5d9799",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-09T22:27:03.760486Z",
+     "iopub.status.busy": "2026-09-09T22:27:03.760382Z",
+     "iopub.status.idle": "2026-09-09T22:27:05.331829Z",
+     "shell.execute_reply": "2026-09-09T22:27:05.331261Z"
+    },
+    "papermill": {
+     "duration": 1.578018,
+     "end_time": "2026-09-09T22:27:05.332906+00:00",
+     "exception": false,
+     "start_time": "2026-09-09T22:27:03.754888+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.plotly.v1+json": {
+       "config": {
+        "plotlyServerURL": "https://plot.ly"
+       },
+       "data": [
+        {
+         "lowerfence": {
+          "bdata": "hAjDHyct5j/HLFO31STmPw==",
+          "dtype": "f8"
+         },
+         "marker": {
+          "color": "#D4A84B"
+         },
+         "median": {
+          "bdata": "1A0NSSdk6j8+CUFj+HzqPw==",
+          "dtype": "f8"
+         },
+         "name": "beta_5",
+         "q1": {
+          "bdata": "POy1vULL6D9nwbOkgdToPw==",
+          "dtype": "f8"
+         },
+         "q3": {
+          "bdata": "5/FODpfq6z/+XFGuKivsPw==",
+          "dtype": "f8"
+         },
+         "type": "box",
+         "upperfence": {
+          "bdata": "Vk1C7hea7j89NFlO61vvPw==",
+          "dtype": "f8"
+         },
+         "x": [
+          "0",
+          "1"
+         ]
+        },
+        {
+         "lowerfence": {
+          "bdata": "3upUL9Wa0r/2MndIm8nRvw==",
+          "dtype": "f8"
+         },
+         "marker": {
+          "color": "#C87533"
+         },
+         "median": {
+          "bdata": "YN4feWDflb+gQqhB3Gd0vw==",
+          "dtype": "f8"
+         },
+         "name": "beta_15",
+         "q1": {
+          "bdata": "XH1Ia4zXvL9Y2kUjRW65vw==",
+          "dtype": "f8"
+         },
+         "q3": {
+          "bdata": "wHjaID3HtD/8dQH+HQ+5Pw==",
+          "dtype": "f8"
+         },
+         "type": "box",
+         "upperfence": {
+          "bdata": "RrU6gSj40T9mR801OerTPw==",
+          "dtype": "f8"
+         },
+         "x": [
+          "0",
+          "1"
+         ]
+        },
+        {
+         "lowerfence": {
+          "bdata": "GX50JfNG5b+Mvv5pBM/kvw==",
+          "dtype": "f8"
+         },
+         "marker": {
+          "color": "#1a2d4a"
+         },
+         "median": {
+          "bdata": "KG9HffVFsL+wOdWyu062vw==",
+          "dtype": "f8"
+         },
+         "name": "beta_60",
+         "q1": {
+          "bdata": "oAqT2VAo0L87h6fm9ALRvw==",
+          "dtype": "f8"
+         },
+         "q3": {
+          "bdata": "HjB5DDiHwz/MUZ8EvUa/Pw==",
+          "dtype": "f8"
+         },
+         "type": "box",
+         "upperfence": {
+          "bdata": "bOPIRIWD6j8guFnAht3pPw==",
+          "dtype": "f8"
+         },
+         "x": [
+          "0",
+          "1"
+         ]
+        }
+       ],
+       "layout": {
+        "boxmode": "group",
+        "height": 440,
+        "margin": {
+         "t": 120
+        },
+        "shapes": [
+         {
+          "line": {
+           "color": "#334155",
+           "dash": "dash"
+          },
+          "type": "line",
+          "x0": 0,
+          "x1": 1,
+          "xref": "x domain",
+          "y0": 0,
+          "y1": 0,
+          "yref": "y"
+         }
+        ],
+        "template": {
+         "layout": {
+          "colorway": [
+           "#0a1628",
+           "#D4A84B",
+           "#C87533",
+           "#10b981",
+           "#ef4444",
+           "#94a3b8"
+          ],
+          "font": {
+           "color": "#334155",
+           "family": "DM Sans, DejaVu Sans, sans-serif",
+           "size": 11
+          },
+          "hoverlabel": {
+           "bgcolor": "white",
+           "font": {
+            "family": "DM Sans, DejaVu Sans, sans-serif",
+            "size": 11
+           }
+          },
+          "legend": {
+           "bgcolor": "rgba(255,255,255,0.8)",
+           "bordercolor": "#e8e8e6",
+           "borderwidth": 1,
+           "font": {
+            "size": 10
+           }
+          },
+          "paper_bgcolor": "#FAFAF9",
+          "plot_bgcolor": "white",
+          "title": {
+           "font": {
+            "color": "#0a1628",
+            "size": 14
+           },
+           "x": 0.5,
+           "xanchor": "center"
+          },
+          "xaxis": {
+           "gridcolor": "#e8e8e6",
+           "gridwidth": 0.5,
+           "linecolor": "#e8e8e6",
+           "showgrid": true,
+           "tickfont": {
+            "size": 10
+           },
+           "title": {
+            "font": {
+             "size": 11
+            }
+           }
+          },
+          "yaxis": {
+           "gridcolor": "#e8e8e6",
+           "gridwidth": 0.5,
+           "linecolor": "#e8e8e6",
+           "showgrid": true,
+           "tickfont": {
+            "size": 10
+           },
+           "title": {
+            "font": {
+             "size": 11
+            }
+           }
+          }
+         }
+        },
+        "title": {
+         "text": "The short-horizon component carries the volatility fit in every fold<br><sup>Distribution of the rolling regression coefficients, one fit retained per<br>symbol-session, on validation rows. Boxes span the quartiles and whiskers the<br>5th to 95th percentiles; the unconstrained fit has tails well beyond them.</sup>"
+        },
+        "xaxis": {
+         "title": {
+          "text": "Fold"
+         }
+        },
+        "yaxis": {
+         "title": {
+          "text": "Rolling regression coefficient"
+         }
+        }
+       }
+      },
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAArwAAAG4CAYAAACnwzTIAAAQAElEQVR4AeydBWAURxfH/5cElw+XUgoUh+JWHIq7u2txd3d39+LWQilSipUCxd0p7m7FnW/fJHu9HGdJLsnd5R94u7Mzb97M/GZ2793s7J7Xu3dvP1PIgGOAY4BjgGOAY4BjgGOAY8BTx4AX+EcCJEACJACAEEiABEiABDyVAB1eT+1ZtosESIAESIAESIAEAkPAA/PQ4fXATmWTSIAESIAESIAESIAE/iNAh/c/FgyRAAk4ToCaJEACJEACJOA2BOjwuk1XsaIkQAIkQAIkQAKuR4A1cgcCdHjdoZdYRxIgARIgARIgARIggUAToMMbaHTMSAKOE6AmCZAACZAACZBA6BGgwxt67FkyCZAACZAACYQ1AmwvCYQKATq8oYKdhZIACZAACZAACZAACYQUATq8IUWa5ThOgJokQAIkQAIkQAIk4EQCdHidCJOmSIAESIAESMCZBGiLBEjAOQTo8DqHI62QAAmQAAmQAAmQAAm4KAE6vC7aMY5Xi5okQAIkQAIkQAIkQAK2CNDhtUWHaSRAAiRAAu5DgDUlARIgASsE6PBaAcNoEiABEiABEiABEiABzyAQ1hxez+g1toIESIAESIAESIAESMBhAnR4HUZFRRIgARLwJAJsCwmQAAmEHQJ0eMNOX7OlJEACJEACJEACJBAmCdh0eMMkETaaBEiABEiABEiABEjAowjQ4fWo7mRjSIAEgokAzZIACZAACbgxATq8btx5rDoJkAAJkAAJkAAJhCwB9yyNDq979htrTQIkQAIkQAIkQAIk4CABOrwOgqIaCZCA4wSoSQIkQAIkQAKuRIAOryv1ButCAiRAAiRAAiTgSQTYFhchQIfXRTqC1SABEiABEiABEiABEggeAnR4g4crrZKA4wSoSQIkQAIkQAIkEKwE6PAGK14aJwESIAESIAEScJQA9UgguAjQ4Q0usrRLAiRAAiRAAiRAAiTgEgTo8LpEN7ASjhOgJgmQAAmQAAmQAAkEjAAd3oDxojYJkAAJkAAJuAYB1oIESMBhAnR4HUZFRRIgARIgARIgARIgAXckQIfXHXvN8TpTkwRIgARIgARIgATCPAE6vGF+CBAACZAACYQFAmwjCZBAWCZAhzcs9z7bTgIkQAIkQAIkQAJhgAAdXpNOZpAESIAESIAESIAESMDzCNDh9bw+ZYtIgARIIKgEmJ8ESIAEPIoAHV6P6k42hgRIgARIgARIgARIwJxA4B1ec0s8JgESIAESIAESIAESIAEXJECH1wU7hVUiARJwLwKsLQmQAAmQgGsToMPr2v3D2pEACZAACZAACZCAuxBw2XrS4XXZrmHFSIAESIAESIAESIAEnEGADq8zKNIGCZCA4wSoSQIkQAIkQAIhTIAObwgDZ3EkQAIkQAIkQAIkIAQoIUeADm/IsWZJJEACJEACJEACJEACoUCADm8oQGeRJOA4AWqSAAmQAAmQAAkElQAd3qASZH4SIAESIAESIIHgJ8ASSCAIBOjwBgEes5IACZAACZAACZAACbg+ATq8rt9HrKHjBKhJAiRAAiRAAiRAAl8QoMP7BZKwFxEnaTZs/Wt3iDa8at1WGDxyUoiWaamw4Gx7gx87o0f/kZaKZRwJ2CUwY+5SFChRw66esxVc5dy01K4UmQrhtw1bLSUFKC55xoJGOyfP/IMYX2fCo8dPlY0Tp8+p44ePnqhjZ262bP8bZao2Qdxk2VGnaQf8tWufKiugZTg2NgJq1fX15XOqXPWmSJAip+LnSI0b/NgFPQeMsqnaskNfdOgx2KYOE92fAB1e9+9Dqy0oVqG+upjKxdyS5ClaxWped06YMnMhCpepHepNSJMqOZIlSRzq9WAF7BP4Jm1ebPhju33FENRImCAeMmdMF2wlHj1+GnJdePrvs2ArI7QNW7sWfJ8zC2LHimGxelEiR0Kh/N8jXDgflW7NhkoM4GbgsInImS0jbpzdjSVzJiDG/6KrsnQzjvZJcI8NvT6uth8wdAKyZ8mAq6d2KX6uVj/Wx7UJ0OF17f4JUu1GD+6BdSvnKJk6bpCyNW54b3Us8ZNHD1Bx3AQPgZ6dW+HHxqHveAdP62g1uAlUKFMUk0b3D+5iwqR9cTbz5c5use3JkyXBmmUz8b/o0SymByXy+s3byJU9CyJGjKDMyBcaKUsdBGATVseGOb8AIKMqCYAOrwcPArmY5s+TAyJZMqZXLc2QLrU6lrhs2jdlFalt7t1/iGr1WkFmuvIVq4YVq9Zrsf/9P3f+Muo264g0WYsiZebCkFtA9maGRk+cjeIV6yN+8hxqJqlRy27/GdRCHz9+QseeQ5A2ezFk+L4UBo2YhA8fPmgpvv/vPXiI5u16qXQpU/LfvHXHN1Hb7j1wRNn9Y+tOFCpdC3Kbq782g9Jn8FjoMyUygzV/8S+atvX/9tp++OhJVKz1I5Kky4es+cpC7L9+/cZocOzkuShVuRFkJihnoQqImTizSjNd0iA6UhdzGTl+ptJ99+49hoyajBwFyyNxmjwoW60p9uw/rNL0TZyk2bBo+a82+0nX1fefPn2C3P78oWwdJEqVGzLrP+unZXoy7DGWekvbps9ZguwFyqt+Gj52Gj5+/Ihf121Wt2elb7r3GwFpg25Ybot36D4YtZu0V+NF+nfAsAkB6l+9bKmvcPk2Q0E0bdMDd+8/0ItR+81/7kLJSg1V/0gdR4yboeqnErVNHDvcsuUvh2fPX6hbpNI/6XIU13JZ/i96skxF6iPnSo0GbSDli/aZcxfRre9w5CpcSZ1HFWo2x/FTZyXJKMKl96AxaN2pH9LnLKHGlaVxvGvPQdVvpksahPnkGQsh56f0pdzFWPv7VqNtCdg750RH5Nr1W5D8Ek6aPj+k3XKuybGIvXPzydN/0aX3cHU+yHitXLslTp09L1ktyoKlq9R5LG0wVWjRvg/qNetkjFr2y1rIuSztK1SqFn5a9LMxzTzw4uUrdc7INUbqIPlWr/3DqLb057XqXLV0LTBd0uCXwbgzXdJgzUbbLgMg57cxkxaQcy1j7tKQ8aod+vsvY0MYy/ip2ait4i3HuoiyvT4RHV3knDYdG46eK3p+fW/run7l2g1Vz9NnL+jqar9w2Wp1Tr9//14d27IhCpbGvDP4rVy9QczD3vVZKZlsZNzI8oVUWX5Q17NeA0ebpDLoyQTo8Hpy7wagbROnzUOmDGkxbdxgpEr5LVp06IOr124qC/cfPEKFGs2Q6bt0WPfzXGz+bSH+97+oqK592MtFXimZbf7cuQez5y/D4D6dcOXkTuzctEK7lZfJn9Zyzan+8P4DRmkz0dUqlsKkGQuw6jffD6zPnz+jRv22OPfPJaxeMgNbfluE23fuoXKdFtAvtPD7Gzt5DsYM6Ymb5/aga/tmGNK3M7JkSo+nN48raVi3qp+m5Z2ttt+6fRflazRHgnhxcXjXOkwZOxDLtA/SLr2H+TN27OQZHD52CisXTMW1M3/7S5ODzm2bqLrodVowc6xEa0wyqn3/YeM1XiswUmNxfO/vkOUQFWr+iAuXrql0fTP7p+Vo0bQuRKd29Qr++knXMd2PHD8DE6f/hHYtGuLs4S0YNag7Xr95q1QcZXzpyjVs+fNvjW1zNKxTVXPsF6lyV6xah6YNamhSE/OXrMKK1euVXX2zZOVvWvsy4+CO3zBhZF8tfQPGTJqjkh0tW7hKv/+8cBrWLJ+Jy1dvYMTYGcqGbHb8vR/tugxEw7pVVP9MHz8YBw4dx8DhEyXZKLa4Sb9GjxZV3SKV/jlzcLMxn3mgTpMO2pepM5g8ZiDOHNqCZo1q4d9/nyu1f589Q4b0abQxMAW7t/yMHwrmQeXaLb5w0OdpTlzyb5Ngl3ZOLJzlOw7EwFiTcSzjV+JMZdSEmVi7cSsG9umolb0Z3Tu0gHyJkC98oufIOSd6Ikm+SYTtG5ZKEFdP71Jjc9ak/8a0rXNTMtVr1hnPX7zA7MnDcWzP7yhbqrBqq5wvkm4u5UsXxeMnT/GX1l962httHK7buA2Vy5dUUeK8yxfpWlXL4fTBTWjSoLr6Qrx4xRqVbr559+4dIkSIiPHD+6rzoXWzeug1cIzxeYTa1coH+FpgXoY1G3VrVsT6P7bDdJ2vrC+9p30Zq1GlrLkZpEuTQjGOFCkils+frMIy1kxnd+31yRdGzSLsnStm6rB3XZflWLmyZ9a+2Ppek/X8q9duQqVyxREuXDi7NvQ85mPeGfyqVy4DGW+OXJ/1esi+tzZG1mlfFOfPGI1t6xbj3v1H+HPHHkmieDgBOryOdrCH69WsWh59urXVPrh+wKxJQyEOwOFjJ1Wr5WKV8bvUmsPTDCmTJ1HrUocP6IbTZy5oH/6nlY755s7dB4gVM4bm8GRC5MiRkFFzBFo2reNPLWP61JrjMADlShVBvx7tULRQHhw4fELpiCMjF/BJY/ojberkSJrka+327gCcv3gVv2/eoXT0TY9OLZA9a0b4+PggapTIerTDe1ttl9kMsTl+RB/EiR0TeXJlQ9/ubSHO3IOHj/2VIU6d1FPY+UswO5AZpNad+mJArw4oXCA3ZLZ4zoKV6NKuOX4okEdxGzGwK75KGA9zFy73l7tx/WooojlSMWP8D62a1UW8OLFx5Pgpfzr6wQdttnzCtJ/Qq0srVCxbTPWpOFLtWzZUKo4y/vDhI5b9NBHyQS6Oe5mShbHz7wNYNHuc+uDr3vFHFPshnzbT4r8estauQ6tGkHWKUmdxSOYv8Z1td7RsaadwEq4yhupUL6+NkWOq/rIZP3WecjprVimn+idHtkxae1tCxqyk6xIQbnoe873MuopMGz8I3+fIosZa0UJ5Ua1SaaWaO2dW1KtZCeK4JP76Kwjn77Q7Kr9v2q7S9Y3cbenUponqZ9OxYmscv337DtKXgzVnV1jK7faSxQqggfYFZMHSX5RpR845pejAxta5uXP3AXXeT9W+/GXT7hLJWtjG9aoja+b0WKU5Q5bMSz+WLFoQq3/7z3la/8ef2jnrjVLFCqoss+cvR+kShSDLgGTMCEtxambNW6bSzTdyfZEvuOnTplQspR/kC9nyX9aZqzr9WBzBlMmTwrSs5b+shzj20jdOL9ABg8LY1rlibkLOEXvX9crlS+AXkz4TB1PO3SoVSilzjtgQRfMx7yx+Abk+Sz1kdlfy9OzcUl3L48WNDbluv3z1SpIpHk7Ay8Pbx+Y5SCBdmpRGTXEcv9E+sPXZCzXDt323ur2l34KT2/ZykbjiNwtszOwXKFY4Hx48fITCpWur247LtdlAuZ3nl6x2aVOnUHt9I47Cw0e+TuTlq9eRIH5cZM6QTk9G6pTJlEh9jJFaIKs2m6vtbP7vN2Scv/pfv3HbqG+77deRP28OyMyMnkHaJmGpo+xFUmuz4o580ImTXKdJR5TUPuTFGZS8V6/fUrPWRQvnlUMl0gfiDF++cl0d65uvEsbXg2ofP14cjfNjFTbfXLx8HeIo5czmu8TCPF3qaU42AwAAEABJREFUn8ABxjIbGSFCeGP2pNrsYCqtL2SGR49U4+Wx/3pkSJ9KT1b7TNodhLv3HuDVq9faTO11h/o3caKEKq++iRM7tppV0o//uXAZ8rYPfVzKvmj5epAPtjt37+tq2pcHx7kZM5kFLl66quzIGk+zJHUo7ZLlFIW0W/Fxk2VX402cgxs376h0fZM5Y1o96G9vaxzLeSZ9WbJSQ2VX2inSf+h4XLl6U9mRcWnvnFOKDmxsnZuXLl+DnPtxkmbzV5c/tuyEflfIUhFVKpTUZkX/hMzsSvrqdX+gYtnixvWsFzS+8gVC0nSR47PnL0HuCOhxpntZAlGmahO1hER4jBg3Hea8TfWdGW5crxqW/vybMvnvs+fYsOlP1KpWTh2HxsbeuWJeJ7mObrFzXa9UrgRu3rprXF61eu1mNekhDqvYc8SG6Fka887gd0m7PjpyfZY6iMh1X8ZSwXy55VBJtKhRkC93dhXmxrMJ0OH17P51uHU+Pt7+dA0Gg/Yh4xtlMBhQRftGL7fgzKVqxVK+SmZb+ea8a9NK1NZm5F5qDs7wsdNRqFRNf86KpTKBz0ZLpg6VHunt7b+eEh8pYkTZ2ZQ2PzbAgb9+M8o3ib8y6luqx+f/qgHzMr3NWIkhR+ogSzHqNu2IuHFiYerYQZLNn4iTaxrh4+37lLhpnJfXl6esaV1NdfWwwWDQg1/sHWHsY8bcYDB8wcRgkPFiAg3W/975rf1zpGzL7f2vHIPBgLHDesF8XMpxwgTxjJWwbMeY7HDAYLDOUm6nHzt5GpPHDsD5o9tUnWQ2Vm+vXkgkvweW9GN9b2sMGQy+5e7dtkrZlfbpsu/P1cqEI+ecUnRgY+mc0M9Ng8EAKUsv33QvD8VaM6/P5G7c8heePP0Xm7f9DZlBNNU3P9ekHuKgGAy+7TfVlecMRo6fqd0daqud12sUF7lLZc7bNI8zw3LHQ76IHDpyAst+XqcxiYPC+f9zpJxZliO2LI/x/84VcxsGg/3ruvRz0UJ58Ou6LSr7au1LSuXy/13zDQb7NiSjpTHvLH7mY8bS9VnqYCo+Pl6mh3Akj78MPHBLAv573WlNoCFPIpA6ZXLs3ndI3XoPSLtkNrJ5o1oYPqAb9m5dhevaTNehI77LJOzZ+TbpN9rMwh2YztI9fPQE8o3e2gybbjNixPD4/Mn/hV4u3KlSJIUuuq69ffJk3+DEqXP+1I4eO6OOpY4q4OCmfbfBuK3NOi6dOwHmM6bemlN54pSvXd2cLFX4VitfPw7oPsW336hyDhz+bwmAqQ2pvzwEGBjGpnashU+ePu8v6fjJs4gfN45a4uCsstNpdwn+3LnXXzmBORBn89PnTzazptBuYct6YpkZt6QoD5+VLVkEGdKlRswY/1Oz66fP+X/gx1I+R+KSJ0us7jJs+8v2WsOAnHMRIkRQRVtbh68SLWxSp/pWfXGVh8EsJFuNki84lbVZ3l/XbdYcqE34OlECFMib06gvSwROnPrHeCyBoydOQ/pYwuay79Ax5M2VDTLbKHcqJP3kaf/nqqVrgegFRKzZkDs6VbWJgGW/rMfCZavUchaD4UvHPCBlBbZPAlKGruvodV0mO9as3wR5eE36vEaVMroJOGrDmMEk4Ax+Ab0+y0SHwWDQrun/jTN5kPLocf/XXpNqMuhBBOjwelBnBldTGterqkw3a9cTJ7QPFPmAPPvPRfVWBbmVpxLNNvJyeHmjgNxalqSduw+qJ/STJf1aDu2KfBDKLfD23QbinwtXILdKO/UcgiTazKw+U2TNSDLNWb5+8zbsvUXCWn7TeFlHKLfB5A0S4nDLA1GDR01CneoV1Eytqa6tsLwp4rcNW7Bw5hgkiB/Xn6osl2jeqCZkFly+WDx+8hSjJszCydP/oFnDmv50A3IgM8YdWjXC0NFTsWb9FvUmAvnAmjh9vjITFMbKgJ2NrMGWsqQftu3Yg6mzF6GRdhtYsjmr7M7tmkLenzt87DQ1RmRsyjICmfmTchwVWbYhH+i29OXNJnLrs2WHvth38ChkbG/9azd+/vV3lS1D+tTYufuAGucyVlp27At1fqjUoG2kL2WN97gpc7Xb6GvVA2Cy9vuXNRuhP9QV0HMu8dcJ1ReiU2f8fzGxV1NZqywz160798OfO/eoJQry5gx5S4lwsZW/SvmS2LRtJxYtX4Mq5UvAYPjPQZSxLmti5el7GTO/rtuEhUt/RfPGtSyazJAulXpQVM4XuXsibDb/ucufrjOuBbZs1KlRQeuP33Dm3EXtmlDeX9mBOQhsnwSmLEev67KuWsaaXH+l7+VhNr08R23o+ub7oPIL6PVZnseoX6syho2ZirP/XFJjt++QceqOg3ndeOx5BOjwel6fOr1FMlu16dcFiBwpknqFUNL0+dGp51A12xrOx8dieVGjRsbUWYvwdercap1fiw69MXpID5ivDbSYWYuU23PLf5qEqFGjomKt5ihWoZ76cPxl0XSEDx9O07D+v3D+75HxuzSQesq6PnE2rWvbTvk6UUKs/3kODh09qV7BJO0oUigPxgztZTujWer+Q8fx8tUryKugpE666I7ZwF4dIQ+Wdeg+CJlyl1aO02/LZyJ5siRmlgJ22K3Dj2jdrB7GTJylXiUk61vlSXKxEhTGkt+eNNac25PaFyTphw7dB6NmlbKQh94kn7PKlg/gdSvnQB52/KFsHaTNVgzytoN3795KMQ5L2x8baON1oRqrtl5LJm9VyPhdWshrxWRsN23dA+JkS0HD+ndVYflBlwIlayB1ym/xQ0Hn3eLu1Kaxun0vDwplyFUK+UtUV86u/FCClB/Qc07WLnZs3RjlazRT7TZ9LZnYsyULZo1F8R/yo9eAMUiesRBqNWqvjdn92vkaBbb+8n6fDbLURL54VdKcX1Pd8qWLYvyIPpg2ZzHS5yiBidPmY1Cfjqhbo6KpmjEsD6iVKVEIRcrWRc5ClSCOe8fWTYzpEnDGtcCWDXl4MUniRBqLfEj0VQIpMkgSlD4JaMGOXtejRI4MuXOxX5tRr1SuuL9iHLXhL5PJQVD5Beb6PLR/F+TOmRWVav2I74tUVq8wlLFnUi0Gg5FAaJqmwxua9EOw7HR+r8WRp9jNi3149TCKFsrrL3rnphVo0aS2MU4eKJPXFh3f8zuun92Njat/wgJttjJy5EhGHdNAkYJ5IGsL9fV9V0/v0mYraxlVflk8DX27tzMeS2DEwO6azbESVJJAmwmdN20kzh7aggvHtmtpYyC3pFSitpGLltiPaLYmUpwped2PpInYei2ZI22XNxusXTFbtfvI3+sxuE9ndXtZq4L637ltE8VDHZhsFswcC2mTRE2fMFitMZT6mIq84UDSxYmX9YcHd6zFjXN7lJMtb4SQNF0cqauuq+9lqUSbH+vj7y0/496lg3h07QjEMdPT7TG21Db5QQ3hq9uQ/dB+XdRrvSSsS8QI4TFnygjV7pP7NqJ/z/bqVUZ6emDKlhfuXzrh/y0dMvP669IZuHxyB/45ug3SV6ZjyxFupYoXVNylb2y9lkw+4OWLm7zKTHRlXMtaRGmTLJuR9spacbEhfSs/cCBsJF3E0ri3No7l/NupnYeST8RgMECcvK1rF+HW+b04tHMtpB8qlSshyertHbbOOaVktunRqaXqH2mLnN+SbKmOMo5lPEu6iMyUyRsBpDypy/YNS7Fy4VR8lzaVJFsVg8GAY7s3qDIt6cpbGf76fZlq318bl6FB7Sr+bF08/hdkDEiknOfSz0d3r4eIXCu6dWhufN2ariOMpH0iDev63q2SMaTbyZAutaqPvG1C8sjbQERX3soix1KOJRuS9urVa8iDmLWqlZdDu3Lnwn6ULFrAqCe/6CZlGSO0gKU+0aL9/TcfG5bOU2mftNNfRrMDR6/rMyYOUYyaN/rvGq6bsmfD0njS8waVn9ixd31eoH1OybI60RWRsStvZjh3ZKsaiyMH9cDMiUMxYURfSaZ4MAE6vB7cuWwaCbgfAdaYBNyHwLQ5S9RbJsqW/MF9Ku1CNSU/F+qMMFAVOrxhoJPZRBIgARIgAecRkNdxybIk+cGC+TNG+7tz4bxSPNcS+TnYt1RzKgE6vE7FSWMkQAJCwNZtTEmnkIA7E0ieLIm6xf/7qnmQdaju3JbQqDv5hQZ1lkmHl2PAIwnoP0YgPwCQq3Al9Og/0t9bG+R36OUpe0uNl/gFS1dZSlJx8jS8vPBfDjr0GGz8KVM5tifmtk1t2ctrId1ulLzDtNfA0ahUuwU2bdvlT/+PrTtx4dI1Y1yuwhXVU8vGiGAI9BwwClKumC5YsqZ600FwM5CyQktsjbOQrpM+FirW+lGNBXmLSvGK9SFvuJDzQ+8XS/Wyl24pjx4ndk3HmR4fmnv5ta0KNZtj7OS5aNtlAOQX9KQ+cxYsx7t37yUYKDE/v60ZceaYL1ahPuStINbKYjwJkIAvATq8vhy49UACY4b2xN2L+zFn6gj8++8L1GnS0dhKeWjB0svQReHFy5dYvOI3CVqUPLmyokEd/w/TWFS0EGluOyi2LJj/IkocjQsXr0Ae6ipRJL+/9K3bd0NuLfqLDIWD4GYQCk0yFmlrnBmVQiggY+H8hSuQB7BkLMyYuwRrl8+GPITYtEFN5Mia0WpN7KVbzagluMo406pi/D9p+nysXjJdvTWkzY8NkCF9apUmb8AIyg9XmJ/fyqiFjSePeQvNDaEoFkMCtgnQ4bXNh6luTkDeUiBPYU8dNxBPnj6F/DiANElek/X6zVv1MvUGP3aBzHSlyVoU8k7PidN+wvkLlyEzYZNnLIS8F7R+886oWrcVZEZ3z/4jWLDkvxngdb9vQ9lqTVGodC1s37lXzENmiiZodtSBtpHXkcm7Rc1tm9q6cfM2ajVuhxIVG6j9rdt3tZxQZXbpPVzN0pau0hhn/7mo4k03b9++Q+dew1CkXF2UqdoE0k6ZqWrduR+Onzqn2iL24fcn75zdtG0nho+ZptIePHysUmS2r1TlRqjdpD2ev3ip4uQdq41bdVe2Zab4/MWrKt50I1zadxuEyrVbYtZPyyBlWWqLaR49bMpA7FhqqzzN/WP73pDXqkldZHbY0qyWzFL3HjQGVeq0VD+WsnzVOlVv4T9m0hy9SMg7W/MWq4pq9VpB+lZm3CTRkfzPnr+AtFVe55Uyc2H1LlrJO2rCLNVH8lqz0RNnSxT0cSYHs+cvg7w6Teoyb9FKiYL0sRw3bNFV9cOAYRNUvPlG3mks41Fm89JmL6ZmIS31ueT78OEDxE6hUrUg+n9oM/n6WJD3aIsdkctXb6Bmo3aq3Moar4NHTkh2WCpLxrOefkjTK1e9qeLaskNf4zgRdnLnQ2w30M4pGT+WxpklTqpgCxtrbZRzUsqQfpZzQt7ZK9kttV3iTaVb3+G4qZ1bVbTzWepaqfaP6p3X8stt8s7t2o3bo0X7PqZZVFjaZ29smZ/f8iVD8sm1oWajtqq/xZgjY95aW+SduDDd0eYAABAASURBVFI/OdebtO6Bd9q5LzZNRcaVlNngx87qVYitO/XDG+16Jzq2+s+0faJLIQFPIuDlSY1hW0jAGgF5tVDObJm1W/j+nbXpcxajWcOa2LxmIfZs+wVRo0RB+1aNkCrlt5CZsLYt6iuT167fgryD1dKra27fuYu1K2Zh3LDeaKc5ffp7WVVGs40l27rKwBGTUDDv99i0ZgHy5MyOQSMn60nw9jaoGamZE4dgmOakGhP8AktWrtFuaz6GvLJqUO8OkB898Pb2wthhvZAjW0bVlsRff+WnDaRPmxIlihRAzy6tVFrcOLFUWuaM6dUr1rJlzohFy35VcUNGTkHRwnmxbd1i9O/ZTnOsh6h4843BYMCqJdMgry6y1RbzfObHltoqt9/llry0r36tSjh+6qx5NuOxvFZqlTZ7Fz9eXMxb9DNWLZ6GLb8tVF8U5IcSxAkT5+aPXxdg6rjB2H/Q/y/R2cu/buM29c7VtStm49T+TcicIR2uXrsJ+ZIhM+mnD2xCvVr+3x177vxl9UVA0qU+8kVK/+Jw6fI1xVXG25Onz5TDaWyMFpBfgmrWpgfat2yo2iHrRn18vGGpz0V3xeoNePb8JbasXYgV8ydh6KgpePX6tb+xIGV9lSCe6nsJly5eUCsJ6p2klspSidpG7HfqORSjBvdQ4yFThrSYNP0nLcX3v4wfsSeveZPxYz7OXr58ZZOTr5X/ttbaKBp37t3HotnjIDwmzVig3oFsqe3yRVP0dRk1uCfix4tjbLu8QlHS5PVy8trDpfMmQl7DJXHmYm9smJ/fcWLHwLqVcyGvWqtTvSKGjp5mblIdWxrz1toi54L8KqCcj3VrVLB6Lsg4l/d7yyvjokSJhBWr16v+tdV/evvyfp9d1YsbEvAkAl6e1Bi2hQRsEfDy+nK4Z8v8HabMXKDW8t2999Dqj1rkz5sD1t45XKtaeYjtrJotcRxv37lnqxpW0+THLRrUrqzSG9evCvlVN3WgbQoXyKN+eENebn/+4hUtxv//g4dPak5WJaWTLUsGyDthb9y841/JgaMihfIorexZvsOFy1dVePe+w2qWW2bDBgybiBPajLFKMNvIDxEYDL6/nGWrLWbZvji01NZjJ86itsZZlOXdpd8mTSxBi1KymK/zJi/Kf6jNXMvsadV6rXHm3AWInSPHT0F+5ENe8i+cSpi8FxXan7386dOkxB9bd0B+NOTvfYcQK2YM5UA9efKv9mVkKhavWIPYWpxmyvj/4JHjKF+6KOTnVEVf3pEqcaKQOlVy6L9eJT/KcMFsBl36MaZmr3CB3KKudGW8WevzvdodCGljtfptILPhDx8/wT/aHQuV2c7GWll6NkmX2dGeA0ZDxsOa9ZshPxmtpxf7IZ8KJowfzzh+VITfRhxNW5z81Iw7a20Uhdw5shjPyejRoqr34Qal7WLTntgbG+b55SerV6/dBLmLMHfhSpw9f9FcRR1bGvPW2nL0+BnjuSBj4lsr54L8JHPSJF8r+0UL58Pho6e0Oy931Ox2zwGjYan/9PapTNyQgIcR+NID8LAGsjkkoBO4cOkKUnybRD9U+0b1qmmzVT2RIH4c7UOpk5qpUwlmmwg2ft3N29vHqC2/PPfx4yf4aHGmM70fP3w06lgLyAymzNxJeoTw4WVnFD1eHB251WlMMAn4eHsbj8L5hMNn7Z8xwsFA+HDhlKYq5/0HFRY7K+ZPNs6IXTvzt4o334SP4JtX4m21RdJtiaW2ij1vk/aFN+Njak9nJ3kqlSturPfebavQqU0TSLyX13+s5Gd7A5I/c8Z0ak10hnSpMWr8TPy6brP6IRKZUS2QNxf+3nsIvQaONTWpwqblhAvno+ohCab9ZjAY8P6DL3dJExH+0p8SNhfTvKIjutK+Pt3aGNstP9ySK3tm86wWjyW/2LGYqEVKuvyCnMziivzx63z1gxNakvqv18dL+3L5wW/8qAS/TaRIEdXMsy1OfqrGnW5TIqRuUgcJ+2iz3LIXMRg0blp5QWm72LEn9saWef7Z81dojvh9jBjYDfKjJK9evTJXUcd6WxQ3v/631haJ93bgXBA9ZdxvI8fCzlb/6e3zy8IdCXgUAS+Pag0b4zwCHmRJLvTyVPanT5+RJ1c2fy3799lz9ettdapXgPxij9x6lmUNz7R4f4o2DlasXqdupx47cQYPHz3G14kS4JtvvsL1m7dVLlkOcV5ztuXAlm15aEjqKXoyG+SokyL6ObJlUDOL0tajx0/jwcOH+MZkCYPomEuUyBHx/PkL8+gvjgvkyalmLiVB7MutewnbkqC0xZLdrJnTQ2aaJU2WDzgyY5k7Zxas0mbXLl6+Jtlw89Yd9YVGZuL37D+s4uTLgx5WESYba/llzMhMbekShVCzSlkc1WaMX2qOjMFgQL7c2dGxdRMcPXHaxBKQI2smrP19GyTv4ydPtfBWyBIbf0pWDqQfZVzt+Hu/0pA1nJ8+fYK1Ps+XJ7t212Ih5I0BkkHWbMoaXgnbE2tl6fkk/fGTJ9i4eYeKknbLml91YGVjOs5E32D4ktOps+ehr6M2NWOtjaY6puGgtF3sRIkSBY6c+9bGhvn5ffnadeTLkwNfJYyPzX/ukiIclnxW+tHRc+G0dkdD7nLIObt05VrI3azA9J/DFaYiCbg4ATq8Lt5BrF7gCcjsSuXaLVGqciOcOvMPFs8Z94Wxrn2GI2XmwtrsbmfIcoQihXIjapTIKFuyMOo07YDJMxZ+kcc8Im7s2PihTB3IA1djhvaCzL7kz51DPRAntw0nz1yIFMmSqGy2bPfv0U694kweWvvr733o272NyuPIRtYH/i96dPVQV5/B4zBxVH9VD1t5q1cui/V//KketNIfWrOk37d7W82BfgJ5uEoeyNqwabslNX9xQWmLP0N+B3VrVIQ8UFSjQRvIw4CyrEBuY/slW9zJuz6lHq079VMPi0lfvH7zRv38bcF8udRDiPLQz7fJEuN/0aN+YSO51meW8v+qOdEJU+ZSD7ztPXhUrQG/eu0Wvk6TRz0kNm7KHPTTmJkaTJPqWzSuV1WxloelfmxcG6lSJDVVsRqW8TR17ECMnTwH8qBS6qxF8EG7Y2Ctz2tWKYdc2TNBHizLU7QK+g4Zb9W2eYK1snQ9SZ85aZh6KFMeiMuWrzxkDbKebmlvOs6OHDsDS5z2axxPnv5yXba1NloqR+KC0nbJ36ppXXTtO/yLh9YkzVSsjQ3z87tR3aroPXC0GmuyHMTUhr2wtbbUq1kJN7Qv03Iu9B0yDsmTfWPRlLx5YvSEWchfvDqiRI6EmlXLqWtCQPvPonFGkoAbEqDD64adxirbJ9C3ezvs3/4rVi+dDrntKg+qxIzxP2PGnZtWKMd2lvbhfeHYdvVA2rD+XRHO75a+5F8yZwLkobXqlctozmc7Y15Zfzmwd0d1LA+xTRzVD39tXAZ5MEXW1EmC2JEHpeS2r7we7e8tPyPG/6JLkrKl2za1JQ+VLZs3ST20JntZrysZpIyihfJKUMnhXevU3nQTIUJ49VCSPMiy4Ze5yJ0zq0qWh1CkLHVgtpEHihbMHKNuz4uzv3/7GvUzqaKWX5uVmjxmgATVF4Fp4wdBHn6R2+ND+nZW8aYb8zpaa8vwAd1Q0m/N7I4/lqs+MGVgbkdva/jw4TBueG+sWDAFLZrUQcyY/7O43tq0DVK/SuVKKJ5/rl+CQzvXIm3qFBKtHqyTH8eYNLq/Niv/BBm/S6PiHcnfUHNi7lzYj58XTYOMH2mrsLx78YB6qEziCuTNqezp40wOmjWsBamHcGxcr7pEqYffNq7+SYVl073jj8b1mXKsS/asGSEPyUn/Xj+7W7XdWp8bDAb07NxK9deeravUQ4jCz3ws6GyljBEDuxv7xVJZpunykJ48FCjj+9yRrahSoZSY0M43y+MnfdqU0MdZ/jzZYYnTsRNntS8EvkyUMb+NtTaan5NyniX5JpFaw26p7X7mjLvje343hmWc59fGu0RUKlcccr5YemjNkbEhNkyvHcJc8slYk76VsOg4MuYNBsv9KMtCpo4bpM4FeWhPxnWc2DHFrD+R9cNSrlx7RD9ixAgq3ZH+U4rckICHEaDD65QOpRESIIHgJPDm7TukyFRIzTJ36T0Mg/t2ClJx8uopeS2ZzPo21xxReZAsSAaZOUgExOmU2/5BMsLMJEACJGCDAB1eG3CYRAIk4BoE5FbxzX/2qlnL9T/PgcxSBaVmMlu6e8svyl7Vir4zlEGxx7wmBBgMdQJyd8j0zkGoV4gVIAEXIECH1wU6gVUgARIgARIgARIgARIIPgKh4fAGX2tomQRIgARIgARIgARIgATMCNDhNQPCQxIgARIIOQIsiQRIgARIICQI0OENCcosgwRIgARIgARIgARIwDqBYE6hwxvMgGmeBEiABEiABEiABEggdAnQ4Q1d/iydBEjAcQLUJAESIAESIIFAEaDDGyhszEQCJEACJEACJEACoUWA5QaUAB3egBKjPgmQAAmQAAmQAAmQgFsRoMPrVt3FytoikKtwRbx589aWir+0ngNG4Y+tO/3FBdfBw0dPUKxC/eAyb9GusyMLlqyJFy9fwVZbpI2Sbq1syb9g6Spj8m8btqL/0PHGY3cKyFiL8XUmiCROkwcNfuyM02cvuFMTHK7rmXMX8efOPUb9Dj0GY+tfu43HrhKQ8/nCpWvG6hQoUcM4ZotXDN3zT+rWo/9IY90cDVhjbe/csZbP0XLt6c1ZsBzv3r1Xardu30Wpyo1UmBsScFUCdHhdtWdYL48i8L/oUTF6cA+PaFNQ2vLi5UssXvGbkUOeXFnRoE4V47G7BeLHjYOnN4/jnyPbkPG7dJgwbZ67NcGh+p47fxE7du13SDc0lbZu341LV/5zeCeM7ItIESOEZpWCrezQPnfmLfoZ7977OrzB1kjnGaYlEgAdXg6CUCEgM2ENfuwCmXVJk7UoHj95irLVmuLqtZvG+siM7YOHj7Fy9QZt9qwLajRogxwFy2PZL2sxbMxUFC1fD6069sPHjx+h/w0aOQllqjZBpdotcO36LRV94+Zt1GrcDiUqNlB7mY1QCVY2lur24cMHDBg2AYVK1VIztTJbI9kt6T57/gLtuw1C+RrNkDJzYTUz9u+zF+jad4Rkwdu379C51zAUKVdX1XXvgSMqXm9nlTotUbpKY/y6bpOKt7XZteegmln5oWwddOk9HPqMi7CTmdOKtX5U7J6/eOnPjByLjh5578FD5C9eXR0OGjEJ2fKXw/c/VMbchStUnOnGtC2vX79Bi/Z9VFuatO6Bd1rbRPfTp0+qbTLDJrO+u/cdkmhMnPYTzl+4DKnX5BkLsWf/ESxY4jvja62fZKZK2iZ9KlzO/nNR2TLdCLv6zTujat1WEH1rjKvXb41z5y+rrFnzlcXCZatVWNqw/9AxNUNrPi6Vgp1N5MiRED5cOMSNE0tpWiu/ZsO22PDHdqUzQWPRb8g4FV6+ap3QG8lHAAAQAElEQVRiWLhMbYyZNEfFWRpHKsFkM2rCLDXW0+UojtETZ6sU6ddeA0cr/sJMPw9kRjDD96UgfSLjTx8rwsse34nT5uO337eqftu+c68q548tO9WxnBN6n1g7T1QGk834qfOQt1hVSH9Iv0ndJDlTntKyUyKceg8ao8KSbq3ucq5Vrt0SA4ZPxKZtOzF8zDRVL7l2dOg+GK/N7vp8CMC5rAr321gb03I9kX5r2KKrKleuE35ZsGX73+q8knH5x9YderRxL3XR2yzXPrlbcPGyr8Oes1AFSLooW2Jteu6s1fpGro9yDgsLyaPL58+fIRxGjJuuoiyNNWlDodK1tGtFZ3XdevT4yRfXMJXZb7Ni1Xpcv3EbtRu3V+e/RL95+xbC4AftWiTXHokTOXTkBMpVb6rGd8sOfSHXHomnkEBIE6DDG9LEWZ4iMH3OYjRrWBOb1yzEnm2/IGqUKKhRpYw2+/erShfnI02q5EYH4t79h5g/Ywx+WTQdPfqNQrYsGbF17SLIh9C2Hf/dao0dKxY2/DIXRQrmwVDNKRZjAzUHrmDe77FpzQLkyZkdg0ZOlmj/YnJkqW4rNKf72fOX2LJ2IVbMn4Sho6bg6b/PYEl33cZtSPRVAqxdMRun9m9C5gzpTKwDS1auwcNHj1X9B/XugJYd+xqd9jv37mPR7HH4fdU8TJqxQLXPX2aTA/kwbN25P4YP6Kps3b57V30Z0FUyZ0yPNctmolTxgli0zJernhYtahSkSJ4UBw4dV1HrtA/MsqWKqHDNquVxeNc6bF23GKvXbvY3Y6YUTDaLlv+KT58/YZumW7dGBRw/dValGgwGTBjZDzs3rcCsSUPRzc/Zb9+qEVKl/FbVq20L/7eYbfWTt7cBq5dMx8yJQzBMc2hUIWYbcewWzhqLCSP6WmWcI1tmHDxyHHfu3sfXiRLi0JGTysqR4yeRLfN3FvtTKVjZyBcFcVJEps1ZhOYNaylNa308ecxADBs7VTnWK1evR8/OrSAOjsyWrVo8DVt+W4izmkMvywfsjSNxkOTL0q9LZ+D0gU2oV6uiKls2Gb9Lo86D+rUqa+VNkyhtHKbFoR2/4a+NyxAhQjis0MpXCdrGHt/2rRqiQumiqt8KF8it5QAkj5Q9fGBX6H2ywsp5ojL4beRL4vJf1uGPXxdg0ugB2H/wmF+K9V3mDNbrbjAYsGrJNAzo2R4lihRAzy6tVD31Lx/mVq3V0dK5bJrXYLA8pkXn0uVr6N+znSr3ydNnOHbyDN5rs5+deg7FzEnDsFy7Zly5ekNU/YmPjw+SJ02izrGDmmNYMF8uNT5lLCf6KiEkXTJYYi3xugwfOx0LZo7Frs0rMW38IBVtMBi068onNGvbE3It7dGppdWxJhlOnTmPAb06qOvWH1t32ryG1ahSFt8k/gpL503EDO2clPw6AxnD585fUgxkMkIYjNLubsk1IpPWj5Om/yTqFBIIcQJeIV4iCyQBjYA4F1NmLsDYyXNx995DhA8fDpXLl4DMVMiMxMrVv6N6pbKapu//HNkyIFKkiEjyTSJE1Zy1wvm/VwlZMqXDhYtXVVg2dWqUl526TX70+CkVPnT0JBrUrqzCjetXNTp5KsLCxlLd9mozkUc0e9Xqt0HjVt3xUJsB+UebqbSkmz5NSshszsjxM/G3NrMZK2YMf6UcPHxSc04qwWAwIFuWDIgXNzZu3LyjdHLnyAKZLZSD6NGiamweSNCiXLtxC4kSxkfmjOng5eWltbEqDh4+YdQt9kM+FU4YPx4uXP6PkYrUNuU0B3ftxq1aCFi38U+U1xwaOXj58iVkhrBes06aY3gP5/65LNEW5ejxM6hdzZe5OELfJk2s9AwGA86cu4CW2oxOxx5DNDsPIF8QVKKVja1+Klwgj+KVSPsicf7iFYsW8ufNYWR30ArjXNkzKSd3n+ZkVSpbHMJQnN/48eIq58JSf1oszC9SX9Jw79JBDO3XGX2GjFUp1soXJ6xj6ybarHxD7YtKNzWm5cvdQ+1OhsyOVa3XWnE7duIs7I2j+PHi4MmTfzVnc6r2RXENYpuMs2KF80P+ShTJr7XXd0yEC+cDmVmt1aidmlkXp0R0RBzhK3qmUihfbtUnObNlgt4n1s4T03xHtPOoYtlikC9dCeLHRYmiBUyTLYZt1b34D/lVPSxmtBBprY72+t5gsD6mU2tfzpMl8R37CRNo55t2Tbqu3VlKql2v0qVJocZWzar/Xc9Mq5VTG5Pi7MoXsZZN62rn8EkcOHwcMlZ1PUus9TTZf5cuFXoPGotpsxera4HEyXW07+AxSJk8GVo0qS1RsDbWJFG+JOltsDf2RN9cUqZIBsnv7e2NLJnSq+uyXNdu3r6LngNGQ+7qrFm/GcdP+n4pNs/PYxIIbgJ0eIObMO1bJNCoXjWMGtwTCeLHQf3mnSCzVVEiR0b2LJkgt++27diN4kXyGfPK7WL9wMfHWznI0P68vb3wXrtFqQXVfx9vH7X39vLCp0+fVVgu/JJHDiKEDy87fyIfArkKV4LIX7v2wVLdxEafbm3UDI7Mmp49tEX7QMpsUTez5oDKzFeGdKkxSnN6f123GeZ/PtqHgh4XziccPmv/5Fivp4QNBoM2S/RBglbFVD9cOG9IPXVlH78yvDQWH95/aadMiR/U7fW79x/g/oNHSJs6uVpuITPO1SqWxvKfJml9kB8vX73STX6xl/K8/cqRxPB+fI8eP62WKnRq21TNzH6tOaovX1q3I3nFlt4e837S41VbTPpb8ukSQfvSpIdlr7dfwjpjcc7EmRDnImf2zIgTOxY2abNZunNhqe8lvz2JECE8KmoO9Katu4yqlsqXRFmGIvuPnz7KTvVZpXLFjWNr77ZV6NSmCeyNI/kCKHccCuTNhb/3HtK+pPg622JUWMreVLr0GYbUKZNh9pQREKf75avXxmRH+BqV/QLhwvuda1r/y90GiZZyLZ0nkqaL6Hh5eeuHyhk0HpgEPpgsVbJV9/ARwpnksh+U8i3V0V7f2xrTpn1tMBjUNemzdvnx1tjoNZIxqIdN9zL2Dmpf0M5rTnJJzfm/cOmKmuXNnjWjUc0Sa2OiFpg9eTjq166EF9o5Vl37Uv7p0yf1JaC4NuP9x9YdxmUE0nZLY00zAdNzzt7YE31zCR/uv34wGHyvy3JdS+13R0eum3/8Oh8rF041z8pjEggRAl4hUgoL8TACQW/Ov8+eq1tidapXULMB+rrK6pVLQz7cypQojHAmF1BHS1z681qlunjFGjV7Kgc5tA8Ofa3m3IUrlaMq8brk0hyf/dt/hUghbebYUt3y5cmOKTMXqg8UyXdIu/0oayAt6Urc/6JHQ+kShVBTu/V3VJvRkjy6yGy11E8+fI5qjuGDhw/xzddf6ckW97N+WoaHj574S0uSOJE2c3pf3TqUD7gFS1YjV47M/nRsHcgMW/p0KdFvyHhUKldCqcravRj/i676xMvLgL/sPKiUNXN67N53WOWVLy0y6y0Hcps+S6a02uxSEly5dgNn/rko0WrpyjOt79WB2cZeP5mp2zy0xjhixAiQmfO9B44qB1+cjelzF0OWOkD7k76TW7Wm41LWHEo/ack2/2/bsQeJEyVQOtbKF8f00NET2PzbInTvOwLPnr9A7pxZsGrtJnW7WTLfvHUHwlLqYmscvdS+iBgMBuTLnV05sEdPnJbsSiydB3LLuYTmAEn7t27/W+k5uomsfRl9ZrYO3FJea+eJqW62zBmwfuM25YTdvfdArXPV07/WbuPLelI53rn7gOyUOFr3KJEj4rnGVGWysrFWR+Ft3vemJqyNaVMd03AS7Za/9KX0scTrX3QkbCo5tBny3dqdIDnvJF7uCO34ez++z5FFDh0SqXum79JqX5Qa4/HTf43XKbnr0rJJHdRp0kGt77c21swLEXu2xp7oR4kSBdbOZUkXkeva4ydPsHHzDjlUX55luYc64IYEQpgAHd4QBs7ifAl07TNcPdBVv3lntU63SKHcKkHWsElA1ojJPqBy+85d9WDZxi070LtLa5W9f4922PrXbvXQ2l9/70Pf7m1UvLWNpbrVrFIO4hzJwxd5ilZBX81JlPyWdH/VnJeEKXOhWr1W2HvwqFqrLLq61KleEf+LHl09dNdn8DhMHNUfpjNBup7pfuL0+dpM2H+zYpLm4+OD8SP6omf/0cpW3DixNQe7nCQ5LGVL/qAeCpTlDZLpq4TxkeLbJOrBvKZteiBdmpQSbVXq1ayEG9qtW3lgpu+QcUie7BulK7ep//r7AOQ25qTpCyAzRpIQNUpklC1ZGHWadsDkGQslyigB7SdjRgsBW4xzZs+IBNqdBS8vL+2OQgb8c+EK5Il3MWOpPy9euorOvYdJ8hcizoW0UR7Ma9q6B4b07aJ0LJX/4cNHdOs7XK3pTJPqW7RuVl9zekdqzJJA2t66Uz/8ULYOxN7rN29gbxxdvXYLX6fJo/pq3JQ56Ne9rSpbNpbOg3YtG0EerqrbrCMiRYogag6LONWvtBnh6vVbQ39ozVJma+eJqW76tClRuUJJ7Xysj3ra+Z9FuyOipzdtUB1V6raC1FG+EOrxjta9euWyWP/Hn+pBPnloTc9vurdWR0t9b5rP2piGqZJJWL6wDx/YDc3a9EDtJu2188R32ZKJigrKORFFOy+yZv5OHWfPklHrn0jal8PI6tiRTe4iVbQ7VBUhd2c6tGqovtTp+apXLgNZ9iHnsyw5sDTWdF19b2/siV6rpnXRVRvPLdr3kUOLItc1WcMsrzCTcyRbvvKQLy8WlRlJAsFMgA5vMAOmecsEZk0ahgvHtkMeMhrWvyvkw0E0ZT3lt0kTI2P6NHKoRC7Yfbu3U2HZHN/zu+yUNG1QEx1aNVLh/dvXYMTA7vhr4zLIkgJZ7ysJibXZ02XzJqmH1mQv60AlfviAbpBbiBI2FUt1MxgM6Nm5FbZvWIo9W1dh4+qf1LIKS7oN61bFnQv78fOiaZB0KT9O7JiQhzmknAgRwmPssF6Qhzg2/DJXm+HLKtEwb6fcApQ2XL56XatnQegzQErZb5M/Tw5Vlz/XL8GYoT1VnSRJWETUZjMlLDqTxwyQ4BciH/7yWi1ZzqAnThk7UNVVHoKZN22kqpek7fhjufoQNm2L3FafOm4QViyYoh62O7RzLSRdZhGlfdKGiaP6QR4w1LlLXy6ZMwHy0FqFMkUxsHdHMQ/hJP2zac0CyF7Xl4fQihbKq3RkIw/Uyd5UzNlZYyx5BvfprOxLOKvmZEj7ZbZbjqW/zMelrEcUvpJuKsL3wZVDaimC9O21M3+rWX3RsVS+xMnY+S5tKlGBjJPpEwarsMywS7ulHGGYNnUKlW4+jpSy3ya95jjevXhA9ZXUu0DenH4pwICeHb44D2TWWu5iLJ49Xi0nEq6SQfb2+IpTNnPiUHU7WmYNreUxGCyfJ1KOqXRs3VidR8ItWZKvjUnCYd+fqyF1HDe8N4b2079AVFB3b88ktgAAEABJREFUYCRelkJJ+ZJJ9qZ1FyYLZo5R53/cOLHUQ5NSdxmTm9cslCwwGCzXURia973K4LexNqZlnMr1wE8N3Tv+aFzXXqxwPnVuLJ07EauXTlfXJ13PdC/nSrsWDVSUnBd//b5MhWVj3kZ9/JueO2cObtb4rIEsbWhcr7pkw/jhfdTDu3LQ5sf66lorX/KEsflYM2+DjE1bY09sVipXHHIey0Nr5vlNGchDu6uWTFfj9NyRrahSoZRkp5BAiBOgwxv8yFmCgwR+WbMRFWo2Q+e2TR3METbUvk36jXKQw0Zr2UoSIAESIAEScD4BOrzOZ0qLgSRQtWIpHNyxFrKONpAmmI0EwjwB09l914PxZY1khl9mK79MYQwJkAAJOI8AHV7nsaQlEiABEiABEiABEiABFyTgcg6vCzJilUiABEiABEiABEiABNyYAB1eN+48Vp0ESMCjCbBxJEACJEACTiJAh9dJIGmGBEiABEiABEiABEggOAgE3SYd3qAzpAUSIAESIAESIAESIAEXJkCH14U7h1UjARJwnAA1SYAESIAESMAaATq81sgwngRIgARIgARIgATcjwBrbIEAHV4LUBjlmgRmzF2KGF9nMsrqtX+oip45dxF/7tyjwrLp0GMwtv61W4JW5cXLV1iwdJXVdGsJy35ZiyLl6qJgyZpYuXqDUS15xoLGeuUpWsUYLz+p+e7de+NxrsIV8ebNW+OxKwdM6/7w0RPIT4NKfX/bsBUDhk2QoFPEvC+E6+CRk5xiO7SNmDIMSF0KlKgB4RKQPJZ0/9i6Ez36j/wi6e79B2jwY2dUrPUj9h08qvaiZH4uSZwujpxXuq4je2mfI+eg6djrOWAUpE2O2A+sjmkZcp5LPc1tucJ5LPWScWJeN/M+dHa/mZfHYxJwFwJ0eN2lp1hPRUB+Olh+ClakcvmSKu7c+YvYsWu/Cju6efHyJRav+M1RdaV39p+LmDFnKeTnctf/MhfTZi/GvQcPVZr87K/USUR+PlZFapt5i37Gu/f/ObxalGv8d6AWpnX/X/SoGD24hwO5Aq4SmL4IeCmhk8OUYUBqMGFkX0SKGCEgWQKk+8eWHcj4XTo1ljNnSIdBfTqq/IE5l1TGQGwc7ffgHHuBqLbLZwnJPnR5GKwgCZgQoMNrAoNB9yQwcdp8/Pb7VjVLtX3nXtWIP7bsVMeFStWCOKoq0mQzcdpPOH/hstKZPGMh3r59h869hqnZ2zJVm2DvgSMw/ztz7gIyZUiLaFGjKMmQPjW2/Pm3uZrxeMWq9bh+4zZqN26PFu37GOOHj52GUpUboXaT9nj+4qUxXg/IjEz7boNQtlpTFCpdC3qbPnz4oGZWpU0y2/qHNnsneWRGtH7zzqhatxUk7/0Hj9C0TQ8Ur1gfqbL8gAOHjosalq9ap9pXuExtjJk0R8Xdun0XctywRVfFQp+5Na/7v89eoGvfESqP6UZmChu36q7sVqrdAucvXlXJa7X+qNGgDfIXr47KtVuqOKln83a9VNh0Y94Xknbx8nVUqdNS5f913SaJUmKpDSrBZJMpT2nj0YY/tqP3oDHqWNh06T0cUs/SVRobx8WnT58gM8rCIWPu0pg+Z4nSnz1/GX4oW0fxmbdopYqzxksSR02YpWyny1EcoyfOhjlD0ZGZQamPtG33vkMYNGISsuUvh+9/qIy5C1eIipIO3QfjtXYnwFZ5h46cQLnqTRX7lh36GsfSlu1/K24yHv7YukPZM90cPnpSa+NirX5rVZ8Lj35DxisVS+eSSvDbWDqvLly6BmmXjNWajdpC6izqp89e0GaRu6hxmCZrUTx+8lSijWLe79IPcu7JrKWMb+EjytbGnjlv0dXlg3au6OPg6rWb6u7LxcvXVHLOQhUg6dbGrlJyYDNIuwsh9RV+167fUjks9cnLV68gZX7+/Fnp3L5zT40pOdi156C6Fsg4k7Gp3w0Snv2Hjlf90+DHLsa+vXTlmoqT8Tty/HQx8YVY6kNL/SYM5Hy3dD2RMuX8zVGwPOSu1rAxU1G0fD206tgPHz9+hKf9sT1hgwAd3rDRzx7TyhHjpiNp+vzqwvvk6b+qXe1bNUSF0kXVbFXhArlVnLe3Ab8unYHhA7ti2JhpKs50075VI6RK+a3K07ZFfSxZuQYPHz3G1rWLMKh3B7Ts2PeLC3va1Clx/ORZyAeYiITv3H2gzL548QqJUuWGfHiIkyWRNaqUxTeJv8LSeRMxY+IQiVKSOWN6bFz9E7JlzohFy35VcZY261bOxuLZ49C1z3CIM7Bi9QY8e/4SW9YuxIr5kzB01BQ8/feZyiofuAtnjcWEEX01520ykif7BpvXLMS+P1cjRfIkkA/7edps86rF07Dlt4XK2dOXgVzSHIH+PdspFk+ePsOxk2dgre6qMJPNkJFTULRwXmxbtxhio3Mv33YOHzsdC2aOxa7NKzFt/CCVo2D+XOjYuokKm27M+0LS7ty7j0Va29dqDIZrXxCk/bbaIHkcERkXq5dMx0ytP/RxsVz7YnLsxFn8sXo+juxai9LFC+Hc+cuY9dMyNYaEmXwp0p15S7zEqZIvSTLmTh/YhHq1KlplmDF9GqzS6pD3++yoWbU8Du9ah60av9VrN0McGvN2WCpPnI5OPYdilDbrLuzli9ik6T/hvXY3QeJnThqG5doYuXL1hrk5ZMuSAY3qVkf9WlVUn8+Y4Ntnotjewrkk8boIP2mj6XkVJ3YMrFs5F3/9vgx1qlfE0NHTlPr0OYvRrGFNNQ73bPsFUaNEUfH6pr3ZOWgwGDBhZD/s3LQCsyYNRTcLX7D0vJZ462my9/HxQfKkSRTPg9oXg4L5cuHgkeOQ8yTRVwkh6dbGruR3RGLHioUN2p2eIgXzYKjmEFrrkyiRI0PO9T/9vozLeKtRuaxyult37o/hA7pCrju3795VzqVetlwn5G5SqeIFjdeJwdr5VrFMMfy+ap52ByCirupv395CH1rqN1vXk3v3H2L+jDH4ZdF09Og3CtmyZFR1lPNw2449/srjAQm4CwE6vO7SU6wnqlQoiYvHt2sO32K8efsWA4ZNtEqlUL7cMBgMyJktE85fvGJVT084ePik5qRUUnnEIYgXNzZu3Lzjl+y7S5cmheYoVEWeolWRo2BFfPVVPHh5+Z5CO/5YjiundkI+bNp3H4jLV6/7ZrKwLVIoj4rNnuU7XLh8VYXNN6JjMBjwdaKEiB0rJm7euou9+4/gyPFTqFa/DWRW9eHjJ/hHm6WWvPnz5kDkyJEkiL/3HkK7lg1VOFbMGBDZf+gYHj58jIbaTG7Veq0hs9Xi5EH7S50qOZIlSayFgIQJ4uGC3yytirCz2b3vsFrLLGtBpT9OnDqncnyXLhV6Dxqrln3ojOLHjYO0qZPDkb9c2TOp9sSM8T8kiB8Pd+89gK02OGJTdAoXyKP6ONFXCYzjYo/WhuaNayNChPDKEUryTSLlHJXXvkT9L3o0xa9CmaIqTmxY4hU/Xhw8efKv9uVqKhavWIPYGnfRtSQlixU0Rr98+RK9Bo5GvWadcOfuPZz757IxTQ9YKk/G5s3bd9FzwGgI+zXrN6svY9dv3kZSrf4yVsWpq1m1rG7GKXtL51WkiBGxeu0myF2GuQtX4uz5i6qsbJm/w5SZCzB28lyt/x4ifPhwKt7axmAwqHHZUput7thjiMbjAfQvdOZ5HOGdUxtD4uyKo9uyaV3IOX7g8HHI2BJ71saupDkidWqUV2oN6lTBUe28tNYnolSjShltRn29BLX9OlTRrmXXbtxCooTxkTljOnUdaVC7qlbHE0pHNsV+yCc7JNTGv36dOHriNGpV8y23bo1KKt2RjaV+s3U9yZEtAyJFigg5F6JGjYLC+b9XxWTJlC5A1weViRsScBECvp/WLlIZVoMEbBGIGyeWckhSajOWvbq0wrETZ6yqhwvvo9K8vb3VTIo6sLPx0XR1lXA+4fBZ+6cf6/uGdavi+J7fcebgZkSPFg3ffJ1QJSWIH1d9oFcqVwJFC+XDqTPnVbylTfhwvh/84gh+eP/Bkgr87n4a0+R2qEifbm3UrJzM/Jw9tEX78M6sdCKYORMRwodX8fpG8lYqV9yYd++2VejUpolKNm23wWDAe+12sEpwYCOMVsyfbLR77YzvEo/Zk4ejfu1KePHyFaprDrrMDDlgzqiiM5II4fRe42SrDaJnST6Y3X718fFWamJTbunKgdgNF843Xo518dFmCfVwuHA+Wp/43pL2MRknBoMvL3EOZOa9QN5c6gtHr4Fj9axf7PW+efv2nbqTUK1iaSz/aRKKF8mv7h6YZ7BUnnBP7XeHQsbCH7/Ox8qFU7U6AjLmdRsyjvWwM/aWzqvZ81doDu19jBjYDXOmjMAr7Ra+lNWoXjVtBrqn9oUljuYMd4LMykq8NTl6/DQWLNHGZdumkFn4r7UvJS+18WNJ3xHeucTh1b7Iysx8yaIFcOHSFfWlJXvWjMqkMLQ0dlWiAxsfb79rjPal99MnsfYZlvpETMkM8zHNWd3x936kSZUCci2TeB+/8ShhGYMyFiUsove7Gqva+Jc4uS6E9zvXZUxKnCNiqd+kLGvXk/B+1yixLXXUy/T29sL7AFwfJD+FBFyFgJerVIT1IAF7BJ49f6FU5EL9++a/kCVTenUcWbtl+MzCWliVaGUjt1efPXtuTJUZDZmZE9vywfvg4UPNmf3KmK4HZCmDrLNbtPxX7Pz7AEppt7/Fqfv06ZNSkYfYZEmAzHBKRBTtNq5pORLniKxYvU4tYxCnXpZafJ0oAfLlya7NmC1UTqTYkPWCUhcJm0re77Nh4vQFxiipX+6cWbBKm4WTZQGScPPWHbsOiCN1L5Anp5rVFJvCTm7rS/hfjW2m79JqTnVjPH76r6rzqbPnIW94kHRTMe8L0zTTsKNt+Fq7Za2vI925+4CpCYvhPBqvOQtWqHXcoiC8cmTNhLW/b4O0Q9aerv19q3a3wPfLheiYi4wLg8GAfLmzq2UbMhMnOrYYPtJm6OVhRxnHXl4G/BWABy+/+forPH7yBBs375BilKMs4y5J4q+0uwF3oJ8rskZUKTi4Ccy5dPnadW1s5sBX2mzl5j93GUsSdrKkp071CupclWUixkQtYN7vMjazZEoL+UJ75doNnPnHd6ZYU/3ivzXepoo5tLs7u/cdgjCWeLnTIQ7n9zmyyCGsjV2V6MBm6c9rlZZcN+SukLU+ESWDwYBK2pfhVp36oXqlMhKFJIkT4c7d+5B+k+vHgiWrkSuH9TEmmbJq1zx9TO/YvV+ivhBH+9DR68kXBfhFyBrth4+e+B1xRwKuT4AOr+v3kbvVMNjq27ZLf/XwSeqsRXD5ynUM6NVelSVOxqtXr7WZxNbQH/BSCTY2UaNERtmShVGnaQfI+kxZe/i/6NHVgxl9Bo/DxFH9/c2U6aYKlqyJhClzQRzepfMmQOxcuHgFcZNlR+wkWVG7cQf079Ee3yb9RmVppceYZmUAABAASURBVN1K7dp3uL+H1lSCnU3c2LHxQ5k6kAetxgztpepSs0o5yKyVPKgkrz7r6/egkbmpPt3b4PTZ86otidPkwcnT55A8WRKtXu3QWvvA/aFsHcht8Ndv3phn9XfsSN37dm+LBw+fQB74koe1NmzarmzkLlJFPcjUsmNfdGjVUJsNj4r9B49qdTmr0k03wtC0L0zTTMOOtqFpg+qoUrcV6jbrqM14+s7KmtoxD9eoXAapkidDsfL1kOH7Upg5bxnSpPoWjetVVQ+hia0fG9dGqhRJzbMaj69eu4WvNdbFKtTHuClz0E/jIom2GIqDmOLbJJA88pBhujQpJYtD4q3NMss63TkLlqv82fKVx6XL1xBOm5kbrs20NmvTA/JQpNxmd8ign1JgzqVG2l2P3gNHq4cmTcuTtecpMxfWZnc7qxnNIoVy+5XiuzPv9xLaLOxf2pdIGZuTtC9scqvfV/PLrTXepppiP4p2nmfN/J2Kzp4lo3abPpI6ZyXC2tiVNEfk9p27kDX7G7fsQO8urdU5aqlPdFuVypXEu3fvULxIPhUldxDGj+iLnv1Hq3M1bpzYkHNcJVrZ9OvRFrIWXx5I3L5zn0UtR/tQynLkemKxEC1y+Lhp2jl9TAvxPwm4BwE6vO7RT6ylRkAegpLXfp0/+ifktU36zI18sM2cOFTd0pWH1uTBraKF8mo5fP/LQ0G+If/bvt3bYcmcCZCH1mT95thhvSAPAG34ZS5y58zqX9nv6NDOtXh07Yh6ECer3wepzNBJnIjkL1W8oJ82tFmd4qoM/aG1/dvXIKLf66by58mByWMGGHVNA+VKF8FfG5dBHgSSNkmawWBAz86tsH3DUsirz+TBN7nVWF1z2KQtoiOSIF5czJs2EvIgzI1ze4xtkRmmTWsW4M/1SyDtSJs6BWQtq9iRfCLdO/6I2n5rBCuV+6/ucWLHVA+7iY6sZx3Qq4MElSMjD6VJnWSJxZC+nVW8LPmQtsrShsb1qqu4YyfOak6kb1hFmGyk/npfmLdHbtnLWkJRr6TNkpm3QeJNRXTkYb3Fs8dj3PDeGNqvi0q2Ni7E8ZD27Ny0Aif3bUTntk2UfrOGtRQraZveBmu80qdNibsXDyhGsyYNQ4G8OZWNSiYMJUKY6P0vx1PGDlR5ZGxLn0nbJV7qIuPaWnmiI68Tk4ff5CHEc0e2okqFUhKNYoXzYcWCKVg6dyJWL52OEQO7q3jTTYsmtdHmx/oqStgKYzmQMk3PJYnTxRq/jOnTQNr1y+JpkPEjYckjHC4c2w55mHJY/67KGZd4UzHt9+jRoqrzT+oycVQ/NX6l/aZjb/iAbpDlCdZ4m9qWsJyP7Vo0kKA6z+V8UgfaJm6cWOqBSulf07Grl6GpQNbmCxMJm4q0UbjKOSoP8QlDSf+yT3z7RNLOnb+EBrUr++Mg1wA5/+ScHDO0p1oWJbpiXx8noqNfJ+SL9IKZYyCspZ9knIi+qUh9JU2WuMi1w1q/GQyOXU9kCZduv2mDmujQqpE6lPOrjDZpoA64IQE3IECH1w06iVUkAU8gIB/aMqvpCW1hG0ggIAQGDp+IoaMno0WTugHJRl0SIAEnEqDD60SYgTHFPCRgTsB8RsY8ncckQALuRaB/z/Y4uGMtZLbavWrO2pKA5xCgw+s5fcmWkAAJkIA7E2DdSYAESCDYCNDhDTa0NEwCJEACJEACJEACJOAKBNzL4XUFYqwDCZAACZAACZAACZCAWxGgw+tW3cXKkgAJkIAvAW5JgARIgAQcJ0CH13FW1CQBEiABEiABEiABEnAtAg7Vhg6vQ5ioRAIkQAIkQAIkQAIk4K4E6PC6a8+x3iRAAo4ToCYJkAAJkECYJkCHN0x3PxtPAiRAAiRAAiQQlgiE1bbS4Q1iz4cLFx6UsMng3bt37HuOf46BMDgGeO6HzWu+/lnvqNvw+PEjUIKPgaP9oOvR4dVJcE8CJOBHgDsSIAESIAFnEIgXLwEozmcQmL6hwxsYasxDAiRAAiRAAiTg+QTYQo8hQIfXY7qSDSEBEiABEiABEiABErBEgA6vJSqMIwHHCVCTBEiABEiABEjAxQnQ4XWgg548fYYufcegcIUmGDXpJwdyUIUESIAESIAEwhoBtpcEXJcAHV4H+6Z08QJoVq+Kg9pUIwESIAESIAESIAEScBUCdHgd6ImYMaLjh/w5ESlSBAe0qWKLANNIgARIgARIgARIIKQJ0OENIvHPnz+DQgYcAxwDHAMcAwEcA/zscNPPzyC6DXazP7n0Bx6cXhpg+fDmsV3bYVmBDm8Qe//Nm9eghE0GHz9+YN9z/HMMhMExwHM/bF7z9c/6ILoNdrM/ubxJc3aXBVg+vKbDawsuHV5bdBxIixQpMoJNaNul2fr4hHPp+nFc8tzkGAieMcBzP3i4ust4dcA1cIpKxJgpEDnud3bFyyeiU8rzdCN0eD29h9k+EiABEggkgccXf8fpFWWdKmIzMNVhHhIIawQixUyOKPEy2hUvn8hBQlO5fns8e/7CYRsXr1zHzj2HHNY3Vbxw6RpyFKlhlHY9hpsmB2uYDq8DeD98/IjcJeqqV5L9umGbCv9z4YoDOalCAiRAAiRAAiRAAp5D4PLVm9hz4FigG5Q9c3oc3LZCyaQRPQNtJ6AZPcjhDWjTHdf38fbG3k2L/UnqlMkcN0BNEiABEnBDArFSlEb6Guvtit40R3TFpq7PPQmQgGsQmDn/ZzRu2xcNW/fG+UtXVaUePXmKnoPGo1azrmjUpjdOnb2o4ucuXoUduw+iWYf+2Lx9D7bt3IcSVZujWqNO6DN0El68fKX0XG1Dh9fVesQF6yO3IHlb0wU7hlUiAWsEGE8CJEACASAQPnw4zJs8GFXKFdPuZs+D/E2csRiZM6TFstmjMaB7a/QdNlmi0aRuFRTMmwOzJwxE8cJ5kDpFMqxdOgUr543FN18nxJJfNig9a5tT5y7i+2K1NCe6D46f+seamtPj6fA6HSkNkgAJkAAJkAAJkID7EBBHV2pbtkRBXLl2S70y78jxM9oM7m41kztk7Ew8fPwEDx5++SYIcZbnL12Dtt2HYdfew7h46ZqYsiiJvoqP31dMx5Zf56BIwe/RsfdIvHr9BsH5p9umw6uT4N4qgVi8rWmVDRNIgARIgARIwN0J+Ph4qyYYDAZ4aQK/v7FDuqmZXJnN3bVhIeLGieWX8t9u2LhZSBg/Lob1bY+OLevj9Zu3/yWahSJHiohoUaMoqVutrMp3/eYdM63gOaTDGzxcaZUESMBtCLCiJEACJBC2Caxat0UB+GPb3/gmcUIYDAbkyp4R0+YuV7O9knjw6CnZQZzWf03e6iAOa4G82RE9WlTs2ndE6VjbmK7vlTc2PH76L2QZhDV9Z8bT4XUmTdoiARIgARIgARIgATcjII5o9cadsXz1RnRv30TVvm3zOnj37h1qN+uGUtVbYNVaX6c4W+Z0+PTxE9p0Gwp5aK1xnUpo0LKXWtLw4cMHldfaZv2mv9QryXKXqIPRU37CyP6dlANtTd+Z8XR4nUmTtkiABEiABEiABEjAjQisXjgR3ds1UQ+dzZ86FKmSJ1W1jxE9GuRhtWVzRmPjyhkY0b+jio8UMSJGDuiEKaN6q4fWypYohN+WTMbkkb3QuXVDFa8ULWxqVi6tXke2d9MSzBo/ABnTp7KgFTxRdHiDhyutkoCnEmC7SIAESIAEQoDA6yeX8PL+Cbvy6YNrvgYsBBAFqAg6vAHCRWUSIAESIAESIAESEALBK2+eXMSrB6fsyqcPIfOWg4C0dv/hE2jecYA/0V9rFhA7ztSlw+tMmrRFAiRAAiRAAiRAAkEgEPPbEoibvlaAxSfSl29QCEI1gpQ1V7aMasmCLFvQZXCvtkGyGdTMdHiDSpD5ScAGASaRAAmQAAmQQEAIxExeUnN2awdYfCK6jsMbkPaGlC4d3pAizXJIgARIwAUIXNzYCs7+5UT4/TnbrtTVzzR37k+ALSCBUCVAhzdU8Yde4bcOTMSVP3s4VfTWONvu7YMTddPckwAJBJnA5yBboAESIAEScDcCdHjdrcecVN/Xjy/YXQjvyGJ5Ux29aqZxAQpbWZz/+vFF3TT3JEACTiIQM3npAN8yjZs+4LdZA5NH6uakZtIMCZAACSgCdHgVhrC7ifpVLvwvaRGXFKlb2O0ZtpwESCAsE2Dbwy6B+/tX49aWWQGW988ehl1oDrScDq8DkDxTxfe2ZrhIsRA+SnyXFKmbsP/82beuEqaQAAmQAAmQgCcTeLD/V9zaOjvA8u45HV5b44IOry06Lp3GypEACZAACZAACXgqgSiJ0iDat1ntinf4yJ6KwKntosPrVJw0RgIkQAIkEOIEWCAJeCCByF+nQ/Tk2e2Kd4SgObyV67fHs+cvHCZ48cp17NxzyGF9U8UnT5+hY6+RyF+mPkZMmGOahCIVmyBHkRpKJN1fohMO6PA6AaI7m5CH1xz56cLQ0JG6CVuDwSA7SjAQWLBiAxJlLONUWbjy92CoKU06m8CTS7/jwemlLilSN2e3l/ZIgAScQ+Dy1ZvYc+BYoI2VLVkQPzao9kV+b28vHNy2QsmuDQu/SA9qRFhxeIPKyWPzO/rThc5420JAbUjdBDzX8AoFCgmQAAmQAAkED4GZ839G47Z90bB1b5y/dFUV8ujJU/QcNB61mnVFoza9cersRRU/d/Eq7Nh9EM069Mfm7Xuwbec+lKjaHNUadUKfoZPw4uUrpWdpEzNGdBQp8D0iRYpoKTlY4+jwBite1zceMWYKRI77nUuK1E0IGgyc4RUOwSENapTBrRMb7IpetiO69auX1tW5d0kCvpWSV38F5pVhIZFH6uZbS26Di8Dx0xcwdtoSp4rYDK760m7wEggfPhzmTR6MKuWKYdSkeZC/iTMWI3OGtFg2ezQGdG+NvsMmSzSa1K2CgnlzYPaEgSheOA9Sp0iGtUunYOW8sfjm64RY8ssGpRfQzadPn5C/dD1UbdgRazduD2h2u/p0eO0i8myFSLFSIkq8jC4pUjehzxleoUAhARIgAecREOd03IylcKaITefVkJZCkoA4ulJe2RIFceXaLcjn7pHjZ7QZ3N1qJnfI2Jl4+PgJHjx8LGr+RJzl+UvXoG33Ydi19zAuXrrmL93RA3Gst6+bjxaNamDKnKU4duqco1kd0rPo8DqUk0okQAIkQAIkQAJuSSBT+pTo1KK2XdEb54iu2NT1uXcvAj4+3qrCBoMBXprA72/skG5qJldmc2Vdbdw4sfxS/tsNGzcLCePHxbC+7dGxZX28fvP2v8QAhMS2j7c3ihb8HiV+yGdcQhEAEzZV6fDaxMNEEiCBME6AzScBjyQgzmnnVnVgT/TG29OTdLGp63PvXgRWrduiKvzHtr/xTeKEMBgMyJU9I6bNXa5meyXx4NFTskPkSBHxr8lbHa7fvIMCebMjerSo2LXviNIJ6Oblq9f4+OmTyvb02XMc0sq6fPXEAAAQAElEQVT6Lm0KdeysDR1eZ5GkHRIgARJwCwK+a+I/vHmMdy/vuaR8ePPILUiykiTgKQTkQbPqjTtj+eqN6N6+iWpW2+Z18O7dO9Ru1g2lqrfAqrW+TnG2zOnw6eMntOk2FPLQWuM6ldCgZS+1pOHDhw8qr7XNh48f1WvH5JVk4mTLa8jOnb+MG5rTnKdEHZXWouNA1K5aBpm/S2PNTKDi6fAGCpvnZHpyaSNc99VEGz0HNFtCAi5G4Pmtffj36jaXlOe39rsYLVaHBDyXwOqFE9G9XRP10Nn8qUORKnlS1dgY0aNBHlZbNmc0Nq6cgRH9O6r4SBEjYuSATpgyqrd6aK1siUL4bclkTB7ZC51bN1TxStHCRpYs6K8e0/dpUn0Lkf1blqlXki2fOwblShaykDtoUXR4g8aPuUmABEwIMOj6BCLFTun0t7LorXb2G1+krrpt7kkgrBF4dfMMnl06ZFc+vrX+GrCwxsxWe+nw2qLjwWkpSk5F+hrrnSo6LmfbTVFyim6aexIggSASSJSzI5L9MMKpolfJ2Xalrrpt7knAzQgEubovb53D88tH7MrHd67n8O4/fALNOw7wJ/przYIMJpAG3MbhbdF58BdNrPtjzy/iGEECJEACJEACJEAC7kogbq5KSFS0WYAlfLQ4LtPkXNkyYtb4Af5kcK+2oVo/t3F4zSnJE31v370zj+YxCbgPAdaUBEiABEiABMwIxMtVGYmKNQ+whIvuOg6vWZNc4tDlHd5ZC35G7hJ1cfzUP2ovYZG6LXqictmiLgGRlSABEiABEiABEgg8AeYkgeAm4PIOb/MG1bB302JULV9c7SUs8uvCCahVpVRw86F9EiABEiABEiABEiABNyfg8g6vzrdz6/p6kPswSYCNJgESIAESIAESIIHAEXAbh/fvfUfRrMNA5C/dwN/ShsA1m7lIgARIgARIwE0JsNoeTWDxLxsxbvrSAMu9B489mktQG+c2Du/cxavRpU0D/LX+J39LG4IKgPlJgARIgARIgARIwFUILFm1CeNmaA5vAOU+HV6bXeg2Dm/8eLGROkVSeHu5TZURin9OLfrD60d4ef+kXdELdURXbOr63JMACbgmATlPHTmf9do7ois2dX3uSYAErBPIkC45cmfPYFeiRI5o3QhTjATcxnuMHSsGVq/fihcvXe8Fy0aaHhp4dms/rm7vaVf05juiKzZ1fe5JgARck4Ccp46cz3rtHdEVm7p+yOxZCgm4J4GMaVMgdw7N4bUjUaJEDlIDK9dvj2fPXzhs4+KV69i555DD+uaKp85eQL2WPfF9sVooXqUZPn76pFSOnTyn4ms37wZ5Q5eKdOLGbRze1eu2YvTk+ShWuTnX8DpxADhiKlyk2E7/KVKx6UjZ1CEBEgg9AnKeOvvngsVm6LWIJZMACQSVwOWrN7HnwLFAmZHfUGjXYzgqlCyMv9YvwOwJA+FlMODz58/oPWQierRvgoXTh2Pbzn04cvxMoMqwlsltHF55FZklsdawgMRT1zaBaIlyIdkPI5wqYtN2qUwlARIIbQJynvLcD+1eYPkkEPwEZs7/GY3b9kXD1r1x/tJVVeCjJ0/Rc9B41GrWFY3a9MapsxdV/NzFq7Bj90E069Afm7fvUc5piarNUa1RJ/QZOsnmnfjtfx9AutTJUbVCcUSMEB5JEn8Fg8GAcxeuQGaq06dJAR9vb5T4IS927j2synPWxm0cXmnwidPnsXLNJgni4aMnuHr9tgpzQwIkQAIk4BQCNEICJBAGCYQPHw7zJg9GlXLFMGrSPMjfxBmLkTlDWiybPRoDurdG32GTJRpN6lZBwbw51Oxs8cJ5kDpFMqxdOgUr543FN18nxJJfNig9S5vbd+6r6GoNO6rlDPOXrVHH9x48QqIE8VRYNokTJcC9+w8l6DRxG4d3wbK1GD5hLn77fbtqvEx/Dx03W4W5IQESIAESIAESIAESCBwBcXQlZ9kSBXHl2i21xECWFGzevlvN5A4ZOxMPHz/Bg4dfvvpMnOX5S9egbfdh2KXNyl68dE1MWRTx3W7fvY8xg7ti6axR+Ovvgzh09JTSNXgZ1F42BoPz3dOAW5SahIL8sW0XFk4bimjRoqjS48aJhZevXqkwNyRAAiRAAiRAAiRAAoEj4OPjrTIaDAa1phZ+f2OHdFMzubLWdteGhRDfyy/JuBs2bhYSxo+LYX3bo2PL+nj95q0xzTwgLyCQZQuylCFO7JjImD4Vzl28ivhxY+PJ02dG9UePnyJ+vDjGY2cE3MbhjRAxIsKF8/HXZgMM/o55QAIkQAIhSYBlkQAJkIAnEFi1botqxh/b/sY3iRPCYDAgV/aMmDZ3uZrtlcSDfjOxkSNFxL8mb3W4fvMOCuTNjujRomLXviOialUK5smu1uvKG7fevnuHE6fPI22qb5EmZTI1e3zj1l311oatf+1F/tzZrNoJTILbOLwx/xcdZ/65pNooU+JzF/+KFN9+o465IQESIAESIAESIAESCBwBcUCrN+6M5as3onv7JspI2+Z18E5zSms364ZS1Vtg1Vpfpzhb5nT49PET2nQbqh5aa1ynEhq07KWWNHz48EHltbaRGeIGNcurB+QatemDooVyI1umdMrBHtK7HXoNnoB6LXoge9bvVLw1O4GJdxuHt3/3Fli9fhtOn7uEAmUaQr4FdGxZNzBtZh4SIAESIAESIAESIAGNwOqFE9G9XRP10Nn8qUORKnlSLRaIET0a5GG1ZXNGY+PKGRjRv6OKj6TdcR85oBOmjOqN4oXzoGyJQvhtyWRMHtkLnVs3VPFK0cpG9FfOG6vW8NatVtaolTlDGiyaMULF/9igmjHeWQG3cXgFfJ/OzfH7iqn4dfFErRNaIoY26+ssELRDAiQQzARongRIgARIwGECJ85exN6DJ+3KS/4gl0NMXd7hlTUjMtUuexF5V9uVazchYRGHWkklEiABEiABEiABEnARAo5U4+SZS9h7SHN47cjLV28cMReiOvsPn0DzjgP8if5asxCtiElhLu/wylpdeT+b7C2JSVsYJAESIAESIAESIAG3JlCnSgl0alE7wBIvbiyXaXeubBkxa/wAfzK4V9tQrZ/LO7wzxvZF8qSJIXtLEqr0WDgJBBsBGiYBEiABEgiLBOpWLYVOLWsHWOK7kMPriv3m8g6vDm3D5p14+q/JO9qePMXGrX/rydyTAAmQAAmQAAl4IgG2iQScQMBtHF75qTrTh9Rix4yBhct/cwICmiABEiABEiABEiABEvBkAm7j8L5588748mPpEHkX75u37yVIIQESIAESIAESIAESIAGrBNzG4U2UMB7mLFplbMisBb8gSeKExmMGSIAESIAESIAESIAESMASAbdxeAf2aIVbdx4gX6n6yF+6AeTNDf27tbTUJsaRAAmQAAmQAAmQAAmQgJGA2zi8sWL+T/3YxLplU7Bu2WT069oCMWNENzaEAccJUJMESIAESIAESIAEwhIBt3F49U4RJ9f04TU9nnsSIAESIAESCCABqpNAsBK4f/8uKM5nEJhOc3mHN3eJujh55gJkb0kC02jmIQESIAESIAESIIHgJBArVmxQgo9BQPvO5R3euZMGIkO6lMj0XWrs3bT4CwlogwOszwwkQAIkQAIkQAIkQAJuTcDlHd6RE+cFK+Djp/5BwzZ9Ua9lL39vgTAt9OLl6/5mmDv2Hm2azDAJkAAJhAkCbCQJkAAJuCsBl3d43717h1kLfsa9+4/UXsKmEhTw8i7ffsOnolvbhvhpymD8uesAjp44a9FktkzpjLPL44d2tajDSBIgARIgARIgARIgAdcj4GSH1/kN7NCyvvON+ln85+JVRI4cCelSJ4ePtzeKF86DXfuO+KVyRwIkQAIkQAIkQAIk4AkEXN7hvXX7Hpo3qIb48WKrvYRNJSidcO/BYyRKENdoInGi+Gom2RhhEjj9zyX1DuCm7QfgxOnzxpT379+BEjYZfPz4Mcz0vT7gOdYDMNZ5bfDY84Pnftg+D/TrIffuRcDlHd41v28PVqIGL4OJfcs4vkoYD2uXTMLGn6fjhwK50KXfWLx6/cYkH4NhkYDBdOiERQBsMwmEUQI898Nox7PZgSbgChkte3iuUDO/OsSJ/T806zAQ8uBYi86DYS5+aoHaxY8bC0+ePjfmffzkqZpJNkb4BSJHiohoUaMoqV2lFBLEi4Mbt+6q1HDhwoMSNhl4eXmHmb5Xg13bcKyHzbHOfvff7zz3/fMIa+NDuxTyvxsScHmHd9yQbujcur5yMpvUrQRzCQrz1CmS4uGjJ8p5/fjpE7bt2I9832dVJu/ef4ir12+r8IuXr9ReNuJ4P/n3GRInSiCHFBIgAacQoBESIAESIAESCD4CLu/wStPTpEyGvl2aI0eW774QSQ+sGAwGDOzRCn2HTUHD1n2QLUs6ZM2YVpn7c+cBLFu9UYV/37JLvZYsf5mGGDttIYb1aQeZ9VWJ3JAACZAACZAACZCAswjQTrAQcAuHV1oeJUoktOsxAtUadZZD/HPhCmbMX6nCQdnID1rMnzoEi6YPQ7N6VYymalctjZ4dmqjj6hVLqFeS7dowH9PH9FE/hKESuCEBEiABEiABEiABEnB5Am7j8A4cNROli+VD7JgxFNRUKZLi771HVZgbEghjBNhcEiABEiABEiCBABBwG4dXfoCiZJF8gAHqz2Aw4NPnTyrMDQmQAAmQAAmQQFgkwDaTgGME3Mbh/fwZ+PDhg7FV8rBZOB8f4zEDJEACJEACJEACJEACJGCJgNs4vDUqlYD8DLD8xPDM+T+jWceBqF+jvKU2MY4E/BHgAQmQAAmQAAmQQNgm4DYOb5niBdCmWS38kD8Hnj1/iYnDeqBIwVxhu/fYehIgARIgARJwnAA1SSDMEnAbh1d66KsE8dC2eR10bdsQ33zN9+AKEwoJkAAJkAAJkAAJkIBtAm7j8J4+dxFd+o5B6RqtlHTtPxanz12y3TqmBpwAc5AACZAACZAACZCAhxFwG4d36LjZSJI4IaaO6q1Efuls+IQ5HtYdbA4JkAAJkICrEGA9SIAEPIeA2zi8nz9/VssZkiVJBJF2zetAXlXmOV3BlpAACZAACZAACZAACQQHAbdxeD99+oQnT58ZGchryYwHoRZgwSRAAiRAAiRAAiRAAq5OwG0c3lpVSqNGk65o0XmwktrNe6ButbKuzpf1IwESIIGwQYCtJAESIAEXJuA2Dm/F0j9g3uSBKFowl5J5kwehfKnCLoyWVSMBEiABEiABEiABEnAFAiHp8AapvZeu3EDMGP9D1fLFlcT4XzRcunojSDaZmQRIgARIgARIgARIwPMJuI3D23/ENIQPF87YI+HC+aD/8GnGYwZIgARIwH0IsKYkQAIkQAIhScBtHN4PHz9AnFwdToTw4fH23Tv9kHsSIAESIAESIAESIAF3IxBC9XUbh9dgMGD/4RNGLHsPHvc342tMYIAESIAEbXxg0wAAEABJREFUSIAESIAESIAETAi4jcPbp3NzjJ26QL2hQd7UMGHGIvTu3MykKQySAAl4KAE2iwRIgARIgASCRMBtHN70aVJg2ZzRqF6xhJJls0chXerkQWo8M5MACZAACZAACZCA+xBgTQNLwG0cXmmgt5cXfsifU4mXFpY4CgmQAAmQAAk4g8CLq8fx7NIhu/Ly6lG7OmJH7DmjXrRBAiQQdAJu5fAGvbm0QAKeT4AtJAESCByB8wu74uzMFnblyoKOdnXEjtgLXE2YiwRIwNkE6PA6myjtkQAJkAAJuCWBqEkyItq3WW1K+BgJVNtkb09X7CllbkKLAMslASMBOrxGFAyQAAmQAAmEZQKpGoxBuhazbErc7OUUItnb0xV7SpkbEiCBUCfgNg7vhw8fsO/Qccxb/CtmLfjZKKFOkBVwbwIWai/r7mT9nT3hOj4L8BhFAiRAAiRAAi5IwG0c3t5DJmHVuq14+54/NuGC48ijqiTr7mT9nT3hOj6P6nY2hgTCPAECIAFPJuA2Du+bt+8xemBntGxUA80bVDOKJ3cO2xY6BGTdnb21ebJ+T2one3u6Yk90KSRAAiRAAiRAAqFDwG0c3vDhffD+/YfQocRS/QiEjZ2su7O3Nk/W7wkN2dvTFXuiSyEBEiABEiABEggdAm7j8L579wHVm3TB+OkLjet3ZS1v6GBjqSRAAiRAAmGaABtPAiTgVgTcxuFNn+ZblCqSF1EiR3IrwKwsCZAACZAACZAACZBA6BJwG4fXdN2uaTh08dksnYkkQAIkQAIkQAIkQAIuQMBtHN4nT59hyc8bIG9rEFm6aiMkzgUYsgokQAIkQAI2CTCRBEiABEKXgNs4vP1HTMNfuw8ha6a0Sv7cuR8DR80IXXosnQRIgARIgARIgARIwOUJuIzDa4/U3fsPMGNcX1QpV0zJjLF9cPP2XXvZmE4CJEACJEACJEACJBDGCbiNw+vl9WVVvbwMYbz72HwSIAEPJMAmkQAJkAAJOJnAl16kkwtwlrnMGdKiVZchxleStewyFDmyZHCWedohARIgARIgARIgARJwKQLOq4zbOLzd2jZEuRIFce3GHSUVSxdG59b1nUeClkiABEiABEiABEiABDySgNs4vLKkoazm8A7t0w4iZYoXgMR5ZK+wUSRAAg4ToCIJkAAJkAAJ2CPg8g5vi86DcenqDcjekthrINNJgARIgARIgARIIAwQYBNtEHB5h7dJ3UqIHzc2ZG9JbLSNSSRAAiRAAiRAAiRAAiQAl3d4c2T5DlGjRIbsdcmaKR3ixomt4tiHJEACASBAVRIgARIgARIIgwRc3uHV+2TExHl48fIVnj1/gdrNuqFtt6FYuGKdnsw9CZCAH4Hjpy9gz8ETThU/0061KXU8duq8bpp7EiABEghRAiwsbBFwG4f3zLlLaqZ378HjyJ0jE5bPHY2NW3aGrd5ia0nAAQKd+01AtSY9nSp6sc6227HveN009yRAAiRAAiQQbATcxuH18vat6pHjZ5ExfWpEiRwJ3j4+wQaGhkkAcG8G8eLGxNcJ47mkSN3cmy5rTwIkQAIk4E4EfL1IN6jx1wnjo/fQydh/+CRyZEmvljfgsxtUnFUkgRAm8NnvxChe+HtUr1jUJaVE4dwhTIXFkQAJBIkAM5OAmxNwG4e3V6emkB+bmDamN6JFjYKn/z5Dg1rl3Rw/q08CJEACJEACziHA9fvO4UgrnknAbRzeyJEiajO73+GrBPFw9cYdHDhyCgXzZvfMXnHPVrHWJEACJEACoUiA6/dDET6LdnkCbuPwNmzTVy1juHn7Hjr2Gok9+49h6NjZLg+YFSQBEiABEghrBEK3vbJG/muu3w/dTmDpLkfAbRxefP6s3tKw79BxlCtZCGMGd8H5S1ddDigrRAIkQAIk4BoEPrx8imeXDjlV3j65oxone2fb/vDyibId2A3X7weWHPOFBQJu4/B++vQZb96+w+HjZ5A+TXLVN14Gt6m+qq/phmESIAESIIHgJfD8ylGcndnCqfLw8HpVadk72/azS4eVbW5IgAScT8BtPEZZr1uneQ/cvH0f2TKlxb0HjxAxYgTnE6FFEiABEiCBkCQQ7GV5hYuI8DETOk3CxYjvNFtSL6lfsENgASQQxgm4jcPbpG4lrFowDoumD4OPjw8ihA+H3p2bhfHuY/MdIfDk1Hbs75bdqXJrq+/6cdk72/aT03850izqkAAJ2CHw+bPvuyvDx0iAuNnLOU1iZi7lNFtSrwixEtppCZNJgASCSsA9HF6tle/ev8e8JWvQf8Q07Qh4/OQ5rly9pcLckIAtAvqHni0dl0rz+5B2qTqxMiRAAiRAAiTgxgTcxuEdOGoG7t57iOs3fR8Y+CphXCxcsdaN0bPqIU0gYtykSFSsudMkXqGGTrMl9ZL6hTQTlud+BFhjEiABEiCBgBNwG4f36rVbkB+fiBAhvGplRG3//sMHFeaGBEiABEiABEiABEggTBEIUGPdxuH18fH217APdHb98eABCZAACZAACZAACZCAZQJu4/BmTJ8ai1aux4sXr3DgyEl06TcWhfPntNwqxpIACZCAEKCQAAmQAAmQgEbAbRzeTq3qIXas/yFcOB+Mn74YPxTIhSZ1KmlN4H8SIAESIAESIAESIAFbBMJ6mls4vB8+fsSYKQtQumh+/DRlMJbNHonyJQvByyvkqr9yzSbUbdET9Vv2xs69R8L6uGH7SYAESIAESIAESMBtCIScxxgEJD7e3rh6PfReQXbtxh0sXL4OM8f1w6gBHTF07Cz1q29BaBKzkoALEmCVSIAESIAESMAzCbiFwyvo48SOiS79xmDLX3tx8Ogpo0hacMvf+45AfuktSuRISBA/DtKkTIaDR06BfyRAAiRAAiRAAh5IgE3yOAJu4/Dee/AIL16+xqp1WzF38a9GCYkeefDoMb5KENdY1Ndfxcf9h4/U8aFjp2FPlKKdjT0bkm7HhEoWPXuiFO1s7NmQdDsmVLLo2ROlaGdjz4ak2zGhkk9eewx7ohTtbMTGqetPbdqyY0Ilix1dzmlD6vyziDh24Za/MaUU7Wyk/bq8f/8O4Xy88PjJU9y7/9AodkyoZFN9a2GlaGdjLa8eL3WzY0Il622ytVeKdja28utpdkyoZF3X1l4p2tnYyq+n2TGhknVdW3ulaGdjK7+eZseEStZ1be2Vop2Nrfx6mh0TKlnOJTmn5NzSzzPzvVK0szHPY+nct2NCJZvb0Y/PGs/920rP3kZnYL43Pfft2ZB0/Xy0tRc9e2Irv55mz4akm7fH0rHo2RNL+czj7NmQdPM8+rGkUdyPgNs4vDPG9oUlCSnkBpP1wgaDwVhsi04DYVdatEALe0I7thkFgc/MmTNVf929ewd9lx6xK+vXr4c96bv0CAauPGHTlj0bkm5an9EHvDDx/FfoOnmt/zFlb+xIugmfVy+eIU6MSDh69AT+3LHbKFKePTHVtxa2Z0PSreXV448cPa765Pbt28HW7/7OORM+Vs9X4WhPaMet+qvblHXqnJJzy/RcMw2f2zQf9sRUX8KWzn17NiRd8lqS0fsMqp7dpq63zVcfn1bGoem5L+ehPdHPR1t7ezYk3VZ+PU30RHbu2GH93LfSLn/nrM7A1j6Y7agGcON2BNzG4TVdxqCHL125gU+fPgU79LixY+Hp03+N5cjsVLw4sdVxutTfwp507doV9sSeDUm3Z0PSRc+eiJ49sWdD0u3ZkHTRsyeiZ0/s2ZB0azYqVKig+ip27NhI/VU0u5I3b17YE7GTKmEUm7bs2ZB0saNLypifkDLaa6T5Jo6/MWWtXabx0n5dvLy98fb9R0SLFhUxY/7PKFKePTHVtxa2Z0PSreXV46Vu0P7ixIlj89zQ22Rrb8rBWthWfj3NWl7TeF3X1t5U31rYVn49zVpe03hd19beVN9a2FZ+Pc1aXtN4XdfW3lTfWthWfj3NWl7TeDmX5JyyJdG83sGe2Mqvp9mzIem6rrV9mm9i2zwf9LbpDMz3Xt7/nftyHtoT/Xy0tbdnQ9JjxvzvOmPNluiJZM6SRTvzAUvnvnl7LB3rDGztLeUzj7OVX08zz6MfqwZw43YE3MbhnTpnOdr1GIGBI2cokXCPQRNQsV4HHD1xNljB5/s+K3btO4K3795pt4n/xZl/LiNX9gyqzIXTR8CeJE+eHPbEng1Jt2dD0kXPnoiePbFnQ9Lt2ZB00bMnomdP7NmQdGs2EiRIoPrK8O4Veufztivejy/BnoidXnm8bNqyZ0PSxY4uXTI8RYfUdzC5a3V/Y8pau0zjpf26RIseE4//fYOcObKiZNFCRokZM6bm/NoWU31rYWfYyZUjm+qT8OHD2zw39DbZ2ptysBa2lV9Ps5bXNF7XtbU31bcWtpVfT7OW1zRe17W1N9W3FraVX0+zltc0Xte1tTfVtxa2lV9Ps5bXNH5yl2rqnOr2/WcMqZ3VosTJVgb2xDzvgOoZv7Blz4akm9vRj7vl+qzqOalTFZvng942nYH53vTcd8Z5KtcAZ9uJHj261XPfvD2WjnUGtvaW8pnH2cqvp5nn0Y9VA7hxOwJu4/DGiR0DYwd3wbplk5VIOMnXCTF6YCeMm74oWMEnSZwQlcoUQZN2/dGh1yh0bFUf4cOFC9YyPc24K7Tnw6uneH75iNPk5bXjTrMl9ZL6KU6fP6sdNyRAAkEj8NnvXPLyiYgIsRI5TcLHTOg0W1Iv7wiRgtZQ5iYBErBLwG0c3nsPHiNPzswwGAxKJHz73gOkTpHUbiOdoVC9YgksnjFcm3kbioJ5fGennGGXNkKOgE/kGIj2bVanSZQkmZxmS+ol9VM0tDGu9tyQAAl4IgG2iQRIIBQIuI3Dq7m5OHDkpBHR/sMn4O3trY4lTQW4IQEbBHyixED05NmdJlGSZXGaLamX1E9V329WSoW5IQESIAESIAESCDIBt3F4e3VqitGT56NCnXZKxk5dgJ4dmuDV6zeoWqFYkEG4lAFWhgRIgARIgARIgARIwGkE3MbhlR97WDlvDMYP7a5kxdwxSJc6OSJHiqh+ZthpRGiIBEiABEjAZQiwIiRAAiTgDAJu4/C+e/8ePy39DQuW/4ZvkybClWu3sW3HfmcwoA0S8EgCi1duxLjpS11SFq383SOZs1EkQAIkQAKuScBtHN6Bo2bg7r2HuH7zjiL5VcK4WLhiLQB1yA0JkAAJkAAJkAAJkAAJWCTgNg7v1Wu3IOt4I0QIrxoSUdu///BBhbkhARL4kkDd6qXQqWVtl5R61Ut/WWHGBJ0ALZAACZAACVgk4DYOr4+P7xsZ9FZ8oLOro+CeBEiABEiABKC/sWjz9n1YuWarS8qm7XvZUyQQIgTMC3Ebhzdj+tRYtHI9Xrx4pV5P1qXfWBTOn9O8PTwmARIgARIgAUXAYDCo/acPb/D28S2nybsnd5xmS+r18e1rVc+gbj7D90dr7j94gpt37rukSN2C2k7mJzDs4uAAABAASURBVIHAEHAbh7dTq3qIHet/CBfOB+OnL8YPBXKhSZ1KgWkz85AACZAAAEIIKwTePbmLh4c3OE2eHt/kNFtSr3dP7zqlKwzaHK8YKl4oF6qVL+KSUqxwLqkihQRCnIBbOLwfPn7EmCkLULpofvw0ZTCWzR6pXkXm5eUW1Q/xTmWBlgl8ePkUzy4dcpq8vHLUabakXlI/VXO/WSkV5oYESCDQBOTHXKI58dcVxVb4GAlUfWQvx86UcFFjKtuB3egzvPHixULiRPFdUhLEjR3Y5jFfcBIIA7bdwmP08fbG1eu3wkB3sInBSeDDq6d4fvmI0+TlteNOsyX1kvoFZ/tpmwTCGoFoybIgXYtZTpW42cspjLJ3tu1o32ZTtrkhARJwPgG3cHil2XFix0SXfmOw5a+9OHj0lFEkjUICtghEip8MiYo2c6pE02aNpEzZO9t2pLhJxbSrCetDAiRAAiRAAm5LwG0c3nsPHuHFy9dYtW4r5i7+1ShuS54VDzECkeIlw9fFf3SqRPebiZG9s21HjEeHN8QGBwsiARIggQATYAZ3JOA2Du+MsX1hSdwROutMAiRAAiRAAiRAAiQQcgTcxuENOSQsiQSCToAWSIAESIAESIAEXIcAHV7X6QvWhARIgARIgAQ8jQDbQwIuQYAOr0t0AytBAiRAAiRAAiRAAiQQXATo8AYXWdp1nAA1SYAESIAESIAESCAYCbiNw9ui82CYS49BE7B6/VbID1MEIyOaJgESIAESIIEQIcBCSIAEgoeA2zi8yb5JhE+fPqFYoe+VSDicjw/2HjyOERPmBg8dWiUBEiABEiABEiABEnB7Am7j8J755xKmj+2LKuWKKZHwleu3MHpgZ5w+d9HtO8LxBlCTBEiABEiABEiABEggIATcxuF99+4dDGYtkziJihQxouwoJEACJEACYYkA20oCJEACDhJwG4c3e5YMaN1tGH77/U8lrbsORc6sGfHq9Rt8+vzZweZSjQRIgARIgARIgARIIKwRcBuHt1OreihXsiAOHDmlpEKpwpC4yJEiYv6Uwdb6jfEkQAIkQAIkQAIkQAJhnIDbOLwGgwGli+bH0D7tlJQqmg9eXm5T/TA+zNh8EiCB0CfAGpAACZBA2CXgNh7jjVt3MX3eCrTtPtzf68nCbtex5SRAAiRAAiRAAiRAAo4Q8OfwOpIhtHSGjJ2F//0vOupWL4MmdSsZJbTqw3JJgARIgARIgARIgATcg4DbOLzRo0VB7SqlkCtbRuTI8p1R3AMza0kCIUfA4Pc+k/v3H+PGrXsuKXcfPAo5IIEriblIgARIgAQ8iIDbOLzhw4XD1eu3PQg9m0ICwUtg81/78fPabS4pW7bvD97G0zoJkAAJkICTCHiGGbdxeC9fu4VazbqhXsteXMPrGWOPrQgmApnSp8T32b5zquhVdbbdzN+l0k1zTwIk4CQCJ05dwN6DJ11Sjp8+76RW0gwJBIyA2zi88gqySSN6oF3z2uAa3oB1MrXDFoGxgzpg1U8jnSo6QWt2Axs/fnBH3TT3JEACTiJw4sxF7D2kObwuKCdOX3RSK2mGBAJGwG0cXtN1u6bhgDWX2iRAAiRAAiRgmcD5BV1wZkZzm/Lg0DqVWfb2dMWeUg6hTf3qZdCpRW2nil51Z9ttUKOMbtrT9myPixJweYe3RefBuHT1hr9lDBKni4tyZbXcmMCLq8fx7NIhm/L2yR3VQtnb0xV7SpkbEiABlybw4toJPL98xKa8e3pXtUH29nTFnlIOoY04kZ1b1YEzRa+6M22KrYY1y+qmuSeBECHg8g6vLF+IHze2v2UMEqdLiFBiIWGKwPmFXXF2Zgub8vDwesVE9vZ0xZ5S1jfckwAJuCSBVPVHI+2PM+xKsgbj7eqIHbHnkg1lpUggDBJweYdXli9EjRLZ+BoyOTaVMNhnbHIwE4iaJCOifZvVrkRJmsmujtgRe8FcZZonARJwAoGo2jkdPXl22JMoSbPY1REbYs8J1fJoE2wcCYQUAZd3eKfMWQZbElKgWE7YIZCqwRikazHLriRrMNGujtgRe2GHHltKAiRAAiRAAq5HwOUdXpndtSWuh5Q1ci4BWiMBEiABEiABEiCBoBFweYe3Ya0KsCVBaz5zkwAJkAAJkICbEGA1SYAEAk3A5R1eW8sZJC3QLWdGEiABEiABEiABEiCBMEHA5R1eW8sZJC1M9JLjjaQmCZAACZAACZAACZCAGQGXd3htLWeQNLP28JAESIAESIAEABACCZAACfxHwOUdXr2qT54+w5KfN6D3kElKlq7aCInT07knARIgARIgARIgARIgAUsE3Mbh7T9iGv7afQhZM6VV8ufO/Rg4aoalNjkcR0USIAESIAESIAESIAHPJ+A2Du/d+w8wY1xfVClXTMmMsX1w87bvTzx6fjexhSRAAiQQrARonARIgAQ8moDbOLxeXl9W1cvL4NGdw8aRAAmQAAmQAAmQAAkEncCXXqQ1m6EcnzlDWrTqMgSzFvyspGWXociRJUMo14rFkwAJkAAJkAAJkAAJuDoBt3F4u7VtiHIlCuLajTtKKpYujM6t67s6X9aPBEjAAwmwSSRAAiRAAu5FwG0cXlnSUFZzeIf2aYchvdsiUqSIaN5xkHvRZm1JgARIgARIgARIwHMIuE1LXN7hPX/pGhq16YvCFZqo15HJg2rVG3fBT0vXoGm9Sm4DmhUlARIgARIgARIgARIIHQIu7/AOGTMLuXNkxKAerRE71v/QotMQZMucHgunDcX32TOFDjWWSgIk4DgBapIACZAACZBAKBNweYf31evXaN6gGvLnzopOrRrgpXbcsWVdGAx8Q0Mojx0WTwIkQAIkQAIkEAACVA09Ai7v8JqjiRE9GiKED28ezWMSIAESIAESIAESIAESsEjA5R3eW3fuI3eJuka5e/+hMSzxFlvFSBJwWwKsOAmQAAmQAAmQgLMJuLzDO2lED9gSZwOhPRIgARIgARIgARcgwCqQgBMJuLzDmyPLd7AlTmRBUyRAAiRAAiRAAiRAAh5IwOUdXg9kziY5jwAtkQAJkAAJkAAJkIBdAnR47SKiAgmQAAmQAAm4OgHWjwRIwBaBMO/wHj/1Dxq26Yt6LXthzqJVFlmt+HWTvwflFq5YZ1GPkSRAAiRAAiRAAiRAAq5HIEw7vJ8/f0a/4VPRrW1D/DRlMP7cdQBHT5y12EtN6lbG3k2LldSvUc6ijqtHsn4kQAIkQAIkQAIkEBYJhGmH95+LVxE5ciSkS50cPt7eKF44D3btOxIWxwHbTAIkQAJhiQDbSgIkEMYIhGmH996Dx0iUIK6xyxMnio979x8Zj00DS3/5HYUrNEG3AeNw/+FjY9KnT59ACasMPoeZvtcHPMd6WB3rbLf/sc9z3z+PsDU+9Osh9+5FwKMd3ms37qB5x4EW5eWr16qnDF6mP1FsgkOl+m6KFfoem1fNwKLpwxAtalQMGTPLN0Hbvn37BpSwyeDjxw9hpu+1oa7+c6yHzbHOfvff7zz3/fMIa+NDXQy5cTsClj08t2uG5QonSZwQYwd3sShRIkdC/Lix8OTpc2Pmx0+eIn682MZjPRAr5v/g4+ODr7+Kj44t6+Ls+ct6EiJFikwJowzChQsXZvpeH/Ac72HzfGe/++93nvv+eYS18aFfD7l3LwJe7lXdgNc2WtQo2qzslyKWUqdIioePnuDGrbv4+OkTtu3Yj3zfZ5Uk3L3/EFev31bhFy9fqb1s/ty5H2lTfStBCgmQAAmQAAmQAAmQgBsQcJLD6wYttVBFg8GAgT1aoe+wKWjYug+yZUmHrBnTKs0/dx7AstUbVXjImJnqtWRFKjbF/sMn0bdLc/CPBEiABEiABEiABEjAPQiEaYdXuijTd6kxf+oQtT63Wb0qEqWkdtXS6NmhiQqP6N9RvY5s25o5GNqnHeLGiaXiuSEBEiCBLwgwggRIgARIwOUIhHmH1+V6hBUiARIgARIgARIgAQ8g4EpNoMPrSr3BupAACZAACZAACZAACTidAB1epyOlQRIgAccJUJMESIAESIAEgp8AHd7gZ8wSSIAESIAESIAESMA2AaYGKwE6vMGKl8ZJgARIgARIgARIgARCmwAd3tDuAZZPAo4ToCYJkAAJkAAJkEAgCNDhDQQ0ZiEBEiABEiABEghNAiybBAJGgA5vwHhRmwRIgARIgARIgARIwM0I0OF1sw5jdR0nQE0SIAESIAESIAESEAJ0eIUChQRIgARIgAQ8lwBbRgJhngAd3jA/BAiABEiABEiABEiABDybAB1ez+5fx1tHTRIgARIgARIgARLwUAJ0eD20Y9ksEiABEiCBwBFgLhIgAc8jQIfX8/qULSIBEiABEiABEiABEjAhQIfXBIbjQWqSAAmQAAmQgPsSWLBiAxJlLGNX9BY6ortw5e+6Ovck4HIE6PC6XJewQiRAAiTgRgRYVRIgARJwAwJ0eN2gk1hFEgguApzlCS6ytEsCrk2gQY0yuHVig1OlfvXSrt1o1i5MEwgJhzdMA2bjSYAESIAESIAESIAEQpcAHd7Q5c/SSSBUCXCWJ6TxszwSIAESIIHQIECHNzSos0wSIAESIAESIAESCMsEQrjtdHhDGDiLIwESIAESIAESIAESCFkCdHhDljdLIwEScJwANUmABEiABEjAKQTo8DoFI42QAAmQAAmQAAmQQHARoN2gEqDDG1SCzE8CJEACJEACJEACJODSBOjwunT3sHIk4DgBapIACZAACZAACVgmQIfXMhfGkgAJkAAJkAAJuCcB1poEviBAh/cLJIwgARIgARIgARIgARLwJAJ0eD2pN9kWxwlQkwRIgARIgARIIMwQoMMbZrqaDSUBEiABEiCBLwkwhgTCAgE6vEHs5ffv34ESNhmEDx+efc/xzzEQBscAz/2wec3XP+uD6DYweygRoMMbSuDdq1jWlgRIgARIgARIgATclwAdXvftO9acBEiABEggpAmwPBIgAbckQIfXLbuNlQ5NAg8fPUGbbsPQuG0/9Bo8Ea/fvAnN6rBsEiCBECKw5vc/UatpV+QuURdPnj4LoVJZDAmQgDMI0OF1BkX/Nnjk4QQmzlyC77NnwrzJgxA9ejQs+fl3D28xm0cCJCAE4seNjUG92iBO7JhySCEBEnAjAnR43aizWFXXILB7/zGUKZ5fVaZMsfz4e/9RFeaGBEjAnIBnHefOkQkpv03iWY1ia0ggjBCgwxtGOprNdA6Bl69ew2AAYsaIrgwmThQfDx4+VmFuSIAESIAESIAEXJNAqDu8romFtSIB6wS8vP47bQyG/8LWczCFBEiABEiABEggNAnw0zo06bNstyMQJXIkfPz4Ce/ev1d1f/TkKeLGiaXC3JBAEAkwOwmQAAmQQDARoMMbTGBp1nMJ5MmZGVv/2qsauHn7HuTLlVmFuSEBEiABEiABEnAGAefboMPrfKa06OEEOrSog3WbdqrXkl2/cQeDBYbLAAAHv0lEQVR1qpXx8BazeSRAAkJg+rwV6pVk8mrC0jVaoUu/MRJNIQEScAMCXm5QR1aRBFyKgLySaPqYPuq1ZMP6tkekiBFdqn5hpTJsJwmENIGWjWtg76bFRhkzqEtIV4HlkQAJBJIAHd5AgmM2EiABEiABEiABEnABAqyCAwTo8DoAiSokQAIkQAIkQAIkQALuS4AOr/v2HWtOAo4ToCYJkAAJkAAJhGECdHjDcOez6SRAAiRAAiQQ1giwvWGTAB3esNnvbDUJkAAJkAAJkAAJhBkCdHjDTFezoY4ToCYJkAAJkAAJkIAnEaDD60m9ybaQAAmQAAmQgDMJ0BYJeAgBOrwe0pFsBgmQAAmQAAmQAAmQgGUCdHgtc2Gs4wSoSQIkQAIkQAIkQAIuTYAOr0t3DytHAiRAAiTgPgRYUxIgAVclQIfXVXuG9SIBEiABEiABEiABEnAKATq8TsHouBFqkgAJkAAJkAAJkAAJhCwBOrwhy5ulkQAJkAAJ+BLglgRIgARCjAAd3hBDzYJIgARIgARIgARIgARCg4BrO7yhQYRlkgAJkAAJkAAJkAAJeBQBOrwe1Z1sDAmQgKcSYLtIgARIgAQCT4AOb+DZMScJkAAJkAAJkAAJkEDIEghUaXR4A4WNmUiABEiABEiABEiABNyFAB1ed+kp1pMESMBxAtQkARIgARIgARMCdHhNYDBIAiRAAiRAAiRAAp5EgG3xJUCH15cDtyRAAiRAAiRAAiRAAh5KgA6vh3Ysm0UCjhOgJgmQAAmQAAl4NgE6vJ7dv2wdCZAACZAACZCAowSo57EE6PB6bNeyYSRAAgElcPHydeQuUdefLP3ld5tm2vccid37j1nUadF5MI6eOGsxjZEkQAIkQAIhR4AOb8ixZkmeQYCt8HAC0aNFxd5Ni41Su2ppD28xm0cCJEACnk+ADq/n9zFbSAIkEEQCz1+8xOAxs1C3RU/U/bEnflr6m0WL5y5cQdP2/TUZgO4DxuHN23cW9RhJAp5BgK0gAfchQIfXffqKNSUBEggBAs+ev/C3pOHhoyeYtWAVnr94gYXThmLiiO5Ys2Eb/t539IvaDBw1HaWL5seciQNQvtQP+EdzgL9QYgQJkAAJkECIE6DDG+LIw1aBbC0JuBsB8yUNcWLHxJHjZ1C7Sml4eXkhdswYKFUsHw4fP+2vaf8+e4H7Dx6jYpkfVHzeXJmRJHFCFeaGBEiABEggdAnQ4Q1d/iydBEjADQh8xmf4+Hgba+rj7YPPnz8bjyUgOuIQi8ixiOjJnkICAAiBBEggFAnQ4Q1F+CyaBEjAPQhky5Qey1ZtVE7uoydPsenP3ciRJYO/yseIHg1xYsfA8VP/qPjbd+/j6vVbKswNCZAACZBA6BKgwxu6/P2XziMSIAGXJNC8QRVEjBgR9Vv1RvseI1G6WAHIkgXzyg7o1hLzl61F665DMW7qQiRMENdchcckQAIkQAKhQIAObyhAZ5EkQAKuSSDFt99g0y8zvqhctKhR0LdLcyyaPgyLZw5Ho9oVjDoTh3c3Or+pUybD+KFdMXV0b4wZ3AU//zQWWTKmNeoy4DgBapIACZCAMwnQ4XUmTdoiARIgARIgARIgARJwOQJu7PC6HEtWiARIgARIgARIgARIwAUJ0OF1wU5hlUiABEggQASoTAIkQAIkYJMAHV6beJhIAiRAAiRAAiRAAiTgLgSs1ZMOrzUyjCcBEiABEiABEiABEvAIAnR4PaIb2QgSIAHHCVCTBEiABEggrBGgwxvWepztJQESIAESIAESIAEhEIaEDm8Y6mw2lQRIgARIgARIgATCIgE6vGGx19lmEnCcADVJgARIgARIwO0J0OF1+y5kA0iABEiABEiABIKfAEtwZwJ0eN2591h3EiABEiABEiABEiABuwTo8NpFRAUScJwANUmABEiABEiABFyPAB1e1+sT1ogESIAESIAE3J0A608CLkWADq9LdQcrQwIkQAIkQAIkQAIk4GwCdHidTZT2HCdATRIgARIgARIgARIIAQJ0eEMAMosgARIgARIgAVsEmEYCJBC8BOjwBi9fWicBEiABEiABEiABEghlAnR4Q7kDHC+emiRAAiRAAiRAAiRAAoEhQIc3MNSYhwRIgARIIPQIsGQSIAESCCABOrwBBEZ1EiABEiABEiABEiAB9yLgqQ6ve/UCa0sCJEACJEACJEACJBBsBOjwBhtaGiYBEiABVyDAOpAACZAACdDh5RggARIgARIgARIgARLwaALK4fXoFrJxJEACJEACJEACJEACYZoAHd4w3f1sPAmQgBkBHpIACZAACXggATq8HtipbBIJkAAJkAAJkAAJBI2AZ+Wmw+tZ/cnWkAAJkAAJkAAJkAAJmBGgw2sGhIckQAKOE6AmCZAACZAACbgDATq87tBLrCMJkAAJkAAJkIArE2DdXJwAHV4X7yBWjwRIgARIgARIgARIIGgE6PAGjR9zk4DjBKhJAiRAAiRAAiQQKgTo8IYKdhZKAiRAAiRAAmGXAFtOAiFNgA5vSBNneSRAAiRAAiRAAiRAAiFKgA5viOJmYY4ToCYJkAAJkAAJkAAJOIcAHV7ncKQVEiABEiABEggeArRKAiQQZAJ0eIOMkAZIgARIgARIgARIgARcmcD/AQAA///PePIZAAAABklEQVQDACWCeFBPslmGAAAAAElFTkSuQmCC"
+     },
+     "metadata": {
+      "image/png": {
+       "alt": "Grouped box plots with one group of three boxes per fold along the horizontal axis, coloured amber, copper and slate for the 5-, 15- and 60-minute components. A dashed rule marks zero. In every fold the amber 5-minute box sits highest and above the rule, while the copper and slate boxes for the two longer horizons sit lower and straddle it. Boxes span the quartiles and the whiskers the 5th to 95th percentiles."
+      }
+     },
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "fig = go.Figure()\n",
     "_component_colors = {\n",
@@ -1985,13 +3970,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3d2c8a6f",
+   "id": "2156ef6d",
    "metadata": {
     "papermill": {
-     "duration": 0.010729,
-     "end_time": "2026-09-04T04:43:26.487660+00:00",
+     "duration": 0.004921,
+     "end_time": "2026-09-09T22:27:05.345439+00:00",
      "exception": false,
-     "start_time": "2026-09-04T04:43:26.476931+00:00",
+     "start_time": "2026-09-09T22:27:05.340518+00:00",
      "status": "completed"
     },
     "tags": [
@@ -2013,13 +3998,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f114bbc8",
+   "id": "db1afd32",
    "metadata": {
     "papermill": {
-     "duration": 0.005595,
-     "end_time": "2026-09-04T04:43:26.503075+00:00",
+     "duration": 0.004899,
+     "end_time": "2026-09-09T22:27:05.355291+00:00",
      "exception": false,
-     "start_time": "2026-09-04T04:43:26.497480+00:00",
+     "start_time": "2026-09-09T22:27:05.350392+00:00",
      "status": "completed"
     }
    },
@@ -2033,10 +4018,32 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "efdd76ce",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 34,
+   "id": "14d5b27c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-09T22:27:05.366744Z",
+     "iopub.status.busy": "2026-09-09T22:27:05.366632Z",
+     "iopub.status.idle": "2026-09-09T22:27:11.461159Z",
+     "shell.execute_reply": "2026-09-09T22:27:11.460372Z"
+    },
+    "papermill": {
+     "duration": 6.100957,
+     "end_time": "2026-09-09T22:27:11.461797+00:00",
+     "exception": false,
+     "start_time": "2026-09-09T22:27:05.360840+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "22 features on 20,010,985 rows; 14,045 warm-up rows dropped.\n"
+     ]
+    }
+   ],
    "source": [
     "temporal_df = har_df.join(fft_df, on=[\"timestamp\", \"symbol\"], how=\"inner\")\n",
     "temporal_df = temporal_df.join(sig_df, on=[\"timestamp\", \"symbol\"], how=\"inner\")\n",
@@ -2064,13 +4071,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7f2451c0",
+   "id": "1cd7bca1",
    "metadata": {
     "papermill": {
-     "duration": 0.007877,
-     "end_time": "2026-09-04T04:43:30.904706+00:00",
+     "duration": 0.009596,
+     "end_time": "2026-09-09T22:27:11.481328+00:00",
      "exception": false,
-     "start_time": "2026-09-04T04:43:30.896829+00:00",
+     "start_time": "2026-09-09T22:27:11.471732+00:00",
      "status": "completed"
     }
    },
@@ -2084,10 +4091,72 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "e35d7589",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 35,
+   "id": "530e4a77",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-09T22:27:11.494201Z",
+     "iopub.status.busy": "2026-09-09T22:27:11.494089Z",
+     "iopub.status.idle": "2026-09-09T22:27:16.235953Z",
+     "shell.execute_reply": "2026-09-09T22:27:16.235569Z"
+    },
+    "papermill": {
+     "duration": 4.748238,
+     "end_time": "2026-09-09T22:27:16.236632+00:00",
+     "exception": false,
+     "start_time": "2026-09-09T22:27:11.488394+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div><style>\n",
+       ".dataframe > thead > tr,\n",
+       ".dataframe > tbody > tr {\n",
+       "  text-align: right;\n",
+       "  white-space: pre-wrap;\n",
+       "}\n",
+       "</style>\n",
+       "<small>shape: (22, 4)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>feature</th><th>rows with a value</th><th>median</th><th>width of the 5th to 95th percentile range</th></tr><tr><td>str</td><td>str</td><td>str</td><td>str</td></tr></thead><tbody><tr><td>&quot;har_rv5_pred&quot;</td><td>&quot;10,063,258&quot;</td><td>&quot;3.75e-07&quot;</td><td>&quot;3.12e-06&quot;</td></tr><tr><td>&quot;har_residual&quot;</td><td>&quot;10,063,248&quot;</td><td>&quot;-1.8e-08&quot;</td><td>&quot;1.19e-06&quot;</td></tr><tr><td>&quot;vol_spectral_energy&quot;</td><td>&quot;10,063,258&quot;</td><td>&quot;1.29e+03&quot;</td><td>&quot;6.33e+03&quot;</td></tr><tr><td>&quot;vol_dominant_period&quot;</td><td>&quot;10,063,258&quot;</td><td>&quot;12&quot;</td><td>&quot;57.9&quot;</td></tr><tr><td>&quot;vol_spectral_entropy&quot;</td><td>&quot;10,063,258&quot;</td><td>&quot;2.95&quot;</td><td>&quot;0.798&quot;</td></tr><tr><td>&quot;vol_low_freq_ratio&quot;</td><td>&quot;10,063,258&quot;</td><td>&quot;0.127&quot;</td><td>&quot;0.493&quot;</td></tr><tr><td>&quot;rv_spectral_energy&quot;</td><td>&quot;10,062,480&quot;</td><td>&quot;1.08e-09&quot;</td><td>&quot;5.5e-08&quot;</td></tr><tr><td>&quot;rv_dominant_period&quot;</td><td>&quot;10,062,480&quot;</td><td>&quot;5&quot;</td><td>&quot;58&quot;</td></tr><tr><td>&quot;rv_spectral_entropy&quot;</td><td>&quot;10,062,480&quot;</td><td>&quot;3.05&quot;</td><td>&quot;0.347&quot;</td></tr><tr><td>&quot;rv_low_freq_ratio&quot;</td><td>&quot;10,062,480&quot;</td><td>&quot;0.0808&quot;</td><td>&quot;0.191&quot;</td></tr><tr><td>&quot;sig1_ret&quot;</td><td>&quot;10,063,258&quot;</td><td>&quot;-0.000719&quot;</td><td>&quot;3.41&quot;</td></tr><tr><td>&quot;sig1_svs&quot;</td><td>&quot;10,063,258&quot;</td><td>&quot;0.000526&quot;</td><td>&quot;3.29&quot;</td></tr><tr><td>&quot;sig1_trd&quot;</td><td>&quot;10,063,258&quot;</td><td>&quot;0.224&quot;</td><td>&quot;3.37&quot;</td></tr><tr><td>&quot;sig2_ret_ret&quot;</td><td>&quot;10,063,258&quot;</td><td>&quot;0.184&quot;</td><td>&quot;2.17&quot;</td></tr><tr><td>&quot;sig2_ret_svs&quot;</td><td>&quot;10,063,258&quot;</td><td>&quot;-1.07&quot;</td><td>&quot;27.9&quot;</td></tr><tr><td>&quot;sig2_ret_trd&quot;</td><td>&quot;10,063,258&quot;</td><td>&quot;-0.6&quot;</td><td>&quot;40.4&quot;</td></tr><tr><td>&quot;sig2_svs_ret&quot;</td><td>&quot;10,063,258&quot;</td><td>&quot;1.52&quot;</td><td>&quot;27.9&quot;</td></tr><tr><td>&quot;sig2_svs_svs&quot;</td><td>&quot;10,063,258&quot;</td><td>&quot;0.259&quot;</td><td>&quot;1.82&quot;</td></tr><tr><td>&quot;sig2_svs_trd&quot;</td><td>&quot;10,063,258&quot;</td><td>&quot;-0.137&quot;</td><td>&quot;41.1&quot;</td></tr><tr><td>&quot;sig2_trd_ret&quot;</td><td>&quot;10,063,258&quot;</td><td>&quot;0.576&quot;</td><td>&quot;40.1&quot;</td></tr><tr><td>&quot;sig2_trd_svs&quot;</td><td>&quot;10,063,258&quot;</td><td>&quot;0.127&quot;</td><td>&quot;40.9&quot;</td></tr><tr><td>&quot;sig2_trd_trd&quot;</td><td>&quot;10,063,258&quot;</td><td>&quot;0.216&quot;</td><td>&quot;2.27&quot;</td></tr></tbody></table></div>"
+      ],
+      "text/plain": [
+       "shape: (22, 4)\n",
+       "┌──────────────────────┬───────────────────┬───────────┬─────────────────────────────────┐\n",
+       "│ feature              ┆ rows with a value ┆ median    ┆ width of the 5th to 95th perce… │\n",
+       "│ ---                  ┆ ---               ┆ ---       ┆ ---                             │\n",
+       "│ str                  ┆ str               ┆ str       ┆ str                             │\n",
+       "╞══════════════════════╪═══════════════════╪═══════════╪═════════════════════════════════╡\n",
+       "│ har_rv5_pred         ┆ 10,063,258        ┆ 3.75e-07  ┆ 3.12e-06                        │\n",
+       "│ har_residual         ┆ 10,063,248        ┆ -1.8e-08  ┆ 1.19e-06                        │\n",
+       "│ vol_spectral_energy  ┆ 10,063,258        ┆ 1.29e+03  ┆ 6.33e+03                        │\n",
+       "│ vol_dominant_period  ┆ 10,063,258        ┆ 12        ┆ 57.9                            │\n",
+       "│ vol_spectral_entropy ┆ 10,063,258        ┆ 2.95      ┆ 0.798                           │\n",
+       "│ vol_low_freq_ratio   ┆ 10,063,258        ┆ 0.127     ┆ 0.493                           │\n",
+       "│ rv_spectral_energy   ┆ 10,062,480        ┆ 1.08e-09  ┆ 5.5e-08                         │\n",
+       "│ rv_dominant_period   ┆ 10,062,480        ┆ 5         ┆ 58                              │\n",
+       "│ rv_spectral_entropy  ┆ 10,062,480        ┆ 3.05      ┆ 0.347                           │\n",
+       "│ rv_low_freq_ratio    ┆ 10,062,480        ┆ 0.0808    ┆ 0.191                           │\n",
+       "│ sig1_ret             ┆ 10,063,258        ┆ -0.000719 ┆ 3.41                            │\n",
+       "│ sig1_svs             ┆ 10,063,258        ┆ 0.000526  ┆ 3.29                            │\n",
+       "│ sig1_trd             ┆ 10,063,258        ┆ 0.224     ┆ 3.37                            │\n",
+       "│ sig2_ret_ret         ┆ 10,063,258        ┆ 0.184     ┆ 2.17                            │\n",
+       "│ sig2_ret_svs         ┆ 10,063,258        ┆ -1.07     ┆ 27.9                            │\n",
+       "│ sig2_ret_trd         ┆ 10,063,258        ┆ -0.6      ┆ 40.4                            │\n",
+       "│ sig2_svs_ret         ┆ 10,063,258        ┆ 1.52      ┆ 27.9                            │\n",
+       "│ sig2_svs_svs         ┆ 10,063,258        ┆ 0.259     ┆ 1.82                            │\n",
+       "│ sig2_svs_trd         ┆ 10,063,258        ┆ -0.137    ┆ 41.1                            │\n",
+       "│ sig2_trd_ret         ┆ 10,063,258        ┆ 0.576     ┆ 40.1                            │\n",
+       "│ sig2_trd_svs         ┆ 10,063,258        ┆ 0.127     ┆ 40.9                            │\n",
+       "│ sig2_trd_trd         ┆ 10,063,258        ┆ 0.216     ┆ 2.27                            │\n",
+       "└──────────────────────┴───────────────────┴───────────┴─────────────────────────────────┘"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "_n = len(temporal_feature_cols)\n",
     "_stats = (\n",
@@ -2117,13 +4186,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6c8a7f4c",
+   "id": "d769f52d",
    "metadata": {
     "papermill": {
-     "duration": 0.006295,
-     "end_time": "2026-09-04T04:43:35.062307+00:00",
+     "duration": 0.005047,
+     "end_time": "2026-09-09T22:27:16.246996+00:00",
      "exception": false,
-     "start_time": "2026-09-04T04:43:35.056012+00:00",
+     "start_time": "2026-09-09T22:27:16.241949+00:00",
      "status": "completed"
     }
    },
@@ -2136,10 +4205,54 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "41f50952",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 36,
+   "id": "d2d16dc3",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-09T22:27:16.257733Z",
+     "iopub.status.busy": "2026-09-09T22:27:16.257624Z",
+     "iopub.status.idle": "2026-09-09T22:27:19.743743Z",
+     "shell.execute_reply": "2026-09-09T22:27:19.743288Z"
+    },
+    "papermill": {
+     "duration": 3.492159,
+     "end_time": "2026-09-09T22:27:19.744155+00:00",
+     "exception": false,
+     "start_time": "2026-09-09T22:27:16.251996+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div><style>\n",
+       ".dataframe > thead > tr,\n",
+       ".dataframe > tbody > tr {\n",
+       "  text-align: right;\n",
+       "  white-space: pre-wrap;\n",
+       "}\n",
+       "</style>\n",
+       "<small>shape: (4, 2)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>frame</th><th>rows</th></tr><tr><td>str</td><td>str</td></tr></thead><tbody><tr><td>&quot;labels&quot;</td><td>&quot;19,020,702&quot;</td></tr><tr><td>&quot;this notebook&quot;</td><td>&quot;20,010,985&quot;</td></tr><tr><td>&quot;financial features&quot;</td><td>&quot;16,871,167&quot;</td></tr><tr><td>&quot;all of them&quot;</td><td>&quot;15,892,541&quot;</td></tr></tbody></table></div>"
+      ],
+      "text/plain": [
+       "shape: (4, 2)\n",
+       "┌────────────────────┬────────────┐\n",
+       "│ frame              ┆ rows       │\n",
+       "│ ---                ┆ ---        │\n",
+       "│ str                ┆ str        │\n",
+       "╞════════════════════╪════════════╡\n",
+       "│ labels             ┆ 19,020,702 │\n",
+       "│ this notebook      ┆ 20,010,985 │\n",
+       "│ financial features ┆ 16,871,167 │\n",
+       "│ all of them        ┆ 15,892,541 │\n",
+       "└────────────────────┴────────────┘"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "labels_path = LABELS_DIR / f\"{PRIMARY_LABEL}.parquet\"\n",
     "features_path = FEATURES_DIR / \"financial.parquet\"\n",
@@ -2167,13 +4280,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d5ea58bc",
+   "id": "08f3a9ee",
    "metadata": {
     "papermill": {
-     "duration": 0.010148,
-     "end_time": "2026-09-04T04:43:38.199091+00:00",
+     "duration": 0.005272,
+     "end_time": "2026-09-09T22:27:19.755213+00:00",
      "exception": false,
-     "start_time": "2026-09-04T04:43:38.188943+00:00",
+     "start_time": "2026-09-09T22:27:19.749941+00:00",
      "status": "completed"
     }
    },
@@ -2217,10 +4330,32 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "12ec86f3",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 37,
+   "id": "180f9305",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-09T22:27:19.766457Z",
+     "iopub.status.busy": "2026-09-09T22:27:19.766351Z",
+     "iopub.status.idle": "2026-09-09T22:27:20.044346Z",
+     "shell.execute_reply": "2026-09-09T22:27:20.043974Z"
+    },
+    "papermill": {
+     "duration": 0.284464,
+     "end_time": "2026-09-09T22:27:20.044906+00:00",
+     "exception": false,
+     "start_time": "2026-09-09T22:27:19.760442+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "20,010,985 rows, one per (timestamp, symbol), 22 features stored as Float32.\n"
+     ]
+    }
+   ],
    "source": [
     "FEATURE_COLS = [c for c in temporal_clean.columns if c not in (\"timestamp\", \"symbol\")]\n",
     "temporal_out = temporal_clean.with_columns(\n",
@@ -2234,13 +4369,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0cca4eab",
+   "id": "10cc0709",
    "metadata": {
     "papermill": {
-     "duration": 0.005796,
-     "end_time": "2026-09-04T04:43:38.488978+00:00",
+     "duration": 0.005278,
+     "end_time": "2026-09-09T22:27:20.055797+00:00",
      "exception": false,
-     "start_time": "2026-09-04T04:43:38.483182+00:00",
+     "start_time": "2026-09-09T22:27:20.050519+00:00",
      "status": "completed"
     }
    },
@@ -2271,10 +4406,74 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "2745154a",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 38,
+   "id": "655a5ab7",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-09T22:27:20.066872Z",
+     "iopub.status.busy": "2026-09-09T22:27:20.066765Z",
+     "iopub.status.idle": "2026-09-09T22:27:21.602539Z",
+     "shell.execute_reply": "2026-09-09T22:27:21.602188Z"
+    },
+    "papermill": {
+     "duration": 1.541745,
+     "end_time": "2026-09-09T22:27:21.602844+00:00",
+     "exception": false,
+     "start_time": "2026-09-09T22:27:20.061099+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div><style>\n",
+       ".dataframe > thead > tr,\n",
+       ".dataframe > tbody > tr {\n",
+       "  text-align: right;\n",
+       "  white-space: pre-wrap;\n",
+       "}\n",
+       "</style>\n",
+       "<small>shape: (16, 7)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>label</th><th>fold</th><th>window</th><th>decision times asked for</th><th>in the panel</th><th>in the artifact</th><th>lost to warm-up</th></tr><tr><td>str</td><td>i64</td><td>str</td><td>i64</td><td>i64</td><td>i64</td><td>i64</td></tr></thead><tbody><tr><td>&quot;fwd_dir_15m&quot;</td><td>0</td><td>&quot;train&quot;</td><td>46361</td><td>46361</td><td>46240</td><td>121</td></tr><tr><td>&quot;fwd_dir_15m&quot;</td><td>0</td><td>&quot;validation&quot;</td><td>47092</td><td>47092</td><td>47092</td><td>0</td></tr><tr><td>&quot;fwd_dir_15m&quot;</td><td>1</td><td>&quot;train&quot;</td><td>47076</td><td>47076</td><td>47076</td><td>0</td></tr><tr><td>&quot;fwd_dir_15m&quot;</td><td>1</td><td>&quot;validation&quot;</td><td>47092</td><td>47092</td><td>47092</td><td>0</td></tr><tr><td>&quot;fwd_ret_15m&quot;</td><td>0</td><td>&quot;train&quot;</td><td>46361</td><td>46361</td><td>46240</td><td>121</td></tr><tr><td>&quot;fwd_ret_15m&quot;</td><td>0</td><td>&quot;validation&quot;</td><td>47092</td><td>47092</td><td>47092</td><td>0</td></tr><tr><td>&quot;fwd_ret_15m&quot;</td><td>1</td><td>&quot;train&quot;</td><td>47076</td><td>47076</td><td>47076</td><td>0</td></tr><tr><td>&quot;fwd_ret_15m&quot;</td><td>1</td><td>&quot;validation&quot;</td><td>47092</td><td>47092</td><td>47092</td><td>0</td></tr><tr><td>&quot;fwd_ret_5m&quot;</td><td>0</td><td>&quot;train&quot;</td><td>47610</td><td>47610</td><td>47489</td><td>121</td></tr><tr><td>&quot;fwd_ret_5m&quot;</td><td>0</td><td>&quot;validation&quot;</td><td>48361</td><td>48361</td><td>48361</td><td>0</td></tr><tr><td>&quot;fwd_ret_5m&quot;</td><td>1</td><td>&quot;train&quot;</td><td>48355</td><td>48355</td><td>48355</td><td>0</td></tr><tr><td>&quot;fwd_ret_5m&quot;</td><td>1</td><td>&quot;validation&quot;</td><td>48361</td><td>48361</td><td>48361</td><td>0</td></tr><tr><td>&quot;fwd_ret_60m&quot;</td><td>0</td><td>&quot;train&quot;</td><td>40736</td><td>40736</td><td>40615</td><td>121</td></tr><tr><td>&quot;fwd_ret_60m&quot;</td><td>0</td><td>&quot;validation&quot;</td><td>41403</td><td>41403</td><td>41403</td><td>0</td></tr><tr><td>&quot;fwd_ret_60m&quot;</td><td>1</td><td>&quot;train&quot;</td><td>41352</td><td>41352</td><td>41352</td><td>0</td></tr><tr><td>&quot;fwd_ret_60m&quot;</td><td>1</td><td>&quot;validation&quot;</td><td>41403</td><td>41403</td><td>41403</td><td>0</td></tr></tbody></table></div>"
+      ],
+      "text/plain": [
+       "shape: (16, 7)\n",
+       "┌─────────────┬──────┬────────────┬───────────────────┬──────────────┬──────────┬──────────────────┐\n",
+       "│ label       ┆ fold ┆ window     ┆ decision times    ┆ in the panel ┆ in the   ┆ lost to warm-up  │\n",
+       "│ ---         ┆ ---  ┆ ---        ┆ asked for         ┆ ---          ┆ artifact ┆ ---              │\n",
+       "│ str         ┆ i64  ┆ str        ┆ ---               ┆ i64          ┆ ---      ┆ i64              │\n",
+       "│             ┆      ┆            ┆ i64               ┆              ┆ i64      ┆                  │\n",
+       "╞═════════════╪══════╪════════════╪═══════════════════╪══════════════╪══════════╪══════════════════╡\n",
+       "│ fwd_dir_15m ┆ 0    ┆ train      ┆ 46361             ┆ 46361        ┆ 46240    ┆ 121              │\n",
+       "│ fwd_dir_15m ┆ 0    ┆ validation ┆ 47092             ┆ 47092        ┆ 47092    ┆ 0                │\n",
+       "│ fwd_dir_15m ┆ 1    ┆ train      ┆ 47076             ┆ 47076        ┆ 47076    ┆ 0                │\n",
+       "│ fwd_dir_15m ┆ 1    ┆ validation ┆ 47092             ┆ 47092        ┆ 47092    ┆ 0                │\n",
+       "│ fwd_ret_15m ┆ 0    ┆ train      ┆ 46361             ┆ 46361        ┆ 46240    ┆ 121              │\n",
+       "│ fwd_ret_15m ┆ 0    ┆ validation ┆ 47092             ┆ 47092        ┆ 47092    ┆ 0                │\n",
+       "│ fwd_ret_15m ┆ 1    ┆ train      ┆ 47076             ┆ 47076        ┆ 47076    ┆ 0                │\n",
+       "│ fwd_ret_15m ┆ 1    ┆ validation ┆ 47092             ┆ 47092        ┆ 47092    ┆ 0                │\n",
+       "│ fwd_ret_5m  ┆ 0    ┆ train      ┆ 47610             ┆ 47610        ┆ 47489    ┆ 121              │\n",
+       "│ fwd_ret_5m  ┆ 0    ┆ validation ┆ 48361             ┆ 48361        ┆ 48361    ┆ 0                │\n",
+       "│ fwd_ret_5m  ┆ 1    ┆ train      ┆ 48355             ┆ 48355        ┆ 48355    ┆ 0                │\n",
+       "│ fwd_ret_5m  ┆ 1    ┆ validation ┆ 48361             ┆ 48361        ┆ 48361    ┆ 0                │\n",
+       "│ fwd_ret_60m ┆ 0    ┆ train      ┆ 40736             ┆ 40736        ┆ 40615    ┆ 121              │\n",
+       "│ fwd_ret_60m ┆ 0    ┆ validation ┆ 41403             ┆ 41403        ┆ 41403    ┆ 0                │\n",
+       "│ fwd_ret_60m ┆ 1    ┆ train      ┆ 41352             ┆ 41352        ┆ 41352    ┆ 0                │\n",
+       "│ fwd_ret_60m ┆ 1    ┆ validation ┆ 41403             ┆ 41403        ┆ 41403    ┆ 0                │\n",
+       "└─────────────┴──────┴────────────┴───────────────────┴──────────────┴──────────┴──────────────────┘"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Every fold window of all 4 configured targets is carried by the artifact from 2020-01-02 11:31:00 on; 121 earlier decision times are lost to the 121-bar warm-up.\n"
+     ]
+    }
+   ],
    "source": [
     "written_ts = set(temporal_out[\"timestamp\"].unique().to_list())\n",
     "ARTIFACT_START = temporal_out[\"timestamp\"].min()\n",
@@ -2326,13 +4525,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cad138d4",
+   "id": "1fe27c81",
    "metadata": {
     "papermill": {
-     "duration": 0.008956,
-     "end_time": "2026-09-04T04:43:40.274707+00:00",
+     "duration": 0.004998,
+     "end_time": "2026-09-09T22:27:21.613439+00:00",
      "exception": false,
-     "start_time": "2026-09-04T04:43:40.265751+00:00",
+     "start_time": "2026-09-09T22:27:21.608441+00:00",
      "status": "completed"
     }
    },
@@ -2360,10 +4559,32 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "b57de07f",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 39,
+   "id": "9ef39d62",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-09T22:27:21.624892Z",
+     "iopub.status.busy": "2026-09-09T22:27:21.624787Z",
+     "iopub.status.idle": "2026-09-09T22:27:25.848747Z",
+     "shell.execute_reply": "2026-09-09T22:27:25.847934Z"
+    },
+    "papermill": {
+     "duration": 4.230151,
+     "end_time": "2026-09-09T22:27:25.849035+00:00",
+     "exception": false,
+     "start_time": "2026-09-09T22:27:21.618884+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Wrote features/model_based.parquet, digest a10dbed1701bef51, 20,010,985 rows\n"
+     ]
+    }
+   ],
    "source": [
     "record = write_model_based(\n",
     "    temporal_out,\n",
@@ -2386,10 +4607,32 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "cb1f7b50",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 40,
+   "id": "eb60a455",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-09T22:27:25.890832Z",
+     "iopub.status.busy": "2026-09-09T22:27:25.890701Z",
+     "iopub.status.idle": "2026-09-09T22:27:25.896911Z",
+     "shell.execute_reply": "2026-09-09T22:27:25.896532Z"
+    },
+    "papermill": {
+     "duration": 0.042424,
+     "end_time": "2026-09-09T22:27:25.897199+00:00",
+     "exception": false,
+     "start_time": "2026-09-09T22:27:25.854775+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Artifact reconciled: 20,010,985 rows on (timestamp, symbol), 22 Float32 features, no fold column.\n"
+     ]
+    }
+   ],
    "source": [
     "_written = pl.scan_parquet(OUTPUT_DIR / \"model_based.parquet\")\n",
     "_written_schema = _written.collect_schema()\n",
@@ -2409,13 +4652,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "668841dc",
+   "id": "d11f57a5",
    "metadata": {
     "papermill": {
-     "duration": 0.006203,
-     "end_time": "2026-09-04T04:43:44.315881+00:00",
+     "duration": 0.005153,
+     "end_time": "2026-09-09T22:27:25.907843+00:00",
      "exception": false,
-     "start_time": "2026-09-04T04:43:44.309678+00:00",
+     "start_time": "2026-09-09T22:27:25.902690+00:00",
      "status": "completed"
     }
    },
@@ -2453,10 +4696,32 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "74d6763f",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 41,
+   "id": "56f0e9f7",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-09T22:27:25.919962Z",
+     "iopub.status.busy": "2026-09-09T22:27:25.919765Z",
+     "iopub.status.idle": "2026-09-09T22:27:28.113917Z",
+     "shell.execute_reply": "2026-09-09T22:27:28.113431Z"
+    },
+    "papermill": {
+     "duration": 2.201063,
+     "end_time": "2026-09-09T22:27:28.114453+00:00",
+     "exception": false,
+     "start_time": "2026-09-09T22:27:25.913390+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "9,569,191 labelled validation rows spanning 2020-06-30 10:48:00 to 2021-06-30 15:43:00, thinned to 6,279 decision times (638,097 rows).\n"
+     ]
+    }
+   ],
    "source": [
     "labels_primary = pl.read_parquet(labels_path)\n",
     "eval_df = validation_rows(temporal_clean).join(\n",
@@ -2477,13 +4742,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "99387f0b",
+   "id": "f8e60ccd",
    "metadata": {
     "papermill": {
-     "duration": 0.00615,
-     "end_time": "2026-09-04T04:43:46.224496+00:00",
+     "duration": 0.010717,
+     "end_time": "2026-09-09T22:27:28.136260+00:00",
      "exception": false,
-     "start_time": "2026-09-04T04:43:46.218346+00:00",
+     "start_time": "2026-09-09T22:27:28.125543+00:00",
      "status": "completed"
     }
    },
@@ -2495,10 +4760,32 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "8ce37749",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 42,
+   "id": "2b3e4428",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-09T22:27:28.180518Z",
+     "iopub.status.busy": "2026-09-09T22:27:28.180396Z",
+     "iopub.status.idle": "2026-09-09T22:27:30.112335Z",
+     "shell.execute_reply": "2026-09-09T22:27:30.110074Z"
+    },
+    "papermill": {
+     "duration": 1.971265,
+     "end_time": "2026-09-09T22:27:30.112905+00:00",
+     "exception": false,
+     "start_time": "2026-09-09T22:27:28.141640+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "IC series computed for 22/22 features\n"
+     ]
+    }
+   ],
    "source": [
     "n_symbols = eval_sample[\"symbol\"].n_unique()\n",
     "min_cs_size = min(10, n_symbols)\n",
@@ -2526,13 +4813,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "44a9da86",
+   "id": "b7bb46d0",
    "metadata": {
     "papermill": {
-     "duration": 0.04385,
-     "end_time": "2026-09-04T04:43:48.212967+00:00",
+     "duration": 0.038052,
+     "end_time": "2026-09-09T22:27:30.160232+00:00",
      "exception": false,
-     "start_time": "2026-09-04T04:43:48.169117+00:00",
+     "start_time": "2026-09-09T22:27:30.122180+00:00",
      "status": "completed"
     }
    },
@@ -2548,9 +4835,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "50e31b4b",
-   "metadata": {},
+   "execution_count": 43,
+   "id": "10930cd7",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-09T22:27:30.185248Z",
+     "iopub.status.busy": "2026-09-09T22:27:30.185073Z",
+     "iopub.status.idle": "2026-09-09T22:27:30.234210Z",
+     "shell.execute_reply": "2026-09-09T22:27:30.233731Z"
+    },
+    "papermill": {
+     "duration": 0.068812,
+     "end_time": "2026-09-09T22:27:30.234705+00:00",
+     "exception": false,
+     "start_time": "2026-09-09T22:27:30.165893+00:00",
+     "status": "completed"
+    }
+   },
    "outputs": [],
    "source": [
     "IC_LABEL_HORIZON = max(1, -(-LABEL_HORIZON_BARS // IC_SAMPLE_STEP))\n",
@@ -2584,10 +4885,36 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "6758c415",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 44,
+   "id": "4177893c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-09T22:27:30.328540Z",
+     "iopub.status.busy": "2026-09-09T22:27:30.328368Z",
+     "iopub.status.idle": "2026-09-09T22:27:30.337751Z",
+     "shell.execute_reply": "2026-09-09T22:27:30.337233Z"
+    },
+    "papermill": {
+     "duration": 0.09712,
+     "end_time": "2026-09-09T22:27:30.338058+00:00",
+     "exception": false,
+     "start_time": "2026-09-09T22:27:30.240938+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Features tested: 22\n",
+      "Significant before any correction (|t| > 1.96): 7\n",
+      "Retained by Benjamini-Hochberg at 5%: 2\n",
+      "Newey-West lags chosen by the automatic rule: 10\n",
+      "Ratio of uncorrected to corrected |t|: 1.0x\n"
+     ]
+    }
+   ],
    "source": [
     "n_tested = len(hac_df)\n",
     "n_naive_sig = (\n",
@@ -2617,13 +4944,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0af045d0",
+   "id": "e47ec43b",
    "metadata": {
     "papermill": {
-     "duration": 0.484502,
-     "end_time": "2026-09-04T04:43:48.911872+00:00",
+     "duration": 0.371912,
+     "end_time": "2026-09-09T22:27:30.715887+00:00",
      "exception": false,
-     "start_time": "2026-09-04T04:43:48.427370+00:00",
+     "start_time": "2026-09-09T22:27:30.343975+00:00",
      "status": "completed"
     }
    },
@@ -2637,10 +4964,236 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "8e240cbb",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 45,
+   "id": "5bb24ab3",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-09T22:27:30.737482Z",
+     "iopub.status.busy": "2026-09-09T22:27:30.737312Z",
+     "iopub.status.idle": "2026-09-09T22:27:32.088203Z",
+     "shell.execute_reply": "2026-09-09T22:27:32.087535Z"
+    },
+    "papermill": {
+     "duration": 1.362296,
+     "end_time": "2026-09-09T22:27:32.088726+00:00",
+     "exception": false,
+     "start_time": "2026-09-09T22:27:30.726430+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.plotly.v1+json": {
+       "config": {
+        "plotlyServerURL": "https://plot.ly"
+       },
+       "data": [
+        {
+         "error_x": {
+          "array": [
+           0.003253668386233757,
+           0.005770942456514869,
+           0.0026430127821167573,
+           0.0026129168834793026,
+           0.00503630881183971,
+           0.0031546752192397848,
+           0.0029578337126791956,
+           0.0037708959985846193,
+           0.0026002269145091236,
+           0.002740636110325301,
+           0.0027684212639028437,
+           0.002862353367215992,
+           0.0031808745479595503,
+           0.002723052755389431,
+           0.0030599662704423776,
+           0.0028671342817450703,
+           0.0035950173146766804,
+           0.0029048648385145014,
+           0.0025321021419892906,
+           0.0026600680965675307,
+           0.0026389658289721436,
+           0.0032411254998047697
+          ],
+          "color": "#1a2d4a",
+          "thickness": 1,
+          "type": "data"
+         },
+         "marker": {
+          "color": [
+           "#ef4444",
+           "#334155",
+           "#334155",
+           "#334155",
+           "#334155",
+           "#334155",
+           "#334155",
+           "#334155",
+           "#334155",
+           "#334155",
+           "#334155",
+           "#334155",
+           "#334155",
+           "#334155",
+           "#334155",
+           "#334155",
+           "#334155",
+           "#334155",
+           "#334155",
+           "#334155",
+           "#334155",
+           "#10b981"
+          ]
+         },
+         "orientation": "h",
+         "showlegend": false,
+         "type": "bar",
+         "x": {
+          "bdata": "9S9jbPE+gr/J4eWRVTJzvxGXqzH3IGy/VTwPcZIVab9TxpGPbllkv1vsI2Dcs2K/s8dQxGM/VL/8EkVw3+pGvzFKps7MLEW/Pbz4XMDpPr9ebG7fD8kOv8K1rHtJZA2/Zmy7niOzJj+OYLckvGU4P7WqF3TbDUc/C8zXWXtqUj8d7Ohcz1xcPxOF8kh9iVw/TeVAzJSiZT8qYPQyNW5pP33dRdLEKms/XqD8/588gj8=",
+          "dtype": "f8"
+         },
+         "y": [
+          "sig2_ret_trd",
+          "rv_spectral_energy",
+          "sig2_svs_trd",
+          "sig2_trd_trd",
+          "har_rv5_pred",
+          "sig2_ret_ret",
+          "rv_low_freq_ratio",
+          "sig1_ret",
+          "sig1_svs",
+          "sig2_ret_svs",
+          "rv_dominant_period",
+          "vol_dominant_period",
+          "vol_spectral_energy",
+          "sig2_svs_ret",
+          "vol_low_freq_ratio",
+          "vol_spectral_entropy",
+          "har_residual",
+          "sig1_trd",
+          "sig2_svs_svs",
+          "rv_spectral_entropy",
+          "sig2_trd_svs",
+          "sig2_trd_ret"
+         ]
+        }
+       ],
+       "layout": {
+        "height": 580,
+        "margin": {
+         "l": 180,
+         "t": 120
+        },
+        "shapes": [
+         {
+          "line": {
+           "color": "#334155",
+           "dash": "dash"
+          },
+          "type": "line",
+          "x0": 0,
+          "x1": 0,
+          "xref": "x",
+          "y0": 0,
+          "y1": 1,
+          "yref": "y domain"
+         }
+        ],
+        "template": {
+         "layout": {
+          "colorway": [
+           "#0a1628",
+           "#D4A84B",
+           "#C87533",
+           "#10b981",
+           "#ef4444",
+           "#94a3b8"
+          ],
+          "font": {
+           "color": "#334155",
+           "family": "DM Sans, DejaVu Sans, sans-serif",
+           "size": 11
+          },
+          "hoverlabel": {
+           "bgcolor": "white",
+           "font": {
+            "family": "DM Sans, DejaVu Sans, sans-serif",
+            "size": 11
+           }
+          },
+          "legend": {
+           "bgcolor": "rgba(255,255,255,0.8)",
+           "bordercolor": "#e8e8e6",
+           "borderwidth": 1,
+           "font": {
+            "size": 10
+           }
+          },
+          "paper_bgcolor": "#FAFAF9",
+          "plot_bgcolor": "white",
+          "title": {
+           "font": {
+            "color": "#0a1628",
+            "size": 14
+           },
+           "x": 0.5,
+           "xanchor": "center"
+          },
+          "xaxis": {
+           "gridcolor": "#e8e8e6",
+           "gridwidth": 0.5,
+           "linecolor": "#e8e8e6",
+           "showgrid": true,
+           "tickfont": {
+            "size": 10
+           },
+           "title": {
+            "font": {
+             "size": 11
+            }
+           }
+          },
+          "yaxis": {
+           "gridcolor": "#e8e8e6",
+           "gridwidth": 0.5,
+           "linecolor": "#e8e8e6",
+           "showgrid": true,
+           "tickfont": {
+            "size": 10
+           },
+           "title": {
+            "font": {
+             "size": 11
+            }
+           }
+          }
+         }
+        },
+        "title": {
+         "text": "A few features rank the cross-section; the rest cannot be told from zero<br><sup>Mean cross-sectional Spearman IC against the primary label on validation<br>rows, with Newey-West 95% intervals. Coloured bars are the features retained by<br>Benjamini-Hochberg at 5% across those tested.</sup>"
+        },
+        "xaxis": {
+         "title": {
+          "text": "Mean cross-sectional Spearman IC (validation folds)"
+         }
+        },
+        "yaxis": {
+         "title": {
+          "text": "Feature"
+         }
+        }
+       }
+      },
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAArwAAAJECAYAAAD0e/c3AAAQAElEQVR4AeydBWATSxPH/6nj/sHD3bVAcXd3dyjuULQUK1CkOBRpcSnycHd3d3crPNyqwLezbUIakja1kKRT2L293Vn77d5lbm7vziIgwP8XO2bAc4DnAM8BngM8B3gO8BzgOWCuc8AC/McEmAATYAIAGAITYAJMgAmYKwFWeM11ZLlfTIAJMAEmwASYABOIDAEzzMMKrxkOKneJCTABJsAEmAATYAJM4DcBVnh/s+AQE2AC+hNgSSbABJgAE2ACJkOAFV6TGSpuKBNgAkyACTABJmB8BLhFpkCAFV5TGCVuIxNgAkyACTABJsAEmECkCbDCG2l0nJEJ6E+AJZkAE2ACTIAJMIG/R4AV3r/HnmtmAkyACTABJhDbCHB/mcBfIcAK71/BzpUyASbABJgAE2ACTIAJGIoAK7yGIs316E+AJZkAE2ACTIAJMAEmEI0EWOGNRphcFBNgAkyACTCB6CTAZTEBJhA9BFjhjR6OXAoTYAJMgAkwASbABJiAkRJghddIB0b/ZrEkE2ACTIAJMAEmwASYQFgEWOENiw6nMQEmwASYgOkQ4JYyASbABHQQYIVXBxiOZgJMgAkwASbABJgAEzAPArFN4TWPUeNeMAEmwASYABNgAkyACehNgBVevVGxIBNgAkzAnAhwX5gAE2ACsYcAK7yxZ6y5p0yACTABJsAEmAATiJUEwlR4YyUR7jQTYAJMgAkwASbABJiAWRFghdeshpM7wwSYQAwR4GKZABNgAkzAhAmwwmvCg8dNZwJMgAkwASbABJiAYQmYZm2s8JrmuHGrmQATYAJMgAkwASbABPQkwAqvnqBYjAkwAf0JsCQTYAJMgAkwAWMiwAqvMY0Gt4UJMAEmwASYABMwJwLcFyMhwAqvkQwEN4MJMAEmwASYABNgAkwgZgiwwhszXLlUJqA/AZZkAkyACTABJsAEYpQAK7wxipcLZwJMgAkwASbABPQlwHJMIKYIsMIbU2S5XCbABJgAE2ACTIAJMAGjIMAKr1EMAzdCfwIsyQSYABNgAkyACTCBiBFghTdivFiaCTABJsAEmIBxEOBWMAEmoDcBVnj1RsWCTIAJMAEmwASYABNgAqZIgBVeUxw1/dvMkkyACTABJsAEmAATiPUEWOGN9VOAATABJsAEYgMB7iMTYAKxmQArvLF59LnvTIAJMAEmwASYABOIBQRY4VUbZA4yASbABJgAE2ACTIAJmB8BVnjNb0y5R0yACTCBqBLg/EyACTABsyLACq9ZDSd3hgkwASbABJgAE2ACTECTQOQVXs2SeJ8JMAEmwASYABNgAkyACRghAVZ4jXBQuElMgAmYFgFuLRNgAkyACRg3AVZ4jXt8uHVMgAkwASbABJgAEzAVAkbbTlZ4jXZouGFMgAkwASbABJgAE2AC0UGAFd7ooMhlMAEmoD8BlmQCTIAJMAEmYGACrPAaGDhXxwSYABNgAkyACTABIsDOcARY4TUca66JCTABJsAEmAATYAJM4C8QYIX3L0DnKpmA/gRYkgkwASbABJgAE4gqAVZ4o0qQ8zMBJsAEmAATYAIxT4BrYAJRIMAKbxTgcVYmwASYABNgAkyACTAB4yfACq/xjxG3UH8CLMkEmAATYAJMgAkwgT8IsML7BxLTjfDwXIly1ZsjcdoCmLNguUE68vDxU7Ry7IfM+cohfa5SBqnT3CuZOnsRajTsEOVuRlc5UW5ILCogS/5y2LJjv9H0OHnGwth/+ITRtIcb8ieBU2cvynO2n5//n4lRiolc5ms378j2vHv/UWcBK9ZsQrEK9XWmUwL/NhAFdsZEgBVeYxoNtbYEBgYiW8EKyJinDL5++66Woj345r93GD5mCgb17YL3Ty+hV9e22gWjOXb+olX4/t0P549uwdNb0ffDSkq081j3aG6t+RZHFxs7dh8y3w4aWc/ogrJCrZZ/tKq4QyEkS5r4j/iYjtDVnpiuNzrLN7dj/tKVG1Jx/Pjpc3Ri0rusv11/TP026A2ABZmABgFWeDWAGMvuzr1HkDtnNpQpWRTrN+4It1kvXvpImXJlisHCQr9hlRmi6L149Rr5cmdH0iSG/5GPYtM5OxOIdgKrvGagdIki0V4uF8gETI0A/zaY2oiZf3sNpxmZP8to7aH3v1vQsG414apj9b/bwizba9kaKK1N6XKWlFYFpQK89+AxVG/QHhlyl0aRsnUxcdp8/PjxQ5a3X9zqpPigoCC5T7egaDmEk7Ob3Cdv4rR5aNy6BwX/cDkKVQJZFWfNXybr7DfUVcp8+PgJVIZ96dqg9jRs2R3Xb92VaeTdvH0fg13cxC2xBnIZRL3mXXDl+i1Kkq6302hZ7tyFK0DtIXfn3iMZR5ZMKRTiUTylK/urvI1PFi+H8vWQJF1BKRlem6h97bo6IXfRqrLOPA7VcPjYaZlXm0dMyALdc8BIkGz9Fl2lmOdSb8mLLPPEe/yUOVDyJQHl7cuDR0/KMSM+dZo64sKla5Ss1T1/8UqO3YBh4/Hr168/ZAqXqYPPX77KpSXEgvqgLkTzo2i5unLZiWOvofB58596MsKaI6EE1XYOHDkJajeNB93apLsL37/7SgldbKiPxInmHM2NEa5T4evrJ/OQt3XnftBcoXTqR/maLfBSXFBRWkTHh+6K9BviipKVG8nxTJO9BGieUlnkfohjYPb85ShdpQkojY4fqp/SlI6OB+WcyGlfGTTWt+48wOr1W0FtV1rQqK1LV/4rs2kuaQivz8r5unCJN8IaI1m4Di+s9lCW12/eokmbHvJYo/6u3bCdolXu9t2HaN25P6iPdFepez8XhGeVpKUSy1ZvkONFc33S9AXyvBIe0ykzPVG1flukzFJUjkuH7oNlO3Qd8zJRw/v58yfmL1qNirVbybGrUq8tiB+J0biPmzxb1kHHFs2hjVt3U5LK6WAe6rigOewybir6DxuHXEWqIF/xGhg7cVaoYzkgIBBUF40b1VW7iSNOnrkg63ny9IU8vmmH+NAc6dJnOO3qdEdPnkX5Gi2QNkcJ1GzUETS/1IUjcpyGVX9Y7VavTz1M51M6n1FfWnbqi0+fvqgn/xHW9tugPPft3n8UNC6psjrg2MlzCK89ynz7Dh2X+egY69F/JP57+x6Xr91Em84D5J1QukOg/B34o0EigsadxkHT0dwVyXrNX23zPrz2U9nsjIOAhXE0g1uhTsDn9X9C2TqDujUro0aVcrh772EohVFdlsKO7Zpj35bgNbvP75zCx+dXkCZ1Khw5fgZ9nMagfetGuHBsG+ZNd8XZ81cwxm0mZUPxooXwTSgpyhPryTMXkSJ5UnHSPi/TyTt19hJKFCtMwT/cnUsHUL1yWfTt3l7WOWOii5Rp03kgvnz9Cs/Zbrh8cidq16ggfhi7QXky+vT5M/LlyYl1y+bgxL71qFiupExXKmKz3UejVvUK6NmljSyX+pMjWyZZtj4enQQvXL4uyp+LJzePyyzhtWmIyySkTZMKezYtxaPrRzHOZSDixLGTeXV5i1esR5bMGXBsz1osXzhVin3+8h0D+zji6uldmDxuKE6cvgi3qR4yTd1bvnoTpo4fjrOHNyNdmtTo1s9ZqzJLCn0N8ePXuH4NTHNzhkKhUC9GhmlsEyaID7IuEqub5/bKePIePnqK7bsPoV/PThjcr6tozwVMnDqfkqQLb45IIQ2P8pBCUKViGZw/uhWrF88Ut/GTIjDkwonENdnQ2Ndt1gWp/pdCzsU5U8fAWyiOTs4TSFzMl2/o1HMomjeujSunduLyiR1o37KRqr8RHZ+ZHovx+OlzeM2ZhBd3T8F7yUyk+ed/si7yJs9YgK279mPMiP64eX4vhvTrhtETZoB+jCmdlghVFYpUvLhxsWHlPJw88C9KCcvt5y9f0LJJXTk/ChXIo5qf7Vs3pmyhXHh9VgrTfCXFfv1yD2xeswAPHz8LNUbrxB0e+pF+++6DMkuobXjtIRYF8uWCxzRXZM+WWcy1EXj85Lksg/pZr1lnFMibG9vWL8JecR5JlCg+mrbrBVIspZAOjxSFDm0a4/aF/eju2ArhMaWLPLogdB0xAI+uHcVRcdw4FC4gS4/IMT9p+nzMnLcEfbq1x60L+zB57BD4hqx/DQgIgK2tHaa7uch51LNzGwwf4/7HOubwmFOjVq3diqL2+eU5io49mtMbtuymJOlGTZgOz6VrMcl1qKwrZ/YsqNe8K+49eIIM6dPg0I7VUu7xjWOg43LhrAlyX5c3z2uVPMYvibmfK0dWNGjZDXShTvJ0zIV1LicZdRdW/WG1W70MZXjNhm3yAq9vjw64dGI7ShQtjNnCyKFM17bV9dtAslNne8F93DA8v30SdAzp254Zc5egeaM6GCvmz5nzl9BzgAucx0yVd1TGiuP42o274gJkLlWh1Q3s3UmOA40FuWULpko5h8L55Ta8+SuFhDdJXNypz3t92y+y8v+/TIAVXn0HwIByy1ZvRNWKZZAkcSLY2dmifu2qWLlmU4RbMH3uYnTu0EKeJJInS4Ki4sdluFN30ImbCosfLy7ohH78dLBV4pRQeEl5phM2KZ9+4keElOCSxQqRuF7u6Imz0jIxVyg0hQvlE4pQYnRs0xT2BfNgw9Y9sowSDvZo07yB/FFIlza1VJjz5s6BnXsOyfTo8GZMckHGDGlBiqA+bXrl8xoF8+UGtSeJ4N6gTlUUKxJsHdbVnkL582BAr05yOQfVQ3IDxUmV+kf7FcuWxJD+XbFq3VZKCuWGO/UUTPLin1T/Q+9ubeWP5Ov/3qpkFAoFyOpdu0lHwacdhg7orkqLSICUUG+hkLZqWg/dOrVE144tceb8ZVUR4c0RlaBagPK0aFxXKBzt8L8UyZAlUwZQvxMlTKCS0mSz3HsjaL5NnzgCNBdLFisMlyG9BZst0lLzTihztG69tFAqEydKKMeOlEjiQ4VGdHxe+fyHTBnTIXfOrCCltWwpBzSqV4OKgr9/AGZ4LIGr+JGsVK4kqN3Vq5RFu1aNsWz1v1JmibDYUvysKSORK0cWOcYthaIb3pyQmUO88PocIiaP89HD+8k+5xcXgq2a1sXZC7/HiC5Cy5cpDmtrK2WWCG2bi7EaMbi3uPCsiIWzxstj4sLla7IMOhfkz5sDg/p2RrYsGZApQzq4jR6MGzfvyeNYCunwWjapgzo1KslzlK2NDcJjSmNCS58cxHkobtw4oL6SoqyjeK3RdLeE6hnu1AP1a1eRfSGliS66KQOVT33JkyubHLMmDWqivRjXNRp3yegYD4s5lVW5Qil5cUNlVqlQGpXKl8K5i8Hc6M6E17J1cOrTBXSck8zEMYOQWlxULVq+hrJH2NEFvn3BvNLo4DZ6kBzvTduCz5l0zIV1Lte3ssi0e9mqjfJOI52zk4hzI52vconjSt86NeWGDuiGIuJCwsrKCpYWFtCX46ihfeQ5rJU4l/Xu1g57Dx7HhNFO8pzWtkVDdBW/dRcuX9WsTuv+1Ru3pcJMXNZ67wAAEABJREFUc6BC2RJ6nROUBanPe2vRB33br8zP279HwOLvVc01ayNAt6xXrt0sTzDK9IZ1q2H9pp0gBVQZp8/2jrAMu06aBbIOKV3lum3kQ3CvfN7IIkiZPRVyG+6wsAhXLFscJYvZ4/jJ81IxsrG2lkqxFNbDe/DwibAaf0fyjIVD1bt731GVVem7sCrT0ory4vZdikxFpBxZMJ49f6VHDeGL5BBWLFJWlJL6tKmxsKD2E7fA6bb1zHlLcVFYiJX5dW0L5s/1R9Lpc5fQUtzyy1m4suxXveZdQBZ76rO6cNrUKVW7KZInk2G6RScDwiPrZB1xi9RZKMZ0ESKiIvWfLNDqluqM6dMKBfOdqix95ohKOCRAeRxCrCIhUX9sNNk8EJbmMqWKhrKakxJBGR8+fgq6OClVvAiqCKsqLY8gSyDdlqV0cmGNT1Vxi1w5v4tVaEDiaCCOmeXiwrGZsFTSbfRde4+oLOiPhHWTlN7qDdrLMVLmHTV+Oh49DrZ83n/4GHTBRj/KssBIeOH1WVlkujT/KINymzxZMpDlVe4Ij36QN3svkIq52I3w/9w5s6nyUH/Si4tMpbX4waMn2HfoRCgOtAzo2/fvIE6qjBoB2i2YLw9tpCPZ8JjSeP/39h0q1GwpLHGzQZZDWoojC9DTu//wqVROHArrvhj1/ncrajXuJJdw0NjSsizNc0t4zKk5af75fYzSforkSVTHzuOnL0AXaKQUUxo5YktjRXdVaD+iji4AlHlsbKyRJ1d2ae2nODrmwjuXk1x4LjLtpv6UK+0Qqmi6AAsVEYEde3FnRCkekfbkFhcxynwZ0qWRwTxqc5viXr/5fW6TAlo8Os+26tQf1cXd0349OkgJfeavFBSe+ryPSPtFVv7/lwmwwvuXB0Cz+oNHT+HZ85do381J9SNEStO79x+xbdcBTfEw9xUKBaZOGA66faPplJazkkLJOHbqvLQwfv36Td5iIgslLWU4dfYiSjgUAp3Iw6xILVGhUEirn2Z9tE+3BUmUbjFevnYDs6eOxt1LB2T7yNIWEBhIyTqdQqH4I43WYmpGxrGzCxWlUOjRJqFYLp43GenFifTk6fOoVKe1uG0XvEwkVGFqO3GE9V1tF6Q8NGnTE80a1sGeTcvw7slF7NywWIpo9k3bg4V0sSOFhZda/NiWLG6PteJ2Nq1LFFGR+m9laRkqn0KhUCl+lKBQhD9HSO4P9+dQhBLRZEOJlhptsbQK3bYNKz2E1bcX7Gxt4f3vdhSr2ADHxdykvMPDGB/PWW44e3iLdGuWziJx0Hw6uGMVaDkOKa9d+w6XFyKUqFAEN/7UgQ1y7tHcVLrTBzeSSLS58PpMFYU3F0gmKs5Kg7NCQXMguESFQgGyfCv7r76li4xgKe2+XRxbVYJCET5TuhtwbM86tBQW7G/iotdt6jyUr9E8lHKvKjCcgEIRXJ+mGK1PplvOI4f2FvNhsxxfsm5H9Pijci0stNUReg295rnRyjJyVniqT5tTnhMUikgep9oKFXERbbfmPNY8r4gi9f6veX6mjPq0R71OhSJ4bNTzKRQ0r0OPD5Wt7ugipbVjf2lFnzt1rCpJoQguT59zgvq8Vxag3g6Ki+55QGWyizoBi6gXoa0EjossAbr1Vl3cXt22zgvqjtYuUVpEys2dIytIgQ4rD92iDQr6gbmey0EKFh24pYoXxgmh9J08IxReces5rPyaaTmyZ5Y/YMp1wZrptE+KdO3qlZAvdw55O5csQzdu36MklbO1sQ2lmFECWVjIIqRu6b599z4lhen0aRMVUK1SGdAShLXL5ohblY7YtH0PRevtLl6+IW7XJ0W9WpXlcg36kbh2447e+dUFybK+fME0xI1jB1Kiw1N66Ufk56+f6kXoFc6txxzRLIgs6OcuXNWMDnM/S6b0uHr9diiZS5dvyv3MGdPLLS3foXk+Uty6PLh9FQoXzIfd+4/INPJ0jQ+tV8yeNSPI0S15kiVXIG8ukAVnwczxWLpgCsjK++nzF2TJlE5amg8cPkliWl3WzBmllT9IbV2yuqCdnQ1+/Qz7x1WfPquXGZWwPu3RVn6ObFnksU63urWl6xunD1Mqiy7kuohbz26jB+PU/g14Ku7qnA9ZJqDtmKc86i5r5vSwtbUJteRDPf30+csoJc5ZdF5LlTKFTLombl/LQDR6GdOnAR3fV68Hz2Fl0RevXEdmMddp31ZcuNE2vLXQJEOObrPTllxAQCBu3LqLTBnS0i4ic5xqq1+fdssK1Tzqz/Wboc9j6m1VE41wMDLtiXAlahn6DnbFS3F3c/WiGXIeKZOy6HFOUMqqbw3dfvW6ORxxAqzwRpxZjOWg24z0pHirpvXl68jolWRKR4vkDxw5CfXbvOE1hB6eorcouE31AD2kQideWjpAFhBlXlpXWaRQPvkAUaliRWQ0reu9//CJXNJQMgLrdykzWYfJutZz4EihbJ8EKae0Hpie8qXb/SSTL08O0LpaUiaoz937u4AUEUpTuswZ0+LWnQehHpzJKZQzWt9J6ytJ7sPHT1CGaV+X06dN9NT9xZBlDF+EpZvW6mXKkE5XkVrj84hbkC99XoNe3E4CxH5WOA93kJwuZyNua64SJ2Zauxme0ktLF27cCn3RoKtc9Xh95oi6PIX79+wo31RAfaNb72TZnjp70R9jSLJKR+v/nj57KZ90pzGnhyddJ88CrcdLkTypGOv7oDLojRSUh+brAzEHM4X84Ed0fOgNH3sOHJNPXtNdgKPHz4IUIFpbTRd1tPZy2pxFsh/vP3yUb4v4d/Mu0HIiqr9D68agNxX0GTRWtO0BSIbehqBc/5xJKOlPxZ0YkiF5bU7V54mzoK3P2vJoi6M3VNAx+11YRbWlU5w+7SE5TdexTWMZ1bnPMJASQ+eIW3fuy3H6JC4OZKIenj5M6YMc9MEC5cXb0RPn5FsPMoljnarILLa3NI55ild3VA9dxIyfMhebt++Tbyehi2tahkRy+XJnxwVxHNN4kTWPxnjvwWOUFK2Olgl16dAcbsJKTcYBqm/yjIW4Ji5wO7dvLutKl/YfqVRdv3lX7ofnTZ6xQF5k0S33oaMmIzAwCI3r15TZInOcaqtfn3bLCtW8dq0aYtXaLfItORB/tGRkrzi2RDDK/yPTnshWSm9S2bJjH5YvcJfnAvVyaF6Fd05Ql1eGDdl+ZZ28jTwBVngjzy7ac9LT2GSpozcfaBZOFguyjqxcu0kzSec+KXpkJT4rrHH0Cp9chasIpcILAQH+ofKQUktWVrLsUoKduFVPDw/RbRlSfikuIm7Zwqmgh+6Gj3ZHlvzl0aJDX6HgnkH8+PFkMRNGDZKKLL0yqmz1ZsiRLTMqlish05Req2b1hXL/HEnTFwKtw7tz7xESiPxecydKy2uyDPao1bgjlD8uyny6tuG16fWbt6gpyqO66BVD9MM/1rmfruK0xufOmRV0m6xHPxfQWtKpc7wQ0TKUBStvZdJYrFkSfJuelF5dSk/vru0wd+FyyUrztWTKMrVt9Z0j6nnLlS6GdcvnCIvpYfm6tMJl6uLI8dOgBzjU5dTDadP8g+3rvXD+0jXQK8m69XNGpfIl4T5+uBSLGyeOLCNvseqyD4XL1kW1ymVBDxyRQETH58fPn+glLrponpDbseegfGuIQhF863JAr46g29700Fa+YjVQplpTqezGixuHqpPLcravX4wvX7+iQcuu8pVu08V40sNWJFChTHHkz5sTGfOUAc0Z+jGleHUXXp/VZcMKk3XNbaoHNG/Lq+fRpz3q8spwksSJQMtviH+bkNc7DRg2HrT+OKzxVOZX34bHNH78uGKOrgC9douY0RyYMm4o6I0EVI62Y57iNd3gfl1Bb19wn7lQfpyHnkt4HfKqPZovtaqVR6XareFQvgFI2ezfs5NmEdGyP2Z4f9CDc/2GjEWBEjXFOe4stqxZIO4gZJDl0/mqv7g4rNuss5wj4b2WbEBPR7QSt9vzFquG23cfYNPq+aALfCqshIO9vOMX3rmcZJVOV/3htVuZX7mluy5D+ncDvY2gYKlaWLdxJ/r3ij6mEW2Psl0R3Z45f0U+X0KvIKT5p3R0MUllhTd/SUabM1T7tdVtinF/s82s8P5N+hp19+jcGo9vHIO1tbVGSvAuvW7KeVCv4B0Nn97AQOvvyGKrnkQWYjpxPrx2BPSqmK1rPeEypI+6iNynvPS0szKBHpJ5cfcU6MpXGadtu2bpbIxx7h8qidpAT7/Sekgq49CO1UJBmou8wgJKgrSWz2vORJw9vAXUJ1pGQK/UGj/SiZKlyySsqxePb5dr8KhtObJlkvGVy5fC3s3LQetjT4pbonVrVpYyaVKnkun0toBdG5fIsLoXXpvoFWo+98/Ksqg+4qQsU70cZfhfud40NEdKa1y/Bo7tXYczhzaBbssr10eq/3BR+aTIkjw5emsBxSkfWtHsAylZ1CdyFKY8mq5G1XJ4dvukbD8xpXTNciiOlls8uHqEgiqnzxxRCYcE6AEkag99XY/aTryUbdPFhuYXyVEeGlvXEQPl0gIqkpYlUBqVRY7Gd+bkkfK2MaVHdHz6dGuHe5cPSR5U3rkjW+VdEyqLnEKhkMr0/q0r5GvL6PVqNOcb1KlGydLlzJ4ZKzynydduKcvIlzuHTKN1tyRP8eTojRKUQGyJMYXJhdVnStdnjG7dvo+a1cqrlB/Kp+l0teft4wugY0Zd/uietfJpd2UcsadXZl05uRM0NjSuy4QVTDmeSjn1rbZyFYqwmVYqVxJ0TiBe5Ohc17l9C1Wxuo55lUBIgJYS0Jckj+9bj9cPzslzAV1EUzJxoPMbvT6L3GKPSRjcrwvoHETp5PRhrm0OTxwzBMtCXmVF5dAdGFofTHOLjj26oCtZrDAlqdzQAd1Vc5AYqxLUAqTMEo/qVcri1vl9sk+09p/mjpqYnL/hncvV5Smsrf7w2k1znNqj/sVA4k3HCL0ukNrQt3t7nDm0marQ6TR/G5T9VD/3Uebw2qMtHz00R22k/EpXq3oFOX+V+5rbeTNcVWNBeZWOfn9IVqEIe/6SjLZ5H177KR874yDACq9xjAO3ggkwAUmAPU0CJ89eAlnYNON5nwkwASbABPQnwAqv/qxYkgkwASZgcAL0URl6AM/gFXOFTIAJ/F0CXHu0EmCFN1pxcmFMgAkwASbABJgAE2ACxkaAFV5jGxFuzx8E/Pz85UMf9EECZSJ9lYxekK984EAZH8u2WrvrtWwN6LVGlEhvB6CPOVA4uhyVWbV+2z+K+/L1G3oOGIniFRvKB9Oat+/9h4ypRdDcy2lfWdXsy1dvon6LrsiQuzRKV2kC+oAKvW1EJRCNAeIcmbGjtyAsW71Ba0s001689EGNhh20ykZn5NBRk7B7/9HoLFLvsujtEKMnzAhTvt9QV+w/fCJMGfVEfcpUl4+J8LDRk1VMy1ZrBhpbzXroYyrUVs149f2YPl+o18VhJvA3CbDC+yLjNBoAABAASURBVDfpc916EVAoFEiVMgWOnTgH5dsLNm/bKz9NqlAEP3WvV0GxRIjePKB8oj9RwviY4jrUID1ftHwd6FPGR3evBT2URp8xNkjFBqqELrKatO2J2tUryP4tW+guXzvl5x8QIy2I7Nh9/fYNK9du0dqmsNK0ZoimSPpaYGTe+BJN1Zt9MfQpdW0fe9Gn43/rfKFP2yImw9JMIGwCrPCGzYdTjYQAPZldrGghnL1wRbZo++6DqFmtggyTd/7iVdRp6gj6Qlr3fi4gayPFk3UjX/EaIAvIwOETVJZPsug4ObuhQctuqNmoI27duU/ioRy9mow+50mvsclfoibmea0CWcTK12yBdl0Hgl43RO/69FzqDXrtG8ktXrFOlkEfyOg7eKyUyVawgnwnsbY4Kazm0bt023V1AllQybJI7/ckCyJZqMrXaAGy+O0OsZRpax99aYred9uyY1906zsCnz5/xSCXibIGevUcMSBGtRp3An0ABOKPXofXTtTZqFV3yWLTtuAPblD5JEfsqF5636gQ1/n/7bv3cCicH/TUMgnRZ1Zpq86MGJEVmCynlKZr3MZOnIXCZepIa/Gi5WtJVLpiFerDeaw7qK1btu8Fldeh+2CUqdoUQ0ZOlF8jpDaTe+XzRua59+AJKB+NW/MOveUYUoKuflOaNrdyzRbUrlEJpLzRE+xZMmVA/54dQW8AUZfXVd/3777o2tcZ9Bqtjj2GoFz15vL9vLo4q4+drrZqm1MzPZbg7r2H0hI9e/5y9aZBW5qfvz/adxsk5zBZBJUZ6NO/NFeIsfssL2V0qC1xpTsvxJuOJeV7wun4ovnfsGV3LFziDbIinhPHKGWmPCPHTUO1+u3kMUvvrabxLFahAZRf1tPFkDi07TIQjVv3ANVRu4kjHj95TsVKV0zMD3qPrdzR4uk6H5Dotp0HQOXRPDl09BRFyfcEazv2ZKIWj76S2aJjH9k32tLcJzFqa3jnG+KhfA815SlRqRHoHeZhtZnkyPUb4gpfcSeMwtPnLkapKo3RVFyc0SdzKY6ctmMqOs8XVAc7JmDMBFjhNebR4baFIlCnRkVs330AZGmj96WSI4svfViA3h06WVgyD2xbiQL5cmHWvOBXkxUU4fNHtuDwLm/Y2lpj7cbtqjItLRXYuGoeFswchwnuHqp4ZWDNhu24fPUWdm9ciovHtqJm1fIyid7tSa9do9doPXj0TP6g06t6Nqz0ACkYd+8/looXvdaMZK6f2YOC+XJrjZMFqnnzvFbKdwvTq9dOHvhXKFPxRJt34POXb9i3dTnWLp2F8ZPngD54oK19zRrVRvp0qbF68UzMF/1SKxqr1m0WCtZ70Ku46P3A9MEPYkcyr16/ka/gotchzZq/TL4nWaFQYMakkTi6Zy0WzhqPwSGKM8lrc62bNcD8RaulMkplKH/sSZYUeXpfJb0eKl68OKJP2+VHIXSNW/PGdXHh2DbsF+O5cete0MctqBxy9Pq2DWLcitjnB32cYszwflLu5OmLoHp2/LsIzRrVkuNC8smTJca2dYtweKc36KMu46d4ULR02votE7R4Dx89gT5WSl310UcXaL4S/7YtGuDK9VuyFoVCoRdnbW3dtusANOdZ3x4dkD1bZtBr03p3C730RFsaMRw1rA/o4Th6/+vlazdBH55ZvGI9aE5T/K0793Hw6EnZXk2P3kdMzNu2aIgJU3+zVSgU2LDKA106tNDMAnqN4p7Ny5A5Y3q4iosb+sDKSq8ZcJ00W8rqYkiJpFQvXzgVMya6yHFWvpv8zPnLyJk9C+hDJiSnzYV1Pnj5ygdb1y7EtAnO6CMuVulCZO3GHVqPPW1lU9wY0ZdypYqD+lbSoQjGhvSH0sI739QRF1PrN+8iUdy8fR8p/5ccqf6XQpw7ckHXOUwKq3k0/+mLnLs3LcOsKaNx5txlVaq2Yyo6zxeqijjABIyUACu8Rjow3Kw/CdDHMA4fPYONW/agTs3KKoFnz1/h+UsfDBs9RVq1NgvL35Vrt2S6tbUVyOLRokMf0KeS6QddJgivQtmSUCgUUmG4e/+RiAn9/+TpC+jSsaW8bU3vI6b3lZIE/cDTO0MpfO7iFdQVbUmUMAGSJkksPytMcXlyZsPu/UdAa4yPnz4v07TFURnqrnDBvJizYBmmzl4En9dvpbX01JmLoE+WNmnbC2QZfPv+A+4IC56u9qmXpx4+d+Ea2ghFS6FQoHChfPLjCsSOZEoULQTle1fpa2Q+r/+TbG7evofuwmLef+g4vPL5TyraJK/N5cyeGcf3rkfXTi1xTljiyTL4/sNHKZo7R1ZkDPlqWuUKpXHh0nVQ3brG7Zu4LU+WQ/oYwiuf17h956Esh7zqVcrRRrpsWTNJBd/W1ga5cmaFQ5H8Mr5QgTy49/CxDNPHXDZu3QOyDNKyi1tqn6PW1m+ZSYcn0OlI+R2tqz66eGrZpK4UpPeIZs6YToYVCoVQcO6Fy1lbW/WZU7KSMDxiSPOZ7qJIbuKCjZTHt2/fgyy/jdv0lO2j9kPLX5UKZWQsffqZLPZyR3j08RmFQiFCf/4vV7qYjCxUILe8QLWzs0W2LBlAF7OUoIshpZUpVVQ1VxvWrQb6OiVdSNAHEZo2qE0iOl1Y54MWYmzoPb724hgkpfnlq9fQdezpqoA+rNKuZUOZ3LFtY9AXBeWO8MI739D7m6kvQlT2qW7NShREWG2WAmoenSfoYxj00QlaBkYfb1EmaxxToY4ppYz6NqLnC/W8HGYCxkiAFV5jHBVuUygC9GNGjn6QizvYw0NYQWupLWf4hV+gr7WRRYvc7k1L5YcuqBCnERNEWiZ4zpmI/j074Zu4rUzx5KysLGkD+pELCgqSYXWP6rS2DpZRj7e1sVHfDfVxDvpxonwF8+eWX0rKlzsHJk9fgE3b9kJbHCkWxcStXHKHj51GhzZNMNl1GFKlTC4UtAHydi2VN2JwL2mxo/7Ry+mLFSko1zNra1+oxmnsWFn+7o+1lbUg90tKKFnQjkKhkJ81pU+2Llu1AQN6O0pLeNrUqfDt23cS0enshOJCig59sMFeKJ0HDgdbBakP6ploX9e4+fsHoHt/FzSpXxP0lbmqlcqIcftdrzp/G7WPtFhaWIL6RPVQOCgweEw9l64VFw9vMHHMYNAHT75//12Wtn5Tfm0uc6YMQlG/oS0pVJyu+qjPlmr8bULmkb6ctbVV25wK1Rg9dtQZKhQWch02tbVBnaqqOXfqgJgHvbR/XYtktVVjY2utLVrGKeskHlZWv+WUZeliSJltbX7Lx4sbF0UKFcDufUdx4MgJVK1UmkR0urDOB5aWVqp81lZW4g7ET3mMaTv2VIIaAWq/cpzU5ymJKeN1nW/SpU0NGzGf6W7Glh37UDPkHBdWm6lcdUf1W1j8PsatRD8oPbxjimS0uYicL7Tl5zgmYEwELIypMdwWIyJgpE3p0LoxnPo4hvrqVHrxQ/H+wwfs2hv8BbFvQqGh27LUBbpdW61SWZDVcv+h4xSltytZvDC8lq0F/VhQpq9alL2i9gWENeYAPn3+ArJmkoXGoXBBuU9W35rVyqN5o9q4dOW61jhSXOmrbOTI6kfl0JKEVk3roZBQGG/ffYjSJYsIq+9yKOsnKxq9hUFX++LFi4fPoj3UZnVXtHA+rFy7Wf6IX7pyA/+9fQtipy6jHqbb2oUK5JKWt0dPnuGmuK2tnq4ZpnYRA4p/++4D6IebvqpH+zeEpZiUe/pBXr1uK8iSTXVrG7d3woJNX6aj/ltYKHD42BkqItLu4ZOngmFRpP4nJfYePBbpclo1q4stO/aC1hQrL5BoradyXJQF66rPvmAenBB3DUiO1p2SlZ7CEeVMeZSO5ovmPIuvY/wpT1hplK50JRwKYYOwilPbKI7WllKbKazpVq/fKqNobtGdA7kTRU8XQ23FNm1YE6QU0kWwtVAYtcko48I6H6zduE0u5bl89SbevnuPtGlSiXmj/dhTlqe5LWqfH8u9N8pouptAx7fc0dOju0V0VyhVyhSg5QyULaw2U7q6I+v0yTMXZBTNUWU4rGMqus4XslL2mIARE2CF14gHh5v2J4Hc4rZ1u5aNQiVYCqvZglkThHK6Rj7UVbh0XdCPBAn16d4BdGu9def+iBPHlqL0ds0a1kL2LJlQpW4b0INvCxZ7/5GXbuN3bNMY9MBOo9Y9QG8myJ41IzYJZeGfbMXQpE0PnDp3Sa7L1RanWeCgEW7IVrCCsO4OlGsRK5UvIRTmOihWpIB8wKdk5UZwGTddZtPVvh6OrTHIxU0+tCYFQzxav5ooYULQQ1MjXKdh5uRRIHYhyX9s6Hbo4eNnQa/hmjVvmbRQ/yGkFvH46QtUrN1KtjNf8eooX6YklLeu8+XJgSkzFsqHy2jtdfPGdWTd2saNFNOsmTOAHpRz7DUUuXNmU6sl4kG6SHIeM0U+6ETLKCJeQnAOUkDWL5+LbbsOoky1ZrK8M+evwM7WJlggxNdVX+tm9UEPFDZr1wszPJaAliPQhVhEOYdUIzfa5lT8eHFRu3oFtHLsJ9eUS8EQL6y0EBG5oQfyRg3tI18zR2NKc8DXz0+maXovX/mgfI0W2LXvCJydemomR2pfF0NthZULWR5B61G1pavHhXU+SJEsGSrWagV6wMx9/HA5P5s3Cj726IFY9WNPvUz1MDHbf/iEfGjt8PHTcBnSSz053DAtY1i3cQfq1Kiokg2rzSqhkEDeXNnFcVdczs22XQcinpgLlBTWMRVd5wuqhx0TMGYCFsbcOG4bEyACduI2+c1zeykYyvXq2hZD+neVcQXz5caGVfOCH7y5uB+N6tWQ8WQpJevpSs/pcqkAPehCCbStXL4UBaWjB6RkQM2j24H0cBo9tHXt9C4M7N1JrvfdtXGJmhSEMtsCB7evwqEdq9GxTVOZ1l5Yol/dO4P1KzywUCjjdLtSW5wUVvNI9t7lQ6CHciaMGgSyWCkUCgwb2EOWf3L/BlD9NuK2rrb2UVF0K3qV1wzQQ2vJkyWRTCjeVihmUycMBz3Yt+PfRSjhYE/RaCoUe5chfWSYPFo2QeuVSRkjWdqfOXkk6GErekCKyty7eTmJhnKN69fA5RM7sG2dF6jvU8YNVaXTmsx/V3rg+L71mDttLGhMKVHXuM2ZOka2e9mCqVjsMUm2keTPHNqsykttIRYUT27eDFeUKVmUgkJJzoo1S2fLcP48OUH5qH6aLxSmBF39pjSlo3beFvNJuU9LCIgH3eKn8oYO6BZqSQvJ6aqPxmyamzPWLpuDbp1aIUmSRHKNdlic6YExKlNXW3XNKRpPmgOaD61RWeppmgyJj3KdcYM61eTDVzS3zx/dilw5slL2P9zoYf1AD4XSg5s0b0hA8/iaOGYIqlcuS0lyLIgr7bRp3kB1DNP+lZM7aSNfOUjjRIypTRSmBE0OFPfK5w0yZ0wn89C+pqO1sXQcU3xY5wOa49QPerhR+YYRhUL7sadeJpW0DNAfAAAQAElEQVSrdHScey+eJbnRlvhSmiYPbecbkqP8H59fUZ1HKE5Xm91GD1YxPbpnLehihuT79+wI4rZ60Ux5rFNbKV7XMdWgTlXQXInq+YLqYMcEjJkAK7zRMjpcCBNgAkwgbAL0vt6sBcrLOw5OzhPg6jIg7AycGi6BfzfvQr3mncXFqGO4sizABJhA7CbACm/sHn/uPROIcQJk5VK3xMZ4hUZaAVngnt85JS3129d7gazbRtpUvZtFlleltVaVyYCBxvVr4NyRrfI2vgGr5aqYABMwQQKs8JrgoHGTmQATYAJMgAkwASbABPQn8DcUXv1bx5JMgAkwASbABJgAE2ACTCCKBFjhjSJAzs4EmAATiDwBzskEmAATYAKGIMAKryEocx1MgAkwASbABJgAE2ACugnEcAorvDEMmItnAkyACTABJsAEmAAT+LsEWOH9u/y5dibABPQnwJJMgAkwASbABCJFgBXeSGHjTEyACTABJsAEmAAT+FsEuN6IEmCFN6LEWJ4JMAEmwASYABNgAkzApAiwwmtSw8WNjSqBoaMmYff+o7IYr2VrEBAQKMPkFatQH35+/hTU6VwnzULGPGXw5es3KfP23QdQPrnzF7yKtVvhzr1HsmZqU+K0BXDs5Dm5//PnT9nWwMDffZQJYXhfv33HstUbtEpQeSNcp4LqrFy3DW7cuqeSy5K/HKhuciUrN5Lxv379wmAXN9Rt1hmTZyyUceSNmzwbp89douAfbsuO/Rg1fvof8eoRN2/fx8GjJ9WjYiRcrnpzEI/IFL5+0075RbW0OUqgeoP2oP2wyolKXWGVqyuNGBNrzXSay+EdA5p5/ta+5jzoN9QV+w+fiHRzVq7djPotumLq7EURLoPOKfcePIlwvpjOoG+7ylZrFum5rt4Hqo/OsepxFI7q2FAZ7JhAVAmwwhtVgpzfpAg4tmuOovb5ZZsXr1iPgAgogzKT8FIkT4IlK/8Vob//v0ihvDh/6apsyJnzl1GqeBFcuHxd7l+7eQd5cmWHtbW13NfH+/rtG1au3aJVdOmqf/Hp0xfs37oCHtNc0XPASJVc4kQJ8fH5FelO7t8g4x88eorv3/2wda0njp86B19fPzx/8Uq41yhetJCU0fRKFrNHu1bBCrNmmnL/9t37OHLsjHLX6LZ7Dx7DuClzMLhvV9y+eAATRjnh9Zu34L/oJRDd82DG3MXYsNIDA3t3inBD9x86gQePjE/h1bddMya5II6dbYT7bUIZuKlMAKzw8iSIMQJ0Vd938Fg0bNkdC5d4S8tjjYYdpIXQydkNZF0lJa1z72GyDavWbUH+EjVl+P7DJ2jatqcMk3WwQctuyF20KqbM9JRx2rygoCAUKBmc//GT59LiSOWQrEP5eqB0suqeu3gVazdsx9NnL9GyY1906zuCRKRzm+oBamPLTn1VVlyZEOIpFAq0a9kYK9dslO0PiZYbKn/0hBkoX6MFqtRrq7IkUz9u330oZexL18Zy740yTPVS/3Xlo7aQkimFhdd/2Djs2H1IhH7/L1wwHy5cui4jzl+8Bsd2TVUK8IVL11C4YB7Zb23tIgttu65OqFq/LXLaV8b7Dx8x02MJ7t57KC1ds+cvl+UqvRu37qNkcXtYWFgge9aMgs9XPHryTJn8x9bO1kbK/PjxA4GBQbC0tJSW3sH9u/whq4w4eeYilq0KVphp/tA8obGv2agjbt25L8VmeizFlp37ZRsPHT0Fnzf/oWOPIahUpzVI9u79x1KO8ivn36z5S0NZ4l//9xZlqjaVcmMnzkLhMnVQvGJDLFq+Vsape5+/fAWVQ5bqbAUrhGtdXrjYGyMG9UKNquUQP15c2BfMi15d28oiyfpO86uisMxT3+gYkAlqnudSb3mMVKjVEotXrJMpZM1s3r63DJPnPNZdNRfIKkv7jVp1x4nT57FmwzbJgvK7z/IicemmC4WuVJXG8rh6JI4PGanFGyvuYtRq3EmyfPL0hZQga3C+4jVAlsCBwyeo5r46YzrGt4pxadaul2RLx73MrOaRFZTaW75mCzTv0BsvXvrI1HUbd6Btl4Fo3LoHqMwgcSxrm7NSOMTTnAcUvXvfUTkv6BhUzhd9yqI7Ec9FWxqJ+nftPaJzTmnjQMfRngNH4ebuIev+7+171XmI2kTHLI0PhalvNJeIDfE6L85FdZo6yvHq3s9FHC/fSEweJzSXdZ3z9ClHW7t0zfV+Q1zhK+5u0XjQvGnfbZDsC42BbJDwdLV136Hjcrxp7HbvPyIktf/ftvMAajdxBI09HbckRft0rqYwOZobxI/C7JhAdBOwiO4CuTwmoE5AoVBgwyoPdGzTBD0HjoLb6EHSQvjSxwfe/24VClleobBdk1nOCwUtU4a0UhE9e+EKitgXAJ0MT529iE2r5+PG2T1o06K+lNXmWVlZIUvGDNLSQkptudLFcO7iFdCPdprU/4DSlfmaNaqN9OlSY/XimZg/cxwQklAwfx7s2rhEtCs/VnhvCokNvYkfPy5qVaso26+eslb8aH/+8g37ti7H2qWzMH7yHHz89BlFCxeU7Xjl8wZp0/yD80IxpXwXr5BCmhe68rVoXFco5jtIVC61oB+JqpVKy32lV8Q+329+4sezUvlS+O+/9zL5/MXrKFwov87y53mtROf2zbF383KcPPCvUM7ioW+PDsieLTM2ey9A725tZTlKL1eOzDh99jJoqQJdSDx9/govX72WyV+/fkea7CVAigb9wFMk9dVeKOTd+7ugXauGuHHrLhImjI/MGdNTsl7O0lKBjavmYcHMcZggFArK1LdHe9SrWVm2sULZEhg3aQ4qVyiFA9tWYtSwPhg4fByJSadQKOT869OtPbJmyYiz56/I+G1CMatdo5IMNxecLxzbhv0i/8ate+X8kQkh3rZdB5AmdSppqb5+Zg8K5ssdkqJ9Q5Zth8IF/kgkxUvbMaAuSBdGpAjRfCdr42xx0aFU4NXlNMP58+QU/ZyHlP9LIZTk9aC8+7YslxcJtPzjxq17WPPvNuzetAyzpozGmXOXNYtQ7SdLmhQ7/l2ESuVKYrz7XBlfMF8unD+yBYd3ecPW1lrMqe0ynjyFIphxlw4t4DZ1HpYtmIpje9fBY/pYSg7lkidLjG3rFuHwTm+0alof46d4qNLpOF2+cCpmTHQR5e+AtmNJJSwCmvNARImLKoU8V7iNGaSaL7qOL5JXusmuwwS75HJO0YWKrjmljUOeXNlQrVJZDHPqIfOnSJ5UWazWrUIRzKtT26YYMGw8JrsOlXO3gGA8a94S6HvOUyjCLkdbu8Kb69TgB8LYQMcRnQM+fPyMy9dugi5atbWVlktR/IJZE7BGnPMePdZ9AfzylY84hhZi2gRn9BGGEFoi1axRLaxcu4mqBV3858yeBeHxk8LsMYFIELCIRB7OwgT0JlC1YhkoFAo8efYCaf5JiYL5c0sLIVlJz124KpXQ9OnS4Nnzl7gnLHON69fAWaHsksJarEgB+SP04cMn8eM1V5wYNyNZksRh1u0g8lBeUnS7O7bGuQvXZHlUVpgZQxIrlS8pQ7RU4N7DxzKszevRuQ3mL1otlT9AAfo7deYiLl65jiZte0mL49v3H3BHWEupblJyTwslo0HtqpIFKb+knJASritfRqH8k1WUfgB37DkolOwKfyxPyJIpA968fYdPn7+A1psmTBAfmTKkk5bX85euoKhQiHWVX1hYHucsWCbXLPq8fgsbG2vqhk7XtkUjqexkyV8eXfs6I0/ObHIsKcOR3Wvw6PpRoTC3R98hY/Dw8VOKRt/u7bFQ/Bg2b1QHU+d4idvFjiAL97DRk3FKXMhIoTC8CmVLQqFQSIXz7v3gtcqa4idOXwBZCGn95egJM3H1+m2ViHL+UUQdoeBu3bWfgti26yDqCqWZdr59+4bhY6agTecBeOXzGrfvPKRolaN+kuVq0vQFOC4sqEmThD0HKaNCoaBNKKfrGFAXonlL7UqUMAGonnq1KsuLJXUZbeHqVcrJaFIa3goLI1noGrfpiZu37+Hy1VtyXtavXQUJ4sdDqpQpUK1yWej6a9Wsrkxq16oRLon5TDvW1lYgC3GLDn1AVvjbdx9QtHTqjPPmzg7nsVPh4blSNTekUIgXx84OG7fukdbcRcvX4dbd+yEpQJlSRRE3bhy5r2vOysQwvPKlS8j5QhccyvkSmbJ0zamwOITRrFBJSl7PxAUjWZWHjZ4Cmrubt+/FlWu39D7nhVdOqEpDdsKb6ySWI3sW0DmEwv+k+p88L+tq61Nx3s6YPg1y58wqz+XNG9embFpdiyZ15ZywF+cdUmpfvnqNhnWrge4K0EX0uo070bSB7vxaC+VIJhABAqzwRgAWi0acgI3tbyXKyspSVYC1tWWIsgg4FM6Pg+LWdPJkSYSCVkD+wJ8XynCxIgURJ46dtJiWLVUMx0+dF4rJVFUZ2gKkXJKSS1ax6uJH/d6DR7K8IiHrdrXlUY+zCVnvSrftgwKD1JNkmE7M+AVphSjhYC9uKx+U8eRR2ojBvaSVh6wjt87vA/XBQVj7zkol/gocihRE8mRJsWf/UZEWbAXUlY/KbCYsIKvWbZYPPZFVmuKKVWggbs83kIoq7RcVfaMlGmQdof3ChfJg74FjCBDtTy0uMnSV30FY3ScLy1aqlMnRtssAkGJN+XU5UohJ/uG1IyDr4fuPn5AxfVopnkooUZTeoE41VC5fGtdv3pXxSo+spGVKFAX9wNNt/dHD+omxdFcm69wq54wcD3GbW5vgLzEga5fOVnF/cvO4Skx9/pFVnqzPtATizX/vkCtHFvj7B4As0E3q18SaJbNQtVIZfPv+XZWfAgXFRRpZXPPlzoHJQundtG0vRet0WTKlx/mQddWaQsr+ULy12jFA+0pHF0HKsLW1lTxO6MKHLGLKeLK4KcO0tbWxoY2UbVCnqorFqQMbMKBXJxlvYfH7+FOvQ2ZU86wsreSepYUFfv4Uk13sOY2YgBzZMsFzzkT079lJMPIVscH/1Rl7znZD25YN5MVXU3Hh9/Pnz2ChEN9z6Vr4vH6DiWMGw0uU9V2Nta3aBZeuORtSjM6NtU1I2y0t5VIeEoxMWbrmVFgcqC5tLujHj1DRSl5UR46Quyl0vti9aSnWLZ+r9zkvvHJCVSp29JnrQgxWgh1tySkUCgSK405XW3+J6WGpJm9t9ft8T/nVnWXIvKI4a3E37sePn4gXNy6KFCoAWopy4MgJcfyVpmR2TCBGCFjESKlcqJkTiHj3MggrLlk16fYY/QguW7URxYoWlAUVFQqhh+cKkHKYM3tmXLh8A3ZC0bWzsxU/rN+lxaZ0iSLyh/bS1Rsyz669R4T1KTgsI0I8KuuEsMLRQ1QURVayI8fPQNtDUvHixcPnz19ILFKuR+fWmLdolcgrzvrCL12yCOYsWC5/7MUuzl+8ClqjSf0gy+ups5ekklWsSAGRbyVoqQPJ6cpHafVqVZEWsVc+/4FuARG+LAAAEABJREFUW1PcmUObQG5g7+CHa8hi4rnUG/YF81AyChfMB1qrTIo2Regqn6zC6dOlFreW66FQgTyg2+nxw2BCD52RovVBKLrOY92RS4wVWYC+fvsuFKNgxYbWxtIYk6WP6iYXGBiI5as3yGUtlJ+sO7a2NogfLy4i8xdX/Eh+DnlLBuUvW9JB3gGgMCk3p3RYjsm6mSd3NowcNx0NhGJO8u+EFZ7mCvXfwkKBw1oehiNOZHGtWa08mjeqLebddcoKWiZAb+mQO2peZ3Frf+yk2dh/+ISMpfm+XViUwzoGpKDwitoXEBavA9Ji//7DRxHeLy4ICyJtmpR49sJHSEDOqVNnLsmwplfCoRA2CAsqLTmhtOcvXoEuZGiOnDxzgaKkIqgMywgNb/X6rTJm5drNKFwonwzTbe5qlcqC5vH+Q78vKGSimkesCuTNJZTsjqALIpobasl4+OQpSpcsCroQ23vwmHpSqHBpHceSupDmPFBPUw/rU5a6PIV1zSldHOLFtcOXL18pq3RpU/+jWp989MRZGafppU+bGu8/fACdyyiNLrTo2KGtQqGA5jmPZLQ5XeWQrHq79JnrlEeb01VHBnH+oDn2OaTvdDGrLT/Frd24TZ4nLl+9ibfv3os5nYqi0bRhTdCFRK1qFf64gyUF2GMC0USAFd5oAsnFhE3ASlzRT5/ogmGjpoBeaZUieTKhPNSRmUgZvXPvkfhhzy/3/5ciKYraB//QPn7yAmlzlpQPgU0Tt8RHDuktZf7dskv+oModNY+UqHhCkaIfeIouUii/sJjE0apc9XBsjUEubqEeWqM8+rqsmTMgr7D6KeWbi9v2pMzSQyj0ai4XoVgp0xyK5EcqYUm1sLAQFo18oP7SGwkoPax8pGBQX+h2IMlqc4XFLUJ6GIiUNkrPlycHnorbpfYF8tKu5KytXYNGuCFbwQrCujtQWqwrlS8hOdWuXgGtHPuB1o/KAkI8soz+L3NR5CtWXShfrzDLfbRMuXf/EVJkKoJkGezRsmM/jBraN9Q63cUr1gurXyP5Y0bK0P0Hj0EPoZUrXVzmj6hHisD3775o2rYnaF2zi5gT/739AHrYhh7y2bEn9IN96uXXrl5RLn+g5Q0UT4oXjWOVem3h2GuouDWbjaJDuU1CgfwnWzE0adMDp85dkuueScBtmofWtbDVhJWYHlobP2Uu6OG05u17w9fPT97y1XUMUHnk6IKvY5vG8oExeoCqa8eWyJ41o7SElRW3/Kmd3fqNQAZxG5nkNV2WTBkE/z7oOWCkrJtulVPdeXNlR/kyxUEPFrXtOhB0jGjmVe6/fOWD8jVaYNe+I3B26imj+3TvIPm27txfHE+2Mk6bV6JSI3H3ob60mvfr0V4qyOpyHVo3hvOYKbIddJtcPU09HNYxoZTTnAfKeM2tPmVp5tE1p7RyEJmbNqyN7bsPynH77+170MOjNH7Eiy7ChMgf/8kySmtf6eKUxrVw6boghVrXOe+PAkIidJVDyertshZ3r8Kb65RHm9NVB5XpJqz1ncWx07JTX4Q1pimSJUPFWq1AD9y5jx8OKpPqomctaKu8g0VhdkwgJghYxEShXCYTIAL08Enl8qUoKF0ZYdmhB8IObl8F9/HDVGtGyfJGr7QqHGJNWr1oJiaMGiTz0IMXPvfPylvotBa0bCkHGf9RWBkrli0hw5oePbzUp1s7GU0PXtEDMnJHeBPHDAEtdRBBYeWrilVeM6B8aO3Moc2wE1ZlSqO2zg5R6Ghf6VyG9EH71o2Vu1g0d6Kwtm6W+wqFAsMG9sChHatBr+aivtqE3KZ1HTEQ3otnSTl7oaBSf6nfFKFQ6M5H1sEXL1+jSYOaJKrVUVupPLrlTgL0I/T6wTl069SSdqWFXFu7iOe9y4dADwoRb8pHGaiPxIXY0b7S0bq+d08u4vmdU1jpOR0pUySXSYWEdZjiyRF7euhHJoR4pLTVqVFJ7ikUCtBt250bFsOpj6OMU/fq1aqMMc79ZZTm/KEHyyiBLmoWzBwvy6GH1lIkTyofkCLutIxknMtAEoNmfook5YdY0XIG2ic3Z+oYOb+WLZiKxR6T0LRhLYrGkd1r5AUAjfere2ewfoWHXI+cTljmSIAY1BIXBxTWdI3r15DzgOY69Vc5fjRWNC8oXv0YUNZF5XRu3wKUTv3p2KYpRUk3aexQ2U5qI42Zsm71eUuCZL3es3mZLOP80a3IlSMrRYs7JB3x70oP0PFF40SsZYKaR2XRMXJ4l7d8+EupWLdqWk/M801y3GlZC7GlbLStrHaM3zy3V8htBi1tUG87yZLLnyenTKd2DOnfVYYpnpjTvKMwOYVC9zFB6eQ054FmW5TzRaEIvywq78rJnbSRTtec0sUhT65sWLbAXTKjvDQGpw9ulLymuTlj/EgnWa5mG+kByA2r5slxvX1xPxrVqwEqS9s5TxYQ4ulTDolSWert0jXXj+5ZK+c6PZxJ85PykqMxatmkLgWhra2UUKVCaaxdNkfOq42r54HmD8WrO2rvzMkjQfOKzsd03CrTX/m8ERfI6VR3sJTxvGUC0U2AFd7oJvpneRwTAwToR0Kh+PPBoBio6q8VeevOA2mlIyU/WdLEf60dXDETYAJMICYI/Lt5F+o17ywfZo2J8rlMJqBOgBVedRocZgJGRICskGQNGTqgmxG1ipvCBKJCgPMygd8E6E7IuSNbQcttfsdyiAnEDAFWeGOGK5fKBJgAE2ACTIAJMAEmYCQEjE7hNRIu3AwmwASYABNgAkyACTABMyHACq+ZDCR3gwkwAbMjwB1iAkyACTCBaCLACm80geRimAATYAJMgAkwASbABGKCQNTLZIU36gy5BCbABJgAE2ACTIAJMAEjJsAKrxEPDjeNCTAB/QmwJBNgAkyACTABXQRY4dVFhuOZABNgAkyACTABJmB6BLjFWgiwwqsFCkcxAWMjUKNhByROWwDJMtijbrPO2LbrQKSbWLZaM3z99j3S+ZUZh46ahN37jyp3tW51yew/fAIdewwJladCrZa4c+9RqDh9dvoNdQWVpym7buMOuE6apRltkH3iu2z1Bp11ZclfTo4njWnJyo2kHH2CdrCLmxzfyTMWyjjyxk2ejdPnLlHQqB19IjcgIFC28cVLH9CclTsx7NEcvPfgSaRqiUxeykPzOlIVciYmwAT+GgFWeP8aeq6YCUSMAH2u+M3DcxjQqxMGjXCLWGY16RmTXBDHzlYtJnJBx3bNUdQ+f5iZ9ZEJswATTfz67RtWrt2is/WJEyXEx+dXpKNxJcEHj57i+3c/bF3rieOnzsHX1w/PX7wS7jWKFy1EIkbtFq9Yj4DAYIXXkA3df+gEHjyKnMIblbyG7CPXxQSYQNQJsMIbdYZcAhMwGAFLS0skSpgAqf6XQlXnmg3bUKlOa5CF1H2Wl4wnCxvtt+82CPVbdMXoCTNkPHn9hrjC188fP3/+RK3GnUAW3yr12uLE6fOUDGXeDt0Ho0zVphgycqK0KJMsuVc+b6QcWfTOXbwqw8Uq1Meo8dNlXe26OuHL128yXl1GRujpeS71lp9Vpj4sXrFOlWvj1t2oWr+tbFe7rgNV8bv3HZV1l6/RArfu3FfFk+WvYcvuICvqnAXLVfG6mJWv2QJUbl1hRf/06TO69nVG5bptpDW6XPXmePvug6oMCuhiONNjCe7eeyjbNHv+73opjy5nZ2sjuH3Fjx8/EBgYBBprsvQO7t9FVxZQ/4g9tbt5h95y7EiY2kXWbeKXv0RNzPNaJdNITtm/QKGcauP8+ctX9B08VlqasxWsgINHT0JbHNWjdGs3bMfTZy/RsmNfdOs7Qkb7+fuD5l/F2q3k3JCRwjt28py0/lK8k7MblFZh6muDlt2Qu2hVTJnpKSQBnzf/SfY0vynt7v3HMl7p3bh1D3sOHIWbu4dk/d/b9zgv5mSdpo7ymOjez0UwDZ6LW3fuR7N2veTcoTkRkbz7Dh2X+Rq37iHuahxRVs9bMyHA3YgdBFjhjR3jzL00AwKktNEtcFJOhzn1kD26//AJFgvL2oaVHti3ZblU9khBocQHIm3UsD7Y7L0AHz5+xuVrNyla5RQKBWZMGomje9Zi4azxGOwyUZVGeccM74f921bi5OmLIOVgx7+L0KxRLSxc4q2SUw8UzJ9H1lWjajms8N6knqQ1TMor9UfpLl25IeVu330o69i0ej6oX6QwkqJDVrzRbrOwxGMyju1dh5FD+0h58iwtFSB5tzGDMEEoPxRH7vyla/Cc44adG5bAa/laqSCGxez6zbsYLfpNVtY1QomjZQb7t65A2xYNcOX6LSoylFMotDPs26MDsmfLLHn07tY2VB7a+fr1O9JkLwFS0HfsPkRRSJvmH9gXzIfu/V3QrlVDwfwuEiaMj8wZ00PXX/JkibFt3SIc3umNVk3rY/wUDylKbb989RZ2b1yKi8e2ombV8jJevX8PHj3TypmWy6RJnUpamq+f2YOC+XLLCx7NOFlgiNesUW2kT5caqxfPxPyZ42QszSGafzQvb999IOdfUFAQeg4cBbfRg0BcX/r4wPvfrXj85DlOnb0ox/DG2T1o06K+LGPcpDmoXKEUDoh5SGUNHB5ctkwUXp5c2VCtUlnQ8UDzPGmSRBgwbDwmuw6VeQrky4VZ85YIScBt6jwsWzBVzh2P6WOhb166MKAyF8yagDVLZ+HR42eyPPaYABMwLQIWptVcbi0T+BsEjKNOuvX94dllHN7lLS1mfsJKe+b8ZbwVVq32wpLbuE1P3Lx9D6ToQPzlyJ4FmTKkEyHgn1T/w737oa1jCoVCypMVrP/QcXjl8x8+CqsmZciWNZNUYGxtbZArZ1Y4FMlP0ShUIA/uPQxdjkwQXpWKpYUv6kop6tIhIwVCvIZ1q0N5W5+2VDYlnbt4BXVrVpaW7KRJEqNercqguNPnLqNhnaogxYvksmTKQBvpypcuAYVCAYfCBXD3/u91wDWrVkCypIlBSwhqV6+Ii5evISxm+fPmVDEjji2b1A0uv0xxoXgGs5QRIZ5CoZthiIjWzZHda/Do+lH07dEefYeMwcPHT6Vc3+7txcXHBDRvVAdT53hhYG9HLPfeiGGjJ0uFUAqpeXHs7LBx6x607TIQi5avw62792XqydMX0KVjS9D4WVlZIUP6NDJevX/EVBvnPDmzSSvmpOkLcFxY/WkMtMXJAsPwaA7R/CNLNY0tzb8nz14gzT8pUTB/blhYWKBdy8Y4d+EqUv4vOT58+CQuVuZi5drNSCbGnYo+IfpBa7GD71LMxNXrtylap3v2/BWev/QRvKZIi+/m7Xtx5VrwhUre3NnhPHYqPDxXyro1C9GV9+nzl8go+OUWxwGxbN64tmZW3mcCTMAECLDCawKDxE1kAkoCCoUCeXNlR4rkSUEWR7JANqhTVVoSycJ16sAGucaX5K0sLWkjnUKhQKCwrsmdEI8sqstWCXmhVG1cNQ9phVXvW8jDbDbW1uM+XC8AABAASURBVCFSgKWFJaytgvcpHBQYpEpTDyjrI0VGU4aUzGIVGoDc4WOn1bNpDZNioUywtrYC9ZMchZXx6ltrGyu5ayn6TFZEuSM8K6vfpzhrofj9+PlTlqWLma2NjcgV/J/qo/KC9wAbtTRlXFgMlTLatqlSphDlWaNBnWqoXL40yPKqLkdW1jIlikrljZYAjB7WD8PHuKuLyLDn0rXwef0GE8cMhtecifj+/buMp7ZbW1vKsLqn3j+KtxJMaEuO2FI+UkbJWp4vdw5MFkrvpm17oS2O8oTlbNTmkEJhoZp/Vla/22Ut2kh1xoljh31bl6NsqWI4fuq86OtUWfQv/MLapbNV8/vJzeMyXpdH8jlCLOt0POzetBTrls+V4p6z3dC2ZQPQA4VN2/aSS3pkQoinK++vX4D6PLC2Cj4WQrLFvg33mAmYKIHfvwYm2gFuNhOIbQRe+bwRt7vvIWWK5CjhUAgbhIWPbtMTB3rIiW4PUzg8R3kKFciFbFky4NGTZ7iptvY1vLwRTS9WpCDOHNokXXlhLQ0rf1H7Ati68wA+ff6C9x8+ivB+YbktCHpwiyx2tMaY8pPiQtuw3J79x/Du/Udpud6x5yCKFMqvNzP7gnlAFkYqn5jeufeQgqGcLobx48XDZ9H+UMIhO9RuWmNLu6//ewtaakLWR9onR7fQl6/egI5tmsj1vHRxQ5ba+PHiUnIo9/DJU5QuWRSphdV078FjqrSSxQvDa9la+PsHyDiqUwbUPF2ciTutE69ZrbywNNfGpSvX5VhoxqkVJYPxwuizFBBehnRpxJ2EN7LPxGDZqo0oVrQgvglFXaFQoHSJIujfsxMuXb0hpIGyJR2k1Zd2SDGmZQ8UVnfx4trhy5evMip92tRiznzArr1H5D6VS3xph/pVIG8ucUHYEe8/fpKKrz55M6RLDTquaB0zlUMXILQlR/EPIvnAHOVnxwSYgOEIsMJrONaxpSbuZwwR6Dd0rHyQqFDp2ujSoTkyZkgLuq0/amgf9BwwEvQQEN369fXz06sF1SqXxeHjZ0F5Zs1bJq14emWMYaGc2TMLZa8x6CGlRq17oKu4NZ89a0ZkzZwBA/t0Rvvug1G6ShN06OYUbkvy5cmBxm16yIek2rZoBCpHX2atm9WXD2LRg04zPJaAbusnTBA/VJ26GJJyWrt6BbRy7Adag6ye6d79R0iRqYh8xVzLjv0wamhfZFZbp0trstu2bARrYSElBe3+g8eo2agjypUurl6MDHdo3RjOY6aAHqaiW/IyUnjNGtZC9iyZUKVuG+QrXgMLFnuL2ND/dXHeJC6g/slWDE0Et1PnLqFz++bQFhe6NKCHY2sMcnFTPbSmmU77ZFGePtEFw0ZNkQ8DpkieTCjVdfD4yQukzVkSVeq1xbQ5Xhg5pDeJw0Vs/3v7QT6QSQ+z7dgTvN5ZJoZ4TRvWxvbdB+V8ef/hE2itrdeyNbKswqXrgtYSk2iJSo3EHYb6oDXS/Xq0B42lPnlpHNyEBb1zr6Fo2akv1Dlv3r4PS1b+S8WzYwJMwMgJsMJr5APEzWMCRGDXxiXYu3k56GEqn/tnMXRAd4qWjm6L79m8DAe3r8L5o1uRK0dWuc6V8kgB4Q3p3xXK9aj+Af6IG8dO/uDTw0B063fm5JGgh4hofSw59bzzZriijLAiimJA6xjXiFvMFJ44ZgiqC6WZwmcObYZdyKvOSHa2+2iKFrfaf8vIiBCvcvlSWOwxKWQveHNox2rkyJZJ7nRu30L2h+I6tmkq48ijta30ENTxfeuxfoUHRWGGUKCoPLkjvAvHtgkfaCqUvuULp4LKoKUevbq2lfHk6cPMxsYa09ycsXbZHHTr1ApJkiSSyxAov9KR0qSNIaW7DOmDVV4zoPnQGq1nfffkIshR3hpVy5G4ypGCX6dGJbmvUCjkLfmdGxbDqY+jjFP38ufJKazmm/HvSg/QGNM4UDoplvTw3dE9a3Ht9C4M7N3pjzlBcto4t2/dGK/unZF8F86agHTCaqotjvKruwZ1qsr+0kNrmnOI2qacfzQ/aH7RfHUfP0wypQfIaF7T2FKdZUs5yKJTJE8KesCMxvDW+X0Y5zJQxqt7lHfZAnf5wBvJ00N2G1bNkw9x3r64H43q1ZDiN8/tlaxoaYNyTumbt0qF0nIerF40ExtXz5PzmgqlOaWtTZQW7NhnAkzAWAiwwmssI8HtYAIGINC0bU9x29gBtM7WANWZdBV+/gHIWqA86NVeTs4T4OoywKT7w41nAkyACcRmAqzw/uXR5+qZgCEJ0AM8UycMN2SVJlsXLUt4fueUtBBvX+8FshyabGe44UyACTCBWE6AFd5YPgG4+0yACTABIyHAzWACTIAJxBgBVnhjDC0XzASYABNgAkyACTABJmAMBExL4TUGYtwGJsAEmAATYAJMgAkwAZMiwAqvSQ0XN5YJMAEmEEyAfSbABJgAE9CfACu8+rNiSSbABJgAE2ACTIAJMAHjIqBXa1jh1QsTCzEBJsAEmAATYAJMgAmYKgFWeE115LjdTIAJ6E+AJZkAE2ACTCBWE2CFN1YPP3eeCTABJsAEmAATiE0EYmtfWeGNrSNvpv22traBOTsLC0v8+PHTrPtoiPELCgqCpaUVc4zC8VKrWXeUqNYar/97zxyjwDEgIBBWVtbMMAoMlT9nhjh3/M06lP3kbeQIsMIbOW6ciwmYMQHuGhPQn8D5j89x/P1jdpFkcOrTs1jN7suPAP0nG0sygSgQYIU3CvA4KxNgAkwgthJw6tYM7/rnQ4fnO1Hn/HJ2kWTQ5Po61L2wItbye/DtnXEfQtw6syHACq/ZDCV3hAkwASbABJgAE2ACTEAbAVZ4tVGJBXGtuw7D23cfwuzpjr1H0bnfGFRu0BkDXabg0ZMXOuUfPH6GY6cu6kzXTOjvPAV37j3SjI7Qvq+fH9Zt3hOhPDEgzEUyASbABGKegP8PWFxha2jMg45aDTfuPMT12w+jVgjnjhECrPDGCFbjL3RYf0ckSpggzIam/F8yzJk8DNu8ZyNblgyYv2StTnlShk+du6IzPSYS/PwCsGnHgZgomstkAkyACRgXAd8fsNn61Lja9EdrOGLPwdPYc/AUgzBCAqzwGuGgRHeTFq/chO5O41CvVR9MnbtcFu823QufPn+R4WXeW9Gkw0D0GuIG53GzsPrfnTK+SME8sLWxQRw7O5RyKITXb3VbhBev2iQsvBfQbaAr9h+hA/4E+g2fjF6DJ2Do2BnwDwjAqIkeaN1tGAaMmIyv377LOrR5ZHlu1skJw11noseg8fB581acQE6gTffhMv/0ecvx4+dPeK3cCJ/Xb2Wd8xbrVsa11cFxTIAJMAEmwASYQOwhYBF7uho7e+ojFMITZy9jnvsIbFk1C22a1Q4F4t7DJ9i88yAWzx4LN5c+uHVX+zID7w07Ucw+b6i86jsdWzVAmRKFMX+qCyqXKy6TXrx6jUmj+2PiyH7YsvMQPn/5huUe4+HYphGu37onZXR5T5/7wLFtI3hMcYa/fyCWCqV85oQhoPz+AUHYtvswHFs3RKqUyWWd3Ts201UUxzMBJsAEmAATYAKxnAArvGY+AZIlTSwUxgDMXeQt17smTBA/VI+v37qPcqUKI0H8eNJVLOsQKp12Vq3fgY+fv6Jj6wa0q7ezL5Ab8eLGkfLXbt5D/VoVYWFhgdw5skgnE3R46dOmQuYMaWXqleu38e27L4YL6zNZfK9cv4ObOtZIff/+DebsfH2/i/H0M+s+GmL8AgL8QSwNUZe51kEMf/36JY9R9iJFIMKZFH5BsBt/yaxc+8aD4VCtfZRcqdpdQC6q5URH/oUrNiEwMDBGztERnjCcIRQBVnhD4TC/HWtrKyz1GIeSRQvi/sNnGOU2J1Qn6QfL0tJSFWdl9TtMkWcvXsOFKzcwY8JgubyB4vR1NtbWoUStwqgnlKDYsbZSy6tQCOuxvbTkkgXZ23MShg9wFFJ//reziwNzdra2dvIF9ebcR0P0jV70TywNUZe51kEv4FcoFH8ehBwTYwR+2VrCv1sus3JuM52w3sstSs57/liQi2o50ZG/ad3KsLKyipHfIfBflAiwwhslfDGcORqK/+7rBwgrTKH8udC1Q2Ncv/0gVKl5c2XDxSu3hMgv6c5fuqFKv3LjDpas3oIJLv1go6G8qoRCArTO99OXryF7f27y5c6Gc5euyYSPnz7jzr3HMqyPV6Rgbhw+fg4PHj2T4h8+fga9FSJuXDt8+RJ6LTBZkNlZSEs6c2AOMTkHFApWduUJyZCeYP4rmR3Myf2T5n/IkO6fKDm6I0guquVER/7EiRJAoVDEyDkY/BclAqzwRgmf8WemB74q1O0kH/iaNnc5nHq1D9Xo7FkyoHypoug9xA1OI92RPGlixI8fV8rM8VyDy9duo0LdjvIToo3bD5Dx2jz7Ajnx6+dP9B02ST60pilTr2YFfPj4BX2GTsSYyQuQKmUyTRGd+6lT/Q8De7bD+Gmesh9tezjjo1B66YG6WlXLyDr5oTWd+DiBCcQIAff5a5Fs+jVYffCPkfI1C+V9JsAEmEBUCLDCGxV6JpCX1sEe27kMK+ZNwPgRfVChdFHZ6pUL3JA8WRIZblyvCuZMHo5xzr3x8dNX5M2ZTcZ7zhiFU3tWqty/S6fJeG0eWXgnuPTFTLch8qG1ahVLCSW1rUqUlNMxQ3tg1sShmD5+ENZ4TUGObJlU6eoBahe1Tz2uYhkH+WAd9WPb6tkoXDCPTKaH1ahO2soI9pgAE2AC5kjARoEfBZKaY8/Mqk95cmYGObPqlJl0xsJM+gGAexJZAkPGzEDTjgPRsfdIlBcKceaMaSJbFOdjAkyACTCBmCAQ1xqBdTPERMlcZjQSqFahOKpXLBGNJXJR0UWAFd7oImnC5cyZNAzrFk+Ft+dkNG9YPcye0ENs9E5fdUfv1w0zk47ET5+/yvcDq5dFYYrXkYWjmQAT0IcAyzABJsAEmEAoAqzwhsLBO+ERcLDPJ9/pS+/1VTpaqhBePm3piRLG/6MsKpPitclzHBNgAsZHoGt6BwzJUo5dJBkMSF8yVrNLZZvA+CY1t8isCCg7wwqvkgRvmQATYAJMIMIEumUohqFC2WNXLlIcBqQrgSGZy0YqrzkwT2Ub+t3wEZ6AnIEJ6EnAQk85FmMCTIAJmCkB7hYTYAJMgAmYOwFWeM19hLl/TIAJMAEmwASYABPQh4AZy7DCa8aDy11jAkyACcQ0gfqte6NIxaZm5R4/fRHT2Lh8JsAEDEyAFV4DA+fqmICJE+DmMwFJwKlbM8SPayvCCuH4PxNgAkzAuAmwwmvc4xOtrfv85at8325YhdKX2dyme6FGk+5o7jgIy7y3hiWOY6cuys/8hikUknjj9gP5NbeQXd4wASYQSwj8/PkL5GJJdw3WTT//AHz+8s1g9XFFmgR435QIsMJrSqMVxbbGjRsHIwd1C7MUCwsL0JfXdq2fJ78d9SsOAAAQAElEQVTMtn7LXjx49ExnnlPnruDRE779pxMQJzABJgC/gB/49NWfSUQzgZ37T2D4BI9oLpWLYwLmSYAVXvMcV2l1HTpmOjr0ckHVRl3x/KUPvn/3xdgp82WPyTJAH4xo3W0YBrpMQed+Y3Dn3iP8L3lSZMsc/DWfLBnTIUumdHjp8x+0/d17+ERYeC9g0YoN6DbQFU+evQJ9sW36vOXoNcQNh46fAynErboMleVv33NEWzGquAePn0GzzfT1N3WFm+ohS7E2WVVBRhTgpjABJsAEmAATYAJ/nwArvH9/DGKkBavX70SdGhWwZI4rNi6fjqRJEoeqZ9P2A/j2/TtWzJuALm0b4/qte6HSaYcUzVt3HyJfnmy0+4cjxbhMicLo1KYR5k91QYZ0/0iZdGlSgb7eVqaEPcZP9cSw/p2wcPpI/PfuvUzX5Wlrc6WyxbDvyCmZ5e37j/B5/RZ5cmaBNlkpxB4TYAJMgAkYIwFuExP4qwQs/mrtXHmMEcgvlFTvDbvgKayvz174IG4cu1B13bzzAHWqV4BCoUCObJmQO0eWUOkfP3/BMNcZGOHUFYkTRuxLOOVLO8iyXrx8g2RJEyFvrmyynga1K8t4XZ62NlerVAoHjpyRWfYePIlqFUvKsDZZSvD394c5u4CAAAQGBpp1Hw0xfoGBQcwwiscKzcNfv37RYaeXCwr6iY9f/EzCTZq1HINGzzSIc5m4AIPHzIpUXas37Iavr1+sn8sBAYEgZ4hzx9+sQ68DjYV0EmCFVyca006oV7MiRgzojDSpUmDE+DkgS616j+h3ysrSUhVlZfU7/OPnT4ydPA/9u7dFWWGlVQnpGbCxtlJJWqrXoRZWCagF6mlpc/KkiZFMWKdpucX+I6dRpXwJmUNX/2gNsjk7hUIhLx7MuY+G6ZsChqnHwqzrQQT+xNSFtTjPmILLkimtMAJkNojLmS0jcmXPFKm60qROadbzS/9jVCE4kOPjDfynkwArvDrRmHbCl6/fkCplctSsUhYO9nn/UHhpWcCFKzdkJz9/+Yo79x7LMFm+Rrl5yHwlihaQcWF5ceLY4vPnr1pF0qT+H95/+IQPHz/L9LMXr8mtLk9XmyuWdcDK9TtA6Vkzp5fZKaytf9bW1jB3Z2VlZfZ9jOkxpAuxmK7D3MsnhgqFQh6P+niWlhaIF8faJFzjOhXRoUUdg7hWjapprUef+suVKARbW5tYfz6gcyI5cz/mwH9RIsAKb5TwGW/mybOWoHKDznBycUeAuH1brWKpUI1tULuSUEY/o++wSZgyeykyZUiDePHigpTgA0dPw2XCHJSo1lq6nfuOhsqrvlOzchmcOn8FPQaNlw+tqaeRBXlY/04YPWmerIfWBKuna4Z1tZnaTtZd2irz6JJVpvOWCTABJsAEmAATYAJKAqzwKkmY3DbsBrsO74X9mzzh7uoEF6cuiBc3DhImiI91i6fKjLTsYGi/TpjpNgTdOzaFn58f/kmVAsWLFMCpPStDObISy0xavCyZ0mHKmIHwmOIsH1qj8qkepWixwvllHVTPjAlD4D7WSZn0x1Zbm0koUcL4sj2ObRrSrnS6ZGUie0yACcQ4Aff5a/H1u7+o55dwYf+3EIZghUJ4YYtxagQJ2AnrbiJxXo9gNhZnArGSACu8sXLYgR8/fqJGk26gV4YNd52FAT3bwdKCp0MsnQ7cbSYQowTsbK2QOIFtzNURS0uuWbkUxg/vHkt7z91mAhEjwBpOxHiZjbS1tRUObV2MVQsnYunccShaKG+YfVu1fge6O40L5SguzEw6Emktr2ZZ9E5gHeIczQSYABNgAkyACTCBKBGILQpvlCBxZqBVk1qY5z4ilKM4ROLPwT5fqHKo3DFDe0SiJM7CBJjA3yaQN2dWFC6Q26ycnS1bo//2vOL6mUB0E2CFN7qJcnlMgAkwAaMmEL2NGzeiLxZMH21Wjt4AE72UuDQmwAT+NgFWeP/2CHD9TIAJMAEmwASYABNgAjFKQKvCG6M1cuFMgAkwASbABJgAE2ACTMCABFjhNSBsrooJMAGTI8ANDofAiHEz0bX/aJN2czxXh9NLTmYCTMDUCbDCa+ojyO1nAkyACfxFAtdv38eFKzdN2t1/+PQvEuSqmYCpEDDtdrLCa9rjx61nAkyACfwVAk7dmiF+XHqbAX9Q4q8MAFfKBJhAhAiwwhshXKYlvG7zHvj6+UW40dM8lmHPwRMRzqcrw4PHz3Ds1EVdyRxvRgS4K0yACNCHbd598qUgu2gmsGbTXniu2BzNpXJxTMD8CbDCa8ZjvGnHAfj5Bfz1Hj568gKnzl356+3gBjABJmAYAvSx4aAf5BumvthUy7sPn/Dm3YfY1GVT7Su328gIsMIbDQPStONATJ+3HL2GuGHeknUYOnaGqtRzl66jv/MU1b5mYPHKTfLrZfVa9cHUuctlMpVH4c79xqBTn1G49/CJjP/58yfmeHmjZZchaNvdGTv3HZXxv379gseiNWjddRjqt+4rZXbsPQqf128xaNQ0Vf1UrrKdh46fw8FjZ1GreU+06DwYI93m4uu377K88Lxbdx+i20BXtOk+HE4u7nj34aPM4jbdCxOmeaHnoPFo18MZl67ekvGLV20SFt4LMs/+I6el9bjf8MnoNXiCZOXz5i0GukxB+54jZN4Hj57JfGRlVsq1cBwk+0UJ85euw+p/d1JQunmL18J7wy4ZZo8JMAEmwASYABNgApoEWOHVJBLJ/XRpUmHOpGHo0q4xbty6Dz//AFnS/sOnUaV8MRnW9HyEQnri7GX51bEtq2ahTbPaKpEM6VLBc8Yo9O7cAlNmL5Xx24US+9/bD6BPAXu4O2Pdln14/PQltu89gvOXb8Jz5ihsWjEDdaqVR62qZUEvT58yZgCmjx8k85OnbGeF0kWRPUsGbFw+HasXTkL6tKngvTF8pfGHULrHTJ6Hvl1bYcW8CahSoQRmzl9FRUv348cPzBIcPNxHYMb8lTKuY6sGKFOiMOZPdUHlcsVl3ItXrzFpdH9MHNkPsxeuRq7sWWS/alQuDbcZi6QMeUq5FfPdcO/BU5y5cA21q5bDll0HKRmk7O89dAq1q5WV+z9+BMFkXCTb+vPnD7PvY0yPITOM+nFCDOVBp8MT1+Hw9QsyCffs5X/YtufoX3G7DpyMUL037zzi4/+PcyedE8lFfV7H9LknKuXrONQ4Wk8CrPDqCSo8sfKlHaSIpYUFShQtiMPHz4KUw6OnLqJsySIyTdNLljQx/IViPHeRN9Zt3oOECeKrREhBpJ2C+XLi6fNXUrG7IJTauw+eoM/QiXAaORXvxa2t2/ce4vylm2jZuCbi2NlBoVAgQ7p/KKtWp2wnJdrYWGP5mq0gK+rx05fwQI8nlV/5vMHr/95j5oJV0mK7Ydt+UBuoPHIlHArA0sIC8eLGwcdPXyhKq7MvkFvKUOLVm/fQuF4VCkpF/fHTFwgKCpL7BfLmkHJWVlYoXiQ/rouLibSpUyJ50iQgS/PJs1eEspwJCeLHk/KUz5zdD3FBQc6c+2iIvtHdEkPUY8510DpduuCUB54WTyq8AULhNQH3VCi8m3cdxd9w2/edxJbd+td98+4j8dvyQ54jzWl+RaUvdE4kF5UyTCGvlsOMoyJAgBXeCMAKS9TG2kqVXFlYdOnW/elzV1EgTzbEjxdXlaYesBZ5lnqMQ0mhIN9/+Ayj3OaoktV/SBRQyHiFQgHH1g2lpZSspVuFVbh6pdIyzcryd/0yQoen3s5JMxfhn5Qp4Dq8p7TY+uq13lch8iRXtWHh9FFYt3iqqjYLoewqd37SL55yR2NrY20dKsZaKLQUoVAooFAIF1KOZhFKLnWqlxOW7aPCHUatauUoq3S2tnawNWNnY2MLa2sb2JpxHw3RNysra9gyQ9hGgYG1OIYVCoU87rR5dAgnTWgHU3CliuTGohkj/oqbO9EJXtP1r7txnYqwsbaFbRTGztzy2tjYgJy59UuzP9qOM47TnwArvPqz0luyaKG8uCtuv2/bfUje8teV8buvH4TpFoXy50LXDo1x/fYDlSg9cEY7ew+dRLq0qaQSWKxwPqxcvx1fvn6jJNDbDz5++ozCBXNjzaZd4tahKE+kfPvuK3xIi++nz19lWJv37IUPSpewl5bl42cuaRP5Iy51qhTSsrAn5C0OgYFBuHrj7h9y6hFkef70RXc78ufOBrIUUx7qb8b0aaSVmPZPnbuM/96+h6+fH3buP4Z8ubNSNCqUcQBdUNy590RcMBSQcewxASbABJgAE2ACTEAbAVZ4tVGJYpxCoUCZ4vY4ff4aShWz11kaPaxVoW4n+fDXtLnL4dSrvUr26zdftOg8BGs37cGg3sHxtL61ZLGC6D5wHJo7DoLLhDn4+fMXalcti7y5ssoH3Oq37guPRWtlObTMYbbnKtVDazJSzWvfoh469R4llzTQ7Ry1JJ1BsuCOH9EHO/cdlw+m1W3ZO5Siri2jfYGc+PXzJ/oOmwSyfGvK9O7SEleu3wY9tLZl5yEM7ddRJZI9S0YMcHGXaaTwFyucX6bZiiv6wgVyo3qlkvJiQEayxwSYABOIDQS4j0yACUSYACu8EUb2Z4Z14pa++vpbkiAl9fC2xbCztaFdrS5zhrQ4tnOZfPiLlMgKpYuq5Lq2awxvz0lYNGsMsmXOoIrv3KYRVi5wwxqvKfJhs6RJEoGU0F6OLeT+5pUzVQoyPSA21XWQ6qE1zXbWrFIWG5ZNw4wJg9G/e1vMdBsi6xnQox2qVSwlw9o8ag/JLvMYj13r56FloxpSbFh/R1QUlle5I7xtq2cLH9LSPMGlryyf2kRlD+zZVqaRl+p/yUHtXDp3HOZOcUaWjOkoWjp6yI4ejlu7yB3URxkpPFra8OjpC9StXkHs8X8mwAQMTcB9/lp8/e4vqv3z9WOWFgq5lEEk8v9oJtCiQTV0aVM/mkvl4piA+RNghdc8x9ise0Xv9aVXouXOkUm+icKsO8udYwImSEChUMDain9eYmLokiZJiBTJksRE0VwmEzBrAnxGMtDwjproId+3291pnGp79uI1rbVrWmK1ChkgMiJtjonmaFqClXVkypAGK+e7Sau0Mo63TIAJMAHtBDiWCTABJgCwwmugWTBmaA/5vt157iNUWwf7fAaqPXLVmGKbI9dTzsUEmEBkCWxeORvnD64zaTfDbWhku8/5mAATMBECrPACMJGx4mYyASbABJgAE2ACTIAJRIIAK7yRgMZZmAATYAJmSoC7xQSYABMwSwKs8JrlsHKnmAATYAKGIeC9YQcWLF1n9I7eWW4YIlwLE2ACxkgg4gqvMfaC28QEmAATYAJ/hcDaTbvhufxfo3cfP335K3y4UibABIyDACu8xjEO3AomwARMkAA3mQkwASbABEyDACu8pjFOUWrlwWNn4TbdK8wy6KtvJFOjSXf5Fbdl3lvDlOdEJsAEYjcBp27NED+uLXz9fsA/8EfshhENvf/2hr+77gAAEABJREFU3RdT5q6IhpK4CCbwVwgYfaWs8Br9EEW9gYXy5USLRjXDLMjCwgKN61WRX06jr76t37IXDx49CzMPJzIBJsAE/AODEBT0k0FEkcB3Xz+sXL87iqVwdibABHQRYIVXFxkTjX/w+BmGjpmODr1cULVRVzx/6YNL127De8NO2aOnz33khy8c+47C5FlLUKdlbxn/v+RJVZ8wzpIxHbJkSoeXPv9B19/ilZtkOfVa9cHUucvx9dt31BVh+uQv5fHzD0CNpj3ED2EQDh0/h77DJqFF5yFo2SX488Uko+m0tb1j75GhFO9uA11x4/YDaJPVLI/3jYwAN4cJMAEmwASYwF8iwArvXwIfU9WuXr8TdWpUwJI5rti4fDqSJkkcqqo5XqtRulgheM0cg/Rp/4GvsCqEEhA7ZNm9dfch8uXJJvb+/O/z+i1OnL0sP6CxZdUstGlWG/HjxUX2zOlx9uJ1meHIiXMo6VAQVlZWmOPpjYmj+sLbcxJmTtCt8Gpre6WyxbDvyClZ5tv3H0F158mZBdpkpRB7TIAJGJwAXej+/PkLxuy+fP2Oz1++Ga2j9v389cvgY8cV/h0CXKvhCbDCa3jmMVpjfqGkem/YBc8VG/DshQ/ixrELVd+tOw9Rv1ZFGafcyp0Q7+PnLxjmOgMjnLoiccIEIbGhN8mSJoa/sODOXeSNdZv3IGGC+FKgcvniOHDkjAzvO3wKVcoXk+F8ubPBffYy0LrgsE7o2tperVIpVZl7D55EtYolZZnaZCnh+/dvMGfn6/sdAQH+Zt1HQ4xfQEAAiKUh6jLXOmgekqJLOtqX7wF48+G7UbtGHYfCoVp7o3PlG/RAseodUKN5X9CdMXOdLzHZLz8/P5CLyTqMoWz6jWMXeQKs8EaenVHmrFezIkYM6Iw0qVJgxPg5IEutekPpx8nWxlpGWVlZQqFQyDB5P37+xNjJ89C/e1uULWFPUVqdtbUVlnqMQ8miBXH/4TOMcpsj5cqXdsCpc5eFBeUrbtx+iKIhn04ePaQ7mjWsjl/iX6/BE0AndZlBw9PW9uRCuU4mrNR37j3C/iOnhRJdQubSJksJcePGg3k47f2IEycubGxszbqPhhg/GxsbEEtD1GWuddiIeahQKMQ5BEgYzxapksUzard33SzcPrne6NzF/ctw68Q6HN/uibh2tnxsR+IcbmdnB3Lmeqwp+0W/cewiT8Ai8lk5pzES+PL1G1KlTI6aVcrCwT7vHwpv7pyZhVJ6VTb97IVrIAsN7QQGBgnF1UPmK1G0AEXpdN9pGYTQnAvlz4WuHRrj+u0HUtbO1gZ5c2fFpFlLULGMAywtgqcXtSl7lgxo36IerCwt4PPmnZTX9EhOW9srlnXAyvU7QOlZM6eX2SisTVYmsscEmAATYALmQ4B7wgSigUCwRhINBXERxkGAHkSr3KAznFzcESCU2GoVS4VqWC/Hlti25zB6DhqPC1duImmShDL9wpUbOHD0NFwmzEGJaq2l27nvqEzT9HzevEWFup3QpvtwTJu7HE692qtEKpcrjoNHz6ByuWKquJZdhqJBm35wHjdLWGhLImO6f1Rp6gFdbac+kHWXtkp5XbLKdN4yASbABJgAE2ACTEBJgBVeJQkz2boO74X9mzzh7uoEF6cuiBc3jrS2DuvvKHuYLGkiTB49AHOnOCN/7uyqNzMUL1IAp/asDOXISiwzaXiZM6TFsZ3LsGLeBNArzCqULqqSqFS2uCyDrL/KyG2rZ2PTihlStmPrBsroP7ba2k5CiRLGl2U6tmlIu9JpyMp+ygT2mAATMCgBO1tr2FhbGrROc6wsfty4GNyrjTl2jfvEBIyCACu8RjEMhmvE3fuPUb5OR7TuNgybdhxAr84tDFc518QEmIDZEHCfvxZfv/vDzsYC1lb8U4Io/sWJY4tWjatHsRTKzo4JMAFtBPgspY2KGceR5fXwtsVYOd8NMyYMwT8pU4TZ21ETPeT7drs7jVNtz168Fmae8BIpv3p5FKZ6wsvH6UyACTABJsAEmAATiAwBVngjQ83E80Sk+WOG9pDv253nPkK1dbDPF5Ei/pCl/OrlUZjq+UOQI5gAEzB6Aq7D+2D+tFFG71L9L7nRs+QGMgEmEHMEWOGNObZcMhNgAkzA7AnQe7aLFMwDY3d2drbaxoLjmAATiCUEWOGNJQPN3WQCTIAJMAEmwASYQGwlwApveCPP6UyACTABJqCTwJOnL3H/4VODuHcfPupsBycwASbABMIiwApvWHQ4jQkwASbABFQEtAX6DndDc0cng7j1m/doawLHMQEmwATCJcAKb7iIWIAJMAEmwASYABNgAkzAlAlEs8Jryii47ZEl0LrrMLx99yHM7Fdu3EGX/mNQqkZb0FfTEMbfg8fPcOzUxTAkQif1d56CO/cehY7kPSbABP4g8Pb9R1y/9eCPeI6IeQLXbz/Ef+GcJ2O+FVwDE4i9BFjhjb1jH209p6+4JUqYIMzy7Gxt0bVdY5QvVSRMOUp89OQFTp27QkF2TMB0CRhhyy9cuY2p81dHS8ucujVDvDj05gNFtJRn7oXM8lyDMxdumHs3uX9MwGgJsMJrtENjfA379t0Xru4L0XXAWFRt1BV7D52UjXSb7oVPn7/I8DLvrWjSYSB6DXGD87hZWP3vThmfI2tGFC6YBxYW4U+5xas2CQvvBXQb6CqtwXsOnkC/4ZPRa/AEDB07A/4BAaAPVdDX4gaMmIyv377LOthjAkyACTABJsAEjI+AMbQofO3DGFrJbTAKAoePn0OSxAmwYNpI7FznId+7qd6wew+fYPPOg1g8eyzcXPrg1t3ILTPo2KoBypQojPlTXVC5XHFZxYtXrzFpdH9MHNkPW3Yewucv37DcYzwc2zQSt2jvSRn2mAATYAJMgAkwASagjQArvNqocJxWAtmzZsDJs5excNl6YYG9iKRJEoWSu37rPsqVKowE8eNJV7GsQ6j0qOzYF8iNeHHjyCKu3byH+rUqSmtx7hxZQE4mCM/X9zvM2fn5+SIgwN8M+2jYcQsQdwmIpTnPFW19o7lzVRw/tVr2Q1Td2JneePb6E95+/G4wt8h7R5TbHdV+Rzb/xau3tR67gYEBfDxH8bzt7+8HctrmvDnFiZ84/h8FAqzwRgFebMuaLXMGLJw+CjmzZ8G6zXuwZuPuUAh+/foFS0tLVZyV1e+wKjKSARtr61A5rXTUY2NjC3N21tY2grGVWffRxgBjaGVlBWJpiLqMqQ4rK2tkTJ8aowZ1jrJrXrcskieOiwTxbA3mqpYrGuV2R0ffI1NGloxpQfw154OlJR/Pmkwiuk9cyUU0n9HK6zgHhvoR5J0IE2CFN8LIYm+GT5+/In68uChbwh4Na1cCWXTVaeTNlQ0Xr9wCKb7kzl+K3AMacezs8OnLV/WiQ4Xz5c6Gc5euybiPnz7jzr3HMkweKdzsLMEMwmZAa8ljIyPqd0JxB8ahUB5E1WXPlAZxbK1ha21pMJcu9f+i3O6o9juy+RMljC/vSmnOOxoTzTjeD/v4ja18wH9RImARpdycOVYROHT8LMrUao8eg8bjyIkL6NCqXqj+Z8+SAeVLFUXvIW5wGumO5EkTI378uFLm9PkrKFGttXwIzWXCHFRu0FnGa/PsC+TEr58/0XfYJCmvKVOvZgV8+PgFfYZOxJjJC5AqZTJNEXPf5/4xASbABJgAE2ACESBgEQFZFo3lBOrXrIhjO5bCY4ozxjn3QpaM6SSRlQvckDxZEhluXK8K5kweLtJ74+Onr8ibM5uML16kAE7tWaly+zd5ynhtHll4J7j0xUy3IfKhtWoVS2Fgz7YqUVsbG4wZ2gOzJg7F9PGDsMZrCnJky6RK5wATYALaCSRPlhj5cmXRnsixMUogb84s+F/y4PNkjFYU6wrnDjMB/QhY6CfGUkxAPwJDxsxA044D0bH3SJQvXRSZM6bRLyNLMQEmEOMECufPiQHdWsZ4PVzBnwT6dG4GB/s8fyZwDBNgAgYhwAqvQTDHnkrmTBqGdYunwttzMpo3rB5mx89evIbuTuNCOXq/bpiZIpHIWZgAE4h+Au7z1+Kbr78o+Jdw/J8JMAEmYNwEWOE17vEx69Y52OfDPPcRoRwtVTDrTnPnmICZEShXsihqVC5jEJctSwYzo2fw7nCFTCDWEmCFN9YOPXecCTABJhB1Av17tIXr8N4GcZXKFo96g7kEJsAEYiUBVnhj5bCH0WlOYgJMgAkwASbABJiAmRFghdfMBpS7wwSYABNgAtFDgEthAkzAfAiwwms+Y8k9YQJMgAkYnEC7HsNRtVFng7gjJ88bvH9cIRNgAuZBgBXeKI0jZ2YCTIAJxG4Cnz5/wfsPnwziAgICYjds7j0TYAKRJsAKb6TRcUYmwASYABNQEeAAE2ACTMCICbDCa8SDE5Wm7Tl4AlPnLo9KEdGe9+Cxs3Cb7qW13Dote2uN1yeydbdhePvugz6iLMMEzI5A8y7OOHb6ktn1KzZ3yGn0LKzesCc2I+C+M4FoJ2BIhTfaG88FmhaBQvlyokWjmqbVaG4tE2ACWgk4dWuGeHFsRZpCOP7PBJgAEzBuAqzwGvf4RKl1r3zeoM/QiWjWyQnrNv+2FsxbvBZkUaV4rxUbVHXQJ4Gnz1uOXkPccOj4OVW8ekBT5tbdh+g20BVtug+Hk4s73n34KMUpf99hk9Ci8xC07DJExl26dhveG3bK8POXr+UX1hz7jsKkmYtlHHn/bt2LhcvWU1A6KuPOvUcy3HXAWFHeYLTuOgxHTvDDKxIKeyZKgJvNBJgAE2AChiTACq8haRu4rlev32KCSx8smTMOG7btw8fPX2QLqlUsjW2rZ2OZxwRcv/UAFy7fkPHkpUuTCnMmDUOF0kVpV6tTypQtWRhjJs9D366tsGLeBFSpUAIz56+SeeZ4emPiqL7w9pyEmROCFV6ZEOLN8fJGiaIF4DVzDNKmTglfX7+QFN2bIX06ifImY/r4QaD8vn5/5gkMDIC5ux8/gsy+jzE9hubE0M/PX1zQ7sOUOSsM6jbtPoX3n3zx5VuAwdymHUcM2kdDMJ3luRbuc0OPHRkSzGmOxvTxHBQUCHIxXc/fLl/3r6OJpxio+azwGgj036gmX57siB8vLuLGsUOmDGnx7LmPbIZ/gD/IkjtgxBS8ePUa9x89l/HklS/tQJswnVKGLMiv/3uPmQtWSSvvhm37cfveQ5k3X+5scJ+9DMu8t+Lnr18yTt27cfsBGtWpLKMa1a0it+F5j5+9EAr2fLi4zcWXr9/w4uWb8LJwOhOIRQToODO0MyzeXzB0/2K+Pjo9koNa336Bl4kYdmZxbbGBACu8ZjzK1lZWqt5ZWliIK2CyDAbBZcIc0Cc6yVJarWIpfFezrtpY/86jyqwR+C2jwD8pk2P+VBfpFk4fhXWLp0rp0UO6o1nD6uIU/gu9Bk+An3+AjFd54gxva2Mtd62sLKFQBJ/gLS0tQynIP+JyUqgAABAASURBVH78kDJk8fDesAttmtbB3CnOyJopPdTbLYWEZ21tA3N3lpZWZt9HjTGM9v6aE0M7O1s0rV8Fg3q1NahrUL0kkiaKgwTxbAzmGtYqb9A+GoJp3y7NRJ/aCPd7/HJnzwRLPs71Pu6trKxBLqbPG3+7fPBflAiwwhslfKaX+eOnz+IkYo38wvprY22NU+euRLoTqVOlkEr0noMnZBmBgUG4euOuDJMFNnuWDGjfoh6sLC3g8+adjFd6eXJlxYmzwXWfOX8Nv4QCTGmpU/1PZbn98PEz7j54QtF48uwlsmfNgMwZ0+Dz56+4ceeBjGePCTABJsAEmEDsIcA9jSwBVngjS85E86VInhS5c2QBvcpr0Mipcv1sZLtiIazG40f0wc59x9GuhzPqtuyN67eDFdGWXYaiQZt+cB43C1XKl0TGdP+EqqaXYwts230IPQeNx879x2BrawP6K1wwN5698AE9oDZj/kqkTxucr3Rxe9y4dV/GT5+3ArmzZyZxdkyACTABJsAEmAATCJcAK7zhIjJNAVqqMLBnW1XjSTEtlD+X3Hdx6oKV893g7uqEMUN7oEPLejKeliMkTBBfhnV5mjLZMmfATLchWOYxHrvWz0PLRjVkVnoobtOKGaB6O7ZuIOMqlnHAsP6OMkwPqrmPdZLLE8Y798aONXNlvJWlJZbOHYcF00bKtnnNHI0c2TLJtcjK+LHDesp8ZKWmTNSX5MmSUJAdAIYQuwisWTgeZYoXil2dNvPeuo/uI86l1cy8l9w9JmBYAqzwGpY318YEmAATYAJMgAkYhgDXwgRUBFjhVaHggDqBURM95HtyuzuNU23PXrymLsJhJsAEYjEB9/lr8c3XH4kSxkfSJIkM4mxsbGIxce46E2ACUSHACm9U6JlxXlrqMM99BNSdg30+8+sx94gJMIEoEaD3ee/d4AlDuHIli0SprZyZCTCB2EuAFd7YO/bccybABJgAE2ACKgIcYALmTIAVXnMeXe4bE2ACTIAJMAEmwASYAFjh5UkQAQIsygSYABMITWC6x3K4TJgdJXfizKXQhfIeE2ACTCCaCbDCG81AuTgmwASYQGwicOTkOezafyxK7tHTF6aHjFvMBJiASRFghdekhosbywSYABNgAkyACTABJhBRAqzwRpSY/vJScprHMuw5eEKGDe2t27wHvn5+Ea42utv84PEzHDt1McLt4AxMgAnoT2DU5IW4fe+J/hlYMsoETp2/hpkL10S5HC6ACTCBmCfACm/MM/5rNWzacQB+fgF/rX5lxY+evMCpc1eUu7xlAkwgBghcuXEPn798jYGSo6NI8yzjzdsP4iLjsXl2jnvFBMyMACu8ERjQE2cuY+jYGaoc5y5dR3/nKXL/0tVb6NxvDNr1cIbLhDn48vWbjA/PW7xyk/ywQ71WfTB17nIp3rTjQBmm8jr1GYV7D4OtNj9//sQcL2+07DIEbbs7Y+e+o1L+169f8Fi0Bq27DkP91n2lzI69R+Hz+i0GjZqmaiOVO33ecvQa4oZDx8/h4LGzqNW8J1p0HoyRbnPx9dt3WV543q27D9FtoCvadB8OJxd3vPvwUWZxm+6FCdO80HPQeMmBmFDC4lWbhIX3gsyz/8hpafHuN3wyeg2eIHn6vHmLgS5T0L7nCJn3waNnlC2UXAvHQbJflDB/6Tqs/ncnBaWbt3gtvDfskmH2mAATMAwBp27NEC+OrahMIRz/ZwJMgAkYNwGjUXiNG1Nw64oXzY8bt+7Dzz9ARuw/fBpVyhdD0I8fUmHs3rEplnmMh6WlJVas3SZlwvJ8hEJ64uxl+XGHLatmoU2z2irxDOlSwXPGKPTu3AJTZi+V8duFEvufsCgsnTsOHu7OWLdlHx4/fYnte4/g/OWb8Jw5CptWzECdauVRq2pZpEqZHFPGDMD08YNkfvLSpUmFOZOGoULposieJQM2Lp+O1QsnIX3aVPDeGL7S+EMo3WMmz0Pfrq2wYt4EVKlQAjPnr6KipfshWMwS5Xu4j8CM+StlXMdWDVCmRGHMn+qCyuWKy7gXr15j0uj+mDiyH2YvXI1c2bOA+lWjcmm4zVgkZchTyq2Y74Z7D57izIVrqF21HLbsOkjJIGV/76FTqF2trNz/+fMHzN39+vXT7PsY02NojgzpPHTzzgN5jNBxEtPu7sPn8PULREDgjyi7R+I8FtPtjYny7z96iqDAoCgdj+Y4F2P6+I2t5csfOfYiTYAV3gigs7SwQImiBXH4+FmQ4nf01EWULVkEL16+QYIE8WCfP5csrWn9qrgqbi/KnTC8ZEkTw18oz3MXeWPd5j1ImCC+SpoURNopmC8nnj5/JRW7C0KpvfvgCfoMnQinkVPx/sMncTvtIc5fuomWjWsijp0dFAoFMqT7h7JqdeVLO6jibWyssXzNVpC19fjpS3jw8KkqTVfglc8bvP7vPWYuWCUtthu27ZdtUMqXcCgASwsLxIsbBx8/fVFG/7G1L5BbylDC1Zv30LheFQpKRf3x0xcICgqS+wXy5pByVlZWKF4kP66LC460qVMiedIkIEvzybNXhLKcCQnix5PyAQEBMGcXGBgo2ZhzHw3Rt6CgHyCWhqgrEnVEag77+vpj2dqdGD99iUHc+h3H8e7Td3z+5h9lt2v/KYO0ObrZbN5xWBhA/CM1Xsp5QUYCZZi3kTt/B4nfC3Lmzk/+yLEXaQKs8EYQXWVh0aXb8qfPXUWBPNkQP15cWYK1UMhkQHiknP3CLxEK+7+1tRWWeoxDSaFE33/4DKPc5qgy/Pr1O78CChmvUCjg2LqhtJSStXSrsApXr1RapllZWslteJ6NqFMpM2nmIvyTMgVch/eUFltfvdb7KkSe5Ko2LJw+CusWT1UWCQuh7Cp3fqr1QRmn3NpYWyuDcqvkp1AooFAIF1KOZhFKLnWqlxOW7aPCHUatauVkGeTZ2cWBOTtbWztYW9uYdR8NMX7WYv4RS0PUZag6EsSPi0kje2PrymkGcc69myNtykRInjhulF2Pjo0M0uboZuPUqy3ii4vtqIyxlZU1H89RPG/b2NiCXFTGwRTyIlb+RV+nLaKvqNhRUtFCeXFX3FrftvuQvJ1PvU6T+n/4/OUbrty4Q7tYv2UvCubLIcNhed99/SBMtygkLMNdOzTG9dsPVOL0wBnt7D10EunSppJKYLHC+bBy/XbV+mB6+8HHT59RuGBurNm0S9xeFOWJTN+++wof0uL76fNXGdbmPXvhg9Il7KVl+fiZS9pE/ohLnSqFtDAq3zwRKG7nXb1x9w859QiyPH8K42Ga/LmzgSzFlIf6mzF9Gmklpv1T5y7jv7fvZd927j+GfLmzUjQqlHEAXXTcufdEXDAUkHHsMQEmwASYABNgAkxAGwFWeLVRCSNOoVCgTHF7nD5/DaWK2UtJK0tLjBzUFXM818iHtfz8/NGmaR2ZFpZHD2tVqNtJPvw1be5yOPVqrxL/+s0XLToPwdpNezCod3A8rW8tWawgug8ch+aOg+TDcT9//kLtqmWRN1dW0ANu9Vv3hceitbIcWuYw23OV6qE1GanmtW9RD516j5JLGuh2kFqSziBZcMeP6IOd+47LvtZt2TuUoq4to32BnPj18yf6DpsEso5ryvTu0hJXrt8GPbS2ZechDO3XUSWSPUtGDHBxl2mk8BcrnF+m2drYoHCB3KheqaS8GJCR7MVKAtxpJsAEmAATYALhEWCFNzxCWtJJAT28bTHsbG1UqWSl9ZwxSj605jq8l2qpw4Ae7VCtYimVnHogc4a0OLZzmXz4i5TICqWLqpK7tmsMb89JWDRrDLJlzqCK79ymEVYucMMarynyYbOkSRLJZQS9HFvI/c0rZ6oUZHpAbKrrINVDa+sWT5XWXGVhNauUxYZl0zBjwmD0794WM92GyKSw2kwC1B6SpQf0dq2fh5aNalA0hvV3REVheZU7wtu2erbwIS3NE1z6yvKpTcRjYM+2Mo28VP9LDmrn0rnjMHeKM7JkTEfR0tFDdvRw3NpF7qA+ykjh0dIG+jpT3eoVxB7/ZwJMYOyQrsiZLSODMCCBkkXzoW+XFgaskatiAmES4MQwCLDCGwYcTjJOAvReX3olWu4cmeSbKIyzldwqJmBYAvlzZxUXtMEPbxq25thbW4pkScRFxm+DROwlwT1nAsZPgBVeA43RqIke8n273Z3GqbZnL17TWrumJVarkAEiI9LmmGiOpiVYWUemDGmwcr6btEor43irJwEWYwJMgAkwASYQCwmwwmugQR8ztId83+489xGqrYN9PgPVHrlqTLHNkesp52ICTCCiBNznr8U3X3/MnDAUa7zco+ToOYSI1s/yTCCqBDh/7CLACm/sGm/uLRNgAkwgWglkSJ8aWTOnj5JLnChhtLaJC2MCTIAJaBJghVeTCO8zARUBDjABJsAEmAATYALmQIAVXnMYRe4DE2ACTOAvEThy4hx27T8Wrrt+695faiFXGy0EuBAmYOIEWOE18QHk5jMBJsAE/iaB6fOWw2XC7HDdll2H/mYzuW4mwARiOQFWeGP5BIjG7nNRTIAJMAEmwASYABMwSgKs8BrlsACtuw3D23cftLbu85evaNbJSWtaVCPp871dB4zFrIWrolpUlPOv27xHflKYCqI+N+04kILsmECsIrB1zzG89PkvVvXZWDsbEBiEJd7b9GgeizABJmBsBFjhNbYR+cvt8Vy+AbMmDkWfLq3+ckuATTsOwM8vQLYjbtw4GDmomwyzxwRiE4Hla3fg8bNXsanLRttXPz9/TJq93Gjbxw1jAkxANwFWeHWzibaUE2cuY+jYGaryzl26jv7OU+T+xm370b6Xi7Toei7/V8ZFxAsUFofJs5aAvjzWQZRz8NhZmb3f8Mm4++CJDFOa54oNMrxg6Xps3L5fhjW9KbOX4u3bD+g7bBJ27T8Ot+leGDtlPnoNcQO17d2Hj3AeN0u21bHvKNy4/UAW8fzla/kxDYqbNHMx6rTsLeO1eWS1Juv0cNeZ6DFoPHzevAVZlFt0HozWXYfhyInzMtuOvUfh8/otBo2aBmL1/buvbItMFF5UuYki+D8TYAJMgAkwASYQSwiwwmuAgS5eND9u3LoPP/9ga+X+w6dRpXwxPHz8AotWbcI0Vyd4zhiFg0JZPXXuSoRatHX3ITx94YOlc8dh1ODumDhjET59/or8ebLj8rXb+PrtO2xtbHDtRvAT0ldv3EXBvLm01jGod3skSBAP86e6oEbl0lLGPyAQs9yGoHPbxpi90BsF8+WUXzlzceqG0ZM8pMwcL2+UKFoAXjPHIG3qlPD19ZPxurynz33g2LYRPKY4I9X/kmNIn07w9pyM6eMHgcry9fNDraplkSplckwZM0DGq5cVHdzUy+MwE2ACESfg1K0Z4sWxFRkVwkXpP2dmAkyACcQ4AVZ4YxwxYGlhIRTCgjh8/Cx+/PyJo6cuomzJIrhy4zbKly6KpEkSIY6dHWpWKQusnsP6AAAQAElEQVRSSCPSpMvX7qBBzYqyjozpUyNvriy4c/8R7PPnFOXfleWRMvpNWEiDfvzA0+evkDljGr2rKFeyMCxE+ynDZaFA7zt8Ct0GusJthhfevv+I/96+l5beRnUqkwga1a0it2F56dOmQuYMaVUij5+9wJjJ8+HiNhdfvn7Di5dvVGnaAmFx+/btK8zZff/+Df7+fmbdR0OMn7+/P4ilIeqKah0fP31B6+4jka1YI6Ny3YbPxYNn7/Hq7Te93MIV242q/ZHhaV+pDcgIENUxVc8fEOAP9X0OR/wc7uvrKwwtvmbPUdvvIcfpT8A0FF79+2O0kpWFRXf/kdM4fe4qCuTJhvjx4sq2WltZyi15VpaW+CX+UTgizsraSiVuZWWFX7+AvLmz4frNe0LpvYOCebMjV/bM2LLzIPLkzKKS1SdA5anLTRYWV7IAkzu0ZRFSJE8KqtDWxlqKWYn+KBQKGdblWVsFy1L6rbsP4b1hF9o0rYO5wuKbNVN6fA/HQkz5rEU9tCWnzi1u3HgwZxcnTlzY2NiadR8NMX424q4HsTREXVGtI1HC+PCcPhyXDq4wKjd9pCMypUmMlEnj6uXaN69mVO2PDM+jWxfAxtoqWo8/a2ubaC0vqvPNFPPbCYMROVNse0TaTL937CJPwCLyWTlnRAgULZQXdx88xbbdh1ClQgmZtUCenDhy8gLef/gk30awc/8xFMqXU6bp6xXMlwPbdh2SluPHT19Ka2uu7JlASiAtCTh07KxUfgsIpZcUy/x5I1a+ejuK2ufF/CXrhX4rNGqRcP7yDeEDeXJlxbot+2SY1tb+Io1b7oXvPXn2EtmzZpBW58+fv+LGnQeqTGT1puUZqoiQQFjcFAoFFAp2CgUzUCjMhwEdC3SRTM5YXBw7W3n3x8JCIbbhOxtra3mhbyztj2w7FArzmVcKBfdFoTAdBuC/KBFghTdK+PTPrFAoUKa4PU6fv4ZSxexlRlpa0KZJbQxwcUfnfmNQtoQ9ihXOL9P09epWr4D/pUiG9j1HYMzkeXDq1R4JE8SX2fMLSzKFaQ1vgbw58OLVG6FQ55BpkfF6OjZHQEAA2nQbLh9M27T9gCyml2MLHDt1AS06D8H9h88QJ46djNfHKy2Y0PrmrgPGYvq8FcidPbMqW8vGNTHbc5V8aE0VKQLRwU0Uw/+ZABNgAkyACTAB0yUQoZazwhshXFETpofCDm9bDDtbG1VBDetUxtI5rvJBMHowTJmwcr4bkidLotwNtSUldu0idxlnLW6vDe7TASvmTcASUU6F0kVlPHk9O7WQD5JR+H/Jk+LUnpVyaQPt63I71wY/iEbpw/o7omIZBwpKlzhhAvlqsJUL3LBt9WyMH9FHxtODavPcR8DbcxKGD3CUcbo86hPlV6aTlYUeuFswbSTGDusplzXkz5NdJlcuVxxTXQfJh9aoz+sWT5Xx5OniRmnsmIA5EahbvSxSp0phTl0y2b7Y2FijY8u6Jtt+bjgTiM0EWOGNzaPPfWcC5k7ADPrXtmlNZEz3jxn0xPS7QMaKwb3amH5HuAdMIBYSYIXXiAed1q92dxon33GrvqX4qDSb8quXpwxTfFTKVeYl6y+VpSxXfUvxSjneMgEmwASYABNgAoYhENtrYYXXiGcAPZ1NSwU0HcVHpdmUX7NM2qf4qJSrnpfKojI1HcWry3GYCTAB0yWQK0sq9OveVi9HS5RMt6fccibABEydACu8pj6C3H4mEG0EuCAmoD8B9/lrcf76E5QvVQStm9QO10X0gVz9W8KSTIAJMIHwCbDCGz4jlmACTIAJMAEmwARiEwHuq9kRYIXX7IaUO8QEmAATMBwB+hIcvUtc3Rmudq6JCTABJqAfAVZ49ePEUkxAkwDvMwEmIAi07zkcVRt1DuXoC4oiif8zASbABIyGACu8RjMU3BAmwASYABNgAqZIgNvMBIyfACu8xj9G0drC1l2H4e27D2GW6bFoDZo7DkLt5r0wdsp8+AcEhCn/txJ9/fywbvOev1U918sEDELg2YvX+Pzlm0Hqiq2V3Lr3GD9//oyt3ed+M4FYQYAV3lgxzL87SV9PS5Qwwe8ILaEC+XJijdcULJ83HrQub9P2g1qkIhYVE9J+fgHYtONATBTNZTIBoyHgOm0Rjp66ZDTtMceG1G09EL5+/ubYNe4TE2ACIQRY4Q0BYW6bb9994eq+EF0HjEXVRl2x99BJ2UW36V749PmLDC/z3oomHQai1xA3OI+bhdX/7pTxpRwKym3SJIlQUCi/b96+k/vavAePn2HomOno0MtF1vP8pQ9me64OZXlduGw9lq/dBm2y2sokC3SzTk4Y7joTPQaNh8+bt9hz8ATadB+O1t2GYfq85fghrDFeKzfC5/VbdBvoinmL12oriuOYABNgAsZGgNvDBJjAXyDACu9fgG6IKg8fP4ckiRNgwbSR2LnOA0UK5glV7b2HT7B550Esnj0Wbi59cOvuo1DptOPr54fte47AwT4v7Wp1q9fvRJ0aFbBkjis2Lp+OpEkSo0r5Ejhw9IxKft/h06gq4rTJqoQ0Ak+f+8CxbSN4THGGv38glgrlfOaEIVjuMR7+AUHYtvswHFs3RKqUyTF/qgu6d2ymUQLvMgEmwASYABNgAkwgmAArvMEcjMuPhtZkz5oBJ89eBllXj526KBTRRKFKvX7rPsqVKowE8eNJV7GsQ6j0X79+YcT42ahYxgHFixQIlaa+kz9PNnhv2AXPFRvw7IUP4saxQ85smeRSiLfvP+LOvUdInCihVEy1yaqXpR5OnzYVMmdIK6OuXL8NslgPF1ZosvheuX4HN28/lGmanp9Q0s3Z+fv7IzAwEObcR0P0jRgSS0PUFdU6aO7PWbQe7XuPMSpnZW2HT18D8P6Tn3C+odwIt/lG1dbw2AUGBv21Yyoo6O/VHdW5aSz5AwICQM5Y2hNT7dD8veP9iBGwiJg4S5sKgWyZM2Dh9FHImT2LXF6wZuPuUE0nhdbS0lIVZ2X1O0yRXkKBJcW1R6fmtKvT1atZESMGdEaaVCmEgjxHWIqDFVH6jOjegyex9/ApUJgK0CVLaZrO2sr6d5RCgTIl7KUll6y53p6TMHyA4+90tZCVlRXM2dGYWVhYmHUfDTF+xJBYGqKuqNZhY22NEkXyoUndSkblShfNjYTxbBHXzvoPV7V8sWhrqyH6TfMhquMU2fwKhYKP5yiety0sLEEusmNgKvnAf1EiYBGl3JzZaAl8+vwV8ePFRVmhKDasXQlk0VVvbN5c2XDxyi2Q4kvu/KUbquS1m/bg7buP6Ny2sSpOV+DL12/SeluzSlm59OHW3WCFt3ql0tgnlN0DR86gUrliMrsuWZkYhlekYG7QEo0Hj55JqQ8fP8v1wHHj2uHLl+8yTumZyokrKu20FBcqUcnPea1gSgytra1QuEBO1KpS2qhckfzZED+uDexsrf5wZUsUMqq2hsfO0tLirymdlnw8RwN7S1EGOfM2eID/okTAIkq5jSIzN0IbgUPHz6JMrfbyoa8jJy6gQ6t6ocSyZ8mA8qWKovcQNziNdEfypIkRP35cBP34gRnzV2Dr7sMoUa21dPTwW6jMajuTZy1B5Qad4eTijgBxW7BaxVIyNUO6f+DnH4C0qVPKsilSlyylheVSp/ofBvZsh/HTPEEPrrXt4YyPQum1tbFBrapl0HfYJH5oLSyAnMYEmAATYAJMIJYTYIXXTCdA/ZoVcWzHUvnQ1zjnXsiSMZ3s6coFbkieLIkMN65XBXMmD8c45974+Okr8ubMBithbTi1ZyXUnYtTFymvzXMd3gv7N3nC3dUJJBcvbhyVGC09oPKVEWHJKmVoS+2jdlJY6Wgt8eLZY7Fi3gRsWz0bhUMewqOH1Wa6DeGH1pSgeGt2BNKnSYVECePp1y+WihSB3NkzwdKCfw4jBY8zMQETIcBHuIkMVEw0c8iYGWjacSA69h6J8qWLInPGNDFRDZfJBJhAFAiMGNARZYoXikIJnDU8AltWuMPOzjY8MU5nAkzAhAhoNpUVXk0isWh/zqRhWLd4Krw9J6N5w+ph9vzsxWvo7jQulBs10SPMPOEl0jpjzTJpn+LDy8vpTIAJMAEmwASYABPQlwArvPqSiuVyDvb5MM99RCg3ZmiPKFFJlDB+qPKU5VN8lArmzExALwIsFFUCKZLER7HC+f9w6kuboloH52cCTIAJRAcBVnijgyKXwQSYABOIhQQc8mfC3Ckj/nDp0/4TC2lwl5mACROIBU1nhTcWDDJ3kQkwASYQ3QTc56/Fut3n8fylT3QXzeUxASbABKKdACu80Y6UC2QCZkmAO8UEmAATYAJMwGQJsMJrskPHDWcCTIAJ/H0CfYe5oX3P4X+/IdwCJmAwAlyRKRJghdcUR43bzASYABMwEgJPnr3E/UfBX0E0kiZxM5gAE2ACfxBghfcPJBzBBKJOgEtgAkyACTABJsAEjIcAK7wGHovW3Ybh7bsPBq41uLp1m/fA188veCcC/t9scwSayaJMwGQIbNl9FCPc5plMe2NbQzsPmIDTF67Htm7HVH+5XCZgFARY4TWKYTBMIzbtOAA/vwDDVMa1MAEmoJOAv38Avn7z1ZnOCX+XwJev3xAYGPh3G8G1MwEmEK0EWOGNAs4TZy5j6NgZqhLOXbqO/s5T5P7GbfvRvpcLyDrqufxfGRee9+27L1zdF6LrgLGo2qgr9h46KbPQ53+nzl2Ozv3GoFOfUbj38ImMf/fhI5zHzZJ1OPYdhRu3H8j4X79+wWPRGrTuOgz1W/fFHC9v7Nh7FD6v32LQqGmqNlK50+ctR68hbjh0/BzmLV6LOi17o1knJ3it2CDL0se7dfchug10RZvuw+Hk4g5qF+Wj8mctXIVuA1zRd9gk/Pf2PUXj58+fsk0tuwxB2+7O2LnvqIzfc/AE+g2fjF6DJ0iufkIpoK+5EcOBLlNk/+/ce4T5S9dh9b87ZR7yqN3eG3ZRkB0TYAJMgAkwASbABP4gwArvH0j0jyheND9u3LoPUswo1/7Dp1GlfDE8fPwCi1ZtwjRXJ3jOGIWDx87i1LkrJBKmOyyUziSJE2DBtJHYuc4DRQrmUclnSJdKltW7cwtMmb1Uxs9e6I2C+XJi5Xw3uDh1w+hJwZ/63b73CM5fvgnPmaOwacUM1KlWHrWqlkWqlMkxZcwATB8/SOYnL12aVKBPDFcoXRTVKpbGttWzscxjAq7feoALl2+QSJjuh1Bex0yeh75dW2HFvAmoUqEEZs5fpcqTKUMazJ/mgqYNqmHl+u0yfrtQvv97+wFL546Dh7sz1m3Zh8dPX8q0F69eY9Lo/pg4sh82bT+Ab9+/y3K7tG0s2nRPytSuWg5bdh2UYVLu9x46hdrVysp9ssqYuwsKCoK59zGm+/fjx4+/ypDqpznvtXILTNV99/WXx9w33yB8+uJnsv3Qxv+/dx9gqOOM5oL6fOdwYISPTRorcubOTh5wP7EtyQAAEABJREFU7EWaACu8kUYHWFpYoETRgjh8/CxI8Tt66iLKliyCKzduo7xQIJMmSYQ4dnaoWaUsrt64G25N2bNmwMmzl7Fw2XocE2VRfmWmMiUKyyApuE+fvwIpepev3ca+w6dA1lW3GV54+/6jtKKev3QTLRvXlHUrFApkSKf7q0flSzvIcsnzD/AHWXwHjJgCUjzvP3pO0WG6Vz5v8Pq/95i5YJVsxwZh2b5976EqT+li9jKc6n/JhFL7SoYvCGX87oMn6DN0IpxGTsX7D5+gzGNfIDeUnyW9eecB6lSvAIVCgRzZMiF3jiwyf9rUKZE8aRKQZfnk2SvIlT0TEsSPJ9N+/fop2JivA36Jfv4y6z4aZgz/PkNa0vDg8TOYqsuYPg2++wUh6MdPBAb9MNl+aONPS05+iTtlvwxwPqFj2hD1cB2m/7sgTv78PwoEWOGNAjzKWllYdPcfOY3T566iQJ5siB8vLkXD2spSbsmzsrQUagopKrSn22XLnAELp49CzuxZQA+Yrdm4WyX8S5x8g3cAhfiHkL/JwmI7f6oLyB3asggpkieVKVaWVnIbnmdjHSwXGBgElwlzUKlscWkBrlaxFL77+oWXXaQr8I+wHFP95Kj96xZPFfHB/y0tg6eYAhb4IaxqEH8KhQKOrRvKNlOeratmoXql0iIFsLG2llvyqMvEjsLkrNSY1qleDtuFpXj73sOoVa0cJUtnY2MLc3bW1jawsrI26z7aGGAMrays/ipDKzGGeXNlgduIXibr2jaqhBRJ4iFRfFskF1tT7otm2+mi2lqciwwxFy3FudoQ9ZhzHXReJGfOfaS+yR859iJNIFgbiXR2zli0UF7cffAU23YfkrfziUiBPDlx5OQFabmktyLs3H8MhfLlpKQw3afPX6XCXLaEPRrWriRu4d9XydMDZ7Sz99BJpEubCgqFAkXt82L+kvXC2hesTJ8PWYJQuGBurNm0S/VGhm/fgx+OIWsz1UHlaLqPnz6DTvD582SXSqc+SzCojNSpUoBuJe05eIJ2xa2ooHCt2cUK55PLG+jBEMr0QFi5qH4Kq7s8ObPgwpXgZRWfv3zFnXuPVckVyjjIi4w7956gZNECqngOMAEmEIsIcFeZABNgAnoSYIVXT1C6xBQKBcoUt8fp89dQKuT2feaMadCmSW0McHGXD1qRAluscH5dRajiDx0/izK12qPHoPE4cuICOrSqp0qj258tOg/B2k17MKh3exnf07E5AgIC0KbbcPmwGa15pYTaVcsib66s8gE3emjNY9FaipbLHGZ7rlI9tCYjQzyyDNOSgdbdhmHQyKkgC0dIUpgbCwsLjB/RBzv3HUe7Hs6o27I3roc8PKcrY43KpVGyWEF0HzgOzR0HScvyz5/BSrt6ngZC6X//4bN84I3WLdN64HghFnRbGxsULpBbWIZLSuVfPR+HmQATYAJMgAkwASagTsDcFV71vsZYmBTQw9sWw87WRlVHwzqVsXSOq3ygrHPbxqp4esAsebIkqn31QP2aFXFsx1J4THHGOOdeyJIxnSq5a7vG8PachEWzxoCWPlBC4oQJMHJQN6xc4AZ62IwUT4onJbSXYwusXjgJm1fOVCnIlcsVx1TXQXLJAsnR0oOECeJTUDoXpy6g9rm7OmHM0B7o0DJY4aY4XW2mjNSemW5DsMxjPHatn4eWjWpQNNTLp4uAOZOHy3jyOrdpBGr3Gq8psp20XpmWUQzs2ZaSpbOxtsLQfp1AZXfv2BR+fn74R1iUKZGWeDx6+gJ1q1egXXZMwKQI1KtRDuOHdzepNsemxnpOc0bxIvliU5e5r0zA7AmwwiuG2F9YSekBKBHk/0ZE4MePn6jRpBtadRmK4a6zMKBnO1haWODRkxegV6DlzpFJvnnCiJrMTWECehGwtbFWPZwJg/1xRfoSSBA/LqytrPQVZzkmwARMgECsV3hPnr2M+q36YtTEuXK4bt97hH7DJ8lwTHm0jra70zhoOorXVqe6pVRbuqHi6J24mm0+e/FajFVvLSy8h7YuxqqFE7F07jjQemmqjJY2kNW5f/e2tMuOCTABJsAEmAATYAJhEgil8IYpaaaJ9FEGz5mjkTRJYtnDnNkygd4RK3diyEuUMD7muY/4w1F8DFUZLcXSMgfNdjvY54uWsrkQJsAETI9ArXL5cP7gOhzfucL0Gs8tZgJMIFYRiPUKL9220nxA6xf+fIAqVs0K7iwTYAJMgAkwASbABMyIACu84rY5ffhAOaYXr95SWXuVcbxlAkyACTCB0ATc56/Fut3n8fylT+gE3mMCTMDMCJhHd2K9wuvUqz3GTpmP+w+fotsAV0yc4YU+XVqax+hyL5gAE2ACMUSAvkYWQ0VzsUyACTCBaCcQqxXeoB8/5IcSpo0bhNFDeqBJ/Srw9pqC7FkyRDtoLpAJmDMB7lvsI+AXEBj7Os09ZgJMwGQJxGqFlz5b67l8A+i9taWLF5Kf1bW0iNVITHYic8OZABNgAkyACRgBAW6CkRKI9dqdra017tx7FCPDc/DYWbjNWKR32XVa9tZbNixBWe90r7BEIpW2bvMe+Pr5RSqvvpki0/b+zlNibAz1bTfLMYHIEBjhNg+fv3yLTFbOE0kCS9dsx4WrtyOZm7MxASZgqgRivcL74tUbtO/lghaOg9BtoKvKmeqAUrsL5cuJFo1qUjBa3aYdB+DnFxCtZWoWFlNt16znr+5z5UwghMD2vSfg5x+zx1RIVbwJIXD24g08f/E6ZI83TIAJxBYCsV7h7d+9DWZNHCq/4tWpdQMoneYE+PrtO+q26gP6pC2l0Y9UjaY9EBQUBJ83bzHQZQra9xyBnoPG48GjZyQSrnv+8rX8+IRj31GYNHOxSj4wMAiTZy2RXxPrIJRxsnpS4tt3H9BcKObO42ZJBZ229FYJ+hhE044DQR/NILlL127De8NOCsJNWHonTPOS7WrXwxmXrt6S8U+evUKTDgPlV8zoYb2Hj1/IeFUd42ejS/8xGDd1IX78/Ikde4/C5/VbDBo1DWRRlcJaPGrH1LnL0bnfGHTqMwr3Hj6RUu8+fAS1t3W3YaD+3rj9QMbvOXgC/YZPRq/BEzB07Ayot10XV/oyHn0Eg8oaMGIyaGxkYewxASbABJiASRHgxjIBQxGI9Qovfb1Lm9McgPjx4iJ75vQ4e/G6TDpy4hxKOhSElZUVZi9cjVzZs4C+Blajcmm9lzHQRy9KFC0Ar5ljQO8C9vUNXi6wdfchPH3hI8sbNbg7Js5YBOVX2F76/IfObRtjxYKJePv+I3btP445k4djaD9HzF+yTrZN0/vx4wdmTRoGD/cRmDF/pUxOkjiB/PAFfcWsU5sGcJ+7VMaTR3U4tm6IhdNHIXGiBDh28iJqVS2LVCmTY8qYAZg+fhCJ6XQZ0qWC54xR6N25BabMDi539kJvFBSWZ/pCmotTN4ye5KHK/+LVa0wa3R8TR/ZTxVFgtg6uW3YekreBl3uMh2ObRrh+6x6JS0cXJOx+yQsz5mAaHJ4+98Gjpy9NztH8ooPumbhwN6X203mW2s7ONI4PHqff40THG7vIE4j1Cq/6Mgb1sDaklcsXx4EjZ2TSvsOnUKV8MRm+evMeGterIsOkGD5++kJafmVEGB5ZORvVqSwlGtUNzk87l6/dQYOaFWFpYYGM6VMjb64suHM/eJ1x6lQpZBw9cJcjawbkzZlFyuXNlRVPnr+i7H+4Eg4FpEy8uHHw8dMXmW5nZ4v9oi+DR0/DopWb8OTZSxlPXpp//gf6fC+F/5c8KR4/e0FBvV2ZEoWlLCm4T0Wb6IR1WVidiVm3ga7igsBLKuv/vX0v5ewL5Aa1Te6oecFcg7moc70meNevVVE+bJg7RxaQU2bz8/OFOTt/fz8EBgaYdR8NMX5BQYEgloaoK6w6/AMC0X3wRLTsOsLkXGDgD3nY9R8xzaTaflGcX43pGPrxI4iP5yietwMC/EEurGPNHNLkAcdepAnEeoVXuYSBti0a1kASYfkkRVIb0fKlHXDq3GVhXfyKG7cfoqh9PpUYfbGNdhQKBRQK4YSySvthul+/YGtjLUWsrCxlPrkjPCtrK+EH/ycrshCVO1aWv+Pp7RLWIXIUDgoK/gGSgmoepSl3f4YUtG7TXjx76YMB3dvCY4ozfH39ofyztLBUBoVSqRDKu/ZyVUIaAVJwlVGChDKIycI6PH+qC8gd2rIIKYQyTYk21sEMKKzpdHElhV8payXYKcNx4sSFOTs7uziwsbE16z4aYvysrW1ALA1RV1h12NnaYMfqGTi1a7HJuYziTk7Nsnlxevcyk2p7KWEAsDGiY8jKylr/49nMz29hHSthpdna2sFWuLBkzCFN+TvH28gRsIhcNvPJpb6coVypInBz6SesndotpfTjlDd3VkyatQQVyzhIqynEX/7c2bBh234RAvYeOikssGlUaTJSh5dHWGVPnL0iU8+cvyZvQ9NOwXw5sG3XIbl29rG41UmW4FzZM1FStDmyvNrnywVapnDq3FUECStDeIXHsbNTLa0IS5YebqN0YpEubSqpyBe1z4v5S9ar+nj+8g0SCdPp4ppP8D536ZrM+/HTZ9y591iG2WMCTIAJMAEmwASYgDYCsV7h1YRC1skPHz9rRqv2K5crjoNHz6ByuWKquN5dWuLK9dugh9ZofenQfh1VaWEFejm2wLbdh+QDZTv3H4OtsPZA/NWtXgH/S5FMljdm8jw49WqPhAnii5Rw/+stQEsw5i1Zix6DxuPi1ZtIlDBBuHlbNq6J2Z6rwnxojQr5+s0XLToPwdpNezCod3uKQk/H5uKWUwDadBsOev3apu0HZHxYni6u9WpWwIePX9Bn6ESMmbxAKO3JwiqG05gAE2ACTIAJMIFYTiDWK7y0plTdNevkhPx5cuicFpXKFsepPStRKH8ulUyq/yXHVNdBWDp3HOZOcUaWjOlkWkVhBR7Wr5MMa/PoQTX3sU4yz3jn3tixZq4Uo2UKg/t0wIp5E7BkjisqlC4q45MnS4KVC9xkmLx+3dqgZpWyFATd4t+2erYMy3r7O8rwMLGlfbkjPKVM9iwZ8O/SaXI5Q+/OLaGM16yjcd2qcGzTUOSEUPKLy36G99Ba13aN4e05CYtmjUG2zBlk3sRCoR45qJtsP9U1fkQfGV+tYikM7NlWhsmjtlKbKayLq62NDcYM7QF6uwa1ZY3XFOTIFr0WcKqfHROIaQLjh3cXF7PxYrqaWFq+9m63b14bhQv8Pn9rl+JYJsAEzI2Ahbl1KKL9obW76m7M0J6hFLCIlsfyTIAJMAF9CdSqUgq0VEpfeZaLOgEH+zxIm/p/US+IS2ACTMCkCMRqhZdG6tXrt1Bfx5sre2b8u3UvJUWbW7V+h3zfLr0vV+koLtoq+AsF0XtwlX1Rbs9evIZ1i6cKi1X0Lr/4C93jKpkAE2ACTIAJMAEzIhDrFd6d+479MZybdxz6Iy4qEa2a1JLvvJ3nPnpT3dIAABAASURBVEK1pTiY8N+YoT1UfVH2y0HtrRUm3DVuOhOIjQQi3Oe6VUqwdTrC1DgDE2ACf4tArFV4z126joXL1uP1m3dyS2FyM+av+FtjwfUyASbABEyGQJp/UsDKMtb+hJjMOHFDmQATCCag/9kqWN7s/SyZ0sHD3dns+8kdZAJMgAkwASbABJhAbCEQaxVeWrfbpV0TTBzZF7RVujrVyvMa1Ngy+7mfTCCSBDgbMHHOaqzbfR7PX/owDibABJiA0ROItQqvcmTodVb0YYdl3ltDLW1QpvOWCTABJsAE/iTw7bvvn5EcwwSYQGwjYDL9jfUK7+JVmzF51mJs3nkQ795/EttDePbitckMIDeUCTABJsAEmAATYAJMIGwCsV7h3X3gmPxAQsoUyUAfPNi4fAb8/P3DphZDqfQFsugo+uCxs3Cb7hUdRYUqY93mPfD18wsVF907kWl7f+cpuHPvUXQ3hcuLLgJcTpgE7j96hotX74Qpw4lRJ/D2/UccPH4+6gVxCUyACZgkgViv8MaNGxdWVlYICAzEj58/5Wt2LBQKkxxMZaML5cuJFo1qKnejbbtpxwH4+QVEW3naCoqptmuri+OYgDEQOHb6CjZsP2gMTTHrNjx68hKzFq4x6z5y54yfALfw7xGI9QpvvDh2CAwMQqYMaTHOfSFmL1wF/4AgvUeELKljp8xHryFumOO1GnVb9cGvX79kfj//ANRo2gNBQdrLe/7ytfwghWPfUZg0c7HMQx61Z/KsJWjTfTg69HIBWT0p/u27D2juOAjO42ahRcj24tVbsoymHQfidoiV89K12/DesJOySEvvhGle6DloPNr1cMYlIU8JT569QpMOA9Gqy1B0G+CKh49fUDT2HDwBJxd39Bk6EdSutZv2yPgde4/C5/VbDBo1DWRRlZFaPGrH1LnL0bnfGHTqMwr3Hj6RUu8+fJTtbt1tmCyX1k1TAtXXb/hk9Bo8AUPHzoB6233evMVAlylo33OEbP8DYQmjPP4BAaAPX1BZA0ZMxtdv3ymaHRNgAkyACTABJsAEtBKI9QrvwJ7tpXW3f/fWSJc6JWxtbeA8wFErLF2R/gGBmOU2BL0cWyJ75vQ4e/G6FD1y4hxKOhSUFmQZoeHN8fJGiaIF4DVzDNKKun19g5cLbN19CE9f+GDp3HEYNbg7Js5YhE+fv8rcL33+Q+e2jbFiwUTQLbpd+49jzuThGNrPEfOXrJMymt6PHz8wa9IweLiPwIz5K2VyksQJ5IcjVi2ciE5tGsB97lIZTx59fW6CSx/ZrgNHT+Pj5y+oVbUsUqVMjiljBmD6+EEkptNlSJcKnjNGoXfnFpgyO7jc2Qu9UVBYnlfOd4OLUzeMnuShyv/i1WtMGt0fE0f2U8VRYPbC1ciVPQuIQ43KpeEmOFD8lp2H8PnLNyz3GA/HNo1w/dY9ijYTx91gAkyACTABJsAEoptArFd4M2dMIxRSSzwTCmbH1g1ArydLkTxphDiXK1kYFhbBKCuXL44DR87I/PsOn0KV8sVkWJtHVs5GdSrLpEZ1q8gteZev3UGDmhVhaWGBjOlTI2+uLLhzP3iNaupUKWSclaUlcmTNgLw5s0i5vLmy4snzV5T9D1fCoYCUiRc3Dj5++iLT7exssV+0c/DoaVi0chOePHsp48krkDcH4seLS0EkS5oIz55H7LVDZUoUlnlJwX0q2kQW78vC6kw8ug10FYqrl1TW/3v7XsrZF8gNapvcUfOu3ryHxvWCuZDC/fjpC2ktvybi69eqKJnnzpEF5JTZvn//BnN2vr7f4e/vZ9Z9NMT4BQT4g1gaoq7w6ggQdyy27D4Kh2rtTcoFBP6Qh12D9oNNot2dB4wXF8pfje7YCQwMMLo2hTdnDZau5/ncz88P5IytXdHdHnnAsRdpAsFaWqSzm37Gk2cvo36rvuIW+VzZGVoW0G/4JBnW16M1wErZ8qUdcOrcZXlivXH7IYra51Mm/bn99Qu2NtYy3srKEgrF77XDVtZWMp48Kl+IUhBWlr/jScm2DpGjcFBQ8A+QFFTzKE25+zOkoHWb9uLZSx8M6N4WHlOcxY//7wf1LIUyjZA/C4WFVDJDdvXakIKrFFRAoQxisrAOz5/qAnKHtiyC8sLCxjqYgUpQLWBtFdxfhUIBhUI4cRFAyaTw05aclWBHW3J2dnFgzs7W1g7W1jZm3UdDjJ+VlTVsBUtD1BVeHdZi/lcqUwTrvdxMylmHHHdz3JxMot2uQ7oinriQD288DJ1uKc7phq7T3OqzsbEBOXPrl2Z/6DeOXeQJWEQ+q3nkpGUFnjNHI2mSxLJDObNlwn9vP8hwZDw7WxvkzZ0Vk2YtQcUyDrC00I04j7DKnjh7RVZz5vw11drfgvlyYNuuQ/IhusdPX4IswbmyZ5Jy0eWR5dU+Xy6kSplcKOhXEfQjKNyi49jZqZZWhCVMD7dR+t5DJ5EubSqpqBa1z4v5S9ar+nj+8g0SCdPlz50NG7btlzJUVsb0aSTPfCL+3KVrFC8s1p9x595jGSaPlHt2FmAGpsNAoVDIOyoZ0v0DU3IpkidGzbJ5UaxwfpNoN53rLC1MZ17wMcxjpTkH6DeOXeQJ6NbGIl+mSeUkCyKtn1Vv9C/8Ut+NcLhyueI4ePQMKpcrFmbeXo4tsG33IflA1s79x0DrhyH+6lavgP+lSAZ6WGvM5Hlw6tU+2r/+RksF5i1Zix6DxuPi1ZtIlDCBqDns/y0b18Rsz1VhPrRGJXz95osWnYeAHngb1Ls9RaGnY3PQrds23YaDXr+2afsBGR+W17tLS1y5fltyoHW7Q/t1lOL1albAh49f5IN1YyYvEEp7MhnPHhNgAkwg9hLgnjMBJhAWAVZ4ra3w/sMnFaOLV2+prL2qyDAC9O7eisKSqy5SqWxxnNqzEoXy51KP/iNMirb7WCfMneKM8c69sWPNXCljLdo0uE8HrJg3AUvmuKJC6aIyPnmyJFi5wE2GyevXrQ1qVilLQdAt/m2rZ8swtYfaRTu0pX0Kk1PKZM+SAf8unSaXM/Tu3BLK+GoVS2Fgz7YkKt34EX1U/SBFfqrroHAfWuvarjG8PSfJ9xtny5xBlpNYKNQjB3WT7ae6qFxK0KyP2kptprRU/0sOqm/p3HGSUZaM6SgatuL21ZihPTBr4lDZljVeU0BfzJOJ7DEBEyOQLXM62OfPYWKtNr3mJk+WWNx1Cz6Xml7rucVMgAlElYBFVAsw9fxkPaXXit1/+FS+nmviDC/0EZZFU++XtvZzHBNgAsZHoHSxAmhUu6LxNczMWpQpfWr06dzMzHrF3WECTEBfArFe4aU1u9PGDcLoIT3QpH4VeAtrIVk/9QWoj9yq9Tvku3K7O41TbSlOn7zGKkPvwVXvD4XPXryGdYunRvvyC2NlwO1iAkzAZAlww5kAE4hlBGKtwkvrSJVjvWbjbpQuXgi0FMHSIvqRtGpSS77zdp77CNWW4mDCf7SkQL0/FHYI640UJtxXbjoTYAJ/EiheKDeUb2r4M5VjmAATYALGRSD6tTvj6p9erVm/Ze+fchzDBJgAE2ACOgkUs88FWxtrnemcwASYABMwJgKs8BrTaHBbmAATYAJGSICbxASYABMwdQKxVuH99s0XC5etl+7L129yq9ynrakPLLefCTABJsAEmAATYAJMIJhANCm8wYWZkp89awZcvHpbuqyZ08utcp+2ptQXbisTYAJMICYIzJi3HEUqNtXqhrl5Yt3u83j+0icmquYymQATYALRSiDWKrz0eduwXLRS5sKYABOIPQS4p0yACTABJmB0BGKtwmt0I2GgBrXuOgxv330IszaPRWvQ3HEQajfvBXpHsX9AQJjy+iQ+ePwMx05d1EeUZZiAWRL49Pkr/AMCzbJvxtIpPz9/fPn63Viaw+1gArGegDEBYIXXmEbDAG2hr5glSpggzJoK5MsJ+nrZ8nnj5VfoNm0/GKa8PomPnrzAqXNX9BFlGSZglgT6DJ+Ko6cumWXfjKVT67cdxLhpi42lOdwOJsAEjIgAK7xGNBjR2ZRv333h6r4QXQeMRdVGXbH30ElZvNt0L3z6/EWGl3lvRZMOA9FriBucx83C6n93yvhSDgXlNmmSRCgolN83b9/JfW3enoMn0G/4ZPQaPAFDx87Auw8fZVmtuw2DY99RuHH7gcy2eNUmYeG9gG4DXbH/yGkZp+mRFXjomOno0MtFtpnWBnbsPRIPHj1TiVJ+KlObrEqIAyZEgJvKBJgAE2ACTCDmCbDCG/OM/0oNh4+fQ5LECbBg2kjsXOeBIgXzhGrHvYdPsHnnQSyePRZuLn1w6+6jUOm04+vnh+17jsDBPi/t6nQvXr3GpNH9MXFkP8xe6C2V5JXz3eDi1A2jJ3nIfB1bNUCZEoVB66Yrlysu4zS91et3ok6NClgyxxUbl09H0iSJUalsMew7ckqKvn3/ET6v3yJPzizQJiuF2GMCTIAJMAEmYIoEuM0xSoAV3hjF+/cKp7dQnDx7Wb5ujdbOkrVWvTXXb91HuVKFkSB+POkqlnVQT8avX78wYvxsVCzjgOJFCoRK09yxL5Ab8eLGkdGXr93GvsOnpCXXbYYXSEn97+17mRaelz9PNnhv2AXPFRvw7IUP4saxQ7VKpXDgyBmZde/Bk6hWsaQMa5OlBH9/f5izCwgIQGBgoFn30RDjFxgYZHCG3319sXj1VgwaPdNk3J7DZ/Hxi59W91OcI+iYmzhzqdH0Z8P2g/D1M61zQFBQkMHnoiGOMUPWERAQCHKGrPNv1EXHG7vIE2CFN/LsjDpntswZsHD6KOTMngXrNu8BfT5ZvcGk0FpaWqqirKx+hynSSyidObNlQo9OzWk3TGdjbR0qffKYAdKSS9bcQ1sWIUXypKHSde3Uq1kRIwZ0RppUKYSyPUdYnR8iedLESCYsvXfuPZJLIaqULyGza5OlBAsLC5ixg0KhkM6c+2iYvikMPk8sLSyRPk0q5M6R2WRcimRJYC3ODdqcAsF/WTOnM5r+/JMyOSwtFAYfWwuLyJ93FArTam9U+hpzeYkhuciPQ8y1LfraBP6LEgFWeKOEz3gz0xPh8ePFRdkS9mhYuxLIoqve2ry5suHilVvSkkvK7/lLN1TJazftwdt3H9G5bWNVnL6BovZ5MX/Jelku5Tl/ObjcOHZ2+PTlK0XpdPQBkFTiB6tmlbJyGcWtuw+lLFmfV67fAUqndyZTJIW1yVoL5dvcnZWVFcy9jzHdP0txsRfTdWiWb2trg8rlHNChRR2Tcfb5siFeHGutTqEIVnkb16lkNP0pWTQ/bGxsTOr4+BtzUXNumua+tWqc6ZxIztT7EV77wX9RIsAKb5TwGW/mQ8fPokyt9ugxaDyOnLiADq3qhWps9iwZUL5UUfQe4ganke7Skho/flwE/fiBGfNXYOvuwyhRrbV09PBbqMxh7PR0bC5uLQWgTbfhqNOyNzZtPyCl7QvkxK+fP9F32CSVGwTpAAAQAElEQVRpqZWRGt7kWUtQuUFnOLm4I0Dccq5WsZSUoO3+I6dBWxkhPF2yIon/MwEmYAACCoUCNcvmRdrUqQxQG1fBBJgAE4gaAVZ4o8bPaHPXr1kRx3YshccUZ4xz7oUsGdPJtq5c4Ibk4jYl7TSuVwVzJg8X6b3x8dNX5M2ZDVbC8nVqz0qoOxenLiSu1ZESOrBnW1Va4oQJMHJQN1A921bPxvgRfWQaWXgnuPTFTLchwspVXMZpeq7De2H/Jk+4uzqB6lSuC06UML5sj2ObhqosumRVAgA4zASMiQDNYzvb0Mt/jKl95tCWOHa2SJggLviPCTABJqBJgBVeTSKxaH/ImBlo2nEg6NVf5UsXReaMaWJR77mrTMCwBGZNGIgyxQsZttJYVlvjOhXh3L9jLOu1Xt1lISYQ6wmwwhuLp8CcScOwbvFUeHtORvOG1cMkcfbiNXR3GhfKjZoY/MqxMDNqSYzOsrQUz1FMgAkwASbABJgAEwhFgBXeUDhi8U44XXewz4d57iNCuTFDe4STS3tydJalvQaOZQJMIDoI0PInelBUm0uZIol8Y0h01MNlMAEmwARimgArvDFNmMtnAkyACZgogdZN62CNl7tW17dTI8SLY2uiPQu72ZzKBJiA+RFghdf8xpR7xASYABNgAkyACTABJqBGgBVeNRj6B1mSCTABJsAEmAATYAJMwFQIsMJrKiPF7WQCTIAJGIAAfZK856BxCM8tXrMLvn4BgAHaxFUwASbABKJKgBXeqBLk/EyACTABMyLw5u17nLlwNVx379FzbDt8Fc9f+phR77krTIAJmCsBQyi85sqO+8UEmAATYAJMgAkwASZgAgRY4TWBQTLWJrbuOgxv330Is3mbdx5EC8dB8hPFHz5+DlOWE5mAuRK4cuMe+rtMB2CuPTR8v7xWboH3xj2Gr5hrZAJMwCQJsMJrksNmHI0e1t8RiRImCLMxKVMkw9jhvUDv8wxTkBOZgBkT+O7rh6fP+dZ/dA7xm7cf8O7Dp+gskstiAkzAkAQMXBcrvAYGborVffvuC1f3heg6YCyqNuqKvYdOym64TffCp89fZHiZ91Y06TAQvYa4wXncLKz+d6eML1G0ALJlziDD4XkPHj/D0DHT8X/2zgMwiqKL4/9LJ/QeKSIdKYI0RXpXUBGxIeVDCL1DaIHQQgiEXkOXKggqKhAFpAsoHQEBkSYgqJTQkpD67ZuQ4xJyySW5JFf+gTc3O/Nm5r3f7F5e5mb3Puvjo8aRvYGd+47GxcvX9E17DPbFmXMXkZiuXokZEiABEiABEiABEjAgwIDXAAaziRPY/fNh5M6VHQunj0bQ+vmoXqVCPMULl65Cti4smzMe/j79cPaPy/HqTT34YkMQ3nmrIT6f64tvVs5Anty50Ljea9i+56Dq4vbdYNz65zYqlCuJxHRFKSoqErYu0dFRNu9jes9hxjOMwoOHj7Fp616Ll6MnzyE0LDJZiYmRKw7YsfdQpvh0UfsDOTo62uqvhWTORav3L72v5dj+5T1RxLbf/2OvOKapJcCAN7Xk7KhdmVLFII8qWrRiA/YdPKYFojnjeX/67J+oX7sasmfLqqRRvZrx6k09eKVCaaz9+gcsXvU1rt24BfcsbmjeuDZ27PlVdbFt5wE0b/SGyiemKxWRkZGwZYmKkjf1KJv2MSPmTwKljBgnbgyZN/k05Nsf9sLS5ehv5xEargW8yUjM04h3+57DmeKTPCUio+cxbj7N+WoLPpiTR2r6kutLJDVtramN/I6jpJ4AA97Us7OMlhlghWxJWDRjDMqVKYn1327Fum9+jDeq/OJzdHTUlzk5PcvrC03ItGrRCKMGdUVhj/wY5TdXWym+hHx5ciGvttJ7/sJl/LTnFzRtUEv1lJiuVLi6usHVhsXFxRXOzi5wtWEfM8I3JydnuGYgQxcXFxQt7IGlM0dZvHTr0Ap5crglKw4OOrnkMMmnd6b49GbDWnBycoJrBs5jeozllMHnYnr4kNl9yvUlktl2pPf46oJjkmoCDHhTjc5+Gt5/8AjZsrqjXq2qeP/txpAVXUPvK75cGsdOnoUEviJHjp8xrDY5//DRY3gUzIcWTeuhZtWKKuCVxrJivHrDFkh9qRIvSpHKJ6arKpmQAAnYJQE6TQIkQALGCDDgNUaG5XoCu34+hLotO6HXED/s2X8Un7Vrpa+TTJmSxdCgdg30HeYPr9FT1apstmzuUoXAZV+qR5LJ48tafNxL1auKRJKA2Z+jSeuu8PKZivCISDRvVFtpyaus7sqrKtASY7paFf+TAAlkAAGdTocW9SqiSCGPDBiNQ5AACZBA2gjYWcCbNlj22vq9Fo2wb8tyzJ8yEhNG9kHJl4oqFKsX+iPucWMftGqKuQHeWn1fBN9/hIrlSiudnp0/xsGtq/UydbyXKk8s8fXug582LsZUXy/4eHVDVvcsSi1njmyqvWeH99WxJMZ0pY5CApZGoEqFMpjhO9DSzLJqe7p2aIVP33/Tqn2g8SRAAhlHgAFvxrG26ZGGjZuJjzoPhjxGrEGdGijxUmGb9pfOkUBKCGTJ4ooXi1jYSmhKHLBA3fx5cyNP7hwWaBlNIgESsEQCDHgtcVas0Ka5k0dg/bJpWLs4AJ8ks+py6Ngp9PSaEE/GTJpvhV7TZBIgARIgARIgAWsgkFTAaw3200YrJFCzaiUETh0VT8YN72WFntBkErA9Am81qYNtXy9OVrz7tkM2dzfbA0CPSIAEbJIAA16bnFY6RQIkYF4C9tObq4sL8uTOmaxkyxq7x95+yNBTEiABaybAgNeaZ4+2kwAJkAAJkAAJkEBGErDSsRjwWunE0WwSIAESMDeBW//exuoNm02SfYdOqccHmtsG9kcCJEAC6UGAAW96UGWfJGDfBOi9lRK4duMWZgauNEl+2PkrA14rnWeaTQL2SIABrz3OOn0mARIggTQSkG9VDNp7Gtf/vpXGnticBGyZAH2zFAIMeC1lJqzYjmnzVmLrzv1JenAv+IH6BrWGrbpAviUtSWUTK0PDwrD+260malONBEwn8Pc/t7Fw5UbTG1DTagmcPncJG77fYbX203ASIAHTCDDgNY0TtZIg8MG7TVH91QpJaMRWtWhWD107tIk9MEMaFhaOjVus/xeVGVCwCzMTuH0nGBuDdpu5V3ZniQQuXrmOnfsOW6JptIkESMCMBBjwmhGmPXS1bPVG9YURrdr1g6zsis9ffb8dR46fkSz2HzqBdt2Go9vAcZg8axm8Rk9V5blz5UCjujUh3zilCpJIbt+5h4+7eMHbdxZ6DfGD3EgjK8gdenqjfY8RmBG4ElHR0Viy+hvc0lbiegz2ReCyL5PokVUkQAIkQAJWQIAmkkC6EWDAm25oba/jW1pwKQGtfGnEd2tmo8PHb8dzMjIyEhOmLsLIwV2xcPpo3LkXHK8+JQd/Xb8Fz45tMH/KSDx5EoHla7/HrInDsHK+H56ER2LTj7vh2f59eBTMhwXTfNCz88cp6Z66JJAsgejoGDx4+Niu5PHjUIjfpkgcwEePQqyaUUhoGGJiouPc4SsJkICNEmDAa6MTmx5u5c2TSws+wzFv6Vq1dzZH9mzxhrlx8z8UyJcb5cuWhE6nQ6sWjeLVp+TgxSIeKFGsiGpy8vQ5PA4JhfeE2eilrfiePH0ev5+7pOoSJiEhj2HLEhoagvDwJzbtY0bMX3h4OISlsbHCwkIhTyyo2bwT7Em6DvbHv/dCTJIo7Q8Cuf5afzbUqhmN8g9UAbuxcyG9yyMiwnk9p/F9OywsDCLpPVeZ3b9cb5TUE2DAm3p2dtfS2dkJy+dPwBs1quDPS9cwxn9uPAYx2pGjo6OWxv53MsjHlpieOjs5P1PWgue6taqqlVxZzV27eDK8B3k+qzfIubtnhS1LlizucHFxtWkfM2L+XFxcICyNjeXmlgXFir6Acwc22JV8sWA8PPJmNUkcHXTqytu+Ya5VM5o+fiBy5sieadeUs7NLqsc2dv7aW7mbmxtEbN1vdcExSTUBh1S3ZEO7IyAf/Wmf/eHVV15G988+wOlzF+MxKPJCfty5G4z7Dx6p8iMnTqvXtCbVq5TH7p8P4+Lla6oreeLDxSvXtF8Sbnj4MESVMSEBEiABEiABEiABYwQY8BojYxPl5nVCbh5r+G4XyM1j0+ethFefTvEGcHJywtD+nTFm0jz0HzEZ9+8/RrasWZVOZFQUajVvrx5JtnHLDpU/f+GyqksuKeRRAIN7/w9+0xersTv2Gong4Adw1VbpWjarq8biTWvJUWQ9CZAACZAACdgvAQa89jv3KfZc9tTuC1qBVYET4TeqHxrWqaH6GNy7I5o3qq3yVSqWxcyJwzQZqq3AuqJS+VKqXLY3HNy6GoZStnRxVZcwyZc3N1Yv9I9XLE94WDZnvBp70xdzUK1K7GPQ5Ga1Wf7DeNNaPFo8SCuBQh750KPj+2ntxqbb63Q6tKhXEUUKeViHn0asrFiuJD5s1cRILYtJgARshQADXluZSQvxY903P+KtD3vi027DERLyBO+82cBCLKMZJGA6gXx5cuG9FvVNb0BNqyVQ8qXCaFSnutXaT8NJgARMI8CA9xkn5sxAoEv71vhhQyDibixzcTa4+SxB/7LXt6fXBPVcX8NXKU+gykMSIAESIAESIAESSDUBBrypRseGaSWQM0c2yDN9E4qUp7VvticBEkg5gRIvFYGvd1/4eicvH73TAK4uxv+gTfnobEECJEAC6UeAAW/6sWXPJEACJGBVBPLmzoW3mtQ1SapUKAVnJ0er8o/GkgAJ2C+BVAe89ouMnpMACZAACZAACZAACVgTAQa81jRbtJUESMASCViNTX9e+gvmklv/3rUav2koCZAACTDg5TlAAiRAAnZC4BNPL5hLZi/7Bo9CwuyEHN0kARIwjYDlajHgtdy5oWUkQAIkQAIkQAIkQAJmIMCA1wwQM7qLBw8f4eMuXukybNBP+9B90HjMXrQmXfpPSafrv92K0LDYFSTx+aPOg1PSnLoWSsBazTp99iJu3w22VvPNbndMTAyC9p7G9b9vmb3vxDoU9jIHidWxjARIgASSI8CANzlCdla/eOXXmD1pOPp1a5fpnstXEIeFhSs73N2zYPSQHirPhAQyg8D0BV/gyImzmTE0x9QIHD15DtO0OdCy/E8CtkKAfmQgAQa8GQjbcKjbd+6pVVpv31noNcQPk2YthaxoxuksWrEBK7/cFHdo9DUiIhIBsz9Hh57e+KyPD3buO6R0B3gH4I+LV1Ve6hav+lrlFy7fgG82/6TyCZMpc5bj9u176D9iMn746Wf4z1iC8VMWoM8wfyxe+RXu3AvGyAmz0b7HCHj2H4Mz5y6qLq7//Y/68ggpmzxrGd75tK8qTyxJ6Petf2+rFeW2XYeiffcR2LP/iGq2Zdte3PrnNoaMmY6BI6cgJCRU2aIqteSbTT+hk+av2CK2aUX8TwIkQAIkQAIkQAKJEylEJAAAEABJREFUEmDAmyiWjCn86/oteHZsg/lTRuK9Fo2wY++v+oG37/4FzRrU0h8by3z/4y78deMWls+bgDFDe2LSzKWQbyp7pUIZnDh1Do8eh8DVxQWnzlxQXfx25g9UqfiyyidMhvTthOzZs2LBNB+81aSOqn4SHoHZ/sPQteMHmLNoLapUKofVC/zh49UDYyfPVzpzl6xFrRqVsWTWOBQpVBChobHbEFRlIomh3x4F8mFYvy5YuzgAM/yGQPoKDQtDy2b14FEwH6aMG6TKDbu5dOUGlq7ZiOm+Xlg8c4wK8g8ePmmoYjt5ekICJEACJEACJJBmAgx404ww9R28WMQDJYoVUR2UK10cd+/dV3sEz1+4jFw5c6iAT1UmkZw4dR6ttWDZ0cEBL71YCBVfLonzf15G1VfK4aQW3EqAK8HoY22FNDIqCn9dv4kSLxVOosf4VfXfqAYHrW8pPaEF0Nt3H0SPwb7wn7lE2frf7btqpbfNO01EBW3ebapek0oM/Ra9K9duYFzAAvj4z8PDR49x4+9/pdionDxzDg3q1ECe3DmRxc0NLZrWg/gpDUJDQ7SA23YlLCwU4eFPbNrHjJjD8PBwCMuUjCXnpu/0pWj56QCrldvBITCXREfHyCWHLgN8M4SH77QlkL38KZkza9CNiAjn9Wzi+7ax+XzyJAwixuptpVxdcExSTcAh1S3ZMM0EnJ3ify1nk/qvY9vOA9imBZWSN3UAJ2cnvaqTkxNitN9DFcuXxunfL2hB73lUqVgGL5cpge+CdqJCuZJ6XVMy0p+hXoC24iorwCK7vluK/PnyQAaM+4pRJydH6HQ6wybP5Q39PvvHJaz9+gd0+OgdzNNWuksVfxEhyawQS4fO2jjyKuLk6IgY7Z/kXVxcYcvi7OwCR0cnm/bRJQPmUM5rYZmSseSPq0/ea4oxQ7parWTP6gpziYODTi459Ov6SYbw+KR1M7hrf+CmZM6sQZfXc9rfs52036Ui1jDfabFRXXBMUk2AAW+q0Zm/4ZuN60BWUHfs+RWN679m0gBVKpXFph92ISo6Glf++luttr5cpjgkCJQtAbv2HYIEv5W1oFcCy1cqljOp38SUalStiAWfb9DiWy2i1hSOnDijpUCFl0th/XfbVV721srd2+rAhOTqtb9RplQxter84MEjnDl/Ud9KAgzZnqEveJqpXKEc9hw4qlbEZfuDPFni1UriF+CoBb8UR3JI5jyQTy1Sep7IH3OlS7yImq9WsFpxdXaEuQRPfypXKJ0hPIS9k7OTzZ3bqTkXU3ruUt823hOfXnJ8SSUBh1S2Y7N0IFCs6AsIexKu9sHmy5PLpBHefbMhCuTPi069R2FcQCC8+nRCjuzZVNtXtF9Ekpc9vJUrlsWNm//iVS1AVpWpSHp7fqJ9nB6ODj281Y1pGzfvUL308WyLfQePom3XYfjz0jVkyeKmyk1J6rxeFWfO/qluXJsRuArltZXouHafftACcxavUTetxZXJq2zJ6PDh2xjkMxVdB4xDvVpV8Vq1V6SKQgIkQAIkIAQoJEAC8Qgw4I2HI+MO8uXNjdUL/Z8bcO3iyZgb4P1cuWGBBLFfLp2qipy1FY+h/T7DqsCJ+HyuLxrWqaHKJendpa26kUzyBfLlwcGtq9XWBjk2JkFfxt6IJvUjBnqiUd2aklWSK0d29WgwsXvTF3PgN6qfKpcb1QKnjoLY7j3IU5UZSxL6nS2rO+SGu4XTR2P8iN5qW8MrFcqo5k3qv45pvkPUTWvi8/pl01S5JO+/0wTLNX/lBjq5oU7KKCSQngQqlS+FfHlN+0M0Pe2w176FfaWXS9qr+/SbBEggjQQY8KYRoBU3p+kkQAIpIDCwe1tUr/xyClrYtqpOp0OLehVRpJBHhjha7ZVyGNTj0wwZi4OQAAnYHgEGvBY8p7J/tafXBPWMW8NXKU+L2dLesL+4vJSnpd+4trL6K33F9Wv4KuVxenwlARIgAcsgQCtIgARsnQADXgue4Zw5skG2CiQUKU+L2dI+YZ9yLOVp6dewrfQlfSYUKTfUY54ESCDjCMjzrd9qUhfmkCoVSqmbYzPOeo5EAiRAAqknwIDXRHZUIwESIAFrJzBueB/4evc1i3z0TgO4uTpbOxLaTwIkYCcEGPDayUTTTRIgARIwEwF2QwIkQAJWR4ABr9VNGQ0mARIgARIgARIgARJICYH0CXhTYgF1SYAESIAEkiTwOCQU1Rt9ZFHiPWkJHoWEJWk3K0mABEjAUggw4LWUmaAdJEACNkmATpEACZAACWQ+AQa8mT8HtIAESIAESIAESIAEbJ1ApvrHgDdT8Wfe4NPmrcTWnfuTNOD4b2cxfPxMNGndFZ79x2LPgaNJ6ptSGRoWhvXfbjVFNVkdc/aV7GBUsDoCpV9rA9kKYHWGW4nBMTExCNp7Gtf/vpUii8//eRUNW/dMURsqkwAJkEBaCTDgTStBK23/wbtNUf3VCkla757FDV59OmHr1wvxv0/ehd+0RUnqm1IZFhaOjVt2mKKarI45+0p2MCpkDAGOQgIkQAIkQALpQIABbzpAtbQul63eqL6trVW7fpCVXbHvq++348jxM5LF/kMn0K7bcHQbOA6TZy2D1+ipqrxs6eLIlycXHB0cUOf1VxEREQFZVVWVCZLbd+7h4y5e8PadhV5D/HDr39tqBblDT2+07zECMwJXIio6GktWf4Nb/9xGj8G+CFz2ZYJeYg/N2Vdsj0xJgARIgARIwLoI0FrzEmDAa16eFtfbLS24lIA2cOoofLdmNjp8/HY8GyMjIzFh6iKMHNwVC6ePxp17wfHq4w42bt6BUiWKIYubW1zRc69/Xb8Fz45tMH/KSDx5EoHla7/HrInDsHK+H56ER2LTj7vh2f59eBTMhwXTfNCz88fP9RFXkNq+IiLCtcDctiUqKtLmfTTHPEZrf2DNXLgWU+auek5mLfoSU+etfq48MV1LKJul+fHwcTgsSWRLg1yvi1duTBHHz9duQtgT275GU3L+8npO+7kQGRkBkZRwt0Zdud4oqSfAgDf17KyiZV5thfaJ9stl3tK1au9sjuzZ4tl94+Z/KJAvN8qXLQmdTodWLRrFq5eD3878gTVfBWH0kO5yaFReLOKBEsWKqPqTp8+p/ZPeE2arFd+Tp8/j93OXVJ0piTn7MmU869Sh1ckTiNFUnpfYYO35csAyy8QqzREL/S/WpUBiRNdCXaFZJEACNkuAAa/NTm2sY87OTlg+fwLeqFEFf166hjH+c2Mrnqbyq8fR0fHpEeBkkJfC/27fxdwlazE3YASKFvaQIqPi7GTwNaNa8Fy3VlW1kiuruWsXT4b3IE+jbRNWpLYvZ2cX2Lo4OjrZvI/mmEMHBwcM6P4phvTp+JwM6P4JvHp3eK48MV1LKBvQvS2yZ3WxKNHpdJCfrh3fTxHHzz59F26utn+dmnoO83pO+7ngpP3ucdLEVObWqifXGyX1BBxS35QtrYFASGiYtmgVg1dfeRndP/sAp89djGd2kRfy487dYNx/8EiVHzlxWr1KIntpR/rNgffArnihYH4pMlmqVymP3T8fxsXL11Sbe8EPcPHKNbi7u+HhwxBVZmpizr5MHZN6JEACJEACJEACtkOAAa/tzGWinsjNYw3f7QK5eWz6vJXqqQuGik5OThjavzPGTJqH/iMm4/79x8iWNatS2fDdNpz6/QLadh2KWs3bK5H+VGUySSGPAhjc+3/wm75Yjd2x10gEa0Gvq4sLWjarq8YydtNawq7N1FfCbnlMAiRAAiRAAiRgJwQY8Nr4RMue2n1BK7AqcCL8RvVDwzo1lMeDe3dE80a1Vb5KxbKYOXGYJkO1FVhXVCpfSpXLTWUHt66GoXgUyKfqEib58ubG6oX+8Yob1a2JZXPGq7E3fTEH1apUUPXS7yz/YUZvWjNnX2pAJnZJ4MKvXyOrexa79N2SnS5bqhh2bQy0ZBPtwDa6SAL2R4ABr/3N+XMer/vmR7z1YU982m04QkKe4J03GzynwwISIAESMCSg0+nQol5FFCmU9N5+wzbMkwAJkEBmEWDAm1nkLWjcLu1b44cNgYi7sczF2RnGzJO9vj29Jqjn+hq+SrmxNsbKpY1hH3F5KTfWhuUkQAIkQAIkQAIkkFICDHhTSszO9XPmyAZ5pm9CkfKUopE2CfuRYylPaV/UJwFbJiBbM47sXA9LkonDPZHN3fhzuW1oPugKCZCADRBgwGsDk0gXSIAESIAESIAESIAEjBNgwGucjek11CQBEiABEiABEiABErBYAgx4LXZqaBgJkIA9Ezhy4gy6DxxrsbJ4zWaEhoU/N0UsIAESIAFLJMCA1xJnhTaRAAnYPQF5bvXRk7/DUuXytVuIio62+3kiABIgAesgkAkBr3WAoZUkQAIkQAIkQAIkQAK2QYABr23MIz7qPBgPHsZ+PXBmuNT8gx7qm9jkG9katuqSoSYMHDkF5y9cztAxOZhxAn1HTMV/d+4ZV2DNMwLMpTuBUf4LcOHStXQfhwOQAAlYNgEGvJY9P1ZjnaOjg/4b2XZ9t9Rq7Kah5idw6PgZhHFvp/nBWliPMTExCNp7Gtf/vmVhlsU35+SZP/Dg0eP4hTwiARKwOALpbRAD3vQmnIH9L1/7HTz7j0GPwb747/ZdNfLOfYfQ8pPeaNt1KEb7z8OjxyGqfOvO/RjgHYA+Qydi+PiZqixhklBnzuIvsP7brXq1RSs2YOWXm/THpmZkNXravJXoOmAcuvQbo62+XFVN/WcswfgpC9BnmD8Wr/wKd+4FY+SE2WjfY4Ty68y5i0rvSXg4xkyar8oHjQrQ+6QqmZAACZAACZAACZBAAgIMeBMAsebD4sUKY8mscWjWoBZWb9isXClTshi+WTkDXyyajBeLeGDtNz+ocklu3PwHk8cOxKTRA+QwUTHUadqgFnbs/VWvt333L2osKYiOjkbDdzvjE88h2Lx1jxQlKcWKemDxzDHo27UtpsxZrtd9Eh6B2f7D0LXjB5izaC2qVCqH1Qv84ePVA2Mnz1d63wXtwoOHj7Fyvh88O7TB6bMXVLkk0dFRsHWJiYm2cB+jceLUOfx69JSZxXz9HTnxOw4dO22x9gm7839eRXhElMWKXG8iJ06ft2iOoWFPLPp6sfzr2fbfU63ld4Zcb5TUE2DAm3p2FtfyjZpVlE2VK5bFlb9uqryLizNWrvtereb+/MtxXLz0lyqXpGrl8pBvcJK8MTHUKVe6OO7eu4/bd4PVntlcOXPAo2A+1XRV4ERs37hYC1Q/xPxlX+LkmfOq3FhSt1Y1VSUB7V/XbyJG+3hUCuq/UQ0ODg6SVUHT9t0H1Yq1/8wlalxZuT71+wW817KR0itftiREVAMtCddWf21ZIiIiEBkZCUv2Uf5ombt0A/xmfG6xEjB3DSbOXG6x9gm79d/vxIPHTyxWoqNjtCsO2vX+lUVzvH0nGBERlnvNREVFWfT1bMnvNXG2yXuiSMxenQoAABAASURBVNyxrb6qCy4u4WuKCcRGFiluxgaWSMDZyUmZpdM5QN5E5WDyrKV4oWB++Hr3Rv/u7eI9N9PF2VlUkpSEOk3qv45tOw9gmxaISj6ucf58eeDk6IjG9WpCVoLPnLsUV5Xoa1yAK5U66ORFidNTH9SBlgSMG4QF03yUyN5gGUcrVmPJq4iTk6O8KHFzywJbFldXNzg7u1i0j1ncXLFkpg++Xz3dYmX9Ej98u3Kqxdon7HwGfYZ8udwtVhwcYq/bRdNHWjTHooULwtXV1WKvGScnZ4u1zVreS11cXCFiLfam1k7wJ00EHNLUmo0tnsC1G7dQp1ZV5MieDT//ejzN9r7ZuA5k1XXHnl/RuP5rqr/HIaH653EGP3iIo9rHxRXKlVB1xpKNW3aoqm27DqBoEQ/odDp1bJjUqFoRCz7foF/9PXLijKquVL40Dh8/pfLB9x9oq81XVJ5JPAI8IAESIAESIAESeEqAAe9TELb60qltK3TpO0ZtaZCPfNLqZ7GiLyDsSTiKFCqIfHlyqe6ua0F1vZad1GPJenv5oW2bt1C5QllVZyx59DgUbbsOw5cbt2JI306JqvX2/ER91Nehhzfe+bQvNm6ODZJbtWiIe8EP0W/4JIwLWAiPgnkTbc9CEiABEiABEgDIgAQABrw2chasXzZNreKKOyVeKoy5Ad6SRYum9fD1iumYOXEoBvbsiFn+w1R580a1Mbh3R5U3lhjTWbt4sr5/aVu2dHHs/2GleizZmkWT0LJZPSlOUrr/7wNIP0tnj0PpEsWU7oiBnmhUt6bKS5IrR3aMHtIDqxf6Y9MXc+A3qp8Uw9XFBeOG98LsScMxw28I1i2ZArFBVTLJdAJz/Ycgf77cmW4HDSABITBhRE+UKfGiZCkkQAJ2TMDBjn2n6ySgJ8CM+QjUeLU83FxdzNcheyKBNBCoXKE0smdzT0MPbEoCJGALBBjw2sIsptGHQ8dOoafXhHgiz7lNY7fqWbkJ+5WxDFej0zoG25MACWQOAZ1Ohxb1KqJIIY/MMYCjphcB9ksCNkmAAa9NTmvKnKpZtRICp46KJ7JlIGW9PK8tfSTsV8Z6XpMlJEACCQlUq1IBC6aPsVjp0rYFV/ITThqPSYAELJYAA16LnRoLNoymkQAJpDuB3LlyoLoW9FqqlCxWCE6O/BWS7icCByABEjALAb5bmQUjOyEBEiABErBHAvSZBEjAOggw4LWOeaKVJEACNkTgj4tXIM+Vtma5ePVvREZF29Cs0BUSIAFbJsCAN91nlwOQAAmQQHwC0+evRI9B46xalq4NUs/kju8Zj0iABEjAMgkw4LXMeaFVJEACJGB7BOgRCZAACWQSAQa8mQQ+M4d98PARPuo8OFkT5i9dh088h+DtT/pg/JQFeBIebrTNvoPHcPHKNaP1CSvkm9MSlsUdSz/SX9xxcq8DR07B+QuXk1NjvY0T+GrTTty5e9/GvcxY98KeRCIiktsWMpY6RyMBEkgPApYW8KaHj+wzAQF39yzqG8wSFD93WLlSOfUtZisD/XD33n1s3LzzOZ24goOHT+Ly1Rtxh2l6lX6kvzR1wsZ2R2DRyo24+e8du/M7PR0OCYtAFPfppidi9k0CJJBBBBjwZhDozBrmcUgofKcuQvdB49GsTXds23UAIVqZrNjG2bRi7ff48LPB6DPMHyMnzMYXXwWpqto1q6jXPLlzoooW/P57O/Fg4sKlq9h38CiWrvoaPQb74uq1m/CfsUStCkufi1d+het//6O+2MKz/xhMnrVM9WssWbZmo+pP+vppzy/YunM/BngHoM/QiRg+fqZaaZYvxmjfYwQGjQrAo8chxrpiOQlYMQHLNj0mJgZBe09r1/YtyzaU1pEACZCARoABrwbBlv/v/vkwcufKjoXTRyNo/Xz1XE9DfyVY/TZoJ5bNGQ9/n344+8fzWwNCw8Kweese1Kxa0bCpPl+6RDHUrVUNXTq0wYJpPihW9AVV9yQ8ArP9h6Frxw8wd8la1KpRGUtmjUORQgURGhqmdBJLOrdrrfqTvprUf12p3Lj5DyaPHYhJowfgu6BdePDwMVbO94OnNubpsxeUDhMSIAESIAESIAEbJGAGlxzM0Ae7sGACZUoVw4FDJ7BoxQZt1fQYZLXW0NzTZ/9E/drVkD1bViWN6tU0rIas4ozym4NGdWvi9eqV49Uld1D/jWpwcIg9xc6cu4g27zRRTdq821S9piSpWrk8srpnUU1O/X4B77VspPouX7YkRFSFljx+/Ai2LCEhj/HkSZhN+5ja+Xvw8BHebT8YpV9rk6y80qADytb6MFk9U/pKjU7QjsO4efuxxUt4RPL7d+WcTO2csd0jhIc/4fWcxvft0NBQbREl1OY5gj9pIhAbjaSpCza2ZAKy+rpoxhiUK1MS67/dinXf/BjPXAloHR0d9WVOTs/yUrhk1dcoV7o4enX5RA5TJE5OTs/0tY8/XV2c1bGModPpVN7UxMU5tm2cvpMRm93ds8KWJUsWd7i4uNq0j6mcP+TIng3rFvvh+M5VycqBLQtx9KcVyeqZ0ldqdJrVfxUF87hbvDg76eIuOaOvck6mds7YLiucnV14PafxfdvNzQ0itn4+Gb0IWWESAQeTtKhktQTuP3iEbFndUa9WVbz/dmPIiq6hMxVfLo1jJ8+qlVwJfo8cP6Ov/nLjVty+E6y2JOgLjWSyZHHFA20sI9Wo8HIp7D90UlX/euSUGk8dJJJk0d687murdYlUqaJK5Uvj8PFTKh98/wHOX7ii8pLodDrodBSdzv4YyPy7Z3FT57uc85Ys8segg4NO+5TCskWn0yG5H51Ox2uODHgOZMA5kNy1+KyeucQIMOBNjIoNle36+RDqtuyEXkP8sGf/UXzWrlU878qULIYGtWug7zB/eI2einx5ciFbNndERkVh5oJV+P7H3ajVvL0SufktXmODgxZN6uLgkZNqHLlpzaBKZft4tsWmH3eht2ZH0E/74OrqAmM/VSuXQ0x0NPqPmAy5aS2hXqsWDXEv+CH6DZ+EcQEL4VEwb0IVHpMACZAACZAACZCAngADXj0K28y816IR9m1ZjvlTRmLCyD4o+VJR9dHv+mXT9A5/0Kop5gZ4a/V9EXz/ESqWKw3ZMnBw62oYio9XN32bhJmSxYtiyrjBahy5aW3EQE+17zdOT25UmzreC/M0O/xG9sWWdfPiqp57lRXeiT79Mct/GOSmteaNamNw7456PVcXF4wb3guzJw3HDL8h6tFpZUsX19czkzwBW9T44N1G2h9sOW3RtUzzyc3FCY6OukwbnwOTAAmQgLkIOJirI/ZjvQSGjZupvoiic9/RaFCnBkq8VNh6naHldkugW4fW8CjA1X5zngDuWZzhnGBfvzn7Z18kYAEEaIKdEGDAaycTnZSbcyePgKz4rl0cgE/efzMpVazZsEU9T7en1wT9q5Ql2chI5aFjp/R9xPUnz9c1os5iEiABEiABEiABEkgVAQa8qcJmv43afdgSgVNHxRMpQyp+alatFK8f6Ve2KqSiq/Rtwt5JwMwE3m5WT90MKs+otlZpXKcqWjWqjCKFPMxMh92RAAmQgPkJMOA1P1P2SAIkQAJJEni7eQN07/SRVUuTutXg6uKcpJ+stD0C9IgErJUAA15rnTnaTQIkQAIkQAIkQAIkYBIBBrwmYaKS6QSoSQIkQAIkQAIkQAKWRYABr2XNB60hARKwIQLtewxH9UYf2aR4T1qCRyFhNjRb6eAKuyQBErAYAgx4LWYqaAgJkAAJkAAJkAAJkEB6EGDAmx5UTe8zQzUfPHyknreb1KC3/r0N/xlL8NaHPfGJ5xCsWPt9UurpUnfxyjXsO3jM5L4HjpyC8xcum6xPReslEPzgEW7c/Nd6HbBQy6NjYhARGW2h1tEsEiABEkg7AQa8aWdoNT24u2fB6CE9krTXwcEB8s1rP2wIhN+oftjw3TZcvHwtyTbmrrx89QYOHj5p7m7Znw0Q2LnvMPxnr7ABTyzLBQl27z96kslGcXgSIAESSD8CDHjTj22m9iyrpMPHzcBnfXzQrE13XP/7FkJCQjF+ygJlV9iTcIyZNB/te4zAYJ8p6DpgnFolLZAvD0qXKAb5KflSUZQsXhR/3/pPDhOVXT8fRv8Rk9G26zB82m2Y0uncd3S8ILnHYF+cOXcRiemqBgmSZWs2aiu8RyHtftrzC7bu3I8B3gHoM3Qiho+fiSfhz2wfNCoAjx6HJOiBhyRAAiRAAiRAAiTwjIBVBbzPzGYuOQJfbAjCO281xOdzffHNyhnIkztXvCYbN+/A45AQrAqciG4dP8Dpsxfi1cuBrOye/eMSKlUoLYeJytzFazFpTH+sXTwZsybGBryN672G7XsOKv3bd4Nx65/bqFCuJBLTVUoJks7tWqNurWpYMM0HTeq/rmpv3PwHk8cOxKTRA/Bd0C48ePgYK+f7wbNDm0RtV42YkAAJpBuBmJgYBO09rf6YTrdB2DEJkAAJmIkAA14zgbS0bl7RgtS1X/+Axau+xrUbt+CexS2eib+fv4h33mwInU6HsqWLo3zZkvHqgx88xAjfmRjl1R25cmSPV2d4UKl8aUyds0Lt9Y3WfgFKXfPGtbFjz6+SxbadB9C80Rsqn5iuqjAhqVq5PLK6Z1Gap36/gPdaNoJsvxC7RVSFloSFhcGW5cmTJ4iIiLBpH5OaP/H9+Knz6NR3XJqku9ckfNZvfJr6MMWG385ewd37oekhZu3zwaMniI6O0a6glP+XczKpOWNdWJLXa2RkZJL15Jc0P+ETrn3qJyJ5W5aUX51sYUiAAa8hDRvKt2rRCKMGdUVhj/wY5TcXslJr6J7Epk6OjvoiJ6dn+ajoaIwPCMTAnh1Rr1ZVvU5imbHDeuLj999EjPavz9CJCHsSjnx5ciGvtqIsN5L9tOcXNG1QSzVNTFdVmJC4OMf/Ridjtjs5OcGWxVGbMwn0bdnHpHwT3wt55MOH7zZOk7zfskGa2ps6vkeB3HB3c7Z4cXN1Un/8IhU/ck4mNWesS/o9SafT2fR7VkbMv4ODo7YA4mjzHFNxedpJE9PcdDBNjVrWRuDho8fwKJgPLZrWQ82qFZ8LeGWLwdGTZ5RbDx4+wvkLV1Q+IiISY/znq3a1alRWZUklMk6ZksXQqW0rODk64Na/d5R6o3o1sXrDFkh9qRIvqjLJJ6arKg2SLG5uuK/ZZFAULysrxYePn1Jlwfcf6G2Xgox4c83sMRy1oDezbcis8cX3gvnzomXTOmmS5g1fR4smtdPUhyk2FMibExJMWrq4ODtqAa9cQSmXzDoXbGVcOadtxZfM80OCXZGk/7jIPPvMY1fKr062MCTAgNeQhg3lA2Z/jiatu8LLZyrCtSC2eaPa8bxr/XZj3L33QN1wNmXOchQvVhhZs7pDguAde3+Bz8S5qNW8vZKg7XvjtTU8+LTbcLTuMAAjJ8zWVnLfwEtFX1DVMp6s7sqrKtD0BvsDAAAQAElEQVQSY7paVbz/VSuXQ4y2yiw3w0kf8Sq1g1YtGuJe8EP0Gz4J4wIWaoF9Xq2U/0nAOAHWkAAJkAAJ2DcBBrw2Ov++3n3w08bFmOrrBR+vbpD9rzmyZ8P6ZdOUxy7OThg+oAtm+Q9Dz84fQfY9veCRH69Xr4yDW1fHkxbaKrFqlEiy6Ys52LhqpnqEWef2rfUaOXNkU314dnhfX2ZMV6/wNCMrvBN9+ivb5KY1CZoH9+74tBZwdXHBuOG9MHvScMzwG4J1S6ZA9iHrFZixWQK5cmZHkRcK2Kx/meWYTqeDo/YJDfhDAiRg6wTs1j8GvHY69VFR0Xjrwx5op63QevvOxqDe/4OjA08HOz0drMbtRnWqY3i//1mNvdZiqIuTA3Jnd7UWc2knCZAACaSYACOcFCOzjQbO2grvru+XYc2iSVg+bwJqvFoxScfWbNiCnl4T4omUJdkomcpDx07F60/6l2cDJ9OM1elNgP2TAAmQAAmQgI0RYMBrYxOaXu60+7AlAqeOiidShjT81KxaKV5/0r9sVUhDl2xKAhZF4OUyJVCtcnmbFGeDJ7tYFHQaQwJmJMCubIcAA17bmUt6QgIkYGEERg7qhoUzxtqkjB/SGR+9WR1FCnlYGHWaQwIkQALPE2DA+zwTlpBACghQlQRIgARIgARIwNIJMOC19BmifSRAAiRAAiRgDQRoIwlYMAEGvBY8OTSNBEgg4whc+esGug8cSzGRweI1mxEaFp5xE8SRSIAESCANBBjwpgEem6aYABuQgMUSePQ4FEdP/k4xkcHla7cQFR1tsfNJw0iABEjAkAADXkMazJMACZAACZBAhhDgICRAAhlJgAFvRtLO5LHWf7tV+wgyLMVWtO8xArfv3EtxOzZIHYGugybil6OnU9eYrUjAygj0Hh6APQeOWZnVNJcESMDaCDDgteAZM7dpG7fsQBj33Jkbq9n7e/joMSIiIszeLzskAUsk8OhRKMIjIi3RNNpEAiRgQwQY8Jp5MmUl9OMuXvD2nYVeQ/wwadZSyMpq3DCLVmzAyi83xR3Ge30cEgrfqYvQfdB4NGvTHdt2HVD1H3UejGnzVqLrgHHo0m8MLly6qsrv3AvGyAmzISuwnv3H4My5i6o8JiYG85euQ/vuI/Be+/6Yu2Qttmzbi1v/3MaQMdMxcOQUpSf9zghciT7D/LHr58MIXPYl3vm0L8T+Jau+VjqmJGf/uIQeg33Roac3vHymQuySdtL/7EVr0GOQL/qPmIz/bt+VYkRHRyubPu02DB17jkTQ9r2qfOvO/RjgHYA+Qydi+PiZCHsSDvnmNfFvsM8U5f/5C5exYPl6fPFVkGojidi99usfJEshARKwTQL0igRIgATSRIABb5rwJd74r+u34NmxDeZPGYn3WjTCjr2/6hW37/4FzRrU0h8bZnZrQWfuXNmxcPpoBK2fj+pVKuirixX1wOKZY9C3a1tMmbNclc9ZtBZVKpXD6gX+8PHqgbGT56vyzdv24MiJ37F41hhsXDUT7zRvgJbN6sGjYD5MGTcIM/yGKD1Jihb2wNzJI9CwTg00b1QHm76YgxXzJ+L02Ys4euKMqCQpctPKuIBA9O/eDqsCJ6Jpw1qYtWCNvk3xYoWxYLoPPmrdHKs3bFblm7Xg+7/b97B83gTMnzoS67/bjit//a3qbtz8B5PHDsSk0QOwcfMOPA4JUf126/iBZtMFpfN2s/r47oedKi/B/bZdB/F283rqWFZGrV2eaIF+0E8HsGT1d8/J0jXfY/m6Lc+VJ6bLsuf5xTFZ8WUQhGXcsbxuDNqDRyERFBMZyB+uQXtPY9r8VWk6H2/9exuRkZGw9us2tfZHRUXZre+pZZawnZw/IgnLbe1Y/ZJjkmoCthPwphqB+Ru+WMQDJYoVUR2XK10cd+/dx+27wZDVyVw5c6jAU1UmSMqUKoYDh05AVoH3HTyGPLlz6jXq1qqm8hLg/nX9JiTQO3HqHLbvPghZXfWfuUSN8Z+2inrk+O/49IMWyOLmBp1Oh2JFX1BtE0sa1KmpL34S/gSy4jto1BRI4Pnn5ev6OmOZm7f+xT//3cWshdpKrrbK+/Wmn3DuwiW9ep3Xqqq8R4G8WlB7U+WPasH4Hxevot/wSfAaPU3xiWtTtXJ5ZHXPovR+P38R77zZUPlQVuNYvmxJVV6kUEHky5MbsrJ84NBJvFymOLJny6rqYmKiNTbWLfJHxM1//sXFK9eek0tXr+PS1RvPlSemy7Ln+cUxSYzhtb9vqacOCH9KdLIsYtQVB/x142aazscQtc0qxuqv29S+9wD263tqmdlru6eXHF9SScAhle3YLAkCzk7O8Wqb1H8d23YewDYtOJV8vEqDg9IlimHRjDEoV6YkZBvEum9+1NfGxMT9egF02j88/QnQVmwXTPOByK7vliJ/vjyqxsnRSb0ml7g4x+pFRETCZ+JcNK73uloBbt6oNkJCw5JrrtXr8IK2cizji4j965dN08pj/zs6xp5iOjhAVjKg/eh0Oni2f1/ZLG2+XzMbbzauo9UALs7P2InLTo6OqlwSJ6dn+XferA9ZKd68bTdaNq8v1UpcXFxh7eKexQ1d2r0H/1F9nhM/714YP6zbc+WJ6bLseX5xTMYN7YqJI3vH49jP82PkzOZqE5IRfjho1zG0nyG9O8bjGMfY1NcSLxaCk5Oz1V+3qX3fcdTeq1Pblu1i3++dnV0g4mID7/9J+aBdbvyfBgKx0UgaOmDT5AlIMCcrsTv2/IrG9V8z2uD+g0fIltUd9WpVxftvN9Y+wv9Trys3nMnBtl0HUFRbQdbpdKhRtSIWfL5BWxmJDYaPPN2CUK1Keazb+IP+iQyPQ0KlqVrxlTHUQYIk+P4D7Q3DGa9UKKOCzoOHTybQSPywkEd+9XHk1p37lYIEzr+d+UPljSWvVauktjfIzVmiI6tuMr7kDaVCuZI4ejJ2W8WDh4+0FfIr+uqGdWvil8O/aWVX8UaNyvpyZkiABEiABEiABEjgKQH9CwNePYr0y8iWArkBK/aj+FxGB9r18yHUbdlJ3ey2Z/9RfNaulV5XHorftuswfLlxK4b07aTKe3t+gvDwcHTo4a1uNpM9r1LxdrN6qPhyKXWDm9y0Nn/pl1KstjnMWbxGf9OaKnyayMqwbBlo32MEhoyeBrH1aVWSLw4ODvAb1Q9B23/G/3qNxLuf9sXppzfPGWv4VpM6eOO1Kug5eAI+8RyiVpajo2ODdsM2rbWg/+69B+qGN9m3XLxYYWTV/iAQHVcXF1SrXF5bGX4DOp1OiigkQAIkQAIkQAIkkCgBBryJYkl9Yb68ubF6of9zHaxdPBlzA7yfKzcskBvc9m1Zrm52mzCyD0q+VFRf3f1/H0D6WDp7HGTrg1TkypEdo4f0UOPJzWYSeEq5BKF9PNvii0WT8e3qWfoAuUn91zHNd4jasiB6svUgR/ZsklXi49UNcgPcVF8vjBveC599GhtwS5n4pZQSScSeWf7DsGK+H37YEIhP27yltAz7L/FS4Xj+d+3QBsJp3ZIpyk7ZryzbKAZrH4+qxlri4uyE4QO6QPru2fkjhIWF4QVtRVmrUqval/+6gXffbCiHNiWLp4/E69Ur2ZRPFu0MjctUAvMmD0WD2lUz1QYOTgIkYPsEGPDa/hxbrYdRUdF468MeaNdtOLx9Z2NQ7//B0cEBl6/egDwCrXzZ4kZvALRapzXDs2dzh7OTk5bjfxKwfQLZsmbh+W7700wPrYSALZvJgDcTZlf20fb0moCEIuWJmWO4UppYfUaVyTNxE9p86NipdBveWVvh3fX9MqxZNEk9wqzGqxXVWLK1QVadB/bsqI6ZkAAJkAAJkAAJkEBSBBjwJkUnnepy5siGwKmjnhMpT6chzdKtbHNIaHfNqpXM0jc7sRYCtmun7Hs/snM9KKYxyJs7h+2eDPSMBEjA5ggw4LW5KaVDJEACJJD+BLx6fIyP3qyOIoU80n8wjkAClkiANlkVAQa8VjVdNJYESIAESIAESIAESCClBBjwppQY9UnAdAIWrRm2ciXsVaLWrsWTVavs1n9zzHvh/fvhEh5u0ec4jSMBEiCBOAIMeONI8JUE7IxAmAR8diqRa9fhyerVsGcGafW98IEDcIuMtLOrhu6mngBbkkDmEmDAm7n8OToJkAAJkAAJkAAJkEA6E2DAm86ALbX79t1H4Pade0mat2XbXnQdMA5NWnfFYJ8p6vm3STYwoVK+RnjfwWOJasYVmqITpyuvA0dOwfkLlyWbLvLDjgMI+ml/uvTNTs1H4KcwHbZrYr4e2RMJkAAJkICtEGDAayszmUI/Rgz0RM4c2ZNsVbBAXswNGIFNa+egdMliWPB57FcUJ9komUr50oiDh08mqWWKTpIdmLny7B9XIGLmbtmdmQn8EekAETN3y+5IIDMIcEwSIAEzE2DAa2agltjdstUb1ZdctGrXD9PmrVQm+s9YgvsPHqr8irXf48PPBqPPMH+MnDAbX3wVpMqrV6kAVxcXZHFzQ+2ar+Kf28ZXhLfu3I8B3gHoM3Qiho+fiejoaMxdshafdhuGjj1HImj7XtXnsjUbse/gUfQY7Iuf9vyiyhImCXUS9v0kPBzyJRjte4zAoFEBePQ4JGEXPCYBEiABEiABEiABPQEHfY4Z6yJgorW3/rmN/YdOqC+5+G7NbHT4+O14LS9cuopvg3Zi2Zzx8Pfpp61kJr41YO3XQXitauw3ncXrwODgxs1/MHnsQEwaPQCbt+3Ff1qAvHzeBMyfOhLrv9uOK3/9jc7tWqNurWpYMM0HTeq/btD6WTYxHcO+vwvahQcPH2PlfD94dmiD02cv6BvHxMQgPST4/kNc1uy3BLly7aZZbPkrErAlCY7WnwbMZCCB9Lje2Gf6vI+Rq3VzzcDL2iaHYsBrk9P6zKm8eXLhyZNwzFu6Fuu/3Yoc2bM9q9Ryp8/+ifq1qyF7tqxKGtWrqZXG/79mwxYEP3iEzu1bx69IcFS1cnlkdc+iSo+e+B1/XLyKfsMnwWv0NNy9dx/nLlxSdalJDPs+9fsFvNeyERwcHFC+bEklcX2GhYXC3BIZGYmvN+/Ep91HZbp06DUGnfqON4sd3e45wZZkU6gu7jTgawYQ6BCVA0v2/o6Ll6+Y/ZpL6TVszfpRUZHkl8b37fDwJxCx5vPAFNsz4LK26SEY8Nr09ALOzk5YPn8C3qhRBX9euoYx/nPjeSx/8Ts6OurLnJye5aXw0LFTOHryDGZOHKq2N0iZMXFxdtZX6XQ6eLZ/X63kymru99rq8puN6+jrU5ox7FvaOhmxOUsWd5hbnDW/urRrhYM/LMt0+XnzYuz+NtAsdvyYPxK2JB2yxsipQclgAm5uWcx+zZn7Grbk/pycnMkvje/brq5ucNXEkufZHLZl8KVtc8M52JxHiTpkv4UhoWHQPuPHq6+8jO6ffYDT5y7Gg1Hx5dI4dvKsphKj5MjxM/r6k2fOnGvLPQAAEABJREFU4/MvvsNEnwFw0YI+fYUJmdeqVcLqDZvx8NFjpS1PXgi+/wCyH/j+w0eqzFiSnE6l8qVx+Pgp1Vz6PH/hisozIQESIAESIAESIIHECDDgTYyKDZXd+vc2Gr7bBR16emP6vJXw6tMpnndlShZDg9o10HeYP7xGT0W+PLmQLZu70pm7eB1OnDqnte+MWs3b44NOg1S5KclbTergjdeqoOfgCfjEcwh8Js5FdHQMqlYuh5joaPQfMdnoTWvJ6bRq0RD3gh+q7RLjAhbCo2BeU0yiDgmQgBCgkAAJkIAdEmDAa+OTXqJYEewLWoFVgRPhN6ofGtapoTxevdAf+fLmVvkPWjXF3ABvTBjZF8H3H6FiudKqfPHMMTi4dbVevlo+XZUnljRvVBuDe3eMV9W1QxvIOOuWTMEXiyYjT+6caoV3ok9/zPIfZvSmNVnhNdRJ2Lc8OWLc8F6YPWk4ZvgNgfRftnTxeGOb8+CtJm9AxJx9si/zE2jsFo0mrlHm75g9kgAJkAAJWD0Bh0Q8YJGdERg2biY+6jwYnfuORgMtIC7xUmE7I5C0uy+Xfgnly6RfQJ306Kw1lUBZpxiUfbaN3NRm1CMBEiABErADAgx47WCSk3Nx7uQRWL9sGtYuDsAn77+ZpLrcxNbTa4J6rm/cqzwTN8lGRirN2ZeRIVhMAmkkwOYkQAIkQAK2QIABry3MYgb6ULNqJfVM38Cpo/Svsr0gNSaYs6/UjG/vbbJNnQp7FWe/CXAPCLBb/80x7xHZ4j/i0N6vJ/pPAjZPwModZMBr5RNI80kgtQScKleGvYpDpUp267u55jzaySm1px7bkQAJkECGE2DAm+HIOWB6EoiICIctS3R0FBwdHSzVR6uxy0kL1uSB/7Z8rqS3b1u+DFQ3tBbMn8dq5j29maSmfxcXZ0RGRpBhGt67436npIa/NbWJ85OvqSPAgDd13NiKBEiABEiABEiABIwQYLGlEWDAa2kzQntIgARIgARIgARIgATMSoABr1lxsjMSMJ1Acpq379xDn6ET1ePivH1nITQsLNEm67/divY9RqBjz5HYe/CYXufboJ1o6zlEfWnIveAH+nJbz0RGRcFv+mJ06j0K3QaOw/W/byXq8snT59Gpj4/6UpYlq77W6xhr/+elvxRL+RIWkYEjp+jb2FvGGDt745DQ37Res8baf7lxa7xzb+WXmxIObbPHppxrxq5Zed/z8pmKhq26IGD25zbLiI6ZRoABr2mcqEUCGU5g1sI1eL16ZSybMx45cmTHmg1Bz9lw9dpNrFy3CQunj0bA2IHwm7YIYU/ClV7B/Hkx3ruP/gtGVKEdJJt+3I2794KxfN4EfPBuU0yauew5r2NiYjDafx6G9u2Ez+f6Yue+Qzj+21mll1T7apXLq32r8oUs8qUnqoGdJUmxszMUz7mb1ms2qfZd2r+vP/c6fvzOc2NbeUGi5pt6riV1zbZoVg/yJUiJDsBCuyLAgNeuppvOWhOB/b+eQMtmdZXJLZvWxc+/Hld5w+TnX46hfu3qyOqeBR4F86Fc6eI4fOw05KdWjcooXaKYZO1K9v9yHC00XuJ0o3qv4cz5i3gcEiqHejn/5xW4a8zKly0JJ0dHNGv4BvZpLEXBlPaiZ6+SFDt7ZRLnd1qvWVPax41lD6+mnmvGrtncuXKgUd2ayJLF1R5w0cdkCDDgTQYQqy2EgJ2ZIQGaTgfIG7a4XrRwQfx3+65k48l/d+6ikEd+fVmRQgXx7+07+mN7zPx35x4Kv1BQuS7BrEeBfPj3v/js/tGOCxtwE77//BvLLan2EjzXeasjPPuPxW9n/lBj2FuSFDt7Y2Hob1qv2eTaf/FVkPpofujY6do1Hv98NrTDlvKmnmtJXbO2xIO+pI0AA9608WNrEkg1gf4jJqs9prLP1FCOPf1o3cHh2eWp0z3LJxxQF09Pi5ITKtjY8bylaxPltu6bH/We6nTPODgY5PUKWkbn8EwHiM9Xp9NpGrH/HZ7mC71QAN+vmY0fNgRCVo69Rk9DSGji+6pjW9pumhQ72/U6ec/Ses0aa9+0wevY9vUCrAqciOzZsmHC1EXJG2MjGqaeazrd89esjSCgG2YiEP9d3kydshsSIIHkCfiN6otpvl7PSdVXXlZbFKKiohEeEaE6unMvGPnz5VF5wyR/3jwIDr6vL5K9qwXy5dUf22Kmc7vWzzETjq3fbqTczZ83N+7eM2AS/AAF8sdnV1A7vhf8UOlLclfjW7BALDdj7d2zuGnBRlYln7Z5C7JyfO1G4jfESZ+2Kkmxs1WfTfFLthWl5ZpNqn2e3Dkhz46WT3AG9myPs39cMsUkq9cx9Vwzds1aPQA6YFYCDHjNitNSOqMd1kAgW1Z3FTxlz5Y13muc7W/UrIKfdh9Uh9t2HUCd16qovHz0efrsBZWv83pVtff0SXi4CvJ+P38Jr1WvpOpsNcni9izwNGTn6uKiXH5D4/TTnl9V/tejp1CiWGH1B4QUyI1pERGRKFvqJcgd8RKwRkVHY4emLyxFx1j7R49DpFqJPLHh3v0HKFrYQx3bU5IUO3vikJivab1mjbU3PPd27v0VL5cpkdjwNleW1Lkm16AsBIjTxq5ZqaOQQBwBBrxxJPhKAhZGYECPdti0da96LNlf126i3YctlYXXtVVF36kLVb5Y0RfQumVjdOk3BgO8AzCwV0e4ODurusBlX6pHGUlg1+LjXvAaPVWV23ry7lsN4eCgU48lW7r6Gwzr30Xv8tCxM3D/wUPodDqMG94LPhPnKr1qr5aHrKyLorH2Qdv3KZ51W3bCtPkrMXFUP8iqr7SxJ9HpjLOzSA4ZaFRar1lj7Sdo17s8Cq/xe56QP+J8vLrBHn50OuPn2sIVG3Dk+BmFwdg1GxkVpa5ZeSTZxi07VP78hcuqDRP7I+Bgfy7TYxKwDgL5tI/mA6eOgjyWbKJPf8jKplhetnRxfLn0WfD60XvNsXqBP1YG+qH+G9VERUnPzh/rH2Mkj9GaOt5Lldt6IjeqjRzUVT2WbNGMMXixyLNV2O3fLNI/pq1yxbJKZ1XgRBg+tshYe+EsHPdtWQ6Zl0rlS9s6SqP+GWNntIGdVKT1mjXWftKYgepa3vHtEvhpf2gltr3JVhEbO9emjBuM5o1qK7eNXbNSLtesocj7p2rExO4IMOAF7G7S6TAJkAAJkAAJkAAJ2BMBBrz2NNv0lQRIgASSJMBKEiABErBNAgx4bXNe6RUJkAAJkAAJkAAJkMBTAikOeJ+24wsJkAAJkAAJkAAJkAAJWAUBBrxWMU00kgRIwAIJ0CQSIAESIAErIcCA10omimaSAAmQAAmQAAmQgGUSsHyrGPBa/hzRQhIgARIgARIgARIggTQQYMCbBnhsSgIkYDoBapIACZAACZBAZhFgwJtZ5DkuCZAACZAACZCAPRKgz5lAgAFvJkDnkCRAAiRAAiRAAiRAAhlHgAFvxrHmSCRgOgFqkgAJkAAJkAAJmI0AA16zoWRHJEACJEACJEAC5ibA/kjAHAQY8JqDIvsgARIgARIgARIgARKwWAIMeC12amiY6QSoSQIkQAIkQAIkQALGCTDgNc6GNSRAAiRAAiRgXQRoLQmQQKIEGPAmioWFJEACJEACJEACJEACtkKAAa+tzKTpflCTBEiABEiABEiABOyKAANeu5puOksCJEACJPCMAHMkQAL2QoABr73MNP0kARIgARIgARIgATslwIA3mYlnNQmQAAmQAAmQAAmQgHUTYMBr3fNH60mABEggowhwHBIgARKwWgIMeK126mg4CZAACZAACZAACZCAKQTMG/CaMiJ1SIAESIAESIAESIAESCADCTDgzUDYHIoELJXA8HEzUKt5e1z/+5beRMlLmdTpC5kxicDNf/7Dd0E74+nWe7sTnoSHxysz18HnX3yHuUvWJtrdN5t/gmf/MWjfYwSatemOCdMWJapnC4V/XvoLb37YQ+9KeEQEFq3YoHzvPmg8+gydqI4jIyP1OoaZJau+xlffbzMsSlH+tzN/oEu/MaqN5Dv3Ha3yCZPDx08rWxKWJzw+euIMfj16Kl6xuc8juc69Rk9FT68JOKKNF28wgwPxJ843g2KVNcWf73/cjcDPv1T6TEggMwgw4M0M6hyTBCyNgE6H0iWKYcu2fXrLJF+qxIuAVgf+pIjArX9uY7MBS2k8Y8IQODs5STbD5O9b/2LmgtUY0KM9Vi/wR9D6+WhYp2aGjZ/ZA/lOWYhjv53Dgmk+WDh9NOYGeKNMyeIIDXvynGmPHodg04970OqtRs/VpaagxEtFMKRvp9Q01bc5fuo8jp38XX8sGXOfR0Hb96F82VIInDoK1atUkCHSRVo0rYvtu37B/QeP0qV/dmrRBCzCOAa8FjENNIIEMp/Am03q4Mcd+xETE6NE8s0avhHPsPXfbkWHnt5KvH1n4c69YFV/7LezeK99f3TsOVLJwcMnVbkkPQb7YurcFeg9xE/VbfhumxQnKl9v2o7/9Yrto/kHPXD33n3I6lGnPj6QleY+w/whq1B79h9Rq5ZS3n/EZFy+ekP1Jyuro/zmQlbzpH3gstgVJeljsM8UyIpbk9ZdsefAUaWfMJHx+2pjtO8+AtL+9p17SuXQsVOqT7FN+v79/EVVLom0kXLxXdqIzfOWrsOlK9cgvk+cvkTUMHDUFEQ8XVk0Zr/YKT4JWxln4Mgp+Pf2XdVe+hX2n3Ybho+7eGH1+i2qPKnkP83+PLlyagFNSaXm5OiI2q9VUXlJZAV/zqI16DZwHNp6DsH23QelWIkxn5OyQ1ZTR/jOVKuXnv3H4pejv0H8kbkTpp9p83jl2k3IXMh4YycHIjIqSo1nrnNIdaYlV7Vxdv98GL4jeiNbVnetJPZ/gzrVkT1b1tgDg3THnl9Q/dWKcHZ2UivxTd/vhgcPnwVnMxeswuKVX6kWco6907YPPtGY+U1frAXQYarcMLl05TqmzFmuL5IV+A8/G4xe2nWwWzt/4yqM8ZRzesv2vdi684A6j+Kum7SeR3Hjyuv32qqr/GEWpI0j5+rjkFAYOzdF31CM+WPsGpRz7/Xqr2j+7DfshnkSyDACDHgzDDUHIgHLJpA9WxaULvmiCjAl8CpbqpgWKGSBFv0qw/cfOqH9sjqAOZNHYFXgRFSpVA4Bs5apuiKFCmL5/AlYGeiHscN6YeKMJZBfnqpSS6KjozFbayf132hBbVwQp1XF/tdS6X+59tG836h+qp+ls8ciW7bYQOXCxavo8dnHmKv18VLRQhgbEIhBvTpi+VxfZcf4KQu0HoAvN/6Iii+XUqt5P2irmW3ebarK5y5eq7X/CMvmjMfmdfNQuUJpVW6YyArfklUbMdN/GFYv9Me6JQHInj2rCuonTFuMIX06YcV8PzXuiPGzVKBmzObeXT5BiZeKqpVF70GehsNAgmhj9ovi1Wt/o1unj5QPbzWpjWVrvpViZMniiokamy8WTcaSWUQaEo0AAAzdSURBVOOwc9+v2urlWVVnLKn4cmmNR2m07ToUw8fPxMYtO/Dw0eN46sU0notmjMHsSSMwfd5K5a/8IWPM5+TsuPLX35g8dqBm41g4OjhA/Ont2RarFkxEyeJFMXTMVHgP6orVmh8PHj7Ezr2/KnvMcQ6pjp4mV/66gSKFCiB/vjxPS5J+kZXguPPC1cUF9d6orl+ll/N3686DaNUidvW34yfvYNPaudp5MgkSyK3ekPQfHzv2/oK9B47gc+18nTlxKGTrRZw1xngWL1YYLZvWQ/NGb6jz6MNWzeKaqNfUnkeq8dPk3TcboFHdGnj/7SZqjNDQMCR1bj5thqT8MXYNSttXtOvu+Kmkz1nRo5BAehBgwJseVNknCVgpgZbN6uOHn/YjaPvPeEv7ZWvoxi+Hf0Pw/YfaSutMteK0bdcB/Pb7n0rFzdVFfRw8dOx0BMxZBvnFef3Gs/3A9d6oqoIfUS6QP5+2IntdsvFE+n/3rQZakFJQlRcp5AEXZ2eVL1OyGF56sZDKnzxzARXKldKvWrb7sAXO/3lFBdiVXi6DLdpqlaw0/vDTz8ibJ5dqU7Xyy5DV3sWrvsap3/9Arpw5VLlh4p7FDQUL5MU0bTVa9sTeC34ICXxOnv4DYdpH4FPnrUAPbbV6RuAq9bHsX9dvIimbDfs2zCdlv+iVKv4iXir6gmTxQsH8aqVYDtxcXXH81DmMC1iAIWOm417wA5z747JUGRVHBwdMGNkH03y9UKViOXz13XZtBX0Uwp4820vcqN5rkB8JDMuVKYFTZ/5EUj4nZ8cbNSojq3sW6VJJiWJFULSwB3Q6HSpXLKP+EMibO5c6HyqUK42L2kq4KLqZ4RySflIrf9/6L15w/Hazutp1sFd1t/fAMRTXAtACT4NnWfmdPn8F+g+fpJ1PF3D+QtLzcPy383jnzYbaH5Du6pxu804T1a8kbqmYV2mX2vNI2hqT5PqMa5eUP8auQWkr5/P1v/+VLCUJAqxKHwIMeNOHK3slAesioLYxQH3cffL0ecgNKoYffYszOl2MtuJUV60EyZ5IWWWUVVSpmxG4Go+0lcOBPTuovYAeBfIhRFstkjoRR+2jdHkVcdCCsMjIaMk+J05OsQFuwgpXLRjSl2m2Ojk+e+uSfbEOWjAl9Y3rv6atAnujXJmSahVK9nBKef/u7dXKbJEXCmqrmCsgH+VKkCwfMYtM0laqHTS7ZMX4XS3odtE+1u4/wl8FYzqdDmVLvaT3W3zfvWkZSmiBnPRtzGapS1SSsF/0HR2f+eag2RQZGfuR/+Zte9RqaIeP3lF7Ueu8XhWGjKWtMZE/Hj55/02s1FZZZVuFBOrGdKVcpzPuc3J2xJsrrTPZIqC9qP+ODg6Q+cLTH0P/zHUOPe1a+wOpMCS4+u/plpC4cmOvMucRT1mLzquvvIyQkDDtD44bCPpprzr3pfzqtZuYMHWRtvJaG9MmDEHn9q0RFvbsDwjRSSgxiFErwXHlTgZ7uZPjGdfmuddUnkfP9WNYkEyfcapJ+WPsGpS28oeWy9M/YuWYQgIZSeDZO2tGjsqxSIAE0kAg/Zo6aYGpfBwvInnDkd6oWQUbg3bi0tXY1Vm5A172XYqOfHxcS1vZkxWcy9pHySJSnhJ5vcYr2Lx1jxak/KOaSf8i6sAgkVXCM+cu4tzTVbW1X/+AMlpAKquKckNMzhzZUK9WVXRu1xqnz15QLaVcgr63mtTBm43rqhVMCWI3fD4NIsP7d4b8MpanKJQrXRztPmypPn6XlbsqFctCguMde2I/epcO4/YoG7NZtmLIx/Wim1CSsj+hruHxlas3UKm8rJAWhgTBBw+fMKxONH/rn9tqBTKuUj5Kf/jwMTwK5o0rwrpvflR58VVWvytVKIWkfE6NHWqAZBJznEOGQxTTVskb1KmBoWNnQM6XuLrdPx95bluH1JUqUVR/7smxSMtm9bB87bc4/ts5NGnwuhThmvbJRRFtxbqC9imDm/aH2I6nWzJUpZGk6ivlINtfYrSAUlT2//ps7pLiKXuPg43c5JXa80jGNyam9pmUP3KtJXYNypjyRIgy2qc1kqeQQEYTYMCb0cQ5HglYOAFZoRFJaObr1Suji7aaNX7KQnTqPQotP+6tffwdG1B6dmwDuQGpp9cEfPFVEEqn4pdabS2g/rh1c3j7zlY3xTVt3U1bNQ5JaAby5c2NUYO7qRuC5CYoeWyTj1d3pRf4+XrUe7uTesSSBMKDe/9PlXcfNA5yE5KXz1T8cekqOrV9V5UbJnfvBaPZ+90hK76j/OaicKGCaFTvdeTOlQOTxgyAPN5LbsCSx17JXlhpa8zmEi8VhWwhGDQqABOf3rQm+iJJ2S/1xqT1203w446f0WOQr8Z6PkwJHCIiIyFbMOQmt3bdhqPbgHHo+PE7kKA+bpyQ0FDIjXBjJ8/HMC3wl+0GuZPwOTV2xI2V1Ks5zqGE/fsM6Y5a2h9S4wLmQ24q7D3EDxcuX0UWN9eEqmrF9kSC/aXvvFlf3cgn+3lle4s0qlmtotqOIf3J/OZOZHuM6BlKY+08KluqGOQGS2ljuOqcFM9G9WriXvB91S7uprW4flN7HsW1T+zV1D6T8sfYNSjjyT5p2ZMsebMJOyIBEwk4mKhHNRIgARsmMGnMQMgNLAldbN2ysRbsDdQXv9eiEZbP9cXyeROw/ZtF+F/b2MBRAr9vV89S2xkkGBUd+UhYGsoWgBqvVpSskhl+Q9TWCXWQIPnovebqhrVVgROxZ/PnyJM7J6St9GGoWr92dSydPU7dBDTLf5jaXyn1slK7d/NyZYfc/FZLW3WW8nVLpih7p/p6wW9kX7WnVMoNpZBHATWmrPjKvle5SU1W8ESnqvbx9rwpIyF+/bhhAQLGDpJiJYnZ7OjggBEDPTF9wlB4P71pTeyKC5qM2Z/Q1wrlSqob7WSgIloALrYtmO6DSaMHYKJPf3h2eF+q8NmnrdDHs63KGyayd1Zu1Pty6VSsWTRJ+ScfwRvq9OvWDnIj3FqNUdMGtfRVxnxOyo5u//sQInGdJPSnRdN68PXuE1et7O7b9VN1bI5zSB6jJ/OjOtQS+fhc7Fm/bJo6r2QOu3ZoA8MtBZqa+l++bElt5TcEt+8Gq2NJZM/uwa2r4ePVTQ6VSJ9yzq0M9FPz69Xnf2qLiVS+UqGMOi/j8sJe8iLi5+xJw1UbeZVHpEl5UjxlfDnXZLy4m9bSeh7JmIYyoEcHfPpBC32RsXPT0DdRNuaPsWvwXvAD3LkTjCqVyklzCglkOAEGvBmOnANmMAEORwIkQAImERjcqyNka4VJylRKEQHhOrBXhxS1oTIJmJMAA15z0mRfJEACJGBFBGT10orMTXdTZYU4Pb98Id0dSHaAzFOQT3xk33zmWcCR7Z0AA157PwPoPwmQAAmQAAmQAAnYOAEGvDY+wSl1j/okQAIkQAIkQAIkYGsEGPDa2ozSHxIgARIgAXMQYB8kQAI2RIABrw1NJl0hARIgARIgARIgARJ4ngAD3ueZmF5CTRIgARIgARIgARIgAYsnwIDX4qeIBpIACZCA5ROghSRAAiRgyQQY8Fry7NA2EiABEiABEiABEiCBNBPIwIA3zbayAxIgARIgARIgARIgARJIMQEGvClGxgYkQAIkkEYCbE4CJEACJJChBBjwZihuDkYCJEACJEACJEACJBBHIKNeGfBmFGmOQwIkQAIkQAIkQAIkkCkEGPBmCnYOSgIkYDoBapIACZAACZBA2ggw4E0bP7YmARIgARIgARIggYwhwFFSTYABb6rRsSEJkAAJkAAJkAAJkIA1EGDAaw2zRBtJwHQC1CQBEiABEiABEkhAgAFvAiA8JAESIAESIAESsAUC9IEEnhFgwPuMBXMkQAIkQAIkQAIkQAI2SIABrw1OKl0ynQA1SYAESIAESIAEbJ8AA17bn2N6SAIkQAIkQALJEWA9Cdg0AQa8Nj29dI4ESIAESIAESIAESIABL88B0wlQkwRIgARIgARIgASskAADXiucNJpMAiRAAiSQuQQ4OgmQgHURYMBrXfNFa0mABEiABEiABEiABFJIgAFvCoGZrk5NEiABEiABEiABEiABSyDAgNcSZoE2kAAJkIAtE6BvJEACJJDJBBjwZvIEcHgSIAESIAESIAESIIH0JWApAW/6esneSYAESIAESIAESIAE7JYAA167nXo6TgIkYJkEaBUJkAAJkIC5CTDgNTdR9kcCJEACJEACJEACJJB2AmbsgQGvGWGyKxIgARIgARIgARIgAcsjwIDX8uaEFpEACZhOgJokQAIkQAIkkCwBBrzJIqICCZAACZAACZAACVg6AdqXFAEGvEnRYR0JkAAJkAAJkAAJkIDVE2DAa/VTSAdIwHQC1CQBEiABEiABeyTwfwAAAP//Ck3AGgAAAAZJREFUAwBtCv6qzoVHowAAAABJRU5ErkJggg=="
+     },
+     "metadata": {
+      "image/png": {
+       "alt": "Horizontal bar chart with one bar per temporal feature, feature names down the left and mean cross-sectional Spearman IC across the bottom, sorted from the most positive at the top to the most negative at the bottom. Every bar is short, within one hundredth of zero, and each carries a Newey-West 95% interval whisker. A dashed rule marks zero; most whiskers cross it and those bars are left dark slate, while the two features Benjamini-Hochberg retains are coloured, green for the positive IC at the top and red for the negative one at the bottom."
+      }
+     },
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "if n_tested > 0:\n",
     "    plot_ic = hac_df.sort(\"mean_ic\")\n",
@@ -2700,13 +5253,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "888dc7d0",
+   "id": "bcb1ecf9",
    "metadata": {
     "papermill": {
-     "duration": 0.007921,
-     "end_time": "2026-09-04T04:43:50.710641+00:00",
+     "duration": 0.006069,
+     "end_time": "2026-09-09T22:27:32.107070+00:00",
      "exception": false,
-     "start_time": "2026-09-04T04:43:50.702720+00:00",
+     "start_time": "2026-09-09T22:27:32.101001+00:00",
      "status": "completed"
     },
     "tags": [
@@ -2743,13 +5296,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c56f5dd2",
+   "id": "41422248",
    "metadata": {
     "papermill": {
-     "duration": 0.00808,
-     "end_time": "2026-09-04T04:43:50.726857+00:00",
+     "duration": 0.005868,
+     "end_time": "2026-09-09T22:27:32.118829+00:00",
      "exception": false,
-     "start_time": "2026-09-04T04:43:50.718777+00:00",
+     "start_time": "2026-09-09T22:27:32.112961+00:00",
      "status": "completed"
     }
    },
@@ -2825,6 +5378,27 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.14.3"
+  },
+  "ml4t_provenance": {
+   "executed_at": "2026-09-09T22:27:43.969059+00:00",
+   "executor": "local-uv",
+   "library_digest": "fd6f165b3d48671b67a1529ac0a831b517ed55bcd2bc147442cefeb52dd122bc",
+   "outputs_digest": "4d3aac4d8aee8c006f3d2785cc4251b9946dcf7061baf3aa520ff4164d514fd1",
+   "parameters": {},
+   "production": true,
+   "source_py_blob": "3e3d930148f92957595a57c0c7d4225dd49c251b"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 5795.680309,
+   "end_time": "2026-09-09T22:27:35.244324+00:00",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "~/ml4t/public-nasdaq/case_studies/nasdaq100_microstructure/.04_model_based_features.build.3544804.ipynb",
+   "output_path": "~/ml4t/public-nasdaq/case_studies/nasdaq100_microstructure/.04_model_based_features.papermill.3544804.ipynb",
+   "parameters": {},
+   "start_time": "2026-09-09T20:50:59.564015+00:00",
+   "version": "2.7.0"
   }
  },
  "nbformat": 4,

--- a/case_studies/nasdaq100_microstructure/06_linear.ipynb
+++ b/case_studies/nasdaq100_microstructure/06_linear.ipynb
@@ -2,8 +2,16 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "6ce9dfbf",
-   "metadata": {},
+   "id": "5a4fd5bc",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002303,
+     "end_time": "2026-09-10T02:34:07.020878+00:00",
+     "exception": false,
+     "start_time": "2026-09-10T02:34:07.018575+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "# NASDAQ-100 microstructure: what a linear map of order flow is worth\n",
     "\n",
@@ -63,9 +71,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "f991afad",
-   "metadata": {},
+   "execution_count": 1,
+   "id": "fff460c8",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-10T02:34:07.024048Z",
+     "iopub.status.busy": "2026-09-10T02:34:07.023939Z",
+     "iopub.status.idle": "2026-09-10T02:34:09.277497Z",
+     "shell.execute_reply": "2026-09-10T02:34:09.277026Z"
+    },
+    "papermill": {
+     "duration": 2.256324,
+     "end_time": "2026-09-10T02:34:09.278436+00:00",
+     "exception": false,
+     "start_time": "2026-09-10T02:34:07.022112+00:00",
+     "status": "completed"
+    }
+   },
    "outputs": [],
    "source": [
     "\"\"\"Fit the declared NASDAQ-100 microstructure linear population on the validation folds.\"\"\"\n",
@@ -90,9 +112,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "45c4caf7",
+   "execution_count": 2,
+   "id": "2bc46088",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-10T02:34:09.282533Z",
+     "iopub.status.busy": "2026-09-10T02:34:09.282326Z",
+     "iopub.status.idle": "2026-09-10T02:34:09.284430Z",
+     "shell.execute_reply": "2026-09-10T02:34:09.284114Z"
+    },
+    "papermill": {
+     "duration": 0.004104,
+     "end_time": "2026-09-10T02:34:09.284677+00:00",
+     "exception": false,
+     "start_time": "2026-09-10T02:34:09.280573+00:00",
+     "status": "completed"
+    },
     "tags": [
      "parameters"
     ]
@@ -110,9 +145,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "a4077a8f",
-   "metadata": {},
+   "execution_count": 4,
+   "id": "ddf6f0ea",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-10T02:34:09.291540Z",
+     "iopub.status.busy": "2026-09-10T02:34:09.291411Z",
+     "iopub.status.idle": "2026-09-10T02:34:38.591591Z",
+     "shell.execute_reply": "2026-09-10T02:34:38.591077Z"
+    },
+    "papermill": {
+     "duration": 29.30204,
+     "end_time": "2026-09-10T02:34:38.592060+00:00",
+     "exception": false,
+     "start_time": "2026-09-10T02:34:09.290020+00:00",
+     "status": "completed"
+    }
+   },
    "outputs": [],
    "source": [
     "study = open_study(\n",
@@ -125,8 +174,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "003157bb",
-   "metadata": {},
+   "id": "b3b2539b",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001038,
+     "end_time": "2026-09-10T02:34:38.594405+00:00",
+     "exception": false,
+     "start_time": "2026-09-10T02:34:38.593367+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "## 1. Which label, and which models\n",
     "\n",
@@ -145,18 +202,51 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "a3f5447f",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 5,
+   "id": "f49c04cb",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-10T02:34:38.597227Z",
+     "iopub.status.busy": "2026-09-10T02:34:38.597131Z",
+     "iopub.status.idle": "2026-09-10T02:34:38.616402Z",
+     "shell.execute_reply": "2026-09-10T02:34:38.615995Z"
+    },
+    "papermill": {
+     "duration": 0.021195,
+     "end_time": "2026-09-10T02:34:38.616658+00:00",
+     "exception": false,
+     "start_time": "2026-09-10T02:34:38.595463+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "('fwd_dir_15m', 'fwd_ret_15m', 'fwd_ret_5m', 'fwd_ret_60m')"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "declared_labels(study, \"linear\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "ac3f2e56",
-   "metadata": {},
+   "id": "32fbe853",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001082,
+     "end_time": "2026-09-10T02:34:38.619066+00:00",
+     "exception": false,
+     "start_time": "2026-09-10T02:34:38.617984+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "Each name in the menu resolves to a preset file in the shared directory\n",
     "`case_studies/config/{model_type}/`, which holds that configuration's hyperparameters. The\n",
@@ -182,10 +272,62 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "8c729bb0",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 6,
+   "id": "2cd89923",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-10T02:34:38.621895Z",
+     "iopub.status.busy": "2026-09-10T02:34:38.621807Z",
+     "iopub.status.idle": "2026-09-10T02:34:38.663206Z",
+     "shell.execute_reply": "2026-09-10T02:34:38.662690Z"
+    },
+    "papermill": {
+     "duration": 0.0433,
+     "end_time": "2026-09-10T02:34:38.663498+00:00",
+     "exception": false,
+     "start_time": "2026-09-10T02:34:38.620198+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div><style>\n",
+       ".dataframe > thead > tr,\n",
+       ".dataframe > tbody > tr {\n",
+       "  text-align: right;\n",
+       "  white-space: pre-wrap;\n",
+       "}\n",
+       "</style>\n",
+       "<small>shape: (61, 5)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>family</th><th>label</th><th>config_name</th><th>model_class</th><th>params</th></tr><tr><td>str</td><td>str</td><td>str</td><td>str</td><td>str</td></tr></thead><tbody><tr><td>&quot;linear&quot;</td><td>&quot;fwd_dir_15m&quot;</td><td>&quot;logistic_none&quot;</td><td>&quot;LogisticRegression&quot;</td><td>&quot;max_iter=1000, penalty=None, s…</td></tr><tr><td>&quot;linear&quot;</td><td>&quot;fwd_dir_15m&quot;</td><td>&quot;logistic_l2_C0.001&quot;</td><td>&quot;LogisticRegression&quot;</td><td>&quot;C=0.001, max_iter=1000, solver…</td></tr><tr><td>&quot;linear&quot;</td><td>&quot;fwd_dir_15m&quot;</td><td>&quot;logistic_l2_C0.01&quot;</td><td>&quot;LogisticRegression&quot;</td><td>&quot;C=0.01, max_iter=1000, solver=…</td></tr><tr><td>&quot;linear&quot;</td><td>&quot;fwd_dir_15m&quot;</td><td>&quot;logistic_l2_C0.1&quot;</td><td>&quot;LogisticRegression&quot;</td><td>&quot;C=0.1, max_iter=1000, solver=l…</td></tr><tr><td>&quot;linear&quot;</td><td>&quot;fwd_dir_15m&quot;</td><td>&quot;logistic_l2_C1.0&quot;</td><td>&quot;LogisticRegression&quot;</td><td>&quot;C=1.0, max_iter=1000, solver=l…</td></tr><tr><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td></tr><tr><td>&quot;linear&quot;</td><td>&quot;fwd_ret_60m&quot;</td><td>&quot;ridge_a10000000.0&quot;</td><td>&quot;Ridge&quot;</td><td>&quot;alpha=10000000.0&quot;</td></tr><tr><td>&quot;linear&quot;</td><td>&quot;fwd_ret_60m&quot;</td><td>&quot;lasso_a0.01&quot;</td><td>&quot;Lasso&quot;</td><td>&quot;alpha=0.01, max_iter=1000&quot;</td></tr><tr><td>&quot;linear&quot;</td><td>&quot;fwd_ret_60m&quot;</td><td>&quot;lasso_a0.1&quot;</td><td>&quot;Lasso&quot;</td><td>&quot;alpha=0.1, max_iter=1000&quot;</td></tr><tr><td>&quot;linear&quot;</td><td>&quot;fwd_ret_60m&quot;</td><td>&quot;enet_a0.01&quot;</td><td>&quot;ElasticNet&quot;</td><td>&quot;alpha=0.01, l1_ratio=0.5, max_…</td></tr><tr><td>&quot;linear&quot;</td><td>&quot;fwd_ret_60m&quot;</td><td>&quot;enet_a0.1&quot;</td><td>&quot;ElasticNet&quot;</td><td>&quot;alpha=0.1, l1_ratio=0.5, max_i…</td></tr></tbody></table></div>"
+      ],
+      "text/plain": [
+       "shape: (61, 5)\n",
+       "┌────────┬─────────────┬────────────────────┬────────────────────┬─────────────────────────────────┐\n",
+       "│ family ┆ label       ┆ config_name        ┆ model_class        ┆ params                          │\n",
+       "│ ---    ┆ ---         ┆ ---                ┆ ---                ┆ ---                             │\n",
+       "│ str    ┆ str         ┆ str                ┆ str                ┆ str                             │\n",
+       "╞════════╪═════════════╪════════════════════╪════════════════════╪═════════════════════════════════╡\n",
+       "│ linear ┆ fwd_dir_15m ┆ logistic_none      ┆ LogisticRegression ┆ max_iter=1000, penalty=None, s… │\n",
+       "│ linear ┆ fwd_dir_15m ┆ logistic_l2_C0.001 ┆ LogisticRegression ┆ C=0.001, max_iter=1000, solver… │\n",
+       "│ linear ┆ fwd_dir_15m ┆ logistic_l2_C0.01  ┆ LogisticRegression ┆ C=0.01, max_iter=1000, solver=… │\n",
+       "│ linear ┆ fwd_dir_15m ┆ logistic_l2_C0.1   ┆ LogisticRegression ┆ C=0.1, max_iter=1000, solver=l… │\n",
+       "│ linear ┆ fwd_dir_15m ┆ logistic_l2_C1.0   ┆ LogisticRegression ┆ C=1.0, max_iter=1000, solver=l… │\n",
+       "│ …      ┆ …           ┆ …                  ┆ …                  ┆ …                               │\n",
+       "│ linear ┆ fwd_ret_60m ┆ ridge_a10000000.0  ┆ Ridge              ┆ alpha=10000000.0                │\n",
+       "│ linear ┆ fwd_ret_60m ┆ lasso_a0.01        ┆ Lasso              ┆ alpha=0.01, max_iter=1000       │\n",
+       "│ linear ┆ fwd_ret_60m ┆ lasso_a0.1         ┆ Lasso              ┆ alpha=0.1, max_iter=1000        │\n",
+       "│ linear ┆ fwd_ret_60m ┆ enet_a0.01         ┆ ElasticNet         ┆ alpha=0.01, l1_ratio=0.5, max_… │\n",
+       "│ linear ┆ fwd_ret_60m ┆ enet_a0.1          ┆ ElasticNet         ┆ alpha=0.1, l1_ratio=0.5, max_i… │\n",
+       "└────────┴─────────────┴────────────────────┴────────────────────┴─────────────────────────────────┘"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "configs = load_model_configs(\n",
     "    study,\n",
@@ -198,8 +340,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "40708f69",
-   "metadata": {},
+   "id": "58892dc4",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001137,
+     "end_time": "2026-09-10T02:34:38.665979+00:00",
+     "exception": false,
+     "start_time": "2026-09-10T02:34:38.664842+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "`LABELS` and `CONFIG_NAMES` both narrow what is fitted, and a narrowed run declares a different\n",
     "member set from the canonical population. A population is immutable once written, so such a\n",
@@ -212,9 +362,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "be50ec0d",
-   "metadata": {},
+   "execution_count": 7,
+   "id": "1d416316",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-10T02:34:38.669023Z",
+     "iopub.status.busy": "2026-09-10T02:34:38.668882Z",
+     "iopub.status.idle": "2026-09-10T02:34:38.702868Z",
+     "shell.execute_reply": "2026-09-10T02:34:38.702444Z"
+    },
+    "papermill": {
+     "duration": 0.036138,
+     "end_time": "2026-09-10T02:34:38.703299+00:00",
+     "exception": false,
+     "start_time": "2026-09-10T02:34:38.667161+00:00",
+     "status": "completed"
+    }
+   },
    "outputs": [],
    "source": [
     "if narrows_declared_catalog(study, \"linear\", configs) and not POPULATION_NAME:\n",
@@ -226,8 +390,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e9e677d8",
-   "metadata": {},
+   "id": "4bd3de1b",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001144,
+     "end_time": "2026-09-10T02:34:38.705845+00:00",
+     "exception": false,
+     "start_time": "2026-09-10T02:34:38.704701+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "## 2. Binding the declarations to the data\n",
     "\n",
@@ -263,10 +435,62 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "3a63cd80",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 8,
+   "id": "6c749ad6",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-10T02:34:38.708864Z",
+     "iopub.status.busy": "2026-09-10T02:34:38.708772Z",
+     "iopub.status.idle": "2026-09-10T02:36:29.471394Z",
+     "shell.execute_reply": "2026-09-10T02:36:29.470730Z"
+    },
+    "papermill": {
+     "duration": 110.767568,
+     "end_time": "2026-09-10T02:36:29.474596+00:00",
+     "exception": false,
+     "start_time": "2026-09-10T02:34:38.707028+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div><style>\n",
+       ".dataframe > thead > tr,\n",
+       ".dataframe > tbody > tr {\n",
+       "  text-align: right;\n",
+       "  white-space: pre-wrap;\n",
+       "}\n",
+       "</style>\n",
+       "<small>shape: (61, 5)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>config_name</th><th>checkpoint_kind</th><th>checkpoint_value</th><th>training_hash</th><th>prediction_hash</th></tr><tr><td>str</td><td>str</td><td>null</td><td>str</td><td>str</td></tr></thead><tbody><tr><td>&quot;logistic_none&quot;</td><td>&quot;final&quot;</td><td>null</td><td>&quot;8445df336e51&quot;</td><td>&quot;6b63c9265064&quot;</td></tr><tr><td>&quot;logistic_l2_C0.001&quot;</td><td>&quot;final&quot;</td><td>null</td><td>&quot;7361c6123f9f&quot;</td><td>&quot;64d831ba26ac&quot;</td></tr><tr><td>&quot;logistic_l2_C0.01&quot;</td><td>&quot;final&quot;</td><td>null</td><td>&quot;f3caae8f0a27&quot;</td><td>&quot;318833237ee8&quot;</td></tr><tr><td>&quot;logistic_l2_C0.1&quot;</td><td>&quot;final&quot;</td><td>null</td><td>&quot;b7187bb90995&quot;</td><td>&quot;dc42a58acc2a&quot;</td></tr><tr><td>&quot;logistic_l2_C1.0&quot;</td><td>&quot;final&quot;</td><td>null</td><td>&quot;e3f431013724&quot;</td><td>&quot;9b8d1ad79eee&quot;</td></tr><tr><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td></tr><tr><td>&quot;ridge_a10000000.0&quot;</td><td>&quot;final&quot;</td><td>null</td><td>&quot;c64d85a2c518&quot;</td><td>&quot;35224053aa51&quot;</td></tr><tr><td>&quot;lasso_a0.01&quot;</td><td>&quot;final&quot;</td><td>null</td><td>&quot;30b5c6daaf2e&quot;</td><td>&quot;dc09e63952d1&quot;</td></tr><tr><td>&quot;lasso_a0.1&quot;</td><td>&quot;final&quot;</td><td>null</td><td>&quot;2ef500d83038&quot;</td><td>&quot;637739502737&quot;</td></tr><tr><td>&quot;enet_a0.01&quot;</td><td>&quot;final&quot;</td><td>null</td><td>&quot;368227935bcd&quot;</td><td>&quot;672e7468f9b3&quot;</td></tr><tr><td>&quot;enet_a0.1&quot;</td><td>&quot;final&quot;</td><td>null</td><td>&quot;5a6ad76f2be6&quot;</td><td>&quot;cd69c71335de&quot;</td></tr></tbody></table></div>"
+      ],
+      "text/plain": [
+       "shape: (61, 5)\n",
+       "┌────────────────────┬─────────────────┬──────────────────┬───────────────┬─────────────────┐\n",
+       "│ config_name        ┆ checkpoint_kind ┆ checkpoint_value ┆ training_hash ┆ prediction_hash │\n",
+       "│ ---                ┆ ---             ┆ ---              ┆ ---           ┆ ---             │\n",
+       "│ str                ┆ str             ┆ null             ┆ str           ┆ str             │\n",
+       "╞════════════════════╪═════════════════╪══════════════════╪═══════════════╪═════════════════╡\n",
+       "│ logistic_none      ┆ final           ┆ null             ┆ 8445df336e51  ┆ 6b63c9265064    │\n",
+       "│ logistic_l2_C0.001 ┆ final           ┆ null             ┆ 7361c6123f9f  ┆ 64d831ba26ac    │\n",
+       "│ logistic_l2_C0.01  ┆ final           ┆ null             ┆ f3caae8f0a27  ┆ 318833237ee8    │\n",
+       "│ logistic_l2_C0.1   ┆ final           ┆ null             ┆ b7187bb90995  ┆ dc42a58acc2a    │\n",
+       "│ logistic_l2_C1.0   ┆ final           ┆ null             ┆ e3f431013724  ┆ 9b8d1ad79eee    │\n",
+       "│ …                  ┆ …               ┆ …                ┆ …             ┆ …               │\n",
+       "│ ridge_a10000000.0  ┆ final           ┆ null             ┆ c64d85a2c518  ┆ 35224053aa51    │\n",
+       "│ lasso_a0.01        ┆ final           ┆ null             ┆ 30b5c6daaf2e  ┆ dc09e63952d1    │\n",
+       "│ lasso_a0.1         ┆ final           ┆ null             ┆ 2ef500d83038  ┆ 637739502737    │\n",
+       "│ enet_a0.01         ┆ final           ┆ null             ┆ 368227935bcd  ┆ 672e7468f9b3    │\n",
+       "│ enet_a0.1          ┆ final           ┆ null             ┆ 5a6ad76f2be6  ┆ cd69c71335de    │\n",
+       "└────────────────────┴─────────────────┴──────────────────┴───────────────┴─────────────────┘"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "requests = model_requests(\n",
     "    study,\n",
@@ -290,8 +514,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "aa1ce576",
-   "metadata": {},
+   "id": "ab5e18dc",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001929,
+     "end_time": "2026-09-10T02:36:29.479158+00:00",
+     "exception": false,
+     "start_time": "2026-09-10T02:36:29.477229+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "## 3. Fitting the population\n",
     "\n",
@@ -329,10 +561,318 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "ff0d9016",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 9,
+   "id": "475ac399",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-10T02:36:29.482655Z",
+     "iopub.status.busy": "2026-09-10T02:36:29.482469Z",
+     "iopub.status.idle": "2026-09-10T02:46:49.962863Z",
+     "shell.execute_reply": "2026-09-10T02:46:49.962400Z"
+    },
+    "papermill": {
+     "duration": 620.486167,
+     "end_time": "2026-09-10T02:46:49.966622+00:00",
+     "exception": false,
+     "start_time": "2026-09-10T02:36:29.480455+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[02:38:33] linear group {\"cv\":null,\": 16 configurations x 2 folds, fold-major\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[02:39:20] fold 0 of 2 prepared in 47.0s; 16 configurations to fit on it\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[02:39:34]   fold 0 fitted for ols in   13.9s (config total    13.9s)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[02:40:30]   fold 0 fitted for ridge_a0.001 in   56.0s (config total    56.0s)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[02:41:18]   fold 0 fitted for ridge_a0.01 in   47.6s (config total    47.6s)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[02:42:04]   fold 0 fitted for ridge_a0.1 in   46.0s (config total    46.0s)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "~/ml4t/public-nasdaq/.venv/lib/python3.14/site-packages/sklearn/linear_model/_ridge.py:213: LinAlgWarning: An ill-conditioned matrix detected: slice 0 has rcond = 1.8090322129182823e-08.\n",
+      "  return linalg.solve(A, Xy, assume_a=\"pos\", overwrite_a=True).T\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[02:42:05]   fold 0 fitted for ridge_a1.0 in    1.3s (config total     1.3s)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[02:42:06]   fold 0 fitted for ridge_a10.0 in    1.3s (config total     1.3s)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[02:42:08]   fold 0 fitted for ridge_a100.0 in    1.4s (config total     1.4s)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[02:42:09]   fold 0 fitted for ridge_a1000.0 in    1.3s (config total     1.3s)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[02:42:10]   fold 0 fitted for ridge_a10000.0 in    1.3s (config total     1.3s)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[02:42:11]   fold 0 fitted for ridge_a100000.0 in    1.3s (config total     1.3s)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[02:42:13]   fold 0 fitted for ridge_a1000000.0 in    1.3s (config total     1.3s)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[02:42:14]   fold 0 fitted for ridge_a10000000.0 in    1.3s (config total     1.3s)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[02:42:17]   fold 0 fitted for lasso_a0.01 in    2.9s (config total     2.9s)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[02:42:20]   fold 0 fitted for lasso_a0.1 in    2.8s (config total     2.8s)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[02:42:23]   fold 0 fitted for enet_a0.01 in    2.8s (config total     2.8s)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[02:42:26]   fold 0 fitted for enet_a0.1 in    3.2s (config total     3.2s)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[02:43:04] fold 1 of 2 prepared in 38.2s; 16 configurations to fit on it\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[02:43:16]   fold 1 fitted for ols in   12.0s (config total    25.9s)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "~/ml4t/public-nasdaq/.venv/lib/python3.14/site-packages/sklearn/linear_model/_ridge.py:213: LinAlgWarning: An ill-conditioned matrix detected: slice 0 has rcond = 1.8111383920382806e-11.\n",
+      "  return linalg.solve(A, Xy, assume_a=\"pos\", overwrite_a=True).T\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[02:43:17]   fold 1 fitted for ridge_a0.001 in    1.3s (config total    57.3s)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "~/ml4t/public-nasdaq/.venv/lib/python3.14/site-packages/sklearn/linear_model/_ridge.py:213: LinAlgWarning: An ill-conditioned matrix detected: slice 0 has rcond = 1.8111380450935854e-10.\n",
+      "  return linalg.solve(A, Xy, assume_a=\"pos\", overwrite_a=True).T\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[02:43:19]   fold 1 fitted for ridge_a0.01 in    1.3s (config total    48.9s)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "~/ml4t/public-nasdaq/.venv/lib/python3.14/site-packages/sklearn/linear_model/_ridge.py:213: LinAlgWarning: An ill-conditioned matrix detected: slice 0 has rcond = 1.8111381283603123e-09.\n",
+      "  return linalg.solve(A, Xy, assume_a=\"pos\", overwrite_a=True).T\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[02:43:20]   fold 1 fitted for ridge_a0.1 in    1.2s (config total    47.2s)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "~/ml4t/public-nasdaq/.venv/lib/python3.14/site-packages/sklearn/linear_model/_ridge.py:213: LinAlgWarning: An ill-conditioned matrix detected: slice 0 has rcond = 1.6979274874984185e-08.\n",
+      "  return linalg.solve(A, Xy, assume_a=\"pos\", overwrite_a=True).T\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[02:43:21]   fold 1 fitted for ridge_a1.0 in    1.2s (config total     2.5s)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[02:43:22]   fold 1 fitted for ridge_a10.0 in    1.3s (config total     2.6s)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[02:43:24]   fold 1 fitted for ridge_a100.0 in    1.3s (config total     2.6s)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[02:43:25]   fold 1 fitted for ridge_a1000.0 in    1.2s (config total     2.5s)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[02:43:26]   fold 1 fitted for ridge_a10000.0 in    1.2s (config total     2.5s)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[02:43:27]   fold 1 fitted for ridge_a100000.0 in    1.4s (config total     2.6s)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[02:43:29]   fold 1 fitted for ridge_a1000000.0 in    1.2s (config total     2.6s)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[02:43:30]   fold 1 fitted for ridge_a10000000.0 in    1.2s (config total     2.5s)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[02:43:33]   fold 1 fitted for lasso_a0.01 in    2.7s (config total     5.6s)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[02:43:35]   fold 1 fitted for lasso_a0.1 in    2.7s (config total     5.5s)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[02:43:38]   fold 1 fitted for enet_a0.01 in    2.9s (config total     5.7s)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[02:43:41]   fold 1 fitted for enet_a0.1 in    2.7s (config total     5.9s)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "61 configurations: 32 folds fitted, 90 reused\n",
+      "population nasdaq100_microstructure-linear-validation-v1: 61 prediction sets\n"
+     ]
+    }
+   ],
    "source": [
     "population_name = POPULATION_NAME or \"nasdaq100_microstructure-linear-validation-v1\"\n",
     "execution, population = run_model_population(\n",
@@ -347,8 +887,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b7ae10af",
-   "metadata": {},
+   "id": "f25e0fe3",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003309,
+     "end_time": "2026-09-10T02:46:49.973347+00:00",
+     "exception": false,
+     "start_time": "2026-09-10T02:46:49.970038+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "`reused` is not zero on a second run. Every identity is re-derived from the inputs, the\n",
     "registry already holds the matching rows, and the runner returns the stored result rather than\n",
@@ -385,8 +933,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2e5a22a4",
-   "metadata": {},
+   "id": "28217d49",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002965,
+     "end_time": "2026-09-10T02:46:49.979737+00:00",
+     "exception": false,
+     "start_time": "2026-09-10T02:46:49.976772+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "## 4. What came out\n",
     "\n",
@@ -417,14 +973,103 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "6f76b57a",
+   "execution_count": 10,
+   "id": "30ae9c15",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-10T02:46:49.983997Z",
+     "iopub.status.busy": "2026-09-10T02:46:49.983894Z",
+     "iopub.status.idle": "2026-09-10T02:46:50.004887Z",
+     "shell.execute_reply": "2026-09-10T02:46:50.004620Z"
+    },
+    "papermill": {
+     "duration": 0.023757,
+     "end_time": "2026-09-10T02:46:50.005283+00:00",
+     "exception": false,
+     "start_time": "2026-09-10T02:46:49.981526+00:00",
+     "status": "completed"
+    },
     "tags": [
      "results"
     ]
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "fwd_dir_15m: full coverage is 78,812.0 scored decision times\n",
+      "fwd_ret_15m: full coverage is 78,812.0 scored decision times\n",
+      "fwd_ret_5m: full coverage is 81,350.0 scored decision times\n",
+      "fwd_ret_60m: full coverage is 67,434.0 scored decision times\n",
+      "61 candidate models across 4 labels\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div><style>\n",
+       ".dataframe > thead > tr,\n",
+       ".dataframe > tbody > tr {\n",
+       "  text-align: right;\n",
+       "  white-space: pre-wrap;\n",
+       "}\n",
+       "</style>\n",
+       "<small>shape: (61, 8)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>label</th><th>config_name</th><th>model_class</th><th>params</th><th>ic_mean</th><th>ic_std</th><th>ic_n_days</th><th>full_coverage</th></tr><tr><td>str</td><td>str</td><td>str</td><td>str</td><td>f64</td><td>f64</td><td>f64</td><td>bool</td></tr></thead><tbody><tr><td>&quot;fwd_dir_15m&quot;</td><td>&quot;logistic_l1_C0.001&quot;</td><td>&quot;LogisticRegression&quot;</td><td>&quot;C=0.001, max_iter=200, penalty…</td><td>0.009105</td><td>0.000895</td><td>78812.0</td><td>true</td></tr><tr><td>&quot;fwd_dir_15m&quot;</td><td>&quot;logistic_l1_C0.01&quot;</td><td>&quot;LogisticRegression&quot;</td><td>&quot;C=0.01, max_iter=200, penalty=…</td><td>0.00898</td><td>0.000704</td><td>78812.0</td><td>true</td></tr><tr><td>&quot;fwd_dir_15m&quot;</td><td>&quot;logistic_l1_C0.1&quot;</td><td>&quot;LogisticRegression&quot;</td><td>&quot;C=0.1, max_iter=200, penalty=l…</td><td>0.008968</td><td>0.000717</td><td>78812.0</td><td>true</td></tr><tr><td>&quot;fwd_dir_15m&quot;</td><td>&quot;logistic_l1_C1.0&quot;</td><td>&quot;LogisticRegression&quot;</td><td>&quot;C=1.0, max_iter=200, penalty=l…</td><td>0.008918</td><td>0.000695</td><td>78812.0</td><td>true</td></tr><tr><td>&quot;fwd_dir_15m&quot;</td><td>&quot;logistic_l1_C10.0&quot;</td><td>&quot;LogisticRegression&quot;</td><td>&quot;C=10.0, max_iter=200, penalty=…</td><td>0.008918</td><td>0.000695</td><td>78812.0</td><td>true</td></tr><tr><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td></tr><tr><td>&quot;fwd_ret_60m&quot;</td><td>&quot;ols&quot;</td><td>&quot;LinearRegression&quot;</td><td>&quot;defaults&quot;</td><td>0.00218</td><td>0.003253</td><td>67434.0</td><td>true</td></tr><tr><td>&quot;fwd_ret_60m&quot;</td><td>&quot;enet_a0.1&quot;</td><td>&quot;ElasticNet&quot;</td><td>&quot;alpha=0.1, l1_ratio=0.5, max_i…</td><td>2.0457e-16</td><td>3.5027e-18</td><td>17902.0</td><td>false</td></tr><tr><td>&quot;fwd_ret_60m&quot;</td><td>&quot;lasso_a0.01&quot;</td><td>&quot;Lasso&quot;</td><td>&quot;alpha=0.01, max_iter=1000&quot;</td><td>2.0457e-16</td><td>3.5027e-18</td><td>17902.0</td><td>false</td></tr><tr><td>&quot;fwd_ret_60m&quot;</td><td>&quot;lasso_a0.1&quot;</td><td>&quot;Lasso&quot;</td><td>&quot;alpha=0.1, max_iter=1000&quot;</td><td>2.0457e-16</td><td>3.5027e-18</td><td>17902.0</td><td>false</td></tr><tr><td>&quot;fwd_ret_60m&quot;</td><td>&quot;enet_a0.01&quot;</td><td>&quot;ElasticNet&quot;</td><td>&quot;alpha=0.01, l1_ratio=0.5, max_…</td><td>2.0457e-16</td><td>3.5027e-18</td><td>17902.0</td><td>false</td></tr></tbody></table></div>"
+      ],
+      "text/plain": [
+       "shape: (61, 8)\n",
+       "┌────────────┬────────────┬────────────┬───────────┬───────────┬───────────┬───────────┬───────────┐\n",
+       "│ label      ┆ config_nam ┆ model_clas ┆ params    ┆ ic_mean   ┆ ic_std    ┆ ic_n_days ┆ full_cove │\n",
+       "│ ---        ┆ e          ┆ s          ┆ ---       ┆ ---       ┆ ---       ┆ ---       ┆ rage      │\n",
+       "│ str        ┆ ---        ┆ ---        ┆ str       ┆ f64       ┆ f64       ┆ f64       ┆ ---       │\n",
+       "│            ┆ str        ┆ str        ┆           ┆           ┆           ┆           ┆ bool      │\n",
+       "╞════════════╪════════════╪════════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╡\n",
+       "│ fwd_dir_15 ┆ logistic_l ┆ LogisticRe ┆ C=0.001,  ┆ 0.009105  ┆ 0.000895  ┆ 78812.0   ┆ true      │\n",
+       "│ m          ┆ 1_C0.001   ┆ gression   ┆ max_iter= ┆           ┆           ┆           ┆           │\n",
+       "│            ┆            ┆            ┆ 200,      ┆           ┆           ┆           ┆           │\n",
+       "│            ┆            ┆            ┆ penalty…  ┆           ┆           ┆           ┆           │\n",
+       "│ fwd_dir_15 ┆ logistic_l ┆ LogisticRe ┆ C=0.01,   ┆ 0.00898   ┆ 0.000704  ┆ 78812.0   ┆ true      │\n",
+       "│ m          ┆ 1_C0.01    ┆ gression   ┆ max_iter= ┆           ┆           ┆           ┆           │\n",
+       "│            ┆            ┆            ┆ 200,      ┆           ┆           ┆           ┆           │\n",
+       "│            ┆            ┆            ┆ penalty=… ┆           ┆           ┆           ┆           │\n",
+       "│ fwd_dir_15 ┆ logistic_l ┆ LogisticRe ┆ C=0.1,    ┆ 0.008968  ┆ 0.000717  ┆ 78812.0   ┆ true      │\n",
+       "│ m          ┆ 1_C0.1     ┆ gression   ┆ max_iter= ┆           ┆           ┆           ┆           │\n",
+       "│            ┆            ┆            ┆ 200, pena ┆           ┆           ┆           ┆           │\n",
+       "│            ┆            ┆            ┆ lty=l…    ┆           ┆           ┆           ┆           │\n",
+       "│ fwd_dir_15 ┆ logistic_l ┆ LogisticRe ┆ C=1.0,    ┆ 0.008918  ┆ 0.000695  ┆ 78812.0   ┆ true      │\n",
+       "│ m          ┆ 1_C1.0     ┆ gression   ┆ max_iter= ┆           ┆           ┆           ┆           │\n",
+       "│            ┆            ┆            ┆ 200, pena ┆           ┆           ┆           ┆           │\n",
+       "│            ┆            ┆            ┆ lty=l…    ┆           ┆           ┆           ┆           │\n",
+       "│ fwd_dir_15 ┆ logistic_l ┆ LogisticRe ┆ C=10.0,   ┆ 0.008918  ┆ 0.000695  ┆ 78812.0   ┆ true      │\n",
+       "│ m          ┆ 1_C10.0    ┆ gression   ┆ max_iter= ┆           ┆           ┆           ┆           │\n",
+       "│            ┆            ┆            ┆ 200,      ┆           ┆           ┆           ┆           │\n",
+       "│            ┆            ┆            ┆ penalty=… ┆           ┆           ┆           ┆           │\n",
+       "│ …          ┆ …          ┆ …          ┆ …         ┆ …         ┆ …         ┆ …         ┆ …         │\n",
+       "│ fwd_ret_60 ┆ ols        ┆ LinearRegr ┆ defaults  ┆ 0.00218   ┆ 0.003253  ┆ 67434.0   ┆ true      │\n",
+       "│ m          ┆            ┆ ession     ┆           ┆           ┆           ┆           ┆           │\n",
+       "│ fwd_ret_60 ┆ enet_a0.1  ┆ ElasticNet ┆ alpha=0.1 ┆ 2.0457e-1 ┆ 3.5027e-1 ┆ 17902.0   ┆ false     │\n",
+       "│ m          ┆            ┆            ┆ , l1_rati ┆ 6         ┆ 8         ┆           ┆           │\n",
+       "│            ┆            ┆            ┆ o=0.5,    ┆           ┆           ┆           ┆           │\n",
+       "│            ┆            ┆            ┆ max_i…    ┆           ┆           ┆           ┆           │\n",
+       "│ fwd_ret_60 ┆ lasso_a0.0 ┆ Lasso      ┆ alpha=0.0 ┆ 2.0457e-1 ┆ 3.5027e-1 ┆ 17902.0   ┆ false     │\n",
+       "│ m          ┆ 1          ┆            ┆ 1, max_it ┆ 6         ┆ 8         ┆           ┆           │\n",
+       "│            ┆            ┆            ┆ er=1000   ┆           ┆           ┆           ┆           │\n",
+       "│ fwd_ret_60 ┆ lasso_a0.1 ┆ Lasso      ┆ alpha=0.1 ┆ 2.0457e-1 ┆ 3.5027e-1 ┆ 17902.0   ┆ false     │\n",
+       "│ m          ┆            ┆            ┆ , max_ite ┆ 6         ┆ 8         ┆           ┆           │\n",
+       "│            ┆            ┆            ┆ r=1000    ┆           ┆           ┆           ┆           │\n",
+       "│ fwd_ret_60 ┆ enet_a0.01 ┆ ElasticNet ┆ alpha=0.0 ┆ 2.0457e-1 ┆ 3.5027e-1 ┆ 17902.0   ┆ false     │\n",
+       "│ m          ┆            ┆            ┆ 1, l1_rat ┆ 6         ┆ 8         ┆           ┆           │\n",
+       "│            ┆            ┆            ┆ io=0.5,   ┆           ┆           ┆           ┆           │\n",
+       "│            ┆            ┆            ┆ max_…     ┆           ┆           ┆           ┆           │\n",
+       "└────────────┴────────────┴────────────┴───────────┴───────────┴───────────┴───────────┴───────────┘"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "catalog = (\n",
     "    execution.catalog_rows.select(\n",
@@ -487,8 +1132,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "db96b4a2",
-   "metadata": {},
+   "id": "24a9d1d6",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001888,
+     "end_time": "2026-09-10T02:46:50.009226+00:00",
+     "exception": false,
+     "start_time": "2026-09-10T02:46:50.007338+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "### What the grid does on each label\n",
     "\n",
@@ -510,14 +1163,58 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "382dc64e",
+   "execution_count": 11,
+   "id": "4127e857",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-10T02:46:50.013583Z",
+     "iopub.status.busy": "2026-09-10T02:46:50.013496Z",
+     "iopub.status.idle": "2026-09-10T02:46:50.016866Z",
+     "shell.execute_reply": "2026-09-10T02:46:50.016588Z"
+    },
+    "papermill": {
+     "duration": 0.005893,
+     "end_time": "2026-09-10T02:46:50.017104+00:00",
+     "exception": false,
+     "start_time": "2026-09-10T02:46:50.011211+00:00",
+     "status": "completed"
+    },
     "tags": [
      "results"
     ]
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div><style>\n",
+       ".dataframe > thead > tr,\n",
+       ".dataframe > tbody > tr {\n",
+       "  text-align: right;\n",
+       "  white-space: pre-wrap;\n",
+       "}\n",
+       "</style>\n",
+       "<small>shape: (4, 7)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>label</th><th>task</th><th>configurations</th><th>scored_times</th><th>best_ic</th><th>worst_ic</th><th>n_positive</th></tr><tr><td>str</td><td>str</td><td>u32</td><td>f64</td><td>f64</td><td>f64</td><td>u32</td></tr></thead><tbody><tr><td>&quot;fwd_ret_5m&quot;</td><td>&quot;regression&quot;</td><td>12</td><td>81350.0</td><td>0.011674</td><td>0.000462</td><td>12</td></tr><tr><td>&quot;fwd_dir_15m&quot;</td><td>&quot;classification&quot;</td><td>13</td><td>78812.0</td><td>0.009105</td><td>0.008519</td><td>13</td></tr><tr><td>&quot;fwd_ret_60m&quot;</td><td>&quot;regression&quot;</td><td>12</td><td>67434.0</td><td>0.007782</td><td>0.00218</td><td>12</td></tr><tr><td>&quot;fwd_ret_15m&quot;</td><td>&quot;regression&quot;</td><td>12</td><td>78812.0</td><td>0.007555</td><td>0.000777</td><td>12</td></tr></tbody></table></div>"
+      ],
+      "text/plain": [
+       "shape: (4, 7)\n",
+       "┌─────────────┬────────────────┬────────────────┬──────────────┬──────────┬──────────┬────────────┐\n",
+       "│ label       ┆ task           ┆ configurations ┆ scored_times ┆ best_ic  ┆ worst_ic ┆ n_positive │\n",
+       "│ ---         ┆ ---            ┆ ---            ┆ ---          ┆ ---      ┆ ---      ┆ ---        │\n",
+       "│ str         ┆ str            ┆ u32            ┆ f64          ┆ f64      ┆ f64      ┆ u32        │\n",
+       "╞═════════════╪════════════════╪════════════════╪══════════════╪══════════╪══════════╪════════════╡\n",
+       "│ fwd_ret_5m  ┆ regression     ┆ 12             ┆ 81350.0      ┆ 0.011674 ┆ 0.000462 ┆ 12         │\n",
+       "│ fwd_dir_15m ┆ classification ┆ 13             ┆ 78812.0      ┆ 0.009105 ┆ 0.008519 ┆ 13         │\n",
+       "│ fwd_ret_60m ┆ regression     ┆ 12             ┆ 67434.0      ┆ 0.007782 ┆ 0.00218  ┆ 12         │\n",
+       "│ fwd_ret_15m ┆ regression     ┆ 12             ┆ 78812.0      ┆ 0.007555 ┆ 0.000777 ┆ 12         │\n",
+       "└─────────────┴────────────────┴────────────────┴──────────────┴──────────┴──────────┴────────────┘"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "by_label = (\n",
     "    catalog.filter(\"full_coverage\")\n",
@@ -537,9 +1234,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "36f9c7a9",
+   "id": "a16a528e",
    "metadata": {
-    "lines_to_next_cell": 2
+    "lines_to_next_cell": 2,
+    "papermill": {
+     "duration": 0.001806,
+     "end_time": "2026-09-10T02:46:50.020807+00:00",
+     "exception": false,
+     "start_time": "2026-09-10T02:46:50.019001+00:00",
+     "status": "completed"
+    }
    },
    "source": [
     "### How the penalty grid ranks\n",
@@ -556,10 +1260,519 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "751df473",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 12,
+   "id": "f228f41f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-10T02:46:50.025067Z",
+     "iopub.status.busy": "2026-09-10T02:46:50.024991Z",
+     "iopub.status.idle": "2026-09-10T02:46:51.606578Z",
+     "shell.execute_reply": "2026-09-10T02:46:51.604968Z"
+    },
+    "papermill": {
+     "duration": 1.587415,
+     "end_time": "2026-09-10T02:46:51.610090+00:00",
+     "exception": false,
+     "start_time": "2026-09-10T02:46:50.022675+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.plotly.v1+json": {
+       "config": {
+        "plotlyServerURL": "https://plot.ly"
+       },
+       "data": [
+        {
+         "marker": {
+          "color": [
+           "#D4A84B",
+           "#0a1628",
+           "#0a1628",
+           "#0a1628",
+           "#0a1628",
+           "#0a1628",
+           "#0a1628",
+           "#0a1628",
+           "#0a1628",
+           "#0a1628",
+           "#0a1628",
+           "#0a1628"
+          ]
+         },
+         "showlegend": false,
+         "type": "bar",
+         "x": [
+          "ridge_a1000000.0",
+          "ridge_a100000.0",
+          "ridge_a10000.0",
+          "ridge_a1000.0",
+          "ridge_a100.0",
+          "ridge_a10.0",
+          "ridge_a1.0",
+          "ridge_a0.01",
+          "ridge_a0.1",
+          "ridge_a0.001",
+          "ridge_a10000000.0",
+          "ols"
+         ],
+         "xaxis": "x",
+         "y": [
+          0.007554546090482393,
+          0.006823863850884878,
+          0.006266410632647606,
+          0.006051960087670789,
+          0.00602214396127055,
+          0.006017544365864513,
+          0.006016971398436478,
+          0.006016623404327569,
+          0.006016623404327569,
+          0.006016623404327569,
+          0.0056128684862582845,
+          0.0007766211804253007
+         ],
+         "yaxis": "y"
+        },
+        {
+         "marker": {
+          "color": [
+           "#D4A84B",
+           "#0a1628",
+           "#0a1628",
+           "#0a1628",
+           "#0a1628",
+           "#0a1628",
+           "#0a1628",
+           "#0a1628",
+           "#0a1628",
+           "#0a1628",
+           "#0a1628",
+           "#0a1628",
+           "#0a1628"
+          ]
+         },
+         "showlegend": false,
+         "type": "bar",
+         "x": [
+          "logistic_l1_C0.001",
+          "logistic_l1_C0.01",
+          "logistic_l1_C0.1",
+          "logistic_l1_C1.0",
+          "logistic_l1_C10.0",
+          "logistic_l1_C100.0",
+          "logistic_l2_C0.001",
+          "logistic_l2_C1.0",
+          "logistic_l2_C0.01",
+          "logistic_l2_C0.1",
+          "logistic_none",
+          "logistic_l2_C100.0",
+          "logistic_l2_C10.0"
+         ],
+         "xaxis": "x2",
+         "y": [
+          0.00910483781594685,
+          0.008980468349112987,
+          0.008967555106549127,
+          0.008918473016922192,
+          0.008918399655208971,
+          0.008917559700282105,
+          0.008587589707204,
+          0.008542236013589237,
+          0.008539829535588302,
+          0.008534760946891795,
+          0.008527565082581061,
+          0.008523935584573176,
+          0.00851851514075641
+         ],
+         "yaxis": "y2"
+        },
+        {
+         "marker": {
+          "color": [
+           "#D4A84B",
+           "#0a1628",
+           "#0a1628",
+           "#0a1628",
+           "#0a1628",
+           "#0a1628",
+           "#0a1628",
+           "#0a1628",
+           "#0a1628",
+           "#0a1628",
+           "#0a1628",
+           "#0a1628"
+          ]
+         },
+         "showlegend": false,
+         "type": "bar",
+         "x": [
+          "ridge_a1000000.0",
+          "ridge_a100000.0",
+          "ridge_a10000.0",
+          "ridge_a1000.0",
+          "ridge_a100.0",
+          "ridge_a10.0",
+          "ridge_a1.0",
+          "ridge_a0.01",
+          "ridge_a0.1",
+          "ridge_a0.001",
+          "ridge_a10000000.0",
+          "ols"
+         ],
+         "xaxis": "x3",
+         "y": [
+          0.011673529955674842,
+          0.011244266306396682,
+          0.010930097350463845,
+          0.010739909427949695,
+          0.010712568095949232,
+          0.010708470302885957,
+          0.01070724776666791,
+          0.010708573405908159,
+          0.010708604170701918,
+          0.010708517383535112,
+          0.010485387233498084,
+          0.0004624047106415106
+         ],
+         "yaxis": "y3"
+        },
+        {
+         "marker": {
+          "color": [
+           "#D4A84B",
+           "#0a1628",
+           "#0a1628",
+           "#0a1628",
+           "#0a1628",
+           "#0a1628",
+           "#0a1628",
+           "#0a1628",
+           "#0a1628",
+           "#0a1628",
+           "#0a1628",
+           "#0a1628"
+          ]
+         },
+         "showlegend": false,
+         "type": "bar",
+         "x": [
+          "ridge_a1000000.0",
+          "ridge_a100000.0",
+          "ridge_a10000.0",
+          "ridge_a1000.0",
+          "ridge_a100.0",
+          "ridge_a10.0",
+          "ridge_a1.0",
+          "ridge_a0.01",
+          "ridge_a0.1",
+          "ridge_a0.001",
+          "ridge_a10000000.0",
+          "ols"
+         ],
+         "xaxis": "x4",
+         "y": [
+          0.007781740648248239,
+          0.0057371032305019295,
+          0.004831523255374549,
+          0.004568120612762783,
+          0.004534659030852683,
+          0.004535897290604859,
+          0.004536553242176822,
+          0.004536660984610759,
+          0.004536679990132501,
+          0.004536631340726496,
+          0.0049611328898379724,
+          0.0021802174555330517
+         ],
+         "yaxis": "y4"
+        }
+       ],
+       "layout": {
+        "annotations": [
+         {
+          "font": {
+           "size": 16
+          },
+          "showarrow": false,
+          "text": "fwd_ret_15m (primary)",
+          "x": 0.5,
+          "xanchor": "center",
+          "xref": "paper",
+          "y": 1.0,
+          "yanchor": "bottom",
+          "yref": "paper"
+         },
+         {
+          "font": {
+           "size": 16
+          },
+          "showarrow": false,
+          "text": "fwd_dir_15m (variant)",
+          "x": 0.5,
+          "xanchor": "center",
+          "xref": "paper",
+          "y": 0.7375,
+          "yanchor": "bottom",
+          "yref": "paper"
+         },
+         {
+          "font": {
+           "size": 16
+          },
+          "showarrow": false,
+          "text": "fwd_ret_5m (variant)",
+          "x": 0.5,
+          "xanchor": "center",
+          "xref": "paper",
+          "y": 0.475,
+          "yanchor": "bottom",
+          "yref": "paper"
+         },
+         {
+          "font": {
+           "size": 16
+          },
+          "showarrow": false,
+          "text": "fwd_ret_60m (variant)",
+          "x": 0.5,
+          "xanchor": "center",
+          "xref": "paper",
+          "y": 0.2125,
+          "yanchor": "bottom",
+          "yref": "paper"
+         }
+        ],
+        "height": 1120,
+        "margin": {
+         "t": 90
+        },
+        "shapes": [
+         {
+          "line": {
+           "color": "#334155",
+           "dash": "dash",
+           "width": 1
+          },
+          "type": "line",
+          "x0": 0,
+          "x1": 1,
+          "xref": "x domain",
+          "y0": 0,
+          "y1": 0,
+          "yref": "y"
+         },
+         {
+          "line": {
+           "color": "#334155",
+           "dash": "dash",
+           "width": 1
+          },
+          "type": "line",
+          "x0": 0,
+          "x1": 1,
+          "xref": "x2 domain",
+          "y0": 0,
+          "y1": 0,
+          "yref": "y2"
+         },
+         {
+          "line": {
+           "color": "#334155",
+           "dash": "dash",
+           "width": 1
+          },
+          "type": "line",
+          "x0": 0,
+          "x1": 1,
+          "xref": "x3 domain",
+          "y0": 0,
+          "y1": 0,
+          "yref": "y3"
+         },
+         {
+          "line": {
+           "color": "#334155",
+           "dash": "dash",
+           "width": 1
+          },
+          "type": "line",
+          "x0": 0,
+          "x1": 1,
+          "xref": "x4 domain",
+          "y0": 0,
+          "y1": 0,
+          "yref": "y4"
+         }
+        ],
+        "template": {
+         "layout": {
+          "colorway": [
+           "#0a1628",
+           "#D4A84B",
+           "#C87533",
+           "#10b981",
+           "#ef4444",
+           "#94a3b8"
+          ],
+          "font": {
+           "color": "#334155",
+           "family": "DM Sans, DejaVu Sans, sans-serif",
+           "size": 11
+          },
+          "hoverlabel": {
+           "bgcolor": "white",
+           "font": {
+            "family": "DM Sans, DejaVu Sans, sans-serif",
+            "size": 11
+           }
+          },
+          "legend": {
+           "bgcolor": "rgba(255,255,255,0.8)",
+           "bordercolor": "#e8e8e6",
+           "borderwidth": 1,
+           "font": {
+            "size": 10
+           }
+          },
+          "paper_bgcolor": "#FAFAF9",
+          "plot_bgcolor": "white",
+          "title": {
+           "font": {
+            "color": "#0a1628",
+            "size": 14
+           },
+           "x": 0.5,
+           "xanchor": "center"
+          },
+          "xaxis": {
+           "gridcolor": "#e8e8e6",
+           "gridwidth": 0.5,
+           "linecolor": "#e8e8e6",
+           "showgrid": true,
+           "tickfont": {
+            "size": 10
+           },
+           "title": {
+            "font": {
+             "size": 11
+            }
+           }
+          },
+          "yaxis": {
+           "gridcolor": "#e8e8e6",
+           "gridwidth": 0.5,
+           "linecolor": "#e8e8e6",
+           "showgrid": true,
+           "tickfont": {
+            "size": 10
+           },
+           "title": {
+            "font": {
+             "size": 11
+            }
+           }
+          }
+         }
+        },
+        "title": {
+         "text": "Which side of zero the grid sits on depends on the horizon, not the penalty"
+        },
+        "width": 1100,
+        "xaxis": {
+         "anchor": "y",
+         "domain": [
+          0.0,
+          1.0
+         ],
+         "matches": "x4",
+         "showticklabels": false
+        },
+        "xaxis2": {
+         "anchor": "y2",
+         "domain": [
+          0.0,
+          1.0
+         ],
+         "matches": "x4",
+         "showticklabels": false
+        },
+        "xaxis3": {
+         "anchor": "y3",
+         "domain": [
+          0.0,
+          1.0
+         ],
+         "matches": "x4",
+         "showticklabels": false
+        },
+        "xaxis4": {
+         "anchor": "y4",
+         "domain": [
+          0.0,
+          1.0
+         ],
+         "tickangle": -45,
+         "title": {
+          "text": "Configuration, ordered by rank on fwd_ret_15m"
+         }
+        },
+        "yaxis": {
+         "anchor": "x",
+         "domain": [
+          0.7875,
+          1.0
+         ],
+         "title": {
+          "text": "Mean IC (validation)"
+         }
+        },
+        "yaxis2": {
+         "anchor": "x2",
+         "domain": [
+          0.525,
+          0.7375
+         ],
+         "matches": "y",
+         "title": {
+          "text": "Mean IC (validation)"
+         }
+        },
+        "yaxis3": {
+         "anchor": "x3",
+         "domain": [
+          0.2625,
+          0.475
+         ],
+         "matches": "y",
+         "title": {
+          "text": "Mean IC (validation)"
+         }
+        },
+        "yaxis4": {
+         "anchor": "x4",
+         "domain": [
+          0.0,
+          0.2125
+         ],
+         "matches": "y",
+         "title": {
+          "text": "Mean IC (validation)"
+         }
+        }
+       }
+      },
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABEwAAARgCAYAAADzb8P3AAAQAElEQVR4AezdCbxM5RvA8WfutSspRCQkKVmzZK1UqJQoS9YsEUJk30nWqCzZirKl1D+tSqWFLCFb1pRKG9lVlmv7z3OuM+bOnf3OzD0z8/Pxztne9z3P+33PzHUfc2YSkpJOX6BgwDXANcA1wDXANcA1wDXANcA1wDXANcA1wDUQ09cAv/sHmP9IEP4ggAACCCCAAAIIIIAAAgggEHUCBIxAeAVImITXl94RQAABBBBAAAEEEEAAAf8EqIUAApYSIGFiqekgGAQQQAABBBBAAAEEYkeAkSCAAALRLEDCJJpnj9gRQAABBBBAAAEEIinAuRBAAAEE4kiAhEkcTTZDRQABBBBAAAEEUgqwhQACCCCAAAKeBEiYeJJhPwIIIIAAAghEnwARI4AAAggggAACIRIgYRIiSLpBAAEEEEAgHAL0iQACCCCAAAIIIJA+AiRM0sedsyKAAALxKsC4EUAAAQQQQAABBBCICgESJlExTQSJAALWFSAyBBBAAAEEEEAAAQQQiEUBEiaxOKuMCYG0CNAWAQQQQAABBBBAAAEEEEBASJhwEcS8AANEAAEEEEAAAQQQQAABBBBAIFABEiaBiqV/fSJAAAEEEEAAAQQQQAABBBBAAIEwC1ggYRLmEdI9AggggAACCCCAAAIIIIAAAghYQCC6QiBhEl3zRbQIIIAAAggggAACCCCAAAJWESCOmBYgYRLT08vgEEAAAQQQQAABBBBAAAH/BaiJAAKXBEiYXLJgDQEEEEAAAQQQQAABBGJLgNEggAACQQuQMAmajoYIIIAAAggggAACCERagPMhgAACCERKgIRJpKQ5DwIIIIAAAggggEBqAfYggAACCCBgUQESJhadGMJCAAEEEEAAgegUIGoEEEAAAQQQiA0BEiaxMY+MAgEEEEAAgXAJ0C8CCCCAAAIIIBCXAiRM4nLaGTQCCCAQzwKMHQEEEEAAAQQQQAAB3wIkTHwbUQMBBBCwtgDRIYAAAggggAACCCCAQMgFSJiEnJQOEUAgrQK0RwABBBBAAAEEEEAAAQTSW4CESXrPAOePBwHGiAACCCCAAAIIIIAAAgggEGUCJEyibMKsES5RIIAAAggggAACCCCAAAIIIBDbAiRMdH4pCCCAAAIIIIAAAggggAACCCAQ+wIBjJCESQBYVEUAAQQQQAABBBBAAAEEEEDASgLEEj4BEibhs6VnBBBAAAEEEEAAAQQQQACBwASojYBlBEiYWGYqCAQBBBBAAAEEEEAAAQRiT4ARIYBAtAqQMInWmSNuBBBAAAEEEEAAAQTSQ4BzIoAAAnEiQMIkTiaaYSKAAAIIIIAAAgi4F2AvAggggAAC7gRImLhTYR8CCCCAAAIIIBC9AkSOAAIIIIAAAiEQIGESAkS6QAABBBBAAIFwCtA3AggggAACCCAQeQESJpE354wIIJBGgdVrN0jOa8vIqVOnPfY0fdbrcnudJh6Pux5o2KKzjBg7yXV30Ntbtu00Yjx46IjHPn76+Vejzh9/7vNYJxQHzpw5I937jZAyVe83zrdx87ZQdBvRPiZMniX3Pdwmouf0dbKipe+Q9z763Gs1NV/0zkep6/ixJ9Br2I8uI1pl3huL5baa9SN6zrScLJriDdfzIVz96rxE+/WsYwhXyV24vHz+1cpwdW+Jfm8oc6fP10tLBEoQCCCAgIsACRMXEDYRQCByAh26DRBNVDif0UyG9Bs61nm36C8zeYpUkNOnk1Ls97RxTb6rpWzpEp4Oh31/9mxZ5c4alSVjxgxhP5evE3z4yZfyvv0X+/cWzpSjv2+WcmVu8dUk4OOhbHDdzdXkI3vMoewzHH1VrlROcl2VMxxdG326XsNTZsyVmnWbGcd4iB+BaHk++JoR1+vZV/1oOq5JaE3iHz123GvYPIeTefz1Sq7NIwIIIJC+AiRM0tefsyMQ1wI1qlaUNes2ytmzZx0Oq77dKMWLFZFVazY49umKblerXF4yZ86kmz7LQ3XvkUnPDfVZz0OFNO8uWqSQvLtwhlyR4/I095XWDvQdLNcXuU4KF7o2rV3R3klgwSsvSvUqFZz2hHY1va/h0I6G3uJdgOs53q8Axo8AAghEpwAJk+icN6JGIEABa1avUulW+fe/E7L2u82OAFd/+510eryF7PjhJzly9Jhj//JVa6XqbeUd27qiyRb9H/eCN1WVBxs/Lt9t/F53G8Xd27+Xfb3KqKf/Y6u3CgwY/pycOHHSqK8P586dlx79n5WbK9SSUpXvk2fGTEqRzNE6zmXrjh/ksSd6SYmKtUX/d/GWSnXkqxVrjCrubsn5Yvkq0XivLV5F7qnXUrZu323UdX749IsVcm+D1lKoRHWpcHs9GfP8dDl37pxzlVTrOu76TZ8w2txa/QEZNGKCnDx5yqjXtnNfY3v9hi1GjDpu44DLQ+7C5Y3jOg7nYlbTueg1cLRo/+r9cLNOouM3j5tv5df/Qa1050NyZcGyxqH9Bw6KvpNITYuVrSltOvWR3//4yzjm7qF8jQfl+D//SvPHuxvxqK1zvVfmvCEV76gn15e6Qx7v0k/2/X3Acfic3Wny9LlSvVYjKXBjFcP6/SWfO467W7lw4YJMnPaa6HkL31JDmrV7SnQMzk76LqiBz4yXJ58eIjrHaq19ud6S88uvv0uTx7pI8vXVQN743wdazWvR+NRS51vd77y/qfz5136jjfM1/Ppb7xvzaP7PrNZ9bf7bRr3nJr4steu3krxFKxpmamwc8PDg7XrRJjrewc9OCOi5oO3UTa9Z0/HYsX90d4ri6/rObb8Ox74wQ+o2bCd6nelcut7SdMT+uuDPtTjz1YUerxUNyle83uZG27sWX9e6+e4583VAx+f6uuXap16XkXw+mOf39jxLSjojz46bbNjqGB5o9Lissr9um23NcX7y+XLR6znfDZVkxap14nw9a12da72OXYse0+LrOjVfc3zNs/blrfhzvXub21/3/mG81ug59NrX8ehrnm47F2/PYa23/++D0qhlZ+P1Q6/7N//3oe52FF/XvaOi04oaR+L5pHOtY9bX6+Ll7jZe8z3djurJS31uuvUe0VtInYZg9NW6Y2/nXawjgAACERVIiOjZOBkCoRKgn5gQuOH6QpL/mrz2f2xvNMZz9uxZWWn/h3fNGlWkSqVy8vU3a439P+75VfRdEtUq32psmw/jXpwpDz94r7wwZrCcPHVaOnYfKPoLsHncefn1N98at//UuquGrF/+vrw+e6LkuuoqOWM/p1nvDfs/UM+eOSvjRvSTRvXvk0nT58j/3vtEPP3pO3isXFsgnyxd/Jr8vHW5PDu4p2TNmsVt9Z9//c3+y3Q3ubVMSdmy5mPp2+MJGTLy+RR1NcZuvYZL6xaPyHcrPpBpL4yQtes3y/DRE1PUc95Ql3pNOki+q/MYbaZMGC4L7b9c9xo4yqg2e+pYGTagu1QsX0b0dpxvv3zX2O/6cPCX74zjWmf/T+uM+voOILNey/Y95Z9//5WXJ4+WTauWyAP31ZSHm3U05sWss+n77fLdpq2yaM5L8uv2b4y5aNKqq+zc9ZO8s2C6fPbePCMZ8HDzjqn+UWz2oePOcfllou/e0Fi2r/vUPCR7ft4rentR9yfbSZ/uT8jKNd/JmAnTHcfHvThD3v/4cxk+qIdsX/+p9O3eUYaNelH0H/OOSi4rCxa9J+MnzpRBfbrYx/WR3F+7psx87Q2XWiKz570lRe3X64qlb8rcmRNSHddkTZPWXeXIseOy/JM35bXp441fEI8e9fwW/X/+/U/aPdlPHm34gGxevUQ2rfxIWjd7RGw2W6r+mzWqZ1xf5crc4pin1i0aiv7y/fJrC2XEoKfl5++Xy3J7fJXsc52qg4s7fF0vF6vJgjffl4q3lpaVn70lz48eaIzf23NBk0OaqHuqcxvZuPJDqVKxvEy2P3/M/nTp7/X9qt26sz1punXtUmnbqpHxC5O21T60tPTzWtTE01tzp8q7b8yQPb/8luJa8RVvIHOjMenrThM/r/W5ry+WCSMHyNqv3pWCBfJ7fd2K9PNBx+LreTZ01Avy8mtvylj766RetzfdWFQeevQJ2f3Tr9rcUSZMfkXGP9tfft+5yu1tgAe9vOb4e53qa463eXYE42PF2/Xua24LXVdAvvzodeMMv2xbYTw/Z04aZWw7P3h6Dpt1Jk6dLWVK3SxTnx8hNxa73n5dDBJNwprH/bnuzbrOy0g8n44eOyb169aWbz5dJG/OnSyZM2WSVh16Gj8DnGPRdU9ej9S71/7z+EyK1+tjx/+R9z76TJraX/+0LQUBBBBIDwESJumh7uac7EIgXgVq1qgsq+y/+Or4v12/Sa66MqfoP6g0YbLq2/W6W1auWW8kIm6rkPyuBWOn/WFo/27StWMraWhPbowe2sv4B7v+L539UKq/L7w0W5o2rCfdOj4mV+fJJXrLTM+u7VLcMlP6luIyefwwefC+u2VIv25yz51VZe13W1L1Ze74a99+KVuqhBS8Nr9cmfMKafBgbXGN0aw7/43Fkif3VTJmeG9jjLVqVpdmjR4yDxtLjbF9m6by6CMPSu5cV4omOQb06mT8smpUcPMwd+E7cln2bPak0SCjjb4LZ3DfrqKJgAMHD7tp4XvXkz2HyEF729lTxxmVl69cK/rOhpfsyZjy5UrZE005pW3LxnJr2Vvkf+8vNeqYDy+OHSx6648mPfSXXP2FZtL4oXJz8aLG/knPDZMffvxFlnz6tdnE76UmtxbaE13NGz8kHds1kyfaNhO9ZrSD06eT5MWpr9oTBz3k7juqGvN6b63b5bHmDWXO68nvxNB6rmXewsXSvMlD9rmrIzmvyCEtmtSXai7vZNI25UrfIk93aWfMnY5N9zmXL1eskV2798jEsUONcep4NYmh/+B3rue8fujQESNxVL1KBePc6qZJEP2sB+d63tb/2nfAiEmTJNmyZZXSt9wknR5v7rGJv9fLPTWr2a/Pekbfeq3efWc1Wbfh0ju4XE8wZ8E78rD9F56WjzYwngv6vLz5phtSVPP3+m7epJ7UvbemMYd6nem6foaRdubvtXil/fmoiUI1VZPmjevZn8ubtAuj+Io30LkJ5Fof0OtJ+3OnpOg8q5MmGvQdDEZgATyE4/mgp/fWr75z7ZU5i6RXtw5y1+1VjetDX9PyX3O1zJr7hjZ3lH5Pd5QK9qRbhgwZjNcoxwE3K66vOf5ep77m2c2p3O7ydr0HMrduO/dz56P2n0+D+nS1J6PvkpmTRoq+zny3Kfk55+917+5UkXg+6c+s++vcaVwP+jNRk6z62rzzhz3uQnK7T2+3bdTg/hTvzHtr8Uf2n9e5pZb99chtI3YigAACERBICNM56BYBBBDwS6Bq5fKyet0G49aXVd9uFE2gaMPKFcvZEykbdFVWfbtBqtvr6T+8jR0XH265+caLayKFCxU01g8ccp8k0F9mK5UvbdTx9HBz8ZS/4Gni5qCH/rQP6974IQAAEABJREFUTdR07zvCuFVDb+vYsGmr7nZbfv71D9F3bGTMmNFx/K7bKzvWdUVjHDF2knFbhb6tW4veuqO3Lf2172+tkqr89PNeqVGtopFQMg/qL7i6vueXvboIqOgvtZ989rXxDhxN8Gjjn/b8Kv+dOCH69m6NySyffLZcnP8HtLj9f0WdP7NFz58vbx7Rf0BrP1qKFysiWvQbgnQ7kKLv8HB+B0/h666VAwcPGV38/OvvxgcC6+1MZny6HDryBfn5l9+NOu4e9J0/JUsUT3GolD1xlmKHfaNs6Zvtj57//vLrb0biTBMlZi2db+d4zf3msnCha6Va5QpS66FWoreHvfzaQtG3q5vH/VnqXKtBzfubGbdJ6Dsn9BYOT239vV4KXJM3RRd5cl/psE5x4OKGvivhjuqVLm4lL/RDj5PXkh/9vb5LlrgpucHFx9K33Gy8Q0Q3/b0WCxa4Rqs7Su5cueTvA4cc277iDXRuArnWr81/yTZP7lxGTMEkN8PxfNBgvPX7y94/jCSfJhi0rhZ9Xa55exXjHWC6bZZby9xirnpdun3N8fN1zdc8ez2x00Fv13sgc+vUZcCrJW4q5mijptfZE/EH7UlV3envda91XUsknk+//f6n6M9CvSVPX3f1A9r1XXe//fGnazhet1s++rDozxVz3Avf/tD+Hwh1JSGBX1e8wnEQAWsIxGwUvALF7NQyMASiQ6BGlYqi/2up/xu16tvvpHKlckbgVSrdKrt+/FmOHD0m36xeL9Xs9YwDTg8ZEhMdWzabzVjXt08bK+4ekqu4O2Lsy5DhUn+6w2bTBhd01W3R/ymePW2cXFewgKxas17ufrCFTJ4+121d3ekcr7Ft/59XXZrFZrPJhFEDRG9FcS36v9FmPddlopODHkt0GYfu86cs+3qV8bktL08eY7wjxGxjs9ns/8uXy21c+j+JZr2sWbKYq46lc4LI3Okar7nf19LVz2azOd7ybbPpXImsXva/VHGu+eIdX137PJ41S2afdVzj0waJCQm68Fj+N3+qDO7bRbJkziz6y8FtdzUwrnePDVwO6LulVixdJM0a17MntU7K6AnT5M77Hk2RHHBpIq7+7q6XhIRkz5RtPT8XtJ5rv64eNltw17f2bT6vbTb/rkV3v2CZfWh/WnzFG+jc+Hut+xObxueruPM1x2izJc9fMM8Hb/2aMekv9Oa6LjMkZtBFiuLu9SBFBfuGp9cc+yE/r9PUzy/TQPvwt/i63v2dW3/P566eu58/Fy4+5Ww2/657d/2622ca2Wz+9evtmtW+9DZLTaoumDVR9JbOw3s3ipqdSTrr7vQe991yczHRd2nqOyT1M7L0c2xaNGngsT4HEAivAL0jkCyQ+idN8n4eEUAAgYgIXFcwvxQrWkhWrFpvfGNOdfv/uOuJs9h/QdXPUJg9723jczL0HSa6P9ii735Y5+X2mmD7rXN3Denb4wl5c84U6dXtcVn8YcpbVMx+ixQqIFu27jQ3jeXm73cYS/OhRPEb5Ivlq81Nv5ZFi1yXqt+Nm7Ybba8vfJ2x9OdBbwto26mP9Hu6k9xX+44UTYrfeL3xC7jelpPigI8NPb9+wKvzu2P0fw71XQ5FixTy2Fp/0Tp/4bzH4+4OFC1S0HiXzbKvVrk77HFfkUIFZev2XSmOf78t5XaKgx42Ctv72Wv/X1bndwrs2v2z6LuDPDQxdut1rm9nH9Kvm3zx4QIpX7aUfPK5+9uVsmTJJBfOX/wNymid/JD/mrzSoU1TGT2sj6z+/H+y9/e/ZL2H22eKhuh6ST7zpcfr7f26OuoHH1+qIeLv9b11e8rnyZZtO0TnSfsK9lrUts7Fn3iz2F+D/J2bYK9155g8rUfy+eApBnN/4esKGImMLVuTX2PM/Rs2bxU1Nbf9WXp7zQnXdepPXK51/JnbzPaEp7Y7f97761YWD89hbeutpOW6D/fzSV/fdS6bNX7IePdg5syZZNvO3cY7kTyNKbMXrxaP1pd5C9+R1xe9J/rOJX2np6d+2B+gANURQCAoARImQbHRCAEEQimg7x7RD6bLe3VuKVzoWkfXlSuWlZmzXzc+y0A/7NJxIIiVHk+2Ff0U/knT5xi//OstIRMmzxJvnzHh6zT6IZcbLt6Gox8SqZ/xYP5i59q2eZP6snP3HtFvLNAPt12/YYtMm7UgRbWe9oTLR598KaMnTDVuddF/fOv989omRUWnDf3MiL2//Wm8M0STEfohsSPGTZLm9n+85sl9lVNNz6t6u03TNl3l7juriSZ/xOWPvttHPxdEP2fgi+Wr5NSp06LfTqPfMqLfVORS3bF5e7VKxocYPtVnuGjyQG/febr/s1LIniS7r1bKpIyjkX1FbwnYtiP1NwjZD3n8q//jrZ+r8PyUWcY8Hz5y1Hjn0tvvfizz33zXY7uWTRvIgjffk8UfLJWjx44bbZcuW+6xvqcDd1a/TW64/jp5qu9w0XPrLxF9h4yRzPZfHjy12bHrR9FrUJNKWkd99K33RZyeA7rfLEXsCbC99qSMxmnue++jz0U/38NMzCxfuc64va1I4UvPI7OuLls+2kDSer1oP67lseYPG456/Yr9z8K335dPl62wr1366+/1re+00X70uTl73iLR9dbNHzE6CvZaNBo7PfiKN9C5CfZadwrJ42oknw8eg7h4QG8x69DmUftr1DTjs6X0Wh/34kzRJGP71o9erOV74es1J1TXqb5LQV8/Tzh9G5rv6FLW8GduC157jfFc37r9h5SNXbbcPYddqrjdTMt1H+7nk/7cLpA/nyz7aqUR+/adPxq357i+g8s4ePHBm1eDB2rbX0OPyavz35amDR+82ML9gr0IIIBAJARImERCmXMggIBXgaqVbhX90MOqlcqnqHdbxXLG/upVKxj/q5niYIAbd9h/oV00d4p8/OlXxtf1lq9RT77+Zo1kdLktJpBu9QNm72/YVvSebf16TU1wPDOwu9su9H8p37Kf/5PPv5ZKd9aXjt0HpUpOVLE7fLDoFdEPmr3rgeZyc/la9l+oX5GkpNNu+9Sd1xa4Rj586xVZv/F74yt/9ZuC7r6zqowfOUAP+1X27T8g+k1E77z/iTEWHY9ZzA7mzJwgte+qIQOGjZeipe+Upm2ekuUrv5XLLssunv7o27jfeHWSvc5lUr9pB6n1UEvjG2DenjdNMmW69Fkuru27PvGYvDRzrmgM+jWVrsc9bT/dpa0M6dfV+JDcUrfdJzXqNDaSJdmzZfXUxEgs9Xqqgzw7booUvqWGvLV4ieiHyebIkcNjG3cHNGHzxmuT5UzSGbnjvqbG7VkN698n+fLmcVfd2Jcta1bjGix5272iYy1/ez2pc8/t0rp5Q+O464N+vk/pkjeJxqn19WuFL7ssm91qnuhXVes+nf/nnu0nrp/HY/YViuvF7Mt5qe/E6Nujo+g3qJStVlcWvbNEenRp51xF/L2++3TvIOMnv2x8TfbsuW+JfuOI/tJqdhbMtWi2NZe+4g10boK91s14vC0j+XzwFod5bPiAHlL/gVr2X4qfkTJV7re/DqyV996YYXyQtlnH19LXa06ortOt23fZkztTJenMGV8heTzuz9xebn8d7GFPytdr0l70eahfseuuQ3fPYad6XleDve7D/XzSxMiCV14QTd5WufsRebRNN+nT/Qnx9rrrzUuTcg0erCOZMmY0PoDdKwoHEUAAgQgIkDCJADKnQAAB7wKNH64r+pkdU194JkVFvd1F9+tXzDof0F+8dH+WLJc+V0K/VUb3lb4l+QMj9VtUli9907mZ6AdkfvzOq7J3x0rjfO+/+bLoN4topbeNz5LopquOMmZ4X5kzY4Jj23VFv2J3349rjb703Nqf/k+b1tM4dJ/Gpdta9EMwv/zoddnwzYfGVxvrt4poHbON1tEPCl38+nTZ8/3XsmvjMtE+B/dNGZfWcy7lytxi1NNxad8jBvU0bk8x63Tv3EY+e8/zZ6sULVJINA53xexDv4lHv3VEPw/kjx9Wi45j0dyXpOTFD97t2bWdqK1Z31xqwkC/2njH+s9k96Yv7Z7jRW/DMo+7W+otQb/tXGXEZH6tsLv+H6p7j/y05WtHFzabzUg2fP7+PNEY9euj3104w/gGHEcllxWbzSZPdWot+vWtOn61/2v/3+L8Lg9314Z2o+fWGHRdS5FCBeWteVPl+zUfi8bdokl92bxqiej1rcddi77VXOdXz6vl0K8bZOK4IY7koOs1rL+46Xi0rhb9Rh1954/OiW5r+WXbCmnfuqnrqVJs+7pe3I3X13NBT9DliVbGda1fj6yO6ur6Ndb+XN/6y7JeXzqebz57K5VfMNeizpPOl8ZpFm/x+pobsw/npa9r3Z/XLef+zPVIPh/8eZ5pslO/zWXd1++LPk8/tCds9du5zHgvjfPS67Mec76e/XnN8XWd+hPrjp0/in57i34DlsbgrvhzvfuaW+1Xb2fUa1aLJvl0n2tx9xzWOgd/+U7uubOarjqK/vxSM3OHr+verOe6jMTzqWzpEqLJfv3MnC2rl4j+7NafR/oNV2Y8P27+SvR5aG578/p17+/25/0DKX6Ome1YIoAAApEWIGESaXHOhwACCCBgGQH9wGG9pUDvwT90+KhMe2WBzFu4WNq0cP8uD8sETiCRF+CMUSewau1G0Xc+RV3gcRzwyjXr5fOvVtqT38m34cUxBUNHAAGLCJAwschEEAYCCCCAQOQF9O3kq9dukIp31JOSt9WRt95dIrOnjjNuH4l8NJE9I2dDINYF9J11ZUreHOvDjJnxlal6vzzV5xmZPH6Y6DfmxMzAGAgCCES1AAmTqJ4+gkcAAQQQuCgQ1EJvL9DbR/Rt9H/t/tb4phrnt40H1SmNghZwd2tC0J3REIE4F4i255Pewqi3UuqH/sb51DF8BBCwkAAJEwtNBqEggAAClwRYQwABBBBAAAEEEEAAgfQUIGGSnvqcG4F4EmCsCCCAAAIIIIAAAggggEAUCZAwiaLJIlRrCRANAggggAACCCCAAAIIIIBA7AqQMInduQ10ZNRHAAEEEEAAAQQQQAABBBBAAIGLAjGcMLk4QhYIIIAAAggggAACCCCAAAIIIBDDAuEZGgmT8LjSKwIIIIAAAggggAACCCCAAALBCdDKEgIkTCwxDQSBAAIIIIAAAggggAACCMSuACNDIBoFSJhE46wRMwIIIIAAAggggAACCKSnAOdGAIE4ECBhEgeTzBARQAABBBBAAAEEEPAuwFEEEEAAAVcBEiauImwjgAACCCCAAAIIRL8AI0AAAQQQQCCNAiRM0ghIcwQQQAABBBBAIBICnAMBBBBAAAEEIitAwiSy3pwNAQQQQAABBJIFeEQAAQQQQAABBCwtQMLE0tNDcAgggAAC0SNApAgggAACCCCAAAKxJEDCJJZmk7EggAACoRSgLwQQQAABBBBAAAEE4liAhEkcTz5DRyDeBBgvAggggAACCCCAAAIIIHcZPloAABAASURBVOCvAAkTf6Woh4D1BIgIAQQQQAABBBBAAAEEEEAgTAIkTMIES7fBCNAGAQQQQAABBBBAAAEEEEAAAWsIkDAJ5zzQNwIIIIAAAggggAACCCCAAAIIRKVAQAmTqBwhQSOAAAIIIIAAAggggAACCCCAQEACVBYhYcJVgAACCCCAAAIIIIAAAgggEOsCjA+BgAVImARMRgMEEEAAAQQQQAABBBBAIL0FOD8CCIRbgIRJuIXpHwEEEEAAAQQQQAABBHwLUAMBBBCwmAAJE4tNCOEggAACCFhXYNG7S6VNl8FSo25ruadB+5AGunHLDqlSp4Vs2/lTSPv11tl7S76QpV+s9FbF7bG/9h+QoWOmSosn+kuN+x8z4v79z/2p6q5Zv9k4puNyLnUadkxVN1w7xk16VXoMfC6k3b8y7x2p+VC7kPYZic66Dxgnz015LRKn4hwXBVgggAACCES3AAmT6J4/okcAAQQQiJDAvr8PygvT5knh6wrImCHd5bnhT0fozOE7zYefrpDPvlod8An2/31Itmz/Qa7Oc6WUuuVGn+37d28nk8b0c5SxQ7v7bBOKCrv3/CqLP1omndo2DkV3jj6uyZtbSpfwPW5HA4usdGzTSBZ/uEz2/PJHsBHRDgEEEEAAgbgSSIir0TJYBBBAAAEEghT4a98Bo2Xj+rWl2m1lpVzpm43teHwoW+omWTz3RXn+2T5S/bZyPglKFC8qFcuVdBRt77NRCCq89e5ncsP118mNRQt56C243XVr3y4TR/cNrnE6trqpWBF7wi+//O/Dz9IxCk6NAAIIIIBA9AiQMImeuSJSBBBAAIF0Ehg2dpp07j3SOHvbrkOM20zGT5lj3Jaht2cYB+wPP+7Zaxxr3324fevS3/ubdJaJM+Y7dvx34qQMfHaS1Hq4gzRt30dmznlLks6cdRz3Z0X70Ntc5i/6yLg95qHm3aRKnRZy5Ohxo/nqdZuN24f01pH7GneWfs+8KMeO/2sc0we9nWbrjt2y8ttNRsza1+BRU/RQxMvXq74zYti5+2eZNvtNeeSxp+0ufeXV19+T8+fPy3ebtkmvIeMNr1adBsr323f7jPHs2bPy5Tdr5Y6qFVLUNc+1bPla6dhzhNz10OOi8zP6hVdE25iVzXq67NJ3tNzbqKM9pj7GYZ3zmk635Jhz8fb7n4q+o6Vdt6FyX6NOMur5V+T4P/+K3sI0YvxMebBpF2nQqrtRx+jo4sOOH/bI81PnSIuO/eWOB9oY49dbZ/7978TFGsmLxzoPNK6b2QvelcZtexq3Q7338RdS/b5WMm/Rh8mVnB5nzV9sHDt6LPma0EN3Vqsgn36xSs7ZXXWbggACCCCAAAKeBUiYeLbhCAIIIIBAOgtY5fStmtSTru2bGeH06dbGuLWk0UO1pXzpm0U/e8Q4YH9Yv2m7ZEhMlB27fpLTSUn2PSK//PaXkcQoX+YWY1sf+g1/UdZu2CrNGtaVDo81kj/3HZSxE2froYDLgrc/kmxZs8jsKc/IrEnD5fLLssmy5Wvk6UHPSY7LL5N+T7WVdi3qy67dv0inXiOMBISepH+Px0VvLyp5czFjPHrLTJvm9fVQyEtXe8Kh6r0t5eFWPeSZ56bL3wcPuz2HJmz+tSeTurRvKuVK3WQkkmbOfdveZoaULXmz9O7aWjJnziS9h06QU6eTfd12ZN/5vT2pogmHcqWK27dS/312wgypW7uGvP/6JBn4dAf5YsVaeXbCy6kqjp/8qtx9eyVZNHu8DOndMdVx5x0L//eJfL3yO2n6yH3S0H59fLHiW5nw0lzpMXCcXJEju/To3Mq4lUc/V2W7/Rox2x44dFQOHT4mD91XU57p/6TcWa28LF+53p4Ie0lc/2zYslNWrd0oowd3l4WvjJUalctLzRqV5P2Pv0xR9cKFC/LBJ18Zx3JekcNxrEzJm0Rdtkfws3IcJ2cFAQQQQACBKBMgYRJlE0a4CCAQ1QIEH6UC1xcuIMWKXmdEX+LG641bSwoVvEZuLVNCvt+xW5LOnBH9893mbXLPnVV0VTR5oivrN36vCylX+iZjuWHLDvuxbcYvxm2aPSQ1q1eUYX07id62YlQI8CFPriulrz0pkuvKnEYf9t+T5YWp86VC2VuM20bq3FVNGtarLS89N0D22pM3n3+9xjjDLTcVlcuyZzN+kTdvl7m+0LXGsVA9aMKmRpVbRRMxowc/Jbr+pT0xoR+cq++8cD2P3urUu0trw0QTU3oLybw3P5QXR/WVFo3rSu2aVWVonyeMd8qsWbfFtXmK7S3bdhvbJezjNFZcHurde6c8WOdOw0DP271jC+MDcH/Z+6c4/7nLnixpUPduI/l0s33unY+5rl+WPas91j5yzx2V7UmqBvYEyJ3y6Zer5NGH75NuHZrLXfbEhs513jy5jHOZ7W+3G40c1E00CXdHtQrS1V539JCn7ImRzbL3931mNWN58uQpeW54TylapKBcmz+fXHXlFfb5rSX6obvffnfJZMWajbL/wCFp8MDdRjvzoUTx643VLdt+MJY8IIAAAggggIBngQTPhziCAAII+BLgOALxLVC+bAk5c+asbPp+p+j/6K/ftF2qVCxtfBDqhk3bDJzvNm83EhnZs2U1tjd9v8tYVq5Q2liaD1VvK2OuBrSsXrlsivo//rxXDh05muoX5fz5rpYbbygs6zduT1E/nBsliheVccOelsb164gmAnp0amlP4vSTw0eOycL/fZzq1HdWq5hiX/58eSTf1bmlSKECjv06Dt3446/U38qj+81y8PBRyZI5k2TNksXclWJZtVJKt+qVbzWOb9q601iaD+Z+c9vb8naX23/yX3O1Ub1y+UtzbbPZ5Br7uP7482/jmD7ou2Vmz1/suIVKb49qf/G2rr2//6VVHOWmG4vIlTkvvWNED5QpWVwKX5df3l3yhW4a5b0ly+wJlbxya+mbjW3z4fLLskuGDBnk74OHzF0sEUAAAQQQQMCDQIKH/exGID4FGDUCCCAQgEBxewJC36WhSRH9HIpTp07LbfZfjsuXKSHfbd5h9KQJilvLJL+7RHdosiD3VTnFZrPppqPoO0QcGwGsXJnzihS1/9p/0NjWz0jRX7ydi8b45/7kD681KqXDQ+lbbjSSID/89Euqs+e4/PIU+zJmzGhPeGROsS8hIUEyZswgJ+3W4uVPUlKSZMqUyWONK12SDlfkuMyoe+DQEWNpPuSyz5W57mupt90418loj1+3s2VLmbTJZN+vSRI9pkW/femt9z+TmtUrGbcd6Ttqnh3YRQ/J8X/+MZbmw1UucZv79d0pK1ZtEP28koP2Maxet0UeebCWeTjFMmuWzHLqlPdbmlI0YAMBBBBAAIE4FSBhEuMTz/AQQAABBMIroO8y2bB5p/HOjesLXSv6i3elW0vKrh9/Eb3tQT8vQm+PMaPQWyj0czrMbXP5778pP+DT3O9r6ZJ3kQIX39Wgt4Do55K4lq6PP+qry7Af13flhPskOXJkl3/+/c/jacwPxzUrmB+Iq7c4mfuM5QWbsQjnwxfLv5UGdWtKq0cflPvvqWFPupWyJ5XyuD2lzeY+nvvuqW58vss7H34hb3/wmWTIkGh8RotrJ/pOKHXJmTNlcsq1HtsIIIAAAgggIBJtCRPmDAEEEEAAAUsJ6C0P+iGv+vkRFcolf7Crfm5GFvv/4s+c87YkJiRIOafbIsqWKm7/3/3Tsm3njynGsf7iLTwpdgaxUbTwtaK3seg3zpifTeK8LF6siKPX7NmyyJkz5xzbkVhZvnqDccvQjUULh/V0Ra4rYNwm9ee+S7e+OJ9w9bpNzpuy8tsNxna5UilvYTF2hvnh7LlzksXl1qEvlid/1oy/p9Zbj/RDbD9c+rV8+MlyqXVnVdHbb1zbm5+JUrRwQddDbCOAAAIIIGA1gXSPh4RJuk8BASCAAAIIRLNA+bIlRL+iVT/MVT8EVsei35RTtuRN8t3m7XLLzTeI3oKh+7VogqV8mRLS75mJsnnbLuNdEPMWfSgff/6NHk5z0c+n0G+T0Q931a/N/d8Hn8naDd/Le0u+kO4DxhpL8yRFChUQ/bYWTWKs27hV9vz6u3nI61LfpaD1tfz+Z/JniWgCSLd37/nV0XbAiInG1+WuXLtJ9Ot59daToaOnSJ7cVxnfJOOoGIaV8mWTk1c//LjXbe+ff/Wt6FcAa8z6FcPPT50n+gG5+mG+bhuEcWcle6Ltg0++kgMHDxvfYPPGO5/IOx99EfAZH3mwtvEVxvoZNvXvr+m2/Y8/J89Peft167YCOxFAAAEEwihA19EmQMIk2maMeBFAAAEELCWg/1Ovn2OiQVW0/+KrSy0VLv5CWr5M6ncsjB3WQ0qXKCa9Bk+Q2o88ISvXbDS+6UbbhaLoB5rOfGGIyAWRV+a+I0/1Hyvz3/pIri98rZS/mEjQ87Rt3sD4MNYJU16Tbv3GyKsL3tXdPosmiLS+lsUfLTPqDxs7zehj6qxFxrY+FCtaWL5csc4+zvEyeNRk0Xd13Ht3dXl1yjPGt85onXAV/SYaHesap2+OcT5Xry6t5b0lXxoxT3jpNbn79ttkUM/2zlUitt67axspfkMRadahn9R6uIMs/WKljB/+dMDn12RP4esKGN+gU8p+fbnrYM3676XSraUk2M/Mcdcn+xBAII4FGDoCMS5AwiTGJ5jhIYAAAgiERqBiuZKyeul8cb6lxez5s3dmGseyZb304Z7NG9U19nV4rJFZzbHMni2r6NfImu2mPz9Y9DMotH/9ul9HRS8r2ofWb1ivtttat9x0g2i/H781zYjjrVcniH6uybX58zrq6y0bg3p2kPcWTDLqjBjQxXHM24q+g0bP7a68MLK3o6l+bfIHC6cYfS//8DVZNHuCkRhy/WX9jqrljTrXFy7gaKsr+hW882eM1tUURft6vOXDKfa522hcv44s+3qN42ufnetcd+018tpLzxrnXfLmVOnf43HRd+eYdTzFpMf13F++N0tXjeJpLvSri9Uox+WXGfXMh4mj+8qUcQPMTcmd60rRD3k1r4dXp4wwElva9v5atzvqzZk60rhuHDtcVn7/c5/ot+o88uA9LkeSN/WDZr9csVYaN6iTvINHBBBIJcAOBBBAwFmAhImzBusIIIAAAgggEDMCt1e5VfSdJm+9+2nMjMndQPRzWvS2q2cnvCz6obUP1L7DXTV5671Pjc+3qebylcpuK7MzVgQYBwIIIIBAGgRImKQBj6YIIIAAAgggYG0BfedIxowZrB1kGqNb8tk30n3AONFbsPSdKp7GmzlTRuOdNGk8XTo35/QIIIAAAghEToCESeSsORMCCCCAAAJ+CQwdM1XueKCNx6LH/eoowEq/7P3T4znNeLROgN2ma3W9xUlvzTGD8HarjVknossQnExvEVr1yTzjFqySNxfz2KM6qIfHChxAAAEEEEAAgRQCJExScLCBAAIIIIBA+gt07dBM5k0f7bHo8XAlIv9HAAAQAElEQVREWfi6/B7Pacajdbydm2MIIIAAAggggECsCJAwiZWZZBwIIIAAAuEQSJc+c1+VU667Np/HosfDFZi38+qxcJ2XfhFAAAEEEEAAAasJkDCx2owQDwIIIBBWATpHAAEEEEAAAQQQQAABfwRImPij5KVOxoyZJBTl3LlzYrMlhKSvUMSjfWTIkFHOnDljqZg0Lrn4R9etVNRKzawUU0JCgpw/f95ycxjS6z1Ez0GdO51DK82fxnLxcrfcHKqVmmmMVilc7/7/PNK50zm0ytyZcXC9+z+HXO/+W3G9+2+lz0V9bVAzXbdK4Xr3fw517nQOrTJ3Zhy8vvs/h6G+3k17lsEJkDAJzo1WCIRNgI4RQAABBBBAAAEEEEAAAQTSX4CESfrPQaxHwPgQQAABBBBAAAEEEEAAAQQQiDoBEiYBTxkNEEAAAQQQQAABBBBAAAEEEEAg1gUSJNZHyPgQQAABBBBAAAEEEEAAAQQQQEAEg4AEeIdJQFxURgABBBBAAAEEEEAAAQQQsIoAcSAQTgESJuHUpW8EEEAAAQQQQAABBBBAwH8BaiKAgIUESJhYaDIIBQEEEEAAAQQQQACB2BJgNAgggED0CpAwid65I3IEEEAAAQQQQACBSAtwPgQQQACBuBEgYRI3U81AEUAAAQQQQACB1ALsQQABBBBAAAH3AiRM3LuwFwEEEEAAAQSiU4CoEUAAAQQQQACBkAiQMAkJI50ggAACCCAQLgH6RQABBBBAAAEEEEgPARIm6aHOORFAAIF4FmDsCCCAAAIIIIAAAghEgQAJkyiYJEJEAAFrCxAdAggggAACCCCAAAIIxJ4ACZPYm1NGhEBaBWiPAAIIIIAAAggggAACCMS9AAmTuL8E4gGAMSKAAAIIIIAAAggggAACCCAQmAAJk8C8rFGbKBBAAAEEEEAAAQQQQAABBBBAIKwClkiYhHWEdI4AAggggAACCCCAAAIIIIAAApYQiKYgSJhE02wRKwIIIIAAAggggAACCCCAgJUEiCWGBUiYxPDkMjQEEEAAAQQQQAABBBBAIDABaiOAgClAwsSUYIkAAggggAACCCCAAAKxJ8CIEEAAgSAFSJgECUczBBBAAAEEEEAAAQTSQ4BzIoAAAghERoCESWScOQsCCCCAAAIIIICAewH2IoAAAgggYEkBEiaWnBaCQgABBBBAAIHoFSByBBBAAAEEEIgFARImsTCLjAEBBBBAAIFwCtA3AggggAACCCAQhwIkTOJw0hkyAgggEO8CjB8BBBBAAAEEEEAAAV8CJEx8CXEcAQQQsL4AESKAAAIIIIAAAggggECIBUiYhBiU7hBAIBQC9IEAAggggAACCCCAAAIIpK8ACZP09efs8SLAOBFAAAEEEEAAAQQQQAABBKJKgIRJVE2XdYIlEgQQQAABBBBAAAEEEEAAAQRiWYCESfLs8ogAAggggAACCCCAAAIIIIAAArEv4PcISZj4TUVFBBBAAAEEEEAAAQQQQAABBKwmQDzhEiBhEi5Z+kUAAQQQQAABBBBAAAEEEAhcgBYIWEQgbhImi95dKi069pdWnQbK8tUb3PIfPHREuvQZJW27DpEBIybKyVOnjHpHjh6XXoPHS82H2sm4Sa8a+3hAAAEEEEAAAQQQQAABBPwRoA4CCESnQFwkTH797S+Z+8YHMuP5ITJuWA8ZOWGmnDqdlGrGJs5YIJUrlJHZk5+RHDkulwVvLXHUub/27dK+5SOObVYQQAABBBBAAAEEEIhTAYaNAAIIxIVAXCRMvlmzQe6oVkGyZ8sq+fLmlpuKFZF1G7aK65+V326SurVrGLvr1qoh33y70Vi/MmcOuatGJcmaNbOxzQMCCCCAAAIIIIBALAkwFgQQQAABBFILxEXC5MChw5I/Xx7H6K/Nn1f+PnjIsa0r/504KTabiCZHdLtggbxy4OBhXaUggAACCCCAAALRJUC0CCCAAAIIIJBmgbhImKiSLeHSUG02e2ZEd7qUhBR1LtV3qZZi87///pVQlNOnT8nJkydC0lco4jH7SEo6bbmYTp48abc6abm4kpKS5MSJ/ywV10n7NaXXljmfVlmePn3aPocnLGWlc6dzaBUjM46Tlr3erffacOLECTl16pSlriudx9O8vvs9J96ud7VMr2LFn4Vc74H9+8uKc8j17v8cnuTfM36/jlr13zOnTp20/4y24r/fY//fMyl+eWUjYAH/sgIBd2utBnlyXSVHjx5zBHX4yFG5Oncux7au6O06586dl6QzZ3RTDtnr5Ml9lbHu7SF79sskFCVz5iySNWu2kPQVinjMPjJlymy5mLJmzWq3ymq5uDJlyiTZsmW3VFx6Tem1Zc6nVZaZM2e2z6G1rnedO51DqxiZcVj3erfea0O2bNkkS5YslnoO6jzqc1Cfi7ruVNI9zky8vvs9B1a04noP7N9fVpxDXt/9n0N9DdXXUiu9hmos/HvG/znMkiWr/We0Ff/9Hvv/nvH2uyzHfAsk+K4S/TWqV75VVqzZIKeTkuTwkWOyfdceua1CKWNgG7fskDNnzhrrVSuVlc+/Wm2sf/rlKql+W1ljnQcEEEAAAV8CHEcAAQQQQAABBBBAILYE4iJhUqjgNdKg7t3SrttQ6T5gnPTo3EoyZcxozGSfYS/IseP/GOvdOzaXD5YuN75WeO9vf0nzRnWN/WfPnZMqdVoYXym8+KNlxvqu3T8bx3hAAIEYFWBYCCCAAAIIIIAAAgggENcCCfEy+sb168j86aNl7rSRckfV8o5hf/bOTMmd60pjW5fTxg8yvlZ41OCnJGuWLMb+DImJsnrp/BSleLEixjEeEIgWAeJEAAEEEEAAAQQQQAABBBDwXyBuEib+k1AzSgQIEwEEEEAAAQQQQAABBBBAAIGwCZAwCRttoB1THwEEEEAAAQQQQAABBBBAAAEErCIQvoSJVUZIHAgggAACCCCAAAIIIIAAAgggED6BGO2ZhEmMTizDQgABBBBAAAEEEEAAAQQQCE6AVgiogKUTJufOn5e/9h+Qzdt2yY979sqx4/9qzBQEEEAAAQQQQAABBBBAAAH/BaiJAAJBCFgyYbL/wCEZMX6m3NOgvXR8eoRMnvm6DB41WRq2float+0pSz5fEcRQaYIAAggggAACCCCAAAKxIcAoEEAAgfALWDJh0q3faClb6kZZ+vZ0eW/BJHll4nBZ+Mpz8tk7M2Xs0Kdl7XdbZf6ij8KvwxkQQAABBBBAAAEEEIiEAOdAAAEEELCcgCUTJrMnj5AH69wpmTJmTAVWpFABGda3kzR44K5Ux9iBAAIIIIAAAgggYA0BokAAAQQQQCDaBSyZMMmeLatPV3/q+OyECggggAACCCCAgH8C1EIAAQQQQACBOBOwZMLEnINv1myU9t2HS437H5MqdVo4inmcJQIIIIAAAggEK0A7BBBAAAEEEEAAAW8Clk6YzJr/jvTq8ph89eGrsnrpfEfxNiCOIYAAAgjEqQDDRgABBBBAAAEEEEAghAKWTpjkvTqXFL+hsCQmWDpM4Q8CCCAQDgH6RAABBBBAAAEEEEAAgfQTsHQmItdVOeWdDz+Xf/87kX5CnBkBBEIlQD8IIIAAAggggAACCCCAQNQIWDph8s4Hn8tzk1+TWg93cHx+iX6WSdToEmiMCzA8BBBAAAEEEEAAAQQQQACBWBWwdMLE+XNLnNdjdTLSfVwEgAACCCCAAAIIIIAAAggggAAChoClEyYXLlyQnbt/lrff/9Qou378RXSfEbkfD1RBAAEEEEAAAQQQQAABBBBAAIHYFwjHCC2dMBk76VXp3GukbNyy0yidej4r46fMCYcDfSKAAAIIIIAAAggggAACCCBgFQHisICApRMm6zdulUWvjpeRg7oZZdHs52TN+i0WYCMEBBBAAAEEEEAAAQQQQAAB/wWoiUD0CVg6YZIpU0bJfVVOh2ruXFdKxoyJjm1WEEAAAQQQQAABBBBAAIF0EeCkCCAQ8wKWTpjkujKnTJ31hqzbuNUok2cukLx5csf8pDBABBBAAAEEEEAAAQQiLcD5EEAAAQRSClg6YTK8X2c5ePioDB0z1ShHj/0rQ/t0TDkCthBAAAEEEEAAAQQQSC3AHgQQQAABBNIkYOmEyVVXXiFDeneUJW9ONcrg3k+I7kvTiGmMAAIIIIAAAghEpQBBI4AAAggggEAkBSyZMNFbcP7974RxG46uu5ZIAnEuBBBAAAEEEAiTAN0igAACCCCAAAIWFrBkwmTW/MWy/8Ah0aW7YmFPQkMAAQQQiGMBho4AAggggAACCCAQOwKWTJhMnzBYihYuKLp0V2KHn5EggAAClhYgOAQQQAABBBBAAAEE4lbAkgkTczY69hxhrjqWLZ7o71hnBQEEEAhMgNoIIIAAAggggAACCCCAgH8Clk6YuA7hvxMn5XRSkututhGIXwFGjgACCCCAAAIIIIAAAgggEBYBSyZMZs55S6rUaSGbt+4ylrqupUXH/vLwA/eEBYJOrSFAFAgggAACCCCAAAIIIIAAAghYQcCSCZMOjzWS1UvnS8N6tY2lrmtZPPdFafrIfVZw8zcG6iGAAAIIIIAAAggggAACCCCAQBQKBJgwiewIez7ZKrIn5GwIIIAAAggggAACCCCAAAIIICAiIFg6YbL3933SfcBYufPBtiluzWHaEEAAAQQQQAABBBBAAAEEEAhIgMoIBChg6YTJM89NlwfvrSk33VhEPnh9snR5vKm0a9EgwCFSHQEEEEAAAQQQQAABBBCIPQFGhAAC4RWwdMLk1KnTcvftleT8+fOSO9eV0rxRXdnzy+/hFaF3BBBAAAEEEEAAAQQQSA8BzokAAghYSsDSCZNs2bIYWDabTX77Y5+cOp0kh48cN/bxgAACCCCAAAIIIICAtQWIDgEEEEAgmgUsnTApW7K4HD3+jzR9+H5p1r6v1KzXVmrVrBzN3sSOAAIIIIAAAghErwCRI4AAAgggEEcClk6YdG73qOTMcbncWb2CrFgyR1YvnS+PPFjLstNz5sTf8vfWBUGVwzsXycHtC4Nru/tDy5oQGAIIIIAAAlYWIDYEEEAAAQQQQMCTgCUTJus2bhVvxdNg0nv/mf/+lgPbFgZVjux6Sw7teDOotod/JGGS3nPP+RFAAAGLCBAGAggggAACCCCAQIgELJkwmTV/sWiZPHOhdOs3RgaNnCKjnn/FWH9+6twQDZ1uEEAAAQSsL0CECCCAAAIIIIAAAgikj4AlEybTJwwWLXly55TnhveUT96aJovnvSivTBwmha69Jn2kOCsCCCAQCgH6QAABBBBAAAEEEEAAgagQsGTCxJTb//dhqV65nNhsNmPXLTfdYCx5QAAB6wgQCQIIIIAAAggggAACCCAQiwKWTpjYEmyyZv1mh/uu3T/L0eP/OrZZQSAMAnSJAAIIIIAAAggggAACCCCAgFg6YTLw6fYy4aW5cn+TztKoTU8ZPHqK9OjYgmkLX8NDagAAEABJREFUSIDKCCCAAAIIIIAAAggggAACCCAQqIClEyY3FSsii2aPlyljB8rYoU/b1ydIcfu+QAdJfQQQQAABBBBAAAEEEEAAAQQQiDKBdA7XkgmTdRu3yr//nRBdrt+0TQ4dOWIU3daSzmacHgEEEEAAAQQQQAABBBBAAIGABWgQXQKWTJjMmr9Y9h84JLp0V6KLmGgRQAABBBBAAAEEEEAAgZgUYFAIxLSAJRMm0ycMlqKFC4ou3ZWYnhEGhwACCCCAAAIIIIAAAukkwGkRQACBSwKWTJisXLtJvJVL4bOGAAIIIIAAAggggAACHgU4gAACCCAQtIAlEyaLFi8VbyXo0cZpw/c++lRGPjcl4DJq/Esy7sWZAbczz7V2/aY4FWfYCCCAAAIIIBAuAfpFAAEEEEAgUgKWTJhMHN1XvJVI4cTKed5f8rlo8iOY8tzEmUG3Xfvd5lghZBwIIIAAAgiES4B+EUAAAQQQQMCiApZMmDhbnTlzVrbu2G18Y45+Q44W5+OsI4AAAggggICVBIgFAQQQQAABBBCIDQFLJ0y+WbNRHm7VXboPGCfPTX5VuvUbI1NeXhgb8owCAQQQQCA6BIgSAQQQQAABBBBAIC4FLJ0weWnWG/LyxGFyw/XXyaLZE+TVKSPs64XicqIYNAIIIBAqAfpBAAEEEEAAAQQQQAAB3wKWTphkyJAo+a7OLXpbjg7lpmJF5MTJE7pKQQABBEwBlggggAACCCCAAAIIIIBAyAUsnTDJljWLMeCcV1wm7y35QvQWnSNH/zH28YBA7AowMgQQQAABBBBAAAEEEEAAgfQWsHTCpNFDteXo8X+kc7tH5fOvv5X5b30oTzzWML3NOH+gAtRHAAEEEEAAAQQQQAABBBBAIMoELJ0wubX0zZIzx+VStHBBmTy2v0yfMFjK2feltzHnRwABBBBAAAEEEEAAAQQQQACB2BbQhIllR9iy0wDpOfg5+eqb9XL23DnLxklgwQksX7lWgikrVq0TLcG01TbBRUsrBBBAAAEEEEAAAQQQQCDqBRhAAAKWTpi8N3+i1K5ZVRa9t1QebNpVJrw0V/b8+nsAw6OqVQX+O3FC7nv4saDKg40fFy3Btj9x4qRVWYgLAQQQQAABBBBAAAEEAhKgMgLhE7B0wiRDhgxS565qMvW5gcbtOKdOn5bmHfqFT4OeEUAAAQQQQAABBBBAAIH0FODcCCBgGQFLJ0xMpfWbtsnsBYvlsy9Xyx1Vy5u7WSKAAAIIIIAAAggggIDFBQgPAQQQiFYBSydMXn97iTRu21NemDpPShQvKu/MfUHGDO0RrdbEHQUCiz9YKvc2eCyoUr/pE3Lfw62DajvuxRleddZv2BL05718s3p9UG31816OHf/HY1x6TOsEUzSmYD+HRi08BmU/sPOHn4Ie7zervwu67R9/7rOf3fPfYJy0jTpp0fVgiueIRDTmYPrUNmmx0jnyFpfOsZ4j0KJO34TpevcWL8cQQCDuBBgwAggggECcCFg6YfLnvgPy7MBusmDmGGnSoI5cdeUVcTItDDO9BH7/4y9ZsWptUGXlmu+Caqfn++HHPV6H3L5rP3sy5rGAS92GbaVek/YBtzM/H2br9l0e4/p+286g+33o0Q7yQKO2QbXv0K2/x5j0wHMTZwTV7/2PtJYGzTTpFbizemmyTc/vrlj1M3veef+ToKx0vGqlZroeaBk/aaY7Jsc+K17vjuBYQSAmBRgUAggggAACCLgTsGTC5L+LH8rZq8tjcmPRQu7ilqPHjrvdz04EEEAAAQQQiHMBho8AAggggAACCIRAwJIJk3bdhshHny6XM2fOphripu93SrMOfeWDpctTHWMHAggggAACsSjAmBBAAAEEEEAAAQQiL2DJhMnE0f1kw+Ydcn+TzvL4U0OlY88RRnm4VQ8Z9cLL0qJRXWnZ+IHIa3FGBBBAAIFQCNAHAggggAACCCCAAAKWF7BkwiRvnlwyuPcT8tGbL0nXDs2kXYsGRpk0pq8smj1B7q91u+VhCRABBOJJgLEigAACCCCAAAIIIIBArAlYMmFiImfKmFHK3FJcKpYraZRr8+czD7FEAIFwCtA3AggggAACCCCAAAIIIBDnApZOmMT53DD8EArQFQIIIJAWgb2//Skjn5sSVBn7wgwZPWFqUG1nzF6QlrBpiwACCCCAAAIIIJAGARImacBLx6acGgEEEEAgggJ7f/9DRo1/Kagy7sUZMub5aUG1nTH79QiOklMhgAACCCCAAAIIOAtYJGHiHBLrCCCAAAIIIIAAAggggAACCCAQmwLRMypLJky+375bvvxmXSrFZcvXyvZdP6Xazw4EEEAAAQQQQAABBBBAAAEE0kWAk8asgCUTJi9MmydFriuQCv36QgVk+qtvpdrPDgQQQAABBBBAAAEEEEAAgdAI0AsCCCQLWDJhcuz4v1L4uvzJETo9FrEnTP7af8BpD6sIIIAAAggggAACCCCAgFcBDiKAAAJBCVgyYXLhwgWPgzl77pzHYwcPHZEufUZJ265DZMCIiXLy1Cm3dTdv3SWtuwyWlp0GyCvz/ueo46n9j3v2SpU6LRylx8DnHG1YQQABBBBAAAEEEEAgsgKcDQEEEEAgEgKWTJjcWPQ6Wbl2U6rxr1i9QYoXLZRqv7lj4owFUrlCGZk9+RnJkeNyWfDWEvOQY6nJmCGjX5I+XVvLq1NGyBcr1srGLTuM497aly9TQlYvnW+UF0b2NurzgAACCCCAAAIIIBACAbpAAAEEEEDAggKWTJh0e6K5jHr+ZRn94ixZ9vW38smyb+zbr9i3X5Eu7Zt6ZFz57SapW7uGcbxurRryzbcbjXXnh10//iLZsmWVEsWLSobERKlds6qsWLPBqOJPe6MiDwgggAACCCCAgBcBDiGAAAIIIIBA9AtYMmGSP9/VsmDGaLkse1aZMmuhzJq/WK64Iru8/vJYuTZ/Prfq/504KTabyJU5cxjHCxbIKwcOHjbWnR/2HzgsBfLlcezSevv/PiS+2m/b9ZNUv6+VPP7UMNmy7QdHe1YQQAABBBCIAwGGiAACCCCAAAIIxJ2AJRMmOgs5r8ghXds3k8VzX5S3Xp0gT7ZrKjlzXK6HPJaEhEvDsdkurbs2sCXYMyuOnZfqeWqf/5qr5f0Fk+Tjt6bJXbffJr2GTJATJ5M/H+XEif/ELKdOnXT0GskVvc3IjMHd8ty5s5EMx3GupKQkh427uBwVI7ziLhZzn8Yc4XCM0509e9arlc6xUTHCD3pNmzauSz0W4XCM06mFayzO21zvBpPjwdnGdT2+r3cHkWNFr2lXI3NbjzkqRnDF1/VuxhfM8swZ76/RwfSZ1janTp0SLWntJ9TtrWh18uRJOX36tNefHaF28Ke/pKTT9jk8abm4rDiHeq1r8cc1knWsaMX1fun3DX+uBSvOoV7rWvyJP5J1rGgV6us9gv9siclTXcoWWGh4i95dKt6Ku1CzZ8sq586dl6QzZ4zDh44clTy5rzLWnR/y5rlKjhz9x7HrsL1e3qtzibf22bJmkcsvy26UZo/cJ/muzi2//bHP6CNbtuxilixZshr7Iv1gs9kcMZixOC8TEzNEOiTjfJkyZfIal1EpHR6cbVzXNeZ0CEkyZMjg1cpms6VHWKLXtKuRua3H0iMom83m1Spur3cPk2HOl7sl13tKNL2m3TnpPj2WsnZktmw279e7xhZsyZjR+2t0sP2mpV2WLFnsrztZvD7H09J/sG2taJU1a1bJnDmz5awyZcpsn8OslovLinPI9X7p39C+nptc7/5bqSXXu/9eVrQK9fUemX+xxO5ZEqw4tA1bdoi34inmqpXKyudfrTYOf/rlKql+W1ljXW+32bpjt7Fe/IbCot+GowmPc+fPG5+RUr3yrcYxT+3//e+EcVwf9Btzjhw7LgULuL81SOtQEEAg7QL0gAACCCCAAAIIIIAAAgikp4AlEyZjhnQXb8UTWPeOzeWDpcuNrxXe+9tf0rxRXaPq73/skxHjZxjrNptNhvfrLINHTZHWTw6S8uVKyK2lbzaOeWq/5LMVxlcK16jbWiZMnSujBnUTfdeJ0YgHBPwToBYCCCCAAAIIIIAAAggggEAUCSREUaw+Q82d60qZNn6Q6NcKjxr8lGTNksVoU7xYEXlz1nhjXR/KlCwur730rMybNkrat3xEdxnFU/vG9esYXye84qPXjP5LlShm1I/vB0aPAAIIIIAAAggggAACCCCAQOwKxFTCJE3TRGMEEEAAAQQQQAABBBBAAAEEEIh9AT9HSMLETyiqIYAAAggggAACCCCAAAIIIGBFAWIKjwAJk/C40isCCCCAAAIIIIAAAggggEBwArRCwBIClk6Y6DfZTJv9pnTtO1o69hzhKJaQIwgEEEAAAQQQQAABBBBAwC8BKiGAQDQKWDph8uyEmXLFFTmkReO60q5FA0eJRmhiRgABBBBAAAEEEEAgZgQYCAIIIBAHApZOmOS4PLs0e+Q+ua18aalYrqSjxMG8MEQEEEAAAQQQQACBCApwKgQQQAABBFwFLJ0wyZQxo/yy90/XmNlGAAEEEEAAAQQQ8C7AUQQQQAABBBBIo4ClEyZ7fv1DmrbvIy07DXB8fol+lkkax0xzBBBAAAEEEIg6AQJGAAEEEEAAAQQiK2DphMnTnVvKpDH9pFuHZo7PL9HPMoksEWdDAAEEEEAgDAJ0iQACCCCAAAIIIGBpAUsnTJw/t8R53dKiBIcAAgjEqQDDRgABBBBAAAEEEEAglgQsnTA5nZQkcxa+L90HjOWWnFi66hgLAtEhQJQIIIAAAggggAACCCAQxwKWTpg8M266HDh0RA4eOioN6t4ll2XLKjcVKxzH08XQEUiLAG0RQAABBBBAAAEEEEAAAQT8FbB0wmTPL79Jry6PSfbsWaXOXdVk/Ihe8vuf+/0dG/ViXYDxIYAAAggggAACCCCAAAIIIBAmAUsnTLJnz2YM++zZc3Li5Clj/cyZc8YyFh8YEwIIIIAAAggggAACCCCAAAIIWEMgnAmTNI/wsuzZ5ejxf6RapbLSpssgexks+a7OJfxBAAEEEEAAAQQQQAABBBBAAAHLCMRkIJZOmLw4qo/kzHG5tG3RQAb0aC+d2zWRPk+1jcmJYFAIIIAAAggggAACCCCAAAJWESAOBEQsnTDRCdqy7QdZ9O5SKVOyuBS5roD89vs+3U1BAAEEEEAAAQQQQAABBBDwV4B6CCAQsIClEyZzFr4vo1+cJe8t+dIY2IULF2Tk8y8b6zwggAACCCCAAAIIIIBA/AowcgQQQCDcApZOmHyybIXMnTpSLr88u+GQJ/dV8t+JE8Y6DwgggAACCCCAAAIIxJAAQ0EAAQQQsJiApRMmmbNkkYwZM6Qgs4ktxTYbCCCAAAIIIIAAAlYUICYEEEAAAQSiW8DSCZMrr8gh23f9ZAjr7Tiz5i+WG66/ztjmAQEEEEAAAQQQiKgAJ0MAAThPauYAABAASURBVAQQQACBuBKwdMJkaN+O8s6Hy2Tbzp/k9rqt5bc/9kmPTi3iaoIYLAIIIIAAAuESoF8EEEAAAQQQQAABzwKWTpjoVwoP6tlBlrz5kiyeP1GG9e0kOa/I4Xk0HEEAAQQQiGcBxo4AAggggAACCCCAQMgELJkwWbdxqziXnbt/lp9//d2xL2SjpyMEEEDA0gIEhwACCCCAAAIIIIAAAuklYMmESbd+Y8RbSS8szosAAmkUoDkCCCCAAAIIIIAAAgggECUClkyY3FG1vBQvVkQ6t3tUPnxjiqxeOj9FiRJbwowDAYaIAAIIIIAAAggggAACCCAQmwIJVhzWmKE9ZOKovpI5U0bpO+xFear/WPn482/k1OkkK4YbSzExFgQQQAABBBBAAAEEEEAAAQQQsAtYMmFij0uuyHGZNK5fR16ZOEwa1qslE16aIwv/97EeCqBQFQEEEEAAAQQQQAABBBBAAAEEYl8g9CO0bMLk2PF/ZdG7S6Vt1yEyc+7b0rldE2nSoE7oBegRAQQQQAABBBBAAAEEEEAAAasJEE+6C1gyYdJv+AtSv+VTsmv3L9KjU0uZN22UPPzAPZIta5Z0ByMABBBAAAEEEEAAAQQQQACBwAVogUC0CVgyYfL1qu+kQL6r5Y99f8tLs96Qjj1HpCjRhky8CCCAAAIIIIAAAgggEHMCDAgBBGJcwJIJk0lj+slTHZtLuxYN3JYYnxOGhwACCCCAAAIIIIBAOghwSgQQQAABZwFLJkwqlisp3orzAFhHAAEEEEAAAQQQQMCtADsRQAABBBBIg4AlEyZpGA9NEUAAAQQQQACBmBVgYAgggAACCCAQOQESJpGz5kwIIIAAAgggkFKALQQQQAABBBBAwLICJEwsOzUEhgACCCAQfQJEjAACCCCAAAIIIBArAiRMYmUmGQcCCCAQDgH6RAABBBBAAAEEEEAgTgVImMTpxDNsBOJVgHEjgAACCCCAAAIIIIAAAv4IkDDxR4k6CFhXgMgQQAABBBBAAAEEEEAAAQTCIEDCJAyodJkWAdoigAACCCCAAAIIIIAAAgggkP4CJEzCPQf0jwACCCCAAAIIIIAAAggggAACUScQcMIk6kZIwAgggAACCCCAAAIIIIAAAgggELBAvDcgYRLvVwDjRwABBBBAAAEEEEAAAQTiQ4BRIhCQAAmTgLiojAACCCCAAAIIIIAAAghYRYA4EEAgnAIkTMKpS98IIIAAAggggAACCCDgvwA1EUAAAQsJkDCx0GQQCgIIIIAAAggggEBsCTAaBBBAAIHoFSBhEr1zR+QIIIAAAggggECkBTgfAggggAACcSNAwiRuppqBIoAAAggggEBqAfYggAACCCCAAALuBUiYuHdhLwIIIIAAAtEpQNQIIIAAAggggAACIREgYRISRjpBAAEEEAiXAP0igAACCCCAAAIIIJAeAiRM0kOdcyKAQDwLMHYEEEAAAQQQQAABBBCIAgESJlEwSYSIgLUFiA4BBBBAAAEEEEAAAQQQiD0BEiaxN6eMKK0CtEcAAQQQQAABBBBAAAEEEIh7ARImcXAJMEQEEEAAAQQQQAABBBBAAAEEEAhMIBoTJoGNkNoIIIAAAggggAACCCCAAAIIIBCNAukaMwmTdOXn5AgggAACCCCAAAIIIIAAAvEjwEijSYCESTTNFrEigAACCCCAAAIIIIAAAlYSIBYEYliAhEkMTy5DQwABBBBAAAEEEEAAgcAEqI0AAgiYAiRMTAmWCCCAAAIIIIAAAgjEngAjQgABBBAIUoCESZBwNEMAAQQQQAABBBBIDwHOiQACCCCAQGQESJhExpmzIIAAAggggAAC7gXYiwACCCCAAAKWFCBhYslpISgEEEAAAQSiV4DIEUAAAQQQQACBWBAgYRILs8gYEEAAAQTCKUDfCCCAAAIIIIAAAnEoQMIkDiedISOAQLwLMH4EEEAAAQQQQAABBBDwJUDCxJcQxxFAwPoCRIhAnAp8u26TLHrno6DK/95bGlQ7Pd8PP/4cp+IMGwEEEEAAAQTiSYCESTzNNmONGgECRQABBPwRmPna69KmU6+AS9vOvaVj94EBtzPP9emy5f6ERx0EEEAAAQQQQCCqBUiYRPX0RU3wBIoAAggggAACCCCAAAIIIIBAVAmQMAlqumiEAAIIIIAAAggggAACCCCAAAKxLJCcMInlETI2BBBAAAEEEEAAAQQQQAABBBBIFuDRbwESJn5TUREBBBBAAAEEEEAAAQQQQMBqAsSDQLgESJiES5Z+EUAAAQQQQAABBBBAAIHABWiBAAIWESBhYpGJIAwEEEAAAQQQQAABBGJTgFEhgAAC0SlAwiQ6542oEUAAAQQQQAABBNJLgPMigAACCMSFAAkTP6d50btLpUXH/tKq00BZvnqDn62ohgACCCCAAAIIWF+ACBFAAAEEEEAgtQAJk9Qmqfb8+ttfMveND2TG80Nk3LAeMnLCTDl1OilVPXYggAACCCCAgCUECAIBBBBAAAEEEEizAAkTPwi/WbNB7qhWQbJnyyr58uaWm4oVkXUbtgp/EEAAAQQQiIwAZ0EAAQQQQAABBBCItAAJEz/EDxw6LPnz5XHUvDZ/Xvn74CFje8vW7WKWnbt/kYP/SKpiVPTx4K6d6z5PXZw7d072799vFDMW5+U///4rGTJmdBRP/Tjvd67vad25vrv1f/75x2HjHI+ub9u+M+LxaIw6lq3bd3iMa9/fB7Saz6L9+Co+O7FXMPs4bp8jdXFXdG51ju3VPf41+/G29NjY6YBr+z2//JrKSuPRcvjwYaeWKVdd+3G3nbKF+y137c6dP58iJo3FuZw6dSpVZ+76cd2XqpGbHa5tnLf12tH5c47FXP/7779T9ObcztN6igYeNjy1dd5vxuBuqc9R7dq5vqd1reereGrrvF/70Dnaf/E1y11cOsfObdytaz++irt2rvuc+9Br2l08Oq/6XHBt67zt3I+ndef6ntZd2+pz3zUmjccsrq/vZr+u/bjbNut6W7prp/v02jHjMmPxtjTreltq+++37RAtuu6ueGtvHnPXznWfWdfb0rnN1u273Mblrb15zLkfT+tmXW9L17bq9P22nV5fD93159qPu2137Vz3uWun+7baf75rbLru2sbdttbzVdy1c93nrQ+NZ6t9Dl3buNv21o95zF07131mXW9L1zbutr21N4+5a+e6z6zrbWm20Z9Z5rrr0lt785hrG3fbZl1vy9Tt/jb+reu831t785hzfU/rZl1vS3dtXa28tTePuevHdZ9Z19vStY3zthmXt/bmMed2ntbNut6Wnto679fnorc+9JhzfU/rWs9X8dTWeb/2oa8N3uJyru9pXfvxVTy1dd5v9qHxuL6+m8ec63taN+uaS/25TQlegISJn3a2hEtUNpvN0apDj2Fili7D5sqQd7KmKit2ZRZfxV07132e+vho9RF5+umnjWLG4rz8+be/5YZixRzlpuuvEV/FUf+GS+0c+y725auP5V9+5rBxjkfXu/UfE1w8F8/tGotu+4pHj2s9PbfG4K589vW3Pm3MfrSvFMXFSuv5Kmb7n/fu92ilc5s90wWvcZn9eFv6ikWPu7af8sobqeLSeLS8OusVjzG59uNuW8/nq7hrlzFzthQxaSzO5c+9P6aKy10/rvs0luJF8qVqq/vN4trGefvTr9YYcTnHYq4PGjgwRb/O7Tytm+f0tvTU1nn/oEEDjdcGMxbn5YqvPjficq7vad01DndWnto679d+/vh1t8eYNL5MWbI7Xh+c2zqvaz++inN9T+vOfcx+ZabbuPS14qVZb3qNybkfT+ueYnDe79o2W8ZzqWLSeMzy8+9/S7Ebi6Uq5UoUEl+lmP311F1b532e+li14gtHXGYs3pY6r76Ktu/ce6Ro0XV3xVcfetxdO9d9Ws9XcW7j6eeGrz70uHM/nta1nq/i2rZjzxHSpe8o43XHPOarDz1u1vW21Hq+iqf2XfqOlk69Rhhx+epDj3vqx3m/1vNVnOu7W9c59NWHHnfX1nWf1vNVXNu42+7bt59o8daXu3au+7y1N4+5tnG3bdYdMGCg9OzZ0/EcN/fr0l07131az1dxbeNu27mP3r37SP/+/VPF5K6d6z7nfjytu7Zxt+2ubf/+A6RPnz6OuNy1c93nrh/Xfa5t3G27tjG3de50DnXbXTvXfVrPV3Ft427bVx96rXt7fTf79NWPHjfreltqPV9F2+trgy49FV996HFPbZ33az1fxazv7vXdPOarDz1u1jWXjl9cWQlK4FIWIKjm8dEoT66r5OjRY47BHj5yVK7OncvYXrFkvpjl64/my+fvLUhV2vVfKL6Ku3au+zz10XXY6/Laa68axYzFeblq6euy5tOFl8ryT2SNr2LW/8ypnbnPXPro4/1333LYOMdjrjti8tGPEat5Tm9LP/sxz+9uufITu5Wf/TjiN2NytQqgH50jd/HoPp3b5cs+9D5nZgzelgHEs+bThcb18s3HC1LNocajZdGbCzzH5C0O81gQ8aj5ant7dTGLxuJcPl3ybuq47G20rddij+fbFUtTt7XvN65BXXrpR68djck5Fud1Rx8++nHEqPV8FS/xmP04x+C6rs9RIy4/+jHqOcXj1srPfnSOXGNx3tY5NuP3uHSKxTU2x7af8Zj1F7156bXUOR6dV30ueIxFzxOGeDSu5cs+Ml7bXePRmLSssr9mrV66UFzLl5++L76KOru2c9321Mc7b7/hiEvj8FWc4/e07qsPPe6prfN+reerONf3tO6rDz3uqa3zfq3nqzjX97Tuqw897qmt836t56s41/e07qsPPe6prfN+reerONf3tO6rDz3uqa3zfq3nqzjX97Tuqw897qmt836t56s41/e07qsPPW62nTPnNcfz29xnLrWer2LW9bb01Yce99bePKb1fBWzrrelrz70uLf25jGt56uYdb0tffWhx721N+dQ6/kq3voxj/nqQ4+bdb0ttZ6v4q29ecxXH3rcrOttqfV8FW/tzWO++tDjZl1vS63nq3hrbx5z7cP4pZWHoAVImPhBV73yrbJizQY5nZQkh48ck+279shtFUr50ZIq1hEgEgQQQAABBBBAAAEEEEAAAQT8FyBh4odVoYLXSIO6d0u7bkOl+4Bx0qNzK8mUMaMfLcNYha4RQAABBBBAAAEEEEAAAQQQQCBsApZJmIRthCHquHH9OjJ/+miZO22k3FG1fIh6pRsEEEAAAQQQQAABBBBAAAEE4ksgWkZLwiRaZoo4EUAAAQQQQAABBBBAAAEErChATDEqQMIkRieWYSGAAAIIIIAAAggggAACwQnQCgEEVICEiSpQEEAAAQQQQAABBBBAIHYFGBkCCCAQhAAJkyDQaIIAAggggAACCCCAQHoKcG4EEEAAgfALkDAJvzFnQAABBBBAAAEEEPAuwFEEEEAAAQQsJ0DCxHJTQkAIIIAAAgggEP0CjADa+1LlAAAQAElEQVQBBBBAAAEEol2AhEm0zyDxI4AAAgggEAkBzoEAAggggAACCMSZAAmTOJtwhosAAgggkCzAIwIIIIAAAggggAAC3gRImHjT4RgCCCAQPQJEigACCCCAAAIIIIAAAiEUIGESQky6QgCBUArQFwIIIIAAAggggAACCCCQfgIkTNLPnjPHmwDjRQABBBBAAAEEEEAAAQQQiBoBEiZRM1XWC5SIEEAAAQQQQAABBBBAAAEEEIhVARIml2aWNQQQQAABBBBAAAEEEEAAAQQQiH0Bv0ZIwsQvJiohgAACCCCAAAIIIIAAAgggYFUB4gqHAAmTcKjSJwIIIIAAAggggAACCCCAQPACtETAAgIkTCwwCYSAAAIIIIAAAggggAACsS3A6BBAIPoESJhE35wRMQIIIIAAAggggAAC6S3A+RFAAIGYFyBhEvNTzAARQAABBBBAAAEEfAtQAwEEEEAAgZQCJExSerCFAAIIIIAAAgjEhgCjQAABBBBAAIE0CZAwSRMfjRFAAAEEEEAgUgKcBwEEEEAAAQQQiKQACZNIanMuBBBAAAEELgmwhgACCCCAAAIIIGBhARImFp4cQkMAAQSiS4BoEUAAAQQQQAABBBCIHQESJrEzl4wEAQRCLUB/CCCAAAIIIIAAAgggELcCJEziduoZeDwKMGYEEEAAAQQQQAABBBBAAAH/BEiY+OdELWsKEBUCCCCQbgKL3l0qbboMlhp1W8s9DdqHNI6NW3ZIlTotZNvOn9LUr7t+uvQZJT0GPpemfs3G3373vfQZ9rw0bP20EW+Dlt3NQymWa9ZvNo7rmJxLnYYdU9QL18a58+elWYe+MvfND8J1Co/9vjLvHan5UDuPx9N64Lc/9snMOW/JwUNHUnR14uQpUd9lX3+bYj8bCCCAAAIIIOC/AAkT/60iUJNTIIAAAghEg8C+vw/KC9PmSeHrCsiYId3lueFPR0PYRoxFixSUokWuNdbT+rB91x75868DUrxYESlYIK/P7vp3byeTxvRzlLFD3SdYfHYUYIX/vf+ZHD32jzRpUCfAlmmvfk3e3FK6xI1p78hDD3/8tV9eff09OXT4aIoa2bJmkVZNHpTJL78uZ8+eTXGMDQQQQAABBBDwTyC8CRP/YqAWAggggAACUSXw174DRryN69eWareVlXKlbza2o+GhR6eW0uXxpiEJtU2zh2T+jNEycmBXue7aa3z2WaJ4UalYrqSjlC11k882oajw5uKlUuvOypI5U6ZQdBdQH3Vr3y4TR/cNqE2oKtetXUP2HzgkX6/8LlRd0g8CCCCAAAKeBWLwCAmTGJxUhoQAAgggED6BYWOnSefeI40TtO06xLjVZPyUOcZtF3r7hXHA/vDjnr3Gsfbdh9u3Lv29v0lnmThjvmPHfydOysBnJ0mthztI0/Z9jNsrks4E/o4Af/txvSXn61XfGXHqskvf0XJvo45GHI4AI7iiMegtOzt3/yzTZr8pjzz2tD2WvsY7KM6fPy/fbdomvYaMN6xadRoo32/f7TO67bt+kj/3/S13VqvoqPvZV6uNMf/w06+OfeZK9wFjpXmHfuamzF/0kTw9aJzUffRJY4479BgueouRo4J9xYxbl66Gek0435Jz9Pg/MnXWG/LE088Y/Wm/fYY9L3prjb0rx1/tSy1Wrt0k3fqNkbvrP27E8PzUOXL23Dmj3hcr1jpur2rdZbAxJm3z629/GcdzXpFDypQsLku/XGls84AAAgggEJgAtREgYcI1gAACCCCAQAACrZrUk67tmxkt+nRrY9xe0uih2lK+9M2inxliHLA/rN+0XTIkJsoO+y/sp5OS7HtEfrH/Invk6HEpX+YWY1sf+g1/UdZu2CrNGtaVDo81sv9yf1DGTpythwIqae1n/ORX5e7bK8mi2eNlSO+OAZ3b38pd7QmZqve2lIdb9ZBnnpsufx887Lbp4FFT5F97IqlL+6ZSrtRNRhJp5ty37W1mSNmSN0vvrq0lc+ZM0nvoBDl1OtnWbUf2navWbjbmoVSJYvat5L81q1eULFkyy8efr0jecfHx8JFjsm7jNqlzd7WLe0S27/pRil1fSJ7u/Jh0atNYsmfLZiQpttvn1VHp4oo/hqft8e768VepWrGsDOvbWR55sJZ9zg9Ix54j5OSpUxd7urSYZE+u3XdPdVk870Xp+eRj8sEnX8vcNz4wKqhN53aPGuvmtai3POW9OpexTx/Kliou6zduF0046TYFAQTiWoDBI4BAgAIkTAIEozoCCCCAQHwLXF+4gBQrep2BUOLG643bSwoVvEZuLVNCvt+xW5LOnBH9893mbXLPnVV0VTR5oivrN36vCylX+iZjuWHLDvuxbfJM/ydFb2/RX+SH9e0keuuKUcHPh1D0c5c9WdKg7t2S4/LL5Gb7uPw8tV/VtM8aVW6VNs3ry+jBT4muf7lirfGhucf/+TdVH3qbU+8urUU9NBFwU7EiMu/ND+XFUX2lReO6UrtmVRna5wk5dvxfWbNuS6r2zju22uekaJGCkiFDBsduXb/njsryyecr5cKFC479H3/+jZFYeKD27Y59o+zxdmrbxEgmNa5fR14Y2VtuK19KFv7vY3H9449h3jy5jFt0HmtaT+6oWl7aNq8vsyc/I0lJZ+STZanfCfJAnTtFEyZqeFeNSnK/PbZPliUneq7MmUOKXV/QCMO8FvWWpyz2ZJKx0/5Q/IYiRiLG3btp7If5i0CUCxA+AgggEF6BhPB2T+8IIIAAAgjEh0D5siXkzJmzsun7ncYv4es3bZcqFUtLqVtulA2bthkI323ebiRDsmfLamxv+n6XsaxcobSxNB+q3lbGXPVrGYp+qle+1a9zBVNJE0Djhj0tmnC4o1oF6dGppT1p0E/0HR3uEg/Ot8/o+fLnyyP5rs4tRQoV0E2j5M93tbHUDz01Vjw8HDx0VPTWFNfDmoTQ22NWr9vsOPTJFytFEw5XXXmFY5/e9tPvmRelQavuou+O0Vte9NuBfv9zv6OOueKv4VL7eZ7sPVL09izt744H2si//52Q3//YZ3blWJaxXz+ODfvKdQWuMT5o1993jOS+Kqe9lci+/YeMJQ8WFyA8BBBAAAFLCZAwsdR0EAwCCCCAQLQKFL+hsFyWPZtoUmTHD3vk1KnTclv50lK+TAn7vh3GsPTWiFvLJL+7RHdowkB/obXZbLrpKLmuTP4l17HDx0oo+sl18RdrH6cK2eHS9kSAJkF++OmXVH3muPzyFPsyZswoWbNkTrEvISFBMmbMICftzuLlT9KZJMmSOWOqGreWvlly57rS8a6OPb/+Lvq5M/feXdVRVz9XpFu/0ZKYmCjNG94vY4b2MG7B0kTYP//+56hnrvhj+OmXq4xbi0rcdL10bN1IJozoZfSZJ/dVcvR46j4vy57d7N5YJibaRL8m+Yyf33yTJUsmo93ppNPGMtIPnA8BBBBAAIFoFiBhEs2zR+wIIIAAApYSKF+2hGzYvNP4zIjrC10rV+S4TCrdWlJ2/fiLbNn2g/EuggplL31+ib6TQT+rw3UQ//57wnWX1+2Q9HPB5vUc4Tio78gJR7/Ofea4/DI57sGzbu0a8vXK9aKfMfPR0q8lkz0xc/cdlR3NV6zeYLxraHi/ztKwXm25vcqtxjtQLniy8rTf0aOIJkz081SebNdU6t1XU6pWKmv0efx46luTnJoFvaqfmaONc16RMgml+ygIIIAAAggg4F2AhIl3H44igAACCCDgt4C+a0E/5PXb77ZIhXLJiZESNxU1PmB05py3JTEhQcqVvvQVxPqBnPpOlG07f0xxjvUXb+FJsdPLRvD9eOk0zIeW25MRh44clRuLFg7rmQoVLCB/7T/g9hz6WSVJZ87IZ1+ulk+/WiM1a1SSzJmS35GhDfSdHPp5J/rhvbqtRWPetHWnrgZV9FaarFmypGj7zZqNRtImxU4/Ny7Lns2oeTop+bNzjA2nhz/++tvYKl6siLHkAQEEEEAAAQT8FyBh4r8VNRFAAAEErC6QzvHpO0z0l2z9EFb9EFgNR3/ZLlvyJtFbdW65+QbjXQy6X4smWMqXKSH9npkom7ftkn/+/U/mLfpQ9MNH9bi/JVT9+Hs+s55+6Oq6jVtFy7Hj/xm/9Ou6ln37D5rVZMCIifL81Dmycu0m+XrVd/LCtHkydPQU0dtQmj5yn6NeOFYqlC0hGovauvZ/bf58cos9oTV19pty8NAR48NVnevou4NOJyUZc6IfDqvvFOo5aLycP3feuVpA65VuLS0bNm83PutG32GjyZJnJ8xIcV0E0uG1BfIZtyZ9sPRrYx7U3vmbg37c85sUvi6/5MxxeSDdUhcBBBBAAAEE7AIkTOwI/EUAAQSsKkBc0SVQtHBB43NMNOqKF99houv6S7suy5e59O4S3dYydlgPKV2imPQaPEFqP/KErFyzUfo+1VYPBVRC1U8gJ93xw0/Srd8Yo+i30ejtH+b2p1+tdnRVrGhh+XLFOvsYx8vgUZNl9bpNcu/d1eXVKc8Y38rjqBiGlTurV5BsWbPYz3npw12dT6PfuKNxa0JBEyTOx/RzaYb07mjcRlPtvlbSqeezcluFUnJ/rRrO1QJab/hQLWnSoI4Mf2663P5Aaxk/5TXp062t5L8mT0D9mJU17tGDu8ueX36XnoPHG3Ox/+9LH/C6et1mqXNXNbM6SwQQQAABBBAIQICESQBYVEUAgTQL0AECMSGg36Syeul8cXebw2fvzBQ9pr+km4Nt3qiusa/DY43MXY6lfmPOyEHdxGw3/fnBxjsdtA9994Ojoo8Vf/uZMm6AvDCyt6O3O6qWN2K7vnABxz5/VypXKGO01VhdS6smDzq6adPsIflg4RSj7vIPX5NFsycYSSHXD7f1FMuwvp1k/ozRjv7MFe3r8ZYPm5tul3r7S7377pQln33j9njj+nWMuD5+a5rYbKk/x0W/TWfetFGy6pN58sV7r0inNk2M2N9+7XlHf57i1goa35fvzdJVo+g7jjq3e1QWz33ROO+78yfKXTUqycKXx8ngXh2MOvrgqU/9LBW1dr51qNptZWXWpOGiHnqsUMFrtAvjXUv6gcD1769pbPOAAAIIIIAAAoEJkDAJzIvaCLgIsIkAAgggYHWBxx6tJxu37BC9pcbqsYYyvjkL35NHHrxbcl6RI5Td0hcCCCCAAAJxI0DCJG6m2s+BUg0BBBBAAIEYE9CEweDeT8j+A4djbGSeh3Pi5Cm5qVgRadH40jt9PNfmCAIIIIAAAgi4E4j5hIm7QbMPAQQQQACBaBEYOmaq3PFAG49Fj4d6LIs/WubxfBpLg1bdQ33KsPd3zx2V5fYqt4b9PFY5gd4SpreAXZmTd5dYZU6IAwEEEEAg/AKhPgMJk1CL0h8CCCCAAAIhFOjaoZnMmz7aY9HjITyd0VWtO6t4PJ/GMnlMf6MeDwgggAACCCAQVgE6T2cBEibpPAGcHgEEEEAAAW8Cua/K6j2D6AAAEABJREFUKdddm89j0ePe2gdz7LLs2TyeT2O5Nn/eYLqlDQIIIIBA3AsAgEB0CZAwia75IloEEEAAAQQQQAABBBCwigBxIIBATAuQMEnj9CYmZpDEEJTz5y+IzZYgiSHoK1R9JCQkyrlz5yXRQjFpLDplFy6IJFosLita6TV1/vx5SbSY1Xmud0n0c0643v1/jeV699+K13f/rfS5yuu7/168vvtvZdXXd653/+eQ691/K653/61C/e8ZtacEL0DCJHg7o2VCQoKEoly4cD6k/YUiJu3j/PlzIRmf9hWqolA2m1guLrWy2WyWissejuifUNmHqh+ud/9fN3T+dB5DZR+qfrje/Z9Drnf/rbje/bfS1wX1CtVzOlT9WPB6N34u62tWqMYYqn50/nQeQ9VfqPpRK5vNZriFqs+09mMPR/RPWvsJdXuud/9fs3T+dB5DPQdp7S8erne1pwQvQMIkeDtaIoAAAggggAACERbgdAgggAACCCAQKQESJpGS5jwIIIAAAgggkFqAPQgggAACCCCAgEUFSJhYdGIICwEEEEAgOgWIGgEEEEAAAQQQQCA2BEiYxMY8MgoEEEAgXAL0iwACCCCAAAIIIIBAXAqQMInLaWfQCMSzAGNHAAEEEEAAAQQQQAABBHwLkDDxbUQNBKwtQHQIIIAAAggggAACCCCAAAIhFyBhEnJSOkyrAO0RQAABBBBAAAEEEEAAAQQQSG8BEibhnwHOgAACCCCAAAIIIIAAAggggAACUSYQRMIkykZIuAgggAACCCCAAAIIIIAAAgggEIRAfDchYRLf88/oEUAAAQQQQAABBBBAAIH4EWCkCAQgQMIkACyqIoAAAggggAACCCCAAAJWEiAWBBAInwAJk/DZ0jMCCCCAAAIIIIAAAggEJkBtBBBAwDICJEwsMxUEggACCCCAAAIIIBB7AowIAQQQQCBaBUiYROvMETcCCCCAAAIIIJAeApwTAQQQQACBOBEgYRInE80wEUAAAQQQQMC9AHsRQAABBBBAAAF3AiRM3KmwDwEEEEAAgegVIHIEEEAAAQQQQACBEAiQMAkBIl0ggAACCIRTgL4RQAABBBBAAAEEEIi8AAmTyJtzRgQQiHcBxo8AAggggAACCCCAAAKWFyBhYvkpIkAErC9AhAgggAACCCCAAAIIIIBArAmQMIm1GWU8oRCgDwQQQAABBBBAAAEEEEAAgTgXIGESFxcAg0QAAQQQQAABBBBAAAEEEEAAgUAEojNhEsgIqYsAAggggAACCCCAAAIIIIAAAtEpkI5RkzBJR3xOjQACCCCAAAIIIIAAAgggEF8CjDZ6BEiYRM9cESkCCCCAAAIIIIAAAgggYDUB4kEgZgVImMTs1DIwBBBAAAEEEEAAAQQQCFyAFggggECyAAmTZAceEUAAAQQQQAABBBCITQFGhQACCCAQlAAJk6DYaIQAAggggAACCCCQXgKcFwEEEEAAgUgIkDCJhDLnQAABBBBAAAEEPAtwBAEEEEAAAQQsKEDCxIKTQkgIIIAAAghEtwDRI4AAAggggAAC0S9AwiT655ARIIAAAgiEW4D+EUAAAQQQQAABBOJOgIRJ3E05A0YAAQREMEAAAQQQQAABBBBAAAHvAnGTMFn07lJp0bG/tOo0UJav3uBW5eChI9Klzyhp23WIDBgxUU6eOmXUO3L0uPQaPF5qPtROxk161djHAwIIWEqAYBBAAAEEEEAAAQQQQACBkArERcLk19/+krlvfCAznh8i44b1kJETZsqp00mpICfOWCCVK5SR2ZOfkRw5LpcFby1x1Lm/9u3SvuUjjm1WEAivAL0jgAACCCCAAAIIIIAAAgikp0BcJEy+WbNB7qhWQbJnyyr58uaWm4oVkXUbtorrn5XfbpK6tWsYu+vWqiHffLvRWL8yZw65q0YlyZo1s7HNQxACNEEAAQQQQAABBBBAAAEEEEAgigTiImFy4NBhyZ8vj2Nars2fV/4+eMixrSv/nTgpNpuIJkd0u2CBvHLg4GFddVvYiQACCCCAAAIIIIAAAggggAACsStgJkxid4QXR2ZLuDRUm82eGbm433mRkKLOpfrOdVzXT58+JaEoZ86ckaSkpJD0FYp4kvs4LWfPnrVYTKcMJ+tYnbb7JBe1SkpKXj992hpLdTp79owjRqvEpVZnzuj1bg0nddG507h03f8Smuf/aS+vIzqHWrzVSY9jl6zCb+Dv+HQOz9hfS/2tn/Z6/l2/+hw8ExPXu3/jPZ2G178z9vnTkpY+wtFWr3e9vsLRd7B96uuCNa3OyJk0Xe/heE05zb9nvPycOe1yTK/308bzOBxz4atP968zer3ra2lyXO7rpMcxtUrb9R76sehrlcaVHh7eznnGr9d3X9dH6I9fsgp936ddnlv+buv1rl7+1vdVz/X314vbLPwU8C8r4GdnVq2WJ9dVcvToMUd4h48clatz53Js64rernPu3HlJsj+ZdfuQvU6e3FfpqteSmJhBEkNSEiQxUUuo+gtFP4mSYE8iJYZkfKGIx+wjURITtZjb6bnUOUsuNpvtolfydmJi+i8T7PNns6V/HK4WNptNbBaLK9nKZr+2AvGKxLWn17qWSJzL/3OoV6Jlnodm3ImSHJe5He6lf9eKXutaEhP9qx+Jegn214aEhECv9/DHrzFpiYRBIOfQmNQskDbhrqvxaAn3eQLtX691LYG2u1Q/HM/bSL82+DuGRPvPHC3+1o9MveTrKr3icv86ozGl7bpy3++l6y644zZbrPx7JrjxB+KX/Drq6+dOWq7x4NrqtZVouX/PJIT03zPCnzQJJKSpdZQ0rl75VlmxZoOcTkqSw0eOyfZde+S2CqWM6Ddu2WH/n5CzxnrVSmXl869WG+uffrlKqt9W1lj39pAhQwYJRUlISLT/0AxNX6GIx+wjISEhJOMz+wvFMtF4UUu0SFwZ7XEkF40rQ4bkdess9YeHWlkrrmQrvd6tGFcgMekYwlvUSkuGEL3WhKofa742mNd7eOfkkqF/18ql+fOvfoYIvY4kJFjxtUHnUOcPK9/XgVpZcQ41prTMobYNfUng3zP2f6/455q+Vp6e+7F6vXsab0bJkIafBYn2fyv7fg0Jz7k9nTfx4n/AejqevN+/azRDCP9NlL7Xu/vxJluZr6Xu6wRiIPxJk0BCmlpHSeNCBa+RBnXvlnbdhkr3AeOkR+dWkiljRiP6PsNekGPH/zHWu3dsLh8sXS5tuw6Rvb/9Jc0b1TX2nz13TqrUaSHjJr0qiz9aZqzv2v2zcYwHBBBAAAEEEEAAAQQQ8C7AUQQQQCAaBRKiMehgYm5cv47Mnz5a5k4bKXdULe/o4rN3ZkruXFca27qcNn6QzJ78jIwa/JRkzZLF2J/BnqVdvXS+OJfixYoYx3hAAAEEEEAAAQQQiDsBBowAAgggEAcCcZMwiYO5ZIgIIIAAAggggECQAjRDAAEEEEAAAVcBEiauImwjgAACCCCAQPQLMAIEEEAAAQQQQCCNAiRM0ghIcwQQQAABBCIhwDkQQAABBBBAAAEEIitAwiSy3pwNAQQQQCBZgEcEEEAAAQQQQAABBCwtQMLE0tNDcAggED0CRIoAAggggAACCCCAAAKxJGDJhMn58+dlyWfLpUvf0fJwqx5So25rqdOwozTv0E9GPf+K/PbHvliaA8aCgDUFiAoBBBBAAAEEEEAAAQQQiGMBSyZM2nYbKus2bpeWjR+QiaP7yhfvviILXx4rQ/p0lOLFCkmfYS/Isq+/jeNpY+jBCNAGAQQQQAABBBBAAAEEEEAAAX8FLJkw6dutjQy1J0duK19KChbIJxkzZpCrrrxCit9QWB55sJbMnTpSri2Q198xxmo9xoUAAggggAACCCCAAAIIIIAAAmESsFDC5NIIb77x+ksbbtY0gaLJEzeH2IUAAggggAACCCCAAAIIIIAAApYWiI7gLJkwMen0s0qmzX5TuvYdLR17jnAU8zhLBBBAAAEEEEAAAQQQQAABBNJdgABiUsDSCZNnJ8yUK67IIS0a15V2LRo4SkzOBINCAAEEEEAgRgT+3rpAgimHdrwhWoJpq21ihI9hIIAAApYQIAgEEBCxdMIkx+XZpdkj98lt5UtLxXIlHYWJQwABBBBAAAFrCpw/e0oObFsYVDm0Y5E9YbIoqLZ6zgvnTlsThagQQMAKAsSAAAIIBCxg6YRJpowZ5Ze9fwY8KBoggAACCCCAAALOAmvXb5KRz00Jqox7caaMGv9SUG3fX/KZcxip1tdv2CLLV64NuKxYtU6+Wb0+4HbmuY4d/ydVLOyINgHiRQABBBAIt4ClEyZ7fv1DmrbvIy07DXB8fol+lkm4UegfAQQQQAABBGJL4Ft7wkSTHsGU5yYmJ0yCafv+ks+9Qrbv2k/ue/ixgEvdhm2lXpP2Abczz7V1+y6Pce397c+gkkOakBr7wgwZPWFqUO1nzF7gMSY98N5HnwbVr86bJr00vmCKJtv0/J6KmYQKdKlJLy2BtjPre4qH/QgggAACoROwdMLk6c4tZdKYftKtQzPH55foZ5mEbvj0hAACCCCAAAIIhEcgWnvd+/sfxjtqNNEQaBn34gwZ8/y0oNrPmP26VzJNPgUaj1k/LUmvtd9t9hjXfydOBJ20erDx46LFTGIFujxx4qTHuDiAAAIIIBAaAUsnTJw/t8R5PTRDpxcEEEAAAQQQCECAqggggAACCCCAQFwJWDphsm3nj9Jr8Hi5v0lno/QeOkG27fwpriaIwSKAAAIIhEuAfhFAAAEEEEAAAQQQ8Cxg6YTJyOdflkIFr5GXxg00SsEC+WT0i694Hg1HEEAAgXgWYOwIIIAAAggggAACCCAQMgFLJ0wuXLggXTs0lyKFChilm309KSkpZIOnIwQQsLYA0SGAAAIIIIAAAggggAAC6SVg6YTJ+fPn5cjR4w6bg4eOONZZQSAKBQgZAQQQQAABBBAIu8Dk6a9J9rw3B1XyFKkgl+UrEVTbx7v09Tq29Ru2iPktP4Es9duEvlm9Pqi2ep5jx//xGJce0zrBFI1JYwumrVp4DIoDCCBgGQFLJ0yaPnK/NGnX2/GVws069JMWjR6wDB6BIIAAAggggAACCCCAgH8C7bv2C+pbheo2bCv1mrQPqq1++9DW7bs8Bvj9tp1B9/vQox3kgUZtg2rfoVt/jzHpgXZP9gkqaaXJLk16BZswmzJjjp7ebdFvhQq235zXlhEtwbb39q1QVk0Qtu/ST+5t8FjA5f5H2sqDjdsH3M481/derne3E8tOrwKWTpjUv/8umT15uNxzx21GmT35Gal3X02vA0rTQRojgAACCCCAAAIIIIAAAgggkEaB9Ru3yIpVawMu36xeJyvXrA+4nXmu417eUZXGIcVecz9GZOmEicZ/bf580rBebaNcmz+v7qIggAACCCCAAAIIIIAAAggggICTAKuhF7BkwqRKnRby/fbdokt3JfQM9IgAAnK+XF4AABAASURBVAgggAACCCCAAAIIIGAhAUJBIN0FLJkwWb10vpQqUUx06a6kuxoBIIAAAggggAACCCCAAAIBCVAZAQSiTcCSCRMTccJLc81Vx3LE+JmOdVYQQAABBBBAAAEEEEAgnQQ4LQIIIBDjApZOmOze82sq/u07d6faxw4EEEAAAQQQQAABBNIqQHsEEEAAAQScBSyZMHn/k6+kY88R8uOevcZS17U81nmgXF+4oHP8rCOAAAIIIIAAAgi4F2AvAggggAACCKRBwJIJk1tL3yztWjSQfFfnNpa6rmX0kKdk5KBuaRguTRFAAAEEEEAgegWIHAEEEEAAAQQQiJyAJRMm+vXBFcuVlPkzRosuzZI/39WRk+FMCCCAAAIIhFuA/hFAAAEEEEAAAQQsK2DJhImpdTopSeYsfF+6Dxib4tYc8zhLBBBAAAFrCRANAggggAACCCCAAAKxImDphMkz46bLgUNH5OCho9Kg7l1yWbasclOxwrFizzgQQMD6AkSIAAIIIIAAAggggAACcSpg6YTJnl9+k15dHpPs2bNKnbuqyfgRveT3P/fH6VQxbARCIUAfCCCAAAIIIIAAAggggAAC/ghYOmGSPXs2Ywxnz56TEydPGetnzpwzljwgYAjwgAACCCCAAAIIIIAAAggggEAYBCydMLkse3Y5evwfqVaprLTpMsheBku+q3NJLP9hbAgggAACCCCAAAIIIIAAAgggkP4C4U6YpGmEL47qIzlzXC5tWzSQAT3aS+d2TaTPU23T1CeNEUAAAQQQQAABBBBAAAEEEEAg5AIx16GlEybO2mVKFpeK5UpKYkLUhOwcPusIIIAAAggggAACCCCAAAJRJUCw8S5gyexDlTotxFuJ90lj/AgggAACCCCAAAIIIIBAwAI0QACBgAQsmTBZvXS+aGnSoI40e+Q+mTttpLz16gTp1KaJ1L//roAGSGUEEEAAAQQQQAABBBCITQFGhQACCIRTwJIJE3PA323eIV07NJdi1xeSa/PnlVaPPihHjx83D7NEAAEEEEAAAQQQQCCWBBgLAggggICFBCydMElKSpKjxy4lSE6dTpLDRy5tW8iRUBBAAAEEEEAAAQRSCbADAQQQQACB6BWwdMKkVZN60qRdHxn47CQZ+fzL8mi73vLQ/TWjV5vIEUAAAQQQQCC6BYgeAQQQQAABBOJGwNIJk7q1b5dXpzwj5UrfJMVvKCTTnx8s999TI24mh4EigAACCCAQbgH6RwABBBBAAAEEEHAvYOmEiYacP9/V0rBebaPkuzq37qIggAACCCDgSYD9CCCAAAIIIIAAAgiERMCSCZOOPUfIT7/8Jrp0V0IycjpBAAEEokKAIBFAAAEEEEAAAQQQQCA9BCyZMGnXooHkzZNLdOmupAcU50QAgRAJ0A0CCCCAAAIIIIAAAgggEAUClkyYVCxXUi7Lnk106a5EgSshxpEAQ0UAAQQQQAABBBBAAAEEEIg9AUsmTNp1GyreSuxNg6VGRDAIIIAAAggggAACCCCAAAIIxL2AJRMm3Tu2EG8lsFmjNgIIIIAAAggggAACCCCAAAIIxL5AaEdoyYRJqRLFxFsJLQG9IYAAAggggAACCCCAAAIIIGBBAUJKVwFLJkxMkdNJSTJn4fvSfcDYFN+YYx5niQACCCCAAAIIIIAAAgggED0CRIpANAlYOmHyzLjpcuDQETl46Kg0qHuXXJYtq9xUrHA0+RIrAggggAACCCCAAAIIxK4AI0MAgRgWsHTCZM8vv0mvLo9J9uxZpc5d1WT8iF7y+5/7Y3g6GBoCCCCAAAIIIIAAAukpwLkRQAABBEwBSydMsmfPZsR59uw5OXHylLF+5sw5Y8kDAggggAACCCCAAAI+BaiAAAIIIIBAkAKWTphclj27HD3+j1SrVFbadBlkL4Ml39W5hD8IIIAAAggggEC8CjBuBBBAAAEEEIiMgKUTJi+O6iM5c1wubVs0kAE92kvndk2kz1NtIyPDWRBAAAEEEEAgEgKcAwEEEEAAAQQQsKSApRMm46fMkT2//m7AlSlZXCqWKymJCZYO2YiVBwQQQACBeBZg7AgggAACCCCAAAKxIGDp7EP+fHmkz9DnpWWnATJ/0UfG7TmxgM4YEEAAgagSIFgEEEAAAQQQQAABBOJQwNIJk2YN75e3X3tennqiueze86vUb/6UDBgxMQ6niSEjgEAoBegLAQQQQAABBBBAAAEEEPAlYOmEiRl8hbK3yOMtH5ZaNavIl9+sM3ezRACBZAEeEUAAAQQQQAABBBBAAAEEQixg6YTJ2bNnZekXK6Vz75HSocczkiVzZpk3bVSICejOegJEhAACCCCAAAIIIIAAAggggED6Clg6YfJQi6dk2fJv5ZEHa8kHCydLzydbyQ3XX5e+YsGcnTYIIIAAAggggAACCCCAAAIIIBBVAkElTCI1Qn03ybhhT8vdt1eSDImJkTot50EAAQQQQAABBBBAAAEEEEAAARGJZwRLJkxef3uJXLhwQa668gq3c7Ns+VpZtnyN22PsRAABBBBAAAEEEEAAAQQQQMCDALsR8FvAkgmT/QcOSuO2veSVef+TVWs3ybqNW43y4dKvpUvf0TLjtTflmrx5/B4kFRFAAAEEEEAAAQQQQACB2BRgVAggEC4BSyZMenRqJRNH9zXeZfLGO5/IrPmLjbJu4zZ5oHYNef3lcVKieNFwmdAvAggggAACCCCAAAIIpJcA50UAAQQsImDJhIna5M93tbRv1VAmjekn0ycMNsrwfp3l3rur83kmCkRBAAEEEEAAAQQQiAoBgkQAAQQQiE4ByyZMopOTqBFAAAEEEEAAgZgXYIAIIIAAAgjEhQAJk7iYZgaJAAIIIIAAAp4FOIIAAggggAACCKQWIGGS2oQ9CCCAAAIIRLcA0SOAAAIIIIAAAgikWYCESZoJ6QABBBBAINwC9I8AAggggAACCCCAQKQFLJkwGT9ljrz+9pJUFvMWfShTZ72Raj87EEAAgSgTIFwEEEAAAQQQQAABBBCwuIAlEyar1m6SxvVrp6Jr+vC9smL1d6n2swMBBNJbgPMjgAACCCCAAAIIIIAAArElYMmESWJigmTIkEFc/+i+00lnXXc7tg8eOiJd+oyStl2HyIARE+XkqVOOY84rm7fuktZdBkvLTgPklXn/cxzy1P7HPXulSp0WjtJj4HOONqzEqADDQgABBBBAAAEEEEAAAQQQiGsBSyZMMmfK5DbZ8e9/JyRrlsweJ2zijAVSuUIZmT35GcmR43JZ8Fbq23ouXLggQ0a/JH26tpZXp4yQL1aslY1bdhh9emtfvkwJWb10vlFeGNnbqB9ND8SKAAIIIIAAAggggAACCCCAAAL+C1gyYVK/bk3p/8wkOXDwsGMk+w8ckkEjJ0v9unfpPrdl5bebpG7tGsaxurVqyDffbjTWnR92/fiLZMuWVUoULyoZEhOlds2qsmLNBqOKP+2NijwggAACCCCAAAIIIIAAAggggEAkBNLtHJZMmDSsV9ue0CgiDVv3lGYd+krjtj2lSdve9n3XS8N6tdxi/XfipNhsIlfmzGEcL1ggb4qEi7HT/rD/wGEpkC+PfS35r9bb//ch8dV+266fpPp9reTxp4bJlm0/JDfmEQEEEEAAAQQQQAABBBBAAIGABKgcLQKWTJgoXofHGsmHb0yRpo/cJ22aNTDWdZ/NZs+KaAU3JSHh0nBstkvrrlVtCc59XKrnqX3+a66W9xdMko/fmiZ33X6b9BoyQU6cTP58lFOnTkkoypkzZ+T06dMh6SsU8Zh9nDlz1nIxJSUliRYzRqssrWil11RS0hnLzSHXu/+vG0lc735fv1zv/l9X+roZztcs15+7kdrWcXkq+roTqTicz3Pu3Dmv17DeKuxcP1Lr+triyUqPRSoO5/OohaeYdL9aOteP1LpeO3p+TyVScbiex1M8ul9jdq0fiW2dIz2/p6JzHIk4XM+h17SnmPSYa/1IbKuFp5h0v1pGIg7Xc+i1o+f3VFzrO7bDvOIpHt2vMYf59G671znS83sqOsduG4Z5p17TzjGF+XQx3/2lbIEFh3r5ZdnlwTp3yn33VJfLsmfzGmH2bFnl3LnzkmRPPGjFQ0eOSp7cV+lqipI3z1Vy5Og/jn2H7fXyXp1LvLXPljWLaCxamtkTOPmuzi2//bHP6EM/iDYURZM1iYmJxofdhqK/UPWRYE8uhaqvUPWTkJAoWkLVX6j6saJVov2aSkxMsOB1lSCJ9thCZR+qfqw4hwkJXO/+zm+i/ZpKTOR699crnNe7pNMfb2NPtF8f6RFWQkKC19dgm80m6fFHPTx56bH0iMlms3m1Usv0iEs9PFnp/vSISc+p5/ZUNGatE+mic+QpJt1vs0XP9R5uO5uN6z0QY71+PBWu95SS6uFslfIoW4EKJATaIBL1723UUbwVTzFUrVRWPv9qtXH40y9XSfXbyhrrervN1h27jfXiNxQW/TYcTXicO39eln39rVSvfKtxzFN7/bBZo4L9Qb8x58ix41KwQD77lnj9we58ofpad72wfdWP1HFrxpVod9eSwb60TrGmVQZLJiawCuS61WtdSyBtwl+XOfTfOB6tjB+Q6fDg7Wej/iKXDiGJzeb9l6L0iEnP6e261GNaJz2Ktzm02WzpEZL9P2kSvP57Q9LpjzcrN9d7RKK02bjeA4H2Noc2G9e7s6U3K653ZylJ9W//lEfZClQgIdAGkaj/0riB4q14iqF7x+bywdLl0rbrENn721/SvFFdo+rvf+yTEeNnGOs2m02G9+ssg0dNkdZPDpLy5UrIraVvNo55ar/ksxVSpU4LqVG3tUyYOldGDeom+q4ToxEPCCCAAAIIIIAAAhEW4HQIIIAAAgiEXyAh/KcI/AxFixQUb8VTj7lzXSnTxg+S2ZOfkVGDn5KsWbIYVYsXKyJvzhpvrOtDmZLF5bWXnpV500ZJ+5aP6C6jeGrfuH4dWb10vqz46DWj/1Ilihn1eUAAAQQQQAABBEIiQCcIIIAAAgggYDkBSyZMLKdEQAgggAACCCAQkACVEUAAAQQQQACBaBcgYRLtM0j8CCCAAAKREOAcCCCAAAIIIIAAAnEmQMIkziac4SKAAALJAjwigAACCCCAAAIIIICANwHLJ0xOnU6SzVt3ybqNWx3F24A4hgACcSrAsBFAAAEEEEAAAQQQQACBEApYOmEye/5iadCyu7w06w2ZZV83SwjHT1cIWFaAwBBAAAEEEEAAAQQQQAABBNJPwNIJk9Xrt8iSN1+SmS8MlekTBjtK+nFx5jQI0BQBBBBAAAEEEEAAAQQQQACBqBGwdMLkypyXi81msygmYSGAAAIIIIAAAggggAACCCCAQKwKXEqYWHCEWTJnlkEjp8hX36x3fH6JfpaJBUMlJAQQQAABBBBAAAEEEEAAAQSiQ4Ao/RKwdMLk74OH5eDhI/LG4o/5DBO/ppNKCCCAAAIIIIDAU1xfAAAQAElEQVQAAggggED8CTBiBMIhYOmEifPnljivhwOCPhFAAAEEEEAAAQQQQAABiwgQBgIIWEDA0gkT9dm28yeZs/B9mTnnLUfR/RQEEEAAAQQQQAABBBCIFgHiRAABBKJPwNIJk9kL3pVxk2bLu0u+kEOHj9mXX8pvf+yPPmUiRgABBBBAAAEEEIgtAUaDAAIIIBDzApZOmHyybIXMmjRc8ubJJf17PC7vzH1RTp0+HfOTwgARQAABBBBAAIFIC3A+BBBAAAEEEEgpYOmESbZs2SRDhgySdOaMnDt/XrJkziQJNlvKEbCFAAIIIIAAAgikFmAPAggggAACCCCQJgFLJ0yyZ80iZ86clSKFrpVnx8+UyTMXyOmks2kaMI0RQAABBBCITgGiRgABBBBAAAEEEIikgKUTJj2fbG28u6RHpxZSMH9eyZw5kwx8+vFI+nAuBBBAAIFwCdAvAggggAACCCCAAAIWFrB0wuT6wgUke7ascln2bNK2RQPp8FgjyZP7KgtzEhoCCMSzAGNHAAEEEEAAAQQQQACB2BGwdMLk9z/3Sbd+Y6RRm56G+K7dP8v01xYZ6zwggEDYBTgBAggggAACCCCAAAIIIBC3ApZOmAwfN0Pur1Vdcl2Z05igG28oLN+s3mis84BA4AK0QAABBBBAAAEEEEAAAQQQQMA/AUsnTJKSkuTeu6uLXPxiHJvNJucvnBf+XBRggQACCCCAAAIIIIAAAggggAACYRGwVMLEdYQXLoicPXvpW3EOHjoiGTNkcK3GNgIIIIAAAggggAACCCCAAAIIRJFANIRq6YRJkwZ1ZMjol2T/34dkxmtvSfsew6VVk3rR4EqMCCCAAAIIIIAAAggggAAC8SPASGNQwNIJk7q1b5cu7ZvKXTUqyvF//pOJo/rJ3XfcFoPTwJAQQAABBBBAAAEEEEAAASsJEAsCCFg6YaLTkz/f1dK1Q3Pp3bW1XHdtPt1FQQABBBBAAAEEEEAAAQQCE6A2AgggEKCAJRMmHXuOEG8lwDFSHQEEEEAAAQQQQACBmBNgQAgggAAC4RWwZMJk89Zd8u9/J6R0iWJya+mbUpXwktA7AggggAACCCCAQDoIcEoEEEAAAQQsJWDJhMm8aaOkQtkSsmLNRjl67F+pUrGsdHiskaNYSpBgEEAAAQQQQAABtwLsRAABBBBAAIFoFrBkwuSG66+T7h1byoIZo6VqpbLyxuJPpGn7PrJ63eZotiZ2BBBAAAEEoluA6BFAAAEEEEAAgTgSsGTCxNU/wWaTs2fPyfkLF1wPsY0AAggggEDQAjREAAEEEEAAAQQQQMCTgCUTJj/u2SsvTp8nDzXvJm+//6ncfXtleXPWc1KtUllP42A/AggggIAIBggggAACCCCAAAIIIBAiAUsmTFp2GiBbtu2W9o81lOaN6kr27Fnku83bZd3GrUYJ0djpBgEELC9AgAgggAACCCCAAAIIIIBA+ghYMmFSpmRxyZQpoyz5bIXMmr84VUkfKs6KQAgE6AIBBBBAAAEEEEAAAQQQQCAqBCyZMJk+YbB4K1EhGydBMkwEEEAAAQQQQAABBBBAAAEEYlHAkgmTdITm1AgggAACCCCAAAIIIIAAAgggEPsCPkdIwsQnERUQQAABBBBAAAEEEEAAAQQQsLoA8YVagIRJqEXpDwEEEEAAAQQQQAABBBBAIO0C9IBAOguQMEnnCeD0CCCAAAIIIIAAAgggEB8CjBIBBKJLgIRJdM0X0SKAAAIIIIAAAgggYBUB4kAAAQRiWoCESUxPL4NDAAEEEEAAAQQQ8F+AmggggAACCFwSIGFyyYI1BBBAAAEEEEAgtgQYDQIIIIAAAggELUDCJGg6GiKAAAIIIIBApAU4HwIIIIAAAgggECkBEiaRkuY8CCCAAAIIpBZgDwIIIIAAAggggIBFBUiYWHRiCAsBBBCITgGiRgABBBBAAAEEEEAgNgRImMTGPDIKBBAIlwD9IoAAAggggAACCCCAQFwKkDCJy2ln0PEswNgRQAABBBBAAAEEEEAAAQR8C5Aw8W1EDWsLEB0CCCCAAAIIIIAAAggggAACIRcgYRJy0rR2SHsEEEAAAQQQQAABBBBAAAEEEEhvgfAnTNJ7hJwfAQQQQAABBBBAAAEEEEAAAQTCLxBjZyBhEmMTynAQQAABBBBAAAEEEEAAAQRCI0Av8S1AwiS+55/RI4AAAggggAACCCCAQPwIMFIEEAhAgIRJAFhURQABBBBAAAEEEEAAASsJEAsCCCAQPgESJuGzpWcEEEAAAQQQQAABBAIToDYCCCCAgGUESJhYZioIBAEEEEAAAQQQiD0BRoQAAggggEC0CpAwidaZI24EEEAAAQQQSA8BzokAAggggAACcSJAwiROJpphIoAAAggg4F6AvQgggAACCCCAAALuBEiYuFNhHwIIIIBA9AoQOQIIIIAAAggggAACIRAgYRICRLpAAAEEwilA3wgggAACCCCAAAIIIBB5ARImkTfnjAjEuwDjRwABBBBAAAEEEEAAAQQsL0DCxPJTRIDWFyBCBBBAAAEEEEAAAQQQQACBWBMgYRJrMxqK8dAHAggggAACCCCAAAIIIIAAAnEuEBcJkzifY4aPAAIIIIAAAggggAACCCCAQFwIhHKQJExCqUlfCCCAAAIIIIAAAggggAACCIROgJ7SUYCESTric2oEEEAAAQQQQAABBBBAIL4EGC0C0SNAwiR65opIEUAAAQQQQAABBBBAwGoCxIMAAjErQMIkZqeWgSGAAAIIIIAAAgggELgALRBAAAEEkgVImCQ78IgAAggggAACCCAQmwKMCgEEEEAAgaAESJgExUYjBBBAAAEEEEAgvQQ4LwIIIIAAAghEQoCESSSUOQcCCCCAAAIIeBbgCAIIIIAAAgggYEEBEiYWnBRCQgABBBCIbgGiRwABBBBAAAEEEIh+ARIm0T+HjAABBBAItwD9I4AAAggggAACCCAQdwIkTOJuyhkwAgiIYIAAAggggAACCCCAAAIIeBcgYeLdh6MIRIcAUSKAAAIIIIAAAggggAACCIRUgIRJSDnpLFQC9IMAAggggAACCCCAAAIIIIBAegqQMPFTf9G7S6VFx/7SqtNAWb56g5+tHNVYQQABBBBAAAEEEEAAAQQQQACBKBIIMmESRSMMQai//vaXzH3jA5nx/BAZN6yHjJwwU06dTgpBz3SBAAIIIIAAAggggAACCCCAgJUF4jc2EiZ+zP03azbIHdUqSPZsWSVf3txyU7Eism7DVuEPAggggAACCCCAAAIIIIBAlAkQLgJ+CpAw8QPqwKHDkj9fHkfNa/Pnlb8PHnJss4IAAggggAACCCCAAAIIpJcA50UAgfAIkDDx09WWcInKZrM5Wt1Tr6X4Kr169RJfpW6j9lKnQWuvffnqQ4/7ikWPaz1fRevVeqiVPNjkCY8x+epDj2s/vorW81Wc+7j34baixXmfrvvqQ49rPV9F6/kq7vpQKzUzj/nqQ4+bdb0ttZ6v4ql97fqt5f6Gjxtz6KsPPe6pH+f9Ws9Xca7vbl2v9759+/p8Xrhr67rPVyx63LWNu+3evXvLoEGDvMbkrp3rPj2fr+Laxt222Ue/fv1Fi7ntvHTXznWfc31P665t3G27tlUrNXPe766d6z7n+p7WXdu423bXtk+fvtK//wDHHLpr57rPXT+u+1zbuNt2beO8PWDAQNHr3V07133O7Tytu7Zxt+2prblf505fs9y1dd5n1ve2dK6v67UfflyGL86aouz7J5v4Kq5t3G376qN334HG653G4VreeGeJFCtWzCj58+YSX8Wsq8sbLrbTdefiqw89/v32nzzGpDEmJGb2GYv243xeXdeYtOi6WbSer2LWHTB8gse4XnnlZZ8xmf24LjUmLbrfVyx6XOuZxZaQyW1M5vX30+5dHuMy+/C01Jj0fL6Ku/YL//dRirjMeHQ50P78dtenu35c911z9VWixV17c59rG+fteo92MOLSOFzLF8s+S2Hl3M7TunlObzF5amvu1+vdNRbnbTmXZMRl1veyNOo5x+QuLm/tzWPax8svz3T8bHCOR9f1ejfreltqP65FY9Ji7vfW3jxm1r1w9rTHmPS14fsdPxmvV2Y716XZj7ulGZNrG3fbru2Xff5pqrg0Hi31mnTwGJNrP67bGpM+D93F4LzPtZ25PWTIYEdcGotzcX59N/sy23lbal1fMXlrr69Jeg05x+K8rq/veg4t3voxj2k9LRqTFl13LWZdb0vX13fHL66sBCVwKQsQVPP4aJQn11Vy9Ogxx2APHzkqV+fOZWwP69tRfJVmzZqKrzK0T0cZ3q+j17589aHHfcWix7Wer6L1tGhcunRXfPWhx921c92n9XwV1zbu4vLVhx537cfdttbzVdy1c43JVx963F0/rvu0nq/i2sbc1mvKjMtXH3rcbOdtqfV8FW/t9ZjG1Ly57+eF1vVVfMWix331oce1XrNmzb0+V7Wer5Lcj/ex+epDjzv307Sp+/60nq/i3I+ndV996PHUbVNbaT1fJXU/qcfmqw897q6f5GuqmWMOtZ6v4q4f132++tDjrm1SbjcTjU3r+Sop26W20eO++tDjWs9X0eeh1vVWfPWhx1O37yTdunZPUa68ta/4Ktqma5enpMuTT6Voq/vN4qsP9/Ek/2wdO/QpmTK2r1HefG2i+CpmXV1OHt3HaKfrzsVXH3p8wogeXn+2Txzdy2cs2o/zeXX9pbF9xDUureeraFstIwd18RhXtyef8BmT9uGuaEwamx7zFYse13pmUYvU11NHx3P6+TFDPMZl9uFpqXHp+XwVd+312nGOS68zs7Rq1cJtTKn7Sb72nPdrLG+86v1adK7vum7GZMbivBzc/+kUcbm2dbet8WjxFpO7ds779Hp3jsN1fdbUsUZczm08rWssZlk0Z6K4i8tTW+f92ode066xmNt6zLm+p3Xtx7VoTBqbud9TW+f9Zl21MGNwXercPj/iabevO2ZfZj/ulhqX7jfreltqPeei1467eDSm4f06eYzJuQ9P6/o89BaLHvPU1jkmjcW56HNU2zoXT/0479f6vmJyru+6PmH0YOP1yTkW53V9TdNzaHFt625b62nR11BPcblr57rP9fXd+KWVh6AFSJj4QVe98q2yYs0GOZ2UJIePHJPtu/bIbRVKGS1vq1RRfJVSpUqJr1KlciV7P1o89+erDz3uKxY9rvV8Fa2nJTku9zH56kOPax++itbzVZz7qHxbJXEXl68+9LhzP57WtZ6v4q6ta0y++tDj7vpx3af1fBXXNpe2L1n56kOPX2rnfs71uNbzVbSet6JWpUqV9vm88NaHecxXLHrcrOttqfXKlPEek7f25jHtx1cx63pbmn2ULl1aPMXlrb15zOzH29Ks623p2t5dTN7am8dc+3G3bdb1tnTXTq8p57i8tTePue8n5Wu2Wdfb0ls/yTGVtr/Ge35eyHiFSAAAEABJREFUmX1768c8Ztb1tjTrelvq89BbH3rMW3vzmNbzVcy63pbah6fXdz2mxVt785jW81XMut6Wzn14svLW3jzm3I+ndbOut2Xqtpde381j3tqbx8y63pZmXW/L2zz8+yfZKvnfM97am8e8xWEeM+t6W5p1PS01Lm/tzWOe2jvvN+t6WzrX97Tu7fXd7NtTW+f9Zl1vS+f6ntbN9smvWSlfB81jnto67zfrels61/e0nrK9+5+Fnto670/ZT2jHlWx16d8Ozuf1tB7OeMy+k+MqZamfO3q96/PQk4u53xyDt6VZ19vSW3vzmLb3FZNZ19tS+/FVvLU3j13qI/Xru3nMrOttadY1l8YvrTwELUDCxA+6QgWvkQZ175Z23YZK9wHjpEfnVpIpY0Y/WlIFAQQQQAABBKJBgBgRQAABBBBAAAFXARImriIethvXryPzp4+WudNGyh1Vy3uoxW4EEEAAAQQsIUAQCCCAAAIIIIAAAmkUIGGSRkCaI4AAAghEQoBzIIAAAggggAACCCAQWQESJpH15mwIIIBAsgCPCCCAAAIIIIAAAgggYGkBEiaWnh6CQyB6BIgUAQQQQAABBBBAAAEEEIglARImsTSbjCWUAvSFAAIIIIAAAggggAACCCAQxwIkTOJm8hkoAggggAACCCCAAAIIIIAAAgj4KxC9CRN/R0g9BBBAAAEEEEAAAQQQQAABBBCIXoF0ipyESTrBc1oEEEAAAQQQQAABBBBAAIH4FGDU0SFAwiQ65okoEUAAAQQQQAABBBBAAAGrChAXAjEpQMIkJqeVQSGAAAIIIIAAAggggEDwArREAAEEREiYcBUggAACCCCAAAIIIBDrAowPAQQQQCBgARImAZPRAAEEEEAAAQQQQCC9BTg/AggggAAC4RYgYRJuYfpHAAEEEEAAAQR8C1ADAQQQQAABBCwmQMLEYhNCOAgggAACCMSGAKNAAAEEEEAAAQSiW4CESXTPH9EjgAACCERKgPMggAACCCCAAAIIxJUACZO4mm4GiwACCFwSYA0BBBBAAAEEEEAAAQQ8C5Aw8WzDEQQQiC4BokUAAQQQQAABBBBAAAEEQiZAwiRklHSEQKgF6A8BBBBAAAEEEEAAAQQQQCC9BEiYpJd8PJ6XMSOAAAIIIIAAAggggAACCCAQJQIkTNIwUTRFAAEEEEAAAQQQQAABBBBAAIHYFHBOmMTmCBkVAggggAACCCCAAAIIIIAAAgg4C7DuhwAJEz+QqIIAAggggAACCCCAAAIIIGBlAWJDIPQCJExCb0qPCCCAAAIIIIAAAggggEDaBGiNAALpLkDCJN2ngAAQQAABBBBAAAEEEIh9AUaIAAIIRJsACZNomzHiRQABBBBAAAEEELCCADEggAACCMS4AAmTGJ9ghocAAggggAACCPgnQC0EEEAAAQQQcBYgYeKswToCCCCAAAJpEFj07lJp02Ww1KjbWu5p0D4NPaVuunHLDqlSp4Vs2/lT6oNh2vPeki9k6RcrA+59zfrNRqwar3Op07BjwH0F0+Dc+fPSrENfmfvmB8E0T1ObV+a9IzUfapemPrw1/u2PfTJzzlty8NCRFNVOnDwl6rvs629T7GcDAQQQQAABBIIXIGESvB0tEUAAAQQQcAjs+/ugvDBtnhS+roCMGdJdnhv+tONYqFYi3c+Hn66Qz75aHfRp+3dvJ5PG9HOUsUO7B91XIA3/9/5ncvTYP9KkQZ1AmoWk7jV5c0vpEjeGpC93nfzx13559fX35NDhoykOZ8uaRVo1eVAmv/y6nD17NsUxNhBAAAEEEEAgOAESJsG50QoBBBBAIO0CMdXDX/sOGONpXL+2VLutrJQrfbOxHc8PJYoXlYrlSjpK2VI3RYTjzcVLpdadlSVzpkwROZ/zSerWvl0mju7rvCti63Vr15D9Bw7J1yu/i9g5ORECCCCAAAKxLEDCJJZnl7EhgECEBThdvAoMGztNOvceaQy/bdchxu0o46fMMW7N0Fs0jAP2hx/37DWOte8+3L516e/9TTrLxBnzHTv+O3FSBj47SWo93EGatu9j3IKRdCawdw1oH3o7zPxFH8nQMVPloebdjHMfOXrcOM/qdZuN24f09pH7GneWfs+8KMeO/2sc04cWT/SXrTt2y8pvNxnttK/Bo6booZCVF6fPEx37vv0HRQ31lpInnn5Gli1fa5xj8UfLRLfveuhx6T5gnBx0eVeFUcnlYfuun+TPfX/LndUqOo589tVqYww//PSrY5+50n3AWGneoZ+5Ker19KBxUvfRJ43569BjuOgtRo4K9pWvV31n9KfLLn1Hy72NOhrzZD8kOt81nW7JOXr8H5k66w1jHLpf++0z7HnRW2u0vlm0LzVeuXaTdOs3Ru6u/7gRw/NT58jZc+eMal+sWCs9Bj5nrLfuMtiIQdv8+ttfxr6cV+SQMiWLy9IvA7+NyuiABwQQQAABBBBIIUDCJAUHGwggkEKADQQQ8EugVZN60rV9M6Nun25tjFtQGj1UW8qXvln0s0eMA/aH9Zu2S4bERNlh/6X+dFKSfY/IL/ZfdjWJUb7MLca2PvQb/qKs3bBVmjWsKx0ea2RPAByUsRNn66GAy4K3PxK9XWP2lGdk1qThcvll2ewJiTXy9KDnJMfll0m/p9pKuxb1ZdfuX6RTrxFy/vx54xz9ezxu3F5U8uZixnj01po2zesbx/x96GpPJlS9t6U83KqHPPPcdPn74OFUTU+ePCXd+o+WQgXzS59urSVL5swyaOQkeXnu2/Lex19J/fvvkidaN5Kff/1dRj0/M1V71x2r1m42jEuVKOY4VLN6RcmSJbN8/PkKxz5dOXzkmKzbuE3q3F1NN42yfdePUuz6QvJ058ekU5vGkj1bNiNJsd0+Z0YFp4fxk1+Vu2+vJItmj5chvTs6Hbm0evp0kuz68VepWrGsDOvbWR55sJZ9Pg/8n737AHCi6AI4/nL0KlIEFaQoolhA4AOUpqIgRQUVVEBAEASk9957700UaTbsKIIFFVAQpSgiIohIV2kiUo727VvYkMul3OVSNrk/Otk2Mzvz273N5mV3I626DJFTp09fyXh5bLIROKvxQEV5d8FE6fJCE1my7CuZ//oSc+ldd9wibZo/ZY53v7yf6XbJe00uc56+lLyjmHy/8WfndtR5JAQQQAABBBAITICASWBulEIAAQQQQMApUKTQ9VL0xhvM6eI3FzFvQSlY4FopVaK4bN66XeLPnhX9t/6HLfLAvXfrqHxvBE905PuNm3Ugd915iznc8ONWY9kWGdzrBXm2waOiH/YH9mgtenuLmSGZL3lyXS09jKBIrqtzmHVcvCgyYfpCKVPyNvPWker3V5AnHqkm08b0lt1G8Oazr9aaa7jtlhsla5bMclX2LGZ/9NaaIgXzm8sSvySco4GYSneXEg2wjOjXQXT8i1XrzCtajv97IkHm00ZA4YXnGoj2tWrl8jKsbztxOBxGcONrmT2hv2jwQJ9F0rxRXVnz3Y/y74n/EpR3n9CrYm4sXEDSpk3rXKTjD1QpL8s++1ouKsDlJR9/ttoMLNSuVvnyHJHhRntbN3vSDITUr1NdJgzrJuVK3yGvvf2xuP+7v3JZqVurqhl4utXY7u7LdTpvnlymc5OnH5Eq95SWZg3ryMtTBkt8/FlZ9nniK0FqV7/X7LMa3l+prNQ02rbs80uBnqtzZJeiRQpotWLtZ7pdMmZIb87Tl2I3FTYDMZ6uptHlJAQQQAABBBBIukBc0rOSEwEEEEAAgVQiEKRuli5ZXM6ePSebNv9iflD/3giS3P2/O+WO226WDZu2mGtZ/8PPosGQLJkzmdObNm8zh+XL3GkOrZd7ypWwRpM1rFi+ZIL8O37fLYePHpO6tasmmH9dvmvk5psKmVcnJFgQwIT2Z/TAzqIBhyoVykin1s8YQYOeold0uAce0sTFSaXydznXokEaDQzo1RTp06Vzzr/u2mvM8X0H/jKH3l4OHT4memuK+3INvOjtMXorkrVs2YqvzWBQzquvsmbJ5p+3m7cn1W3cUfTqGL3l5dv1m2Xv/j+deayRiuVLWaM+h/pLQy90G2befqT1Van9rJz476Ts3XcwUbkSxr7hOvOG66+V/Qf+NgM7rvO9jefOmcNcdPDPw+aQFwQQQAABBBAIXICASeB2lEQAAQSiRoCGRkagmBGA0ACABkW2/rpTTp8+I+VK3ymlSxSX9T9sNRult0+UKnHp6hKdoUEF/dDrcDh00pn0ChHnRDJGrs5xJRigxQ78eUgHos9I0Q/vrknbuP/PSw+vNTMF8eVOIxCQ75rc8utvuxLUmj17VokzgiauMzVQkvlyAMmar/N0XG/h0aG3FH82XjJmuBJosfKVuvNWyZ3raudVHTv/2Cv6TJmHqt5jZTGfK9K+5whJkyaNNHyipowc0Mm8HUmDXJ6ubMl1OTjhrMDDyCdffCODx8yS4rcUkVZN68m4IV3NOvPkzinHjie+WiZrliwJakmTxiHnL1yQs0n85ZuMGS9dbXIm/kyCephAAAEEEEAAgeQLEDBJvhklEEAg8gK0AIGoEdCrTDb88It55Ybe0nKVESAoW+p22bZjl/y45VfzSgO9PcbqkF7tcOLkKWvSOTxx4qRzPDkjbnEXuf7ylRrtWzY0P7jrMzBcU7vnnkpO9cnKq1fbJKtAAJn1VpbjXqxqVaskX339vejzYz5a/pVoEKZqlfLOtaxas8G8ImhQzzbmbUqV7y5lXoFy8WLC4JWzgLf5zgwiGjDR56m80PxpeaTGfXJP2ZJmncddHrDrkj3Fo0cvP9Q3x1XZUlwXFSCAAAIIIJDaBQiYpPY9gP7bRIBmIIBArArolQ36kNdv1/8oZe669GDX4rfcaD6EdPa8tyRNXJzcdeetzu7rQzv1SpQtv+xwztOR7y/fwqPjKUk3FsoveqXHL9t/Nz+46zMwXFOxooWd1WfJnNEIIFz6hRbnzABHVhrBCL0V6OYbCwVYQ9KKFSxwvRzwcpWMPqsk/uxZ+fSLNfLJl2vlvkplJUP6S1dkaO16JYc+70QfzKvTmrTNm376RUcDSvoQ3UwZMyYou3rtRjNok2BmEieyZsls5jwTf+m5OOaEy4t1y5LrdnRZzCgCCCCAAAIIJEOAgEkysMiaDAGyIoAAAgiYAnqFiX4Q14e56kNgdaZ+IC95+y2y/oef5bZbbzKvdND5mjTAUrpEcek5eJL8sGWb+ZDTBW9+KPqAUl2e0qQBgW7tmoo+3FV/qeXtJZ/Kug2b5f2lK6Rj71Hm0FpH4YLXi/46jAY7vtv4k+htLNYyX8PeQybJ+Onz5Ot1m+Srb9bLhBkLZMCIqaK3oTz9eA1fRVO8rEzJ4nLwz0Omm3tl+a/LJ/ow2+kvvyGHDh81H67qmkev/DkTHy/qrQ+H1auAuvQdKxfOX3DNlqzxsqXulA3Gdt60+Rcj+HRONFgydNysBNs8ORXmvz6fpHj0bKgAABAASURBVEuXVpYs/0p0m2jSB+dadezYuUcK3XCd5MiezZrFEAEEEEAAAQQCFCBgkkQ4siGAAAIIIBCIwI2FCpi/NqNl/3f5ChMd1w/2Oixd4srVJTqtadTATnJn8aLStd84qfb48/L12o3mL93osmAkvS1Ef4FGLorMmf+OdOg1ShYu/kiKFMovpUteugpG19OsYV3Rh7aOm/qKtO85UuYuek9n+01FbywkX6z6zmj/WOk3fIqs+W6TPFS1osydOtj8RRm/FaQgw70Vy0jmTBmNdf7gsZZq990jetuKBhQ0QOKaSZ85079bK/M2mgo1GkvrLkOlXJk7pOaDlVyzJWv8iUcfFP2Vn0FjZkrl2k1lrGHZvX0zue7aPMmqx8qs7R7Rr6Ps3LVXuvQba26XP/+68oDXNd/9IPrLR1Z+hggggAACCCCQfAGrBAETS4IhAggggAACKRDQ21rWLF8onm6F+PSd2aLL9IO8tYqG9WqZ81o2qWfNcg6zZM4kw/q2F6vczPH9zKshtA69QsKZ0ceI1qH5n3ikmsdct91yk2i9Hy+eYbZj8dxxos81yX9dXmf+bFmzSN8uLeX9RZPNPEN6t3Uu8zWiPxG85LWpZpmVH74ib748zgz4uD+4tmOrZ2TpG9MTVfXugonS5YXGCebrQ2O1P663LyXIcHlCb395pMa9svTT1ZfnJBzUr1PdbJf22+FI/GwS/TWdBTOGyzfLFsiK9+dI62efNNv+1ivjnRXpzwNrW4oUut45zxp57pnH5Iv3X7ImRa8matP8KXl3/kRzve8tnCT6c8GvvTha+nVt6cznrU7dfrou11uHKpQrKS9NHiRqq8sKFrjWrEevSNKHBtepeZ85zQsCCCCAAAKXBRgEKEDAJEA4iiGAAAIIIICAPQWaPPWIbPxxq+gtNfZsYWhaNe+19+Xxh6uKp59VDs0aqRUBBBCIlADrRSA8AgRMwuPMWhBAAAEEEEAgTAIaMOjX7Xn58+8jYVpj5Fdz8tRpuaVoYWlU/+HIN4YWIIBA8gUogQACthQgYGLLzUKjEEAAAQQQ8C4wYOR0qVL7Wa9Jl3svHfiSXbv3e12n1R7NE/gaglfygSrlRX8WOHg12rsmvd1Lb++6Okd2ezeU1qUaATqKAAIIxIIAAZNY2Ir0AQEEEEAgVQm0a9lAFswc4TXp8lCA6K+v+FqvLtM8oVg3dSIQYQFWjwACCCCQCgUImKTCjU6XEUAAAQSiWyB3zhxyQ/58XpMuD1UPfa1Xl4VqvdQbbAHqQwABBBBAAAF/AgRM/An5We5wOMThSHm6ePGiUY8YKeV1ORzBq+NSu4JXn8OR8rrE+GfHdtmxTQa32LFdl9ok7O/GBnI4fP9NiPHvkpfvfA5HeJfbsU0GAfu7geBwJG1fsOM2NHb3wLdhEvvtcCTNx+G4ks+OVkbzbGwlHN+NDeRwXNmHHI7E42L8s+O+Zcc2GXzs7waCw5F4P3I4Es+z4zY0dncbb8PEhg5HJOdJUK3UnhS4AAGTwO3MkmnTppNgpAsXLhj1xQWlrmC0R+tIkyatnDt3zlZt0naJ8c/hcNiuXWqlZtpGuySHI8484NqlPVY72N+TftwwdndxONjfrX3H19ARY/u7r76mdJkeq/SYldJ6gl2e/T3pxwb296Rbsb8n3Ur/pvXYoGY6bpfE/p70bajbTrehXbad1Q6O70nfhsHe39WeFLgAAZPA7SiJAAIIIJB0AXIigAACCCCAAAIIIBBVAgRMompz0VgEELCPAC1BAAEEEEAAAQQQQACBWBYgYBLLW5e+IZAcAfIigAACCCCAAAIIIIAAAgg4BQiYOCkYiTUB+oMAAggggAACCCCAAAIIIIBAoAIETAKVC3851ogAAggggAACCCCAAAIIIIAAAmESiGDAJEw9ZDUIIIAAAggggAACCCCAAAIIIBBBgehcNQGT6NxutBoBBBBAAAEEEEAAAQQQQCBSAqw3VQgQMEkVm5lOIoAAAggggAACCCCAAALeBViCAAKJBQiYJDYJeM6Fs//Jf39tDiidOrRFTv79U2Blj/wacJspiAACCCCAAAIIIIBADArQJQQQQCDFAgRMUkx4pYLTx36XXV/0Cijt/3qg7FnZN6Cy+74df6URjCGAAAIIIIAAAgjEoABdQgABBBAItwABk3CLsz4EEEAAAQQQQAABEQwQQAABBBCwuQABE5tvIJqHAAIIIIAAAtEhQCsRQAABBBBAILYECJjE1vakNwgggAACCARLgHoQQAABBBBAAIFULUDAJFVvfjqPAAIIpCYB+ooAAggggAACCCCAQNIFCJgk3YqcCCCAgL0EaA0CCCCAAAIIIIAAAgiETICASchoqRgBBJIrQH4EEEAAAQQQQAABBBBAwC4CBEzssiVC2I7mL3SXLHlvTXbKmq+45ClcJtnlrHVNnTUvhL2KiqppJAIIIIAAAggggAACCCCAQJQKEDCJ0g0XmWazVgQQQAABBBBAAAEEEEAAAQRSh0DqDpikjm1MLxFAAAEEEEAAAQQQQAABBBBI3QIB9J6ASQBoFEEAAQQQQAABBBBAAAEEEEAgkgKsO/QCBExCb8waEEAAAQQQQAABBBBAAAEEfAuwFAHbCRAwsd0mSR0N+u/kyYAfJpsjfwnRZD1cNrnDkydPpQ5keokAAggggAACCCAQQQFWjQAC0S5AwCTatyDtRwABBBBAAAEEEEAgHAKsAwEEEEhlAgRMUtkGp7sIIIAAAggggAAClwR4RQABBBBAwJcAARNfOixLdQLvLlkuD9VtElCq8/TzUuOxpgGVHT1xlk/rmS8tkmFjpiY7jRg3XUZNmJnscta69uzd77Vd/xz/V1Z+vS6gtHrN97Lqm+8CKvv9hh+9tkkX/PLrbwHVq31ZvWZ9wGX37T+oq/eatP5AkjppCqSslvHaIGOBtlnzBJJSYqXbyFi91/91GwfSJnVabexbgZTVMrpPe20UCxCIDgFaiQACCCCAAAJBFCBgEkRMqop+gb37Dhgf5NcFlL5euz6gcqu+WSe/7tjpE2/Wy4tk+NhpyU4jxs0wAiazkl3OWtduHwGTzVt+MQJETQJKjz7VUmrXaxZQ2Zbte/m0GjNpVkD11ny8qdRtoEGvwPqkwTZvDdNn9tR4LLB6H67/nGgKtPxJH8/seeeDZQFZaVvUSs10PLlp7OTZ3qjM+S3a9QyoXbWeaCaPPNkioLLah59+3maunxc7CdAWBBBAAAEEEEAgcgIETCJnz5oRQAABBFKbAP1FAAEEEEAAAQQQiBoBAiZRs6loKAIIIGA/AVqEAAIIIIAAAggggECsChAwidUtS78QQCAQAcog4FFg88/bAno+kT4T6ZEnW4reLqTjyU0t2vb02B5mIoAAAggggAACCIRegIBJ6I1ZAwIRFGDVCCAQDIF//jke8DOKvl77vaxe811A5ddv2hyM5lMHAggggAACCCCAQAACBEwCQKNIBAVYNQIIIIAAAggggAACCCCAAAJhECBgEgZkX6tgGQIIIIAAAggggAACCCCAAAII2E8g2AET+/XwcovefG+5NGrVSxq37iMr12y4PDfh4NDho9K2+3Bp1q6/9B4ySU6dPm1mOHrsuHTtN1bue7S5jJ4815zHCwIIIIAAAggggAACCCCAAAKpWCDmu54qAiZ/7Dkg819fIrPG95fRAzvJsHGz5fSZ+EQbd9KsRVK+TAl5ecpgyZ49myxavNSZp2a1ytLimced04wggAACCCCAAAIIIIAAAgjEkgB9QSChQKoImKxeu0GqVCgjWTJnknx5c8stRQvLdxt+Evd/X3+7SWpVq2TOrvVgJVn97UZz/Ooc2eX+SmUlU6YM5jQvCCCAAAIIIIAAAggggIDtBWggAgikSCBVBEz+PnxErsuXxwmV/7q88tehw85pHfnv5ClxOEQ0OKLTBa7PK38fOqKjPtP58+fFNfnMHMKFrm1wH7948WII1+y96gsXLiSwcW+X95KhXeLeDtdpbXNo1+65dt1GFy6cF2/Jc6nQz/XWHmt+6FvgeQ3W+j0N1dJzqdDO1X3HdV9yHw/t2r3X7t4O12lts/eSoVui28i1He7joVuz75rd2+E+7bt06JZ62s+DMU+3QzDqCW4dF4zjoCbvx8Pgri9p68EqaU66bS5e1O2nKelltJyV3P/ugjWtx7tg1RWserRNmoJVX7DqiWSbrP0g8fCCXNq3zkviZYHta8Go56Jxjq1ewagreHWo1UXjWBo5F899uWC0SZP3dgVrH05OPbr9kpM/HHkv+V3w+TkqOe0I3RlK6qg5VQRMdFM64q501eEwIiM60y3FJchzJb9btgSTZ8/Gi5XOnz+XYFm4JvRgbbXB01APBOFqi+t6zhvBJE/tsea55g3nuLV+T0NtczjbYq1LD4xnzpwRb0m3sZU3nMOzZ896bZMuC2dbrHWphTcnnc/+bkldGp51OUa5j0duf7/gPG66t0mndRtfan14X88bx3Bdv6eky8LbmktrU4szZ+KNv8Pgpvj4eDl37lzQ601pW88axxxNKa0n2OXVSs2CXW9K6tP2aLtSUkcoyp49e878+w607rM+jlkpWabvsykpH4qy586dNf4Oz5peoag/0DojaaXv456S7u+6b3laFsl5Z81jlh6fzxjHU3uk+Pgzxn6lx3d7tMfaPpeszvp0Ohuiv39f9Z7383nFV9nQLTtrbsNg1X/pjILXQAWSFhUItHablMuTK6ccO/aPszVHjh6Ta3Lnck7riN6uc/78BYk3Dnw6fdjIkyd3Th31mTJmzCRWSp8+MrfsOBwOZxustrgO06RJ47MPoVqYLl06n+0K1Xr91etq4z6ubfZXPhTL06RJK5kyZfaaHA6HROJfhgwZvbZJl0WiTQ6Hw2ub1JD9PeFWcd/HXacjt7+n8XlscDgis7/rMdzVx3VclyWUDc+Uw6H7eyZjnw9u0r7p9s+UKbj1prS+DBkyiKaU1hPs8mqlZsGuNyX1ZcyYUdKnTx/0fSMlbdKy6dOnN7ahvncEtm9ldDmvCuZ42rTpfB53grmupNaV3jhv1JTU/OHKF0krfR/3lDI693fv50qeyoV6XnrjbzCDj3OlUK/fU/0Zjb8hPWZ5WhbJeXps1+SrDdr2cCe1Cvc6/a1P9yndt/zlS+ry8JyxxO5a4mK3a1d6VrF8KVm1doOcMb5RO3L0H/l5204pV+YOM8PGH7cakf1LV4bcU7akfPblGnP+J198IxXLlTTHeUEAAQQQQACBVCpAtxFAAAEEEEAg1QqkioBJwQLXSt1aVaV5+wHSsfdo6dSmsaRPl87c6N0HTpB/jv9rjnds1VCWLF9p/qzw7j0HpGG9Wub8c+fPy93VG5k/KfzuR5+b49u2/24u4wUBBBBAAIFoEqCtCCCAAAIIIIAAAkkTiEtatujPVb9OdVk4c4TMnzFMqtxT2tmhT9+ZLblzXW1O63DG2L7mzwoP79f0DcP1AAAQAElEQVRBMmXMaM5PmyaNrFm+MEEqVrSwuYwXBBBAAIGICrByBBBAAAEEEEAAAQRCIpBqAiYh0aNSBBBAIOgCVIgAAggggAACCCCAAAJ2ECBgYoetQBsQiGUB+oYAAggggAACCCCAAAIIRKEAAZMo3Gg0ObICrB0BBBBAAAEEEEAAAQQQQCD2BQiYxP429tdDliOAAAIIIIAAAggggAACCCCAgJuAbQMmFy9elE2bf5EPl38lLy96T954d7l8vnKd/H3oiFsX3CeZRgABBBBAAAEEEEAAAQQQQACB2BcIbQ9tGTD5cvX38mTzrjJj7pvy3cYtcur0Kdm1e58s+3yVtOw0WIaOmy3Hjv8bWhlqRwABBBBAAAEEEEAAAQQQQCCcAqzLVgK2DJh8+MmXMn5oN5k1vr8M6tlGXmj+tPTo0EzGDOoib80bL3fedrMs/XS1rSBpDAIIIIAAAggggAACCCCAQEIBphCIZgFbBkzGDu4q+a/L59E1TVycPPLQvdLg8RoelzMTAQQQQAABBBBAAAEEEAiRANUigEAqErBlwMTV//SZePnhp23y3cafnMl1OeMIIIAAAggggAACCCAQqADlEEAAAQS8Cdg6YPLywnel7jMdZdpLr8tLxriVvHWG+QgggAACCCCAAAKpXIDuI4AAAgggECQBWwdM1nz/oyx9Y5rMnjBAZo7r50xB6jvVIIAAAggggAACtheggQgggAACCCAQGQFbB0yuzpFNHA5HZGRYKwIIIIAAAgiEQoA6EUAAAQQQQACBqBCwdcAkY4YM0nfYVNGfGeYZJlGxP9FIBBBAIBUK0GUEEEAAAQQQQACBWBSwdcDkr0NH5NCRo/L6ux/zDJNY3PvoEwII2FOAViGAAAIIIIAAAggggIDYOmDi+twS13G2GwIIIJAcAfIigAACCCCAAAIIIIAAAskVsHXA5Oix47Jo8UfSZ+hkM7369sei85LbSfIjEGMCdAcBBBBAAAEEEEAAAQQQQCDEArYOmAwYOV2+/Pp7KVXiVjOtWPmtDBo9M8QkVB9+AdaIAAIIIIAAAggggAACCCCAgL0EbB0wOfjX3zJzfD95/OEHzTRzXF/Zu/+gvQQ9tYZ5CCCAAAIIIIAAAggggAACCCAQ1QJJCphEqodxcYmbFxfniFRzWC8CCCCAAAIIIIAAAggggAACMS1A564IJI5IXFkW8bGSd9wqbboOldnzFpupdddh8r+77oh4u2gAAggggAACCCCAAAIIIIBAVAjQSAQCFrB1wKR7u6bycPUq8seeA2aqU/M+6fJC44A7S0EEEEAAAQQQQAABBBBAILoFaD0CCIRLwNYBE70lp7YRMBnWt71oqlWtsui8cOGwHgQQQAABBBBAAAEEEAixANUjgAACNhWwZcBEb8E5+Nch8zYcHXdPNrWkWQgggAACCCCAAAIICAQIIIAAArEhYMuASWzQ0gsEEEAAAQQQQCAmBOgEAggggAACqVLAlgGTlk3qSb5rckuVe8qIjrumCuVKpcoNRacRQAABBBBAIFgC1IMAAggggAACCPgXsGXAxGr2hJkLrVHncMSEOc5xRhBAAAEEEEBAREBAAAEEEEAAAQQQCLqALQMme/f/Kd9t/ElOnDhpDnVc01ffrJcz8fFBR6BCBBBAAAF7CdAaBBBAAAEEEEAAAQQiLWDLgMmGH7fKSwvfFX3wqw6t9OXq76Rvl5aRNmP9CCCAQHIFyI8AAggggAACCCCAAAJRJmDLgMkjD90rM8f1k/bPNzSHOq5pQPdWUuL2YlFGTHMRiEUB+oQAAggggAACCCCAAAIIxLaALQMmFrkGTs6ePSc/bd0uekuOlazlDBEImgAVIYAAAggggAACCCCAAAIIIOAiYOuAyeq1G+Wxxh2lY+/RMmbKXGnfc6RMffE1l+Yz6k2A+QgggAACCCCAAAIIIIAAAgggELiArQMm0156XV6cNFBuKnKDvPnyOJk7dYgxXjDw3lISAQQQQAABBBBAAAEEEEAAAQTsLGCbttk6YJI2bRrJd01u0dtyVOyWooXl5KmTOkpCAAEEEEAAAQQQQAABBBBAIAoEaGK0Ctg6YJI5U0bTNcdVWeX9pStEb9E5euxfcx4vCCCAAAIIIIAAAggggAACERBglQikEgFbB0zqPVpNjh3/V9o0f0o+++pbWbj4Q3m+yROpZNPQTQQQQAABBBBAAAEEEAiHAOtAAAEEPAnYOmDyQJXykiN7NrmxUAGZMqqXzBzXT+6681ZP/WAeAggggAACCCCAAAIIXBLgFQEEEEAgCAK2DJjMnrdYfKUg9JsqEEAAAQQQQAABBKJGgIYigAACCCAQfgFbBkwshh2/75HX3lkmvxnD/QcPydtLPpctv+y0FjNEAAEEEEAAAQSiU4BWI4AAAggggIDtBWwZMGnZpJ5oOnL0uLz9yngZNbCzDOzRWt5fNFnSpHHYHpUGIoAAAgggkNoE6C8CCCCAAAIIIBBrArYMmFjIp06dlpxXX2VNSsYM6SVd2rTOaUYQQAABBBAIkQDVIoAAAggggAACCKRyAVsHTHLnulpmvPyG7Ny1T/46dERefWupnD9/IZVvMrqPAAIIBCJAGQQQQAABBBBAAAEEEEiOgK0DJoN6tZHDR/+Rtj2GSdMX+squ3fulb7fnk9M/8iKAQKwK0C8EEEAAAQQQQAABBBBAIIQCtg6Y6E8K9+3SUpa+Md1MvTs/Z/7McAg9qBqBiAmwYgQQQAABBBBAAAEEEEAAAfsI2DJgoj8pfPCvQ15/Wtg+fLTEhwCLEEAAAQQQQAABBBBAAAEEEIhaAVsGTOypSasQQAABBBBAAAEEEEAAAQQQQCD2BS710JYBk5ZN6km+a3KLDj2lS03nFQEEEEAAAQQQQAABBBBAAAEE/AqQISABWwZMps55TXylgHpKIQQQQAABBBBAAAEEEEAAgZgQoBMIhEPAlgGTrFkyi68UDhjWgQACCCCAAAIIIIAAAgiESYDVIICADQVsGTBp+vSj4ivZ0JEmIYAAAggggAACCCCAgFOAEQQQQCD6BWwZMHFl3fLLbzLvtQ8S/GKO63LGEUAAAQQQQAABBBAIuQArQAABBBBIdQK2Dpi8vOg9GT35ZXlv6Qo5fOQfY/iF7Nn3Z6rbSHQYAQQQQAABBBAItgD1IYAAAggggIBvAVsHTJZ9vkpemjxI8ubJJb06PSfvzJ8op8+c8d0jliKAAAIIIIBAahSgzwgggAACCCCAQFAFbB0wyZw5s6RNm1biz56V8xcuSMYM6SXO4QgqAJUhgAACCCBgTwFahQACCCCAAAIIIBBJAVsHTLJkyihnz56TwgXzy9Cxs2XK7EVyJv5cJL1YNwIIIIBAoAKUQwABBBBAAAEEEEAgigRsHTDp8kJT8+qSTq0bSYHr8kqGDOmlT+fnooiXpiKAQCwL0DcEEEAAAQQQQAABBBCIXQFbB0x2/rHHDJJkzZJZmjWqKy2b1JM8uXPG7tagZwhEVoC1I4AAAggggAACCCCAAAIIXBawdcBk2eerpfZTL8iEGfNl5x97LzeZAQJJFSAfAggggAACCCCAAAIIIIAAAoEJ2DpgMnZwV5k3fZjoFSad+4yRZ1r3lsXvfxJYT2OhFH1AAAEEEEAAAQQQQAABBBBAAIGwCEQ0YJKUHubNk0taNH5C3po3Xu64taiMnz4/KcXIgwACCCCAAAIIIIAAAggggAACNhGIxmbE2b3Rhw4flRcXvC2PN+4kGzdvlfYtG9q9ybQPAQQQQAABBBBAAAEEEEAgtgXoXSoQsHXApGv/sdKoVS85ceI/GTekq7z24mh5+vEaqWCz0EUEEEAAAQQQQAABBBBAIJwCrAsBBNwFbB0wqfFAZfnw9WnSqXVjuanIDe5tZxoBBBBAAAEEEEAAAQQQ8CzAXAQQQCCFArYMmGz9dafZraqVy0raNGnMcdcXvU3n522/uc5iHAEEEEAAAQQQQACBmBagcwgggAAC4RWwZcBk1OS5MmTMLNnw41Y5e/acU+TAn3/LSwvflfrNuomOOxcwggACCCCAAAIIIBBtArQXAQQQQAABWwvYMmDy8uRBUqrErfLi/Lfl/jrPyd3VG5mpdZeh8udfh+WVaUOlauXytoalcQgggAACCCCQ2gToLwIIIIAAAgjEkoAtAyZxcXFSq1plmTG2r6z66BVZs3yhmd5bOEl6d35ObsifL5a2AX1BAAEEEEDAngK0CgEEEEAAAQQQSMUCtgyYpOLtQdcRQAABBEIoQNUIIIAAAggggAACCCRVgIBJUqXIhwACCNhPgBYhgAACCCCAAAIIIIBAiAQImIQIlmoRQCAQAcoggAACCCCAAAIIIIAAAvYQIGBij+1AK2JVgH4hgAACCCCAAAIIIIAAAghEpYAtAyYfLPtS3v3o80Sgby/5VJZ9vjrRfGaET4A1IYAAAggggAACCCCAAAIIIJAaBGwZMFm0+EOpWrlcIv8Hqtwtr7+7PNH8FMygKAIIIIAAAggggAACCCCAAAIIxL5Asntoy4DJhQsXJXu2rIk6c1X2rHLixH+J5jMDAQQQQAABBBBAAAEEEEAAgdQlQG9DLWDLgInD4bnbFy5c8Lzg8txDh49K2+7DpVm7/tJ7yCQ5dfr05SUJBz/8tE2atu0nz7TuLXMWvO1c6K38jp275e7qjZypU58xzjKMIIAAAggggAACCCCAAAIIBEGAKhCwmYAtAyZ3/6+EvDj/Lbl48aKTS8dfnP+2VChX0jnPfWTSrEVSvkwJeXnKYMmePZssWrzUPYtZZ/8R06R7u6Yyd+oQWbFqnWz8cauZz1f50iWKy5rlC800YVg3Mz8vCCCAAAIIIIAAAggggIA3AeYjgEB0C9gyYNLq2fqy/oet8tRz3WTM1Fdk+Pg58mTzrkZg4xdp2aSeV/Gvv90ktapVMpfXerCSrP52oznu+rJtxy7JnDmTFC92o6RNk0aq3XePrFq7wcySlPJmRl4QQAABBBBAAAEEEEh9AvQYAQQQSFUCtgyYZMqYUWaO6yftWzaSkydPy0Xjv46tnpGZ4/tJFiPY4WkL/XfylOitPFfnyG4uLnB9Xvn70BFz3PXlz7+PyPX58jhnab4//zos/spv2fabVKzRWJ7rMFB+3PKrs/z58+fkSjrvnB/ukSttcG3PpXG9Oifc7dH16S1UvtqleSKRfLVJ2xyJNuk28tWuSLRJ13n+/HmX/fvS/nTeuc+zv6uRlXTfuWLjbnXOyhb2oa82aZvD3iBjhezvBkIy/ve1DVOy7MIFX3/fiffhlKwr6WW1TZoitX7P67Wn1TmxY7vs2Cbd/7y3y/M21zKhT+eN91hNkWxD4nXb0+oc+7vz/CvxNnPfV+25Dc+zv0doGybjlIOsHgRsGTCx2qm33wzo3kr6dG4h95Qtac32OoyLu9Idh+PKuHsBR5zrQ1Ku5PNW/rprr5EPFk2WjxfPkPsrl5Ou/cfJyVOX4/x3TAAAEABJREFUno9y7tw5sdJ548Ol+7rCMa0fPqw2eBpevHghHM1ItA49WHtqjzUvUYEwzbDW72mobQ5TMxKsRreRp/ZY8y663J6WoGCIJ3SfttrgPtRlIV69x+rVwr0trtMX2d8TuLnauI+zvyegEt2n3Y2saV2WMHd4pi4af/tWG4I9vHDhovP9K9h1B1qf7pOaAi0fqnJ2tNJ98vz5C4m3oct5Sag8fNV74cIFn39LvsqGctkF9vck7yt2tGJ/v/J5Iyl/J3bchnps15SU9oczjx2tgr2/h+eMJXbXciVaYKM+9hw8UXwlT03VK0/0xCH+7Flz8eGjxyRP7pzmuOtL3jw55eixf52zjhj58l6Ty7xyxVv5zJkySrasWczU4PEaku+a3LJn30GzjgwZMkqGyyl9+vTmvHC/OBwOyXC5DZ6GcXFpwt0kc31p06aTDD7aZWaKwIuvNmmbI9Ak0W3kq10Oh2uQL3wt1H3aW7t0WfhacmVNDgf7+xUN/2Petp/OZ39P6Kf7tLp4SrosYe7wTDkcvvd3T21N6ry0adNKBh/H6EgsS5cuvWhyXbcdxu1olT59BsPK9/tsJOzSGu/92rZIrNvXOtOyv0uGJP6929FK96l06djfo3kb6rFdU1L7EK58qWF/D88ZS+yuJc6OXSt1563iK3lrs16F8tmXa8zFn3zxjVS8/IBYvd3mp63bzfnFbiok+ms4GvA4b3wL8vlX30rF8qXMZd7Kn/jvpLlcX/QXc47+c1wKXJ9PJ0kIIIAAAggkR4C8CCCAAAIIIIAAAlEiYMuASf061cVX8mbbsVVDWbJ8pfmzwrv3HJCG9WqZWffuOyhDxs4yxx0Ohwzq2Ub6DZ8qTV/oK6XvKm4GZ3Sht/JLP11l/qRwpVpNZdz0+TK8b3vRq060DAkBBBBI3QL0HgEEEEAAAQQQQACB2BSIi6Vu5c51tcwY21f0Z4WH9+sg+vBY7V+xooXljZfG6qiZStxeTF6ZNlQWzBguLZ553JynL97K1zcCOPqTwqs+esWs/47iRTU7CQEEYlGAPiGAAAIIIIAAAggggAAChkBMBUyM/vA/Agi4CTCJAAIIIIAAAggggAACCCCQfAECJsk3o0RkBVg7AggggAACCCCAAAIIIIAAAiEXIGAScmJ/K2A5AggggAACCCCAAAIIIIAAAgjYTSD4AZMg9nD12o3SouMgqVSzifnQ1burNzKHQVwFVSGAAAIIIIAAAggggAACCCCAQCACMV7G1gGTlxa+I13bNpEvP5wr+tBVK8X4NqF7CCCAAAIIIIAAAggggAACERBglQi4Ctg6YJL3mlxS7KZCkibO1s0U/iGAAAIIIIAAAggggAACNhSgSQggkAIBW0cicuXMIe98+Jmc+O9kCrpIUQQQQAABBBBAAAEEEIgNAXqBAAIIhE/A1gGTd5Z8JmOmvCIPPtbSfHYJzzAJ347BmhBAAAEEEEAAAQTCIMAqEEAAAQRsK2DrgIn1zBL3oW01aRgCCCCAAAIIIJDKBeg+AggggAACsSJg64BJrCDTDwQQQAABBBCIWgEajgACCCCAAAKpVMDWAZPdew9Kx96j5N6Hm3FLTirdQek2AggggECwBagPAQQQQAABBBBAICkCtg6YDB4zUx5+6D655ebCsuTVKdL2uaeleaO6SekXeRBAAAEEUosA/UQAAQQQQAABBBBAIAQCtg6YnD59RqpWLisXLlyQ3Lmulob1asnOXXtDwECVCCCAgH0EaAkCCCCAAAIIIIAAAghEXsDWAZPMmTOaQg6HQ/bsOyinz8TLkaPHzXm8IIBA1AjQUAQQQAABBBBAAAEEEEAg6gRsHTApeXsxOXb8X3n6sZrSoEUPue+RZvLgfeWjDpkGx5oA/UEAAQQQQAABBBBAAAEEEIh1AVsHTNo0f0pyZM8m91YsI6uWzhP9eeHHH34w1rdJ+PvHGhFAAAEEEEAAAQQQQAABBBBAIIGArQMm8WfPysuL3pMBI6ebjd65a598/tW35rivF5YhgAACCCCAAAIIIIAAAggggEDsC4Syh7YOmAwaPVMO/nlIdu89YBpcd20emf/GB+Y4LwgggAACCCCAAAIIIIAAAgjEmADdsZGArQMmu/7YJ707PycZMqQ3yTIaw7PnzpnjvCCAAAIIIIAAAggggAACCNhdgPYhEL0Ctg6YpE2bJoHsOYIlCTyYQAABBBBAAAEEEEAAgTALsDoEEEg1ArYOmNx5WzFZ8OaHcuLESVm3YbN07T9O7qtUNtVsHDqKAAIIIIAAAggggECoBagfAQQQQMCzgK0DJp3bPCO5cl4l6dKllQkzFsr9lctJ84Z1PfeEuQgggAACCCCAAAIIiGCAAAIIIIBAUARsHTBxOBxS84FKMnfqEHntxVHyyEP3SlycrZsclI1CJQgggAACCCCAwBUBxhBAAAEEEEAgEgK2jD7MnrdYfKVIQLFOBBBAAAEEEAiSANUggAACCCCAAAJRIGDLgMncV9+XL7/+Xjb8+IvHFAWuNBEBBBBAIBUJ0FUEEEAAAQQQQACB2BOwZcCkfcuGkjFDBsmcKYM8VruqTB7ZU2aO6+dMsbcZ6BECCCBgKwEagwACCCCAAAIIIIBAqheIs6PA04/XkJenDJa2LRrItu2/S5PWvWXI2Nny+x/77Nhc2oQAArYXoIEIIIAAAggggAACCCCAQPIEbBkwsbpQpGB+ebZhXan3aHX56uvvZOPmrdYihgikbgF6jwACCCCAAAIIIIAAAgggEFIBWwZMzp0/L199s156DZkoTzXvLn/s3S9zJg+Wx2o/EFIMKo+cAGtGAAEEEEAAAQQQQAABBBBAwE4CtgyYPPxUW5n32vtyT9mS8vb88dKpdWMpVOBaO7n5awvLEUAAAQQQQAABBBBAAAEEEEAgigWSGDAJbw+PHf9Xtv66U4aPnyP3PtxM7q7eKEEKb2tYGwIIIIAAAggggAACCCCAAAKpRYB+WgK2DJisWb5QfCWr8QwRQAABBBBAAAEEEEAAAQQQ8CnAQgQCFLBlwCTAvlAMAQQQQAABBBBAAAEEEIh5ATqIAALhESBgEh5n1oIAAggggAACCCCAAAKeBZiLAAII2FKAgIktNwuNQgABBBBAAAEEEIheAVqOAAIIIBALAgRMYmEr0gcEEEAAAQQQQCCUAtSNAAIIIIBAKhQgYJIKNzpdRgABBBBAILUL0H8EEEAAAQQQQMCfAAETf0IsRwABBBBAwP4CtBABBBBAAAEEEEAgyAIETIIMSnUIIIAAAsEQoA4EEEAAAQQQQAABBCIrQMAksv6sHQEEUosA/UQAAQQQQAABBBBAAIGoEiBgElWbi8YiYB8BWoIAAggggAACCCCAAAIIxLIAAZNY3rr0LTkC5EUAAQQQQAABBBBAAAEEEEDAKUDAxEkRayP0BwEEEEAAAQQQQAABBBBAAAEEAhWInoBJoD2kHAIIIIAAAggggAACCCCAAAIIRI+ATVpKwMQmG4JmIIAAAggggAACCCCAAAIIxKYAvYpOAQIm0bndaDUCCCCAAAIIIIAAAgggECkB1otAqhAgYJIqNjOdRAABBBBAAAEEEEAAAe8CLEEAAQQSCxAwSWzCHAQQQAABBBBAAAEEoluA1iOAAAIIpFiAgEmKCakAAQQQQAABBBBAINQC1I8AAggggEC4BQiYhFuc9SGAAAIIIIAAAiIYIIAAAggggIDNBQiY2HwD0TwEEEAAAQSiQ4BWIoAAAggggAACsSVAwCS2tie9QQABBBAIlgD1IIAAAggggAACCKRqAQImqXrz03kEEEhNAvQVAQQQQAABBBBAAAEEki5AwCTpVuREAAF7CdAaBBBAAAEEEEAAAQQQQCBkAgRMQkZLxQgkV4D8CCCAAAIIIIAAAggggAACdhEgYGKXLRGL7aBPCCCAAAIIIIAAAggggAACCESpAAGTZGw4siKAAAIIIIAAAggggAACCCCAQOwLaA8JmKgCCQEEEEAAAQQQQAABBBBAAIHYFaBnAQgQMAkAjSIIIIAAAggggAACCCCAAAKRFGDdCIRegIBJ6I1ZAwIIIIAAAggggAACCCDgW4ClCCBgOwECJrbbJDQIAQQQQAABBBBAAIHoF6AHCCCAQLQLEDCJ9i1I+xFAAAEEEEAAAQTCIcA6EEAAAQRSmQABk1S2wekuAggggAACCCBwSYBXBBBAAAEEEPAlQMDElw7LEEAAAQQQQCB6BGgpAggggAACCCAQRAECJkHEpCoEEEAAAQSCKUBdCCCAAAIIIIAAApETIGASOXvWjAACCKQ2AfqLAAIIIIAAAggggEDUCBAwiZpNRUMRQMB+ArQIAQQQQAABBBBAAAEEYlWAgEmsbln6hUAgApRBAAEEEEAAAQQQQAABBBAwBQiYmAy8xKoA/UIAAQQQQAABBBBAAAEEEEAgEAECJoGoRa4Ma0YAAQQQQMAp8P5Hn8iwMVOTnYaPnSajJ85OdjlrXeu+3+RsAyMIIIAAAggggECsCkQ4YBKrrPQLAQQQQACB0At8sPQz0eBHIGnMpNkBl123/ofQd441IIAAAggggECMCURfdwiYRN82o8UIIIAAAggggAACCCCAAAKRFmD9MS9AwCTmNzEdRAABBBBAAAEEEEAAAQT8C5ADAQQSChAwSejhderN95ZLo1a9pHHrPrJyzQav+ViAAAIIIIAAAggggAACthCgEQgggECKBAiYJIHvjz0HZP7rS2TW+P4yemAnGTZutpw+E5+EkmRBAAEEEEAAAQQQQCBYAtSDAAIIIBBOAQImSdBevXaDVKlQRrJkziT58uaWW4oWlu82/CT8QwABBBBAAAEEEEiBAEURQAABBBCwsQABkyRsnL8PH5Hr8uVx5sx/XV7569Bhc3rIqElipUlz3pavfkmTKJkZ/bx4Kuc+z1sVJ06ckKVLl5rJaovrcMfve+SqHFc7k7d6XOe75vc27prf0/jPP//stHFtj46PGj897O3RNmpfRo6f5rVdX329TrP5TVqPv+S3EiODVceO33d7bZNuW93GRnav/1v1+Bp6LeyywL38wjfeTdQubY+mtWvXupRMOOpej6fphCU8T3kqdzr+fII2aVtc0759+xJV5qke93mJCnmY4V7GdfrL1d/K4JET5aOPPkqUli1blqA213LexhMU8DLhrazr/I8//jhRe6w26t+oVu2a39u45vOXvJV1na916Day2uBpeObseefxwbWs67jW4y+55vc27lrHmjVrPFrpdtW/BW916HzXeryNaz5/yb2s/u1/+OGH4poGjZggVtrhdny36nevx9O0ldfX0FM5nbdlyxZnm6y2+Bq6tt/buJYfOnqKaNJxT8lbWdf5nsq5z3PN723ctczI8TPMv2/XeTruqaz7PM3nL7mX8TTtXseQUZNl+Nipzn1Bl3sq5z5P8/lL7mU8TXurY/jYacY2nGy2y1M593nu9ejfm3vydJxwnytlcYUAABAASURBVOdexn1at6F7GU/T7uU8TXsq5z7PUzn3eXp81uRe1nXavYynadf83sY9lXOfZ5Vdvny5x2OhLncv42la8/lLnsrpPD1HtJLre7s6LVu23DzXdZ1v5fU1dM3vbdxXeWuZp7JqpW2zlll5fQ2tvL6Gvspby3yV/+STT0wrK6+voa96rGW+ylvLrLzehsuMc6HhxjHLyu9t6K2863xvZV3nu+b3Nq75R02YaR6zdNxT8lbWdb6ncu7zXPN7G7fKDBszRUaMm57gfNda5q2s63wrrzXU921S4AIETJJo54i7QuVwOJyl/vhjj1jptz3/yoY/iyZKy/beJ/7S9wdulPUHb0pU1rU+b3V8vvsu2bp1q5mstrgOixa6XmpWvceZBnd/TvwlzV/j/rvlofvKO8vpPNfkr44bb7jGaePaHh3fv/+gs15/9ehy1/XWuL+8x3ZpPn9J69F1axs8pRzZMvu10XVoPe7J3Urz+UtWHTcVvN6rlW7bVo0f9dkuqx5PQ/XS+f7aoss1n2s6e+ZMonZpezQ5LsR7bZNrHZ7Gaxj7lq7PX/JU9p4ytydok7bFNT1YqVSidnmqx32etmVg12aJyup8K7mXcZ3WfWf37r2ybdu2ROmPXbtkSI8WzuRaztu4ld9atzXtOvRW1nX+H3/sStQeq41FC+Uz2+Sa39u463p1fFC35mZZHbeSt7Ku8zWvbiOrDZ6G95S5w3l8cC3rOq71uCe1cm2Xa35v4651xF0869FKt+u5+PhEbar1QAWx0tCeLcVb0nbpeqy8vobudbRuUke2b9+eIO3du1+sdHPh/M42uNbrXo+naTVxLeNpfGjPlh77dXPha51tstria+jeB0/TWn7fvgOiScc9JU/l3Od5Kuc+z72Mp2nXMvq+4TptjXsq5z7Pyutr6F7G07Sn8vv2HXTuC7rcUzn3eZrPX3Iv42naWx2uVp7Kuc9zr0f/3tyTp+OE+zz3Mq7Te/bsM/cr9zKepl3LeRv3VM59nreyrvO3b99h/B3t8Hjcsepzze9t3Mrra+itrOt8q/xvv+2UX3/91WO7XPN7G7fq8TX0Vtb13Mz1vX3btl8Nq1/Nc13X+a75vY275vc27q2s63xPZXUbqpW1zDW/t3Err6+ht7Ku872V/+WXXwyrHaaVa35v497qcZ3vrazrfNf8nsZ1G+7evS/BOZxreWvcU1n3eVZeX0P3Mp6mtbweH3ToLXkq5z7PW1nX+e5lPE1fyb9XdhvnlFemr3ze9FTOfZ57OecHV0YCErgSBQioeOoolCdXTjl27B9nZ48cPSbX5M5lTs+YNFz8pfbt24m/NGvKSJk5eYTPuvzVocv9tUWXaz5/SfNpe7RdOu4p+atDl3sq5z5P8/lLrmVmTh4pntrlrw5d7lqPt3HN5y95KuveJn916HJP9bjP03z+knsZ12n10ml/dehyzecvaT5/yV8dum/5q0OX+6tHl2s+f0nz+UtaR8eOHXz+rfqrQ5e3a9dW/CXN5y9ZdWi7NFnTrkN/dehy1/zexjWfv+RetkOH9on66a8OXe5ej6dpzecveSqnTq7t8lxHwmO2p3rc53mrZ/rEYWKltm1fEG9J26V1Wnl9Db3V4TrfV3lrmWt+b+PaLyu/t6G3sq7zvZV1ne+a39u45tc2adJxT8lbWdf5nsq5z3PN723ctYy3Nnkr6zrftR5v4675vY27l9U2aXKd762s63zX/N7GXfN7G/dWVtukSZd7K+s6X/O5Ji3rnvTvx19yL+M+re87/urQ5e7lPE1rPn/JUzn3eXps0OSrLvcynqZ9lbeWeSrnPs/K63octeZZQ/cynqatvL6Gnsq5z1Mb19ShQ4dE79HuZTxNu9bhbdxTOfd5nsp2MN4LXee7l/E07Zrf27incu7zvJXV+db5jHsZT9Oa31/yVM59nr861Er/Dt3LuU/7q0eXu5fxNK35/CUt537+rvNck786dLlrfm/jms9fssqqk7d2+atDl1v1WEPzQysvAQsQMEkCXcXypWTV2g1yxviG8cjRf+TnbTulnPENaBKKkgUBBBAIrQC1I4AAAggggAACCCCAQEgECJgkgbVggWulbq2q0rz9AOnYe7R0atNY0qdLl4SSZEEAgeQKkB8BBBBAAAEEEEAAAQQQsIMAAZMkboX6darLwpkjZP6MYVLlntJJLEU2BAQCBBBAAAEEEEAAAQQQQACBKBQgYBKFGy2yTWbtCCCAAAIIIIAAAggggAACCMS+AAGT2N/G9BABBBBAAAEEEEAAAQQQQAABBJIpQMAkmWBkRwABBBBAAAEEEEAAAQQQQMAOArQhtAIETELrS+0IIIAAAggggAACCCCAAAJJEyAXArYSIGBiq81BYxBAAAEEEEAAAQQQQCB2BOgJAghEswABk2jeerQdAQQQQAABBBBAAIFwCrAuBBBAIBUJEDBJRRubriKAAAIIIIAAAggkFGAKAQQQQAABbwIETLzJMB8BBBBAAAEEEIg+AVqMAAIIIIAAAkESIGASJEiqQQABBBBAAIFQCFAnAggggAACCCAQGQECJpFxZ60IIIAAAqlVgH4jgAACCCCAAAIIRIUAAZOo2Ew0EgEEELCvAC1DAAEEEEAAAQQQQCAWBQiYxOJWpU8IIJASAcoigAACCCCAAAIIIIAAAkLAhJ0AgZgXoIMIIIAAAggggAACCCCAAALJFSBgklwx8kdegBYggAACCCCAAAIIIIAAAgggEGIBAiYhBk5K9eRBAAEEEEAAAQQQQAABBBBAAAF7CYQiYGKvHtIaBBBAAAEEEEAAAQQQQAABBBAIhUBM10nAJKY3L51DAAEEEEAAAQQQQAABBBBIugA5EbgiQMDkigVjCCCAAAIIIIAAAggggEBsCdAbBBAIWICAScB0FEQAAQQQQAABBBBAAIFwC7A+BBBAIFwCBEzCJc16EEAAAQQQQAABBBBILMAcBBBAAAGbChAwsemGoVkIIIAAAggggEB0CtBqBBBAAAEEYkOAgElsbEd6gQACCCCAAAKhEqBeBBBAAAEEEEiVAgRMUuVmp9MIIIAAAqlZgL4jgAACCCCAAAII+BcgYOLfiBwIIIAAAvYWoHUIIIAAAggggAACCARdgIBJ0EmpEAEEEEipAOWjQeDN95bLs237SaVaTeWBui2C2uSNP26Vu6s3ki2//BbUen1V9v7SFbJ8xde+svhc9tvve6Tf8KnycIN28kjD9jJkzCz5aev2BGXOnj0nM+a+IU8/183MM3ryXDn2z/EEeUI5oevr1GdMKFfhse45C96R+x5t7nFZMGZeuHBBZs9bLD9u+TVRdR17j5YxU19JNJ8ZCCCAAAIIIOBfgICJfyNyIIBASgUoj0CMCRz865BMmLFACt1wvYzs31HGDOoc9T388JNV8umXawLqx9frNslzHQdKXFyctH3uKTNduHhRtu/c7azvvPGh/vnOg+WDpV9KvUerm3k2/fSLNGnTVw4fPebMF6qR7Tv/kHc/+lxaN6sfqlV4rffavLnlzuI3e12e0gVqPffV940A1Y5EVbV6tp68++HnsnPXvkTLmIEAAggggAACvgXifC9mKQIIeBJgHgIIpG6BAwf/NgHq16kmFcqVlLvuvNWcTo0vetXIyAlzpP6j1WRQzzZS/f4KUu2+e2RA91ZSt1ZVJ8nX326Srb/ulB4dmstjDz9g5hnZv5P8deiILFn2lTNfqEYWv/ep3FTkBrn5xoKhWoXXemtVqyyTRvTwujyUC24pWtgI7F0nb3/4aShXQ90IIIAAAgjEpAABk5jcrMnuFAUQQAABBJIoMHDUDGnTbZiZu1m7/uatM2OnzjNvudBbL8wFxsuOnbvNZS06DjKmrvxf88k2MmnWQueM/06ekj5DJ8uDj7WUp1t0N2+tiD97zrk8KSNah97Cs/DNj2TAyOnyaMP25rqPHrt0u8ua734wbx/S20Jq1G8jPQdPlH+On3BW3ej5XqK3z2hQQ+vRpLfXODP4GHlv6Qr5598T0uTpR33kEvN2n2xZs0ile0o5892QP5/cfmtR+eSLb5zzvvpmvdn2X7b/LjNefkMeb9LZcOkhegWF3nqyftMW6dp/rKhX49Z9ZPPP251lvY2cO3dOvli9TqrcU8aZ5cjRf6RCjcby2tsfO+dZI/Ne+8Bcpnl03udffSu63Z9o2lkq124qjVr1kleNchcvXtTFZvK1DXS/UHsz4+UX3Vad+46WWk+9YO47LTsNkrXf/3B56aWBZaFX8LTvOVKq1nnOzD9++jw5d/68mem4YV+pZhNzfMqLr5p2uv30ahpzpvFyb4Uy8smKb0Sv8jEm+R8BBBBAAAEEkigQowGTJPaebAgggAACCCRToPGTj0i7Fg3MUt3bPyuTR/aUeo9Wk9J33ir67BFzgfHy/aafJW2aNLJ1229yJj7emCOya88B0SBG6RK3mdP60nPQRFm34Sdp8EQtadmknuw/eEhGTXpZFyU7LXrrI8mcKaO8PHWwvDR5kGTLmlk+X7lWOvcdI9mzZZWeHZpJ80Z1ZNv2XdK66xDRAISupFen50RvL9LghfZH07MN6+giv2nTT9vk+muvkbc++FSeMAIKVWo/Kw1b9pTF738irgGF/Qf+khsLF5A0cQlPPW6+qaDs2Xsw0Xo0YHPCCCa1bfG03HXHLWYgafb8t2TwmFlS8vZbpVu7ppIhQ3rpNmCcnD5zyTdRJZdnbDaCKif+O2nUU+zyHJGcV18lZUreZgZynDMvj3z8+SopW+oOM4/O2rVnv2TMmEGaGkGhfl2fl9uK3Siz5r4pixYv1cUJkqdtkCDD5Ymft+2QokUKSuc2TaT1s/UlS+bMos9X+dnYXy5ncQ4mGwG2Gg9UlHcXTJQuLzQxr8iZ//oSc3nmzJlk4vDu5rhe0aPbTlPFcneZ8/SlxO23iPb/5zA+E0fXS0IAAQQQQCA8AqFbS8KzltCth5oRQAABBBCICYEiha6XojfeYPal+M1F5H933S4FC1wrpUoUl81bt0v82bOi/9b/sEUeuPduHRUNnujI9xs360DuuvMWc7jhx63Gsi0yuNcL8myDR+W+iv+TgT1aS3HjA7mZIZkveXJdLT2MoEiuq3OYdegFEBOmLzQDA3pLiN4u88Qj1WTamN6y2wjefPbVWnMNt91yo2TNklmuyp7F7I/2qUjB/OYyfy979x2UI0ePy9xX35MaD1SS/t1aSb68uWT89PmycPFHzuKHj/4j2Y0AjnPG5ZEcV2Uzr5Y4dvzfy3MuDfRWp25tm5omGpjSW0sWvPGhTBzeQxrVr2Xe0jOg+/OiV8qs/e7HS4W8vP64Zbu5pLjRT3Pk8stDVSvIth27ZO/+KwEbvbLlD8OmxgMVLucSI8hU1ww21a5eRR40tqkGmJo1rCtvvLfMmccacd8GadOmtRYlGA7v10FaN3tSqlYuK/XrVJcJw7pJudJ3eLzipXb1ew3biqJBr/vtzSmNAAAQAElEQVQrlZWa1SrLMiOoI8Y/DcqVNgI/xqjkvy6vc/vlyZ1TZ5mpeLEi5vDHLYkfCmsu4AUBBBBAwF4CtMY2AnG2aQkNQQABBBBAIIoFSpcsLvo8j02bfzGvrPh+089y9//ulDtuu1k2bNpi9mz9Dz+bgYwsmTOZ05s2bzOH5cvcaQ6tl3vKlbBGkzWsWL5kgvw7ft9tPlC1bu2qCeZfl+8aufmmQvL9xp8TzA9k4uy5c6K3hegVH80b1ZWqVcrJuCHdzGeFzHvt/QRVOhyOBNM6kXiOzhW5t8L/Lo1cfr0uXx7Jd01uKVzw+stzRLQfOrHvwJ868JoOHTkmGTOkl0wZMybIc78RrMiYMYO8//EXzvkff7bKvJqkSoUrt+8c/POQjJz0sjz1XDfRX0XSW15mvvKmHDp8VE6dPu0sqyPu20DneUp61YveGlW3cUe556FnzFtpvl2/2QjeJO5LCWMfcq3jhuuvlf0H/nZeIeS6zNN4tqxZRAM3fx067Gkx8xBAAIGQC7ACBKJVIC5aG067EUAAAQQQsJNAMSMAoVdpaFBEH256+vQZKVf6Tildoris/2Gr2VQNUJQqcenqEp2hz8jInTOHOBwJwwZ6hYguT266OsdVCYocMD7o6wx9Rop+yHdN2sb9f156eK3mCTTlyZXTLFr57tLm0HqpZEzrcz00qKDz9BaYf0+c1NEE6Z/j/5m36eTIni3B/OzZEk6nS5fOCHhkSJBHf5UnXbq0RtDiTIL57hPx8fGSPn1699mSwZinzzVZ9vk3ZpBLn/HxyYo1cn+lcuYyLaDPCunUd7T8umOXPFLjfvNhtnrLS+OnHtbF5hUu5sjlF/dtcHl2gsGefQelfc8RkiZNGmn4RE0ZOaCTeWuXBtj+PfFfgrw6kTVLFh04U5o0DtG2arDKOdPPSCYjMHT6tO9bl/xUwWIEELgiwBgCCKQSAQImqWRD000EEEAAgdAL6FUmG374xbxyo0jB/HJV9qxSttTt5m0fejuEPkdCn5thtUSDCPqcDmvaGp7wEFiwlvkausVdRJ8tovnbt2xofiDXD/quqd1zT+niFKVcOS8FadKkSXhKkSZNmgT15r76Kvlt1x4zMOG6YNuO3+WaPLlcZwV9PHv2LOIpEKErqvFARfNKke82/iRr1v0gemtQTZfbcX7buVt27d4vrZvVlwaP15AHqpQXvWUpS+bMWjxRct8GiTIYM1at2WBejaS/KvTEI9Wk8t2lzDovXnQYS4P/vz5LRvufI0fCIFTw10SN0StAyxFAAAEEPAkkPLvxlIN5CCCAAAIIIJAkgVJ33ir6kNdv1/8oZe669GBXfW6G3vYxe95bkiYuTu4y8liVlbyjmOiVKFt+2WHNMoffX76Fx5xIwcuNhfKL3saiz+XQD/nuqVjRws7as2TOaHyIv/TLK86ZSRipWL6UmUuvnjFHLr+sN/qQPVtWyZ3ranPOPWVLmldjrPxmvTmtL7v3HhS9NaWCywNKdX6wU+EbrjcDNfsP/pWoag1oaRuXf/6NfPz5arO9+jwaK6NeyaHjmTNl0oEzrVj5rXM8uSNap94io88fscoePnpMNv30izWZrKHWo+lM/KXn57gXVmedd2OhAjpIHYleIoAAAgggEAQBAiZBQKQKBBBAAAEEVECvMNEPw/owV+tDt36QLXn7LbL+h5/ltltvkvTp0mlWM2mApXSJ4tJz8CT5Ycs28yqIBW9+KB9/ttpcntIX/VCuzxbRh7u26jJE3l7yqazbsFneX7pCOvYeZQ6tdRQueL3oL7SsXLNB9GqLnX/stRb5HOqDakvecYv0HzlNXlr4ruhP8HbpN8bs77MNrvzSzsMP3StFCuaXYeNflHeWfCb6U8I9Bk2QHFdllyaXb2/xuaIULCx9+aGov+7YnagWh8MhD1W9R75Y/Z2sNvpeq1qlBLdI3Vi4gOhtU/Nff1/0GTV/HToiQ8bMkt//2JeorqTO0CDNmfh40W2tV3/og2e79B0rF85f8FqFvwXazpXffG9uX91+fxvttMrs+P0Pc7R0yeLmkBcEEEAAAQQQSJoAAZOkOZELAQQQQAABvwL6DX7WLJdu1fjf5StMtFCZyx9US5e4VScTpFEDO8mdxYtK137jpNrjz8vXazeav3STIFMKJvTKjtkT+otcFJkz/x3p0GuU+es1RQrll9KXAwlavf7qiz7odNzUV6R9z5Eyd9F7OttvcjgcMn5oVylf5g55zwjEDB03S/4+dEz6dmkpTz32kLO8PmtEf53n1puLyOz5b8mIiS9JlsyZZNroPqJXeDgzhmAkb55cZl/Xrv/RY+01Hqgk+vBW/YWj2tUqJ8ijzzkZOaCj/HfytDxQt4U89kxHM2/H1o0S5EvOhD7vRn9NSINGFWo0ltZdhko5w6/mg5WSU02CvAO6tzaDT72HTDa33+pvNzqXr/1+s5QtdYcE+mwcZ0WMIIAAAgggkMoECJiksg1OdxFAAAEEUi6gt7asWb5QrtzScqXOT9+ZLbosc6Yrv8jSsF4tc17LJvWuZLw8pkGDYX3bi1Vu5vh+UuOBimb+22658XIu3wOtQ9epz8PwlPO2W24SrffjxTPMehfPHSf6XJP81+V1ZtdfUtEgx/uLJpt5hvRu61zmb0R/fWZEv46y5NUp8sUHL8v8GcOkllvgQevQq0kmjeghyxbPlC/ef0nmTBooRQpdr4ucqco9pc31u88f2KO1LJw1wpnPGln54Svy3DOPWZNeh/XrVJfPv1orGhRxz1SkYH5znWqY/7p87otF/aaO7i1ffThXVn88X4b36yB1a1U1y+gtT1rA1zbQ9ml/NZ+VdBsvmDFcvlm2QFa8P0daP/ukGSh765XxVhbxZqHbWduqwRwrc+GC18uEYd3ks3dfNNul7dNlp8/Eyxer1kn9utV1koQAAggggAACyRAgYJIMLLIigAACqUaAjiIQYwL6YFW90mTxe5/EWM98d2fx+5+Yz7GpULak74wsRQABBBBAAIFEAgRMEpEwAwEEYlGAPiGAAAK9Oj0nemtQapLIkD6daL9TU5/pKwIIIIAAAsESIGASLEnqQSC8AqwNAQRSicCAkdOlSu1nvSZdHgqKXbv3e12n1R7NE4p1h6pOvcVJb80JVf12rFf7q/22Y9toEwIIIIAAAnYXIGBi9y2UatpHRxFAAAEEPAm0a9lAFswc4TXpck/lUjqv0A3XeV2n1R7Nk9L1UB4BBBBAAAEEELCrAAGTUG0Z6kUAAQQQQCAIArlz5pAb8ufzmnR5EFbjsQpf69VlHgsxEwEEEEAAAQQQiBGBJAdMYqS/dAMBBBBAAAEEEEAAAQQQQAABBHwIsOiSAAGTSw4Bv6ZLl16CkS5evChxcWmCUlcw2qN1pE2bTs6dO2erNmm7RByi/3TcTuncufOiZnZqk+5Tum/ZqU3aFm2Ttk3H7ZJ0251jf0/y3/s59vckW7G/J/19Uji+J3m/0mOo7lt2OYZa7dA2adusaTsMOb4n/W9QtxfH96R7sb8n3coGx3ePx9fUsL8L/1IkQMAkRXzBK3zhwgXRg27wagxOTXZsk8jF4HQuyLVcvHghyDUGo7qLttyv2N+Ts23Z35Ouxf6edCvjSGoE6pOTPzx52d+T7sz+nnQr9vfkWXE+k1SvyJ7PeG/lRY7v3nHcllzk/N1NhEl3AQIm7iJMI4AAAggggAACCCCAQHgFWBsCCCBgQwECJjbcKDQJAQQQQAABBBBAILoFaD0CCCCAQPQLEDCJ/m1IDxBAAAEEEEAAgVALUD8CCCCAAAKpToCASarb5HQYAQQQQAABBEQwQAABBBBAAAEEfAsQMPHtw1IEEEAAAQSiQ4BWIoAAAggggAACCARVgIBJUDmpDAEEEEAgWALUgwACCCCAAAIIIIBAJAUImERSn3UjgEBqEqCvCCCAAAIIIIAAAgggEEUCBEyiaGPRVATsJUBrEEAAAQQQQAABBBBAAIHYFSBgErvblp4lV4D8CCCAAAIIIIAAAggggAACCFwWIGByGSIWB/QJAQQQQAABBBBAAAEEEEAAAQQCE4imgElgPaQUAggggAACCCCAAAIIIIAAAghEk4At2krAxBabgUYggAACCCCAAAIIIIAAAgjErgA9i0YBAibRuNVoMwIIIIAAAggggAACCCAQSQHWjUAqECBgkgo2Ml1EAAEEEEAAAQQQQAAB3wIsRQABBNwFCJi4izCNAAIIIIAAAggggED0C9ADBBBAAIEUChAwSSEgxRFAAAEEEEAAAQTCIcA6EEAAAQQQCK8AAZPwerM2BBBAAAEEEEDgkgCvCCCAAAIIIGBrAQImtt48NA4BBBBAAIHoEaClCCCAAAIIIIBALAkQMImlrUlfEEAAAQSCKUBdCCCAAAIIIIAAAqlYgIBJKt74dB0BBFKbAP1FAAEEEEAAAQQQQACBpAoQMEmqFPkQQMB+ArQIAQQQQAABBBBAAAEEEAiRAAGTEMFSLQKBCFAGAQQQQAABBBBAAAEEEEDAHgIETOyxHWK1FfQLAQQQQAABBBBAAAEEEEAAgagUIGCSrM1GZgQQQAABBBBAAAEEEEAAAQQQiH0BEQImqWEr00cEEEAAAQQQQAABBBBAAIHULUDvky1AwCTZZBRAAAEEEEAAAQQQQAABBBCItADrRyDUAgRMQi1M/QgggAACCCCAAAIIIICAfwFyIICAzQQImNhsg9AcBBBAAAEEEEAAAQRiQ4BeIIAAAtEtQMAkurcfrUcAAQQQQAABBBAIlwDrQQABBBBIVQIETFLV5qazCCCAAAIIIIDAFQHGEEAAAQQQQMC7AAET7zYsQQABBBBAAIHoEqC1CCCAAAIIIIBA0ARSTcDkzfeWS6NWvaRx6z6ycs0Gj4CHDh+Vtt2HS7N2/aX3kEly6vRpM9/RY8ela7+xct+jzWX05LnmPF4QQAABBBAIvQBrQAABBBBAAAEEEIiUQKoImPyx54DMf32JzBrfX0YP7CTDxs2W02fiE5lPmrVIypcpIS9PGSzZs2eTRYuXOvPUrFZZWjzzuHOaEQQQQACBAAQoggACCCCAAAIIIIBAlAikioDJ6rUbpEqFMpIlcybJlze33FK0sHy34Sdx//f1t5ukVrVK5uxaD1aS1d9uNMevzpFd7q9UVjJlymBO84IAAghYAgwRQAABBBBAAAEEEEAgNgVSRcDk78NH5Lp8eZxbMP91eeWvQ4ed0zry38lT4nCIaHBEpwtcn1f+PnRER0kIpCYB+ooAAggggAACCCCAAAIIIGAIpIqAidFPccRd6arDYURGdKZbikuQ50p+t2wJJk+e/E+CkeLjz8jp06eCUlcw2qN1nDp1UuLj423VJm3X6dOnDavTSWxXcLaPrtdTUiMrnT0bL9a4XYa6T+m+ZZf2WO3Q/UrbZk3bZZjcbehpnwj2PDvt765902148uRJW/wdWu06deqUnDlzJoxt0v77T/o3OzzKggAAEABJREFUqPv7JS//+cOR75RxfNf9PRzrSs46zpw5bWxDPb7bw8lqu1qpmTVth6HuU2fM/d1eVinf30Pxvn2S85lknK9G8viuf2eeku7vum95WhbJeWqlbYtkGzyt2zpmeVoWqXlnLh/ffa3fej8P51C3obYpnOv0t65TQT6fSfDhlYlkCyQtKpDsau1VIE+unHLs2D/ORh05ekyuyZ3LOa0jervO+fMXJP7sWZ2Uw0aePLlzmuO+XjJlyizBSOnSpZcMGTL6rytI60tKmzNmzCTp06ezVZu03RkyZBBNOh7plMHYZlZKmzadZHCZtst4usv7ll3ao+1Il86eVsndhuHY/3Rf1xSOdSVnHenTpzeODZmMFJxjYHLW7S1vxowZjWOWtitcbdJjtv9k/Q1myuQ/b7jyqJXu7+FaX1LXkz59BmMbZjD2K/tYadvVSs103C5Jj6Xpzb9De1mlfH8Pxd+vns+E89iQtD7osV2Tt2NapOZf2q8ic3zX/dpbsvYtb8sjMT9WzmfCYZf+8vHd17oisc/rZ52MxmeeSKzb2zozBvl8xtdnWZb5F4jznyW0OcJRe8XypWTV2g1yJj5ejhz9R37etlPKlbnDXPXGH7fK2bPnzPF7ypaUz75cY45/8sU3UrFcSXPc14vD4RCHI3aTSOz2zeFIed/0qiQrORwOscbtMnQ4LvXRLu2x2uFw2LddVhuTMnQ4LvXD4Uh9QzH+ORypr98Oh2uf48ThSEqyyiQlbzjzaLvCub6krEvbpCkpecOZx65tisV2aZ+Cn4xDljgcwa/X4Yi9OiNp5e291+G45OxteaTmOxz2bVekTLyt1+Hwb+VwXMrjcIRvKBK+dTkckVmX2OxftDUnLtoaHEh7Cxa4VurWqirN2w+Qjr1HS6c2jSW98Q231tV94AT55/i/OiodWzWUJctXSrN2/WX3ngPSsF4tc/658+fl7uqNZPTkufLuR5+b49u2/24u4wUBBBBAAAEEEEAAAQQQQCBVCtDpGBeIi/H+ObtXv051WThzhMyfMUyq3FPaOf/Td2ZL7lxXm9M6nDG2r7w8ZbAM79dBMmXMaM5PmyaNrFm+MEEqVrSwuYwXBBBAAAEEEEAAAQQQQCA2BOgFAgi4CqSagIlrpxlHAAEEEEAAAQQQQACBVCBAFxFAAIEUCBAwSQEeRRFAAAEEEEAAAQQQCKcA60IAAQQQCJ8AAZPwWbMmBBBAAAEEEEAAgYQCTCGAAAIIIGBbAQImtt00NAwBBBBAAAEEok+AFiOAAAIIIIBArAjYOmBy/sIFOfDn3/LDlm2yY+du+ef4iVhxpx8IIIAAAghEhwCtRAABBBBAAAEEUqmALQMmf/59WIaMnS0P1G0hrToPkSmzX5V+w6fIE007S/1mXWTpZ6tS6eai2wgggAACKRWgPAIIIIAAAggggAACSRGwZcCkfc8RUvKOm2X5WzPl/UWTZc6kQfLanDGiPwE8akBnWbf+J1n45kdJ6R95EEAAgVgXoH8IIIAAAggggAACCCAQAgFbBkxenjJEHq5+r6RPly5RlwsXvF4G9mgtdWvfn2gZMxBAIBYE6AMCCCCAAAIIIIAAAgggEHkBWwZMsmTO5FcmKXn8VkIGBMIhwDoQQAABBBBAAAEEEEAAAQSiTsCWARNLcfXajdKi4yCpVLOJ3F29kTNZyxlGRoC1IoAAAggggAACCCCAAAIIIBDrArYOmLy08B3p2raJfPnhXFmzfKEzBXmjUB0CCCCAAAIIIIAAAggggAACCMS+QLJ6aOuASd5rckmxmwpJmjhbN1P4hwACCCCAAAIIIIAAAggggED4BVhjKAVsHYnIlTOHvPPhZ3Liv5OhNKBuBBBAAAEEEEAAAQQQQAABOwjQBgRsJGDrgMk7Sz6TMVNekQcfa+l8fok+y8RGfjQFAQQQQAABBBBAAAEEEPAqwAIEEIheAVsHTFyfW+I6Hr3ctBwBBBBAAAEEEEAAgagWoPEIIIBAqhGwdcBEt8LFixdl5659ZtJxnUdCAAEEEEAAAQQQQCA4AtSCAAIIIICAZwFbB0zeX7rCvB2nfc8Roqna48/LB8u+9NwT5iKAAAIIIIAAAgiIYIAAAggggAACQRGwdcBk4eKPZGCPNrLktSlm6t+tlSx4Y0lQOk4lCCCAAAIIIBAdArQSAQQQQAABBBCIhICtAyZp06aViuXvEofDYaZKd5eSuDhHJJxYJwIIIIAAAsESoB4EEEAAAQQQQACBKBCwdcAkTZo4WfPdD07G1Ws3Svr06Z3TjCCAAAII2EGANiCAAAIIIIAAAgggEHsCtg6Y9OzQTMZOnef8SeGJMxeIzou9zUCPEEDAVgI0BgEEEEAAAQQQQAABBFK9gK0DJrffWlTeemWcLJo1ykyL546T2265KdVvNAAQSK4A+RFAAAEEEEAAAQQQQAABBJInYMuAyXcbf5IT/50UHX6/aYscPnrUTDqu85LXRXLHoABdQgABBBBAAAEEEEAAAQQQQCCkArYMmLy08F358+/DokNPKaQiEamclSKAAAIIIIAAAggggAACCCCAgJ0EQhMwSWEPZ47rJzcWKiA69JRSWD3FEUAAAQQQQAABBBBAAAEEEEAgGAIxXIctAyaWd6suQ6xR57DR872c44wggAACCCCAAAIIIIAAAgggEEwB6kLAErB1wMRqpDX87+QpORMfb00yRAABBBBAAAEEEEAAAQQQ8C3AUgQQCFDAlgGT2fMWy93VG8kPP20zhzquqVGrXvJY7QcC7CrFEEAAAQQQQAABBBBAIPoF6AECCCAQHgFbBkxaNqkna5YvlCceqWYOdVzTu/MnytOP1wiPDGtBAAEEEEAAAQQQQCAcAqwDAQQQQMCWArYMmFhSXV5obI0yRAABBBBAAAEEEIgSAZqJAAIIIIBALAjYOmCye+9B6dh7lNz7cLMEt+bEAjx9QAABBBBAAIGoEaChCCCAAAIIIJAKBWwdMBk8ZqY8/NB9csvNhWXJq1Ok7XNPS/NGdVPhZqLLCCCAAAIIBFOAuhBAAAEEEEAAAQT8Cdg6YHL69BmpWrmsXLhwQXLnuloa1qslO3ft9deniC0/+fdPsuWN2gGl396vJ9verhNQ2R0ft4pYn1kxAgggYAsBGoEAAggggAACCCCAQJAFbB0wyZw5o9ldh8Mhe/YdlNNn4uXI0ePmPF4QQACBWBagbwgggAACCCCAAAIIIBBZAVsHTEreXkyOHf9Xnn6spjRo0UPue6SZPHhf+ciKsXYEEAhEgDIIIIAAAggggAACCCCAQFQJ2Dpg0qb5U5Ijeza5t2IZWbV0nvkTw48//GBUAdPYWBWgXwgggAACCCCAAAIIIIAAArEsYMuAyXcbfxJfKZY3SMT6xooRQAABBBBAAAEEEEAAAQQQQMApYMuAyUsL3xVNU2a/Ju17jpS+w6bK8PFzzPHx0+c7G+9rhGUIIIAAAggggAACCCCAAAIIIBD7AqHqoS0DJjPH9RNNeXLnkDGDusiyxTPk3QUTZc6kgVIw/7WhsqBeBBBAAAEEEEAAAQQQQAABBCItwPptImDLgIll8+dfR6Ri+bvE4XCYs2675SZzyAsCCCCAAAIIIIAAAggggEC0CNBOBKJTwNYBE0ecQ9Z+/4NTdtv23+XY8RPOaUYQQAABBBBAAAEEEEAAgbALsEIEEEgVArYOmPTp3ELGTZsvNZ9sI/We7SL9RkyVTq0apYoNQycRQAABBBBAAAEEEAiXAOtBAAEEEEgsYOuAyS1FC8ubL4+VqaP6yKgBnY3xcVLMmJe4G8xBAAEEEEAAAQQQQMApwAgCCCCAAAIpFrB1wER753A4pEih682k0yQEEEAAAQQQQCD1CdBjBBBAAAEEEAi3gC0DJndXbySbf94uOvSUwo3E+hBAAAEEEEAgyAJUhwACCCCAAAII2FzAlgGTNcsXyh3Fi4oOPSWbm9I8BBBAAIFUKECXEUAAAQQQQAABBGJLwJYBk9gipjcIIIBAVArQaAQQQAABBBBAAAEEUrWALQMmVWo/K75Sqt5idB4BBAIUoBgCCCCAAAIIIIAAAgggkHQBWwZMvvpwrvhKSe8eORGIYQG6hgACCCCAAAIIIIAAAgggEDIBWwZMQtZbKra1AI1DAAEEEEAAAQQQQAABBBBAwC4Ctg6Y7N57UDr2HiX3PtwswS/m2AXPTztYjAACCCCAAAIIIIAAAggggAACUSqQjIBJ+Hs4eMxMefih++SWmwvLklenSNvnnpbmjeqGvyGsEQEEEEAAAQQQQAABBBBAAIFUI0BHVcDWAZPTp89I1cpl5cKFC5I719XSsF4t2blrr7abhAACCCCAAAIIIIAAAggggEDSBMiFQAACtg6YZM6c0eySw+GQPfsOyukz8XLk6HFzHi8IIIAAAggggAACCCCAQGoVoN8IIBB6AVsHTEreXkyOHf9Xnn6spjRo0UPue6SZPHhf+dCrsAYEEEAAAQQQQAABBBAIpwDrQgABBGwnYOuASZvmT0mO7Nnk3oplZNXSebJm+UJ5/OEHbYdIgxBAAAEEEEAAAQQQSCjAFAIIIIBAtAvYOmDS6Ple8upbS82rTKIdmvYjgAACCCCAAAJRLUDjEUAAAQQQSGUCtg6Y9OvaUv7Ys1/qP9tVuvYfKytWrZNz58+nsk1EdxFAAAEEEEAgFALUiQACCCCAAAII+BKwdcCkWNHC0qvTc/L+oklSodxdMv+NJfLwU2199YdlCCCAAAIIpFYB+o0AAggggAACCCAQRAFbB0xc+xnncLhOMo4AAgggEPMCdBABBBBAAAEEEEAAgcgJ2Dpgsm377zJiwhx5tGEHWbV2gzR+8mFZ8vrUyGmxZgQQQCAlApRFAAEEEEAAAQQQQACBqBGwdcBkyNjZUrDAdfLm3LEydnBXub9SWUmbJk3U4NJQBGJdgP4hgAACCCCAAAIIIIAAArEqYOuAycJZI6TBEzXNnxaO1Q1Av2wlQGMQQAABBBBAAAEEEEAAAQQQMAVsGTDRX8TZf/Avs4HuL/8cPyFjp86TBW9+6L6I6UQCzEAAAQQQQAABBBBAAAEEEEAAgUAEbBkwqV3tXunQa5S80G2YTHvpNZk9b7GZBo+ZKQ1b9pRTp8/Iw9UrB9JfyiCAAAIIIIAAAggggAACCCCAgN0FbNA+WwZM7q1YRt58eaw827COZMqYyclU8vZiMnfqYOnXtaXkuCq7cz4jvgXe/+gTGTZmarLT8LHTZPTE2ckuZ61r3febfDeMpQgggAACCCCAAAIIIIBAKhGgm9EnYMuAiTI6HA4pU/I2aWYETVo2qSeaHqlxn+TJnVMXk5Ih8MHSz0SDH4GkMZNmB1x23fofktFKsiKAAAIIIIAAAggggEAUCdBUBGJewLYBk5iXp4MIIIAAAggggAACCCBgIwGaggACCCQUIGCS0IMpBBBAAAEEEEAAAQRiQ4BeIIAAAgikSICASYr4KPNwUo0AABAASURBVIwAAggggAACCCAQLgHWgwACCCCAQDgFbBkwOXz0mPz62x+JHLbt2CVHjx1PNJ8ZCCCAAAIIIIBAFArQZAQQQAABBBCwsYAtAyYjJ74khw4fTcR26PAxmThzYaL5zEAAAQQQQAABOwjQBgQQQAABBBBAIHYEbBkw2bFzj9xTtmQi5QrlSsrP235LNJ8ZCCCAAAIIhESAShFAAAEEEEAAAQRSrYAtAyZp06bxukEuXLjodZleldK2+3Bp1q6/9B4ySU6dPu0x7w8/bZOmbfvJM617y5wFbzvzeCu/Y+duubt6I2fq1GeMswwjCCCAQDQJ0FYEEEAAAQQQQAABBBBImoAtAyZX58gue/cfTNSDXXsOSK6cVyWab82YNGuRlC9TQl6eMliyZ88mixYvtRY5hxcvXpT+I6ZJ93ZNZe7UIbJi1TrZ+ONWc7mv8qVLFJc1yxeaacKwbmZ+XhBAIOICNAABBBBAAAEEEEAAAQQQCImALQMmzzd5Qtr3HCWffPGNHDv+r/x96Igs+3y1dO4zWlo0ftwrxNffbpJa1SqZy2s9WElWf7vRHHd90QfHZs6cSYoXu1HSpkkj1e67R1at3WBmSUp5MyMvCIRMgIoRQAABBBBAAAEEEEAAAQTsIGDLgEnpkrdJr07N5fV3lkmNeq3lkYbt5a0PPjXn/e+u2z26/XfylDgcInp1imYocH1eM9Ci467pz7+PyPX58jhnab4//zos/spv2fabVKzRWJ7rMFB+3PKrszwjfgRYjAACCCCAAAIIIIAAAggggEAUCtgyYKKOGhjRW2veWzhJlrw2VeZMGiQ6T5d5S3FxV7rjcFwZd8/viDMiK86ZV/J5K3/dtdfIB4smy8eLZ8j9lctJ1/7j5OSpS89H+e+/E2KlU6dOOWsN58jFixecbbDa4jo8d+5cOJvjXFd8/Bmf7XJtY3LG1VlTcsqEI2+o+puStp88eVJOnz4dku2QknadOXNaTp06abt22XEbnjKOK5pS4h2Ksna0Yn+/8n6UlG1ux22o+7qmpLQ/nHnsaMX+zv4eqr8B9vek71uczyTdSo/tmkK13wZab2rY350fzhgJSOBKtCCg4qEp9Nvve8RKJ06clH/++dc5rfM9rTVL5kxy/vwFiT971lx8+OgxyZM7pznu+pI3T045euxf56wjRr681+QSX+UzZ8oo2bJmMVODx2tIvmtyy559l56xkjlzFrFSxowZnfWGc0SDQ1YbPA3Tpk0bzuY415UuXXqnjad2BTpPnTUFWj5U5ULV35S0N1OmTJIhQ4aQbIeUtCt9+gySMWMm27XLjtswo3Fc0ZQS71CUtaNVKPf333btlccbvRBQqte4vTzxTNuAynbsMTRkfyd23Ia6r2sKxT6bkjrtaBXK/T0lVhzfr5wX+nPUfV2Tv3zhXs7+nvRtyP6edCvd1zWFe3/2t77UsL87P5xdGuE1mQJxycwfluwvdB8mvpK3RtxTtqR89uUac7E+/6RiuZLmuN5u89PW7eZ4sZsKif4ajgY8zl+4IJ9/9a1ULF/KXOat/In/TprL9UV/MefoP8elwPX5dFIcDkeCZM6MwIvDkbAdDseV6Qg0x1ylw3GlDQ4H4w4HBg4HBg4HBg5H9BkcP/6vrPpmXUDp67Xfy+o13wVUdv2mzQneYxyO6LNzOGizw4GBw4GBw4GBw4GBw4GBwxFMA+pyOHwbmB/MeAlYwJYBk2WLZ4qv5K23HVs1lCXLV0qzdv1l954D0rBeLTPr3n0HZcjYWea4w+GQQT3bSL/hU6XpC32l9F3FpdSdt5rLvJVf+ukqubt6I6lUq6mMmz5fhvdtL3rViVmIl4AETp8+Iw/VbRJQql3vOdEUaPmAGkwhBBBAAAEEEEAAAQRCLUD9CCBgK4E4W7UmhY3JnetqmTG2r7w8ZbAM79dBMmW8dItMsaKF5Y2XxjprL3F7MXll2lBZMGO4tHjmyq/ueCtfv051WbN8oaz66BWz/juKF3XWxUhgAucvnA/o21b9hle/qdWk44Gkkycj86yZwKQohQACCCCAAAIIRK8ALUcAAQSiWSCmAibRvCFoOwIIIIAAAggggIDtBWggAggggEAqEiBgkoo2Nl1FAAEEEEAAAQQSCjCFAAIIIIAAAt4ECJh4k2F+qhTYt/+grPx6XUBp9Zr1AZXT9f3y62+p0ptOI4AAAkEXoEIEEEAAAQQQQCBIArYOmJw7d07Wfv+DvLzwXZk9b7EzBanvVINAIoF3PlgmNR5rElCq2+B5qfl404DKjp08O1FbXGe0aNszoAfk1ny8mTxcv0VAZfWhupt/3ubajATjukzzBJIeebKl1HqiWUDtUosEDXGbGDVhZkD11nisqdR5+vmAyqrBu0uWu7XkyqRdH3Ksbda2B5LUSs0CKTt64qWHcF8RSjim2ziQekO5vydsYXinWBsCCCCAAAIIIIBAZARsHTDpM3SyvL3kMzlzNj4yOqwVAZsIfL/xx4AekqsPx9WfNA3k4bhaRn9K1RvBP/8cD6hNWq+2Sdum48lN6zdt9tYkc/6vO3amoF3rAy6rVyeZDfDwYteHHO/ddyDg/n69NmAr0W3kgck5y477u7NxjCCAAAIIIIAAAgikGgFbB0xOnzkrYwZ1kdbPPiktm9RzplSzdegoAghEgQBNRAABBBBAAAEEEEAAgVgUsHXAJH36tHL27LlYdKdPCNhXgJYhgAACCCCAAAIIIIAAAgiIrQMm8fHnpH7zrjJhxnzn80v0WSZsNwSSI0BeBBBAAAEEEEAAAQQQQAABBJIrYOuAyW23FJEaVStIlsyZktuvWM5P3xBAAAEEEEAAAQQQQAABBBBAIMQCNgiYeO+h63NLXMe9l2AJAggggAACCCCAAAIIIIAAAgjYUyC6WmXrgMmZ+HiZ99oH0rH3KGnVZYgzRRcxrUUAAQQQQAABBBBAAAEEEIhJAToV0wK2DpgMHj1T/j58VA4dPiZ1a90vWTNnkluKForpDULnEEAAAQQQQAABBBBAAIFICbBeBBC4ImDrgMnOXXuka9smkiVLJql+fwUZO6Sr7N3/55XWM4YAAggggAACCCCAAAIIeBdgCQIIIBCwgK0DJlmyZDY7du7ceTl56rQ5fvbseXPICwIIIIAAAggggAACqU+AHiOAAAIIhEvA1gGTrFmyyLHj/0qFsiXl2bZ9jdRP8l2TS/iHAAIIIIAAAgggECMCdAMBBBBAAAGbCtg6YDJxeHfJkT2bNGtUV3p3aiFtmj8p3Ts0syklzUIAAQQQQAABBEQwQAABBBBAAIHYELB1wESJ9Zdytv66U0rcXkz+d9ftkibO9k3WZpMQQAABBBCIFQH6gQACCCCAAAIIpEoBW0cfvlm3Seo07CADRk4zN84v238X/Ylhc4IXBBBAAAEEAhKgEAIIIIAAAggggAAC/gVsHTCZOuc1eXHSQMl5dQ6zJ7cULSx/HzpqjvOCAAIIIHBZgAECCCCAAAIIIIAAAggEXcDWAZN0adNK/uvyJuj0RbmYYJoJBBCIPQF6hAACCCCAAAIIIIAAAghEWsDeAZN0aeXI0X+cRht+3Oq82sQ5kxEE7C9ACxFAAAEEEEAAAQQQQAABBKJMwNYBk65tm8rgMTNlx87d0qrzEBk5cY60b9kgyohjsbn0CQEEEEAAAQQQQAABBBBAAIHYFrB1wESfWTJ+aDcZ2KON1KvzoLw2Z4zcfGPB4G8RakQAAQQQQAABBBBAAAEEEEAAgdgXSEYPbR0w0X7ExcVJxfJ3SdXK5SVNnO2bq00mIYAAAggggAACCCCAAAIIIBAWAVYSOgFbRiDurt5IfKXQcVAzAggggAACCCCAAAIIIIBABAVYNQK2EbBlwCRH9mxyY+EC0qb5UzJ5ZM9EyTZ6NAQBBBBAAAEEEEAAAQQQ8CnAQgQQiFYBWwZMlrw+VVo0fkJ+3rZDpsx+Tbb88psULHCd/O+u280k/EMAAQQQQAABBBBAAIHICLBWBBBAIJUI2DJgkjZNGqlyT2kZ0a+jTB/bR7JmySQNW/aU95auSCWbhW4igAACCCCAAAIIhEuA9SCAAAIIIOBJwJYBE6uhu3bvl3mvvy+vvvWxlCt9p9x5283WIoYIIIAAAggggAACngWYiwACCCCAAAJBELBlwOSNd5dLkzZ9pEu/sZIlc2aZM2mgDO3TVooUzB+ELlMFAggggAACCESXAK1FAAEEEEAAAQTCL2DLgMnEmQskTZo0Uu2+uyU+Pl7e+uATmT1vsTOFn4k1IoAAAgggEEQBqkIAAQQQQAABBBCwvYAtAybPNnhUype5QxwO2/vRQAQQQAABEQEBAQQQQAABBBBAAIFYE7BlwKRlk3riK8XaRqA/CCBgOwEahAACCCCAAAIIIIAAAqlcwJYBk1S+Teg+AiEQoEoEEEAAAQQQQAABBBBAAIHkCBAwSY4Wee0jQEsQQAABBBBAAAEEEEAAAQQQCKEAAZMQ4ianavIigAACCCCAAAIIIIAAAggggIB9BEIVMLFPD2kJAggggAACCCCAAAIIIIAAAgiESiBm6yVgErOblo4hgAACCCCAAAIIIIAAAggkX4ASCFwSIGByyYFXBBBAAAEEEEAAAQQQQCA2BegVAggEJEDAJCA2CiGAAAIIIIAAAggggECkBFgvAgggEA4BAibhUGYdCCCAAAIIIIAAAgh4F2AJAggggIANBQiY2HCj0CQEEEAAAQSSIvDLr7/Jyq/XBZRWr1kfUDld3779B5PSPPKkagE6jwACCCCAQPQLEDCJ/m1IDxBAAAEEUqnAmEmzpMZjTZKdaj7eVOo2eD7Z5ax1vbtkeeoTp8cIIIAAAgggkOoECJikuk1OhxFAAAEEEBDBAAEEEEAAAQQQQMC3AAET3z4sRQABBBCIDgFaiQACCCCAAAIIIIBAUAUImASVk8oQQACBYAlQDwIIIIAAAggggAACCERSgIBJJPVZNwKpSYC+IoAAAggggAACCCCAAAJRJEDAJIo2Fk21lwCtQQABBBBAAAEEEEAAAQQQiF0BAiaxu22T2zPyI4AAAggggAACCCCAAAIIIIDAZYEYDphc7iEDBBBAAAEEEEAAAQQQQAABBBCIYYHQdI2ASWhcqRUBBBBAAAEEEEAAAQQQQACBwAQoZQsBAia22Aw0AgEEEEAAAQQQQAABBBCIXQF6hkA0ChAwicatRpsRQAABBBBAAAEEEEAgkgKsGwEEUoEAAZNUsJHpIgIIIIAAAggggAACvgVYigACCCDgLkDAxF2EaQQQQAABBBBAAIHoF6AHCCCAAAIIpFCAgEkKASmOAAIIIIAAAgiEQ4B1IIAAAggggEB4BQiYhNebtSGAAAIIIIDAJQFeEUAAAQQQQAABWwsQMLH15qFxCCCAAALRI0BLEUAAAQQQQAABBGJJgIBJLG1N+oIAAggEU4C6EEAAAQQQQAABBBBIxQIETFLxxqfrCKQ2Afqvct7OAAAQAElEQVSLAAIIIIAAAggggAACCCRVgIBJUqXIh4D9BGgRAggggAACCCCAAAIIIIBAiAQImIQIlmoDEaAMAggggAACCCCAAAIIIIAAAvYQIGASyu1A3QgggAACCCCAAAIIIIAAAgggEJUCyQqYRGUPaTQCCCCAAAIIIIAAAggggAACCCRLgMwiBEzYCxBAAAEEEEAAAQQQQAABBGJdgP4hkGwBAibJJqMAAggggAACCCCAAAIIIBBpAdaPAAKhFiBgEmph6kcAAQQQQAABBBBAAAH/AuRAAAEEbCZAwMRmG4TmIIAAAggggAACCMSGAL1AAAEEEIhuAQIm0b39aD0CCCCAAAIIIBAuAdaDAAIIIIBAqhIgYJKqNjedRQABBBBAAIErAowhgAACCCCAAALeBQiYeLdhCQIIIIAAAtElQGsRQAABBBBAAAEEgiZAwCRolFSEAAIIIBBsAepDAAEEEEAAAQQQQCBSAgRMIiXPehFAIDUK0GcEEEAAAQQQQAABBBCIEgECJkncUG++t1wateoljVv3kZVrNiSxFNkQiHUB+ocAAggggAACCCCAAAIIxKYAAZMkbNc/9hyQ+a8vkVnj+8vogZ1k2LjZcvpMfBJKkiXqBGgwAggggAACCCCAAAIIIIAAAoYAARMDwd//q9dukCoVykiWzJkkX97cckvRwvLdhp8kGv7RRgQQQAABBBBAAAEEEEAAAQQQSL5AtAVMkt/DIJT4+/ARuS5fHmdN+a/LK38dOuycZgQBBBBAAAEEEEAAAQQQQAABBIIqEPHKCJgkcRM44q5QORwOZ6ky99cXK1V+crA0mZU5UVq24Zz4S57Kuc/zVseij3+XBx980ExWW1yHP2zdJbfedoczFcibXfwl1/zexv3VsXDeS04b1/boeJXaTcPeHm2v9qVy7SZe2zXvzaV+bax6tC5fSfP5S1b5TT//7rVNum3Pnjzqs11WPb6G/tqiy93Ld+g9OlG7tD2aevXo7rVN7vV4mtb1+UueysWlz5KgTdoW17Txu68TtctTPe7z/LVFl7uXcZ1+5Y2PzHa5tsUar/Poowna5FrO27iuz1/yVtZ1/qOPPmIeG6y2uA4XzX/ZbJdrfm/j/tqiy72VdZ2v+TasW+21Tdq+NBmyOo8PrmVdx7Uef8k1v7dx1zp69ejmsV16zOrYZ4zPNrnW423cWxtc57uXjf/vcKI2aXus5H58t+pyr8fTtJXX19BTOZ2nx3fdVpqstvgaaj5/ScvfXb2RaNJxT8lfHbrcUzn3eZrPX3ItU7n2s/K/qk+af+Ou8/3Voctd83sb13z+knvZcg82kAo1Gidok786dLl7PZ6mNZ+/5KmczqtYs4mUr9bAbJe/OnS5lvGXNJ+/5KsO3Xa6Df3Voct91WMt03z+kpXX17BmzVqiyVddvspby3yVt5ZZeX0NrbyPPlpHqlWrlujYo8t9lbeWaT5/ycrra+hax0MP1ZDatR9O1CZf5a1lrvV4G7fy+hp6Kvvww49IjRo1nO3yVd5a5qke93lWXl9D9zLWtG473YY67au8tUzz+UtWXl9Df3Xovu7r+G7V7a8eXW7l9TXUfP6Sltdjgx4jdNxT8leHLvdUzn2e5ruULn1m8zRulfF0fLeWeSrnPs/Kaw2FfykSuBIFSFE1sV04T66ccuzYP85OHjl6TK7JncucXrN8ofhL7Yd+IP6Svzp0ubc6eo9bIkuXfmQmzecvbV6/Svwlf3Xocn91rPrqM782SalH16P5/CXN5y/5q0OX+6tDl2s+f0nz+Uv+6tDlum03rvvK5zbTfP6Sv7bocn916HJtj6YVny/32ibN5y/p+vwlf3Xocm2La/r26y8StUvz+Uv+2qLL/dWhy13b4jqu5a2k+fwlK6+vob86dLlrG9zH9W9U69d8/pLm85f81aHLtQ7dRu5tcZ3WfP6S1uMv+atDl7vW8flny83jqGtbdFzz+Uuu9Xgb91eHLncvu3HdykRt0nz+kns9nqb91aHLPZXTebrvqI0mzecvaT5/yV8dutxfHbpc8/lLms9f8leHLvdXhy7XfP6S5vOX/NWhy/3Vocs1n7+k+fwlf3Xocn916HLN5y9pPn/JXx263F8dulzz+Uuaz1/yV4cu91eHLtd8/pLm85f81aHL/dWhyzWfv6T5/CV/dehyf3Xocs3nL2k+f8lfHbrcXx26XPP5S5rPX/JXhy73V4cu13z+kubzl3zWcfmzkL86dDn1XPq8phaeUqh8zA+tvAQsQMAkCXQVy5eSVWs3yJn4eDly9B/5edtOKVfmjiSUJAsCCCCAAAIIIIAAAghEiwDtRAABBFwFCJi4angZL1jgWqlbq6o0bz9AOvYeLZ3aNJb06dJ5yc1sBBBAAAEEEEAAAQRsIUAjEEAAAQRSIEDAJIl49etUl4UzR8j8GcOkyj2lk1iKbAgggAACCCCAAALBE6AmBBBAAAEEwidAwCR81qwJAQQQQAABBBBIKMAUAggggAACCNhWgIBJBDfN6TPxsnf/nxFsgedVHz12XI4d/9fzwgjNvXDhguz8Y2+E1u59tXbdhmp17vx57w2PwBK7Wtlxf4/A5mGVQRaw6/4e5G56rI6ZqU/Arvu7HY/vdj2fsetea8fzGbta0a6kC9j1mMX+nvRtGM6cBEzCqe2yrp+2bpdGz/eUgaOmS4+B420TOHnnw8+kZadB0q7HCBk7dZ6cOn3apdWRGf3n+Alp1q6/DB8/R55t20/WbdgcmYa4rdWu27D/iGkyYOR0afpCX3nzveVurY7MpF2t7Li//3viP/Nv77+TpyKzsbys9bdde+TFBW97WRq52bNeWSy79hwIZQOSXbdd93erIxoQ//TLNWKHoCr7u7VVkjZkf0+ak+ay4/Hdruczdj2+2/F8xq5WK1atk8++Wqu7PsmPgF3fo+24v/uhTDWLCZhEaFNPffF1eXnKYJkzaZDUrV1VuvYfK5t/3h6h1lxa7Yn/TsrST1fJ4rnjZP70YXJdvjzSustQ0ZPrSzki87po8YfybIM6htVAGdL7BZk5d7G89cEnkWmMy1rtuA3XfPeDXJ0juyyYMVxmTxggv2z/XfoOmyoXL150aXn4R+1oZdf9XQOVP/2yQzr0GiWhCZokf/ufPXtOeg6aKKvXbJDRk+cmv4IQlXh/6Qr56pvvpW23Yba6As2O+7u1CXRbDhgxXeLi0ojD4bBmR2zI/p50evb3pFvZ9fhux/MZPSbY8fhux/MZu1rpVQkTZiyQGS+/KRoMT/pfSnhybt/5h7Qx3qcbtuwpM195Mzwr9bEWO75H23F/90GY6hYRMInQJv/n33/l3Lnz5trLlykhowd2kSFjZ8rfh46Y8yLxEh9/Vv4zgia6bofDIQ2eqCnPPPmI9B4yOaIfuE/8d0rOnjunzZL81+WTmeP7GYGd1fLt+h/NeZF6seM21A/Y+oauJpkzZZT+3VqZAZTZ897SWRFLIbUKsFd23N/PGfv5mfh4mTNxgJS68xZp33OknLj8NxlgN4NSbN+Bv6Ri+btkttGu3XsP2CZosm3HHzJ2cBfp0aGZGWD6bdeeoPQ3pZXYaX/Xy45/3vabs0uL3vpIHn6oilStXFYOHPxbXn1rqWzbscu5PJwj7O/J097G/p5kMDse37XxJ2x4PmPX47sdz2fsavXzL79Jx+cbyaQR3WX6S2/IJ198o7ubLZKek46bOl8G92wjLxlfFC///BuJ9Hu1nd6jrY1kx/3dahtDEQImEdoLHqhyt4yYOMcZiLghfz6p92h1mf/GhxFqkUjOq6+SXLlymifQViP0pDpH9qzyxervrFlhH1a//x6ZNud155Uu+pPOfbq0kMmzXg17W1xXGKpt6LqO5I7fU7akfLFqnWwx3jytsh2ebyDLVnwth48es2aFfWhHKzvu72nTppWR/TuKDts0f0puv/Umadt9uBk00dsntv66M+zbTldY6IbrpINxMpYhfXoZN7Sr7Ny1V4aOm20ev/4ygryaNF+4U/f2z8p1+a6RSneXki5tmpi3Ev762x9mM7b8ssMcRuLFTvv7nn0HpNuA8WLtO3GOOFmx8ltz+000vpHMcVVW6TtsSiSYzP2c/T3p9OzvSbey4/FdW2/H8xm7Ht/teD5jV6va1Y0geJVy5peKE4f3kCmzX5Wln63SXU709hN9bo45EYGXncYXGddfe43kyJFdho6dLb06NZcbCxUwr4COQHPMVdrpPdpskPFix/3daBb/XxYgYHIZItyDJk89LP+eOGk+a0K/AdT1lypxqxw+clRHI5b6GoGIhYs/lFff/tjZhpJ33GK0K+AP2856Ah0pcXsxefDe8uYHxwN//m1Wowfbs+fOmuORerHjNtSrSvp2fV669hsr32/aYtLoh+9bihYSvXfanBGBFztaKYMd9vdj/xyXcdPmy9Q5r8mhwwn//ju1fkZK3H6zvNBtmAwYMU0++3KNNjuiSYMm44d1E73SZMjYWeaVHVt//T0sbdKg0bzXPpDBY2aKXuLrutJ7K5aRLi80lQ49R8q0l14znwMTqVvR7LS/Fy1SUIb3bS+9Bk8ygybPPFlbqlQoI3Vr3S9jh3SVCuVKSZbMmVwpQzpu1/1db1/sPWSS+dwn6z1ZISK5v+v6vSX2d28yV+bb4fh+pTWXxkrY5HwmGvZ3u5zPRIPVpb3r0mvBAtfKlFG9ZeqLr5m3v/QbPk3+/PvwpYUReL3+urzyw5Zt5jlMrWqVpGypO0RvP3n9nWURaM2lVdrpPfpSi0Tssr9b7WGYUICASUKPJEwFJ4t+iB1nnKyePnNGnm7RXfTe5AnTF8hTj9UIzgoCrCXfNbll5rj+smTZF9KqyxD5YNmX8skXa+ShqhUCrDE4xfTb9vsqlpUGLXvKy4veMx8AW6dm1eBUHmAtdt2GFcqVFA2a6AekIWNmmcGvC+cvSJGC+QPsacqL2dXKDvu7PmOm2E0FzW9cWncd6vxWyFLv2OoZ8+HLmY0PtW1bNLBmR3Sob+xDereVT79cK+YH8HtKh6U90196XeLPxkvVyuXNgMiEGfPl/IULznXrFXGVjWDAdxt/lskje0bsGR1229/1Q9qgnm2k3/Cp5rd61e+vILfdcpPs3X9QuvQbY3zj95zTMNQjdtzfNVA5fvp8qXZfBdFgSZM2vU0nyyJS+7u1fm9D9ndvMpfm2+H4fqklCV8jfT4TTft7pM9nosnKdS/TK2E6tmokb3/wmYwe1EmuzZvHdXHIxw8dOWaee+rVLVmzZJb6darLzj/2SVycQ/ThtC8tfEdaPVsv5O3wtgK7vUdb7Yz0/m61g2FigThJPI85QRTYf/AvWfz+J6LfqrlXq9/qjR7YWXp2aC6Hjx6Xrm2byp233eyeLSTTehD7cPlXovcWuq9Abw+aP324PPJQFfnvv1PGt5BdJFvWLO7Zgj594r+TptXvxkHVU+XNG9WVuVOGiFy8KNXvv9t8xoqnmVqzVQAAEABJREFUfMGeZ8dtqN+c65vO1+s2eeyuHnQXzx0rNxYuIDmuyirD+nXwmC/YM+1o5a+PkdrftV0H/zwkxqd60ctpazxQ0XwQ9EfLV8rHn60W69/cV9+XErffIr07PWdkdVizQzb0tQ1dV6q/WtWrYzOp+UAl19khHV+9doO0aPyE6P49Y2xf4+QrToaNm+1c5w8/bTOfxzHFCJaE45jlyyqSx3cLRJ+Ho78U8seeA8Y+VEyG9WlnBk127tpnBpreXvKZEVxtJcVuKmQVCenQjvu7dvjb9ZulXOk75d6KZaTxkw/LiP4dZcDIacYJ/l5dbKbh4+dIuPZ3f8d3s0HGS7j3d2OVXv+P5P7O+YzXzeJxgd32d4+NdJmpx/tInM9oE+xo5Wt/1zZr0udh6LPrpo3pI3qVoc4LV9JfPtMrPXMY555jprwiU1581QyYPPfM47L4vU9k88+/yoRh3UUDmqFukx3fo/0d38O2v4caP8bq5wqTEG5QPSnVb/n1Qa5te4yQF+e/ZXzWT/xrJeVK3yHNGtYRjQiHsDnOqj/6ZKXok7R/371PnmndS75c/b1zmTWSLl1aqflgZXn68RqSI3s2a3bIhvFnz0qnPmPMbzwnz35Veg6eaD63wX2FatTMCJyULnmb+6KQTNt1G+p9oPrh8cvV3xnbsLdoO90BclyV3Qwq6QfatGnSuC8O+rS2wY77++cr15pPZ9cTCG+dDvf+brUjd64csmfvAbFuNdMP+aMGdpK5r77rvIS2fp1qYQuWJHUbavuH9W1nHiN0PFzphvzXim5PXV9cXJz5XJXjx0845+mVFOEKliTVKtzHd7XRpCdl3QdMkB9++lXGTH3FCABMlyKFCphBk95DJ8ofuw+YfoUKXKvZw5Lstr9bnb6pyA3y5dffmUEknadX4w3s0Ub6ufzCWDj396Qc37Wd4d7f9RcudL/XdXtL4d7fP+J8xtum8Drfbvv7lNmLZOzUeV7bqwvCfT6j69RkN6uk7O/abg1gvjJtqNx8Y0GdDFvau/9P81agZo3qiJ57Tje+2Nj883YZNellub/S/4wvYLua7zt6rhPsRrnXp8cqO56TJuX4Hqn93d2Q6SsCBEyuWAR9bPH7y6V9ywail1/qgeuYcWLfb/g053pWrFpnnsQ6Z4RpRH8VYcqoXtKuRQOZOrqPvP7ux/LuR5871z5hxoIE084FIRz56uvvpWzp26VT68ZG5LmbVCx3l7TqMsQZNNGDcMtOg5zTIWxKgqrtuA2PHjsuB/46ZP4CTp/OLcwrlPoYH4C27dhltl1vUdAAnesvY5gLQvxiRyu9b3fC9IVS+IbrpUOvUeIpaBKJ/d3aFHpZaIMnakm3/uPl+L8nzNl6+Wr1+yvKipXrnNMOR+ivLNGVJWcbaju1TKjTzj/2ij67RNfzbIO6MnbqfPMqEp3W1Kh+bVm+4sovAoTjREzXmxwrzR/u9PHnq6V0ieKit+JMNY73+fLmklnzFkuxooVlaO92kilT+rA0SR82qNtQV2a3/V3bpEmvsLk+Xx7zaiVtr8679eYicvXVV8n2nbt1UsK1vyf3+B6O/V3fUwaPnSmlS94qHfuM8vgLF5zPmLuJ+WLH8xm91UzPo7SBdtrfV67ZIN9u+Ml8Jpann6zXfS8S5zPqpCmCVrr6RCk55+/hOma5NjJD+nSycfNW+XHLdnO2Bm70IbT6Be2SZV+a88L1Ysf36OQe38NlxXr8CxAw8W8UcI5sWTPLr79dOtnSb/i7tW0q+k32G+8uN+u8+393ymO1q5rj4XzJlCmD7Ph9j7nK3DlzyPih3cz7HLf+eukXOB6r/YD8767bzeXhetED+/bLv26h69RbFJ5+rIYMHTtLJyX/dXnl2QZ1wnbSaq7UeLHjNtR9SK9I0BMgo4ly2y03mrfcDBw5zXzWRZq4OGnesI55O44uD1eyo5X+olL75xtIt3ZN5a47i3n8md5I7O+u2+TJutWNDyLFpckLfeW7jT+Zi/RXZ24qUsAcD+eL3bZh/xHTzKByU8PmzfeWm/t617aNRX856K0PPhG9isK0KoyV+35y4OAhyZjxSlCkxTOPy9JPV5nZ9FvTcNzTrg+abtauv/nMqWfb9pN1GzaLnfZ3E+Pyy4AerUV/MlQ/nO3Zd1D0dqbz589L3jy5LucIz8COx3cN19Z8oKJ0btPEvHW4Q08jaHL5HMJS4XzGkhDzPMVO5zN6C0ej53vKwFHTpcfA8aKBk/Dv71d8XMeyZckkA7q3ktGDOssfe/aLBk30uG7lSRMXmfMZa/06tIuVtsWO5+/aLg0E6G31eXLnlBnj+pnnMp98cemLDH0G1IRh3aTmg5U0a9iS3c5ntON2PL5ru0j+BeL8ZyFHoAKP1LhXXnntfdm2/XdnFe1aPC2vv/OxOZ0pY0bRS2rNiTC+1K9TXfqPmCp6n6GuVg9mzZ95TF67/Ms4+oRtDVDosnAlvYxXf3VDH35rrbNWtcqyZ9+fRjpozrr7fyXMYThf7LgNs2bJLPqUcb2sz7LQS8j/V+p25zftd915q+ivO1jLwzG0o9XVObJLtfvuMbv/QvOn5Y7iN5kftvWN/ftNW0Sf3B6J/d1skMtLp9bPSMvGT5iXrT7Turdcn++asActtTl22ob6FH3dfgtmDJfZEwaYD+HsO2yq3F+pnOg3Vp9+uVbqN+sq36z7QRo/9ag2P6zJTlaeOq7PeVq0+CPZ8ONWc7EGWMN9XF+0+EMz0D1n0kAZ0vsFmTl3sWigyy77uwlz+UXfj/V+fz1GtOg40Ayu6tVLV2XPejlH6AZ6S+q363+Ub9dvNj9s2+X4rj9Fr7fs7t570HwGgQpUvruUGTTRwJL+hLc+3FEfDq9+qep8RjG8JLudz0x98XXz+VhzJg2SusaXdF37j5UdO/eIHfZ3PVcpWqSgZMyQXsYO6WJevTRs/ItmMPztJZ+aV15qnnCfz7huWt23I2Wl7dj883bnc83seP6uVwnpDzLoQ+snzJgvV2XPJtNG95F5r30gevzQPqihXmGo4+FKdnyPtuv5e7i2STSvh4BJELeeHtQaPd9LmrcfIJ+vXCf5r8snPTo0Ez2xsO67z2JE07NnyxLEtfqvSh/6V6N+G+k1ZKLobRv6AbJ8mTulpXFS+Nvlb4n0SpOMGTL4ryxIOfTJ4x17j5LHGncyAkjL5Pz5CzJ6YBeZNe8teXHB23LO+GZPV6XR6nRp0+poWJIdt6Fekjpmyiui21B/flZPULu80FgO/vW3dBswTo4d/9e0yXl1DvOkw5wIw8se41vYnbv2Oddkl/3d2SAPIx1bPSN33lZUWnUeInpSpsFCD9mCPst9f/f0sGV96Otbr4wXDRA0furhoLchKRXaaRvq7VOWk26n/t1aiQZQZhvHCL2qatb4/rJ47jgZ2KN1WPZ7Ox4bfG1T3ZY9OzY3vlGeIHp1R/ueI81bRH2VCfayE/+dkrPnzpnVantmju8nSz9dbQQGfpRI7O/u29BsmMuLXgna+tknZdnimTLL2L8qlC3psjQ0o+cMHz0effDxl2I9HD4Sx3f33unDEpu07mteXm/dLmjl0Yfjdn2hiRFUGmGmtGlD/4wsa90aVNLgnzXN+Ywl4X34z7//yrlz580M5cuUMM+1hoydKUeP/iN22N/Nhhkv+qFaHwa6a/d+ad1lqCxZvjIsDzo3Vi12PDZouybNWihjp75ifsF58tRp8wug8hE+f9d2WUmvItQvgRfPHWueu2hAYMSEl8z3an1+yZZt262sIR+6b0N9z4n0ZzC9Wko/D7p23g7Hd9f2MJ40AQImSXPym0tP7CfNWiRjBneWEf07GNHglTJ03GypUqGMjDSmJ8961TixGCnteoyQ1s3q+60vWBn0G6B16zcbHyzGSqN6D4v+zKw+r0Q/OD5S435p0XGQecn7JOOg3KxRnWCt1m8946bPE/327rU5o+ToMeNNu+sQyZIlo/ktyHcbfpIGLbpL94Hj5Y7iRSVf3tx+6wtGBrtuw7fe/1Ry57palrw6WYoXKyIvdBsq27bvEn0z0gdDPdmsmwwcNUO2/LJDHrx8NUUwPHzVcfzfE9K2+3Dp3Hd0ggfO3l+pbET3d6vNGswZPGamGRTZteeANdscPlS1ohw2ThRHD+wUtqfHe9rfDx89ZrZHXzSQqZe06ni404n/Tor+XG8P4+/tm3WbxC7b8B7jw+oXq9YZ+/VvTpIOzzeQZSu+NrbfFTvnwhCO2PXY4K/LelXeB8ZxQ0/QZk/oL7ffWtRfkaAur37/PTJtzuvOoK7eItenSwvR98OgrihxZYnmeNuGGpC2MustQ67T1vxQDue++p7x5UpeGda3vVS/v4K5KnWK5PFdGzFk7Gxp2fQJ0auBPP16X+m7ihvfJGc138drhumXsvSKwN5DJkmbrkMTPI+K8xndYt7TA1XulhET55hXbWiuG/Lnk3qPVpf5b3yok2FNnvZ31wZocPyBKuXl9JkzEq4HeNv12KC36H797UaZNWGAeYWX2qhVpPd3bYOVtu34XfJdk8u8Mk7n6a/Y6bw/jPOuq7JnFb2yV+eHOnnbhpH+DDbv9Q/MZ2ONdXmosR2O76HeHrFYPwGTIG3VI8aH/rg4h+h94dfkziljB3cVvZJk0swFUrrkbfLOgomiP4ur0fPyRoQ/SKv1W82O33dLwRuuMw9m+q3snMmDZPmKb2SF8UFEfwFHT6Yfe7iqzDS+TQvHT3xZDdbLQUvcVsy8baR1syflmfoPS7f+4yXn1VeZl98P6dVWOrdpbJpZZUI9tOs23L7zDyNQUlj0ckb9VnbckK6i3w799fdh6dO5hbwybYj5azhjBnWRNHHh+ZP+0Pjmp/ZDVaTL5W8Zf9u1x7l5Irm/ayP08vEu/cbIk3Ufkmvy5JQmrXuLfhDSZZr0GUKTR/YIW7BE1+ltf9dL8XX5ilXfmn+XOh7OpFdyPd9psBQumN88IevSb6x5G2Gkt6Ea6Mlh367PS1ejTd9v2qKzzL+BW4oWEv1Wy5wRppfIHxsC76h+a6uBEj1+BF5LYCX1Fo0H7y1vBlf1uUtay42FCsjZc2d1NKzJ1zbUhmigZOGbH8nWbb/pZNjSilXfScdWjRKtT0+qI3V816sW9YuMRx66N1G7rBlLln0lTZ5+VMIVLNH1Lnh9iYwyAt2lS95qfgGlwV6dr4nzGVXwnJo89bD8e+Kk+eWYdXVOqRK3yuEjRz0XCOFcb/u7tUq9snDt9z/IlFG9JFvWLNbskA7temz48uvvpWWTeh6voIzk/u66MYoXu1E2bd4mP7scN681vuRMkyY856JWW3xtw0idz5w7d06WfrpSXp09Unbt3mc+n8dqbySP71YbGCZPILx7dPLaFlW59cFwejmtRoSthuuv0Gz+eYf5DWmauDjzeSX6xGhreTiGZYxgzUfLV8nRY8fN1WXMkF6GG99kTZq50Ijgx5uBFA1c6KXIZoYwvSUtAJ0AABAASURBVJQqUdz4YPaec20aBS55RzF5/e1l5jz9JYdwBnB0pXbdhmVL3W5YfSDWrzfoZYbtWjQU/bUQbfe1efPIzWH+6bgnHn3QfDZBpbtLSbd2TUUfArjj8q9J6ElsmrjI7O/q8f7HK2TMoK6if2t6tVLbFk+btyVs2vyLLjZ/NUTvmTYnwvTib3/Xy6KfeuyhMLXmymq+/X6zESipJlWrlDO/bRzSu63MXfSevPr2x2bwTT/wquOVEkEaS2I1FcqVFA2a6E8D6tVx2q4L5y9IESPAk8QqgpLNrseGoHQuxJW0af6U3FexrOg97i8b+9bw8XOkTs2qIV5r4uqTsg0nj+wZ9qtw9Jv0+PiziRqsgd+PPllpfgkT7uP7qVOn5YyHNmkj9UGO+qtHz9SvHdZgia57UK8XRM9p9FtrPV/QK3atZ7Hp+47eDsD5jEolTBos1S9adF97ukV30WfFTZi+QJ56rEbCjGGY0jb42t/1/UafURWuYIl22a7HBvPv8Ey8NjFRmvnKmxE7f9+5a5/oFbxjprxiHCfipXt74xyw1yjz4d5623j2bNnMq+YSNTqEM5KyDcN9PqN/d3OnDhW9Sn6s8UXnb8YXiyMmzHFe6aXHrEicv4dwM8R01QRMUrB59R7fxe9/Ihoo0Wq6t28m/YZPNQIkO3TSvPdSL///4adt5nS4XvSJ6B8u/0r0EjW92kUf8qXPCzly9B+zCXoVx603F5Y/jIinOSMML3pgUKvf/9hnrq3FM4+JXqWgtweZM4wX/abqx5/Da2XXbWhwOP9/oEp50Wi0XiKtVwToAg1U/LFnv45GJGl7rCCbBrs6tWksL3QfLnp/ebN2/URdI9IwY6Utmzwh+iDXgaOmS6+Oz0m9R6vJrca3IHo/tLE4JP/7q9Qu+7t7OzUgUb1qRZk590154N5yovuabs/1m34yT4Tc84diWu/xXbFqnXy9bpPH6rWNen/0jYULSI6rssqwfh085gv2TN2H9Zhlt+N7sPsZjPrcj+/uderVlXOnDBHjTFH0YbQNnqjpniUk0/rssOc7DzZvzdMV2OU9Wttipcp3l5bJsxdZk87h8i++FusKNOfMMI3oSXy2LFnMB/S6r/Ldj1YYwdQ07rNDNq0fDJu27WecL3xlBsGtFbVr0cB8HlVb431HbyXU9x09lljLwzm0y/Hd/ZjlaqCBiNEDO0vPDs3l8NHj5oN7Pd1q5VomFON22d/1C54Oxof85zoMFH02iB2PDVUq/M/4sux90eOr67ZYv2mL7Nv/l+ussI6PmTpX9AqXm4oUkKYv9JNrcuc2b6cvkD+f3P2/O6Vf15ZhbY+1MjtsQw3g6ufAhi17mg8w1r87bZ9+WT1xeHfZZZy3Dxv/orz53nLR4JIuI0WHAAGTALfTTiPCqt96/n3oiOhDXV+c/5aULlFc9A+2Y+/RMnveYtm7/0/RN/J7yt0V4FqSX0y/kZrx8puiv3n+TOteok+o1pPVsqVvl4bP9xJdrs9LOHb8hBQpVCD5KwighJ70deozxvA4aJwYvio9B0+UjBkzyATj4LHgjQ+lz9DJos+cWLL8S7nXeIMIYBUBFbHrNpxinDy73u8YFxcnw/q2k8NHjhlvTn3NX3ZZ9vlquevOWwLqdxIK+cyil9b/+ffhBHmqVi5rPptHA3NNG9SR6/Jdk2B5OCesp+nrbRt6D63e0qQfACLxJq4nOrp+fQZNpPd3b9tA38j17+/6a/OKvtkfOXZcxg3pZt4u561MMOfrrz2tXrvBOFZ9J/oLQfp36V6/PqtHP2RrUNUK1LnnCea0tsGOx/dg9jFYdXk6vut+715/oRuuk2aN6pq3qLovC8X0L9t/l4kzFpoPXtdbW3QdenVCpN+jtR2uSW9J3WOcK+j7ol4JeiY+Xl5e+K58/tVaeahqBdesYR0f1LONcR7ztrxktEUvLdcHV/cdNtX4cJTTDEiHozH6oWLDD1tl0vAeUrt6lUSr7NS6sdyQ/1oZNHqm8R7Z3vySKlGmIM/QW1r0Ib2uD3K0w/Hd0zHLUwBJf8GnWcM6on+PQaZJUnV22N/1tp9uA8dLrWqVZM6kgaK3f9rx2FDlntLm8fL5ToPF+oGGT79cYwSA50iTpx5JkncwM6mbnuMVNQIlRYsUlLq1qkrH5xtJu57DRa8ceqZ+bdFnjwVznd7q0v1dgxI6tPLYYRsOGTvLfLTAvBnD5Ea3z1h6e+z4od3kxy3bzM9inds8YzWdYRQIxEVBG23ZxMXvLzd/cUAvN35l2lDRAES/4dPMBya+OHGg/Pn3USM4sEiaPv2IFCpwbdj68OpbS817P/Xbl6mj+8jr734sehWHXsI6sEcr+WL1OtFvTfV37/X3wMPRsK++/l40YKMnN/pb7BWNAFKrLkPME69Xpg0RjUqPmfKKeXDxdFKU8jZ6rsGO21B/nu3bDT/J7r0HEtzvqJcaa3T6sdpVZc78d0RPsPXp3557Fpq5eo//iIkvyfjp80WfdaFXvOhVTLo2fSNd/N4n5jcL+qFW50U66QfsWk+9YD4bp3mj8D3Q2Or3O0s+E/0Ga/a8t+S5DgPMk7JI7u9WuzwNmzWsa27T2k+1lQaPh+8ybf2AeOCvQ6K/gKMfavXbzz5DJ5q/5qXt1H1OA9Ku90fr/FAnOx4bQt3nQOv3dny3gib6xUHLToMSfUsa6PqSWk6/OOjatmmi27f0ocaRfI92b78GLGeO6yd6Mv1Mq97SvN0A2b3voFjz3POHa7pwweuND5ODZOOPW+XpFj2MD0UjDMvrzWN8ONqgf/svL3pX9BZiDXx7Wqd++bP1150ydXSvsD2TatYrb0qunFeJfrGhtydZ7SpSML9E8vju7ZhltW/FqnXmM0ys6UgN7bC/6zmwXulSze0h+XY7Nug26tmhmVStUl66DRhvfqHwwcdfyuiBneSmIjfo4rAmvVrif3fdLl+s+s55PK9apZx0a/usvPvhirC1RY8Ng8fONIJJt0rHPqPMKzmslUdyG27+ebv89fcR0WdSeftiZ8Wqb41zwUzGMat32J7RY9kwTJlAXMqKp97S2bJmll9/220C6B9GN+PETAMQ+kBJjdzrt9mjB3aWu+681cwT1BcflWXKlEF2/L7HzJE7Zw7RaObbH3wmelJRrvSd5sNo+3Zpad4XbWYKw4t+2N/+2x/ONWlQ5OnHashQIxKbPVtWadW0vui944/UuM+ZJxwjdtyG2bJkEg1mjR7UWfSWm9GT54r1LZFeafJY7QfMgFiLZx4P2xUA1rb44OMvzFsi9OGy+hDJX4wT1V5DJoreJqRvpBrAqflgZSt7xIf67cea5QvlvYWTJNxXvOi3Hl99s954U+wlD957t/HtS7z5C1l673ak9ndfG+TWm4vIF++/JF99ODds3xBpe/SYqVcs6be2Oq0PptZbbgaOnCanTp+WNHFx0rxhHdHbcXR5uJIdjw3h6nty15M1S2bxdnzXuvJfl1eebVDHvN9ep8OV9BvZu8uWSLQ6DeToB/BIvUcnapAxQ4+fetz/8PWpsnDWCBnYo7VxrM1uLIns/zfkz2ccw3rL4rnj5LUXR5tXCOl9+eFo1d59f4ruO3r1hvv6NAinz/QqcH0+0V8l1G+73fOEarpQgeukb9eW5vvw9JfekOUrvnauyq7nM9pAvVVCv3DR8UinSO/vemzQK208OaRNG2cGBSNx/u6pPTqvWcM68s78CbJgxnBzv4tEsETboalhvVryrNEe/TJI36N13r0Vy0j39s/qaFiSw1hLzQcqSuc2Tcxby/QZerpNjdnm/5H6DLbj993yv1K3ebzSbe/+g2bbbitW1NyG2cL0QGNzpbwERSAuKLWksJJoLP5IjXvNewu3bf/d2fx2LZ6W19/52DkdiZH6dapL/xFTzUvrdf16qWHzZx6T196OXLv0jUmvmNAHjWmbNNWqVln2GCdEe4xv0nQ6EsmO21ADbHryp9/CjB3SxYycDxv/ohk0eXvJp3L83xORoDLXmfPqHKI/GTfvtQ/k6quyyaQRPYxvH3+RYeNeNJdH4n5oc8U2fNEnxLdv2cAIVP4uH32yyvjmcajxrUJGI2gyPGzPBrEhS6Im6YftsqXuMIKns53L9Jva/5W63fgg8o05T/8mrNuszBlheLHjsSEM3U7yKg4fPSZ6u+eu3fslKcf3u/9XIsl1ByujXrm46psNiarb8ssO4/1waaL5zLCXQL68uUT3L/fbP7WVevuuPi9Lz2/0/VLnhTK57u+P1rzfvBpIgzWTRvSUybNfNX8JQ7/11ocah7Id7nWrj/4Kh35w9XfM0iuY9KGX7nWEYlqfpaLt0qBWKOpPaZ0aCPT0zCwNpo6Y8FJKq09Web0N9qNPVjrP2ZNVOEKZ9Yu7urXuF338gN5CGK5mWPu7rlM/6+h6K99dygya6JWovxpfzB46ckw+WPalLgp70mPC2u83ix4L3Fc+1DhP1r/TIoWu58oSF5xoGiVgksStpZdaNXq+lzRvP0D03lX9pRL9Rl3/SPXBclpNliyZJHu2LDoatvTOh59JjfptRL/p18tT9RLD8mXulJYdBzrvedQrTTJmyBC2Num9znqf42ONOxkBpGVy/vwFGT2wi8ya95a8uOBt84oEbUye3DklXdq0OhqWpMEZ/ebfWpldtqHVHvehnuBMGNbdPGls3WWo6ENLHQ6He7awTev9tHo11YeffCX6YNVcOXNIxfKl5IlHHgxbG6wV6c9e6j7f9IW+0nPQBOflodZya6i3DM199X1rMmxDfejsjYULyKuLP5IuLzQRdSt0w/XGN5Otwn5lkHZ62kuviT44UY9frn8Dusw1aWA13EG5Li80loN//S3dBowT3a7aHg3OZcyQXkfDkux6fA9L55O5Ev0w1KR1X9m4easZwNUr3+xwfHfvRvNGdWX0lLmizzKxlumHk6lzXpf7K5ezZoV8OMXtmVT+VhiOvz89Brjf/2+Hdrm2QYOk+isuPQZNdP7Kny7/bdceWbFynZQuWVwnQ57c93fXFepxftroPjJl9mvSussQ+fOvQ+aXG655QjWuAct2PUcYx84jcvjIP2KH8xl9ntGAkdNFf4VRf9Gs3/Cpfrsfjv3dvRGPP/ygfLX6e+Oc6soHaw3uTJ71qlQod5d79pBN6y30nfqMllVr1kvTF/p5PY+xGqCBAk3WdCSHeqV4s4Z1PV5NEYp2ue/vruvQK1y6GudZ7Y2/B01p04bvodSu7ShdorhclT2bjJgwx/k5R5cv/WyVZM2cyQy06jQpOgUImCRhu+mHrkmzFsmYwZ3Nyz8//mylDB03W6pUKCMj+3cQPci27znS+PZ4hPngyyRUGZQsGk1dt36zLJ47VhrVe1j0Zzf1eSUdWz0jj9S4X1p0HGTeszpp1kJpFsZnOIybPk8a1a8tr80ZZZzo/COtuw6RLFkymk/R/m7DT9KgRXfpPnC83FG8qOjPbQUFw08l+qY1HdUJAAAQAElEQVTctvtw6dx3tOzctc+ZW+93jOQ2tBqiwRz9mTa9mmTXngPWbPOqhAeqlBd9oNaUkT1tEZnWQIneKtRr8ETzVwr0Ngpng8M0oj+J+GSdh8wrN87EnzO+7f4u0ZrPnT8v+ks5N99YMNGycM0oaqx74sz5Mt74m9D2RMJKjwmZM2WWV6YOkXsr/k8WvLnEY/f15O3QkaNG0Derx+XBnOm6v+8/eEimj+0rOa7KLk8262ZssxnmL4096HZ/eTDX71qXXY/vrm200/iQsbOlZdMnpFPrZ4y//5vNpuk3ti9PGSyROr6bjXB7KVPyNunwfAPj/Weo6Hvg6+8sM957ekjtalXklqKF3XKHZnLlmg3i6ZlU3tamXzZ06jPGDER5y5PS+frt52Av9/97q1uvnHjvoy+8LQ7ZfA163VbsRmnUqpfocyf0OKrfautzHfSX2kK2YpeKh3jY310Wi+77Je4oJoUKXC89OzYPywdI/eWusVNfkUnDe0qzhnWMYEles0mRPp/RW9JvyH+tjBrYWeZNHyZ6i4J+4282zsNLOPZ3D6s1H8o5bkgXmf3KW+aXjR9/ttr8UQQNRjz52EOeigR9nj6X65vvfjCfEzRyQCe5685bRH8kwtuK9PxBz7m2bd/lLUtQ53+38Sd5f+kKn3Xq1YXh+Dv0tr+7Nq70XcWNYEVW87NHzQcquS4K27jD4ZChfdqKXlH/bNt+oj/O0LX/WNFzq57GsSFsDWFFIREgYJIE1iPH/pG4OIfoL21ckzun+RwQvZJk0swFxrcct8k7CyaKvrHr1QDly5RIQo3ByaJvRgVvuE70snb9IDZn8iBZvuIb0Yd76U9+ffDqZHns4aoyc3x/yXdN7uCsNAm17Ni5R0rcVsz8Jl2fiP5M/YelW//x5pvU7AkDZEivttK5TWPTLAnVBSXLh8tXSu2Hqpjf9msE+jfjWyqr4tLGiXWktqG2Yffeg9Kl3xh5su5Dck2enNKkdW9Zt2GzLhJ9mOra73+w1T2P+hC+q3NkM591od/UmA0N88vvf+yTknfcYr4R6a1A+m2HPqfHaoaeXAwYMU3uq1TW+MaopDU77MPnGj9unAgVN/b9HOazacLeAGOFX3+7UWpUrSD68Ea9HaFPlxaiQTm9/NhYbP6vb+h6lYc+LNqcEcIXT/v7ps2/SJ/OLeSVaUNEH9arz8lJExeetye7Ht9DuAkCrlqvADpqvB8+8tC9ierQ95hIHd8TNebyDH2m0typQyVP7lzme7gG5p6sW/3y0tAPsmXJZP7de3omlfva9cNjP+OY1adzy5AGLfUaxZo+7v93b5ceG4798480fuph90Uhn3Y4HNKtXVPzwa8nT56WYjcVlkWzRpjnXSFfubECX/u7sdj8Xz/4Zs+aVXp1Ck+wRFe6ftNWqXxPaSlS6HqdTJAieT5z5OgxsZ6TkiYuTooWKSR//nU4QfusiXDt79b6zKHLSzEjaLpg5nDzPObvw0eld6fnRH8ZKk1ceN53DhhfFNRzuTq3eLEictCLlXU+o8czPd9x6UZIRlev3WicW31sBMSL+axfAzw/bvnVZ55gLPS1v1v1L1n2lTR5+lGpGaFgidWOHNmzmV8ANWtYV/TLoNrV7pX5RvDQ07OYrDIMo0MgPEeG6LDw2sq8eXKJRjg14mpl0g8Wm3/eYXwT+pv5YEK9N1QfZGUtD8ewjPFB/6Plq+TosePm6vQSdv0wq5dD6kMUs2bJbAYu9HYAM0OYXkqVKC6vvPaec216JU5J4xuY199eZs7TNyo9uTYnwvTyxKMPyrMN6kilu0uZJ2D6kKgdO3eba9cPjmni4iQS21Ab8P7HK2TMoK6i+49+Q9u2xdPSY+AE0Q+ROm/i8B62uLJE26op59VXScsm9eSRMD+kV7/90asBtA16yeUY4xu2/06dMrbro6L3mOvVOXpioZfWWsESvTpH80cqpYmLk2fq15amxht5OL6Jce2n7tc6XbDAdTJn4TvyxrvLzGBlmrg4GT5+tuhl3Lpcny2kwZLObZroZMiTr/1dg9LhviLIrsf3kG+IAFZw6tRpORN/1mNJ/cWQnX/slUgc3z026PJM/ZU6/eWn+nWqi95jfnl2yAb63qu36uoHwrvuvNX40FhQ9L3Z1zOpNK8GS7q1fdbjh+BgNFaft9Zn6GS5cPGiqIXW6e/+fw2WhPPYoG3ylPS9ucnTj4g++0wfrOopTyjmJWV/1weg9+78XFiuLLH6qM9COHMmXqxp1+HLC98VfZ9UMz1/cF0WinHX/b3D843k6hzZnavRZ8ycO3fOnJ7/xhLzQd46EY79XdfjL+lVjQ9Xv1caP/mwecWzv/zBWD5w1Azzy4uqVcqZV6lbdZpWZy9ZfbH6O9m+8w9zkZ7ThPp8xjpXMFdovMx85U0jeNRaChe83pjy/L9+AfPGu8uN430hzxmCONff/q77oJ5nRTpYYnVZP3PdV/F/5tVf91YsYwTr+aht2UTzkK3oZevpfat6CagGSjRL9/bNRO/H1G9oddrhcMhDVSvKDz9t08mwpZ+2bpcPl39lviHq1S51a1cVfV7IkaP/mG3QD7O33lxY/ti9z5yOxEuLZx4z2rhS9FYAa/16IPvx5/BaWevWoX5Y1YOYjmsAp1ObxvJC9+GiD45r1q6fEQn+SxdFJLVs8oTovdADR02XXh2fk3qPVpNbi90o+sySSDRIH4amJ8p/Hzric/V6m5PPDEFe+NHyldJz8ATREwh97sWnX6yRIgULmNtw0KiZ8kLzp8xnhehq9QPBA1XK62hIkwbd9ERQnx/ka0XhttKrOPSSUN2GGqzR4FvxYjfJpp9+kVGT50r50nea+5y2WX+JIlzBEl2fHfZ3ux7f1cfOSQNa2bJkkbc++CRRM9/9aIXx5UH47h3X27p2utxemahBEZqhwZFK5UsZ7y/DRK9QsJrh65lUc197X0IZLNE23FjkBjlrfHjtO2yKaFBZ52nSE3pP9///seeA7Dv4l4Ty2KDvv/phR9shIrYb2Gl/d8UpX+ZOWf3tRtEgmOv8f46fkM9WrpUM6dO5zg7puLf9XVeqX2zoLWD6DC29GkHnaQr1/q7HhUGjZ8oTTTvLhh+36iptk/RhqX2HTxXXK2K1cfrrUxcuXpBVazbI5NmLJH269DpbPjLO9/VK2VCdz+jfn54r6NXM5gqNFw1o6bOpjFHzfz1e6DNEzAnjRYMlr7z2gQzv197Y1y6105gdsv/tsr/rvvzme8vl6RY9ZMTEl0Sf2ROyTlOx7QQImHjYJHqw7TV4kuiHDf2m6MX5b0npEsVFgyZ6/+zseYtl7/4/zfsN7wnjA6I++mSlzHj5TfndCIY807qX6AFMbwUqW/p28/5LXa4f3I4Zb5pFChXw0LPgz9KDbavOQ8wH4Vq166VnE4Z3lwVvfCj6jZae2OpT7e+t8D8rS1iH+qwX1zcDXXnVymXN581osKlpgzph/9lZbYOV9OF2Oq4nO1dlz2p+s6Anavqzlzo/nEnvEf/2+x/Mb0SfN7brrt37Pa5ebxkaNu7KL5t4zBSkmXoFVasuQ+TnX3eKGvU3TjZuubmIeZvSilXfytJPV4n+Io31Sxz6Rq/frgVp9V6r+XzlOtEHSOa7JpcMGDlNPvtqrce8evIR6ucS/J+9qwCs4tii5yW4S0spUry4U6DFtbhDcScQSAiEuJCEKAmEBIIHd3coXij9SAtFi7tT3KFQ/pwh+/oSkkBp3r4FFjIrM7M7d+/Om505c+8Z04LJrxQxYSa+LpAH9m7BElwlv8StO3eklcm3orPds3NL4yU04TaeqHBg6fqu1fZdBdUnSRE0W580YwmmiJlszh6zfnsFRoEAPoHfJCnkLTchAGknAO+4nFSJXaYmoTHdflo1qQcHt5BYoAlnkTnwefrsGcaYcFI523U3m2WJohNOGAR5O8gBTuDIybFAk/Lx+P/zXVIu5fqk3h84chwe/pHo7xQgXU/fdn9aTViCwFsL9T2ubtjHcuzfRbTvIdi8bbdMJrmxg8dwtG/ZQFVrFxaeUH1n2sz5K3Hk2BnQUpagIeNYr+JzJ2Lafw3sAweNmoSObRrCtscPoHUGJ1kSu6+abQP7JrQE9xb9mLigyf5DxyXf0pgQd+OEBldlYpuRmPz/JY2A1+RIX7Bs/iZ5r3o1v4N/2AQ8e/6cp5gxf5UAno7IY8qsgCVqWDCxUK3Ud/Y9nz9/Ieqyi3Q1W7xiI8VLMFy9/qfFVuxJUCg94b01YPXeV37EFy5asV4OwPqLGevpYwNEh+chvIPGgoRakyN8cf3POxIB7t6hGWjuq5YqOOs/Zrg77Pt0RFSoJ+YvWyetOAb06gBf137YumOPJEbzcemH5MmTqSLWxOkLkTVLRnAlAJpkK4Xmz5NL8hFwacewMdNRQAA45JlQ0tXYsyPfTwy02aiRNI7mg0q5BFAWLd8Abycbi/s8KjKRu6Fx+wGS76VX5xZKtGp7Lt949fpNOaOYN09OFC2cH7lyfvFG+ZxdmLNoLYa62L6RlhQRz54/l4N85V6s53WqV4LXEBvw95cqVUr4DR8vAYFAT3uwQ1tQzJ4q+dXaz1uyFiMDnEAXtOzZPkeZEoXfKJp1kKb2nmbkJTA1p9299yAeP36C8AAXBHoNROe2TSQZtcFgwGDbrpJ/iRZWbwhqgQhL1Xettu8WeAXvVWQ+0TZER/pJs3LOtBGUyy/i2Ja+1w3f46LV67cnyEkV3+347VSL0Fgpn4NIWgsSNOH3hvHcW5KTiqCJr6uttNIjaEKZGCzh/z9LDMKG+w5G+TJFQdJ803aMMpkGDnhpgfm1AIFN49U41kJ9j+85v69dBT7iGzxt3nJ0tHFFUHg0urRrqrqrrCJbfPU9VaoU8lseHuAsJ2GUvObcT5u7HH26tpGucHVqVELB/Hlw9vylBIu0RNtA0IR9F28BmhDAp3CcSLhw+RoiglxBq0/GqRWsRP8gXdrUAsAcDXLy2PVpL4tu0t4OfR2HgRxGg/p1kXHW1tYI8h4oXchlhEobS9f302cvglw3nds1Bt14+3RtjQOHjyX49Oz7DQubiHKliiaYR0/4sDSgAybxvK/06dLgxOkLMoUdDKLhBCA44M77VQ45yA71dQT9k2UmlTapU6fEKfGjZXFcKpgfoSUrN0nTvkrlS8nBEAeVtE5gHjVC3tw54CVABwI546YswPotvxiLpa9xv+7tMFrMpKnNd0Ehxgp5uvzQFINsOyPnl1+AA9zZC9cwSTb2rg49QRItGWHWzbvdvGXjOti5fjaWz45EjuzZ3u2iJMzFzvzLly9BE1YOKn1FZ4w+3COiZhhLIVhi7tmFFWu3Gl1vWLCVwUquFsRjg8EAu94dQCLTqMlzGWWxcP/BA1y/cVPMxEyE26Ce4CwIl1Rk555C8YNJsMTZjLwE/Ih3H+AFlsUyDQZDrKXrCFKmEgATLVwUuZhPC8FS9V2r7bsW3sm7aoiIRwAAEABJREFUyvBVruwCtPfAomkjMW9yKGixRJPyd73+ffOx/eG1bd7CScU8SuCAiDwc9mKiQYlTa8/fX9vm9eHoFSatKDgjywFR+nRp1RLhjXIMBgMU0IQWhczQpV0T0G2Wx+YMtEjlgIxl+LkPQIUyxcEJH3Kc2bsG48HDR0yKtbwq2y1aCdAtoUqlMjJd7Y2l6vvbnpP6mD0hGHMnDcfM8YGoU73i2y4xa3rc+k4Lj5EqgSUkH2Vd6dOlNbh6i/KgWTJlwLNnz+VpXFDOkm0DuZ4ImngERMiVG8mvN3NcgGpgCYld/cWAnpaxI8fOlBx+oQLApHX95as35EpHE8N9ZFsx2LYraLlLJRK0ZDvGY7WDJeo7XRPZv8qfN5fo5/UyPnLWzBnxzITPi1aPSiLzK30/tcEvRQZ9n/Qa0AGTeHTarGFNTJ+3IpZ/qH2fDpi/dF08udWLatfiewwNjjJ2Kmje26tLKwEEqCyXySM3b1RbDtBIphcZ7IbRk+Zi7cbtoK/f1DnLTXKqf1jjuwr47pvS8AwYg05tGsGhX2fQImbV+p+kMGqwjcuCNL4hmfHuvYeQP08u3Lv/CBOmLYSf2wBppRQxfjaKFc4nn4CdkYUr1sPcswscYKRJnRpuvqNkPSJXEGeNlI720RNn0bRBDezeexh0t5LCqbRRdMXiyFPQa6AvXB16IHu2z2S956CRICvTp4k2xJxgCcsokC+3HKzaOgWAPEaczTh68gxWr9/GZFy7flOuuFEo/1egpZWM/MQ3Wm3fP/HX8tbHf/L0KYIjorFoxQa8KyfVirVbQLDEnDwcbxOcg8jG9aqBrglvy6tWusHwGjR5/OSZdC1Wq9yLl6/C2SdcTvKYDroIZpUqXgh0syLXBXnFXr16BXInKGBJXRU4qdTSw7uUQ3e3zdt34cKla++SXTN5TOs7Jxrp8qGGcEtWbQL5efLliU1UmjxFcmnlcvHyNXS0cTMukqCFtoGgia9rf0RFz5EqIgmtPFBhU6FscVy8cg3s43GilUUWL1IQBE3c/EaBK+nlz5sTak3AarW+001pgEsg7j14KPvI1BND8hTJ8OLFSx6K9zcP0bOWyGPyVnkHj4W5+36yMH2jqgZ0wATAoT9OonNfd/Qa6CO5OHLlyA5aH5C/hB8svpG0aVOLgYe6s0IcxHJGhuUz1K/1HUh+ZDPIF5xZZhwtTVKlTMlDiwf6PI8N9cSYSfNgO8Rfzr6z02MpwUhmR3/W9OnSgPwWlK9di/ooW7KI6iKR8by/cyA6iQ82GcgTEkBtn8edvx6QAxBX39er8gR62ePJ02ey49qtvycKioF2o3rVpbgEAoK9B0nrHBlhpo38MOXNjYPid0mf0dw5v8CA3h3Q3ykQdK0aP20BfmjZAOXLFDNaVphJlFi3jaurfj1+QLnSReE8NFyarf76+x9wtu9uvMbZrrvZeQkIYnH2jIOPAc4BAkx9jEDPgZg0c4noHLqij2gr2rdqINsNcpgYhTPzgZbqu1bbdzO/gve6Pb83cTmp3nYj05m1t+X9L+nkPxg3whtLVm0EBzum9+LMum3PdpIA3ZSTirN7lgRLFBmbNawF254/KKea2BsMBunm+F3FMqrJUyh/HpC/gbPYR0+ciVUuZ7G/yvUlSNYZ6DXQyMPRTkwUmQss0Wp9Z9+vt4Mvdv56EL0dfHDk2OlYuorvRK3fYXxlx42zRH33du4rATa6mhFoU2SytrISoOktOLgPh5P4JmfOlEEmaaVtKFIon3ShlUKpuEmVMgWqf1sBxYvkB93mlaIJ4vh72GPv/sNKlNn3Wq7vzRrUBPmoBrqGgGCIogxrKyv8LUBdclry99m/VwclSdSzbmbv+xkL0w/+kwb+zcWfPGBCIrHIiXMQNswRwUMdsG7TdpA0kX7+IeJ89MS50r+W5qK2okP2b5T7X/IS1YyPEI1+hM0a1kafQX6g+X/kxNlihll9vgv6Ybv4hoODf8WMls/7Va7sKF2yMPLmzinN1wwGA6MtFrJ/8RkOHT2J8VMXgB/SBnWrgoCYmgKxjo2Mmolhbv0xZcwwrN/8P5w+d/ENEWjGp6bP45af92DOojUYMqAbAr0HIjB8Mm7dvosZYwPg2L+rNLnv0LrhG3KaO2KwRyi+yJYFi6ePROZMGWUHusZ35bFq3hi4OfTEzHGB0pqCJHfflC1hbnHk/ePT1YnT5wQ4YQ927r2dbODj0k81P20plNiMmTQX5y9eke+qnQCRaPqfOXMGLJkeLldcWjhthAC9cmO2eM/NGtQSV5j/T0v1nbJEarB9N/9beL8SaIEXHydVQndTk/yZMnCCgPxdS1ZtjgWa0J0wPk6q8mWK8zKzhrPnL8vJlpui7UysILUHtCSF56RPYjIxTW25yN/gJ76F5G8wBU04ucHzqFB3yT9B2egGwPw8NkfQYn1//OQpRo6dLtt0zvwPsu2MVTEWgwnpgNa8y9dsTSg5SeO1Wt85oRPk7QBOIrCvp4Amr8SgNmzMdNmn4TLaijLUaBvYN2Y/me4vSrnx7Z89fw6G+NLMEUe+QZJ2k48jeOggsM5FTJglLXrZD+TiA62b1jNH0W/ck2Vrub5TYPLzcElz8lEpoImoVvhDAJkHDp/AqEAXY98vU4b0krOR11kg6EWaUQOfPGBy++49WFkZQLMzsvyPGOYkLUkiRePBBnXprAj06txS/iAqVyhtxlcR+9aJEaJxELty7mi0aloHE8KHSneA2Feb92z9ll8wc8FqcAb96PGz6D7AG1xRiKX+cfw0MqRLB/fBvYwzRIy3VGDjNcxtAKytrcQMXztjR0xNec4IcCTnl9mQScxsBIyYJHVTIG9ucMCvyEGwxDvGjI8zH0p8Uu5N3Ul43/2HjqJNs/qSwKpKxTIYaNNJgoOnhbxFxKxHehX87F+8eCHq0iqKIwM7DZz1oz89OXCc7LqBriaB4dFIlzYNShQtJE2UJ89cIsEKmvzKC5N48666oiUFeY3UAuEWLl8vuRCUx6X1BGfUqRtyglT/rgI4E/L02TOULFZI/AatJMeKQ9+OoNuccp0591qp73xGrbbvlE2LIW8inFRx5SWfyJxF5iN/jlueck7QhJxZBE3of894WljRKrRRjDUc49QI9+4/FIDueNkWUa6EymT7Th4htcCJA4ePS0L48ACnhESS8WoOtGWBMRuCIIGe9iBociZmaWi2T5y0ohVKTDaz77RY32/fuYv6tb6T3zsqoFjhgrh+4xYP4w3k4SApZ9f2TeNNT8pIrdZ35RkJmij8PARNGF+1clkMcx8A7nmuZmD95nc5sbIJ8LgPi8Dxk+dUEW333kPYd/AYundsLsuzshJ9BI8BcvUsWtoXL1JA1TFF4vVdihhro2Z9Ny2YoAndxQmaEKBPny4N2jSvh/BAZyNYYppfP/74NGD18T3Sv3sish3fvXcfHCApV9Kf9tAfp6QZpLWVFfhxZ4dMSVdj/zZCNA6QShcvDH4g1JDHtIyfd/6O0cGuOCoaeDJrly9dDPTx4wwbB7Qejr3FQM2yliWm8nLgaNOtrSSYM40397FCMJYzxxegxRB9sRvXr4aK5UqC7h3zl/4oRSBirYAl+fPG9r+VGZJowzocMGKiXN2CtyzydX78vGsfD2UoV7ooCJTQD/jJ06cyzuwbgwEPHj4E6w55b8gUnyJ5slgWOJUrlMJff/1ldL8hQBER5CpJVs0lnyZ1JR7WYDDg0pXrUAZeJYoWwJZtu0XK679vvykFzg5xtpYxqVKmAHXF3yXPzRm0Vt/5rFpt3ymbVsLxk2fhGTBazsw2f0dOKoIl5iZ/Tkw/rOMETWYvXA0FNFGDk4oukz9u3mEUbcPW/6FOjcqgJaMxMs4BwRK2755mXCkrLpC6YNmP6Nu9jeR6iSOO8dRSAw9FAJr+EzTxCIiQpJdpUqdSZUJDq/V9wbL14DvJlSM7endpragJaVOnBCcWGHH+4lWs3fQzD2VgfnNy9Gi1vsuHT2BjMBgkUSmBCJIa0+UsMcAigdv86+i4ujpz/pKcjP32m9L/3CvOEWVkv5BAr7naL1q3cGJHKZrW1oNtO+PRo8eYNncFnH1G4oAAWG17/oB5k4ejhfgGKHnNuddifX/b85Kfp20Mifez53/JBQjYZ33bdXr6x6GBTx4w4Wt0GdhTznQcOXaKp3KwT6JJNiIywgIbDtiUYgnglIqHEE1JV3vv7WwjBmyPEC1m+blCTse2jZEmTRps/XmP2qLI8n7Zs192NBQrFxkZz0YZZMaTZJao4FHRmL1wjZwpatfie5w5f1l+QLcIPU2ZvRT9erQ1lktLivxmBEtYULHCBRAhgC7f4eNBy4QGtauAH3kn7xHYuuNXuPiEo2HdqihTogj27D3MS8weCPhxlYS1G36GV+Bo0Ix2sG0X2A4JkLqj69f2nXvhMrAHPv8si9nlUQrQoq4oGz/WL168hM1gPxBo69W5NWYtWo3hkVOxW8wcsQPdvUMz1cFByqaV+n7l2g3Jy0MgnHJpsX2nXFoJBfJ/hb9evBC/vzHy96fIRc6nsfFwUrGTv1AF8mdFjoT2BE1INM7VChLKk9TxKVIkB8kjFXAwpQAkT5yKPTPMNv/a9ZuyaAUscTbjSlksyGCIDaSmSJECCmjKdAauhME9A9sJcw60Wca7BIImAR72SJ06xbtkT5I8Wq3vdWpUwvK1m7Fi7ZZYz5ksWTL5u7x05RoGe4YKACW1TCd4clm0dY79u8lzc2zeVt9ZpiXqO8tNLBgMr0GTCmVLJpYtSdPi6ipF8uQ4d+EqnovJHqWgvfuPgP0/nrMdJVjC1Z/qCtCVceYI6dOnwYlT540rT5UtVUT2r0i+zDaeFjALlr+evDNH+Qnds44G63tCsprGEzTp2akFrK2tTaP1409AA1afwDPGekSaf5J4k3sloUKZ4mJA1hODPEJBAp9LYgaXTO3fVSqrZFFt/0J0XOnWwsbUtNDBtl3xVTyEaKZ51DpOKTpjf966g0wZ0yO5+Cjs3X8YrRrXBgdzasmglMMZhN2/HZAmcX0d/cUH6oqSFGuvpukxl7frauuJrFkySoLChcvXo50ATDhrtGj5BgFWvPZ55MoqFJJuQwXy5uahWcPS1ZswLHQC6LbhFTgGR0+cxahAZ+TNk1N20lo1rQf6aV7/8xby5cllVlmUm/O3RjLcDm0a4uXLv0HCP1p00ZT8yPGT4Cx2t/bNJOikXKPGXou6YtvQZ5CfAI4yy/o0wClQAnCTI3ylSqbNXS59Z8uL9kxGqLTRUn1nu+4+LFK6CJK/YfLMxShfuphm2neVXsm/KoagJX3/2a7TjJ2gpXKDr+LhpGJ+NcifKQPBcFN5GGcaCJqULVXUNMqsx1kzZ0Kfrm0kuLRoxQbUFQMdulay30Az7T+OnwatTtKlSyPlUGOlLBbEb+8LEyC1s5jEmDR9Meg+S8s9zuY+iFmyV42BNmVieCH6M7vE95nHCYJI5uMAABAASURBVAUSi9MlOqH0pI5n/U2gvos+VnbE5WBjfjXqO126XpMavwma3LpzV4AlYeBKf+TXo0442HW2685DswWt1nc+MH9rd+7e52G8wWAwwJSzJN5MSRgZV1d0rS76dT54iO8RAVQC+GOi54Pu2Sx2zfptMDdYwnJKFy8sreDobsOJMoe+neHjYouJ4UNRu1pFnDx9AYXy5WFWVYMW6zsVwN/akWOneZhgqFS+lBxzJJhBT/goNfBJASbsOAwbMQHlyxTFIM/hOH3uH+JNNhwceFz/8w5GT5qD7mKWNm/uL1V96bRo6Wnvg6WrN6NtjyGx3IQ4W3T0xBlEmRCiqSpcnMIKF8wL+vBVa9QNJJdrVK9anBzmP+XA/qqYyeMMCwf9RQvnR66cX7xRMGfTzOnjq8w2KgVHRc+Dr5stKNesCUFYtmYzlotZozrVK2KEvxP4wUqfLq2S3Wx7U7levHyJWQtXIzrSD0MGdMXYMA9pVUUCN7veHUC3jVLFCoLLyVUUHwMOlMwmWMyNuWzdIjFTPdCmI5KLWTSSj7GDHTQqWnKVsJM6YaQ3aFIbc4nZdlrXFXldyNlQs0oFZPssC1o1qYvWzeqCZNSpU6UE+Ruoq26i3TKbkmJubKorRmmlvlMWpT7179Ue08cG4O79h6Kej5UdQ0u375RPq4GDwri+/5SVg5IMFuKkGjV+lnQ3u3vvAUVJMMxbsg7mth7k/Ukeyd8hAUIOOBav3CCtKscMd8eRY2fQpIMdZsxbgXEjPI0ALwe05rQcVEAQ9h2+LpDHCKR+kS0rAr0HYtaC1WjQph/u3LsnBkn9pA7VGGizoGfPn4OTUIeOnuJpgoHEzNPmrkgw3RwJWqzvfE4OIlmf2NYrrmbJklnj2vVbGGjTCSQ/Zz5zB63Wd+W5qZsJ0xaB1oRKXHx7S7YNazZsh4+rrZjgyIJOfd0wyDMMQ536gX1nytq8UW0QcOWxOQO/13TN5QqIHgGjceL0ebANuHvvvhzr3L57Fz07tzSnCAneWyv1XRHw3IUrcPEZ9dZ6RcvslT/+pFym7z8RDXxSgAlZNRrVrSoHsk4CmXdwG25cnpfvm9wI3k42CPV1hJqzViybnYsJ0xchyNsendo0xudZM8PFdxT2HTzKZEnYqDYhmiw4kQ1XB9m5fjb4gafZaCJZzZLEGb2XAgigjjhQ8hWo+ZMnTzEiaoaxPIIl5jY95qpKNEtVCrUyWCFNqlTylFwzPTq2wLgpC7B95z4Zp8aGHfsedt6xCEIpV/LkyWTx9JOuV6syaJZJ/hBGpk6dCj+0aoiOKq2MQ9LZpas2QzGpt7ayQoCnPf5++TemzF5GkVQJH4Kuzl+4LK3fsmbJaNQJQZNWTevCVbQTxkgVDrRY35XHTi9m9k+IGTOec1DEASvrPGfYLdm+Ux6tB4PBAAU0oeUe5SX3jYcKnFRcKcHUkmTv/iO4dfsevJ37IkvmmDpPgeIEtu83b99BhvTp4qQk7enkmUtBV0Y3vwhpYp85UwZMGDkUcxavAQGUyGBXbF0xBcNF34FtftKWHv/d6ILaroeT5CGYv2wdxOuLBaRyYDZ7YjA2Lp2Eft3biXT2gOK/V1LEcmBmep+Z81eKme1K6GPCx2GazmMC+b7Dx4FgD8/VDAaD5ep7Ys9Jqyn2qWaLCQ4CA+nF5MqKOaNR7dtyiV2WpGlaq++mdYvH0+YsF5NPQ1C8SMEEn1sLbcNPO36Vkxmbl0djepQ/zAmexqcIThLT2nmfGEdQVyFDHeDqNwpnzl+SoC7bd1qvx3etWnGWrO+sS6bPGTpmGrgyVb2a35pGxzqmm6Waq1nGKlw/sagGrCxausqFkw2arhEslqZ6BE1otk3ElYNGSyOGnds2Qdo0aeSyxv4edmj6fXVwMHT67EWoRYhG3Wg9LFm1UZrc58+TC/fuP8KEaQvh5zYAHBhFjJ+NYoXzyUdQy/TYY3BvrNv0s+RNYMHNGtWEj+gE0rTv1atXIMlc3+5tMGrcTCN5G/OZM3BGYXKkL/YfOg4SznLwWKVSabliCsE5ls2ZvQBPOxDl5zk7+uVUNG8nuZhdn46ivk+WgxDKYDAYQF6cVk3q8FSV8CHoir7+I/2d5IpCprNqzRrUFCCTnSp6UgrRYn1XZGvWsCami1l+/uaUOPs+HTB/6TrlVDN7LQpiMLweRD5+8gz/27NfNREXr9iIGfNXGcv748TZNwbR5A5he6pk4oCIYDg5vpQ4c+3792qHXb8dlKADXbxYDkGT8SO8JX/WbwLgYZyagZxO7QXATXcg9h2USQtLAalegVHyW6PogBaxcYGQS1euKckgWKJwOFSpVMYYr+aBwWCZ+v62Z+QgMjLYTVob375zTxJ5v+2apEzXUn2ne4RnwBjj4124dFVabZAjRInkwPeOiXvOp942UC9LV21Cr4E++Pab0vAOigLdcQiaBHs7wH1YhJhMeyotL5nX0sFS9T1um3X23CV8FcezwLTNIljibebVLC39LvTyE9aAVcJJH39KzaoV4DSgGwa6BcuQLJnlSHzoP85Ow9qNP6NpgxpyqdfcOb+EbY92yJ0ru+ovgzMbvR180KGPi5GkKj4h1DRNI1pOQrTla7fKVXkISAR62ePJ02ewcwlCt/6eoD80GccpK80OOcPMY3OGm7fuoULZ4ggXgMjilRvQqG41uaRrm26O+KGXE67duCXeaU0xC5pWdBL/hlr/dosOfto0qeDhPxo0rR/Qu4MAmB6gRScH9Bnkh3MXLoP+rWrJE185XKqtRpXyoOm2Qo5mMBiQWczgxpffXHEHj5yEtZVB07oqU7IIPB37wNErDKagSaaMGcyllnjvm0B9hyXqOwfRZ85dNspJyym6JxEI37x9l4xPmza1/O3JE33zVg0YDAK0HGKjiiucIkzndo3RXIBdtCxjO1++dFExWNwEtvHMQ+uToaKjela0WTznd4BgCd0eeW7OwIH9k6fPwW9NypTJETp6mrE49hloDcDfpjFSpQMOpL8pV1zMtDuBHX+6V7Jo6q9ezcqqA6m+brbSMpYDNcpRrlRxRM9aJr55L3mK63/ekjwcPOH7VMCSujUqM8piwWBQv76/y8NyEDkuzDNRC6t3uc+/zaO1+l68SAH4ufcHrQRZ5wvkyw2u+kKrCeXZpsxeCqW9V7NtYPkPHz3RXNvASTG6YE8e5QNn++4YHeIm+jaRIIhZpFA+kL+E9YvyayVQHrXre9w2q1iR/JhpAtzTKpzW4dQRSfYVsCS/mRdoYHl60J4GPgnAhLNSJGhz9AoFB7TsUCivonzZYhK979yuiRzoKvGW2hculFd+GCZMX4g1AjxpVL96oksDmkPO0+cuyqUax43wwlDnfpgwbYHRAsC0PKKtapqmjRo3C+wws1Ft1aSe5G+gdcCMsQFw7N8VUaEe6KCSO4mihxs3b8MzIAL1a32HBVNGCHDpV8lXQl6QedGhCPJyEB/TgaA/Kz9UlFe51pz7tRu3C5DkDEigGuo7WMwoROLy1Ruycx0V5gGbbq0R6jfEnCK8871bNamLBnWqiA/Vyne+JikzcgZh7uI1KFGsEEKNutKmrjhD5OvaH+R3SEodvOu9bmiovtPP3k4ApWzXz5iAJuSjounx6IlzBRAeItsJ257t3vURP/p8HFhz5pFWlYk9LPWbWHpSpllZWSFDhnQ4fuoshorZULaVzRvVRmcbd0RMmCXarwi0aFQLtCpkuSRUdDTj6iAsg4HWnaxjx06cQYUyxUV7PlDMzD5BWNR06S7r4B4CukzQgo/51Qr+YRNBInNOEFSpWEaCIx7+EdLCg8TeP+/cB7WBVJKXc3UeugctXb0JHds0lOro0s8d40Ufwn/EJNDlS0aKTbsW36vC4aDF+s4+6eRZSzBm0hyhicT/1PwdarW+s25RS/2dA+QE2VDnvnDxCZcWs2FjpuPRo6doKfoRzKNW2/Dk6VP0G+IPut1oqW2gDhgI5iZP/toFu0De3KhSuZy0NLl2/abqbYNW6zvrlWmb5WzfA6vXb4OD+3BwDLZ4xQbQEwEx/9RYzTKmKH2nQQ18EoAJSSRpCeHq0AtTZi+H89ARIIrO97Hqx23o1qG5JsASysOGt0fH5rASsx7s9Ks1wGbZStj92yFUE43r/fsPBViyCOPCvMAGj36PSh6CJQrayg+UEp+U+yWrNoLlKPfcf/gYuNIMO6jtWzVA5QqlYO8WgsdPnoIdbMYrec21Zz36cfMO4+1Pnr6AcqIjzVkQEqWGigH3xGmLQMCCq+CwQ8sGmNYcpg2v8QZmOJizaA3mL10vdNVKmpAXL1IQoUIuErqSaLWA+Hh+U7YE1O7kJ/aodC3hu00sjznSjhw7JWdnf2jZQPr0fgi6Yl0PUwns0nJ9X71+O5o0qIEhMVaCpwXQq9SR8uI3uXRWBHp1bolRgS6irSitJH3S+3uiTfcLHY9AT3ujK158Ctmz7xACR06KLylJ46LFoJEDQgKABCWChw6S9+dqWfwOhvo5ImuWzOjZuRUIoMhEseH7Fbsk/3v46LHxnrSCoFx0hSPxNE3+L16+jmHuA5A7R3b8uOkXjPR3NuY354GpXFyFhyTn7LzTLYHuZ/zOhPg4YvGKjahZ9RsJ4JtTHuXelIsDfw4eXX3DpevwxHAfLBJy0EqVq51xVaFMGTLARwxy2b7yWgJkBPN5bM6gtfquPOuM+StBgnN7m05KVLx7gmLL12yNNy0pIvn+lPtoqb5TJvahuALV1h2/gtYStEZtJ0A2O+cgSQo/fSw5QXKB/UDyLFlbvR7OmKtteCz6mdQRYv7R/XugTUe5OiTdm0+euQACgmq3DTHiyB3bKL5TWqzz90UwiWMd8rTRlalbh2ZismWmzKvmRiv1nc9M/STUZh08cgKsV9W+LYtcX34h2ncno4UXwRX2nXkPPXyaGnjdwnzEz87OGIlBB4oP0yKBFnZp1wRXr/0JT/9I0NKE53Sh0JIKaK1g060tOOBWUy42JCwvT+4c2PjTTrnEq/ugXvgsa2ZMmbUUh2PY7tUyTeOA3tYpwAiacKC4fedeighu6E5CwtDgiCk8VSWkSJEcFy9fg6IrLhu3b/8R4zl5QCoJIOfE6fNGeZp8XwMk1lLQfmOCmQ6+r1MFT589xZ69h40lFC6UD/4e9ti7/584Y+InfEC9fP5ZZphyEDBO19XrSqHl+t6meT306NgCJEN0tu8OknifEp1WSs7fp7WVlbSwSpsmNaM+ybBj1+/SfF15eA6269SojOxffKZEvbH//eBRzFm0FkNdbN9IS+qIv168QOtujtJKgwSE1lZWCBBgDsthZ79ksULgN5oEpowzd/Ay4eHgAOnW7TsgqDosbAKGR06B27BR2Pa/vSBgz0EazcjNLdORY6dhyuFAs3r2adZu+hm9HXywUIATNoP85MoX/h52qCUAE3PLpNyfwMehIyfRrONAoZOGEjDJnCkDuGIXgXsOdmlZAcNMAAAQAElEQVTxRctPcq4o15lrr8X6TmBk5oJVsR6Zkyjs48WKjHNCHg5zru7H4rRY3ykXQ7p06aT76cp1Pxkth2mNyt+eg3uIAFIzoVPbxrL9Z35zB4KRM0zcNY6fOofbd+5j6uxlsHMNwsTpC+WqM5RPrbbB9JnpPtLRxg3sM48aPxMD+3bC+UtX0bKzg1x1s2qlsqhdrRL+vHXX9LIkP9ZyfefDvq3N+vX3I2jTrD7Yb1erz0659KB9DXz0gAnZ810deuKX3fvFwPsuOrZphLYCpb55+x6UzjVU/EcketX6n7By3VbwOKboN3b0QWR4I8FMEQSPFDZtcqnQsiVjhvS4eOUaFi5fDwIAjetXN5buZNfN7IzfzRvVhk23NujvHAD6rvYVx1GT5yFy4mys27QD46bOh0Pfzjh5+pwRsDAKaKaDrJkzgTNmXoFjxCzaBok+N6pfA90HeEmZNm/bjYcPH2FQvy5mkuDttyWJK2f5ZohZrJ2/HjBeULhgXrRuWs94rh9AWtmE+AzG3bv35So0ik50Xb3WhJbrO2fXCapS0hpVKmBw/64Y4BKE3XsPoae9dyyeF+b5FEP69Glw4tR5EEDi86dMmUKcn+OhMcxeuAY002YEwZLp81YiyHsg1ACa6tX4VvJO/fTLr0YZDYbXRJyUnRYClEutYOrTTvC7X48fsGbDz2jZuA7YTjQRbf2du/fUEkeWQ+tFUw6H7h1ayEmfmzfvYnSIO7yG9MHzv17IvGpvSEZftXJZ5MuTE6vWbzMWnzFDOrl63pFjp4xxahywzmiuvov6/ODhQ9y8fVdO0lEP7PtdvHydhzJwYm/yrCXymBuCJWpw9GixvvP5Gb4VE09fF8iLU2cv4Oz5S4ySgQNZ/h5Pnbkoz9XaxOVZ8nbqi/VbfkHOHNkkJ4iNmOQkgKKWPKblsJ0ksfmiaSMwa3yQtJaNnDAHY0LcMDLAGVNH+6Fdy+/lCpK01DG9NsmPNVzf+axaa7Mokx4+DA1YmUdMbd01ZYoUEmnNJRo2mtTtPXAUNJ3joEhNSYm8OnqF4eHDJzh97hL6Og4THZ2/3hCBJnRksT5+MnbH9o2MSRSxdNWmN9i0g7wd8HXBPJi3ZC2eP3+BcNHoWlu9ri5qmabR55mrzxQplF9yERDtnTp6GO4/eIxtooM9zN1OzDJkFLNaqeUHIonUkehtLl25LgCcQPBjST6cNRu2yxnQ3l1aiY/n/7BanDv065zoPdRI5CwfyQgnzlgMU9BEjbI/tDKsrV7Pal+++qcE4z40+c0pr1brO12Frv95K9aj16leEeQqGeQxHN07tkCO7NlipX+KJ7TCo0VJ577ucpUEEmzSzH3SjEWSi4Nk0LQ6SZcuDfjdWbhiPYJUAEvoakkLEisra4wf4QW65A3xHoFnz5+Dnf9VP/4kl8LlwFvN98Zvm6lPO4E4P7f+ksSb7eiefYdRp3olNUWSZVEuHnDy4BVewX1wb3Rt3xTJkyUDXS27tGvMZFWD8g4rlCkB8p09e/Yco8bPkjKwXnGSRY0VjGSBMRst1neCugN6dcBaAbx5BY4G+6Dd2jcT7y1c/iZ5HhwRjS8+yyKfQq3V/VgY65XW6jv1MUOAtlt37EFEkAsCPO3g4T8a1AtdwwkmcfKO1md8BrWClegnmPIsESSkRdf3tatIcD5iwmyQC1ENeeiG5xkwWrbZLI/cT9mzZTX2gzmpx7gLl67h6wJ55KpC5AAsW6oIKC+vMVfQcn0/fPQkSNrdonFtzbRZ5noPlrvvx1uy1cf7aLGfrFmDGtLNpErDrpI4LnfO7LEzqHC28addcuUBaZ6aNYs0j+MsqWnR7LSSPb5RveooVfxr06QkO1ZmG3lDdlBnLVyNyXHYtI+fOoeuPzQVQImL+Ag0Bj8WzG/OYCrX3v1H8PjJY1k+fcZ7d2kNO9dgcMULbycbOdtHs+Qh3iOl6aE55VLuTf6PRWJAMdCmowBqMmHCyKGYs3gNOOBoUKeq/LiPCnSGJeqWIqPpnoON0cGuAlBKZRqtH8ejAYPh9ax2uVLF4kn9NKO0WN9pCRccMUWuSDVEDLAJqnK2lm/o0eMnWLR8gwAzbTTDSUW5LBEePHwki2WH+e69+wj0soeH6GATACOQeuTYGTTpYIcZ81aIjqOn7GizoxvsPQjmtizhgGj46KloThLXmNUG2rX4Hk2/rwGbQX5w9hmJbJ+/HjzKh1Bpc+fufWlNqVjoLVqxUbbtLJ5WSyQyHe47WLoPMU6tsGTVRvx58zY4M0w92TkHSbCLvwXf0PFoWLc62F9QSx6WE/cdsu4EeNrjxYuXcnJjbPR8ZBcDOOZVI2ixvlNHSp+G9aeTALVevvxbujq3bFIHLRrVgavfKLTpPgTf16qKZg1rSVWptbqfVuv75JlL5O+frulUCEEwAhPu/hHganqs94xXM/BdRsdYAJnyLFEGAodBo6bAzaEXCE4wztyhQP6vQHdGr8AxEoArVrgA9h86DgKVStlffvEZrK3/GeLRbZXAtJKe1HvqSMv1ne9p6pxlsOneRi6k8c5tVlIrSr/fB6uBf35NH+wjvJvgNK/lKiY718+WRIDvdlXS5mJj8uLlS9AE+rmYSaOJ36E/TmLRig2yIKYRLKlVraLZ2ONfvHgBzjbuFYCELFRskiWzBq03xCEK5M0di00bKv07EsdPO3ny5AKksTaWXrNqBXA2hB9MJZKWQ8Pc+6NcqaJKlFn3+w8dxdJVm5E1c0ZZTuZMGcTsqDc44/GbiT5lokY2GdKnkzwOGhFH02IYDAbV/KE1rYgY4bRY3+nKmCljOpD0lpwXJAplR5ptJwf6rg49VR88xqhLUzubwcNAE/+g8MmiHbUCyTZDhjrIAdrjJ08RKYDUrSumYLivowRLzC38wuXr5SCf5dA9Nu9XOeTggu2md1CUXC2kUb1qCBs2RIDkzqhcQV2S3nMXrmD6vOXSQoLtOdt2hYdjy897UKl8SVnn6KrKZ1AjcGDIJVKXr92KAS6BconlVk3qghwJ5HBgHyJQgBT8NppbHvYbTHk44nuHUZPnYsiAriJ0w+jh7siVQ71JKa3Vd76Pn375Df2G+MsZbVrbWFtZIXjoIAEqvUDQqGj5HtcuGIelM0dBjXdImZSgpfpu2jawj7z3wB8CBKwKAvYjx86UK7uwzzV1jD/cB/WSFr3Kc6ixp8XbrAWr5eqVnv6RskiCgzwIGzNdcvxFifrONo1xagQO9oO8HcA+cODIyXJSzGVgdzi4D0dQeDSotwzp04vf4BdviGOuCK3Vd1qhmi7QMHfJWslNkjF9Oqxa/xOcho4ALRmd7btbpM0y13vQ72s+DXwygIn5VJj4nYm6Eplmh57mvYsFOHLl2g307NwS7Liywa1UvpS8yZr122BOsISFJEuWDFx5wHf4eGkOygZXC2zacf20SxQtiEuXr8kZP8rNkDp1SowQHWoeMxTIlxtffvE5D1UJLRrVhl2fjggQH6jnf/0ly6QVB2dsy5QsIs/1ja6Bj0UDWqzvWTJnAs2NZ8xbicwZ08uB/+8Hj4GdRurdXFZ5vPeHFGiFRzJCru6SLcbUv3iRgggWnWy6e3IQoObzGAwG0LqFXA358uTAjl37YTPYD+R8ohsVLV7OXrgMysrJDTVlu3bjJkjmWr9WFcydNBxc3WXJqo1Q2vYjKvNwKM9OE3rqZFyYJ1o1qSeXx6a1kEU4HMT7e2DCw5HYO6SFhLWVul1LrdV3vsPaYuKLHFA7dv+O5g1rMgrWVlbgYPvvl39jyuxlMk7tjdbqu8FgMLYNqVOngpXBCv0c/RE1eQ6a1K+GL7JlxdYdvyJVyhSIh6zarOqjC5C9azA+/zwzyA9CIlrfkHFgPN3606dPI10IzSpEAjcnaEIZOLbg948g89Qxw5A7V3Z8+00paWmZwKVmidZafU8RZ4GG4kUKYczkeehpPxT37j2Ck113zIgh8bVEm2WWl6Df1KwaUPerZsZHGTtlHrrbeUsujjPnLidY0v/27AeXjkowQxImsFNqikxnzZIJQ537YtdvB8GZh/5OAWIA3h5fiQaOxTYXA3L6mPPYnOH6jVsoLgCJge4hoE+fY/+ukuNFbTZt02ekrv44dlpG9XcOwP2HjxDoNRDsuLbtMQQdbVxRqnhhZM6UQeax1IZm0TWqlJemoQpokj5dWkkeaimZ9HJ1DZhLA1qr7zW+Ky9/a6s3bJOE0GxTq1YuJ2aO6plLBR/cfe/cvQ+u/EQgd92m7dIVVXkIugtODB8qwQAlTo192+b18eLFSwmSpBPtZXSkr5htdwAtgsjD8eTpU2TP9pkaorxRxtETZ6UFCUH7fHlySlA+Kno+uApNBjEbqTYPhyLg/sPHQFdUfl9oVVK5QinYu4WAs/BqczhwcGbKw0F+IK28Qy3Wd75DEtV3+aEJ2rdqKGf+OUHGeO69nGwECFaHp3GC+U+1Vt9N24YHot83boQnPIf0Eb9DJ+TPmxsXL12V1mjm18ybJfC39gqv0KhuNWTKmEESLBP4JUBhMBgswrNkKqXBYJB8jARNwsfNANv3Lu2aSNd/03xqHGutvhOs5OQK3ZZoxV+nekWMCnDGpFE+kmbgxp+3kSuHehY4arwDvQzzauCjAEyWrdmMNKnTYHqUP2pW/QazFq6KV2tcAWDBsvUoXChvvOlJGUkEOj5kumypopg/JRTkwZgU4YOK5UomZbFvvde2X37DgmU/YrBtF4QMdUBgeDTOX7xiGTZtE2mjoufh6bPnsfy0CY7MnRwqPwiejjaqm2KaiBfrsFWTumhQpwpmzl8ZK14/0TXwMWpAi/WdQAnJ22gtUap4IXCw+zHq/t8+E12WQiKi8ejRU1QoUxzjR3pj9sLVcvBP03fOsLHj/2/v+1/zc+DBd0QOjgFOgdLvnh3avfuPwG1YJPzcBpidOyWhZygi+gN79x8FB7LMkyVzRjngmD53eawlmZmmZihSKB+279xrLLK0mDCga0JwxBRjnFoH5DojV5ApDwdXm3jrOzSzgFqs7wT/OCG2eftu+Rvs2Lqh5Och4T+54eg2QcJq9m/MrJ54b19EY/U9bttALioO/M9fvAqnoSNRv3ZVWMqCl2AlXd8oC5VpMBjExN3X0j1u6apNjLJ4MBhegyaPnzwDJ4TVFkir9Z31irrwcbHF4pUbsGbDdmT/4jNYWVuB7cakGYvFpKw9s+hB18A7aeCjAEx+2f07GooBLAERms8SnT4nGlvlB0NNMG36vJUI8h4o/f4Yl5SB/saK6w3vy7JfJYBMk+iVJE3cM685Q1w/voN/nACXZPvi86xiVq2U9Am1cwkSHcMLEsX//LMsGDVuFsqqwKatPLdPyDjcu/8AtatVlFEcoLVv1UDMyoSAH6viRQpqbkBE8izO/kmB9Y2ugY9cA1qr70FeA5E5U3o5sP2Ul8rmd0apepeuXAO/hcN9HUF/etnJF53psWGeOHL0tAQE5U+0ygAAEABJREFU6K+t5FdrT+LZHnbekriUbXvrZnWlewkHRnQR5TeZ8qolD8uhrrwCo8DJFlqRVP+unLROpYtQSORU0OqlV+dWWL1+O7Mbg7kPFogJHQKBR46dRt9ubRA1eZ5cuWvdph0YN3U+HPp2xsnT56SVibllMb3/GqEHui1xIih46CC8ePEC5OFgHjXfoVbru6lcEeNnywkxWk4QZCJIwlU5urVvJidZ3Bx6Qm1rKq3W98TahhQpkqFP11aoU70iq5lqwVRXbKM4uUj3QVopzFm0Br/+fhiejn2wVEzUqibUWwoyGAzwGmIjv4dvyZokyVqv73zI4FHRYrJgjegnZIi1QIO1lRUyZcqIkQFOqvB3URY9fBwa+KABE+VHmyd3DkTPXiotJ/zd7aSfaFD4JNy6fU++paMnzkABS0gMKCOTeGMQ92MH1c13FGgepxVkOkUcP74SRQthy449QtrXf6WKf41CBfJg7/4/XkeILTvVHCCJQ1X+uILR4aOnwFkXpUCL+Gkrhet7XQO6BjStAVoB2HRra1xZQtPCmkk4WuQRiGCnnkWcOX8FyZIlw45dv4NLK0+ftwJd+roL0PkvsE3v3qG5/DYyb0ww+y5g5CRETJgpwXh7t2DQbJugSaumdeEqvpXkzyJ4b3ZBTAqgvnxCxqNiueJCnvuwHRKAVk3roVWTOlj540/4Mttn8Hbui8tXbqBQ/q9MrjTv4fylP0peMVqdjpk0F5u27cbU0cNw/8FjbPvlVwwTfZusWTIiTerUqnX079y9D1pL/CH6UHSbHRoUJZVgysOh1jvUan0nuOUZMEbqhRsCJLfv3Ac5hOxcgzBx+kKMnjQH335TWsxoD0RBFesU5dFqfX9b20B+OvZX+Qxqhfh0VTB/HvHe7CVQcunKdYwf4Y0r1/6UbZpacmmpHK3Xd1IudLX1BNvKJas2Sh7EzJkyyPdGQu/f9h9B9W/LmWXiXEvvSZcl6TXwwQImtOjgj2LfwaNgR3D/oWMoVrgg9h8+huGjp6Fy+VIgkQ9VZm1tDc5imQssYRlWArUc5j4AGTOkB0ETyqcFZJoms6Z+fLWqfoMnT57IJXq379wnEdjypYuCSx3zOSwRypcpjjA/Rwz2DBUfohtGEdT20zYWrB/oGtA1YFEN/LJnv1x9isupJiYISUT/Sf+0jkiCODnSF/sPHceBI8dRrXJZEPzevfeQ5AbxcemHwgXz4uGjJxZRzO69B/H48ROEB7iIAcdAdG7bRFqWkKeAgHyAp50qcnEi4+atO8aylq7ejOaNakmwrVfnlujesTnCRk8FLQK4etAPrRpgyqwlOHHmPPgNMl6YxAe0elVuyf7CinVbQZ3UrFoBUWEeWL/1f9Ly0tvJBiE+g/Hy5UsM8R6JgX07KZeZfT9/2Toxw19Jzl5PjvBFqlQp4Td8vCxXbR4OrdZ3upr5ufcXE3brBQB3D95OfbF+yy/ImSMbyBdEYJcAilSaChut1nfTR9dK20AQ7o/jp42iJdQ2VBB91FBfR9muUvbIiXPQv1d743Wf0oHW6ntc3dO939fNFo79u2HWhCDQinD52i1ibJYOY4a7w1LuXXHl1M8/PA18kIDJ0lWbpPksEXsuSXjuwhWQHfrWnTvio/Ujvq1QSq5Co7yOrwvkMbt/NNnr+wzyg8HKIAlL2angTFGgl2WR6c3b9yBiwiz4mPjxhfoNQZkShbFg6TqcOX8RXX5opqjKYvviRQrCx7mf7BBeufYPaGIxgfSCdQ1YWgOfaPnh42Zg928H5KoIfR39wfY9PlXs2XcIgSMnxZf0ycRlEgB9urSp4eE/GrSk7N6hOYYM6ArOzk6dsxzZPs9qJBVXWykGgwGpU6UyFkurQQ64B3uGSStMtbhUCCYNcAnE3fsPpCx0hTX9xtAVlKv0yESx4cC8cKH8CBk6CAYDbUdFZBL/0e8/OCIaNPPnra1EOU+fPRPg1mOeSmLjBrWrYM/vR+Q5NylTpMAwMTAvV6ooT1UJXLEkTerX79BgMMCudwfp9hU1ea7UTWYxc6uKIDGFaLW+Uy6KSML6rFkzwd/DDt+L98d6FjFhNjq3a8JkVYIW63vcBzcYtNE2XLx8Fc4+4bLtpIxvaxuYh3V+/EgvfJYlE08/yaCl+h73Bcg2K+a7wxXXenRsgXFTFoATxLT8J4F13Gv0c10D76KBDwIwefjodSeCD0TysVkLV2PyKB/QzHh0iJvoLEbi8tUbGGzbVTJrc/le5jVnePzkKbhksFLGopUbUb/Wt3ImhizMtDTxC52A8qWLwVLI9JFjp7Bl+y707d42lh/flu270btLK9C3fagAKdhBVJ7DkvvChfKBy6TRrNyScuhlm0cD+l11DbxNA3TLu3r9ppwdypsnJ4oWzo9cOb944zLOzs9ZtBZDBRD8RuInEkFf+t17D4EuEaG+g+E+LFIA4Jfk00+buwLP/3oOl4E95LlaG34TL16+JovjwP7oyTNYvX6bPL8m3iv5QujmsnjFRhmnxobWLK2a1MNA1xAJmjSuXw0btuxE9Kylkmj8xOnzKFG0QCxRuBpTrIgkPiGQNG6EN5as2ogVYvbTYDCgQ6uG6OPgg+Mnz4IWJ3RTrVCmmLHkAvlySyDMGGGmA86637h5W969QZ2qmDZ3OZRZ+KMnzqJpgxrYvfcwqDeZSaWNFus7H53vkJZwXFGMpMZ2zkGgawetmoJGTYGbQy9V3Te0WN+pJwZyC3KvlbahUP48IB8W286jJ87gXdqGb8qW+KTdObRW31mfTNusZo1qwmf4ONy6c1cu/8z2tG/3Nhg1bibIvcT8etA18D4a0Dxgwgreua87yKavPGCyZNZInjyZPC2QNzeqVC4H76AosEMGlf6xwzcjZg1vFpnMOpmcFeIxw4De7bFj1z5J1MZzBrWR6blLaEFy2TjLJ8sXnTTFj48yaS3QhDzbZ1m0JlZ88uhxugZ0DSSxBjjQoOsBXS0XrVgPXwGIPBHg9IioGcaSCJaYm5PKWJhGD3b+ekBaJ5AHZP+hY6CFHkETN79R4KCkR8fmcslLNcV//tdf0tXTI2A0etoPxfFT5xHoORCTZi5BRxtX9BnkC5J5V65QSnRm76gpmlx9je41Dm4hIMcYly49cPg4GrTpJ91vnOy6qyoPC+MMdVSopwBNNkvQhIPt5o3qYLBXGNp0d0TlCiVR9Ov8zKpaIEdDhz4ucPOLgKNXKNKmTY0BvTugv1MgOvdzx/hpC4QuG6C8AHIICKglmBbrO0Etgl3L124FLZg4QGvVpK6s4w7uIVJ3UcPdoTahMd8JwRut1XfWHUfPUHTo44q1G3/WTNtAwNnPrb8cQxDs1ULbwHeotaDV+h63zaJlf8lihdCmmyN+6OWEazduCZC3JjKkTyva/r+h/9M18L4a0DxgQmuDUD9H+A4fLwnRaJbKBi5szHRR+V/KGaILl66iW4dmGDV+5vvq4V9f17ldYzRvWBNTZi+Ts0EN61bBnMVrwc48b8bVXWpW+UbMGjXiqQxqI9P8COT96ks5kyYFEJuMGdIl4McnEvU/XQO6BnQNWEADyuxx/jy5cO/+I0yYthB+bgMkMM5VJ4oVziel4mB3oQBSzM1JJQvT6GbLz3vA1RqGDOiGQO+BCAyfDFoTFi6UD/4e9mJy4bBFJJ85fyUa1a2KWeODpOsISR0NBgOWTA+H+6DeWDhtBArmz43Zi9agWYNaqsvIQSR5Sgia0DSb/uw/rZqK4b6O+CxrZtXlYYEETSjHklWbsWnbLjnYXrtgHJbNjABdmJhHzRA+bgZG+jtJF+c2zepLXrHvKpbGqnlj4ObQEzPHBYLEvcdOngX7M2rIptX6PmrcLJy9cBnjwjzRqkk9yc9D12y+N65EeOrMRTXUk2AZWqrvBMC5CMOi6SMRHemLLT//iqMnTmumbeCYItDTXoImjx8/k31kS7cNCb5YCyVotb6Hx9Nm9enaGvOiQxHk5YBAr4FySeEi4vuoFWt66P8+SA1oHjChVq8LhLB40YIYKFD7w0dPwrF/V5wXIEnLzg5o22MIqlYqi9rVKuHPW3eZ/XUw8/b4qXO4c++BmEU7CzLH0yrCya6b9IfsPsBLzrA1E4AKV3MwsygJ3p6+egFihu/s+UtyaUIlIzuLTFPO9b2uAV0DugYspYG4s8fkfXry9BnsXILQrb+nGGR/hUb1qkvx2G4Few+COQm8ZUEa3uw/dBRtxGCWq8tUqVgGA206YaBbCE6eOS9JXls3raeK9JzEUCYIWOBvv/8hLQ94nCtHdvTt1lZMKCyVoBdn/AwGK/iHTYRD347InTM7s6keOJglaOLoFSbdJlQXIJ4ClUmM2QtXS9AknixmizJ9hwQjz124CoKWLPA7UbfKlSoirQHYZ+CKJVwGdvLMJQgUg0vFypd5zRm0Ut/jPiMXGOjdpTWoG8Vyyl78DulCTusO1vm416h9bqn6zuWxacmsPO+v+w6jTInCcpUutt2+rv0wYfpiTbUNBJxZrz0CInDm3GVFdH0fowEt1He63ti5BkOxbkuszeLS3QXzfyVdQs8JYNPJrnvMk+i7j14DZnpAzQMm2375DQuW/YjBtl0QMlSgheHROH/xCsaEuGFkgDOmjvZDu5bfgybbRNTNpKc3bjty7EzZ+AcPHSTTyFdCEtqVc8eALPYj/Z2lb7lMtODG2soKAaJzc+/+QxDlt6AoetG6BnQN6BqIpYEt8VhL3Lp9FzPGBkhgPCrUA5ZcwSuWsBo5KfJ1fvy8a59RmnKli4KzZ16BY/Dk6VNjvLkPWjauDa+gKDFTfEYWVbF8SXAwzU4sI3J8+Tm4ehyPGTi7FxHkCg68eW6pwEFkz04twNXzLCVD3HIJmkQGuyFr5oxxk8x6bvoOCUbmyvGFXFpZKTR7ts9hbfVPN5HuJXyHalrkaKW+KzpR9vzNbd+5VzlF6eKF5fsLjphijNPCgSXqe50albB87WbpakYdVK5QCguWr8edu/d5iowZ0iN92jTymButtA0ETQI87JE6dQqKpQcTDWihvrOeVKtcTrrAkcT7Xdos1n/yW6oF8JqoLMkO9RtpQwP/fAm1IQ927PpdzpQp4hz84wRaNq4DzqZVKl8K7oN6yZnHk2cuSCKtzz/LglHjZqGsmAkhK7lynbn29LEnyz99i9l5sLZ6DUiwvLAx00FG+XKliiJP7i8ZpYlgMBhAclfKpQmBdCF0Dega+CQ1oLjeKA+f0Ozx6XMXJQjA2Vsl76e83733IHxCxuGnHb+Bq6dcvf4nnLxHYOuOX+HiE46GdauKGdwi2LNXPXccmrEHeQ2UZuwkTOzavim4fGo3W08xe7wQI8fOAOO0+N7Yl2DnW0uyZcyQTvRj1FsBh88e9x16DO6N6XNXwGnoCMlXQkDg+zpVmFXVsFuD9Z2z2+HjZghQcDH4++vbrQ2iJs+T1rvrNu2QfHUOfTvj5OlzxtWOVFVaIoWpXd/pavi/NqMAABAASURBVPaa1Pg1aMJ6VqtqRXTq64Yxk+bA3T9Ss0A4rRK4ylgi6vwkksxY3/+T/jgxThc4ulYSNNFKm/WfHkq/+IPQgOYAk/Tp0+DEqfPGDw5no7bs2GNUZqniX6NQgTzYu/8PYxxXy2nWoKbx3JwHNCesUKYYSBhHQlqWZTAY4OtqC8pOSw7G6UHXgK4BXQO6BmJrgO1nwIiJRq4nrc4ex5basmdcoWTyzKWoWfUb7Ni9DyRVDQ9wAlcRWrF2C1o1rQe6AHCFoXx5cqkqLAdCNGMn6fqFi9cwKtAZPTu3ELPHaRHgYYcCeXOrKo9e2L/XgOk7fPzkGWaMCwAtAmhtEhHkovqKIFqt736h45AhfXrkyJ4NQwRYyZUZp44ehvsPHmPbL79imLsdsmbJKCbNUoPLmeIT/0fQxJSfh1ZdwUMdpA57dmoJzvx/HCr6OJ9Cy/WdoAldKwmapE+f1uJt1sdZA/SniqsBzQEmNGusU6MyuDLOoT9OopboJD558gT0W9u+cx9mL1yD8qWLWhSd7tS2MVo0rgVHrxHgygBUqsFgkKsScJaI53rQNaBrQNeAroHYGihWuAAigl1B7gS271qxlogtpWXPDh45AcWthZJEz1oiAXl+C72G2ODzrFmwfM1W2PXugIggV5QqVhBcHadi+VL4Kld2XqJqoBk7QRP6/p89fwV1qlcGv5G0/lRVEL2w99aA6Tv88+ZdyZHT9PuaqoAlWqzvnF0ncKMolMcpU6RE7y6tJDgZ7u+MoFGTkTlzBng72SDEZzC4utcQ75GgS7Zy3Qe5T0Kh2R8maDI7hp+H/Xsu0PC1mPRMwmL0W/1HDXyI9Z2AG0ET8lHR9bNNs/pQq836j+rWL/9ANaA5wCQsajpIEEXiP86knTh9HqF+Q1CmRGEsWLoOZ85fRJcfmllc3a2a1EX9Wt9ikEeoETSxuFC6ALoGdA3oGtCwBpau3oRhoRNQ/bsKIOfG0RNnpVWCFqwltKK2Jas2Sd38/fffUqQUyZODs9nyRGyaNayBPfsOiqPXf6lTp8IPrRqiY+uGryMssOWA29e1P6Ki51igdL3IpNCApd6huev7++jm4uWrksD/6InX/Dz8DV65dgOvXr2St8v+xWfI91VOnD77z0o4KVOkwDD3/tBdn6WKjBuCJuTnWbp6M7jCkjFBP9CMBj7U+k7QpHG9auAKbZpRpi7IR6sBTQEmdHO58ectVPu2HIoXKYiQoQ5w9RuFC5euSmR/bJin5OLQiu8xf6zd2lsevPloa6f+YLoGdA180BrgihHKA9BqYpaYaYyO9MOQAV0xNsxD8l+cPX9ZM9YSiqyW3Hs79wXBksCRk+W+R8cW8Asdj83b98jz/YeOo0KZEkYRaf6vhUEaSQHDA1yMcukHZtGAWW9qiXeoxfpeKH8ekJ/HfVgkCJqQ1yJLpgxw8Q3Hnzdv4/6Dh7h99wHym7icFciXGzr3RfzVk6DJONF/t+SqkfFLpsdSAx9yfW/WsBZse/7Ax9CDrgGzakAzgAnJVGnimCljBuMDEzQJ9naA+7AIaJUbpFL5kuDsg1Fo/UDXgK4BXQO6BkAz3x523rGWb7UyWMmlJCH+cenZerUqy5ncm7fvihiA1hIVy5fGrl8PyCWF+zn6w020/3TfkRnec/O/PfvR3zkQ/Yb4gwBN047273mn97ts8qwlEuxQrnZwH45fdu9XTmPtyfwfJL57BJgImpCziyud0TWnXisbXLpyTa4MF+uiJDyhjkyXC07CWxtvVaVh15jj2LtJMxaBIXasZc5IUExdqFX63CXrYDPYT4BjE96rSOotetbS97o2vovi1tn48vz11wt4BUahcfsBqN6ke6wsBBW+/b4zTMORY6dj5eGJpes7ZYgvkNvFz62/BHUJmgzzIEdJZrTr5Qy6AQy06QitTN7FJ78ep2vg32hAr+//Rlt63k9RA1ZaeWiSAY4N85Jo/k7RWVbk4ozHxPChIEKtxOl7XQO6BnQN6BrQtgY4mJgc6QtaRBw4chwcGFWpVBr+YRPx7PlzKTwHXAGediBBICP+vHkHUdFzQZfHGeMCMSHcG24OPXH33gMmv3eYuWAV+nZvgwkjvUEyS5b53jdL7MIE0rjyyN8x5vzMMqB3exQvWoCH8QbqikTiCmhSrlRRzJs8HJuXR2OwbVepy3gv1CM/SA3wPU+euRjjRf30cemniWeIW2cTEqpKpTII9XWMN5n9up3rZ0MJxYvEX+e1Wt85iCQ/D0mNL12+IduirSumgFZyJYsViveZ9UhdAx+qBvT6/qG+OV1uNTSgGcCED8tO85gQd4ydMh+moImp1Qnz6UHXgK4BXQO6Bsyvgf9awu7fDiJtmlTw8B8NEicO6N0B9+4/QItODugzyA/nLlwGiQCVcqbNXY6GdaqiZtUKShTY/tNNkxFnzl8CrTO6D/BCT/uh2LHrd0bLwJnsidMXgVYpvPf+Q8dk/MixM3H81DmEi32/If6wdfKXs+JMpOvL6Elz0K7nEAxwDgQ5tOxcgpiELT/vkWSq8kRsdv12QJYtDkHrg+52AszxGyUJyX/bfwTzl/6Ihu36o6ONKwZ5DMfFy9eYVQBA86R1iZ1zEFg+LW/GRs/HkaOvZ9sfPHwE/xGT0LmfuyQ7nzZ3hbzOYDCAK9/QuqZZR3t0tfXEohUbZNrbNtt++Q29HXxAGR3ch0urGl4Tn9zHTp6VeXs7+MLVN1xaBjEvA5+BhLIkYe9i64F1m3YwWgbqe5z4Vg90C8G8Jevk8yaUd/2WX9Chjwv6Og7D+GkL5PUJbc7QRUu8gw59XEW9iQSXjiS5OnV789Yd42UjomZg6pzlxnPlgJYW7v4R4HvkMxGMoBVE0w52aN/bGYHhk/Hk6VOZXdGHh3+klG2wZxhu3Lwt00w3tICitdTq9dtMo+VxQu+PiXzflJN1K7H3198pAM+f/yXr4IJl69Hoh/7id/KQtxB1KVQGntDSlmk8vnvvPvicrDe8/7kLVxidaHjXdxYV/Wadje/GyZMnQ8O6VeXqMPGlJxSn6F2pL9Tt+UvXQF1yxZkfejnFIj5O6D5qxJPbhaAJSY3PnLusRpF6GboGLKYBvb5bTPV6wRrXgKYAE+oqc6YMGBvqiTmL1hiXFma8HnQN6BrQNfAfNaBfrqIG1m7cLkCSM+CsVajvYLgPi5TkpSP8nRAV5gGbbq1BQm9TkTjoK1uqiGlUrGPvwChUqlAK08cGwKFvJ3gHR+HO3fvGPPny5JRWKSE+DgiJnCLjyZfyVc7s8BjcW1qYhAwdJOO52bRtF3bu2Y+pY/wRGeyKU2cuMPqdwsnT59Gvxw+IGu6OCmWKo2K5klg1dzTmThqO+rW/Q3DE6/K5mg1Z/PnMtHCh5Y1pAZNmLBEDxYeYOS4QkSGuWL5mcywgqELZYhg8oBtmjg/E0lUb4x3Qm96PoIJv6Hg49u+K6VH+KFOyCIaF/ePmEVdu8qM0qltNzJr7olnD2jguABTlfj4h41C9SgXMnhiMMSFumD5vuQSflHRa64wW8R1aN0RCeSlPSORUDHMfgInhQ/HixUsk9u/A4RMY6tJP6DEEr8T/qbOXSrfXRnWrYJnQDa99IgCPzeLdtWpah6dvBNaj4aLORUf6Smucru2bYtW8KPEcIfJ8tuhfKBedv3gFNt3bSdkaijIUEMZgMMBgMIDE8/0FyGbbsx3IW6Zcp+zf9v4kKCfqSGLvb1SgC1KnSinrJ5fMLF+6GHbvPQiCPQTNGHjMOKax7Mkzl4IubrPGB8HbqS/2HTyKd/n3Lu/sbXX2XcphnidPn6FWs55o2XUQCK7RoozxDNQ7AdRZE4JA/g8XnxHwHNIHPy6ZKHSRClu272Y2TYTChfIhwMMeqVOn0IQ8uhC6BsypAb2+m1O7+r0/VA1oDjChIul+ExXqAZLZ8VwPugZ0DcSnAT1O14A2NUDAe/7S9ZKs22AwoHiRgiBowhnlcxevokDe3PimbAk5eH3XJ+Ds+kXyd7SoLy8hEPN1gTw4dPSUPOemTo3K3CFr5ky4eu2mHHDKiAQ2+w8dR6P6NeS3JlmyZGjdtG4COd+MZtl5v8phTLCytkK0GNzTomPlup9w4tQ5Y1piB/sO/IGOrRvByspKyt2wXlXsPXDEeEn178qjlgAtGJHt889w9vwlHiYYDhw5KfVdrPBr94dObRtJkIM8YbzIVG7q9Maft9GicW0mge4VeXJ/KY/JQUHuBj5LvyHkkonEo0dPcfDICZnOzfd1qnAnSTATykt5ypYsDBILMnPHNo24SzDUrlYR2T7LIsGK9i0bYv+h1+W1bf49KAsBiDUbtqNi+ZLIlCF9vPf57pvSSJsmtTGNzxI+bgYc3EJAix1TUKhgvq+QN+aZSdp55txFeR1XRLl0+Rr4PoO9B4GAmEyIs3n7+ysHa6vXXa13eX+8/TflSuC33//AkWOnxLssIAOPf/39iPjdFGcWoZdj6NS2sdQTV22pWbWijH/b5l3e2dvu8S7paYT+V8wZjU3Lo+Fs1x07dv+OaXOXGS/NnycXcgsg02AwCFD1a0mgyt8t3XOqfVsep2Peg/ECCx+Q+JX1w8Ji6MXrGlBFA3p9V0XNeiEfkAasPiBZdVE/dg3oz6drQNfAR6EBDsqePnuKPXsPG5+Hs1b+YpZ27/5/4oyJMQcEIH4/eCzmLPbuFV7JgScHVEpKcgFycGCrnFtb/fNJI4Dx8mXi1gy8zvR+BE0Yx2BtbY2Xf//NQxlevPjnmBEpU8aebXb0DMXXBfKC3CMEhzi7znxvC3yuZMmsjdmSWSdDrGcSciiJBFXiyqGkGfevXgkg6h89UEdWYlCqpJvKzbJ5TwYlneXzmM9PfYwL85SWD7SOWT0/Cm2bvwasmIdLqXKfaF7KI94T8zFQHu4TCsmS/SM7y6eMzEtQoMjX+UBXqSUrN4JWLYyPL5g+43kB0AWMmITva1fByABn9OzcEk+fvubQ4bXW1v+UZyXqj2IBYzAY8EW2rCiYLzdWb9jGrPEGypcsKd+fKOWbssUFaPYHft13BBXKFJOBAMq+A0dBMEVkEb8G8Z7/hV55DcM7vTNm/I+Bvyu6WVtbWeG7imXQuV0TAVadMt6V7jzKibWVFUzrhel7gP5P14CuAV0DugZ0DVhYA//0FCwsyMdYvP5MugZ0Dega+BQ1wIHSxHAfzJi/EqZ8VIUL5kXrpvUSVEn3Di2wbvMOkKT18ZPXPBPkavh55z5pTZAjezYsWbVRXk9LAbpLlPoP5ItlShbGrt8Oyvtx88vuf1auyZM7h+TlYDzDz7v2cRdvePL0Ke7cu4+qlcsic6YMoKuPaUZaO9xNgLi2fOnikgOEIMmtO3dBvo9vypY0vTzeY/KJHD568o200iW+xpFjp0FuEibOW7IOXwu9UwaemwZaaHyWNRMOHD4uo69cuyF5ZXjC/EUK5QM5XmjVwbjTZy+CLjY8Ng2J5S1ZvJBeaonfAAAFCUlEQVSU5+Gjx/KSHYnokRl+2vGbdDuiPhYs+xHlTFy02jSrh8iJc5AqVSpQNuZ/W7h4+Rpy5cwOWjmlEiDX5n/h6pE8eXKMCnTGqTMXETZmerxFve/7i/dmMZG0ZBB4DTb+9D9UKFtChg1bfwHjmMZsZUsWxQ7xu+DxixcvsGffP/WYcW8Lib0zXsv0hOos098WaNWj5OHv4+ede1FK1E0lTt/rGtA1oGtA14CugQ9FA/8GMPlQnkmXU9eArgFdA7oGLKwBAgdjhrtj4ozFsUCTxMTKnzcnooZ7iMHfYXTq6wZbpwAMHz0VWTJnkJf5e9ph+//2gSSRo8bPwlDnfhKgkInvsalbozIK5Msl3S6cvEdIywy6hPJWdNOg2wDJOpmWQgyeGR9fSC0G8J3aNEaH3q7yXrdu342VjXwtQeGTQNcWkr6aJjKNAEDX/p5wcBuORvWqS9cY0zzxHRM4unf/0RtJn2XNDK8hNnKATz3t3ntIcly8kTEmwtfFFtPnrZSEoyTG/TL75zEpgJ+brQBI7qFLPw+07TFEcsaYWt0YM4qDhPLSvYZ8M54BY2DnGozdJlZH4rI3/ooWzo8h4l106OMCAgE9OrU05qlUvpTkM2nbPGHQzZg55qBi+RLSMonv0dErFJkzvq5LMckJ7gjYMNDKhaDJlWt/SsLYuBe87/uLe5+45+VKFQMtgwg+MvCYcUq+Pl1b4eTZ86DLkItvONKkTq0kvfM+oXfGG/C5EqqzTFdC0472aNllEMhPQlJZO5fXpMm7BBDJc4Zuom7nz5sbPU3epXK9vtc1oGtA14CuAU1rQBdOaEAHTIQS9D9dA7oGdA3oGkh6DRB8GB3sKgZzqd755lx6lESqy2ZGYPwIL5A/oniRgvJ6AhgkZ50W5Y+pY4ZJiw6ZIDZculTsjH9c/lNxP5gxLhB0CWIiAYVVc8fwUPKGcBDHewYPHYS/X71C6RKFZRo3Qd4OmDk+ECSqJXks8zH+GzHrTxcVHiuhd5dWWDIjHMzTp2sb/LJuppKENs3qIzzARbq20MqBecgXwgzp06UVgIYNZo0PAslVe3RszmgZWAbLkidiw4E7ryMfyYuXfycIrNSoUgFTRvuBemJZ+fLkFFcDvBfvKU9iNtQL7zs2zFM+56JpI1G2VFGZSoueAAFSzZkUAsaT0PaLz7PKtLj6Tixv/VrfSb3wvfq59Y+lG3mzmI1Nt7YgKS91MT86DNR/JhOeEpKfWlkZUK/mdzFXvLnjPRiUFAJd1MFM8R75DpzsuoEcaUyPqw/WPdaruGkKaOLp2IdJscL7vL9YNxAntObYtGyyOPrnz8OxN+YJHSgxPGaccs7Vo/jb4LPxufiuWQeV9Pj2/+adxa2z8d2Pcfwt8b5KUHTLd67ELZw6En26tJbAFa+Jq3eChP4edkySgb8B+z4d5bG+0TWga0DXQNJqQL+broF/rwEdMPn3OtOv0DWga0DXgK6Bd9RAhvTpYoEQ73iZatloecBlhbvYuoMAi0KAqpoA71EQB9jTBWj0Hpd+sJdwuWVa6PTr0RbJkyf7YJ9DF1zXgK4BXQNJqgH9ZroGdA2YXQM6YGJ2FesF6BrQNaBrQNeAVjWwdOYocAacFg20PqBFglZl/ZTlotUBrY7qVH+9EtKnrIvEnp38P3Rlixvu3L2f2GWJpnkHRUn3ONN7Mi7Ri/REXQPvqQH9Ml0DugZ0DWhNA/8HAAD//ykHpdgAAAAGSURBVAMAGbvscPC2r1YAAAAASUVORK5CYII="
+     },
+     "metadata": {
+      "image/png": {
+       "alt": "Bar charts of mean validation information coefficient for every full-coverage linear configuration, one panel per declared label on one shared vertical scale, each panel's highest bar in amber and the rest in dark navy, with a dashed zero line across each. The bars are held in the primary label's ranking order in every panel, so a panel that does not descend is a horizon that orders the grid differently. Counted from the frame: fwd_dir_15m has 13 of 13 above zero; fwd_ret_15m has 12 of 12 above zero; fwd_ret_5m has 12 of 12 above zero; fwd_ret_60m has 12 of 12 above zero."
+      }
+     },
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "full = catalog.filter(\"full_coverage\")\n",
     "config_order = (\n",
@@ -643,8 +1856,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "66179f41",
-   "metadata": {},
+   "id": "e9e68732",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004562,
+     "end_time": "2026-09-10T02:46:51.621837+00:00",
+     "exception": false,
+     "start_time": "2026-09-10T02:46:51.617275+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "### What shrinkage does on its own\n",
     "\n",
@@ -657,10 +1878,275 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "44c64e06",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 13,
+   "id": "4cdcadca",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-10T02:46:51.627739Z",
+     "iopub.status.busy": "2026-09-10T02:46:51.627631Z",
+     "iopub.status.idle": "2026-09-10T02:46:53.028082Z",
+     "shell.execute_reply": "2026-09-10T02:46:53.025811Z"
+    },
+    "papermill": {
+     "duration": 1.405513,
+     "end_time": "2026-09-10T02:46:53.029982+00:00",
+     "exception": false,
+     "start_time": "2026-09-10T02:46:51.624469+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.plotly.v1+json": {
+       "config": {
+        "plotlyServerURL": "https://plot.ly"
+       },
+       "data": [
+        {
+         "line": {
+          "color": "#0a1628",
+          "width": 2
+         },
+         "marker": {
+          "color": "#0a1628",
+          "size": 7
+         },
+         "mode": "lines+markers",
+         "name": "fwd_ret_15m",
+         "type": "scatter",
+         "x": {
+          "bdata": "AAAAAAAACMAAAAAAAAAAwAAAAAAAAPC/AAAAAAAAAAAAAAAAAADwPwAAAAAAAABAAAAAAAAACEAAAAAAAAAQQAAAAAAAABRAAAAAAAAAGEAAAAAAAAAcQA==",
+          "dtype": "f8"
+         },
+         "y": {
+          "bdata": "Px4QDOOkeD8/HhAM46R4Pz8eEAzjpHg/dDkJdkCleD/Z0A5E2qV4P4jt2PWsqng/SK9zqvDJeD9GPrDLzqp5PyKIJgFX83s/vuFQBoTxfj9pGF3phP12Pw==",
+          "dtype": "f8"
+         }
+        },
+        {
+         "marker": {
+          "color": "#D4A84B",
+          "line": {
+           "width": 3
+          },
+          "size": 13,
+          "symbol": "circle-open"
+         },
+         "mode": "markers",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          6.0
+         ],
+         "y": [
+          0.007554546090482393
+         ]
+        },
+        {
+         "line": {
+          "color": "#10b981",
+          "width": 2
+         },
+         "marker": {
+          "color": "#10b981",
+          "size": 7
+         },
+         "mode": "lines+markers",
+         "name": "fwd_ret_5m",
+         "type": "scatter",
+         "x": {
+          "bdata": "AAAAAAAACMAAAAAAAAAAwAAAAAAAAPC/AAAAAAAAAAAAAAAAAADwPwAAAAAAAABAAAAAAAAACEAAAAAAAAAQQAAAAAAAABRAAAAAAAAAGEAAAAAAAAAcQA==",
+          "dtype": "f8"
+         },
+         "y": {
+          "bdata": "m4Gb31juhT/LgoVkYO6FP6Z/l4Vk7oU/lnDnd67thT+cvO2NUu6FPwO1Bo148IU/kFUKPs7+hT8ceEzVhGKGP1yLbeA7B4c/xaUbq0rohz+quAfaXHmFPw==",
+          "dtype": "f8"
+         }
+        },
+        {
+         "marker": {
+          "color": "#D4A84B",
+          "line": {
+           "width": 3
+          },
+          "size": 13,
+          "symbol": "circle-open"
+         },
+         "mode": "markers",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          6.0
+         ],
+         "y": [
+          0.011673529955674842
+         ]
+        },
+        {
+         "line": {
+          "color": "#ef4444",
+          "width": 2
+         },
+         "marker": {
+          "color": "#ef4444",
+          "size": 7
+         },
+         "mode": "lines+markers",
+         "name": "fwd_ret_60m",
+         "type": "scatter",
+         "x": {
+          "bdata": "AAAAAAAACMAAAAAAAAAAwAAAAAAAAPC/AAAAAAAAAAAAAAAAAADwPwAAAAAAAABAAAAAAAAACEAAAAAAAAAQQAAAAAAAABRAAAAAAAAAGEAAAAAAAAAcQA==",
+          "dtype": "f8"
+         },
+         "y": {
+          "bdata": "Kf3gswCVcj9It/2oCJVyP+tjCsMNlXI/88X8vOuUcj/jrlaoO5RyP2bAxkPvknI/9A0tigW2cj+0ePIlOMpzP48C++vJf3c/nGBxGb/ffz/OGTX4H1J0Pw==",
+          "dtype": "f8"
+         }
+        },
+        {
+         "marker": {
+          "color": "#D4A84B",
+          "line": {
+           "width": 3
+          },
+          "size": 13,
+          "symbol": "circle-open"
+         },
+         "mode": "markers",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          6.0
+         ],
+         "y": [
+          0.007781740648248239
+         ]
+        }
+       ],
+       "layout": {
+        "height": 520,
+        "legend": {
+         "title": {
+          "text": "Label"
+         }
+        },
+        "margin": {
+         "t": 70
+        },
+        "shapes": [
+         {
+          "line": {
+           "color": "#334155",
+           "dash": "dash",
+           "width": 1
+          },
+          "type": "line",
+          "x0": 0,
+          "x1": 1,
+          "xref": "x domain",
+          "y0": 0,
+          "y1": 0,
+          "yref": "y"
+         }
+        ],
+        "template": {
+         "layout": {
+          "colorway": [
+           "#0a1628",
+           "#D4A84B",
+           "#C87533",
+           "#10b981",
+           "#ef4444",
+           "#94a3b8"
+          ],
+          "font": {
+           "color": "#334155",
+           "family": "DM Sans, DejaVu Sans, sans-serif",
+           "size": 11
+          },
+          "hoverlabel": {
+           "bgcolor": "white",
+           "font": {
+            "family": "DM Sans, DejaVu Sans, sans-serif",
+            "size": 11
+           }
+          },
+          "legend": {
+           "bgcolor": "rgba(255,255,255,0.8)",
+           "bordercolor": "#e8e8e6",
+           "borderwidth": 1,
+           "font": {
+            "size": 10
+           }
+          },
+          "paper_bgcolor": "#FAFAF9",
+          "plot_bgcolor": "white",
+          "title": {
+           "font": {
+            "color": "#0a1628",
+            "size": 14
+           },
+           "x": 0.5,
+           "xanchor": "center"
+          },
+          "xaxis": {
+           "gridcolor": "#e8e8e6",
+           "gridwidth": 0.5,
+           "linecolor": "#e8e8e6",
+           "showgrid": true,
+           "tickfont": {
+            "size": 10
+           },
+           "title": {
+            "font": {
+             "size": 11
+            }
+           }
+          },
+          "yaxis": {
+           "gridcolor": "#e8e8e6",
+           "gridwidth": 0.5,
+           "linecolor": "#e8e8e6",
+           "showgrid": true,
+           "tickfont": {
+            "size": 10
+           },
+           "title": {
+            "font": {
+             "size": 11
+            }
+           }
+          }
+         }
+        },
+        "title": {
+         "text": "Ridge IC against penalty strength, over eleven orders of magnitude"
+        },
+        "width": 950,
+        "xaxis": {
+         "title": {
+          "text": "log₁₀(α)  (Ridge penalty strength)"
+         },
+         "zeroline": false
+        },
+        "yaxis": {
+         "title": {
+          "text": "Mean cross-sectional IC (validation)"
+         }
+        }
+       }
+      },
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA7YAAAIICAYAAABaTXIpAAAQAElEQVR4AeydBWAURxfH/xcXJLi7u7u7U9zd3Yu7O8Wd4lrkA4q7u2uRYsXd49++oZdeLkICkb3kn/btzs6OvPnt3rJv34iVm5urN4UMeA/wHuA9wHuA9wDvAd4DvAd4D/Ae4D3Ae8BS7wEr8C8IBJiEBEiABEiABEiABEiABEiABEhArwRo2Or1yliiXtSZBEiABEiABEiABEiABEiABMKBAA3bcIDOKiM3AbaeBEiABEiABEiABEiABEggZAnQsA1ZniyNBEggZAiwFBIgARIgARIgARIgARIIMgEatkFGxYQkQAIkoDcC1IcESIAESIAESIAESEAI0LAVChQSIAESIIGIS4AtIwESIAESIAESiPAEaNhG+EvMBpIACZAACZDA9wkwBQmQAAmQAAlYMgEatpZ89ag7CZAACZAACZBAWBJgXSRAAiRAAjolQMNWpxeGapEACZAACZAACZCAZRKg1iRAAiQQ9gRo2IY9c9ZIAiRAAiRAAiRAAiQQ2Qmw/SRAAiFKgIZtiOJkYSRAAiRAAiRAAiRAAiRAAiFFgOWQQFAJ0LANKimmIwESIAESIAESIAESIAESIAH9EaBGGgEathoE/k8CJEACJEACJEACJEACJEACJGC5BL5v2Fpu26g5CZAACZAACZAACZAACZAACZBAJCBAwzaELjKLIQESIAESIAESIAESIAESIAESCB8CNGzDh3tkrZXtJgESIAESIAESIAESIAESIIEQJ0DDNsSRskAS+FkCzE8CJEACJEACJEACJEACJBAcAjRsg0OLaUmABPRDgJqQAAmQAAmQAAmQAAmQwL8EaNj+C4I7EiABEoiIBNgmEiABEiABEiABEogMBGjYRoarzDaSAAmQAAkERoDnSIAESIAESIAELJwADVsLv4BUnwRIgARIgATChgBrIQESIAESIAH9EqBhq99rQ81IgARIgARIgAQsjQD1JQESIAESCBcCNGzDBTsrJQESIAESIAESIIHIS4AtJwESIIGQJkDDNqSJsjwS0BmBpm17ou+QcYFqla1gRazd8GegaSLjyaCwi+hcmrbthX5Dx0f0Zv5w+yZNX4gKNZr/cH5LzThn4UoUK1/PUtX/Yb3bdxuEbn1H/HD+0Mx4994DNGzVDSmzFEPSDIVCs6pQKzs0n7nLVm9EvhLVQk33UCqYxZIACQSDAA3bYMBiUhLQE4GV6zbDJXE2H8lVpAo69hiMe/cf+VIzfdpUSJEsia+48DrIXbQqxk2Z66v6G3/dRaPW3ZGzcGUkSJNPvXi07NgXFy5d85UuPA5Cmt2MuUtRolKD8GhKiNUpL84Dhk8MsfL8K+j8xauQe/vtu/f+nQ63ODEW/tyxP9zqZ8UkEBiBOQtX4PPnrzhz6H94cP1oYEl1e878mRsWzxvdwqBiwSDApCTwjQAN228cuCUBiyWwZe0CbF4zHz06t8LfmlHbomMfeHt7+7SnX88OaNtCn8bUzr2HUaRcHdz9+4HScem8SejUtinixomJcb/N8WlDeAX0zC68mLBeEiABfRL458kzZMmYFjFjuOhTwSBoxWduECAxCQn8KIFIkI+GbSS4yGxixCZQpGAeFC2UFw3r/ILOmlF47sIV3H/wj0+jzbt2iUe3btNOqqtavhLVsXr9Fp+0xsCdv++jduMOvtKYd1c2elrT5yyNNNlLQLroBcfD9vHTZ3TvOwK5c2TBgW2rlWFbpkRhNK5XHWOG9saCGWON6vjZ79hzCG269EfGPGWRLkcpFX756o2vdHsOHEXxivWROF0BlK7aGP/7c4/yAv7z+KlKJ/WPHD8dZas1QZL0BVXaDZt3qHPGjTm7Wo06YNDISejebyQy5C6DLPkrYPjYafDw8DBmwYSp81WZ8VLlUfU1b99bnRMP+8ARk2D0RopHcvHyP9Q5843U063PCDRo2VWxlXqGjv7NVz2enp6YPmcpCpepjURpCyhP8OZte3yKOn7qnKp/36Fj6py0sUqdVjh7/rJPmqAw8EmsBTr3GgrxWM6ct0yVLW2Q+yBXkSqQrqlaEp///7p9T6W5cv0vnzjTgMRLN2e5hlJOprzlcODwCXXvGr3ayTMVUWXItZa8wkW8xR17DIakr1a/rURj177DKF+9GZJlLAzpFTB28hwIH3VS20i+7123793z0sb3Hz6qrp6ir+itFe3z/4Ilq5GnWFXVDbRVp754+vyFz7mgBNzc3CH3o5Qh16py7VY4dvKsyiofquR+m794lTo2bqTrqehy4fK33g1v3r5DrwFjVO8HKaNGg/YQzsb0xntCfj/y24ifOi8OHzttPO1r/72yfCX+9yCw69C26wA0//e38G9y9QEue6FKmDV/OeRPrllg97SkiZ08F6RLqfH5JPf/mvVb5VSAEhhbyRQQF/l9SLfjtDlKqt96/2ETJLkv+Z7OAZUt18W/+99X4SYH32uDPAfltzltzhL1mxG9TbL7BOW3MHjkZHT5dZh6dkp38nUbt6nfy8RpC1SPGbnXf1+2ziePBOZr957kld+k/MZGTZjh63kk9+jU2YsheSWNPLukh0o+k66/xm77835fFeBvxfSZ69/z5uatv9UzSHpPiF5GkXj5LRif7xIv9YuuRn3evfsg0b4ksHvWV0IekAAJWAQBqxDQkkWQAAnogIC8+GzYskNpYm3t/09bXsLqNuuMN+/e49CONVg8Z6IySN6+/a/Lp7u7O+ppaewd7P9NM0EzCnfDNM3zF6/wS93WyJY5I7asW4hd/1uK6NGjoI5mMHt5eSkdvreRrsaPNQ9D725tYGdn6ye5s5OTnzhjxNt371CtUlkc2bUWa5ZOh72dHZq06alelCXNrTv3UbdpZ1QoUxyXTmzHoN6dMG3OYjnlI25ubrC3d8CUMYNw8fg2dGzdGP2HTYQYxD6J/AmsWLMZeXJmxdHd6zB5zAAs0l4A1//vG3cxIuUFcMTAHvj78iEc2rkGeXNlU6U0qF0VIwf1RI5smfD20UUlzRrVUuf826xY+z8tb3acPvg//DZuENZs+BPy4mlMO/63udi8fQ+GDeyOa2d2oU+3dhDjV4wWYxrZL125EZNG9cepA5uQJFFCtOs2wIdTcBlMnzgUlcqXQMc2jZX+0o70aVOiYd1qWLpqvVTnI6vWafrnzobMGdL6xJkG+gwah8SJ4mPnxsX4+8ohxcbR0QHJkibC/j9XqqT3rh5W9cybNlody0Z4p0qZDIc1tuLhP3jkJLr0GoZmjWri7OEtmD1lBE6duYhhY6ZKch8J7LoF5Z6XsqNFjYIVC35TOl07vcunbOlxsHXHfnTr2BK9u7XF0RNnMXbSHJ/zQQkMGT0F8xevwbgRfdX9mD5tKvxSry3kXjYYDKhXszI2btntq6h1G7cjS8Z0yJ4lo4pv3LonPnz8iPnTx+DCsW2oXKEEajRoB9OXfUk4afoCTBzZD49uHFP3o8SZS1DLMub73nWo+Ut5bNu1H2IsGvMcOX4Gj/55ilrVKqiooN7T839fjXatGilODbQPeu26DYR8sFOF+LMJjK1pcnMuA7TnwRbtY9HiOROwd8tyPHv+CvsOHjPNgvFB/B2alx3Q/e+rcJOD77Xh5vm9KF+6KLq2b6buz9/GDjLJ7Tu4Zv2fsLaxxoRR/ZAjeya07txP+zg4QGvfS+1Z2UU9d+Tjndx7xpzvP3xGzy6t1PN0/Mi+OHriHMZMmmU8DXleTZw6DwO1Z+2FY3+iYtkSmLd4tc95Y0A+wshzf93SWdi0ei7u3nsY4G/Fv+dNujQpjEUFupcPtvIhsWuH5jh/dCsK5MmlfQhc4ivP9+5ZX4l5QAIkYBEE/H/7tQjVLU1J6ksCoUNAvlKLxE2ZG+u0L+/Vq5RDksQJ/a1sv+YRu3nrLqaOG4LkyRIjQ7pUECPs3fsPPuklzd17j5TB9y1NamV0mKYR4yJr5nT4tWtrpEmVTI3hHaN5Wa9eu6U8kj6FBRK4e++BOpvnX8NPHQRxU69mFVQsV1x1uZOXejEwT565APEeShEr125CxnSp0ad7W5WmWOF8aNawppzyEemuJ/pnypBGpaldvaKWphZW/+HXgw2Tv9IlCkGMVMkvHuZSxQvh9LnLKsWTpy9UWWLMOjk5Imum9GjfqqE6F9yNeLK7aS9lLtGjoVSxgsrwXrziD1WMq6sbfpv1u3btuqtz0aNFRfkyRdG0YS0sWfktjUqobfr36oic2TMjQfy46NyuiTKUnr14qZ2B0vVHGKjMJpsm9WvgpuZJEW+0RMvHjVXrtqC+dp3k2D958vQZ5NrJvRrDJTqqVymLfLmz+5fUV1yOrJnQo1NLpbsYmlNmLkLr5vU1w68KYseKAbmf+vdqrz44mGYM7LoF5Z43Lcs87K557FctmgrpNdGuZQNI13+5H83TBXT85ctXLFiyFr26tEHJogVV28YO+xUJE8TFwqWrVbYammF4TPPgmhqpGzZvR/Wq5dT5Q0dPqd/ezEnDkCtHFsSK6YIWjeto1z4T1m/eqdIYN317tENu7eOMjY0Nojg7GaN99sEpy5jpe9dB7mG5Xpu2/vdBYOOWXVp78yNunFgIzj3dokltdd/LfdOhdSPEjR0L5y5eMariax8UtsYMplwkbumqDejXsz0K5ssF0fE37QPTp8+f5ZSS4OhsWrYwD879H5w2KMW+s8meNYP2fB+IqhVLq33CBPEgH3cmaAZr5QolMWPSUHX/nLvw7bkmxfXs3BIF8uaEXEO5R+XZumLtZjmlZNmqjWhY9xftd1wO8sxqVLcaCmnc1EmTjVyzof27Qf5tkedjwzpVcersBZMUIRNcsmIDalQtr3oASZ3y7MuQPrWvwr93z/pKzAMSIAGLIGBlEVpSychDgC0NNoEtaxdg48o5GK55CbNo3ht5+QqokHv3H0IMiQyaQWtMI12ZxVNmPL7/4BGSaoZxnNgxjVFIlSIZokZx9jmWbpu79x9VXd7EqBaJkSQ75KVPxvn6JAwkYDAY1FnxIqtAMDYPHz1Gtz4jIN3MpO44KXKrrnQP/3msSrn34B9kzZxehY2bLJnSGYM++1V/bEalWi1Vl2spZ+zk2Xj46InPef8CibSXQNP4OLFj4MXLVypKDF0Jl6jYQHUrFa+BdF9VJ4O5yZIpra8c2bJkwNNnL/D58xc1llpeqqX7rehtlCGjpuBv7aOEacbECeP5HMbRDAA5ePHyteyU/AgDldFkIwZllQqlIGVJ9M49hzXP4SfUqVlJDv2VWpqXTq6hdCuWLoznLvhvmJhnlpdy07ib2oeaEeOm+boXpeu5eAafPH3ukzSw6xaUe96nIH8C4kE2/Q0lT5rY557wJ7mfKLlfxbAQ49t4UozOEkULqPHnEie/bZFVf2yVQwivv27fQ90a3xjfuXtf/f5iJ8/li8WO3Ydg7s3MmS2TKiOgTXDKMpbxvetgbW2NWto13/ivkS3tXf+/7RCDXcqQ50ZQ72kxxCSPUeLFja3xfKbxIQAAEABJREFU/u+eNsbLPihsJZ2IKZcHDx+rng3FCheQU0rkGVi4QG4Vlk1wdDYtW/IKi6De/8Fpg5T9PZHeAMY0BoMBKZMnVR85jXFyreTfCdPhHSdOn1dDI9LnKq3ur1/qtfF5Hkm+v7V/WzJr//5I2ChZ/HnmJkmUwHha7WPHigXpAaQOQnAjvSiKFc7rq8TiRfL7Ov7ePesrMQ9IgAQsggANW4u4TFSSBHwTMD0Sw1RegLu0a4qa2otj2679TU/7CdtoL5jmkdZW338UyBgqYz6DwYCav1SAdEU1F3lhM6YLbJ82dQp1Wl6IVCCIG9GjRsN2EINyxcKpeHbnNF4/OA9bW1u4u3kEsRRgzfqtaobmwX07q2660o6BvTvDzd090DKsrL4Z5L4TeatD8eoc3rkWDTQvxCfNAB0zaTaKV6gXoi9uop/B8E2H43vX+7kGJ/ZtULoYN1ZWfq+tMJTzP8pA8ppL4/rVIV2yv351xer1m/FLpTJwDqQ7uXiSF80ej6RJEuHYiTMoVaURps9Zal6sn2NHB3tfcQaDAZNG9/fDQa6neKmNia0CuW7GNOZ7IyfzePNj89+UwWBQRpF5uu8dizFrmsbG2sb0UP2+1238Ztiu37xDja1PlDC+SmMwGJRXUdptLtKjQSX6d+Po4PBvyP+dwRD0sowlGAzfvw41qpTDvkPH1e9h194j8PDwROXypVQRBsPP3tOqmAA332MrGf3jYmNjJad8RLrwGg8MhqDrbF72j9z/QWmDUbfA9jY21r5OSzOsrMzj/ruH5UNm7cYdtY8oVbBz4xK8un8O29YvUmXI80gFgrixsvLNU7IF9XcmaUUMhm/cJWwU/z6QWpv9W+ff7zQozw5jHdyTAAnon4DfJ4z+daaGJEACARBo2aQOjhw7g517D/ubInmyJHigeTtNPXY3b/0N8W4ZMyTTvE3maeTFxjRNujSpcFQzRqSLnDFfcPfiwUiXJiVGjJ0ONze/xuQnky5/pmWLF07GfjWo8wvSpUkBe3s7XL1xC+IBMqZLnjQRLl25YTxU+8tXb6q9cXPizAXVVU66v8aPF0dFX756Q+1/ZiPepDbN66sJsI7vWa/xfoIz/3ZVdnCwg7fXNyP4e3VcvvqXryQXL19HvDixId38UqVIAvEQ7j1wzFea4B78CAN7O3v49yJaUvMuim7LVm+AjDdtoBn339OnXKkikC6Na5bMQK8urbBx67cus/b29iqrdGlWgUA2GdOlVsZSIEm+eyoo97wUIsaJl7eXBENU5H6Vl/BLV75NAmUsXLrXpkyR1HiI2tqHK/HSSpfvDZrns+Yv5X3OpUubUhmMcs4n8gcDP1JWUK6DdBOXoQvyAUSutXR7lW65omaqELqnpSxTCSpb0zwSTpokIQwGg/Yc+e+5IcbT+Yv/XaOf1Tmg+1/qN5UfbYNpGT8TPnfhKmLHiql9rCqtxsDLvXrZ7HkqS8pdufYfK6nPPI3EBVf8e97IR833Hz5CPqIZy7vx121jUO1Tar8bc30umT3fg3LPqsK4IQESsBgCNGwt5lJRURL4PgHpKte0YU1Il1r/UhcvnA+pUyZF1z7D8PrNW4iR2GfwWGUcGtOXKJIfybSXOkkjXRiv37ytZlq11wxIY5oWjWupYOsu/SAvC2KASDqZIdh0LK5KFMBGPKxjhv2KQ8dOo0Sl+pi7aCX2HjyGXfsOQ2YflZll/csq3Q7FS7X3wFF1+tqN25AuffKypSK0TYM61dRssDI7rrRTxgzKTL7aKZ//s2RMi7MXrigOYhRPnrFQ1e2T4AcCMvPystUbfT4UHDp6WvNKeSBF8sSqtBTJk2qG7mMEZfZomWRFuuhKWuEyc/4yNG9cW5UjnhsZjyk6r1y3WbVBPjL8sWk7lq/ZpNIEZfONQfAYpNTacv3mHcg1N63DYDBonupqGDzqN3WPmXbZNE1nDMvELuc0/nL84eMnNU5ZXo7lOEniBOqevHLNt3Ev58xFJrSR2WDHTJoFuV9FL5kUZtyUueZJAzwOyj0vmaXL8dXrtyQYLJEZcEWfz5oX37+M8pGiTfN6GKN5+OWDkdyz43+bBzEMWjer55NF7nvpTtl3yHi8eftOjZE0npTxjzKOtWPPwZqhf0y99MvMzDIzrHQjNaYLyv5HygrqdahVrRJWaffs9l0HIePajfqE1D1tLM+4DypbY3rjXgxuGTs+euJMyP0uRtSgkZMVd2Oan9E5sPvfWL5x/6NtMOb/2X2mDGnx+OkzXP7XcJXf27Q5vidikh4bK9b8Dxu37FTPN3ku7dx76GerRkp/njfptY9Z8hHt939nlZffgjFsrLBpwxoQfURXaH8yTGKX2QffoN6zWnb+TwIkYCEEaNhayIWimiQQVAKtmtbFhUvXsGX7Xj9Z5EVs9eLpcNc8pMUq1FfdP2tpXiCjx1IyiMG5btlMfP3ihkJlaqtlVMQzJBMURYsWVZJAJuOQLmlOjo5o3LoHkmcqgh79RuHO3w9ga2Oj0gRlI5OQSNfdFMmTKMNWZjJu1bEvZPbRPt3b+VuEGLArFkyBGJEFStVEveZdIDPROjs5+qQXr5C0Ycfug0iTvSS69x2Bzu2aqvPRo0dT+2YNa6FSueIoVbkR8havDjGiundsqc796CZKFCeIAS1LDMm413bdBkAmZMmgvYhJmWJAydhf4SXnA1ruR9K20IzYy5qHQdKK4V6vZmXIBC5yTqRHpxaQbtQykVeWfBXUesBi1JpykHSByY8wkBmQZUxqzKQ5IG0Qj7+xjsb1qkEM7LqBTBplTPvs+UtUrNVClSFL04hBOnxAN3VaPtB079gCVeu2VueNy/2ok2abAnlzQsaZnzp7CSUrN0SGXGUgM9C6ubmapQz4MCj3PLTsspzWzHlLlU7my/1opwP8XzxHYybNQmDdNof1745qlcugW5/hyFagIg4dPYX/rZ4LGd9uWrBMsiUTU5UvXQzycm96bsm8SShbsgj6D52IVFmLo37zrlo5JxHFZHw8gvgX3LKCeh1qV6+gPoZFixYF8nswVSck7mnT8ozhoLI1pjfuRw3pBWlX9fptkb9UDTWOv2rF0sbTav+jOgd2/6uCzTY/2gazYn7oMGP61Jg5aTg6dBuEfCWqY9KMBTD+Vo0FNqzzC3p1bYOR42eofw9kIkOZRC1atGjGJD+09+95I8+HBTPHqh4esZLlRCXtOWL6AUgqqqc9g+TfkCGjp0CWlFq7YRu6d/L9fJdr+7PPDqmLQgIkoB8CNGz1cy2oCQkEi4DMzCtj6cwzidfrzcMLqFLh29i1JXMnYeywPj7J5Py6ZbNw+cR2yJIljepWw8Vj21Dn30loJKG8TG9YORv//HUc968dgXQzlQk+JK+cF5FlWWQZFsn74PpRbN/wO5bMnQgnp/8MTElnKmcObYZ0PTWNS582JZbPn4JzR7bi5b2zkLIWai8tMmOuaTrTcPasGZUxI2NMLx3fBunSJ/kqlS/hk6x08UI4sH0VZDyYLNUiBrd0ExZPjCSSsV6D+nRRS0HIchCLZo1D725tYFxqRtIsMWP3x/JZkDxyzijCVtLJsXjMZIyrXBeRe1cPo3Wz+nJKidS5adVcyDmRwJb7cdA85LKWr6STazWkX1eIAaYK0jYGgwFimO7ZvExdJ2ErZVevUk47C/VCLnkdTMakyiRPEiezkUoi0UfaI+0X8Z/BRNWtWtKLyD0g10rKEZHu4BIvIl3W5eNJPc0Il+PARJakeXr7lA+LzWvmQzySxjx9e7T3OSf3mcT7x1/iZZz5xpVzcPfyQciyJ1KWtEvOifiXz/S6SZqg3PMVyhbDwxvHlF7y25F8PTu3VPe+hI3yS6XSuHPpoPEQ12/cVrN4mxuiPgm0gJ2dLWSM9+mDm1UdW9ctULPxaqd8/S9eROEuS9D4OqEdyL0tM87KPSi/XbmX1y6d6bPkkrzIS17Te0LL5u//3ytLZn8+uGO1r7xyHQK7DpJY7h/R4fqZ3ZCPVBJnFIMh8Hta0skzorT225awUQ7tXAPRx3hsvv8e24C4CAOZjO/GuT24cPRPjBveF3OnjoLpUjoGQ+A6B1T29+7/4LZB0q/WPloOG9BdggGKf78FMe7Mn8ty73Rq28SnnFraB9DDu9bi5P6N2Ld1hc8cC8Z72mAwqKWG5Fkr11fugyfPniNFssQ+ZQTltyLPUvltGjOlSJZE/dsgZYoYnzdyD+zatFQ934/tWQ/54CDnTZ8hor88F+XaiT5d2zfDyf2+e7QE5Z416sI9CZCA/gnQsNX/NaKGJBDmBKQ72e79R9TMtqfPXkSLDn0gE1QZXyrCXKEfqFC6YJ49fxkyNli6ow0Z/Zta/uQHimKWIBCQ8YdTZixUH1TkA0IQsugqSWje88dOndc+6LTTVXupTLgSiHCVS08N6T4v8x+8ev0WsxesgCwB1LxRrQjXVjaIBEhAvwRo2Or32lAzEghXAh17DIZ0EW3ZqR9SpUgK8aKGq0LBrPzV6zcoX6M5kmUsjOHjpqFpg5ro1qFZMEth8qAQkHHF8VPn07z1Thg7vHdQsugyTWjd87v/txTZMmfQZZupFAmEBAHxvh8/dQ55ilVF5nzlsG7TNiyaNV71HPnx8pmTBEiABIJHgIZt8HgxNQlECgLSnfWv8/tUl0vp6jtz8nDEjOFiUW0f0q8rXvx9RnVVk+5zfXu0g3STtYRG+NddUM96N65XXbGW7rEyc7OedQ1It4hwzwfUNsaTQGgTkO7e0t1XugM/uXVSdVeWLvmhXS/LB0AIJEACPgRo2PqgYIAESIAESIAESIAESIAESCCiEWB7IgcBGraR4zqzlSRAAiRAAiRAAiRAAiRAAiQQEAGLj6dha/GXkA0gARIgARIgARIgARIgARIggchNIGwM28jNmK0nARIgARIgARIgARIgARIgARIIRQI0bEMRbnCLZnoSIAESIAESIAESIAESIAESIIHgE6BhG3xmzBG+BFg7CZAACZAACZAACZAACZAACfgiQMPWFw4ekEBEIcB2kAAJkAAJkAAJkAAJkEDkIUDDNvJca7aUBEjAnACPSYAESIAESIAESIAEIgQBGrYR4jKyESRAAiQQegRYMgmQAAmQAAmQAAnonQANW71fIepHAiRAAiRgCQSoIwmQAAmQAAmQQDgSoGEbjvBZNQmQAAmQAAlELgJsLQmQAAmQAAmEDgEatqHDlaWSAAmQAAmQAAmQwI8RYC4SIAESIIFgE6BhG2xkzEACJEACJEACJEACJBDeBFg/CZAACZgSoGFrSoNhEiABEiABEiABEiABEog4BNgSEog0BGjYRppLzYaSAAmQAAmQAAmQAAmQAAn4JcCYiECAhm1EuIpsAwmQAAmQAAmQAAmQAAmQAAmEJgGdl03DVucXiOqRAAmQAAmQAAmQAAmQAAmQAAkETkAvhm3gWvIsCZAACZAACZAACZAACZAACZAACQRAgIZtAGD0GVIRkzEAABAASURBVE2tSIAESIAESIAESIAESIAESIAEzAnQsDUnwmPLJ8AWkAAJkAAJkAAJkAAJkAAJRCoCNGwj1eVmY0ngPwIMkQAJkAAJkAAJkAAJkEBEIUDDNqJcSbaDBEggNAiwTBIgARIgARIgARIgAQsgQMPWAi4SVSQBEiABfROgdiRAAiRAAiRAAiQQvgRo2IYvf9ZOAiRAAiQQWQiwnSRAAiRAAiRAAqFGgIZtqKFlwSRAAiRAAiRAAsElwPQkQAIkQAIk8CMEaNj+CDXmIQESIAESIAESIIHwI8CaSYAESIAEzAjQsDUDwkMSIAESIAESIAESIIGIQIBtIAESiEwEaNhGpqvNtpIACZAACZAACZAACZCAKQGGSSCCEKBhG0EuJJtBAiRAAiRAAiRAAiRAAiQQOgRYqv4J0LDV/zWihiRAAiRAAiRAAiRAAiRAAiSgdwLhqh8N23DFz8pJgARIgARIgARIgARIgARIgAR+loDlGLY/29JQym9raweKvhl4enrBYLDidYrk96q7uwesrW14H0Ty+8DNzY33QCS/B+Q54OHhwfsgkt8H8l7g5eXF+8AC7gP8xN/r169AsVwGwb30NGyDS0zn6akeCZAACZAACZAACZAACZDANwJx48YHxfIYfLt6wdvSsA0eL6aOGATYChIgARIgARIgARIgARIggQhEgIZtBLqYbAoJhCwBlkYCJEACJEACJEACJEAClkGAhq1lXCdqSQIkoFcC1IsESIAESIAESIAESCDcCdCwDfdLQAVIgARIIOITYAtJgARIgARIgARIIDQJ0LANTbosmwRIgARIgASCToApSYAESIAESIAEfpAADdsfBMdsJEACJEACJEAC4UGAdZIACZBA2BG4e+8RSlVr+UMVPnr8DEUqNfmhvMwUfAI0bIPPjDlIgARIgARIgARIQN8EqB0JkIAvArv2H0O1Rp19xfEgYhGgYRuxridbQwIkQAIkQAIkQAIkEEQCTEYCJBBxCNCwjTjXki0hARIgARIgARIgARIggZAmEOHLO3ryPLoPGIdilZuiToue+GPzLj9tnjp3OcrXaqvE9LyHpyemz1+BSnXbo0TV5hg/bRE8vbz85GdE6BOgYRv6jFkDCZAACZAACZAACZAACZCATgl8/PQZtaqWxZ9rZqN1k5qYMX8lbt6+56OtnL//8DGWzxuHvt1a4rfZy3Dm/BV1fvGKjbh45SbGD+uJZXPG4snTF5i/ZJ06x03YEqBhG7a8WRsJkAAJkAAJkAAJkAAJkICOCJQrWQiF8uVAFGcnlCleEEUL5sbpc5d9NPTSPLADe7ZF7JguKF44LyqXK4ZdB46r82s27kDXto2QKX1qJE4YD+1b1sWfuw+pc9z4QyAUoyKUYfvy1Rt06j0aLToPRv8RU/Hl61d/0clXlWadBqFx+/5YsGy9T5pN2/ahfqtfUaBcI7x5+94n/vyl6+g7/DeUrt4arboOxcFjZ33OMUACJEACJEACJEACJEACJGC5BE5pRmyn3qNQ8pcWyFOqLrbvOYx37z/6NMjRwQExY0T3ORYDVuyOT5+/4O37D5rtMUjlk7wN2/TB02cvfdIyEHYEIpJhi6lzVyB/7mxYNH04okWLihXrtvkh6e3tjcFjZqJ352b4fcYI7Dt8CmK4SsJ4cWJheP9OiB0rhhz6iJOjA3p1aoad6+eiab2qGDVpns85BkiABEiABEiABEiABEiABCyXwKDR01GiSF4snzsWp/asRuWyxXw1RpxlpobuE81wjaUZus5OjrC1tcGGpVNxeu8aX+KrAB6ECYEIZdgePXkBlcoWUeAqlSmCIyfPq7DpRvrLO2k3YcZ0qWBjbY2yJQri8IlzKkmBPNmQJmUyFTbdpEuTAtL1wNrKCoXz54C7u3uA3mDTfPoMUysSIAESIAESIAESIAESIAEjAQ8PT+TNmQUJ48fVPLUfcOi4796Z1lZWWLX+T5VcPLW7DxyDdF+WiIa1KmP8tIX48PGTHMLVzQ0nzlxSYW7ClkCEMWylK4DBAMRwiaYIJkkUDy9evlZh082zF6+RKH4cnyhJ9+z5K5/j7wU2bt2L1JrxK10SJK27u5tm6FL0zMHT0wMeHu7Bu068rhGOl9wHer5PqVvYPEe9vDwi3L3Neyf49w6fB8FnFtHuM3kv8PDg88ASrqu8b4eU/PPkuU+XYek2LPLo8TN079AEbboPRetuQzBh+u/ImTWDryqdnZ3U+NsCZRugUdu+aNO0NnLnyKzStG9RF9kyp0fjdn1RpFITtOsxDJeu3lTnuAlbAhHGsBVsVtrXFNmLGAwBN81gpVnAkkhJwOnUaZPNpat/YcUf2zD417YmsQySQOQlwJaTgKUR8PLytjSVqS8JkEAoERCHSCgVzWJ1SEB6aZp3F5ZjGS8rXY+3r52D+b8Nw6iBXTFheC90bFVftSJl8sTYu2khGtWpguO7VmLHH3PVDMrqpLYR+6NV45rYtHw6Dv+5FL/PGKUMX+2UmkxK4iRMCX0CQbfqQl+Xn6pB+rh7enrBzd1dlfPqzVvEiR1ThU038eLExJu3H3yiXmvp4sWN5XMcUEC8vzMWrMKM8f2QJFF8n2S2tnag6JuBtbUNbGxseZ0i+b0q90E4/VZ57+no3uOzQN/P67D6jfJ5EMnvAxsbeH15AY8P92Fj5c1ntI6e0f49A3xeuhkgge8QiDCGrbSzYN7s2PPv1Nu79h9D4XzZJRrSTfnK9VsqnC51ckjf+If/PFWLJ+89eBKF8+dU5wLaSPoBo6ajf/fWSBDvv27MAaVnPAmQAAmQQHAJMD0JkAAJhC6Bt/f24s7Ozrj2Rw38vasDHh7oo4Vr4q+tLfD0wkJ4e7qFrgIsnQRIIFQJRCjDtlu7htiy8xBkuZ8HD5+gYe1KCt4jzYgdMXGuChsMBgzr2wGDRs9As44DkStHRp9+9LMXrVFL/YghW7FuB/QaPFHlWfe/Xbh87Rbqt+6tzstyQE+fcxpvBYcbEiABEiCBsCPAmkiABIJNwNP1HR4cHoF/Tk7B17d/w9vLw1cZ7p+e49XNjbi9oyO+vrnt6xwPSIAELIeAleWo+n1NZZme2RMHquV+Rg/qCuMETzKr8ZqF34xUKSVb5nRYPHMkls0ejdaNa0qUEhn8fXznchhl4vBe/sbL+fhxY6tz3JAACZAACZAACeiLALUhASMBMWL/3tcPHx6fhPHPYGUL+2iJYe+SCtZ2UYzRcPv4BHf39ILru/s+cQyQAAlYDoEIZdhaDnZqSgIkQAIkQAIkQALhSiBSVP78ygq4vn+g2mpl44D42VsgY631SF5mBpIUH4f01VcjRcmxsIvybf4UMYQfndCcId6eKg83JEAClkOAhq3lXCtqSgIkQAIkQAIkQAIkEEQC0q345fU/fFInKzYcMdPVwPLHF9H+2mY0vrIeY24fgHuM1EhVbjpsHL/1xpPuys+vrMS3P25JgAQshQANW0u5UtSTBEiABEiABEiABEggyARe396mpf22xFfM1BXhFDsjel77E52vbsEfT69g96s7GH/3EIoem4vPBmskyttFS//t/zd3d34LcBs0AkxFAjogQMNWBxeBKpAACZAACZAACZAACYQsAffP/030KUbt7c+v8Pujs34qefD1HRY9PKMZvhl8znl8fetnkimfkwyQwA8SYLbQJUDDNnT5snQSIAESIAESIAESIIFwIODx9Y1PrfNfP0Sj82t8js0DNz6+gJWNI2wcYvqc8nR96xNmgARIIMwI/HBFNGx/GB0zkgAJkAAJkAAJkAAJ6IXAxfdPsPTROfS+vh2lTy7Egc//Gab7Hp/DTc14DUjXPS9v4/ibe/BwffdvEgOs7V3APxIwEti8bTcmTZ+PVes2Q5YGNcb/7P7d+4/oP2IqWncbgtt/PwhWcVeu30b3AeOClce/xIeOnflu3Reu3EDLLoOQr0x97Np/zKeYW3fuI0+puj7Spe8Yn3NhHYhchm1Y02V9JEACJEACJEACJEACIUrgq5cHzrz7BwsfnkGXq1tQ7Pg8xN09EsVPzEfXa1sx/+FpnNXO37By9Km3vUtCrM7ZANFs7H3iTAPP3T6hy4k5wL+zITu4JIfBysY0CcORlIAYsQVKVkeDFl0xZNQUtO7cF7mLVsbJ0xdChMiBo6cQL24szP9tGFKnSBoiZQa3kGOnLuDuvUeBZnOwt0f75nVRonBeP+lyZ8+E03vXKJk2tp+f82EVQcM2rEhbUD1UlQRIgARIgARIgAT0QOCTpzuOv32AOQ9OosOV/6HQsTlIvHcMymge2V7Xt2HZP+dx6cNTeHp7I0OUOKiXMCvGpC+HbXmb4dccDX2akPrpKZR0dsHEDBUR0/Y/g9faYEDtBFnRMWle9Pz83/q1F2CLJ64ffPIzEHkJDBk1GZev3fQFQIzdTr0G+4r7kYOrN25j8cr/Yc+B4+jQa4QW3oQV67aqoibNXIy2PYap8Mmzl5RXVw7ECK3XshdadB6ELTv2S1SAMmrSXAwdNxPttbLnLl6LV2/eot/wKajf+lc07zQA4vH96849HDx6GvOXrENrzWt8/+Fjf8tLnyYFcufIDGvroJuPNZp0xaSZS9C4XV80aNMb4t3t+OtISPymbfv8rednIoOu2c/UwrwkEPEIsEUkQAIkQAIkQAIhSOC9hysOvf4b0+8dQ6tLG5DnyExlxFY8tRj9buzEqscXce3jcxi0/7JEjY9GiXJgQoYK2JWvBf4p3Q/HCrbH7MzV0C5pPhRwSYo4iQrAPnoypaGXxxfcOzAIle3tcatEL5zM3w47czbBw1L9MDtdSbR7fRFZPL4Zsu6asTvayw45Dk/DkL/2QPRShXATIQgsWbkeUeJnDLIsXvGHv+2+fvM2nONlCHI5HboP9FNOpvSpUb9mBVQqWxSzJg5C9qzpcfHqTZXu2s07cHV1g4enJy5euYnsWdKp8PDxszGgZxssnDYcz1++VmkD27i6uWPm+AFo26wOps5ZrpWTAavmT8DQPh0xaPR0pE2VHMUK5UHrprWV1zhZkoSBFefvuSuagZ6/TH3NWB6odDVNlCZlUiybMxb5cmXVjOxZGDukOxbPHIUFS/9Q7TFN+7NhGrY/S5D5SYAEAiHAUyRAAiRAAiTgl8BLt8+Qca2T7h5Gk4vrkE0zIpPtG4dfzizDYM2YXP/0CmQWY3sra+SIlhDNE+fCbxkrY3/+1sqIPVSgDaZnqoJWSfIgT/TEcPCn27DB2g5JCw+CTAolGrh9eIS7u3vg0eGRiPH4GFK9v4s35+bgr61t8P7hYRj/bLO2QMp4WeHq5YlpmpGd9dBUZWxLF2hjGu5JIDQIZM6QBpev/gVXNzfY2dkhS8a0uK4ZuGLY5syWEf88fobYsVxUvMFgQM2qZb6rRrGCuWFl9c3kO3fxGnbtPwrxzI7UvLkvX7/Bi5ffN44DqyRRwnjYtmY2dm9cgFLF8qsxv5+/fIXMWB6xAAAQAElEQVTxr1D+HCqYJWMapEyeGFGjOCNa1ChaO2Lg+YtX6lxIbb61MqRKYzkkQAIkQALBJ8AcJEACJBCBCfzz9T22vbiJsXcOov751ch4cArSHJiI2udWYuTt/djy7DoefHkLJ2tb5HVJjNaasTozc1UcLtAW/5Tqj335W2FyxkpomjgnskdLADuDdZBp2UWJj2TFhsHGMZZPng+PT+L5xQV4enoy3tzZAS/3j9/OaeXGz94KmdJXx7qcDbA1dxNV3zuPr8rYzn1kBlY+vgAveIN/lkugaYOa+Pj0WpClUd3q/jY2Tark+KTdu0Eta9aUkf6WYxppY22NpJrHdMv2A5pnNT2yZU6Hsxeu4cGjJz7jb621NMY8NtY2xmCAe1tb32kmjeytPLMypvfwn0sRJ/Z/M4EHWEggJ5wcHZSxKgZro9qVkSBeHKWvMYutzbf6xbi2+Tcs5+TY3d1DgiEmNGxDDCULIgESIAESCE0CLJsESED/BO59eYP/PbuG4bf2oebZFUi9fyIyH/oNDc+vwTjNsN3x4i81djWqtR0KxUiG9snyY06WajheqD0eluqLnXlbYHyGCmiQMDsyR40HGQP7s612ip0RaSrORYyUZQMsysElBdJUmIlY6ar5pCkUM7nyEC/OVgspnWJCDPSOVzaj8LE52Pnilk86BiI2gT492iGGS3Q/jRzYu7OfuJCIEGN2+botyJYpHXJkTY9N2/YiTapkqmjxjr56/RZv3r5XxzL2VgWCuMmXOytmLVwNb+9vH2dOn7+icjpqxun79/9+4FExQd98/PTZJ7GMoX399h2SJk7gExeWARq2YUmbdZEACZAACZBA6BJg6SQQJgTEa/nXp5dY9+QyBt7cjSpnliL5vnHIcXg6ml38A1P+PoJ9r+7glftnuNg4oGjMFOiSvCAWZq2JM4U74b5mxG7N0xSj05VF3QRZkd45DqxgCDXdrTQdEubpgvTVliNJwb5wSVURURLmQ/wcbZCq3HRNpsEuamJ/6/8lXkacLNQBkzJURFw7Z1z/+AL1zq9C+VO/4/y7x/7mYWTEIZAyeVLcPLcPKxdNxbAB3TF/+ljcunAANX+pECqNFIP26bOXyqiNFcMFBoMVsmdOr+oSj+7AXm3V2NhOvUfh9t3/JjxTCb6z6dymIdzc3NCgdW9UqNMO6zfvVjkqlSmKY6cvoG2PYQho8qjj2nlZ1keW+hkwciqKV2mm8m7deQASX6BcQ0yY8TvGDekB8eKqk2G8sQrj+lgdCZAACZAACZAACYQzgchbvfhp7n95i/PvH+ODp1uQQHhq3p0rH56pbrh9buxQBl2SvWOR7+gstLm8ETPvH8eR1/fwzsMVse2cUCpWKvRIURhLs9XGxSJd8HfJ3vhf7sYYlrY0asTPhFSa99MQpJpDPpG1vQuiJSmMeNnbIH7eXxErbVWItxYIXCMbzbhokSQ3LhTtiv6piyOKtR1Ovn2IkicXqDHCf2ueavAvwhJwcnJE1Ypl0LNza9SvXRUJ4scNsbbWqVYe7ZrX9SmvUL4cOLF7Fezt7FTcxmVT0aReVRWWTf7c2TBj/AAl08cNwJRRfSTaXxnQsy1KFc3vc84lWlTIpFGrFkzA9rVzMHZId3UudcqkmDyyN+ZOHoKAJo8qkCe7Ws7HuKzPgS2LVd56NSqq+OM7V2DelKHImimtipfNhqVTES1qFAmieKE8GNK7vQrLZtH0EQHWJed/RGjY/gg15iEBEiABEiABEiABCyNwU/OwFj0+F9kPT0PJEwuQfO84Ne7VtBlu3p7K6F386Cy6X/tTpUu0dzSKaPmkG+68B6eUQffZ0x3x7aOgfJy06JOqGFbkqIurxbrjVvFe+CNXQwxKUxJV4mVAUkcX0+ItPuxoZYNfUxbFRc3AldmXbTWDV8YI5zkyAz00Xs/dPll8G9kAErBUAjRsLfXKUW8SIAESIAESIAESCCIBL3ij6YW1EM+rMYvEybjXtprXVYxWMV4T7RmjjNnumpEmxq14dmV24CQO0VEpbnoMSF0Ca3M2UAbs9WI9sCpHPfTVDNuKcdIhoX1UY9ERfi9r4cp6udKtunaCLBCv9u/ax4Ac2keDUbf3B9kbHuFBsYFhQmDZms1o032oL5G4H6lc8oVUWT9S/8/koWH7M/SYlwRIgARIgARIgAR0TuCp60dsfnYN4rH1T9W1Ty6rbsZi9Hp4eyG5YwxU1bytgzWv64ZcjVRX4kuah3J59jrolbIIysROrboc+1dWZIsTj/S8LNXVDM4lY6WCeLIn3j2M7IemYq7m3Y5sPAJpL0+FIoHGdauqbsDSFdgoEvcjVUo+YxnGvcT9SFlhnYeGbVgTZ30kQAIkQAIkQAIkEMIExHg9+uY+lv9zXi2h0/TiOhQ7Pg8J9oxGhoOT0ezCHwHWGMPWEcPTlsbm3E3woFRfnC/SGUuy1Ub3FIVRIlZKuNg4BJiXJ74RkBmc1+dqqMYSS/i1+xf0vbFDrc+7+vGlb4m4JYHvEmCCnyFg9TOZmZcESIAESIAESIAESCBsCDxx/QAxXpdpxuuIW/vUpEWmxmvl00vQ+eoWTLp7WPPQXselD0/x1csDzta2yBg1LgKaH6lxohzonLwgisRMDlmGB/z7YQIy+7Osv7swa00kc3RR6/O2v7IJRY/Pxe6Xt3+4XGYkARIwIRBAkIZtAGAYTQIkQAIkQAIkQAJhTcDUeB12ay/E86rGvu4dg4wHp0CM1y6a8Tr57yOQSYuMxqsYpFmjxke1eBnRM2URzMxcFdvzNsfN4j3xqFQ/HCvYHvUTZPPTHCvN2pXZfv2cYMRPEZDZn2X87fgMFRDHzhmXPzxDnXMrUUn7+HD5/dOfKpuZSYAE/Cdg5X90pI1lw0mABEiABEiABEggVAmYGq9DNeO1ycV1KHxsDhKZGa+//X1UeV5l7KuM3RTjNVu0BKgeP5Ma6zor8y/KeP1LM14flOqLgwXa4PdstTAwdQk0SJgd+V2SQNZdNTZmSsbKmJ6pCuolzIqysdOgY7ICOFqonfIsGtNwH3IEZImg1kny4HyRLmqCLVki6Nib+yh6Yh5aXdqgvLkhVxtLIgESoGHLe+AHCDALCZAACZAACZBAQARkrdjH/3YbXvroHMR4bXxhrTJeE+4Z7cvzOlUzXsXzevXjczXxUDQbe2TXjFfx+P2asijEeN2heV5lGR0xXg/kb41FWWuq2YnrJ8ymjFfxCAaki2m8vZU1GiXKgdmZq2FNzvoYma4M0jvHMU3CcCgQkK7gsiSSGLhi6IrBu/7pFeQ+MkONw5XxuKFQLYskgUhHgIZtpLvkbHCYEWBFJEACJEACEZaAGK//fH2PI6/vYYlmvA75aw/EeC0knlfNeM30b7fhrte2QozXrc9vQIzXL14eiK4ZrzmiJUTN+JnVmqhiaO7M2wK3S/TC/ZJ9sF8zXhdqxmv/1MUhxms+zfMa284pwrKMLA2Tayhdk88W7gT5cOHu7aVmTs52aCom3D0EuTciCwu2kwRCgwAN29CgyjJJgASCTIAJSYAESCAsCMgkSuI5zXF0BlIfm6pmDN7+4q9AqzYar4f/NV4Ha8ZrI83zWvDYbIjnNfOh31DlzFJ004zXafeOQYzXa5rnVQyU6DYOEOO1lma89tY8r3OyVMOufC1wp8SvuKcZr/vyt8KCrDUgxqt0Dc7rkhixbGm8BnpBIshJWSJIPlwcyt8GBWMkw0dPN4y+fQCyRNCih2cgSy5FkKayGSQQpgRo2IYpblZGAiRAAj9EgJlIgAR+kkCPa38qz+mDL29Vl1+ZdKnB+dXY8eIWHmmeVzFeFz86i2/G6xqYGq9V/zVep2vG65+a5/X6xxdqtmFZBien5nmtnSALpKvp3CzVsTtfS9xVxmtviPE6XzNe+2me17oJsiJP9MSIaev4ky1h9ohCIEu0+PgzT1NsyNUIWaPGx3O3T+h5fRvyH52lxlZHlHZGlHbIhysZ977mySW8cv8cYs169/4j+o+YitbdhuD23w+CVe6V67fRfcC4YOXxL/GhY2e+W/eq9duQp1RdH1m8apN/RYVrHA3bcMXPykmABEiABEKOAEsiAb8EZKKmU28fYc3jS35PajH1z61CFs3zKsZrd834/Wa83oSp8Zo7eiKI8do3VTEYjVfpMvx3yd7Yq3le52kGrZyroxm4kjYGjVeNLP8PKoESsVKqib/kI0hSRxfc+fxazYZd/MR8tbxTUMthutAhIEasTPglk7wNv70P7a/8T/v4MBvyXAmJGg8cPYV4cWNh/m/DkDpF0pAoMthlHDt1AXfvPfpuvtZNauH03jVKmtWv9t30YZ2Ahm1YE2d9JEACJEACJBCeBCy87pdun5XRKR7WjU+vYt6DUxh75yDEKG18YS0qnV6sJuVJvm88YuwariZqKndqIbwgHYv9abwBEEM0l2a8imEqBqoYquJ5NRqvEpY48cpKGjFeZZInf0pjFAn8MAHptn6xSBeMTV9eefYvvn+ilneqq318ufnp5Q+Xy4w/R2DYrX2QmclNSxFjV4YgmMb9SPjqjdtYvPJ/2HPgODr0GqGFN2HFuq2qqEkzF6Ntj2EqfPLsJeXVlQMxQuu17IUWnQdhy479EhWgjJo0F0PHzUR7rey5i9fi1Zu36Dd8Cuq3/hXNOw2AeHz/unMPB4+exvwl65TX+P7DxwGW59+J7XsOo1v/sejUexSqNOiIpas3Y7nWhmYdByj933/46F+2UImjYRsqWFkoCZAACZAACZBAUAi89fiKW59e4dibB5DZgWWMoUyk0/v6djS/+AeqnF6CAkdnI/X+icpQTXNgouomLB7WFpfWo8+NHRinGbbSjVi6Cko54vF6p5Ur9YvRmsoplgT9FVn2RroO78nXEuKNFeNVvLM0Xv3FxcgwINA2aV5cKtpNLenkaGWDXS9vaR7CWeioeQql23wYqBChq1j+z3nE3D0iyCLp/QNy49MLrYzhmgStrM7XtvgpJlP61KhfswIqlS2KWRMHIXvW9Lh49aZKd+3mHbi6usHD0xMXr9xE9izpVHj4+NkY0LMNFk4bjucvX6u0gW1c3dwxc7xmZDarg6lzlmvlZMCq+RMwtE9HDBo9HWlTJUexQnnQumlt5TVOliRhgMUtX7sVRSo1Qc9BE3zV/fTZS4wd0h3LZo/BsjWb4WBvh8UzRyFXtoxYv3l3gOWF9AkatiFNlOWRAAmQAAmQgA4JiIfhj6dXIGPExACUyZRCQ02ZCOfelzc48+4fyORMy7SXyCl/H0H/m7vQ5vJG1Di7HEWPz0WGg5MRZ/dIpNA8q3mPzlSeVunqJ2MMZSKd+Q9PY9Ozazjy5j7kBVL0F31lRuFUTjHVMjeV4qZHs8S51MzC4uWSCXk2526CowXbQdZ2fVV2kBrveqZwJ1SMk06y+5E6CbP4iWNEkAkwYSgRkCWCBqQuoQzclklyQ5YIWvn4InIfmY5Bf+2GfBAKR8U4iQAAEABJREFUpapZbDgSyJwhDS5f/Quubm6ws7NDloxpcV0zcMWwzakZif88fobYsVxUvMFgQM2qZb6rbbGCuWFl9c3kO3fxGnbtP6o8syM1b+7L12/wIgjGsVRSrmQh7PvfQmUUR4saBcPGzZJoJVkzp0MUZye4RI+G2LFjIF+urCo+Y/pUuBdMD7DK+IMbqx/Mx2wWQED6/s+5fxILH55R3bYsQOUQV1G6qs15dBryYnX786sQL1/vBUrHu32v7kDGjK345wIefn2nd5VDXD9ZTmHbi5uY/c9prH5yCc/cwq5LTIg35gcLFANGDBkxaMSwMRoIP1icRWa7/OEpftU8gI2vbYRMInT+ffC6Wllko02Uli6NeY/MROtLGzDs1l61LE1RzbiU5WpMkvkbdPP2hHiJLrx/gt0vb2OV9nItz5TBf+1RHqQ651aixIn5apxqgj2jkWTvWOQ4PB1lTi6ETM7U5eoWDL+1D7Pvn8C6J5ex/9VdXP7wDE9dP6rZX+UFPpmjC8RDWj5OWsg6q91TFMaodGWVB1Um1jlUoA2uFeuOl2UGQWYUFkN1e97mWJ69DqZkrKRmFhYvlyyhUiRmcmSMEheytqsVDD5tGpehgio7qUN0iBcsS9R4qg5ZcscnEQMkECoEfrzQ2HZOmJihIk4V7ohq8TLC1csTM+4dVzMoyzJS8nz/8dIjZ055xrzWniVBFVlyyz9SqZ1i4XWZwZoMCpJMz1jFv2J8xdlYWyOp5jHdsv2A5llNj2yawXj2wjU8ePTEZ/yttZbGmMnG2sYYDHBva+s7zaSRvZVnVsb0Hv5zKeLEjhlgXtMTMWNEh42NDRInjIeeHZtCPMrG87ZavDFsbWUFY53WVlbw8PBAWP1ZhVVFrCdsCfTWXuDKnVqEfjd3otf1bSh0bLb6Sh+2WoRfbZ7e3qh/fjWkq9qwu/vR4+Z21Y1n5eML4adUGNcsL6O/nFmKmmdXqFk+O13drBj8+fxGGGsSftW9cf+iXq4bnl+DkX8fREeNQV7t5f6A9mIdflqFbc1iuBQ+NkcZMmLQiGGT78gsiJEStpqEX217NGOs5IkFWKB5APe/+Ru/PzqLsicXQeLDT6uwrVl+/6+134Nprbc+vUJn7TchxqYYnWJ8ihEqxqgYpWKcipEab/coZbSW0IxXMWI7XPmfeqaIcbtSM3LF2JX7SYxfecl2sNJefByiIXu0BCgdO7Vah7Vz8oIYlrY0ZmX+BWtzNlCzBV8q2hXPygzAo1L9cKFIF+zO1xKrctTD9ExVMDhNSXRIlh8ynlUm1skSNT4S2EeFteahMG1DcMKJNZ2k7POFO+NOoW44VKCtqiM4ZTAtCYQXgRSOMfB7tlowLhH0zsMVQ7WPVLm0j0grtA/XXgGNIQ8vhX+kXp3m6ZWyCFxsHPxo1y9VMT9xIREhxuzydVuQLVM65MiaHpu27UWaVMlU0Yk0o/LV67d48/a9OpaxtyoQxE2+3Fkxa+FqeGvvyZLl9PkrsoOjowPev/+owgFtPn76byboPQeOI2O6VAElDbd4q3CrmRWHGoEdL/6CdOEyrUA8d8O1B2B4eS3lZcdcZJ0/c/ns6a6WYTDdf9LizEW6upnLB083GGXJP2chHEwZiLHb9epWNdvge+0fBHN55/EV5iJdfcxFjCVzkRdGcxGvmLnIpCfm8sLtE8xFpvz3T8TbaC7i9TCXJ64fMOHOIYjH2pSBcO1wZTNuad7rx1oaMXrM5dHX9zAX8fQGVWQpDXO5/+UtzEW6KprL31/ewFzufn4Nc7mjxZnLba1N5tL/xi6Ip8qUgVx3eTH/69NLmIpMzGEuNz69UF0gTfcyU6q5yLqV5nL143OYi0w+ERS5rHkX/RNZnsRcpH3mIkaGUaRb5x2NlykDuS9bXV6Pc5rX0lzOvvsH5iJdSs3l9LtH8E+kp4i5nHz7EOZyQoszl+NvH8BcZLykuRx9c1/NFPq9/ZHX9yAy8OYu5Rk0ZSDrRP6qffST58S25zfV2E7p9rr+6RWs1byK4pWUl8Wlj84pQ3iBZhTPfXBKeR1naN4S8ZRM/vsIJtw9pMZ3yuRFIzSvpLxoDtY8mQO0Ovvd2An5yCjXoNu1rZoRuQUdNaOw3eVNynMq40ObXlyHRhfWKs+mTBBT6+wKVD+7XH2Uq3x6iZo45mf3lU4t8TPxiZHFvpd3Vfdg6SYs3YWX/XNedR+W6y2/T3nOStp4dlGQWfNwFo+VEjLBTftk+TBIMz6nZqyMFTnqQtZnPVekMx6U6osnpfvjctFu2J+/NdZpRqwYs8M1o7ZL8oIQz0eZ2KnV+q5JNM+pncFaiqeQAAkEkUCWf5cI+iNXQ2SKEhfyb3kn7QOVjEOXZ1kQi2GyYBCQjwpXtGfa0my1MTh1SczWPtBd1Y6rx88UjFKCnlQM2qfPXiqjNlYMFxgMVsieOb0qQDy6A3u1VWNjZbKm23fvq/igbjq3aQg3Nzc0aN0bFeq0w/p/x79WKlMUx05fgExWFdDkUdL1WJb7KVa5KcSgHtqnQ1CrDbN0NGzDDHXYVSQvtP7VJsZtniMz1OQbMlNkWIp0TzOXhHtGw1wS7R0Dc0msxZlLkr1jVXc3031SLc4oPa5t8w+BernNrX3dTLZvHMxFZtA0Fxn7ZS4p90+AuaTS4sxFJjoxF5n0xFzSHpgEc0mnxfkn6Q9MhrnIODVzyXhwCibeOewvg/eaAZ9Xuw8yaWkyH/oN5iLLXphL1kNTEVTJdngazCW7Fmcu4g0yl5zatTGXXJqu5pJbizOXPEdmwlxWP7noL4Mnrh8gY/ryHZ0Fo8i6geYiLwrmImtbmkshzSNqLuIlNZcix+ciKFL0+Dz4J8W0eHMprnnRzEU8a0bZ8fwvfxnc/vgaJY8vQCnNk2kqpU8uhLmI985cxOPpn0hPEXMpf+p3mEsFLc5cKp5aDHOpdHqxGntpug+qoVflzFKIyAcL/yDc+/JW9exoeGENZGynTFTU6tIGtL28EfLxQ14Wu2oGqXRd/vX6dvS9sUONEx30127lKRFDVsaCilErkxeJoSsGr3gyZ90/gTkPTqqPjDIZ0hLNQJYJSMTDuebJJfyhGdAyo+/mZ9fx5/MbypiUCWL2vroD6VEgH6W+Z7gH5/y/H+f9YHC0toW8nLVJmhey1urkjJWwLHsdbMvbDKcLd8S9kr3xpuxg3CjeA4cLtMXGXI0gS5KMTlcOPVIURpPEOdXYVVmfVV7+olrb+amDESRAAiFPoFSsVDhcsJ3qrp/U0UV9qJVnmTxrz7z9/rItIa9RxC7RSXtWVo6bHt1SFELdBFlVD5KQanGdauXRrnldn+IK5cuBE7tXwd7u2/N047KpaFKvqs/5/LmzYcb4AUqmjxuAKaP6+JwzDwzo2Raliub3iXaJFhVD+3TEqgUTsH3tHDXhk5xMnTIpJo/sjbmThyBZkoQS5UcmDO8FWern4NYlGDO4u08X5gqli+DXzs190i+fOw7x48ZWxwXyZMeogV1VOCw2JoZtWFTHOkgg6ATsraxhLtLFzVxkrJS5yCQLCODPwdoGMqbLKFG0FzFzkZczc5GlHcwluo09/IqDFudbXGwcYC4yU6e5xLR1hH8Sy9YJ5hLbzgnmImPKjGJnZY2A/mJq5cWziwJTiW8fBeaSwD6qenib7hNqcf5JIodoMBfp+mcu4qUxFxnz5ke0f6jlH2tTkXF45pLcMQbMRV6wReReQQB/ybR8KZ1iQiahMRcZN2MuaZxjwVzSOseGuaTT4swlvXMcmEuGKHFgLhm1r+/+iXyVNxfxnpmLjBk0F/kN+YvAAGSNGt9HskVLAHORrqTmkiNaQvgnObV4c8kVPRHMRcZRmosYReaS1yUxzCWfSxKYS34tzlwKuCSFqQTEwMHKBmVip4aM66wUNx2qxMsAGcMmYy7rJMiivIsNE2VXxlvzxLnQKkkeyDjO9snyo1PyAuiqveCIcfdryqKQmXTFMByYugSGpCkF8VDKGNEx6cthfIYKmJShIn7TvJvSFVY8mHOyVFMG4qKsNbFE8wIs14zJlTnqYU3O+vhD88Rs1AzILbmbYGuepsrI3Jm3BWTWXvGCHirQBke0F9rjhdrjVKGOOFu4E6Qrr3TtvVqsuzJCbxXvpSZNkuVqHpXui/Ta/QZ//qrESw/RYVz68uittUPaWVl7eRN+8huIrj27/MnGKBIgAR0QMGg6yLNKlgiS50xM7R1CeseUObVI9QS5/fmVloL/k0DkIWAVeZoaQi21gGLkxTYgNU9qL0Hy9d0S5GnpATAX6eJmLo9L94e5TNZeIv1jIP8IXCzaTY3pknFdIg9L9YW5SHc6c5EXRHO5V7KP5tEwl95anG/5W/N6mIssL2Eud0r8Cv/kdoleMBd5cTWXv4r3hFH6pi7mHwKIwX6xaFf18ntD88IY5XqxHjCXa9pLsrnIi7N/It10zEW6I5qLvHybi+jjR4p0gfxjbSry8m4u54t0hrlIl0iRRoly+MsggWacS7liEMgkNOYinipzEQPCXE4W6gBzOaHFmYsYIOZyrGB7mIvM5OqfiBFjLuI9M5dDmkfNXH6Jn9FfBhk0Y/tQwTY4qBlJIgfyt4a5iBFlLvvyt1LjI833e7V4cxFDzFxkHKW5SDdWcxFDzlx25G0Oc5EJhMxFvI2mIoaqfxCqaoasjPeUcZ3Ls9eFdDP7PVstLMhaA3OzVFfjQWdkqgrpbiuezAmagSoz745OVxYj0pbBUM2Ale64/VMXh6x9KoZhz5RF0E0zeDsnL6jGb7ZLmg+tNYO4RZLcaKp5N+WelO64dbUv/tKlt3r8TBA9ZHbfCnHSQpaeEU+MdPktHDM5CsVIpox0MfJzaR8KsmsfIGS8aSbtI4h8LEmjfXCRDzTJHF0gH4zko1M87aNVbO3Dl3w4k49x8uFucNqSalZVUw7yLOii6WkaxzAJkIBlEpDnzIWiXdUSQeJdlJ4g+Y7MggyDkKFNltkqah1UArLETpvuQ2EqEhfU/KbpJJ9pORKWONM0eg1b6VUx6vXjBCppX9sLxkjqp4B6CbMq75KfE6EQEd5F1tHaKl44cz3EwxLXztk8OkIet9RepsWDat64PprBKy+65vER8bhj8vzKA27aNisYlBFiGheRw2K4iAFj2kbp0TBIM3RM4yJyWLypuTSj0LSN8gFQltIwjYvIYVnqRj4oSTdi8ShLd+Mr2ocr8fpH5HazbSQQmQjIs16ea+e1D8PS+0LmWpNhENkPTcXI2/vVPCSRiUdkamvjulUxb8pQXyJxP8JA8oVUWT9S/8/ksfqZzMyrXwJ/5mkG6cY2Jl05NU28eGRmZ66mX4VDWDPpYnhS805Ld74hKUtgcroKOFqwneoiGMJV/UxxoZpXPDXyj5tM3iLdIsXzJJ7JjskKhGq9eipcuiiLx3iF5o0bmKIYZmretwtFu6iupXrSMzR1EcNFDBgxZMSgEcNGDBwxdEKzXv8Xf1UAABAASURBVD2VnVTzZornWHo9bMlaHzeL94R4tiVeT3qGti7SU0G8xOJRlu7G8owI7TpZPgmQQNgTkA/40svkdOFOqkeITNQ56e5hiIErM6A/+PoOMnmdzO8hc4vIhHUBzUUQ9tqzRhL4cQI0bH+cne5zSje2dsnyoWWS3Gocne4VDmEFZVkI6c7XLnEeNE6UAzJ2MYSr0H1xtgYrtdyGdIuUsYL+ebF13wj8nIbSJati3HRonygP6iXIqrpr/lyJlpdbDBgxZMSgEcMmgX1Uy2tECGgcy9YJOaImgLz0hUBxLIIESIAEdE0ghWMMNYZ/X75Wan4CWb1BloHMeWgaZPI6WZFBVoOQCevKn1ykZljWdYOoHAl8hwAN2+8A4mkSIAESsAgCVJIESIAESIAE/CGQI3pCNT+BTE6X1MEFnpB1MnwnlKUN//f0qu9IHpGAhRGgYWthF4zqkgAJkAAJ/DgB5iQBEiCByEpAJqeTnnwBtf/Bl3cBnWI8CVgEARq2FnGZqCQJkAAJkAAJhBkBVkQCJBBBCaR1jh1gy5I6Rg/wHE+QgCUQoGFrCVeJOpIACZAACZAACeiMANUhAcsjIPOv+DfPgL2VNSrGTW95DaLGJGBCgIatCQwGSYAESIAESIAESIAEQpAAi9IVAVk1Yln2uigfJy1i2zkhuo09CsVIhqXZ6yCZo4uudKUyJBBcAjRsg0uM6UmABEiABEiABEiABEggBAmEZVF5XRJjVY56uFW8F+6V7IOteZpCxt+GpQ6WWJf7kSNwXb0abnv2wPtdyI1Hfvf+I/qPmIrW3Ybg9t8PgoXmyvXb6D5gXLDy+Jf40LEzQap70597Ua1RZ+QpVRd9hk72KWr1hu2o3/pXNGzTBwe1snxOhHGAhm0YA2d1JEACJEACJEACJEACJEACwSYQLhnEiP3Yrh0+Dx+Or4sW4cv48fjQqhU8r10LEX0OHD2FeHFjYf5vw5A6RdIQKTO4hRw7dQF37z0KNNuFKzcwc+Fq9O3WGid3r0L7lvVU+vsPH2Pxyk1YMHU4Jo34FcPHz8ZXVzd1Lqw3NGzDmjjrIwESIAESIAESIAESIAESsAgCXxcuhOfdu750FWP385QpvuJ+5ODqjduaUfg/7DlwHB16jdDCm7Bi3VZV1KSZi9G2xzAVPnn2kvLqyoEYofVa9kKLzoOwZcd+iTKT/w5HTZqLoeNmor1W9tzFa/HqzVv0Gz5FeVebdxoA8fj+deceDh49jflL1imvsRiq/5XwX2jz9v2oX7MC8ufOCisrKyRPklCdFG9viSJ54ezkiPjxYiND2pQ4pekL7a9Gk66YNHMJGrfriwZteuPWnfvo+OtISPymbfu0FCH7Pw3bkOXJ0kiABEiABEiABEiABEiABHRKwG3HDrwrWzbI4rZ9u78t8bp/H+/KlAlyOV8mTfJTTqb0qZWxWKlsUcyaOAjZs6bHxas3VbprN+/AVfN8enh64uKVm8ieJR0kLB7RAT3bYOG04Xj+8rVKG9jG1c0dM8cPQNtmdTB1znKtnAxYNX8ChvbpiEGjpyNtquQoVigPWjetrbzGyf41WM3LfPL0hTJMy1RvhdrNe0AMbEnz4tUbJIwfR4JKkiSKj2cvXqmwbNKkTIplc8YiX66smpE9C2OHdMfimaOwYOkfqj2SJqQkWIZtSFXKckiABEiABEiABEiABEiABEiABP4jkDlDGly++hdc3dxgZ2eHLBnT4rpm4IphmzNbRvzz+Blix3JR8QaDATWrlvkvcwChYgVzKw+rnD538Rp27T+qPLMjNW/uy9dv8CIIxrHk9fTykh3+WPIbhvXtqLocf/z0WcUZNA+uCmgbg8Ggbf/7v1D+HOogS8Y0SJk8MaJGcUa0qFG0dsTAcxMDWCX6yQ0N258E6E92RpEACZAACZAACZAACZAACeiQgF358oi+a1eQxa5sWX9bYZU4MaLv3o2gluXYs6e/5ZhG2lhbI6nmMd2y/YDmWU2PbJnT4eyFa3jw6InP+FtrLY0xj421jTEY4N7W1neaSSN7K8+sjOk9/OdSxIkdM8C8pidix4yBvDmzIHq0KMiYLpVmmLrgkWZox4kVA2/fvvdJ+ur1W8SLE8vn2NbmW/3Sfdnm37CclGN3dw8JhphEGsN27aadaNSuH5q0H4BDx8/5C/Cl5krv1Hs0WnQerPqxf/n6VaV7o12sXoMmosQvLTF+2u8qjpufJcD8JEACJEACJEACJEACJKBvAvYNG8IQNaofJR2aNvUTFxIRYswuX7cF2TKlQ46s6bFp216kSZVMFZ0oYTyI4Si2iUTI2FvZB1Xy5c6KWQtXw9vbW2U5ff6K2js6OuD9+48qHNCmaMFcOKt5fL00z+3TZy8hXZATa/oU1TzCMhOyeJlfv3kHGTecP0+2gIoJ1fhIYdjef/gES1dvwdzJgzF+aHeMmjTP39m6ps5dgfy5s2HR9OGIFi0qVqzb5gO/YtmiaN24ps8xAyQQJgRYCQmQAAmQAAmQAAmQQLgRsEqYENFWrIDT4MFwaNECjr17I9qqVbAtVixUdBKDVgxHMWpjxXCBwWCF7JnTq7rEozuwV1s1NrZT71G4ffe+ig/qpnObhnBzc0OD1r1RoU47rN+8W2WtVKYojp2+oCaruv/wsYoz35QrWQgxXKKjYds+6D10Eob17YQozk6QMbk1q5RBs44D0LnPaPTq3Bx2trbm2cPkOFIYtkdOnEOxQrl9ZutKnyYFTp/79oXClPLRkxdQqWwRFVWpTBEcOXlehWO4REPJInnh6GivjrkhARLQFwFqQwIkQAIkQAIkQAKhRsDBAbaFC8O+Xj3YlS4NQ6z/utr+bJ11qpVHu+Z1fYoplC8HTuxeBXs7OxW3cdlUNKlXVYVlI064GeMHQGT6uAGYMqqPRPsrA3q2Rami+X3OuWiOO5k0atWCCdi+do6ayElOpk6ZFJNH9tacgEOUoSpx5mIwGNCzY1M18dTS2WM0Z2BWnyT1alRQ8SvmjUPxQnl84jcsnarG00qExA/p3V6CShZNHxFgXSrBD2wihWH74tVrX7N1idv8+cv/ZusSbp8+f4F2vbQvEdHkEEkSxcOLIA6mVhm4IQESIAF9E6B2JEACJEACJEACJBBhCUQKw1auXmCzdcl5ERnELHsRg+b2l/335OvXL6Dom4F0uXB1/crrFMnvVQ8Pd4T0ffDlyxdQLIuBp6fHd54F+n6e8d+bn7s+8nsVhu7ubvztRsLnl1x7o7i6ukLuA+Mx9z/32wpNft97F+d5YNmazWjTfagvkbgfYSP5QqqsH6n/Z/JECsM2TqyYePv2nQ+n12/eIm5s310InJ0c4enpBTd3d5VOFjAOyixhtrZ2oOibgczAxmuk72sUFtfHysoaNja2Ifp7tbe3A8WyGMhHy7C43yJ8HRb6b5/8Xu3s7NWzQMIUu0j1DPP9u7SBtbVNiP6b4Lt8/rsbUjzUizk3gRJoXLcq5k0Z6kskLtBMAZyUfCFVVgBVhFp0pDBsC+fPicMnzqk1oV6/eYdrN+8iX+4sCur5S9e1L3bfppoumDc79hw4ruJ37T+Gwvmyq3BgG2tra1D0zcDKygoivE76vk6hfX1C4x6wsrLW7i2KZXGw4jM7Ev+79e1etYLBYAiT3+63+qxZl06eldYm9/63a8PngSkTvYbBPxIIIgGrIKaz6GTJkiRA9Uql0LLLEHTrPx7dOzTxma2r99ApePf+g2pft3YNsWXnIbXcz4OHT9CwdiUV7+HpiQLlGqmlfjb+uVeFb976W53jhgRIgARIgARIgARI4IcJMCMJkAAJhAgBqxApxQIKqVOtHJbPGYOls0ehWMFcPhrv3jAPsWPFUMeynz1xoFruZ/SgrnB0cFDxMrX28Z3LYSrp0qRQ57ghARIgARIgARIgARIggdAlwNJJgAS+RyDSGLbfA8HzJEACJEACJEACJEACJEACFkyAqkdqAjRsI/XlZ+NJgARIgARIgARIgARIgAQiE4GI2lYathH1yrJdJEACJEACJEACJEACJEACJBBJCISwYRtJqLGZJEACJEACJEACJEACJEACJEACuiFAwzY8LgXrJAESIAESIAESIAESIAESCHUCz58/BcXyGPzIjUHD9keoMU+YEGAlJEACJEACJEACJEACJPCjBGLGjAWK5TII7nWnYRtcYkxPAvoiQG1IgARIgARIgARIgARIINIToGEb6W8BAiCByECAbSQBEiABEiABEiABEojIBHRp2Hp5eWHb7kPo1GcMajTpjiKVmqFcrXZo2KYvRk9egIf/PI3I14RtIwESIIHwIcBaSYAESIAESIAESMBCCejSsG3RZQhOn7+GxnUqY+qYPti3aQFWzR+Hwb3bIV2aZOg9dAr2HjxpocipNgmQAAmQgCUToO4kQAIkQAIkQAL6I6BLw7ZPl+YYohmx+XJlQZJE8WFra4OYMaIjXerkqFmlDJbOGoXEieLpjyY1IgESIAESIAESEAIUEiABEiABEghTAro0bDOkTRkoBDF0xcgNNBFPkgAJkAAJkAAJkICuCVA5EiABEiCBkCKgS8PW2DgZSzt70Rp07jMG7XqO8BHjee5JgARIgARIgARIgAQiOAE2jwRIgASCQEDXhu3ISfMQPXo0NKpTCS0bVfeRILSLSUiABEiABEiABEiABEgg0hBgQ0kgshPQtWEbLaozGtSsgHy5siJPjsw+EtkvGttPAiRAAiRAAiRAAiRAAiQQbALMEIEJ6NqwtbO1xb0HjyMwfjaNBEiABEiABEiABEiABEiABPREwDJ10bVhe/f+P6jfujcat+/vM75WxtpaJmpqTQIkQAIkQAIkQAIkQAIkQAIkEBoEwtywDU4jenRojGlj+6JLmwY+42tlrG1wymBaEiABEiABEiABEiABEiABEiCBiE1A14at6bha03DEviSqddyQAAmQAAmQAAmQAAmQAAmQAAkEkYCuDdurN26j16CJqFi3g5Jfh0zC1Rt3gtg0Jov4BNhCEiABEiABEiABEiABEiABEgB0bdiOmjwfyZIkwMzxA5QkSRQfY35bwOtGAiQQHAJMSwIkQAIkQAIkQAIkQAIRnICuDVtvb290btMQKZIlUtJFC7u5uUXwS8LmkQAJhAcB1kkCJEACJEACJEACJGC5BHRt2Hp5eeHN2/c+dF++euMTZoAESIAESCDMCbBCEiABEiABEiABEtAlAV0btvVrVkTdlr/6LPXToE1fNKpdWZcgqRQJkAAJkAAJfCPALQmQAAmQAAmQQFgT0LVhW61iSSyaPgyli+VTsmj6cFStUCKsGbE+EiABEiABEiCBkCbA8kiABEiABEggBAno2rCVdiZOGB+1qpZVkjhhPImikAAJkAAJkAAJkECkIMBGkgAJkAAJBI2ALg3bAuUa4fK1W5C9fxK0pjEVCZAACZAACZAACZBAJCDAJpIACZCAPpf7Ob5zObJkTAPZ+ycbPSc4AAAQAElEQVS8biRAAiRAAiRAAiRAAiRAAsEhwLQkELEJ6NJja0Q+aeZSY9BnP2LiPJ8wAyRAAiRAAiRAAiRAAiRAAiQQYgRYkMUS0LVhe+vufT9gr9245SeOESRAAiRAAiRAAiRAAiRAAiRAAmFDQI+16NKw3bzjgFri5/bdB2rfrucItW/aYQBSJk+iR47UiQRIgARIgARIgARIgARIgARIIJwI6NCwBXJmzYCWjaojftzYai9hkTGDu2LUwC7hhIrVkgAJkAAJkAAJkAAJkAAJkAAJ6JGALg1bWdYnT47MWD53DGRvlITx4+qRYfjoxFpJgARIgARIgARIgARIgARIgAQUAV0atkozbePq5oYlqzajW/9xqiuysUuydor/k0CQCDARCZAACZAACZAACZAACZBAxCega8N2+Pg5ePHqDV6+eovqlUoiipMj0qdJHvGvCltIAmFLgLWRAAmQAAmQAAmQAAmQgEUT0LVhe/feQ/Tq1BTOzo4oV7IQJo7ohUePn1k0cCpPAiRgqQSoNwmQAAmQAAmQAAmQgF4J6NqwdXZ2Utw8PDzx+ctXFXZ391R7bkiABEiABHRIgCqRAAmQAAmQAAmQQDgQ0LVhG8XZGW/ff0ChvNnRvNNATQYhftxY4B8JkAAJkAAJWDIB6k4CJEACJEACJBCyBHRt2P42ujdcokVFi0bV0b97a3RoWRe9u7YIWQIsjQRIgARIgARIQI8EqBMJkAAJkAAJBJmArg1b01Zky5xOLf1jbWUxKpuqzzAJkAAJkAAJkAAJhAIBFkkCJEACJCAEdGklFijXCIGJKE4hARIgARIgARIgARIggSARYCISIIEIT0CXhu3xncshUrd6OTSoWQFLZ4/Cut8noX3zuqhWsWSEvyhsIAmQAAmQAAmQAAmQAAmENQHWRwKWTECXhq0R6NmL19G5TUOkSZkMiRPGQ5N6VfD2/Xvjae5JgARIgARIgARIgARIgARIICwJsC6dEtC1Yevm5oa37/4zZL+6uuH1m/+OdcqUapEACZAACZAACZAACZAACZBAJCYQ9k3XtWHbpG5V1G3ZGwNGTsOoyfNRr+Wv+KViibCnxBpJgARIgARIgARIgARIgARIgAR0S0DXhm2lskXx+4zhyJE1PdKlToY5kwehYuki0C1NKkYCJEACJEACJEACJEACJEACJBDmBHRt2AqNhPHjolbVskrix40tUZSgEWAqEiABEiABEiABEiABEiABEogUBHRp2LbrOQJ37j2E7P2TSHFl2MgwIsBqSIAESIAESIAESIAESIAELJ2ALg3blo2qI16cWJC9f2Lp0Kk/CVgcASpMAiRAAiRAAiRAAiRAAjomoEvDNk+OzIji7ATZ+yc65knVSIAEIjEBNp0ESIAESIAESIAESCB8COjSsG3ZZQgCk4BQvXz1Bp16j0aLzoPRf8RUfPn61d+kF6/cRLNOg9C4fX8sWLbeJ01A+b29vTFxxhI0bNPXJ4/E+WRkgARIgARIIKgEmI4ESIAESIAESIAEQpyALg3bbu0aITAJiMLUuSuQP3c2LJo+HNGiRcWKddv8JBWDdPCYmejduRl+nzEC+w6fwvlL11W6gPIfPXkBt+8+wIJpQzF1dB9s33MUN2/fU3m4IQESIAESIIGQJ8ASSYAESIAESIAEgkNAl4ZtloxpEJgE1EAxQCuVLaJOVypTBEdOnldh040YpE5OjsiYLhVsrK1RtkRBHD5xTiUJKL+nl5c6b2VlBSsrA6ytDYgbOyb4RwIkQAIkQAIkEI4EWDUJkAAJkAAJ/EtAl4btv7rB1c0NS1ZtRrf+43zNkGw8b7r/9PkLDAYghks0FZ0kUTy8ePlahU03z168RqL4cXyiJN2z568QWP6CebLBy9sLxau0QIU6HVCtUmnEjBHdpwwGSIAESIAESIAESECvBKjXNwJuHx/j6fl5uHdgAO782QJ3tzbG3d098M+pKfjw+DT4RwIkYNkEdG3YDh8/By9evcHLV29RvVJJRNE8renTJA+QuHhUjScNhoCbZtC8rsZ0wH/pAsp/7+E/iBUzOraunoG1iyZix54jajkiKePTp4+g6JuBq+tXfPnymdcpkt+rbm6u+Pz5E++DSH4fuLu78x6I5PeAPAdcXV15H0Sq++ADnlxZh9s7OuPVX5vx6dlFeHx9DS+PL/jy+i+8/XsvHhwehvtHx+PD26e8N3R2b8j7NoUEgkLgP6suKKnDOM3dew/Rq1NTODs7olzJQpg4ohcePX7mrxbOmtHr6ekFN+2lRRK8evMWcWL77S4cL05MvHn7QZIoea2lixc3FgLLL4ZspnRpECuGC5Ikio8MaVPg6o07Kr+zcxRQ9M3A3t4Bjo5OvE6R/F61s7OHk5Mz74NIfh/Y2tryHojk94A8B+zt7XkfRKL74PXFWXh9dQm8PV0R2N/HR4fw5HA/ONh68/4I8P4I+3e+wK4Zz5GAKQEr0wO9hZ2dnZRKHh6e+Pzl2wzH7u6eKs6/TcG82bHnwHF1atf+YyicL7sKSzfjK9dvqXC61Mk1D/AbPPznKWTs7N6DJ1E4f051LqD8sWLGwIXL1+Hh4aG6LF+5fhtpUyVTebghARIgARIgARIgARLQJ4F39w/g/cPDPso5xkyDFKXGI3XlxUhZeTlSl5+BmGmq+Jx3//wCj09P8zlmgAR+iAAzhQsBXRu2UZyd8fb9BxTSDNbmnQaieadBiK95VwMi1a1dQ2zZeUgt9/Pg4RM0rF1JJX2kGbEjJs5VYYPBgGF9O2DQ6Blo1nEgcuXIiJxZM6hzAeX/pWIJTY+PqNaoG9r3HIkaVUohfZoUKg83JEACJEACJEACJEAC+iPg8eUVHp+Z6aNYtCSFNaN2Ahy+RoPXvuPw2rwd1n+/RYKcbZEoX3efdO8fHce7B4d8jhkgARIIHQIhXapVSBcYkuX9Nro3XKJFRYtG1dG/e2t0aFkXvbu2CLCK2LFiYPbEgWq5n9GDusLRwUGlTacZoWsWTlRh2WTLnA6LZ47Estmj0bpxTYlSElB+ZydHLJg6VI2xXTp7FGpWKaPSc0MCJEACJEACJEACJKBPAm/v71fjaEU7uygJkFgzXt137ML7li3hOm0a3Bctwsdff8WnoUPhkrSE5rmtLEmVvL71p9pzQwIkYDkEdG3YTpyxBHfvP1I0xRjNkyMzrK2CorLKwg0JkAAJkAAJkAAJkEAkJeD6/ts7pDQ/VtqqwPvP+KwZtPh3GUeJF3E/ehRuu3cjdvoacqjE9cNDteeGBEjAcgjo2kpMGD8Oeg+ZjMbt+2P52j8h3ZItB60FaEoVSYAESIAESIAESCCCEjA1bB2iJ8PLnTMAT//nanm9fzEMVrYwWNsrGp6u7+Hl/lmFuSEBErAMAro2bBvUqog/Fk9G17YNcevufVRr2BX9R0y1DLLUMsIQYENIgARIgARIgAQsj4CVta2P0o/PzsG7p98mGPWJNAl4fnqN2zs6wmAwmMR6m4QZJAES0DsBXRu2Rni5s2dCq8Y1UKZEAew/wgW0jVy4JwEdEaAqJEACJEACJKArAg4uKX30cX3/AF42mqHqrYlP7H8B99gGeLq+g5fHt1U4bJ3jw8rW+b8EDJEACeiegK4NWw8PD+zcdxQdfh2FNt2Hw8HeXk34pHuqVJAESIAE/CXASBIgARIggbAi4BDjP8MWXt6IudfD/6o1Y9fWxsXXOUfTvL7O8IAESECvBHRt2P7SqCv2HjqpZiHesmo6enZsgtQpk+qVJfUiARIgARIICQIsgwRIgARCgICd5nUF/vXQWhnwPp8NvFInx4wkaTHyvQfGvfyE5bZR4S3dj1+802o0dkP2hpWNo3bM/0mABCyJgK4N22WzR2P80B4oVTQvbKytLYkrdSUBEiABEiCBUCXAwkmABAIn8PbeHti80AxbzSMrKb+ksMbN/M9w79NZ7HZ7heUf3mGP90NcKmeFtwV8v2d+eHJWslBIgAQsiIAuDduVf2yDt/YQihkjur8o9x46pXlyT/h7jpEkQAIkQAIkQAIk8C8B7iIxAa8LfyHuZne4nPD0cdxGc/RG9xqxsbJvUuwYlQKjmsVD7CT/TTJl90zSesPT9a2WRwtHYn5sOglYGgFdGrbPXrxEnRa9sGDZehw7dQGnz19RsnXnQXTqMwZzF69BgnhxLI019SUBEiABEiABEiABHRKIeCq57doF57V/waA5bOHhjUQFeuGDe8CTQbm6GxDjvAPibPFAtFPfDFqPr28iHhi2iAQiMAErPbate/smmDqmj/Lart6wAwuXb1Ry+vxVVC5bBCvnj0fGdKn0qDp1IgESIAESIAESIAESCEcCrv/7Hz5PmAAZMfshuzXeFrFFt74jUPbXS+j/+1P8cfgtbj92w7tPHth/8SMmrX+BA8+LIW6rUfDW3oyjXvaCwyMr2DjGhq8/HpAACeiagPbz1ad+CePHResmtTBtbF/MmTRIybC+HVC+VGGOt9XnJaNWJEACJEACJEACJBCuBD7Pm4cvM2ZAHLU7YnnhfW4bpU8SF1dkSJcWZ/62xvh1r9Bg7EOU6XcffRY+w5qD77F++3G8tn6FN0W/pY+51xWejx+rvNwEjwBTk0B4EdCtYRteQFgvCZAACZAACZAACZCA5RDw9PTEvgNHsL9OA7itWwcPb290uP8K85+88WlEvRKxcHjLTOzYuBRVK5ZBAs2B4uzkhJzZMiNenNi4fOUazm0fjS+prfExvRUM7l74NHAgvL988SmDARIIQQIsKhQIWIVCmSySBEiABEiABEiABEiABEKNgIeHB3btO4wO3QcidabCeN2nL3K8eQFXL28MhTNydWqHRUs3wTFmWqg/b0/cPzwSqeMbsOr3abhxdi8e3jiKw7vW4ezBNZjVPT2SxFIp8a6wIwwpksHr4UN8GjnyWyS3JEAC4UAgeFXSsA0eL6YmARIgARIgARIgARIIBwLu7u7YvvsA2nbpj2QZC6F6/TZYu2oDZsSwQelojnC3sYGH5mWdsed/6NWlDZIlS4okBfvAysZBaev24RHu7u6BewcG4tn5OXh5ZSkeHBmFpwd7IEcyd5VGNiNXv8C1GvVhiBoVHqdOwVXzAks8hQRIQN8ErPStXuhpx5JJgARIgARIgARIgAT0TcDV1Q1bt+9Fy469kTRDQdRq1B7L12zE23fvUTx7JpwsnBmFojjA4OKCmLNmIVGJ4r4aZOscD8mKDYeNYyyf+E/PLuDt3R14e3szPvxzHF7uH7+dM1jj3LNU2HzsNcq37IYTJcoCBgO+zJ8Pj0uXwD8SIAF9E9ClYTtxxhLIWrbm6Jat3YpZC1ebR/M49AiwZBIgARIgARIgARIIUwJfv7pi09ZdaNq2J5KkL4C6zTph9R9b8P7DR+TJlQ1jhvbGrf0bsSq+M2K9ewNDnDiIOn06rFOk8FdPp9gZkabiXMRIqRmq/qYAHFxSIE2FmWjcZSp+GzcYYIMF9AAAEABJREFU0tW5xsipOJk2E+DtjU9Dh8Lr1SvwjwRIQL8ErPSomqxdW6ea34dP/Rrlcfj4WT2qTJ0iNQE2ngRIgARIgARI4GcIfPr8Gev/tx0NW3ZF4vT51f6PTdsg8fnyZMfYYX1w++JBHNi2Gh2rloXzyOHwevwYVkmSKKPWKn78QKuX7sgJ83RBhhqrkaLUeMTL0R6xMzdV3ty0VRYhVbnpsIuaWJXRull9rFkyA/b2dqixbgduRIkO7w8fvk0m5eGh0nBDAiSgPwK6NGytra1gY2MD8z+Jc3XjA8WcC49JwCIIUEkSIAESIAESMCHw8dNnrFm/FfWad1bdjJu06aE8tV++fEX+PDkwfkQ/Zczu27oKnds1UzMZe/79Nz527gzvFy9gnS4dok6bBqtYsUxKDTxoZRsF4sF1SVkOLqmrIEr8nLB1iusnU+XypbBn8wrEcImOKieu4bmVDTxv38aXWbP8pGUECZCAPgjo0rC1t7PDl69f/RCSB6Cjg72feEaQAAmQQEQhwHaQAAmQQEQmIN2JV6zdhFqN2yOJ5plt0eFXbNm2BzKWtmC+XJg4agDuXD6EvVtXomObJsqYNfLwuHIFH7p2Vd5Tm2zZEGXSJBiiRDGeDvF9zuyZcWjnWsRKmAC1rj/CV2/AbcsWuO3bF+J1sUASIIGfJ6BLw7ZapRLoN3waXrx87dPCZy9eYeCo6ahWqaRPHAMkQAIkQAKRkgAbTQIkYEEE3rx9hyUr16tZjJOkL4A2nfth+64DcHf3QOECeTB5zEDcvXwYuzcvR/tWjRA/bhw/rXM/cQIfe/cGvnyBbaFCcB47Fgb70Hd2pEyeFId3rkO09OnQ6f5LpdenCRMgnmN1wA0JkIBuCOjSsK1VtSwypkuBWs16okGbPqjToifqtvhVi0uJWlXL6AYeFSEBEiABEiAB/RKgZiQQfgRev3mLRcvWomqdVmppng7dB2LXvsPw8vJC0UJ5MWXsIGXM7ty0FG1bNETcOLECVNZt/358GjwYmiUMuwoV4DRkCAz+DFkLsICfPBEndkzVLdkjdx7Mff4eBg8PvP61N7w/ffrJkpmdBEggJAno0rCVBrZpWhtbV89A/ZoV0LxBdRWWOIPBIKcpJEACJEACJEACJPDzBFhCiBF4/uIV5i9ehYo1myljtnOvIdh78Ci8vb1RvEh+TB0/BH9fOYLtG5agTfMGgRqzRqVc//c/fB49GlohcGjYEE49esBgCPt3QQcHe2xYMQf3ipfC2U+usH33Fve7dNXU8jaqyj0JkEA4E9CtYStcokZxRpVyxVGhdGFEcXaSKAoJkAAJkAAJkAAJkEAYEwiouqfPX2D2guUo+0tjpMxSBN36DMfBIyeV8VmiaAFMnzAM968dxZ9//I5WTeshdqwYARXlJ/7rokX4MmOGinfs3h0OzZqpcHhtrKysMHvqaFypWgMvPTzh8uA+DnfrFV7qsF4SIAEzAro0bMvXbofAxKwNPCQBEiABEiABEiABEggjAv88forpcxajZOX6SJWlKHoNGIWjJ85ADL9SxQphxqThuHf1CLauW4QWTeogZgyXYGkmHt5P48fj66pV0AqFU//+sK9YMVhlhGbirn274VbtevDUPNFZrl7E1HbdjZ7b0KyWZZMACXyHgC4N25njByAw+U6beJoESIAESIAESIAESCAECTx89Bi/zVqEYhXqIm2OEug7ZBxOnr4AWYqxTInCmDVlpPLMbl67AM0b1Q62MWtU1dvDA5+HDYP77t2AnR2cR42CXYkSxtO62Vfo0AbPKlZRnunqf11C+0Zt1czOulFQ14pQORIIHQK6NGxTpUiCwCR0ULBUEiABEiABEiABEiABI4H7D/7BxGnzULhMLaTPVQoDhk3AmXOXlDFbrlRRzP5tFB5cP4ZNq+ejaYOaas1XY94f2Xu7uuJT375wP3oUcHRUy/nY5s79I0WFSZ6MPbriS7bsiGZthab3/0Llao0hk2aFSeWsJOITYAuDTUCXhm2wW8EMJEACJEACJEACJEAC3yXw6J8nWLpqg/K+7thz0E8X2tt372Hs5NnIX6IaMuYpjSGjpuD8pauwtbVF+dLFMHfaGDy8cRwbVs5Fk/o1ED1a1O/WGZQE3h8/4mPPnvC4eBEGFxdEnToVNunTByVruKaJP3IEvBIkQAZHWzR48QhFy9XBg4f/hKtOrJwEIhMB07bSsDWlwTAJkAAJkAAJkAAJRFACW7fvRfZCFdG+2wDlfa3ZsB0q1WqOi5euYfTEmchdtAqyFaiAEeOm4fK1m7Czs0WFssUxf8ZY5Zldv2IOGtWthmhRo4QoIa9Xr/ChSxd43rwJq3jxEHX6dFinSBGidYRWYQYHB0QfOxbQ9tVjOKHoh9coUq42Ll25HlpVslwSIIEACNCwDQAMwBMkQAIkQAIkQAIkEDEIfP3qivbdB+LLl6++GiQzGBcoXQOjJszA9Zu3YW9vh0rlS2LhzPGaZ/YE/lg2Gw1q/xLixqxRCa+nT/Ghc2d4PXwIqyRJEEUzaq3ixzeetoi9dcKEcB44UOk6InEMxP/0ESUrN8CuvYdUHDckQAJhQ0CXhu3RUxcQmIQNGtYSJAJMRAIkQAIkQAIkoHsCR06cCXT8Z8VyJbBo1gTNmD2OtUtmol6tKqG+1KLn338ro9b7xQtYp0uHqNOmwSpGDN2z9E9B23z51Dq71trJ9ZmTwsnNDdUbtMXvy9dpMfyfBEggLAjo0rBdu3EnApOwAMM6SCAkCbAsEiABEiABEghLAs9fvMK6jX+ic68hyJq/PKrWaRlg9dLdeN3SWahbszKcnZwCTBeSJzxu3MCHrl3h/fYtbHLlUhNFGaJECckqwrws+6ZNYZMjB6K4uWJ/0WywNhjQqedgDB09Jcx1YYUkEBkJ6NKwnTqmDwKTyHih2GYSiAQE2EQSIAESIIEfJPDq9Vts3LIT3foMR87ClZAic2E0a9cLi5atxZ2/76uZjK2t/H/ty5Mz2w/W+mPZ3M+cURNF4csX2BYqpJb0Mdjb/1hhOsplMBjgPGQIDHHiINarFzjVoobq2j1h6jy0aP8r3N3ddaQtVSGBiEfA/yecjtrp7u6BK9dv4fT5Kz6iI/WoCgmQAAmEMQFWRwIkQALA23fvsWXbHvQaMAp5i1dF0gwF0KhVN8xfvAo3b92FtbU1cufMip6dW+N/axbg6e3TGDm4lx90iRLGR/tWjfzEh1aE2/79+DRgAODmBrsKFeAkhqCma2jVF9blGpydEWXUKMDWFvFPn8SxUX0QwyU61mzYisq1W+DDx09hrRLrI4FIQ8BKzy09cuI8ajTphm79x2PC9N/Rpe9YzJi/Ss8qUzcSIAESIAE9EKAOJBDBCIhBtH3XAfQdMg4FS9VA4nT5Ua95Z8xesBxXNQeAwWBAjqyZ0LVDc8jsxY9vncLB7WswfGAPlC5eCE5OjujSvjkun9yJ2b+Nwqghv6qJoa6e2hViS/Z8D7nrtm34PHo04OUFhyZN4NSjBwwGw/eyWdx5mdHZqde3jwjx16zEkcVTkSRxQhw5fgYlKtbDP4+fWlybqDAJWAIBXRu2MxeuxvypQ5E6ZVKsXTQJv88YoYWTWQJX6kgCJEACJEACuidABfVL4NPnz9i9/wgGjZiEouXrIGGavKjVuD2mz1mMi1euw9vbG1kypkPHNk3UZE///HUSR3b/gdFDeqN86WIBTvyUMnlSNKlfA906tFBL+dhqnsWwoPB16VJ8mfJtrKlj9+5waNw4LKoNtzrsSpaEXcWKgKsrYs6eicP/W4Yc2TKpmacLl62NazduhZturJgEIioBXRu2NjbWiB83NqQ7slyA9GlS4POXzxKkkAAJkAAJkAAJkEBYEAiTOmQZnv2HjmPYmN9QsnJ9zZDNh2r1WmPyjAU4e/6y5uT0Qsb0adCuZUOs+n2amr34xP5NGD+in1qeJ3q0qGGiZ3ArEQP88+TJ+LpsGWBlpboe24vBF9yCLDC9Y+fOsE6dGl5PnsBRM273bF6BMiWL4PmLlxDP7eFjpy2wVVSZBPRLQNeGrZOjgyLnEj0K/rdtH6Rr8pu3H1QcNyRAAiRAAiRAAiRgqQRcXd0gho2sH1v2l8ZIkCavGoM5/re5OHn6Ajw8PJA2dQq0aloPy+ZPwb2rR3H64GZMGj0QVSuWQcwYLjprul91vD098XnYMLht3w7Y2alJouwKF/abMILGGGxs4DxyJAxRo8Lj1CkYNm3EhhVz0FjzmH/89Fld79Xrt0TQ1rNZJBD2BHRt2Nb+pSzevv+ADi3rYc/Bk1i+bivaNq0V9pRYIwmQAAmQAAmQAAn8BAGZEff4qXMYO3k2KtZshoRp86J89SYYPXEmjp44Azkv3YSbN6qN32dPxJ3Lh3D+6DZMHT8ENaqWR5zYMX+i9rDP6u3qqiaJcj96FGpCpUmTYJs7d9grEs41WsWKBeehQwGDAV8WLYLXlSuY89soDO3fXX28aNmhN8ZNmQP+kQAJ/DwBXRu2pYvlh0u0qEiVPAmmj+uHOZMGIUfWDD/fapZAAiRAAiRAAiRAAqFIwFPzVp45dwmTps/HL3VbaYZsPpSu0hAjxk3DwSMn8fWrK5ImSYTG9apj/oyx+Ov8fjWx04xJw1GnRiXEjxsnFLUL3aK9P39Wy/l4nD0Lg4sLokybBpv06UO3Uh2XbpM1KxyaNQO8vfFp6FB4vXqFX7u2UZ54G82rO3zsVLTrNkB1N9dxM8JUNVZGAj9CQNeGrXTDOXHmIhYt34h5S9b5yI80lHlIgARIgARIgARIILQIeHl54fylq5g663fUbNgOidLmQ7EKdTF45GTsOXAUnz9/QcIE8VC/dlU1K/GNs3tx/cwezJk6Gg1q/wJZdie0dAvLcr3evMGHrl3hefMmrOLFQ9Tp02GdNGlYqqDLuhwaNIBN3rzw/vABnwYOhLeHh/LEb123SE30tWzVBtTQ7hu5T3TZACqlRwLUyYyArg3bASOnYf2WPXB1dzNTm4ckQAIkQAIkQAIkEH4EZFKky9duYua8pajTtKNafqdwmVroP2w8duw5CFmeR7yutatXwvSJw3DpxA7cunAAC2aMU7MSy/Iv4ad96NTs9fQpPnbuDK9792CVPDmiaEatVfz4oVOZBZbqrBm0VgkSwPP2bXzR2EgTihTMg/3bViNunNjYve8wSlZugBcvX8spCgmQQDAJWPmbXieRX13dMWFYT7RvXhdtmtb2EZ2oRzVIgARIgARIgAQiEYHrN29j7qIVaNCiK5JlLIj8Jaqh96Ax+HPHPrx7/0GNg61RtbwaFyvjY2Wc7OI5E9GicR2kSpEMEfnP88EDfBCj9tkzWKdLh6hTp8IqRoyI3ORgt83g6Kgmk4K9Pdy2bYPbvn2qjIzp0+DIrnXIkC41Ll+9gSLlauPuvQfqHDckQAJBJ6Brw9bOzgbGpX6C3qSwS8maSIAESIAESIAEIi6B23fvYbYRJ8EAABAASURBVNHStWjatidSZC6M3EWroEe/kfjfn7vw6vVbyMzEMkOxzFQsMxbLzMUyg7HMZJw2dYqIC8asZR43buBjly7wfvsWNrlyIcqkSTA4OZml4qEQkG7ZTn37ShCfJ06E599/q7B0RRfPbeECufHw0WMULVcHJ89cUOe4IQESCBoBXRu2bm4eqNOyF6bMXuozvlbG2gataUylEwJUgwRIgARIgATCnYBM1jRoxCRkzlcWSTMWRqHSNbFt535fet27/whLVq5Hy469kTpbMWQrUAGdfx2CPzZtw/MXryBrxVYsVwLjhvfF8X0b8eD6Mciasu1aNlRrzPoqLJIcuF+4gI89e8L70yfYFi8O51GjYNA8kpGk+T/UTFnyyL5aNWjeG3wcMECxk4KiRnGGjLmtXqUc3rx9B5k1e+uOvXKKQgIkEAQCujZsM6VPiQqlCsHZyTEITWESErBkAtSdBEiABEggNAl0+XUoJs9YgPsP/lETOV24fA21m3RA78Fj0LZLf6TPVQqZ8pZBh+4DsfqPLXjy9Lma1KdcqaIYNeRXHNn1Bx7dPIF1S2ehU9umyJopPQwGQ2iqrPuy3Y4cwSfxPrq5wa5CBTj17w+DtbXu9daDgg7t2sE6fXp4v3iBT8OGQcZsi162trZYvuA39OjUCm5u7qjXrDNmzF0ipygkQALfIaBrw9Z0XK1p+Dtt4mkSIIGISoDtIgESIIFgEpBZZi9euY5Vf2z2N+eMOUuwfM1G1f3TwcEepYoVwrAB3bH/z1V4dvcsNqyci24dWiBHtkywstL1a5O/7QutSNdt2/BZM8jg6QmHpk3h1KNHpDf0g8NaPgA4Dx+ulkPyOH8erkuW+Mo+YlBPTBs/VBm8fQaPxa8DR/s6zwMSIAG/BHT9hH7z9j1WrPsTMjuyyMr12yFxfpvBGBIgARIgASMB7kkgMhCQmWNlVuLd+49ohukmTJw2D70GjELj1t1R9pfGyJKvHOKmyIU4KXKiQMnqkOV4/OMSxdkJg/t2xZ4tK/Dq/gVsXrsAvbq0Qd7c2f1LzjiNwNcVK/BlyhQtBDh27w6HRo1UmJvgEZDJtcS41b6YQJi6nzzpq4CWTeuqHgISOWv+MtRv3kWCFBIggQAIWAUQr4voIWNn4cDRM8iZLYOSfYdOYtj4ObrQjUqQAAmQAAlYNAEqr1MCDx4+xqkzF7Bl2x7MX7wKI8dPR6eeg1GrUXvIcjoy9tU5XgYkz1RIzUpcrV5rtO3SD0NGTcHsBcuxYfMOHD1xRs0q++nzZ9XKBPHjwluF/G6KFy2APt3boUDenH5PMsYXAeku+3n6dHxdvBiwtobTkCGwr1jRVxoeBI+ATYYMcGzbVmX6NHIkPB8/VmHjRsZ0H9y+Bi7Ro2Hztt0oWbk+Xr95azzNPQmQgAkBK5Ow7oJPn7/AnMmDULNKGSVzJg3Eo8dPdacnFSIBEiABEiCBiEkgZFolS+HcvHUXh46ewtoNf2La7N8xYNgENUlT5dot1GzDidPlhxisGXKXQolK9VGveWd06zMcYybNwu/L12H77gM4f+mqGvsqWslEO2lSJUeRgnlRq1pFNe5Vum/OnzEWW9YuxKkDm/Hg+nF8enYddy4dQuXyJSWbH6mt5fUTyQg/BLw9PfF59Gi4bd4M2NnBeexYyCRIfhIyItgE7GvUgG2hQsDXr/g0cCC8tb1pIblzZsXhXeuQIlkSnDx9Qc2Y/ODhP6ZJGCYBEtAI6Nqw9W8si5WVQVOb/5MACZAACZAACQSHwLGTZ9G51xCIh1O67N74605wsvtJ66kZOvIBWiZh2rHnoJpNeNyUOejed4Ra51U8SxnzlEasZNmRME1e5CxcCRVqNEXz9r3Qb+h4/DZrkZqkaf+h45D1YWUWWPl3P16c2MiWOQNk0qYm9Wugd7e2kOV0Viycir1bV+LKqV14ee88nt45gwvHtmPHxiVYMneSmqlYJtxpUPsXlCxWEJkypEGsmC4+ek8ePRBNG9RE0iSJ4OjooCZ/GjusD2pXr+ST5ocDETyjt5sbPg0YAPcDB2BwdlbL+dhmzx7BWx22zZMlgKySJIHXw4f4rH00MK89ZfKkOLRzrRrr/ff9hyhSrjYuXblunozHJBCpCejasM2eJQM69BoJWeJHpH2vUciTI0uAF+zlqzfo1Hs0WnQejP4jpuKL2RcvY8aLV26iWadBaNy+PxYsW2+MRmD5r964rfIUrtAEFet2gKeXl08+PQZkWYOxk2ejbrNOarzRgiWrIS8hetQ1tHR6++696sLWoEVXtO7cF8tWb4R0owqt+vRYroxBk+55NRu2Q+tOfVUXPT3qGZo6ycymMvFG/eZd0K7rAOzadzg0q9Nl2X/d/luNPRSDRgwb8ZrpUtFQUkp+93MXrUCeYlWRLFMRZWCJx1DiQ6lK3RUr3XNl3OmiZWshY1Kly27B0jVw/NQ5P7p++fIV8uIs5zZt3YU5C1dg6OgpaN9tAKrXb6PGq6bMXATRE2VBqixF1bI58oyR2YSHj52Keb+vVOu8imdJZiCWf4/EkEyeLDHy58mBapXLom2LhhjSrxtmTRmpJmc6tncD7lw+hHf/XMbdK4chxzJp0+zfRql0spyO5JP84rWS8hDMv8SJEqj6rmqG8cPrRyHL9XRu1yyYpUS+5N6fP+Nj797wOHsWhpgxEWXaNNikT/9DIJgpYAIGBwc4jxwJaHv3o0fhummTn8QxY7hgz+YVKFOyiHpnLVm5AXbtPeQnHSNIILIS0LVh27tzM1QpVwz3Hz5RUq1iCfTs2CTAazV17grkz50Ni6YPR7RoUbFi3TY/aeVFZvCYmZCyf58xAvsOn8L5S9++eAWU/9PnL+g+YAKqarrs2bQAsycOgpVBv55jmR6+lPawGzFuGrZu36uMma69h6Fu005+eETUiI+fPiNfiWqQLmw7tYe+dH1r17W/8iRE1Dabt+vxk2fIW7wqZEKVHZo3ZeW6/6mPHPLiaZ42oh7f+fs+chWprJZK2HPgKFas3aRezKfO+j2iNtlPu86ev4z8JaupsYdi0IhhI16z9f/b7idtRI2YOW8pevQbiWs3bkGMNukS20/zGE6aPj+iNtlPu2RGVfn3z/SEq6sbWrT/FU3a9ED56k3Vmq3xUuZC7OQ5kDlvWZSu0hANW3ZFz/4jMWHqPCxdtUF9GLp09QaevXipPhTKi3aGdKmVh7R+7aro1qEFxAv6++yJmid1Kc4f3YbHt04pD+vVU7uVx1U8r5PHDFSeWPGgimc2m+ahjR83DsRja6ojw+FLwOv9e3zo2hWeV6/CKl48RJ0+HdZJk4avUhG4duuECeE8cKBq4ZfZs+Fx/boKm25k5u5Nq+ZBJpaS51n1Bm0hz3XTNAyTQGQloGvDVv6Bq6wZk6MGdoFIpbJFA/1H7+jJC6hUtoi6lpXKFMGRk+dV2HRz8/Y9ODk5ImO6VLCxtkbZEgVx+MS3L9YB5T947AwypE2JGlVKw8HeDsmSJND1lPZrN/4J6Rpm2m4Jy/gk+fJ+4PAJGEW6gJnLvoPHYC57Dx6FuYih4J/Iy7O5iJfMXMTgNBcxwMxF9PYjuw5gu5ls27kfRumpvcQ++ueJNNuXzF+8CvMWrVIGvxj9piITlZiLTNRgLv/7c5fyRpjuxathLhu37IS5bNi8Q31oMN2LgWEuf2zaBv9knXZtzUWMdnNZs34r5GPG8xevfLVfDsb/NhcLlqxRXQBXrdsMc1mpGcDmIgahuSxfs0nNRGq+F8+4ucgLsbksWbledV003S9e8QfMRcbWmYv8I+5Hlq7FIjNp3q4XZGyftNtUho6ZgnmaV2nBktUai28i94a5SBpzEc+fucjvylzEI2YuMquluYjRZS6yZqF/Mn3OYpiLeB7NRQx3o7TWPPViwJi2X8IdewzClJkL/Yis82kuYgCai3ww8U/EADIXuefMRbqsmov0MjEX+ThlLqMnzkRQZNSEGRAZN2W2NNmPTJw2X3WJ7T1ojDLeuvUZjs6/DoGwkQ9hwq5Fh1/RtG1PNGrVDeL1r9O0o5rESDyXVeu0QqVazZVRWK5aE5SsXB/FKtRFkXK1lRczf4lqykssXXCzFaigjMUMuUsjbY4SSJW1KFJkLoykGQogUdp8iJ8qt5q9N2bSbJBxpiEpTnHT4+mzF37aLxH3Hz6GPH8OHzuF23fvQT4KSnyihPEh4/pk4poWTepgwK+dIEuPrFk8AzKRzc1z+yBjVx/eOI4zh7aoMa0LZoxT672KF7ROjUooUjAP0qZOgejah2Ypk2JZBLyeP8fHzp3hde8erJInRxTNqLWKG9eyGmGB2trmywf7evUALy98GjwYXm/e+NsK+T2OHNxLnZOeOMPG/KbCkWfDlpKAXwJWfqPCP6ZdzxG4c+8hZO+f+KeheFXFiRrDJZo6nSRRPEg3THVgsnn24jUSxY/jEyPpnj1/hcDyP37y7YWgfqtfVTfkpWu2+OSX7r16kxs3b/voZx7ooRl88iJmlMq1W8BcqtRpCXOpqr3AmcsvdVvBP5HujuYiL4HmUkP7ymgu0p3NXGo1aq9eJH3tG2txZlK7SQcYRQwr87Ybj7v1Haa6aNdt1snXvl7zzjCX+s27wFyka7O5iFfDXORF2FxkGQpzEW+JuciLtH/STDPUzEXGq5mLvIz/uXOfscm+9uK16aK9vLfs2ButOvXxI/Iyby5tOveDucgspP6JGATmIl0YzaVD94Ewl46asWUuMhuqucg/4n5Ea5MYJaZyRvNW+mr8vwfSq6FbnxHK+JcPACLdNKPGXLr3HaG8/Kb7HtpvyFzEo2UuMobRXMRrZi5iVJlLn8Fj4Z/0HTIO5iKeR3PpP2w8jHLj1t1/W+179+HjJzV5z8DhE2Eqg0ZMgrkMHjkZ5iJd3P0T6bJqLvLCZS7Sc8BcpJeJuciMuOYixmpQxGj8vnr91nfj/z16//6DmsRIPizIh4n52ocv+TgiH1fkGSIfeOQjkXxkko9U8pHrzx37IB/adu07rD72yUdCMQqPHD+tJnU5c+4Szl24oj4uylI04iUWD7EYjdK9VyZ8+efxU2Voyocn0U2GTcj1+Pz5C/z7CPGvuhBPjbOTE6JFjYIYLtERO1YMyHhUmfFXutkmS5oIKZMnRZpUyZE+bSo1xjRrpvTIkTWT9lHYYCzG1z5BvNiYN300/rd6Pk7s24i/rxzGhydXcOPsHuz/cyXWLJ6OqeMGo2+PdmjeuBYqliuOnNkzIWGCuNp7t6fFiaenpxqWI0v/GMPcf2NiysHt3j186NQJXo8fwypjRjhNngzvaNEUO9N0lhb28jK9Z73g7e2ly3vYrmkTWGfODO+3b5Vx6+nu5q+eXds3w8KZ49RvWj4eyr/9vtto2l7LDasGcvNjBCJZLl0ati0bVdf+sY4F2fsnAV0j8fAazxkMATfNYGX6D/x/6QLKLw++J8+eY+yQHlg6axQOHj2Dsxeuqqr6pSZWAAAQAElEQVTctYeN3iRKFEelm3+b9GlSomC+XCiUP7cfKVwgN8xFvribS9FCeeGfFCucD+ZSvEh+mEuJIgVgLiWLFoC5lCpWEOZSunghmEuZEoVhLsmSJPSv+SouT86sKFeqyH9SWgubSfkyRWEuFcoWg18prsX5lorlSmgvf76lUrmSMJfK5UvBXKpUKAX/pGrF0jCXXyqVgbnIGDSjJE2cSLXXv42Mz6lRtTxMpeYv5WEutapVgLnUrl4R/kmdGhVhLnU1r4251KtZGeZSv1YVmEuD2lVgLg3rVIW5NKr7C8ylcb1qEEkYP65/zVdx9WpVQpP61TWp4VcaaHFm0rRhTZhL80a1YC4tGteGubTUPF7m0qppXZhL62Z14Z+0aV4P5tK2RX2YS7uWDWAusWP+N3mOarjPxqClbYj2rRop6dC6McylY5vGMJdObZrAP+nctinMpUu7ZjCXru2bw1y6dWgBc+nesQXMpUenljCXnp1bwVx6dWkNU5GhKT7NNgnEihkDQ/p1xfAB3TFK83xIF9oJI/th0qgBmDJ2EKZNGIqZk4djzm+jMH/6GCyaNR5L5k7E8vlTsGLhb1itGX3rls3EhhVzlGG4Ze0CbFv/O3ZuXII9m5dj79YVOLB9NQ7vXItje9bj5P6NmndzM84f+ROXjm/HlZM7ce30boj38/bFA8qofHDtKF7eO+evPNK8o/evHcHdy4dw68J+zfjci6und+HyiR24cPRPnNU8p6cObMLxvRtwZNc6iGd1n2ac7tmyXPOe5jVp+X/B6vIcqFIehfLnQuqUyRA1irMyrl1d3SLkXv699vBwVwaahCluMGfgeuM6PnfrBm/NU2iVPTtsR46Ah62Nn3Tm+Szh2NXVVbuvv8k3fT18jk3PhXfYzd0d1v36AtozyvPGDXyeMzdAPX+pVBqbVs1Vv135EFehRjO8ePkqwPTh3bYfqf+/JxZDJBA4gf+susDTmZ8N1eM8OTIjirMTnjx7CQmbinSb8q9yZydH7R8qL8jDQM6/evMWcWLHlKAviRcnJt68/eAT91pLFy9uLASWP1ZMF2TQvn5LF2T5Qp4lY2rcvPNAleHg4Kh9RdeXFC9SUOlmvrG3t8OOTUuxW3vh2vW/ZTCXnZuWwVx2bFyqxkmZ7rdvWAL/ZNv6xdpLnW/584/fYS5b/1gEc9mybhHMZfPahTCX/61ZAHPZpHkazEVm0DRvvxyLp2OrptOGlfPgIyu0sJmsXz4X5vLHsjnwK7O1ON+ybuksmMvapTNhLmuWzIC5rF48Q3tZ9iurfp8Oc1m5aBrMZcXCqdoL9zcZ3K+LNNmPiFdn/fLZWKa9nJvK0nlTYC5L5k7WXuR9y+I5k+Cf/D57Esxl0eyJMJeFsybAXBbMHA9zmT9jPMxl3vRxmnfJt8ydNhbmMmfqGIi0bt7AT/slInuWjFg0ayJm/zZak1F+ZYoWZyazJo+EucyYNALmMn3icJjLtAnDNCPJt0wdPxTm8tu4ofBPpowdohlavmXymMEwl0mjB8FcGtStJk32I8UK59XyD8JEzYgTmTCyP8xl/Ij+MJdxI/rBPxk7vC/MZcywPjCX0UN7w1xGDfkV5jJy8K8wlxGDesFchg/sCXMZNqAHTEUMbj8AtIhmDWuhd7d26NmlDbp1bAnpQtuhdRO004z9Ntq907JJXTRrWBuN69dAgzrVULdmFe1DTyWIMVitcjntI1RpVCxbEuVKF0Np7QNbyWKFtI97+VG4YF4UyJcL+fPkRJ6c2TQPZxZk0+65zBnTI0O6NEirfWBMlTI5Umje1WRJE0O8rQnix0PcOLERK1ZMODo6hrjIdUyn1as12+d/WSanV9c2IV5XaOgfUmXKv9n29g6wtbXV3b/dolt4i/WNm3Dr2w/49Am2xYsj6tixcIwaLcKwcnR00u73byL3gZ2dnc+x6Tk9hJ3ixkOUkaMg6wV7bt4M67PnAtS1TMmi2PfnKiRMEA9Hjp9BpVot8frN+wDT66F9wdHB56HFAAl8h4DVd86H6+ltuw/7qX/Tn/v9xBkjCubNjj0HjqvDXfuPoXC+7Cos3YyvXL+lwulSJ1czyT3856ma2XjvwZMonD+nOhdQ/iLa+b/ufBt75OrmhsvXbiN9muQqT+Cb8DmbP08O9O3RXv3DbdRAxjiN014848aJZYyK0PuKmtdUJiWxtrb2aad8oJgxabj6qukTGYEDdWtU1l7CK8JgMPi0Mn7cOMqYsrGx8YmLyIF2LRtC7gXTNsqMquNHai9uppERONxN83yKAWPaRDFwxNAxjYvI4a6aR1iWgcmQLrX2gm6PtKlTaJ7oJuijPScjcrtN25Y5Y1qc0zzFsp7rgW2r8ejmCe2j5RLE154JpukYjrwE3E+cwKe+mpfw61fYVa0Kp/79YTD5NzTykgm/ltukSQOnzp2VAp+1jwyeDx6osH+bjOnTqJ4a8pyT5bMKl62tJszzLy3jSCCiEtClYXv6/BW1xI+MfZVlfozy25xlgV6Hbu0aYsvOQ2jReTAePHyChrUrqfSPNCN2xMS5KmwwGDCsbwcMGj0DzToORK4cGZEzawZ1LqD84vltXKcyWncbhlZdh6JUsfw+eVRGHW4G9emCZ3fOQJYzOHt4K2SCj9bN6utQUwChpJUsIyEM9m5Zob3QbcW9q0dR85cKoVSb/ooVo37J3El4dvcMDu9cB5mR9PalgyijeZb0p23oaCQfdNZpHnSZlXXXpqWKwZVTuyBd8UOnRv2VKobLjo1LlCEjBs2dS4e038OfEENHf9qGjkbSA2jEoJ6QSY4eXDsCmal3vOZ5lvjQqVG/pcaPFwd5cmVTY3T1qyU1C2sCbrt2QSYqgqcnHJo1U8aUwfDfR9Gw1of1/UfArlIl2JYoAbi64tPAgfD+8uW/k2aheHHjYL/24UqGlT1/8RIlKtbD4WOnzVLxkAQiLgErS2paqhRJMGvigABVlm7CsycOhCz3M3pQVzg6OKi06dKkwJqFE1VYNtkyp8PimSOxbPZotG5cU6KUBJRfTlYsUxSr5o9TeRrUrCBRuhfpeiwTh8gkImLk6F7hUFDQ0dEB2bNmRKoUyWA6hjoUqgr1In+0AplsJmf2zEieLLEv7+2PlmeJ+cTAzZEtE5IGMvbaEtsVHJ1juERXBo0YNsHJx7QkQAIRi4D38+dw27kTruvWwePkSXxdtQqfJ0wAvL3h2L07HBo2jFgNjgCtcerVC1bJk8PryRN8krVuA2mTjJPfum4Rqlcph4+fPqsJQlev3xJIDp4igYhDQJeGrYypbdO0NsYO7grZG6VKueJqNsiIg58tIQESCGECLI4ESIAESCAAAu7HjuFdixb4PHEivsybh4+aB/DrwoXQvvzCacgQ2FesGEBORocnAYOdHaKMGgU4OcHj1Cn1MQKB/MkY8uULfkOvLm3g4eGBlh16Q5ZXCyQLT5FAhCCgS8PWSHbzjoOQZRCMxzIh1KSZS42H3JMACZAACfwQAWYiARKIdATc3JRBK11afbXdYIBtmTKwK1zYVzQP9EXAKm5cOGsfH0Srr7//Do9LlyQYqAwb0B2zp4xUvbVkebV23QZAlroKNBNPkoAFE9C1YXvh8g24RI/mgzdWDBcEtC6lTyIGSIAESIAESCAkCLAMEohABDwfPoT3hw/+tyigeP9TMzacCNjmzKnGQMPbG5+GDoV0K/+eKk0a1FRLksnwtGWrNqBGw3b4/PnL97LxPAlYJAFdG7afv3zFl69ffcDKWIEvX918jhkgARIgARIgARIIXwKsXf8EPG/dwtclS/SvKDX8LgEZA22bL5/6SPFx8ODvppcEZUsVxZ7NKyBzyezedxglKtXHlBkL0Lh1d9Rt1kl1U/761VWSUkjAogno2rDNlzsr+o+YDpklWWTgqBk+S/NYNHUqTwIkQAIkQAIkEJkIhH1b3dzUJFEfOnXChw4dIONrvQPQwjpt2gDOMFqPBJz69YMhThx43rmDz5MnB0nFnNkzqxUSZMm7K1dvYuCISdiweQe2bt8L6aZcqnIDuLm5B6ksJiIBvRLQtWHbu3MzlCiSB1PnrFBSulg+9OjQWK8sqRcJkAAJkAAJkAAJhCsBmTn3y5w5eFevnhpT63nzJgwxY8KhUSM4amKunBhI9tWqmUeH0zGrDQoBg7Pzt8mkbG3htn07XHfuDEo2JE2SCFPHaV5eg9/kFy5fw9qNf/o9wRgSsCACujZsZXmWquWLY/ncMUoqlysGibMgvlSVBEiABEiABEiABEKXgJcX3I8excc+ffC+SRO4rl+vuqraZM8O50GDEH3lSjU206FpU0RbsgSyfIxjmzZwHjEC0ZcuhRhKoasgSw9RAlph1ilSqOuoBfFlyhR43Lolwe/K42cvAkxz8687AZ7jCRKwBAK6NmwfPX6KLn3HonbznorlzVt/Y87itSrMDQmQAAmQAAmQAAlEZgLer1/j67JleNewoZpMyOPcOWWk2teogWiLFyPKhAmwLVoUsLb2wWSVMCHsypWDfe3asM2fH7Cx8TnHgGURsCtZEvZVqwKenvg0cCC83r//bgNcokUNME306AGfCzCTjk9QtchHwErPTR42fi4qlikMmQ1Z9EybOjmOHD8vQQoJkAAJkAAJkAAJREoCHhcu4NPw4XhXvz6+ah5X75cvIeNkxRMbfe1aOLZvD6tEiSIlm8jWaAftWlunTg35yPFJZkrWvPeBMciXJwdkhmT/0hQpkNe/aMZFbAIRqnW6Nmzd3NxQvlRhwAD1ZzAY4OXtpcLckAAJkAAJkAAJkECkIfDpE1w3bsT7Fi3w8ddf4X74MGBrC7vy5RF1zhxEnTlTeWJhZxdpkLChgEHzuDuPHAlD1KjwvHwZrpqnHoH8xY0TC+OG90V0E8+trXYf9e3RHvnyZA8kJ0+RgP4JWIWaiiFQsLc34OHh4VPSy1dvYKv9gH0iGCABEiABEiABEiCBCEzAOPPt27p18WXWLHg9fAirJEng2KEDXNasgVPPnrBOlSoCE2DTvkfAKlYsOGveWmgOoK+rVsH95MlAs7RuVh8PbxzH2cNbcXzfRjy7cwaD+nQJNA9PkoAlENC1YVu3ejkMHjMTz56/wtzF69C6+zA0qVvVErgGWUcmJAESIAESIAESIAFfBNzd4bZrFz507owP7dqpmW+1L/2wLVYMUSZORLRFi2BfvTrg7OwrGw8iLwGbrFnh2Lq1AvBJ8+B6Pn6swgFtrK2tkT5tKmTNlD7ArskB5WU8CeiVgK4N20pli6JT6/ooWSQP3n/4hKmj+6JUsXx6ZUm9Qo8ASyYBEiABEiCBCE9ALdUzdy7ead7ZzxMmwPPGDRjixlUzGkdfvRrOAwfCJlu2CM+BDfwxAmpCsEKFgK9f1WRS3tr+x0piLhKwTAK6NmwFacL4cdG5TUP06NgEXtI3WSIpJEAC/hBgFAmQAAmQgMUR8PKC+7Fj+Ni377elev74A94fgxd2NwAAEABJREFUP8ImTx44Dx+O6MuWwaFhQxhcXCyuaVQ47Ak4afeRdFWXLuufx44NewVYIwmEIwFdG7Zjpy7Cx0+fNW/tRzRo3Rude4/C0jVbwhEXqyYBErB4AmwACZAACeiAgPfbt/i6YgXeNWqET0OGwOPsWRiiR4e95q2NphmzUUaPhm2BAoCVrl/VdECSKpgSMDg4QCaTgrZ3P3oUrhs2mJ5mmAQiNAFdPy2v3biDKM5OOH76IgrkyYbVCydg++5DEfqCsHEkQAIkoAcC1IEESCB0CHhcvAgZA/muXj18XbwY3i9ewDpzZjj164foq1bBsVUrWMWLFzqVs9RIQcA6YULVbV0a+2XuXHhcvy5BCglEeAK6NmytrL+pd+7idWTNlA7OTo6w5qzIEf6mZANJgARIwEIIUE0SCBoBWapn0ya8b9kSH3v1gvvBg5BleeyrVEG0BQsQdcoU2JUsCdjaBq08piKB7xCwzZcPMuYWXl74NHgwvN68+U4OniYByydgpecmJE4QDwNGTcfJs5eRJ0cm1S0Z3nrWmLqRAAmQAAmQAAn4JhB5jzz//hufNaP1read/TJzJrwePIB1ypRw6toVLmvXwrFLF1glSxZ5AbHloUrAQfP+W2fJAun2Lsatt6dnqNbHwkkgvAno2rDt36MVqlUsgVkTByBqFGe8ffceTetzuZ/wvmlYPwmQAAmQAAmQQAAEZKme3bvxQTNaP7RpA7dt2wDNoLArXRpRp05F1LlzYVe5MmQMpK8SeEACIUzAYGUF56FDYYgZU82w/XXOnBCugcWRgL4I6NqwdXJ00Dy1mSEzI69avx2JE8ZHmeIF9EWQ2pAACZAACZAACUR6Amqpnnnzvi3VM348PK9fh1WCBHDUjNvoa9bAqU8fWGfMGOk5/SwA5g8eAato0aAmk7K2huumTXA7ciR4BTA1CVgQAV0btqYcN2zdY3rIMAmQAAmQAAmQAAmELwGvf5fq6dfv21I969bB+9Mn2BYsiChjxiDakiVqnKMhalTwjwTCkICvqmzSpIFjhw4qTpYA8nzwQIW5IYGIRsBiDNuIBp7tIQESIAESIAESsEwCMmZRLdXTuDHUUj1nzqjung6NGiH6ypVwHjYMNrlzAwYD+EcCeiBgX7UqbEuUAFxd8WngQHh/+aIHtcJZB1Yf0QhYjGFbo3LpiMae7SEBEiABEiABErAgAh6XLvlequf5c9jkyAHnwYOVQevQtCkMsWJZUIuoamQi4NSrF6ySJ4fX48f40Lmzupflw4x8pIGbW2RCwbYGh4AFpbUYw7ZA3uyQ7shu7u4WhJeqkgAJkAAJkAAJWDSBz5/V2ES1VE/PnmqpHoOjI+xr1EC0xYsRZfx42BYpAlhbW3QzqXzEJ2Cws0OUUaPUvep1/766l92PHVPrKX/o2hXgOzb4Z9kEwtOw/S65Zp0GqSV+Hj1+hu79x+HYyQsYNWn+d/MxAQmQAAmQAAmQAAn8DAGfpXrq1oXPUj3p0kG8XjIZlGP79rBKlOhnqmBeEghzAt6vXkHWtjWv2PP2bbjt328ezWMSsCgCujZs4e2NKM5OOHHmIqqUL46JI3rhrzv3LArwzyvLEkiABEiABEiABMKKgNuuXRDvla+leipUQNTZsxF1xgzYlSsHaJ6vsNKH9ZBASBIIbOKowM6FpA4siwRCi4CuDVsvL298dXXD2YvXkCl9KsXAyqBrlZWO3IQDAVZJAiRAAiRAAoERcHPDlwUL8LFpU7jWqYsPmsfV/fhxlcPr2TN17l3Nmvg8YQI8r11T3ljHjh3hsm4dnHr0gHXq1CotNyRgyQQMUaIEqH5g5wLMxBMkoCMCurYSixXKjYZt+uLR4+fIlS0Dnr14BQcHex3hoyokYFkEqC0JkAAJRFYCn3/7Da5r1sDr6VPg61dI18tPgwfjfYcOeN+okTrnLUv1FCuGKJMmqfGz9tWqAc7OkRUZ2x0BCdhkygTY2vrbMtusWf2NZyQJWAoBKz0r2rJRdaxfMhnLZo+GjY0N7O1sMaBnaz2rTN1IgAQsnwBbQAIkENEIvHkDt717/W2V161bMMSNC4dmzRB99Wo4DxwIG77g+8uKkZZPwODiAhkfbjD9YKO9Yzs0bAjrjBktv4FsQaQmoGvD9q879/FF+6oqV+jPXYcwccZS2NnayCGFBEiABEggXAmwchLQDwHvly9V92H3/fuV5/XLtGn4pBmo79u0wdtffsHbOnX8nTBHWmAVPz6ir1gBebGXl36Jo5BARCZgX6UKom/YgGgLFyLqnDlw2bxZfdiJyG1m2yIHAV0btsMnzIGtrS2u3riDNRt3IkPaFBjJWZEjx53JVpIACZBARCDANoQIAa9Hj+Bx9izctm/H16VL8Xn8eHzs1QvvGzfG2zJl8K5+fTXh06fRo9VYWdctW+B+8iS8/v4b+PwZMhllQIpYp0wZ0CnGk0DEJWBlBaukSWGdKhW0l+2I2062LFIRsNJza21tbGBjbY1T566gSvliaFi7klr+R886UzcSIAESIAESIIGgE/D+8AEy3tX92DG4btyIL3Pn4tPw4fjQqRPe1a4NMVzfN2+Oj3374vPkyfi6bBncdu+Gx8WL38bLSlXOzrBOkQK2+fLBvmpVOLZqBecBAxB16lTVvdhFS29bsKCk9CN2xYv7iWMECZAACZCA5RHQtWHrrfG89+Axjp++gCwZ02hHgKenp9pzQwIkQAIkQAIkoHMCXl7wev4cHleuqDGuX1etgkzi9LF/f7xv2RJvq1TBuxo11AzFn4YMwZdZs+D6xx9wP3wYnjdvwvvtW8BggCF2bDX+z7Z4cdjXrQvHzp3hPHIkos6bBxfNO+uyaZMKS5yckzSSVsYMGmLFUmU4dewIu/LlYRUvHmBvrzxVju3awbZECVjIH9UkARIgARIIhICuDdvm9X/B2KkLkTZVcqRPkwIy5jZOrJiBNIenSIAESIAESIAEAiLg/eoVPK9fh3hJA0oTrHg3N3g9eACP06fh9uef+LpoET6PHYuP3bvjXcOGeFuhAt5rezmWeDkv6SS95JPZicXItEqSBDa5csGuYkU11s+pd+9vMxNr3lmXHTsQXTOIxfsqXljxxopXVryz4qWFg0OQVJYJopx69kSUpUthv26tGltoX7NmkPIykSURoK4kQAKRlYCuDdtihXJjzqRB6NWpqbo+aVMlw7SxfVWYmyAQcHeH55076qUD2lfzIOSIeElcXSEzXnr98w8iLYOvX+H511/fuux5Sz+IiHeZv9ciWcLD+9YtyFqV30sbUc+LIaMMGs2wiaht/F67vN+9g7f2W/B+8+Z7SSPceWn7x1698K5ePXzo0kV5ST9PmgRohmlgjRWPqXhOxYMqnlTxqIpnVdaAFU/r20qVlOdVPLDiiRWPrMw+LB5ab81TK89dg4sLrNOmhW3hwrDXvLMyI6uz5p2NOnMmomveWZetWxFNM4ijjB0LJ80gdtAMYbsyZdTMxDKxE6x0/aoSGD6eIwH9EqBmJBABCej6X4s3b99jxbo/MWDkNCUr12+HxEXA6xDiTXLftw9vtReID+3aqZeOdw0aqIk3QrwiHRfoumED3lavDrcePfC5VSu8b9oUnppxo2OVQ1y1rytW4G21avjQsSNkkpX3Ggev+/dDvB7dFqh90Pkyfz7eaQzctZf6j02a4EPXrlDrWOpW6RBWTDNcPk+cqAwZZdBohs1HzRsmBksI16Tb4uTDhozZfFerFjx698G7OnXwadAgSLxulQ5hxWRsqoxJNS3WTfOEyu9D4t127cLX5cshxu7HPn3wvlkzvNW8pzLGVca6Cj8Z+ypjYGUsrIyJlY8lsLaGGJ822bJBjFExSp20Z64YqdF+/x0u27Yh+rp1ECNWjFkxau21f5vEyBVj1xA9uqlKDJMACZCArghQGcsiYKVndYeMnYUDR88gZ7YMSvYdOolh4+foWWVd6CbeuU/jxkF18fpXI+l+9nHoUMhX+3+jIvTO4/x5fJk9G9C81saGej19io/ay6yaIdMYGYH37keO4OvixTIw3aeV0vXv4+DBgGfkGKvuumkTXNeu9Wm/BDyvXVMzqko4MojyoO3c6aup8vsQQ8dXZAQ++LJggRqzadpE9xMnIN5H07hghbUPBvKMFePY+/17iBdYlpyRXgFejx/D6+FDeN27p3rNyDNZvOWeV67A49IlCH+PM2fUrL1iJMpv1f3gQbhpHyRlUiQxOKW7ruvmzWoyJfGUuq5Zg68rV6qJk2RW4GDJkiVwP3XK3+aJoSqe3M8TJuCrlk7q9jh3DqqXizw/nZ1hZZyUqUqVb5My9e+PqNOmqe7B0k042rJliKJ9PJHuw7IWrF2FCqpbsVXixOBsq/5iZyQJkAAJRCQCummLlW408UeRp89fYM7kQahZpYySOZMG4tHjp/6kZJQpAXftpUS6f5nGqfDXr/jYs2ekkM9i2KtG+96Igf+he/dIweDL1Km+G//vkbx0f+zSJVIwEA/Uv832tfO4fFl5biPD70GMIl+N//fA/fhxfNQ8a5GBgbuZYf8vAkjPlg9t20J6Msisu+81j76MB5XuuuKpVF1tNW+/THAkM/P6kkqVvk18pJ1/V7Om8gLLkjPvGzVSvUPet2iB961bQ3rNSI8J8Zb7PHs0j/nHfv0g66xKt95Pw4bh08iR+DxmjProIl5T6db7Zfp0ZXyLp1SM86+aB1QZtJohKTMDB0fg4WFstu+9lRWsM2SAbfHicNC8+TLxUpTRo2E6KVO0efOgJmXSnhtqUqYSJVQemdDJd2E8IgESIAESIIHwI6Brw9ZK+wfXHI2VlcE8isdmBMQrZxblc+hx//43j4F4DSKweAUyjlDGHSuvSQRuv7TPK5BxhB43b0aK+0A8aT43v1lAPLfCKaKLl/ZBy6zpPocRve3G9nmL59Gn1f8FvDVjz/PuXUj3fFkn1evJEzWDr3wAk67aqqvtp08Qz+x/uUxCdnaAoyMMUaJAutQaYsaEIU4c1TXXKlEitUakeDtlnUjpdisGpE3mzJBuuzY5csAmd261PI0sQ2NbpIgyLu1KlYJd2bIQr6dd5cqw/+UXNS7VvnZt2GuGp3T1ddAMcPGMOrRsCcc2bSDdex07doSTZnjKGFWnXr3g1KcPnDXPqvOgQXDWDGfR0URzn6BM2CTeV5mUScqTSZls8uRRS+cEdVImn8IYIAESIAESIIFwJKBrwzZ7lgzo0Gsk5i1Zp6R9r1HIkyNLOOLSZ9XmWslLk3mc8di5c2fVZUy6jUVksa9Y0dhkP3t54YvIbTe2zVZ7QfbT+H8jnEeMiBT3gRgP/zbZ904zSKKMHx85GKRL57vt/x4ZokZFlEmTYLxfIvLeWjMy/222r511smSIOnu28k5GW7gQ0RYvhnSrjb5ihVr7VMaGRt+wAS7/+x9kgiNZC9WX/PknXDZvRvSNG9UkSNHXrEH0lStVGaosKVPzdkadMyRgPsAAABAASURBVAcyxlQMyChTpnxjLvef5qEVT6gYns6DB0OMS6e+feH066+QcapOXbvCsVOnb4arGLCaIasM2saNoQxczdBVBm+NGrDXPMd2VapAZhW2K1cOdqVLw1bzrNoWLQrbQoXUEjm+Gv/vgb1mPP8b5I4ESIAESIAELJqArg3b3p2boUq5Yrj/8ImSahVLoGfHJhYNPCyUl0k5DDFi+KlKPAd2Vat+8xZkyxah9w5Nm8JsbJfiIR4SmeBEjP+ILo7NmsG/2URtixWDbYECEfr6G6+tg2YAqAtvtrGvVAli9BrTReS9Q/36Zq3/dmhfp06kuAfk2toHxEDzglqnTq28k1ZJk0J5WePHhywLY4gVCwYXF8gHADg5QZak+UbOMrcOdevCeeBAZfjKc1AM4Sjahw0xei2zRdSaBEiABEiABHwTsPJ9qJ8jD09PdPh1FCprhu2ogV0gUqlsUe09Xbcq6waewdkZ0TQvhLzUqy5umiHj2LYtomovMbpRMpQVkS6B0ebPh0ODBrDOk0d5LqSrXpQhQ0K5Zv0Ub5UgAWRsnL32QmuTLx/EoBcPkHOfPoEoGbFO2WTNCvHIySyshly5YFumjOqiKd03I1ZLA26NGC5iwIghIwaNePTEwBFDJ+BcEeuMeDBl3Kh0szXkzAnp4iteUomPWC0NpDUGA+SjlnRVjqJ5iuV5KL+PQHLwFAmQAAmQAAlYFAHdWok21tawsbHBl0DGh1kU6TBWVrwNMg5LXt7kJda+Vq1vnocw1iM8qxPvi0Pz5rAdPBj2vXurrnqRbcyYVbJkahbTKCNHQmYslRd6/zzZ4XmdQrtu8cjJGES5Dxx79YJd6dLQHi4/V62F5RYDRgwZMWjEsBEDB5qhY2HN+Cl1ZdyoTIxkM3gQ5AOPfPT7qQKZmQRIgARIgARIQFcErHSljZkyYtzWbtYL46YuUmNsjWNtzZLxkARIgARIQIcEqBIJkAAJkAAJkAAJhBUBXRu2GdOlQNUKxRDDJWpY8WA9JEACJEACJBCWBFgXCZAACZAACZBACBDQtWHbpmlt+Cch0G4WQQIkQAIkQAIkYDEEqCgJkAAJkAAJBE5A14bthOmL8fbde58WvHrzFpNmLvU5ZoAESIAESIAESIAESOBfAtyRAAmQQCQmoGvD9sLlG3CJHs3n8sSK4YIz5y/7HDNAAiRAAiRAAiRAAiRAAsEhwLQkQAIRk4CuDdvPX776mhX546fP2rFbxLwSbBUJkAAJkAAJkAAJkAAJ6IMAtSABiyOga8M2X+6s6D9iOk6fv6Jk4KgZKJw/p8VBpsIkQAIkQAIkQAIkQAIkQAIRjQDboycCujZse3duhhJF8mDqnBVKShfLhx4dGgfI7+WrN+jUezRadB6sGcRTNe/uV3/TXrxyE806DULj9v2xYNl6nzTfy//m7XuU/KUVZi9a45OHARIgARIgARIgARIgARIgARIggQAIhFG0rg1bKysrVC1fHMvnjlFSuVwxSFxAbKbOXYH8ubNh0fThiBYtKlas2+Ynqbe3NwaPmQkxmn+fMQL7Dp/C+UvXVbrv5ZeJq3JmSw8YwD8SIAESIAESIAESIAESIAESIAGdENC1YRsERr6SHD15AZXKFlFxlcoUwZGT51XYdHPz9j04OTkiY7pUsLG2RtkSBXH4xDmVJLD84uV1dLRHpvRpAG+VnBsSIAESIAESIAESIAESIAESIAEdEIgwhu2nz19g0DypMVyiKaxJEsXDi5evVdh08+zFaySKH8cnStI9e/4KgeX38PDA9Pmr0Ll1fZ98xoC7uxv0L5FbR09PD3h4uPM6RfJ7Ve4D/lYj97NArr+XlwefBZH8WSD3AZ8HfBbIe4G838n9QNH3/WB85+aeBL5HIMIYttJQ027KBkPATTNYaRawZFDyX7qA8kuX5hpVSiFa1CgqBzcRlACbRQIkEOEJeHlF+CaygSRAAiRAAiQQKQn8Z9VZePOdnRzh6ekFN3d31ZJXb94iTuyYKmy6iRcnJt68/eAT9VpLFy9uLASWX7o0j5gwFwXKNcK8JeuwdM0W/DZnmSrD1tYOFH0zsLa2gY2NLa9TCN2rlnq/y31gqbpT75B7xtjY2PBZEMmfBfJ74vMg5H5TwtMSxUZ7L7Dh88AinofqhZsbEggCAV0btkdOnEfrbsNQpGJTZVSKYSkSULsK5s2OPQeOq9O79h9D4XzZVVi6GV+5fkuF06VODpn9+OE/T+Gpfbrfe/CkzxJCAeWf/9sQHN+5XEmbprXRpG4VdGsX8OzMqiJuSIAEIjMBtp0ESIAESIAESIAESCAMCejasF24fAN6dWqKA1t/V0al0bgMiE+3dg2xZechtdzPg4dP0LB2JZX0kWbEjpg4V4UNBgOG9e2AQaNnoFnHgciVIyNyZs2gzgWUX53khgRIgARIIIQJsDgSIAESIAESIAESCBkCViFTTOiUIl2ExcNqbRU0NWPHioHZEweq5X5GD+oKRwcHpVi6NCmwZuFEFZZNtszpsHjmSCybPRqtG9eUKCUB5Vcn/900b/AL2reo++8RdyRAAiRAAiQQygRYPAmQAAmQAAmQwHcJBM1i/G4xoZMgVkwXbNi6Bx8/fQ6dClgqCZAACZAACZBAhCDARpAACZAACURuAro2bDds2YMJ0xejTI02QRpjG7kvJVtPAiRAAiRAAiRAAoES4EkSIAESiLAEdG3YGsfUmu8j7NVgw0iABEiABEiABEiABMKZAKsnARKwRAK6NmwtESh1JgESIAESIAESIAESIIEIT4ANJAGdEdC1Yfvg0VN06z8Oxau0YFdknd04VIcESIAESIAESIAESIAESCBwAjwbdgR0bdgOnzAHVcqXQPq0KbBl5XR0alUfLRtVDzs6rIkESIAESIAESIAESIAESIAESCA0CYRI2bo2bL9+dUWponnh5eUFWYqnYe1KuHvvUYg0nIWQAAmQAAmQAAmQAAmQAAmQAAlEDAK6NmydnL6tQ2swGPDwn6f46uqG12/eB488U5MACZAACZAACZAACZAACZAACURoAro2bLNnToe37z+gfo2KaNC6D0pUbYEyJfJH6AsSXo1jvSRAAiRAAiRAAiRAAiRAAiRgqQR0bdh2aFkPLtGionjh3Di8bQlk2Z+aVcpYKmvqbfkE2AISIAESIAESIAESIAESIAEdEtC1Yevm7o5FKzZhyNhZCt3de/9g78GTKswNCZCAXglQLxIgARIgARIgARIgARIIWwK6NmyHjZ+Dp89e4sGjJ4pKwgRxsHTNZhXmhgRIgAQsmgCVJwESIAESIAESIAESCDECujZs793/B/17tIK9vZ1qsIO2d/fwUGFuSIAESIAEIj4BtpAESIAESIAESIAEgkJA14atjY21rzZ40Kj1xYMHJEACJEACJACAEEiABEiABEgg0hPQtWGbNVM6LFu7FR8/fsapc5fRa/AklCiSN9JfNAIgARIgARIgARIILgGmJwESIAESiMgEdG3Y9ujQGLFiRoetrQ2mzF6OkkXzoWXD6hH5erBtJEACJEACJEACJBB+BFgzCZAACVgoAV0btgaDARVLF8HvM0Zg1fxxqFq+OKysdK2yhd4GVJsESIAESIAESIAESCCoBJiOBEhAfwR0aSXOW7IOgYn+MFIjEiABEiABEiABEiABEiABEwIMkkCYEtClYfv7yv/hwNEzOHfphr8SpoRYGQmQAAmQAAmQAAmQAAmQAAmECgEWGlIEdGnYdmnTEA729nBytEeNyqUwbWxfzJk0yEdCqvEshwRIgARIgARIgARIgARIgARIQOcEgqCeVRDShHmS+jUrYNH04ejUugFu3vobTdv3x4iJ8/D3/X/CXBdWSAIkQAIkQAIkQAIkQAIkQAIkoG8CujRsjchSJkuM5g2ro/Yv5XDw6Gmcv3zdeCok9yyLBEiABEiABEiABEiABEiABEjAggno0rD18PTEwWNn0W/Eb6jXsjfuP3qMBdOGo0bl0haM2tJVp/4kQAIkQAIkQAIkQAIkQAIkoE8CujRsq9TrhCWr/oeCebNj/dLJ6N6+CZInSaBPgtSKBEwJMEwCJEACJEACJEACJEACJBDmBHRp2L59/wHX/7qL0ZMXoHiVFihQrpEvCXNKrJAESCBECbAwEiABEiABEiABEiABEghJAro0bI/vXI7AJCQBsCwSIAES0CkBqkUCJEACJEACJEACJBBEAro0bIOoO5ORAAmQAAlEegIEQAIkQAIkQAIkQAIADVveBSRAAiRAAiQQ0QmwfSRAAiRAAiQQwQnQsI3gF5jNIwESIAESIAESCBoBpiIBEiABErBcAjRsLffaUXMSIAESIAESIAESCGsCrI8ESIAEdEmAhq0uLwuVIgESIAESIAESIAESsFwC1JwESCCsCdCwDWvirI8ESIAESIAESIAESIAESAAgAxIIQQI0bEMQJosiARIgARIgARIgARIgARIggZAkwLKCRoCGbdA4MRUJkAAJkAAJkAAJkAAJkAAJkIA+CXC5H51eF6pFAiRAAiRAAiRAAiRAAiRAAiQQRAL02AYFFNOQAAmQAAmQAAmQAAmQAAmQAAnolgANW91eGstTjBqTAAmQAAmQAAmQAAmQAAmQQHgQoGEbHtRZZ2QmwLaTAAmQAAmQAAmQAAmQAAmEMAEatiEMlMWRAAmEBAGWQQIkQAIkQAIkQAIkQAJBJ0DDNuismJIESIAE9EWA2pAACZAACZAACZAACSgCNGwVBm5IgARIgAQiKgG2iwRIgARIgARIIOIToGEb8a8xW0gCJEACJEAC3yPA8yRAAiRAAiRg0QRo2Fr05aPyJEACJEACJEACYUeANZEACZAACeiVAA1bvV4Z6kUCJEACJEACJEAClkiAOpMACZBAOBCgYRsO0FklCZAACZAACZAACZBA5CbA1pMACYQsARq2IcuTpZEACZAACZAACZAACZAACYQMAZZCAkEmQMM2yKiYkARIgARIgARIgARIgARIgAT0RoD6CAEatkKBQgIkQAIkQAIkQAIkQAIkQAIkYLEEvmvYWmzLqDgJkAAJkAAJkAAJkAAJkAAJkECkIBChDNuXr96gU+/RaNF5MPqPmIovX7/6exEvXrmJZp0GoXH7/liwbL1PmoDyn790HX2H/4bS1VujVdehOHjsrE+efwPckQAJkAAJkAAJkAAJkAAJkAAJhBOBCGXYTp27AvlzZ8Oi6cMRLVpUrFi3zQ9Wb29vDB4zE707N8PvM0Zg3+FTEMNVEgaU38nRAb06NcPO9XPRtF5VjJo0T5JTgk2AGUiABEiABEiABEiABEiABEgg5AlEKMP26MkLqFS2iKJUqUwRHDl5XoVNNzdv34OTkyMypksFG2trlC1REIdPnFNJAsqfLk0KxI7pAmsrKxTOnwPu/2fvTgBsqv4Ajv/mzchWsowt+VtSiLKGJCISRSvlH4qMspSisiVbyJLIaEGyRioqUhShf6RYawDEAAAQAElEQVRFRQhR0mLfSoax/O/vTO95ZubNfbO8N++9+/3/O3fuu+d3zj3ncy/jN+e+N4mJPleDTUdsEEAAAQQQQAABBBBAAAEEgiYQMYntsX+OS1SUSIH8+QxeyRJFZd/+g2bfe7Nn30EpUayw55DG7dl7QPxtv2DRMilXtpTkzpXL0wc7qQtwFAEEEEAAAQQQQAABBBAIhkDEJLaK5bJWVPWrlqgo31OLclkZsAaZci7Orv36jVtl9tuL5ZknHzItdZOQcFwooW2QmHhSTpxICNXrxLiC9Gfo1KlE7oMgWYfy34mnTp3iz5zD7wP9fpCYmMh9wH0gJ0+e5D4Ig/tA/71NQcAfgXNZnT/RIRyTN09uOX36jJy0vlnpMA8cOiyFYwvq7nmlaOGCcujwX55jB624okUKiV17Xf2NnzJH4kf1lZIlinna58hxgVBC2yA6OkZiYnJwncL6Xs38PeZyRXMfOPwe0L+r9S9v/UrJ/J+pcDXU7wfR0dF8T3D43wd6H8TExHAfhMF9oH9vUxDwRyBiEludbN1aVeWTFWt0V5Z+ulrq1a5q9vUx4x82bzP75cuVFv30412/75bTZ87IspVrpV6d6qbOV3uN7z9sgvR7PE6KFz33GLM20m+OlGgJZQOXtZIfyuNjbMG5fxxxH1j/WOd+Svt+0n/IYpS2kRN8+PuAe0Dvc+6D8LgP9N/bFAT8EXD5ExQuMY89fJ8sXLLK/LqfX3f9Kfe1usUM/TcriR065lWzHxUVJYP7dJUBw+PlgW5PS41qV0r1qyuaOl/t33pvqWzYtE3axD0l1zZta8ruvftNGzYIIIAAAuElwGgRQAABBBBAIPIEXJE0pdhCBeTlMU+bX/czfEAPzwc86acav/naGM9Uq1QuL9MmPiszXx4uce3u8hz31b5Lx3tkzZJZ55ViRWI97dhBAAEEEEAgwgSYDgIIIIAAAmElEFGJbVjJM1gEEEAAAQQQCHMBho8AAgggECoCJLahciUYBwIIIIAAAgggEIkCzAkBBBAIggCJbRCQOQUCCCCAAAIIIIAAAmkJUIcAApkTILHNnB+tEUAAAQQQQAABBBBAIDgCnAUBnwIktj5pqEAAAQQQQAABBBBAAAEEwk3AmeMlsXXmdWfWCCCAAAIIIIAAAggggEDECKQ7sY2YmTMRBBBAAAEEEEAAAQQQQACBiBAgsQ3MZaRXBBBAAAEEEEAAAQQQQACBIAmQ2AYJmtOkJsAxBBBAAAEEEEAAAQQQQCDzAiS2mTekBwQCK0DvCCCAAAIIIIAAAgggkKYAiW2aPFQigEC4CDBOBBBAAAEEEEAAAecKkNg699ozcwQQcJ4AM0YAAQQQQAABBCJSgMQ2Ii8rk0IAAQQQyLgALRFAAAEEEEAg3ARIbMPtijFeBBBAAAEEQkGAMSCAAAIIIBBCAiS2IXQxGAoCCCCAAAIIRJYAs0EAAQQQCI4AiW1wnDkLAggggAACCCCAQOoCHEUAAQQyLUBim2lCOkAAAQQQQAABBBBAINAC9I8AAmkJkNimpUMdAggggAACCCCAAAIIhI8AI3WsAImtYy89E0cAAQQQQAABBBBAAAEnCkTinElsI/GqMicEEEAAAQQQQAABBBBAwEECAUhsHaTHVBFAAAEEEEAAAQQQQAABBLJdgMQ2uy4B50UAAQQQQAABBBBAAAEEEMgSARLbLGGkk0AJ0C8CCCCAAAIIIIAAAgggYCdAYmsnRD0CoS/ACBFAAAEEEEAAAQQQcLQAia2jLz+TR8BJAswVAQQQQAABBBBAIFIFSGwj9coyLwQQQCAjArRBAAEEEEAAAQTCUIDENgwvGkNGAAEEEMheAc6OAAIIIIAAAqElQGIbWteD0SCAAAIIIBApAswDAQQQQACBoAmQ2AaNmhMhgAACCCCAAALJBXiNAAIIIJAVAiS2WaFIHwgggAACCCCAAAKBE6BnBBBAwEaAxNYGiGoEEEAAAQQQQAABBMJBgDEi4GQBElsnX33mjgACCCCAAAIIIICAswSYbYQKkNhG6IVlWggggAACCCCAAAIIIIBAxgTCrxWJbfhdM0aMAAIIIIAAAggggAACCCDgJZAtia3X+dlFAAEEEEAAAQQQQAABBBBAIFMCJLaZ4gtoYzpHAAEEEEAAAQQQQAABBBDwQ4DE1g8kQkJZgLEhgAACCCCAAAIIIICA0wVIbJ1+BzB/ZwgwSwQQQAABBBBAAAEEIliAxDaCLy5TQwCB9AkQjQACCCCAAAIIIBCeAiS24XndGDUCCCCQXQKcFwEEEEAAAQQQCDkBEtuQuyQMCAEEEEAg/AWYAQIIIIAAAggEU4DENpjanAsBBBBAAAEEzgmwhwACCCCAQBYJkNhmESTdIIAAAggggAACgRCgTwQQQAABewESW3sjIhBAAAEEEEAAAQRCW4DRIYCAwwVIbB1+AzB9BBBAAAEEEEAAAacIME8EIleAxDZyry0zQwABBBBAAAEEEEAAgfQKEB+WAiS2YXnZGDQCCCCAAAIIIIAAAgggkH0CoXZmEttQuyKMBwEEEEAAAQQQQAABBBBAIF0CIZrYpmsOBCOAAAIIIIAAAggggAACCDhYgMQ2nC8+Y0cAAQQQQAABBBBAAAEEEBASWz9vgnnvLpG2D/eV9l36y6o16/xsRVgoCDAGBBBAAAEEEEAAAQQQiGwBEls/ru/OXX/KjLkL5dWxz8ioQY/LsOcnScKJk360JASBsBFgoAgggAACCCCAAAIIhK0Aia0fl+5/X6yTBtfVlLx5ckuxorFS4fIy8tW6H4T/IYCA0wSYLwIIIIAAAggggEAoCpDY+nFV9h04KJcUK+yJvPSSorJ3/wHPa3YQQAABBLwE2EUAAQQQQAABBIIsQGLrJ3iU6xxVVFSUp1XNRq3FrjRp0kTsil0fWm/Xh9ZrnF3ROLti14fW2/Wh9RpnVzTOrtj1ofW++mjRooU0a9bMXAONsyu++vE+bteH1nvH+9rXOLviq633cbs+tN473te+xtkVX229j9v1ofXe8b72Nc6u+GrrfVz7qH/rA1Kr8b0+/7x6x/va137siq+23sft+tB673hf+xpnV3y19T5u14fWe8f72tc4u+Krrfdxuz603jve177GJS8NWnQ87x7w1db7ePI+UnvtHe9rP3m7FK8btjJ/T/lq7z6eol0q34fcsWl9dWo/+vdAy5a32Vo71UfnndZ9467TOLvijk3rq10fWp9We3edxtkVd6x+1X8X3HprixT3gV0fWq/t7YrG2RW7PrTerg+t1zi7onF2xa4PrbfrQ+s1zq5onF1x9+H5Rzc7CNgInMvWbAKdXF24UEE5fPiIh+DgocNSJLaQeb1mySyxK4sXfyB2xa4PrbfrQ+s1zq5onF2x60Pr7frQeo2zKxpnV+z60Hq7PrRe4+yKxtkVuz603q4Prdc4u6JxdsWuD62360PrNc6uaJxdsetD6+360HqNsysaZ1fs+tB6uz60XuPsisbZFbs+tN6uD63XOLuicXbFrg+tt+tD6zXOrmicXbHrQ+vt+tB6jbMrGmdX7PrQers+tF7j0ixLZ9t+r/CrH+v7ksbZlTTHYvWh9XZ9aL3G2RWNsys++jjve6xdH1pPP2n/mwMffHzdA/rnx674aut93K4PrfeO97WvcVrMP7jZIOCHAImtH0j16lSXz75YJydOnpSDh47Ipi07pHbNq/xoSQgCCCCAAAIIIBBoAfpHAAEEECCx9eMeKFWyuNxxy43y4KMD5bF+o+Txru3lghw5/GhJCAIIIIAAAggggEBICDAIBBCIaAESWz8vb+vbm8qsV0bIjJeHSYO6NfxsRVgoCXy7frP0GTJOGt8RJ516DJKVq78JpeExlgAJnDp9WoaNnSwPdHtaOj8+WH77Y3eAzkS3oSzw0mtz5d5OT8qt93aXIaNfMU/ghPJ4GVtgBSZMmi3XNm0r+vdDYM9E76EooE/fPTFgjDS87UFp2LKjbPzxp1AcZraNiRMjEK4CJLbheuUYd7oF8uTOJU90f0CWvPOq3H9vSxn2/KR090GD8BNY+NEKOXjosEyb+Kzc3bKJPDduavhNghFnWqDKVRVk7pTR5oeTBw8dkQWLlme6TzoIT4Gfd/4uW7f/ap68ioqKCs9JMOpMCQwa+bIUKlRA5k9/QebPGCeXXlIsU/3R2JECTDoEBUhsQ/CiMKTACJS/vIzEFswv0S6X1KtTTRITE+V4QkJgTkavISPw+RffSvMm15vxNKpfWzZu2S7H/jluXrNxjsB1taqayRYscLFUtZJcfmWb4XDkZnT8NOndo4Oc1f+fPetIAydPes++A6IrtD27tpMC+fOZcnG+C51MwtwRCKBAcLsmsQ2uN2cLEYEFi5ZJubKlJHeuXCEyIoYRKIF9Bw5JieJFTfcx0dFSrEis7N130Lxm4zwB/WHWoiUrpVb1ys6bPDOWxZ98JjWrXMkKnYPvhT/+3CtFCheUx/uPlhtv72TemqB/LziYhKkjEDECYZvYRswVYCJZJvDxijXmPZT6Pkrvou+n8z7J+o1bZfbbi+WZJx/yPsx+BAtERZ173NDltR/BU2ZqqQictVbnnh42QRpdX0vq1KySSgSHIlng72P/mEfQ27dpGcnTZG42AqfPnJFff9stndrdKe/OGi+5cuaUWfMW2bSiGgEEwkGAxDYcrlLGx+iolk1uuFaeH/pEitKr2/0eh337D0r8lDkSP6qvlCzBe2o8MBG8U7hQAdH3VLqnePDwUfPTevdrvjpHYMrMd6TC5WWk64P3OmfSzNQj8MPmbaLl+ub3mw+OSkw8JbrPWxM8RI7YiS1U0LwtqfrVFeWiC/NK7ZpXy9btOx0xdyaJQKQLkNhG+hV22Pz0m1TykjdPbqOw/8Ah6W+t1vR7PE6KFy1sjiVt2EayQN3aVeWTlWvNFNd+s0HKlioh7nvCHGTjCIE3FyyR/QcOS1z7ux0xXyaZUkBX6dcsmSXukiNHjHy2eDp/H6SkiugjpUsWlzx5csn2X3aZeX7z3Q9yRbnSZp8NAgiEtwCJbXhfP0afDoG33lsqGzZtkzZxT5mf1uuveti9d386enB4aJhOv2WzhuJyRZlf9/ParPnSu8eDYToThp1RAf2VLuNemSnvf7TC82d/6Bg+FT2jnrRDINwFhvTtJkNGvSLtu/SXhIREade6RbhPifEjgIAlQGJrIfCfMwS6dLzH85N690/sixWJdcbkHTxL/cCo/j3jzK/7mfTCQPnPpcUCqkHnoSeg94D7z7z764AnOofeQBlRUAVWLZomem8E9aScLCQELi9bSqa/NMz8+q9+PTtJrpwXhMS4GAQCCGROgMQ2c360RgABBBBIvwAtEEAAAQQQQACBLBUgsc1STjpDAAEEEEAgqwToBwEEEEAAAQT8FSCx9VeKOAQQQAABBBAIPQFGhAACCCCAgCVAYmsh8B8CCCCAAAIIIBDJAswNAQQQiHQB6G5M2QAAEABJREFUEttIv8LMDwEEEEAAAQQQQMAfAWIQQCCMBUhsw/jiMXQEEEAAAQQQQAABBIIrwNkQCE0BEtvQvC6MCgEEEEAAAQQQQAABBMJVgHEHXYDENujknBABBBBAAAEEEEAAAQQQQCArBUhss1KTvhBAAAEEEEAAAQQQQAABBIIuEMGJbdAtOSECCCCAAAIIIIAAAggggEA2CJDYZgN6SJ2SwSCAAAIIIIAAAggggAACYS5AYhvmF5DhB0eAsyCAAAIIIIAAAggggEDoCpDYhu61YWQIhJsA40UAAQQQQAABBBBAIFsESGyzhZ2TIoCAcwWYOQIIIIAAAggggEBWC5DYZrUo/SGAAAIIZF6AHhBAAAEEEEAAgXQIkNimA4tQBBBAAAEEQkmAsSCAAAIIIIBAkgCJbZIDWwQQQAABBBCITAFmhQACCCDgAAESWwdcZKaIAAIIIIAAAgikLUAtAgggEN4CJLbhff0YPQIIIIAAAggggECwBDgPAgiErACJbcheGgaGAAIIIIAAAggggED4CTBiBLJDgMQ2O9Q5JwIIIIAAAggggAACCDhZgLlnsQCJbRaD0h0CCCCAAAIIIIAAAggggEBWCPjfB4mt/1ZEIoAAAggggAACCCCAAAIIhKCAoxPbELweDAkBBBwq0ODWDnLi5MmAz37Dpm3S/9kXbc9z6vRp+W/n3nL46F+2se6AKTPfkbffX2pe/rTjV6nXrL083GuotH24r3TvPUK+XLfB1OmmR9+R8vna73Q3RdE2367fnOJ4uBzwvpaTLZMzZ85k2dAXLVkpu37fnWX9+dPRN99tlLXfnLt2X337g7muqbX9Zdef0vnxwalVcQwBBBBAAIGACpDYBpQ3IjpnEgggEEEC8VPmSNvWt9rOKCY6Wm5v3khmzVtkG6sBfx/7RxZ+tFJua9ZIX5qSN28eeeX5ATLrlRFSo8qVMiZ+mjmum26d7pVKFS/T3Ygu0954T86cPZtlc/xo2efy+597sqw/fzr6dsMWWff9Jn9CpXTJ4lKo4MXy+Zep/9DCr04IQgABBBBAIAMCJLYZQKMJAikFOIJA1gms/Pxr6dRjoDzQfYDoyubPO383nevK34uTZkvrjr2k25PDZLSVKHZ/arip82ejK337DxyWileU9YS/PPVNad+lv/R8epRs27FTHuj2tOzbf9DUN25QRz5Y+pnZt9ssW/mF1KxWWXLkiEk19Po61ax+D3nqJk6ZKxs3bzevf9z2s5lvpx6DpPegsZJw4tzK9aYt2+XBRwda9Ul1auJezdX59Bn8grR9qK+069JPPvzkf6a/5JtJ09+SPkPGiVq1iest/YaO96xEH09IkOcnzhA9fl/nPqKJvzprHw9bq81j4qcbazV6672k1Witmzv/I2nWuqtZ1X6s38hUV1HdfXV/crhZ4Tz69zHTZv+Bcw7a/9TZ72qX5xVdFe01YLR0fOQZaXxHnKxc/Y0s/XS1bPnpF5kwaY7p7/uNW0Tn1ndo0tzUT1fa5727xHioic71wKHDpm+N1de6eq7314hxr4nGa+XBQ0eMva6u672lcVNmzhe99z74eJUsWb7anNNtoNdIY/R+0f72/nvPaF831q8ji5as0F0KAggggAACQRMgsQ0aNSdCAAGBwFZAk55Bo16Wnl3by7T4oVL1qgoyZPQrpt0nVvK45svvZOqEoTJ+RG/Rx31NhbV5d/Fyk5zNeHOh9UrMY83Dx06RkeOnmqRID+qqW+WK5XTXlGUr18qmLTvk9YlD5ZG4+6TP4PGSK1dOKRxb0NQXLHCxXHRhbtn+yy7zOq3NuvU/SpVKl/sMWf3V93JTw7qp1g+25tu88fUyZfwgaWmt+G6xEl13oNa1uLlBUp21guxdN/C5l6T+dTVl1qsjZMJzfWTanHdN4udu6/11564/5LmBj8mcySOleNFYmTprvqnW5O306dMy46VhMm3is7Jn7wGZ9+5SU6cbTXJfHNlXZrw8TOYv/FjcCVyt6lfJwjdelDcmjZSbGtUVTRI13rt079RGXC6XxI/uZ1au812YV5o3vk4WfLDMhB23kupl1jW9s8WN5rX3Jn6ylbx2aG1d6yGyaO5EY6t+5cuVlkc6tzH9ValU3jT55dc/ZOSgx42RPjKsSegEa8wzXx4uev+Msu4BE2htdlvze+6ZHlbsYImKipLlq9ZaR0Venf625MyZU7TNwN5dZN2/j4KXKVVCbmlSX5pac9TV91a33WTi1bPzA62Nma7GeyfnVSpdId9a94MJZIMAAggggECQBEhsgwTNaRBAAAF/BL7fuE0qVSgnV5a/zITf16q5SdaO/XNcvtuwRZrf1EAuzJtHYmJi5K4WjU2MbvSx4bj2d+muKZrcNKhXU3r36GhW+vTgH7v3SdHCSUmrvl63YbPUqnGVRLtcoglMdHSU3Fi/tlZ5StHCsbLrtz2e1752tG93QuyOOfrX33Jt07amzH7rg1QfgT5y9G/Zu++g3H5LI9PsutpVpVTJ4mb/0OGjoivMLW++wby+rta5Ou1789Yd8v6HK0RXVvsMGS/HjiXI+o1bTWzyTa3qlY2bHm9krSjq47W6v/brDfLD5p/kkT4jTNFV6/XWSqjWaalft7rx0f0ilsXPO3/TXXFFu2SKlRz36DvSjGHrT7+Y43abVrc1NfGaMH+wdJXxz5/vohTNqlepKLqaPnnmO7Jh01bJf3G+FDHuA3WvqSJ58+Q2L7/4ar0cPvKX9UOKccZFV3nXb/rJ1OnmmmqVPA7FihTy/NBC53zvnTebZLeI9YONG+rV0nCfpWypS0UfO9aAGtZYd3j98EPvg7/+/kf08XStpyCAAAIIIBAMARLbYChzDgQQQMBfgbNnJcZKmtzhOawE1mWtrLlfx0RHu3dNcut5kWxn9559EmutuOrhEwkn5KzVrz4mnHjqlB4y5eyZ89/7mTtXLql4RRlT596cTEyUHBek/nixO0a/XpAjRhJPndZdT8l30YWyZsksa8UxXurVribPjJhoxuEJsHbOyllxWYm1Fuul+S8m+tz59LgWU2Ft3HXR0dFm/i+N7m9WL3U1cdHceGn174qiFerff1Eivbq19/Qxd8poGT6gh6dttJe3juPUqTOmrmf/UXLFZaVlkLW6OcpaLT1uGZsKm00xa7W4gmW8/LMv5Z33P5Y2dzVLtUWPh9qaVftLixeVsROny/sf+X60N2fOCzx9REWdtVZYr/fMZ8r4wfLhvJc89dHR577tuyz3U17XLMa619yBet+591P7qveS+3i0ZeTdj95rmrjn8hqXO5avCCCAAAIIBErg3He4QJ2BfhFAAAEE/BaoUvkK2fjjdtH3nWqjOe98KFeUK21W5KpeVV6++Hq9HjbF16cKa2XxYoXlzz0HdFdc0S6zEleuTCn57Y9zq69XXXm5fP3tRhOj72XdsfN32bp9p3nt3vy660+50us9ue7jyb+WK1vyvL696wsVyC89reRxz74Doo9Te9fpamVsofzy/Q9bzOE/du+VX35Nek9xgfz5pGCBfNaK6rYUdbpCWeHyMvLipNmiSZQGbP95l7XCe0h3U5QV//vaPEasSdebCz6S6ldXMDG6CqyP4f719zHzWt+Pqu9jNS98bI4nJMihI0elXp1qomNMPifvZjpOXUH1PnZ3yyYy/tXZksv6QYLOwbvOva8r2ZdeUkyaNa4nN994veWz1VTlzZNLjv6VNFZzINmmbq2qsmDxctnx78ryycREz2PFyULPe3l1pfKy+svvzLFT1g8/vlx37j7TJwQOWyvrptKPjT4arau53omyH80IQQABBBBAIFMCrky1pjECCCCAQJYKxBYqIE/36iyjJ0yTDt0HiL5ncsATD5lz6Ic5XVbmUvOBUk8MGGNWdi/Od6Gp08Rt8oy35b3Fn8qbC5aY97Nu+3mnzJy3SG65qYGJ0cd8Nek4/e+vn2nS8FopUbyI6Icf9R82QcYM6SXLP/vK8yFMGntZ2f+Y5M10kMamaaPr5LsNvn9FT948ueWh++82723V5NK7q0FPdZFpc943H9I0duIM0aTcXT/Qqpsyc4Gp0/dxli5VQi7Ol89UD+7TxUpkj0i7h/tJqw69ZMCIeHHPzQR4bSqWLyu9LLM2cU+JJm4d7rvD1OrXCpeXlod7Jv1aoge6Pi2HDh8xdb42urJ93923SJtOvc21OHDwsK9Q6Xz/XTJ87CTRx6X1A5c0sHaNq+WCHDms1eUm+jLV8lDPwdLkzs6i13mrfqhXm5YmrvXtTWXp8tXS9clhoh8eZQ56berUrCIPtr1Dhox+1XwQ2C33dJMNG5N+MOAVlmJXr43+MEUfrdZfB1Wq5CWS/+Kke6tR/VrGROvcHx6VogOvA/rhXo1vqOt1JAx2GSICCCCAQNgLuMJ+BkwAAQQQiACBlYtel5wXJD1S2uC6mvLai4Pl9fikD4kqYyVzOkWXyyUdrYRMPzhqxDOPyZmzZ6VK5aQPELqhXk2ZM3mUvDN9rNxzR1PTV1y7u6Rd61ulQd0a2tx8YvGNDWrLqtXfmNf6WPNTj3aQccN7y4IZ46R2jaskfmRfs0qoAQuXrJB777hZd22LvidY31e5/98kr5yVEC95O+lDr9yNb2veSOZMGW1Wj3UOmmhrXXlr5fWFYU/KxNH9ZczQJ+St15+XaldX1Cr5z6XFrfE9Zer0sd2EhBPWsaKm7pJiReTZ/t1l9qTnTBv9IKeihQuZuuSbspahfjCS+1FjXSnWGH1c9tHO95k+9NcSLZwTL5ocap0+3nxNtcq6a4qO0T3mTu3uNNY6j7j2d8vnH84wMbrxvpZ3t7xJxj77lHk0WM+l9bpy7XJFSZM0kj8d58fzJxmPYf0fkZIlimlTqVG1kjmmj2BXsVZZO9/fykqeW5k690bfbz3NunemTXxWtI/72yQlxclj29/TQh6J+69pljt3TsvyEfOhZH17xslua7W/auWkVW19z+2oQT1NnT7qrSZqYxpam0oVLjMfcmXtmv+WfrpGbr+lodlnE1kCzAYBBBAIZQES21C+OowNAQQQSCagv3amdcde0q5LX5O8uj90KVmYz5ft72kp7sdufQZZFbryGVuwgHnc1nrp13+9urYX92PEfjXwI2jV6q+lYcuO1nz7yXPjpprV7HB+xPX1N94zq7cPd2hlftDgB0FQQvRDuhq2fND86iT99UR3tbhR9IcT6T357r375Z47bxZ9/Dy9bYlHIEIEmAYCCGSTAIltNsFzWgQQQCAjAvNnvCDzpj4vuqL3RPf7zSOt6eknT+5c4v6U4bTaRbtcPj/YyFc7TYRqWiuKvuozcrx5k/ry6ftTza+hmTxuoOivr0lvP8lXKtPbPivjO/z3NrM6rr/rNSv7zWxfuiL82QfTzK9O0l+fpKvrGemzWJFYaVjvmow0pQ0CCDhKgMkikPUCJLZZb0qPCCCAAAIIIIAAAggggEDmBGidLgES23RxEYwAAggQukEAAAM2SURBVAgggAACCCCAAAIIIBAqAu5xkNi6JfiKAAIIIIAAAggggAACCCAQlgIktmleNioRQAABBBBAAAEEEEAAAQRCXYDENtSvUDiMjzEigAACCCCAAAIIIIAAAtkoQGKbjfic2lkCzBYBBBBAAAEEEEAAAQQCI0BiGxhXekUAgYwJ0AoBBBBAAAEEEEAAgXQLkNimm4wGCCCAQHYLcH4EEEAAAQQQQAABbwESW28N9hFAAAEEIkeAmSCAAAIIIICAYwRIbB1zqZkoAggggAACKQU4ggACCCCAQCQIkNhGwlVkDggggAACCCAQSAH6RgABBBAIcQES2xC/QAwPAQQQQAABBBAIDwFGiQACCGSfAIlt9tlzZgQQQAABBBBAAAGnCTBfBBAIiACJbUBY6RQBBBBAAAEEEEAAAQQyKkA7BNIrQGKbXjHiEUAAAQQQQAABBBBAAIHsF2AEXgIktl4Y7CKAAAIIIIAAAggggAACCISfgO/ENvzmwogRQAABBBBAAAEEEEAAAQQcKEBim8mLTnMEEEAAAQQQQAABBBBAAIHsFSCxzV5/p5ydeSKAAAIIIIAAAggggAACARMgsQ0YLR0jkF4B4hFAAAEEEEAAAQQQQCAjAiS2GVGjDQIIZJ8AZ0YAAQQQQAABBBBAIJkAiW0yEF4igAACkSDAHBBAAAEEEEAAAScJkNg66WozVwQQQAABbwH2EUAAAQQQQCBCBEhsI+RCMg0EEEAAAQQCI0CvCCCAAAIIhL4AiW3oXyNGiAACCCCAAAKhLsD4EEAAAQSyVYDENlv5OTkCCCCAAAIIIOAcAWaKAAIIBEqAxDZQsvSLAAIIIIAAAggggED6BWiBAAIZECCxzQAaTRBAAAEEEEAAAQQQQCA7BTg3AucLkNie78ErBBBAAAEEEEAAAQQQQCAyBBw0CxJbB11spooAAggggAACCCCAAAIIRKJAZhLbSPRgTggggAACCCCAAAIIIIAAAmEmQGIb8AvGCRBAAAEEEEAAAQQQQAABBAIpQGIbSF369l+ASAQQQAABBBBAAAEEEEAggwIkthmEoxkC2SHAORFAAAEEEEAAAQQQQCClwP8BAAD//3UZ6UoAAAAGSURBVAMAQJCqZiBcG60AAAAASUVORK5CYII="
+     },
+     "metadata": {
+      "image/png": {
+       "alt": "Line chart of mean validation information coefficient against the base-ten logarithm of the Ridge penalty, one line per label over eleven orders of magnitude, each line's highest point ringed in amber, against a dashed zero line, and no two lines sharing a colour. Read off the frame: fwd_ret_15m peaks at 1e6; fwd_ret_5m peaks at 1e6; fwd_ret_60m peaks at 1e6."
+      }
+     },
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "ridge = (\n",
     "    catalog.filter(pl.col(\"model_class\") == \"Ridge\")\n",
@@ -744,8 +2230,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f599a939",
-   "metadata": {},
+   "id": "3cd1d5ff",
+   "metadata": {
+    "papermill": {
+     "duration": 0.006445,
+     "end_time": "2026-09-10T02:46:53.052466+00:00",
+     "exception": false,
+     "start_time": "2026-09-10T02:46:53.046021+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "## 5. What to notice\n",
     "\n",
@@ -807,6 +2301,43 @@
    "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.14.3"
+  },
+  "ml4t_provenance": {
+   "executed_at": "2026-09-10T02:47:04.308186+00:00",
+   "executor": "local-uv",
+   "library_digest": "3093ad446e0771a7b29facccb4dbcda5363ccb723b0e790f6a13a3bc9d390fce",
+   "outputs_digest": "d30d11322f4a19ee3fc2fc15cb9cef9d8cd7311f3d583d7dbc478165bffeb808",
+   "parameters": {
+    "SUPERSEDES_POPULATION": "3f747814ae67"
+   },
+   "production": true,
+   "source_py_blob": "e6b28bef08afe900901819c87856e8a3a4c5cc3a"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 769.467394,
+   "end_time": "2026-09-10T02:46:55.830488+00:00",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "~/ml4t/public-nasdaq/case_studies/nasdaq100_microstructure/.06_linear.build.1129995.ipynb",
+   "output_path": "~/ml4t/public-nasdaq/case_studies/nasdaq100_microstructure/.06_linear.papermill.1129995.ipynb",
+   "parameters": {
+    "SUPERSEDES_POPULATION": "3f747814ae67"
+   },
+   "start_time": "2026-09-10T02:34:06.363094+00:00",
+   "version": "2.7.0"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Two executed nasdaq stage-06 renders.

`04_model_based_features` ran 2026-09-09T22:27:43Z. `06_linear` ran
2026-09-10T02:47:04Z in 770s at a 32.2 GB peak, its first completion on this
machine: every prior attempt died with a dead kernel at a 48.6 GB peak, and the
panel-retention fix in #903 is what brought it under the ceiling.

`06_linear` registered 61 of 61 predictions into population `3f747814ae67`. The
run carried `SUPERSEDES_POPULATION` because that population already existed from
the attempt that died after registering it; the member list reproduced exactly,
so `OfficialPopulation.create` returned the existing snapshot rather than writing
a second one.

Notebook sources are unchanged from `main` - this is outputs and provenance only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sy1WqyZZTXcoyFYAjVbyiu
