### PR TITLE
Keep a fitted fold's predictions on disk, not in the candidate

### DIFF
--- a/case_studies/utils/gbm.py
+++ b/case_studies/utils/gbm.py
@@ -122,7 +122,7 @@ class _GBMBatchCandidate:
     training: TrainingResult | None = None
     ledger: ExecutionLedger | None = None
     attempt: ExecutionAttempt | None = None
-    frames: list[pl.DataFrame] = field(default_factory=list)
+    shards: list[Path] = field(default_factory=list)
     reused_folds: list[int] = field(default_factory=list)
     fitted_folds: list[int] = field(default_factory=list)
     fit_elapsed_s: float = 0.0
@@ -2315,7 +2315,16 @@ def _gbm_fold_prediction_shard(entries: list[dict[str, Any]], context: GBMContex
 def _fit_or_reuse_gbm_fold(
     candidate: _GBMBatchCandidate,
     fold: dict[str, Any],
-) -> tuple[pl.DataFrame, bool, float]:
+) -> tuple[Path, bool, float]:
+    """Fit one fold of one configuration, and return the shard it is persisted in.
+
+    Returning the path rather than the frame is what bounds the group. Fold-major execution
+    holds one prepared fold and fits every configuration in the compatibility group against it,
+    so a returned frame is retained until that configuration finishes - which is after the last
+    fold, for every configuration at once. A nasdaq fold shard is 1.75 GB in memory, and a
+    fifteen-configuration group over two folds accumulated 52 GB of frames that were already
+    on disk.
+    """
     assert candidate.spec is not None
     assert candidate.context is not None
     assert candidate.training is not None
@@ -2333,7 +2342,7 @@ def _fit_or_reuse_gbm_fold(
         prediction_shard=shard,
         resolved_settings=settings,
     ):
-        return pl.read_parquet(shard), True, 0.0
+        return shard, True, 0.0
 
     started = time.perf_counter()
     staging = training_dir / f".fold_{fold_id}.{uuid.uuid4().hex}.tmp"
@@ -2383,7 +2392,7 @@ def _fit_or_reuse_gbm_fold(
         )
     finally:
         shutil.rmtree(staging, ignore_errors=True)
-    return frame, False, time.perf_counter() - started
+    return shard, False, time.perf_counter() - started
 
 
 def _write_gbm_training_manifest(training: TrainingResult, fold_ids: tuple[int, ...]) -> None:
@@ -2404,33 +2413,32 @@ def _write_gbm_training_manifest(training: TrainingResult, fold_ids: tuple[int, 
         temporary.unlink(missing_ok=True)
 
 
-def _gbm_curves_from_shards(
+def _gbm_checkpoint_curve(
     config_name: str,
-    predictions: pl.DataFrame,
-    checkpoints: tuple[int, ...],
-) -> list[dict[str, Any]]:
-    target = "eval_actual" if "eval_actual" in predictions.columns else "actual"
-    curves = []
-    for checkpoint in checkpoints:
-        frame = predictions.filter(pl.col("checkpoint") == checkpoint)
-        metric = cross_sectional_ic(
-            frame,
-            frame,
-            pred_col="prediction",
-            ret_col=target,
-            date_col="timestamp",
-            entity_col="symbol",
-            min_obs=5,
-        )
-        curves.append(
-            {
-                "config": config_name,
-                "iteration": checkpoint,
-                "ic_mean": float(metric["ic_mean"]),
-                "ic_std": float(metric.get("ic_std", 0.0)),
-            }
-        )
-    return curves
+    checkpoint: int,
+    frame: pl.DataFrame,
+) -> dict[str, Any]:
+    """One learning-curve point, from that checkpoint's predictions alone.
+
+    Taking one checkpoint's frame rather than the whole prediction set is what lets the caller
+    publish and score a checkpoint, release it, and move to the next.
+    """
+    target = "eval_actual" if "eval_actual" in frame.columns else "actual"
+    metric = cross_sectional_ic(
+        frame,
+        frame,
+        pred_col="prediction",
+        ret_col=target,
+        date_col="timestamp",
+        entity_col="symbol",
+        min_obs=5,
+    )
+    return {
+        "config": config_name,
+        "iteration": checkpoint,
+        "ic_mean": float(metric["ic_mean"]),
+        "ic_std": float(metric.get("ic_std", 0.0)),
+    }
 
 
 def _write_gbm_runtime_fields(path: Path, **fields: float) -> None:
@@ -2512,7 +2520,7 @@ def _reuse_gbm_batch_fold(candidate: _GBMBatchCandidate, fold_id: int) -> bool:
         resolved_settings=_gbm_fold_settings(candidate, fold_id),
     ):
         return False
-    candidate.frames.append(pl.read_parquet(shard))
+    candidate.shards.append(shard)
     candidate.reused_folds.append(fold_id)
     return True
 
@@ -2524,11 +2532,11 @@ def _run_gbm_batch_fold(candidate: _GBMBatchCandidate, fold: dict[str, Any]) -> 
     if fold_id in candidate.reused_folds or fold_id in candidate.fitted_folds:
         return
     try:
-        frame, reused, elapsed = _fit_or_reuse_gbm_fold(candidate, fold)
+        shard, reused, elapsed = _fit_or_reuse_gbm_fold(candidate, fold)
     except Exception as exc:
         _fail_gbm_batch_candidate(candidate, exc)
         return
-    candidate.frames.append(frame)
+    candidate.shards.append(shard)
     candidate.fit_elapsed_s += elapsed
     (candidate.reused_folds if reused else candidate.fitted_folds).append(fold_id)
 
@@ -2566,19 +2574,28 @@ def _finish_gbm_batch_candidate(study: Study, candidate: _GBMBatchCandidate) -> 
     assert candidate.training is not None
     assert candidate.attempt is not None
     try:
-        if len(candidate.frames) != len(candidate.context.fold_ids):
+        if len(candidate.shards) != len(candidate.context.fold_ids):
             raise RuntimeError(
-                f"GBM candidate produced {len(candidate.frames)} of "
+                f"GBM candidate produced {len(candidate.shards)} of "
                 f"{len(candidate.context.fold_ids)} fold shards"
             )
         _write_gbm_training_manifest(candidate.training, candidate.context.fold_ids)
-        predictions = pl.concat(candidate.frames).sort("checkpoint", "symbol", "timestamp", "fold")
         prediction_results = []
+        curves = []
         checkpoints = tuple(
             int(item["value"]) for item in candidate.spec["computation"]["checkpoint_schedule"]
         )
+        # One checkpoint at a time, read back from the fold shards this configuration already
+        # persisted. Concatenating every fold and then filtering held the whole prediction set
+        # plus a copy of the slice; a nasdaq configuration is 3.5 GB whole and 0.35 GB a slice.
         for checkpoint in checkpoints:
-            frame = predictions.filter(pl.col("checkpoint") == checkpoint).drop("checkpoint")
+            frame = (
+                pl.scan_parquet(candidate.shards)
+                .filter(pl.col("checkpoint") == checkpoint)
+                .drop("checkpoint")
+                .sort("symbol", "timestamp", "fold")
+                .collect()
+            )
             prediction_results.append(
                 study.results.publish_predictions(
                     candidate.training,
@@ -2593,6 +2610,9 @@ def _finish_gbm_batch_candidate(study: Study, candidate: _GBMBatchCandidate) -> 
                     label=candidate.spec["label"],
                 )
             )
+            curves.append(_gbm_checkpoint_curve(candidate.spec["config_name"], checkpoint, frame))
+            del frame
+        gc.collect()
         curves_path = (
             candidate.training.root
             / "run_log"
@@ -2600,7 +2620,6 @@ def _finish_gbm_batch_candidate(study: Study, candidate: _GBMBatchCandidate) -> 
             / candidate.training.hash
             / "learning_curves.parquet"
         )
-        curves = _gbm_curves_from_shards(candidate.spec["config_name"], predictions, checkpoints)
         _write_learning_curves(curves_path, curves)
         diagnostics = {
             "cache_hit": False,

--- a/case_studies/utils/linear.py
+++ b/case_studies/utils/linear.py
@@ -113,7 +113,7 @@ class _BatchCandidate:
     training: TrainingResult | None = None
     ledger: ExecutionLedger | None = None
     attempt: ExecutionAttempt | None = None
-    frames: list[pl.DataFrame] = field(default_factory=list)
+    shards: list[Path] = field(default_factory=list)
     reused_folds: list[int] = field(default_factory=list)
     fitted_folds: list[int] = field(default_factory=list)
     fit_elapsed_s: float = 0.0
@@ -1026,7 +1026,14 @@ def _fit_or_reuse_fold(
     training: TrainingResult,
     ledger: ExecutionLedger,
     fold: dict[str, Any],
-) -> tuple[pl.DataFrame, bool, float]:
+) -> tuple[Path, bool, float]:
+    """Fit one fold of one configuration, and return the shard it is persisted in.
+
+    Returning the path rather than the frame is what bounds a compatibility group. Fold-major
+    execution fits every configuration in the group against one prepared fold, so a returned
+    frame is retained until that configuration finishes - which is after the last fold, for
+    every configuration at once.
+    """
     fold_id = int(fold["fold"])
     params = spec["computation"]["model"]["effective_params_by_fold"][str(fold_id)]
     model_dir = training.root / "run_log" / "training" / training.hash / "models"
@@ -1043,7 +1050,7 @@ def _fit_or_reuse_fold(
         prediction_shard=shard,
         resolved_settings=params,
     ):
-        return pl.read_parquet(shard), True, 0.0
+        return shard, True, 0.0
     completed = ledger.fold_completion_exists(
         training_hash=training.hash,
         candidate_identity=training.hash,
@@ -1063,6 +1070,7 @@ def _fit_or_reuse_fold(
             )
             if not pl.read_parquet(shard).equals(recovered):
                 raise ValueError("prediction shard changed")
+            del recovered
             ledger.complete_fold(
                 training_hash=training.hash,
                 candidate_identity=training.hash,
@@ -1071,7 +1079,7 @@ def _fit_or_reuse_fold(
                 prediction_shard=shard,
                 resolved_settings=params,
             )
-            return recovered, True, 0.0
+            return shard, True, 0.0
         except Exception as exc:
             raise ValueError(
                 f"locked linear fold {fold_id} has conflicting uncommitted artifacts"
@@ -1125,7 +1133,7 @@ def _fit_or_reuse_fold(
     finally:
         artifact_temp.unlink(missing_ok=True)
         shard_temp.unlink(missing_ok=True)
-    return frame, False, time.perf_counter() - started
+    return shard, False, time.perf_counter() - started
 
 
 def _write_model_manifest(training: TrainingResult, *, immutable: bool = False) -> None:
@@ -1151,20 +1159,20 @@ def _fit_or_reuse_predictions(
     training: TrainingResult,
     ledger: ExecutionLedger,
 ) -> tuple[pl.DataFrame, list[int], list[int]]:
-    prediction_frames = []
+    shards = []
     reused_folds = []
     fitted_folds = []
     for fold in context.folds:
         fold_id = int(fold["fold"])
-        frame, reused, _ = _fit_or_reuse_fold(spec, context, training, ledger, fold)
-        prediction_frames.append(frame)
+        shard, reused, _ = _fit_or_reuse_fold(spec, context, training, ledger, fold)
+        shards.append(shard)
         if reused:
             reused_folds.append(fold_id)
         else:
             fitted_folds.append(fold_id)
 
     _write_model_manifest(training, immutable=context.immutable_recovery)
-    predictions = pl.concat(prediction_frames).sort("symbol", "timestamp", "fold")
+    predictions = pl.scan_parquet(shards).sort("symbol", "timestamp", "fold").collect()
     return predictions, reused_folds, fitted_folds
 
 
@@ -1269,7 +1277,7 @@ def _run_batch_candidate_fold(candidate: _BatchCandidate, fold: dict[str, Any]) 
     if fold_id in candidate.reused_folds or fold_id in candidate.fitted_folds:
         return
     try:
-        frame, reused, elapsed = _fit_or_reuse_fold(
+        shard, reused, elapsed = _fit_or_reuse_fold(
             candidate.spec,
             candidate.context,
             candidate.training,
@@ -1279,7 +1287,7 @@ def _run_batch_candidate_fold(candidate: _BatchCandidate, fold: dict[str, Any]) 
     except Exception as exc:
         _fail_batch_candidate(candidate, exc)
         return
-    candidate.frames.append(frame)
+    candidate.shards.append(shard)
     candidate.fit_elapsed_s += elapsed
     _progress(
         f"  fold {fold_id} {'reused' if reused else 'fitted'} for "
@@ -1308,7 +1316,7 @@ def _reuse_batch_candidate_fold(candidate: _BatchCandidate, fold_id: int) -> boo
         resolved_settings=params,
     ):
         return False
-    candidate.frames.append(pl.read_parquet(shard))
+    candidate.shards.append(shard)
     candidate.reused_folds.append(fold_id)
     return True
 
@@ -1321,13 +1329,15 @@ def _finish_batch_candidate(study: Study, candidate: _BatchCandidate) -> None:
     assert candidate.training is not None
     assert candidate.attempt is not None
     try:
-        if len(candidate.frames) != len(candidate.context.fold_ids):
+        if len(candidate.shards) != len(candidate.context.fold_ids):
             raise RuntimeError(
-                f"linear candidate produced {len(candidate.frames)} of "
+                f"linear candidate produced {len(candidate.shards)} of "
                 f"{len(candidate.context.fold_ids)} fold shards"
             )
         _write_model_manifest(candidate.training)
-        predictions = pl.concat(candidate.frames).sort("symbol", "timestamp", "fold")
+        predictions = (
+            pl.scan_parquet(candidate.shards).sort("symbol", "timestamp", "fold").collect()
+        )
         prediction = study.results.publish_predictions(
             candidate.training,
             checkpoint_kind="final",

--- a/tests/test_research_models.py
+++ b/tests/test_research_models.py
@@ -1909,6 +1909,118 @@ def test_gbm_batch_is_fold_major_and_matches_individual_execution(tmp_path, monk
     assert population.require_complete() == plan.expected_prediction_hashes
 
 
+def _frames_held_by(candidate: Any) -> list[pl.DataFrame]:
+    """Every prediction frame the candidate still references, directly or in one of its lists."""
+    held = []
+    for value in vars(candidate).values():
+        if isinstance(value, pl.DataFrame):
+            held.append(value)
+        elif isinstance(value, list):
+            held.extend(item for item in value if isinstance(item, pl.DataFrame))
+    return held
+
+
+def test_gbm_batch_releases_each_fold_shard_before_the_next_configuration(
+    tmp_path, monkeypatch
+) -> None:
+    """A fitted fold's predictions are on disk, so nothing holds them in memory.
+
+    Fold-major execution fits every configuration in a compatibility group against one prepared
+    fold, so a prediction frame retained by a candidate lives until that candidate finishes -
+    after the last fold, for every candidate at once. nasdaq's fifteen-configuration group over
+    two folds accumulated 52 GB of frames it had already written to parquet, and earlyoom killed
+    the notebook at a 62.4 GB peak. The shard is the durable copy; the frame is not kept.
+    """
+    monkeypatch.setenv("ML4T_FOLD_MEMO_BUDGET_BYTES", "1")
+    from case_studies.utils import folds as fold_utils
+
+    fold_utils.clear_memo()
+    study = _gbm_study(tmp_path / "batch", monkeypatch)
+    shard_frames: list[weakref.ReferenceType[pl.DataFrame]] = []
+    original_shard = gbm_utils._gbm_fold_prediction_shard
+    original_run_fold = gbm_utils._run_gbm_batch_fold
+
+    def observed_shard(entries, context):
+        frame = original_shard(entries, context)
+        shard_frames.append(weakref.ref(frame))
+        return frame
+
+    def observed_run_fold(candidate, fold):
+        gc.collect()
+        assert all(reference() is None for reference in shard_frames)
+        assert not _frames_held_by(candidate)
+        original_run_fold(candidate, fold)
+
+    monkeypatch.setattr(gbm_utils, "_gbm_fold_prediction_shard", observed_shard)
+    monkeypatch.setattr(gbm_utils, "_run_gbm_batch_fold", observed_run_fold)
+    requests = [
+        study.model(
+            family="gbm",
+            label="fwd_ret_1d",
+            config_name="leaves_7_mse",
+            overrides={"device": "cpu", "max_bin": 63, "learning_rate": learning_rate},
+        )
+        for learning_rate in (0.1, 0.2, 0.3)
+    ]
+
+    batch = run_models(study, requests=requests)
+    gc.collect()
+
+    assert len(shard_frames) == 6
+    assert all(reference() is None for reference in shard_frames)
+    assert all(run.diagnostics["compatibility_group_size"] == 3 for run in batch.runs)
+    for run in batch.runs:
+        shard_dir = run.training.root / "run_log" / "training" / run.training.hash
+        shards = sorted((shard_dir / "prediction_folds").glob("fold_*.parquet"))
+        assert [path.name for path in shards] == ["fold_0.parquet", "fold_1.parquet"]
+        assert all(prediction.load().height for prediction in run.predictions)
+
+
+def test_linear_batch_releases_each_fold_shard_before_the_next_configuration(
+    tmp_path, monkeypatch
+) -> None:
+    """The same contract in the linear runner, whose batch path has the same shape."""
+    study = _linear_study(tmp_path / "batch", monkeypatch)
+    shard_frames: list[weakref.ReferenceType[pl.DataFrame]] = []
+    original_frame = linear._prediction_frame
+    original_run_fold = linear._run_batch_candidate_fold
+
+    def observed_frame(fold, predictions, context):
+        frame = original_frame(fold, predictions, context)
+        shard_frames.append(weakref.ref(frame))
+        return frame
+
+    def observed_run_fold(candidate, fold):
+        gc.collect()
+        assert all(reference() is None for reference in shard_frames)
+        assert not _frames_held_by(candidate)
+        original_run_fold(candidate, fold)
+
+    monkeypatch.setattr(linear, "_prediction_frame", observed_frame)
+    monkeypatch.setattr(linear, "_run_batch_candidate_fold", observed_run_fold)
+    requests = [
+        study.model(
+            family="linear",
+            label="fwd_ret_1d",
+            config_name="ridge",
+            overrides={"alpha": alpha},
+        )
+        for alpha in (1.0, 2.0, 3.0)
+    ]
+
+    batch = run_models(study, requests=requests)
+    gc.collect()
+
+    assert len(shard_frames) == 6
+    assert all(reference() is None for reference in shard_frames)
+    assert all(run.diagnostics["compatibility_group_size"] == 3 for run in batch.runs)
+    for run in batch.runs:
+        shard_dir = run.training.root / "run_log" / "training" / run.training.hash
+        shards = sorted((shard_dir / "prediction_folds").glob("fold_*.parquet"))
+        assert [path.name for path in shards] == ["fold_0.parquet", "fold_1.parquet"]
+        assert run.predictions[0].load().height
+
+
 def test_gbm_batch_resolves_fold_dependent_huber_parameters(tmp_path, monkeypatch) -> None:
     study = _gbm_study(tmp_path, monkeypatch)
     original_prepare = gbm_utils.prepare_gbm_folds_from_mds


### PR DESCRIPTION
Fold-major execution fits every configuration in a compatibility group against one
prepared fold, so a prediction frame a candidate retains lives until that candidate
finishes - after the last fold, for every candidate at once. The frame was already
written to parquet before being appended to the list.

nasdaq's `fwd_ret_15m` group is fifteen configurations over two folds, and one shard
is 1.75 GB in memory (39.9M rows across ten checkpoints), so the group accumulated
52 GB of duplicated frames on top of a 25 GB baseline. `07_gbm` grew 25.2 -> 31.0 ->
42.2 -> 57.2 -> 61.8 GB over 2h20m and earlyoom SIGTERMed the kernel at
2026-09-10T05:07:30Z, MemAvailable 24.80%, swap free 0.01%.

## What changed

- `_fit_or_reuse_gbm_fold` and linear's `_fit_or_reuse_fold` return the shard path
  they persisted, and the candidate carries `shards: list[Path]`.
- The reuse path stops reading the shard entirely. A resumed run used to load every
  reused shard into memory only to concatenate it later.
- `_finish_gbm_batch_candidate` reads one checkpoint back through `pl.scan_parquet`,
  publishes it, scores its learning-curve point and releases it. The whole prediction
  set was 3.5 GB per configuration plus a copy of each slice; one slice is 0.35 GB.

Retention is now flat in the size of a compatibility group.

## Verification

Two tests hold the contract: weakrefs to each fold's prediction frame must be dead
before the next configuration's fold call, and no candidate may reference a DataFrame
directly or inside one of its lists. Both fail against the code they replace, checked
by reverting the two source files and re-running.

Predictions and identities are unchanged - the batch-vs-individual equivalence tests
for both families pass. 155 tests green across the gbm, linear, planning and
sp500_options suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sy1WqyZZTXcoyFYAjVbyiu
