### PR TITLE
Cut the sequence runner's checkpoint slices from one frame, lazily

### DIFF
--- a/case_studies/utils/deep_learning.py
+++ b/case_studies/utils/deep_learning.py
@@ -2681,7 +2681,13 @@ def run_dl_cv(
     config_results: list[dict[str, Any]] = []
     all_curves: list[dict] = []
     training_log: list[dict] = []
-    complete_prediction_frames: list[pl.DataFrame] = []
+    # (config, epoch) of every checkpoint that covers all folds, in the order the loop finds
+    # them. Recording the pair rather than the frame is what keeps post-processing from holding
+    # the same rows three times over: every slice appended here was cut from `all_predictions`,
+    # which stays resident, and concatenating the slices at the end made a third copy. One
+    # sequence configuration is every checkpoint epoch on every fold - twenty epochs over two
+    # folds where gradient boosting has ten checkpoints - so the copies are not small.
+    complete_slices: list[tuple[str, int]] = []
     log_dir = save_dir / "_incremental_logs" if save_dir is not None else None
     incremental_logs = pl.DataFrame()
     if log_dir is not None and log_dir.exists():
@@ -2724,7 +2730,7 @@ def run_dl_cv(
                         "ic_n_days": ic_n_days,
                     }
                 )
-                complete_prediction_frames.append(ep_df)
+                complete_slices.append((config_name, int(epoch)))
                 epoch_scores.append((epoch, ic_mean, ic_std, ic_n_days))
 
         if epoch_scores:
@@ -2835,11 +2841,26 @@ def run_dl_cv(
     del config_acc
     gc.collect()
 
+    # Cut in the order the loop recorded them, so the row order is the one the accumulating list
+    # produced. The cuts are lazy and collected once, so the slices are never all materialised
+    # alongside the frame they came from and the result they go into. `all_predictions` is not
+    # read after this and is the largest thing alive.
     complete_predictions = (
-        pl.concat(complete_prediction_frames, how="diagonal_relaxed")
-        if complete_prediction_frames
+        pl.concat(
+            [
+                all_predictions.lazy().filter(
+                    (pl.col("config") == slice_config)
+                    & (pl.col("epoch").cast(pl.Int64) == slice_epoch)
+                )
+                for slice_config, slice_epoch in complete_slices
+            ],
+            how="diagonal_relaxed",
+        ).collect()
+        if complete_slices
         else pl.DataFrame()
     )
+    del all_predictions
+    gc.collect()
 
     learning_curves = pl.DataFrame(all_curves) if all_curves else pl.DataFrame()
     training_log_df = pl.DataFrame(training_log) if training_log else pl.DataFrame()

--- a/tests/test_deep_learning_adapter.py
+++ b/tests/test_deep_learning_adapter.py
@@ -742,3 +742,101 @@ class TestDeclaredTrainSequenceStride:
         dl = setup["modeling"]["dl"]
         assert dl["train_sequence_stride_horizons"] == 1
         assert "max_train_sequences" not in dl
+
+
+def test_run_dl_cv_assembles_predictions_in_config_then_epoch_order(tmp_path) -> None:
+    """What the runner returns is what its own incremental files hold, in the same order.
+
+    Post-processing used to hold the whole prediction set three times over: the frame read back
+    from the incremental parquet files, a filtered copy per configuration, and every eligible
+    epoch slice appended to a list that was then concatenated. Cutting the slices lazily from
+    one frame removes two of those copies, and the thing that could go wrong is order: a single
+    filter over the whole frame returns file order, not configuration-then-epoch order, and the
+    registered prediction set is order-bearing.
+    """
+    import numpy as np
+    import pandas as pd
+
+    rng = np.random.default_rng(0)
+    dates = pd.bdate_range("2024-01-01", periods=120)
+    symbols = ("A", "B", "C", "D", "E", "F", "G", "H", "I", "J")
+    frames = []
+    for symbol in symbols:
+        first = rng.normal(size=len(dates))
+        second = rng.normal(size=len(dates))
+        frames.append(
+            pd.DataFrame(
+                {
+                    "symbol": symbol,
+                    "timestamp": dates,
+                    "f1": first,
+                    "f2": second,
+                    "target": 0.1 * first + 0.05 * second + 0.01 * rng.normal(size=len(dates)),
+                }
+            )
+        )
+    dataset = pd.concat(frames, ignore_index=True)
+    splits = [
+        {
+            "fold": 0,
+            "train_start": dates[0],
+            "train_end": dates[59],
+            "val_start": dates[60],
+            "val_end": dates[79],
+        },
+        {
+            "fold": 1,
+            "train_start": dates[0],
+            "train_end": dates[79],
+            "val_start": dates[80],
+            "val_end": dates[119],
+        },
+    ]
+    config_names = ("nlinear", "lstm_h64")
+    configs = [
+        {
+            "family": "deep_learning",
+            "config_name": name,
+            "n_epochs": 4,
+            "checkpoint_interval": 1,
+            "batch_size": 16,
+            "params": {"architecture": architecture, "lookback": 5},
+        }
+        for name, architecture in zip(config_names, ("nlinear", "lstm"), strict=True)
+    ]
+
+    result = deep_learning.run_dl_cv(
+        dataset,
+        splits,
+        configs=configs,
+        n_features=2,
+        feature_names=["f1", "f2"],
+        label_col="target",
+        date_col="timestamp",
+        entity_col="symbol",
+        device="cpu",
+        register=False,
+        save_dir=tmp_path,
+        seed=0,
+    )
+
+    shards = sorted((tmp_path / "_incremental").glob("*.parquet"))
+    assert shards, "the runner wrote no incremental predictions to reassemble from"
+    persisted = pl.concat(
+        [
+            pl.read_parquet(path).cast({"timestamp": pl.Datetime("us")}, strict=False)
+            for path in shards
+        ],
+        how="diagonal_relaxed",
+    )
+    expected_folds = sorted(int(split["fold"]) for split in splits)
+    parts = []
+    for config_name in config_names:
+        for_config = persisted.filter(pl.col("config") == config_name)
+        for epoch in sorted(for_config["epoch"].unique().to_list()):
+            for_epoch = for_config.filter(pl.col("epoch") == epoch)
+            if sorted(for_epoch["fold_id"].unique().to_list()) == expected_folds:
+                parts.append(for_epoch)
+    assert len(parts) == len(config_names) * 4
+
+    assert result["all_predictions"].equals(pl.concat(parts, how="diagonal_relaxed"))


### PR DESCRIPTION
`run_dl_cv`'s post-processing held the same prediction rows three times: the frame
read back from the incremental parquet files, a filtered copy per configuration, and
every eligible epoch slice appended to a list that was then concatenated. One sequence
configuration is every checkpoint epoch on every fold - twenty epochs over two folds
where gradient boosting has ten checkpoints - so none of those copies are small, and
`run_resolved_request` calls this once per configuration.

The loop now records the `(config, epoch)` of each checkpoint that covers all folds and
cuts them lazily from the one resident frame, collected once, in the order the loop
found them. `all_predictions` is released immediately after.

## Order is what could have broken

A single filter over the whole frame returns file order rather than
configuration-then-epoch order, and a registered prediction set is order-bearing.

Checked by running two configurations over two folds and four checkpoint epochs with
real fits, under this code and under the code it replaces: `all_predictions`,
`predictions` and `learning_curves` come back equal in content **and** row order, and
`predictions.parquet` is identical. The added test pins the same property against the
runner's own incremental files, so a rewrite that reorders fails rather than
re-registering.

Same defect and same shape as #908, which fixes it in the gradient boosting and linear
runners.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sy1WqyZZTXcoyFYAjVbyiu
