### PR TITLE
One checkpoint at a time in every sequence and latent-factor runner

### DIFF
--- a/case_studies/utils/darts_forecasting.py
+++ b/case_studies/utils/darts_forecasting.py
@@ -225,7 +225,12 @@ def _metric_to_float(value: Any) -> float | None:
     return float(value)
 
 
-from case_studies.utils.registry.store import _save_parquet, flush_fold_training_log
+from case_studies.utils.registry.store import (
+    _save_parquet,
+    clear_fold_predictions,
+    flush_fold_training_log,
+    incremental_shard_path,
+)
 
 
 def _flush_darts_fold_training_log(
@@ -241,12 +246,19 @@ def _flush_darts_fold_preds(
     incr_dir: Path,
     config_name: str,
     fold: int,
-    prediction_frames: list[pl.DataFrame],
+    epoch: int,
+    frame: pl.DataFrame,
 ) -> None:
-    """Flush pre-assembled prediction DataFrames (darts builds these during training)."""
-    if not prediction_frames:
+    """Write one checkpoint's predictions to its own shard.
+
+    This used to take every checkpoint the fold had reached and rewrite one file per fold
+    from all of them, so the work and the bytes written grew with the square of the
+    checkpoint schedule and the last checkpoint of a fold concatenated the whole fold to
+    write a file it had already written once per checkpoint.
+    """
+    if frame.is_empty():
         return
-    _save_parquet(incr_dir / f"{config_name}_fold{fold}.parquet", pl.concat(prediction_frames))
+    _save_parquet(incremental_shard_path(incr_dir, config_name, fold, epoch), frame)
 
 
 class _DartsEpochProgressCallback(pl_lightning.callbacks.Callback):
@@ -1221,7 +1233,6 @@ def run_darts_cv(
             train_series = [state.train_target for state in training_states]
             train_covariates = [state.train_covariates for state in training_states]
             epoch_rows: list[dict[str, Any]] = []
-            checkpoint_frames: list[pl.DataFrame] = []
             checkpoint_ics: dict[int, float] = {}
             checkpoint_n_days: dict[int, int] = {}
             n_val_points = 0
@@ -1229,6 +1240,7 @@ def run_darts_cv(
             log_dir = save_dir / "_incremental_logs" if save_dir is not None else None
             if incr_dir is not None:
                 incr_dir.mkdir(parents=True, exist_ok=True)
+                clear_fold_predictions(incr_dir, config_name, split["fold"])
             if log_dir is not None:
                 log_dir.mkdir(parents=True, exist_ok=True)
             t0 = time.perf_counter()
@@ -1307,11 +1319,12 @@ def run_darts_cv(
                     pl.lit(config_name).alias("config"),
                     pl.lit(epochs_trained).alias("epoch"),
                 )
-                checkpoint_frames.append(checkpoint_preds)
                 cfg_prediction_frames.append(checkpoint_preds)
                 prediction_frames.append(checkpoint_preds)
                 if incr_dir is not None:
-                    _flush_darts_fold_preds(incr_dir, config_name, split["fold"], checkpoint_frames)
+                    _flush_darts_fold_preds(
+                        incr_dir, config_name, split["fold"], epochs_trained, checkpoint_preds
+                    )
 
                 _entity = entity_col if entity_col in checkpoint_preds.columns else None
                 ic_result = cross_sectional_ic(

--- a/case_studies/utils/darts_forecasting.py
+++ b/case_studies/utils/darts_forecasting.py
@@ -9,6 +9,7 @@ import os
 import re
 import time
 import uuid
+from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
@@ -248,17 +249,40 @@ def _flush_darts_fold_preds(
     fold: int,
     epoch: int,
     frame: pl.DataFrame,
-) -> None:
-    """Write one checkpoint's predictions to its own shard.
+) -> Path | None:
+    """Write one checkpoint's predictions to its own shard and return its path.
 
     This used to take every checkpoint the fold had reached and rewrite one file per fold
     from all of them, so the work and the bytes written grew with the square of the
     checkpoint schedule and the last checkpoint of a fold concatenated the whole fold to
     write a file it had already written once per checkpoint.
+
+    The path is the return value because the caller scores and assembles from the shard.
+    Keeping the frame as well was one held copy of every checkpoint of every fold of every
+    config, for the length of the run, of something already on disk.
     """
     if frame.is_empty():
-        return
-    _save_parquet(incremental_shard_path(incr_dir, config_name, fold, epoch), frame)
+        return None
+    path = incremental_shard_path(incr_dir, config_name, fold, epoch)
+    _save_parquet(path, frame)
+    return path
+
+
+def _darts_slice_frame(slices: Sequence[Path | pl.DataFrame]) -> pl.DataFrame:
+    """One frame from a run's checkpoint slices, in the order given.
+
+    A slice is the shard the checkpoint was written to, or the frame itself on a run with
+    no save directory to write one. Reading shards back is what lets the scoring loop hold
+    one checkpoint at a time instead of every checkpoint the run has produced.
+    """
+    values = list(slices)
+    if not values:
+        return pl.DataFrame()
+    if isinstance(values[0], pl.DataFrame):
+        return pl.concat(values)
+    from case_studies.utils.deep_learning import _read_prediction_shards
+
+    return _read_prediction_shards(values)
 
 
 class _DartsEpochProgressCallback(pl_lightning.callbacks.Callback):
@@ -1114,7 +1138,12 @@ def run_darts_cv(
     config_results: list[dict[str, Any]] = []
     learning_rows: list[dict[str, Any]] = []
     training_log: list[dict[str, Any]] = []
-    prediction_frames: list[pl.DataFrame] = []
+    # One entry per checkpoint of per fold of per config, and each is a path whenever
+    # there is a save directory to write shards to. `save_dir is None` is the in-memory
+    # run, which cannot register and has nowhere to put them.
+    run_slices: list[Path | pl.DataFrame] = []
+    incr_dir = save_dir / "_incremental" if save_dir is not None else None
+    log_dir = save_dir / "_incremental_logs" if save_dir is not None else None
     has_fold_temporal = temporal_by_fold is not None and temporal_keys and temporal_feature_names
     one_period_dataset: pd.DataFrame | None = None
 
@@ -1147,7 +1176,7 @@ def run_darts_cv(
         checkpoint_interval = int(cfg.get("checkpoint_interval", n_epochs))
         started_at = datetime.now(UTC).isoformat()
         elapsed_total = 0.0
-        cfg_prediction_frames: list[pl.DataFrame] = []
+        cfg_slices: dict[int, dict[int, Path | pl.DataFrame]] = {}
         expected_fold_ids: list[int] = []
 
         print(
@@ -1236,8 +1265,6 @@ def run_darts_cv(
             checkpoint_ics: dict[int, float] = {}
             checkpoint_n_days: dict[int, int] = {}
             n_val_points = 0
-            incr_dir = save_dir / "_incremental" if save_dir is not None else None
-            log_dir = save_dir / "_incremental_logs" if save_dir is not None else None
             if incr_dir is not None:
                 incr_dir.mkdir(parents=True, exist_ok=True)
                 clear_fold_predictions(incr_dir, config_name, split["fold"])
@@ -1319,12 +1346,15 @@ def run_darts_cv(
                     pl.lit(config_name).alias("config"),
                     pl.lit(epochs_trained).alias("epoch"),
                 )
-                cfg_prediction_frames.append(checkpoint_preds)
-                prediction_frames.append(checkpoint_preds)
+                slice_value: Path | pl.DataFrame | None = None
                 if incr_dir is not None:
-                    _flush_darts_fold_preds(
+                    slice_value = _flush_darts_fold_preds(
                         incr_dir, config_name, split["fold"], epochs_trained, checkpoint_preds
                     )
+                if slice_value is None:
+                    slice_value = checkpoint_preds
+                cfg_slices.setdefault(epochs_trained, {})[int(split["fold"])] = slice_value
+                run_slices.append(slice_value)
 
                 _entity = entity_col if entity_col in checkpoint_preds.columns else None
                 ic_result = cross_sectional_ic(
@@ -1388,11 +1418,16 @@ def run_darts_cv(
             print(f"    fold best epoch={fold_best_epoch}, IC={fold_best_ic:+.4f} ({elapsed:.1f}s)")
 
         epoch_scores: list[tuple[int, float, float, int]] = []
-        if cfg_prediction_frames:
-            cfg_all_preds = pl.concat(cfg_prediction_frames)
-            expected_fold_ids = sorted(cfg_all_preds["fold_id"].unique().to_list())
-            for epoch in sorted(cfg_all_preds["epoch"].unique().to_list()):
-                ep_df = cfg_all_preds.filter(pl.col("epoch") == epoch)
+        if cfg_slices:
+            # A fold that reached no checkpoint with predictions is not part of the
+            # population a checkpoint has to cover, which is why this narrows the list the
+            # fold loop appended to rather than using it.
+            expected_fold_ids = sorted(
+                {fold for by_fold in cfg_slices.values() for fold in by_fold}
+            )
+            for epoch in sorted(cfg_slices):
+                epoch_slices = cfg_slices[epoch]
+                ep_df = _darts_slice_frame(list(epoch_slices.values()))
                 _entity = entity_col if entity_col in ep_df.columns else None
                 ic_mean = float(
                     cross_sectional_ic(
@@ -1406,13 +1441,15 @@ def run_darts_cv(
                         min_obs=5,
                     )["ic_mean"]
                 )
-                fold_ids = sorted(ep_df["fold_id"].unique().to_list())
+                fold_ids = sorted(epoch_slices)
                 if fold_ids != expected_fold_ids:
+                    del ep_df
                     continue
+                del ep_df
                 fold_epoch_ics = []
                 fold_n_days = []
                 for fold_id in fold_ids:
-                    fold_df = ep_df.filter(pl.col("fold_id") == fold_id)
+                    fold_df = _darts_slice_frame([epoch_slices[fold_id]])
                     _entity = entity_col if entity_col in fold_df.columns else None
                     ic_result = cross_sectional_ic(
                         fold_df,
@@ -1426,6 +1463,7 @@ def run_darts_cv(
                     )
                     fold_epoch_ics.append(float(ic_result["ic_mean"]))
                     fold_n_days.append(int(ic_result["n_periods"]))
+                    del fold_df
                 ic_std = float(np.nanstd(fold_epoch_ics)) if len(fold_epoch_ics) > 1 else 0.0
                 ic_n_days = sum(fold_n_days)
                 learning_rows.append(
@@ -1477,7 +1515,7 @@ def run_darts_cv(
     if not config_results:
         raise RuntimeError("Darts run produced no config results.")
 
-    all_predictions = pl.concat(prediction_frames) if prediction_frames else pl.DataFrame()
+    all_predictions = _darts_slice_frame(run_slices)
     learning_curves = pl.DataFrame(learning_rows) if learning_rows else pl.DataFrame()
     training_log_df = pl.DataFrame(training_log) if training_log else pl.DataFrame()
     result = assemble_cv_result(

--- a/case_studies/utils/deep_learning.py
+++ b/case_studies/utils/deep_learning.py
@@ -2867,8 +2867,7 @@ def run_dl_cv(
     gc.collect()
 
     # Read in the order the loop recorded, which is the order a single frame cut by
-    # (config, checkpoint) produced: configuration, then checkpoint, then fold. A prediction
-    # set is registered content-addressed, so the row order is a result.
+    # (config, checkpoint) produced: configuration, then checkpoint, then fold.
     complete_predictions = _read_prediction_shards(
         [
             shard

--- a/case_studies/utils/deep_learning.py
+++ b/case_studies/utils/deep_learning.py
@@ -30,7 +30,7 @@ import subprocess
 import time
 import uuid
 import warnings
-from collections.abc import Callable, Mapping
+from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
@@ -56,8 +56,10 @@ from case_studies.utils.cv_results import (
 from case_studies.utils.folds import fold_seed
 from case_studies.utils.registry.store import (
     _save_parquet,
+    clear_fold_predictions,
     flush_fold_predictions,
     flush_fold_training_log,
+    incremental_prediction_shards,
 )
 from case_studies.utils.runtime import cpu_seconds
 from case_studies.utils.sequence_dataset import (
@@ -1778,6 +1780,31 @@ def mc_dropout_predict(
 # ---------------------------------------------------------------------------
 
 
+def _read_prediction_shards(paths: Sequence[Path]) -> pl.DataFrame:
+    """Read incremental prediction shards as one frame, in the order given.
+
+    One read across the whole set, which is both faster than a read per file and leaves a
+    single chunk for the filters downstream. Shards from different folds can disagree on
+    timestamp precision, which a multi-file read rejects; that case falls back to the
+    per-file read the precision cast needs. Both paths cast, because the precision is
+    part of what a registered prediction set hashes.
+    """
+    paths = list(paths)
+    if not paths:
+        return pl.DataFrame()
+    try:
+        frame = pl.read_parquet(paths)
+    except pl.exceptions.PolarsError:
+        return pl.concat(
+            [
+                pl.read_parquet(path).cast({"timestamp": pl.Datetime("us")}, strict=False)
+                for path in paths
+            ],
+            how="diagonal_relaxed",
+        )
+    return frame.cast({"timestamp": pl.Datetime("us")}, strict=False)
+
+
 def _train_one_config(
     model: nn.Module,
     train_loader: DataLoader,
@@ -1789,16 +1816,20 @@ def _train_one_config(
     | None = None,
     epoch_callback: Callable[[dict[str, Any]], None] | None = None,
     state_callback: Callable[[int, nn.Module], None] | None = None,
-) -> tuple[dict[int, float], dict[int, np.ndarray], dict[int, float]]:
-    """Train a single model config, storing predictions at ALL checkpoints.
+) -> tuple[dict[int, float], dict[int, float]]:
+    """Train a single model config, handing each checkpoint's predictions to the caller.
 
-    Trains to completion (no early stopping). Stores predictions at every
-    checkpoint so the caller can select the best epoch after all folds finish.
+    Trains to completion (no early stopping). ``checkpoint_callback`` receives one
+    checkpoint at a time, as it is reached, and owns everything that happens to it.
+    This used to also accumulate every checkpoint's validation predictions and return
+    them, which nothing read: the one caller persists each checkpoint through the
+    callback and deleted the returned dict on the next line. On a nasdaq fold - four
+    million validation rows over a twenty-checkpoint schedule - that dict was 640 MB
+    held to the end of the fold for nothing.
 
     Returns
     -------
     checkpoint_ics : dict[epoch, ic]
-    checkpoint_preds : dict[epoch, np.ndarray]
     epoch_losses : dict[epoch, avg_loss]
     """
     model = model.to(device)
@@ -1807,7 +1838,6 @@ def _train_one_config(
     scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=n_epochs)
 
     checkpoint_ics: dict[int, float] = {}
-    checkpoint_preds: dict[int, np.ndarray] = {}
     epoch_losses: dict[int, float] = {}
 
     for epoch in range(1, n_epochs + 1):
@@ -1880,11 +1910,10 @@ def _train_one_config(
                 min_obs=5,
             )["ic_mean"]
             checkpoint_ics[epoch] = ic
-            checkpoint_preds[epoch] = val_preds.copy()
             if state_callback is not None:
                 state_callback(epoch, model)
             if checkpoint_callback is not None:
-                checkpoint_callback(checkpoint_preds, y_val, val_dates, val_entities)
+                checkpoint_callback({epoch: val_preds}, y_val, val_dates, val_entities)
             if epoch_callback is not None:
                 epoch_callback(
                     {
@@ -1914,7 +1943,7 @@ def _train_one_config(
                 )
             print(f"      epoch {epoch:3d}/{n_epochs}: train_loss={avg_loss:.6f}", flush=True)
 
-    return checkpoint_ics, checkpoint_preds, epoch_losses
+    return checkpoint_ics, epoch_losses
 
 
 # ---------------------------------------------------------------------------
@@ -2516,6 +2545,7 @@ def run_dl_cv(
             y_val_store = val_dates_store = val_entities_store = None
             if incr_dir is not None:
                 incr_dir.mkdir(parents=True, exist_ok=True)
+                clear_fold_predictions(incr_dir, config_name, split["fold"])
                 y_val_store, val_dates_store, val_entities_store = materialize_store_metadata(
                     val_store
                 )
@@ -2615,7 +2645,7 @@ def run_dl_cv(
 
                 train_kwargs["state_callback"] = persist_state
 
-            checkpoint_ics, checkpoint_preds, epoch_losses = _train_one_config(
+            checkpoint_ics, epoch_losses = _train_one_config(
                 model=model,
                 train_loader=train_loader,
                 val_loader=val_loader,
@@ -2642,7 +2672,7 @@ def run_dl_cv(
                 row["best_ic"] = float(checkpoint_ics[best_ep])
             acc.setdefault("training_log", []).extend(epoch_rows)
 
-            del model, checkpoint_preds, train_loader, val_loader
+            del model, train_loader, val_loader
             if torch.cuda.is_available():
                 torch.cuda.empty_cache()
 
@@ -2659,34 +2689,30 @@ def run_dl_cv(
     if n_valid_folds == 0:
         raise ValueError("No valid folds created. Check data size vs lookback.")
 
-    # Reassemble all predictions from incremental saves
+    # Post-processing reads one (config, checkpoint) slice back at a time and drops it
+    # again. It used to reassemble every incremental save into one frame first and then cut
+    # slices out of it, so the whole prediction set was resident while a per-config copy and
+    # a per-epoch copy stood beside it, and the assembled result made a fourth. One sequence
+    # configuration is every checkpoint on every fold - twenty checkpoints over two folds
+    # where gradient boosting has ten - and a nasdaq fold is four million validation rows, so
+    # none of those copies is small.
     incr_dir = save_dir / "_incremental" if save_dir is not None else None
+    shards_by_config: dict[str, dict[int, list[Path]]] = {}
     if incr_dir is not None and incr_dir.exists():
-        parquet_files = sorted(incr_dir.glob("*.parquet"))
-        all_predictions = (
-            pl.concat(
-                [
-                    pl.read_parquet(f).cast({"timestamp": pl.Datetime("us")}, strict=False)
-                    for f in parquet_files
-                ],
-                how="diagonal_relaxed",
-            )
-            if parquet_files
-            else pl.DataFrame()
-        )
-    else:
-        all_predictions = pl.DataFrame()
+        for shard_cfg in configs:
+            by_epoch: dict[int, list[Path]] = {}
+            for _stem, shard_epoch, shard_path in incremental_prediction_shards(
+                incr_dir, shard_cfg["config_name"]
+            ):
+                by_epoch.setdefault(shard_epoch, []).append(shard_path)
+            shards_by_config[shard_cfg["config_name"]] = by_epoch
 
     # --- Aggregate results per config (post-processing) ---
     config_results: list[dict[str, Any]] = []
     all_curves: list[dict] = []
     training_log: list[dict] = []
     # (config, epoch) of every checkpoint that covers all folds, in the order the loop finds
-    # them. Recording the pair rather than the frame is what keeps post-processing from holding
-    # the same rows three times over: every slice appended here was cut from `all_predictions`,
-    # which stays resident, and concatenating the slices at the end made a third copy. One
-    # sequence configuration is every checkpoint epoch on every fold - twenty epochs over two
-    # folds where gradient boosting has ten checkpoints - so the copies are not small.
+    # them. The assembled result is read back from the shards in this order.
     complete_slices: list[tuple[str, int]] = []
     log_dir = save_dir / "_incremental_logs" if save_dir is not None else None
     incremental_logs = pl.DataFrame()
@@ -2700,38 +2726,35 @@ def run_dl_cv(
     for cfg in configs:
         config_name = cfg["config_name"]
         acc = config_acc[config_name]
-        cfg_preds = (
-            all_predictions.filter(pl.col("config") == config_name)
-            if all_predictions.height > 0
-            else pl.DataFrame()
-        )
+        cfg_shards = shards_by_config.get(config_name, {})
 
         epoch_scores: list[tuple[int, float, float, int]] = []
-        if cfg_preds.height > 0:
-            for epoch in sorted(cfg_preds["epoch"].unique().to_list()):
-                ep_df = cfg_preds.filter(pl.col("epoch") == epoch)
-                fold_ids = sorted(ep_df["fold_id"].unique().to_list())
-                if fold_ids != expected_fold_ids:
-                    continue
-                metrics = _decision_time_checkpoint_metrics(
-                    ep_df,
-                    date_col=date_col,
-                    entity_col=entity_col,
-                )
-                ic_mean = float(metrics["ic_mean"])
-                ic_std = float(metrics["ic_std"])
-                ic_n_days = int(metrics["ic_n_days"])
-                all_curves.append(
-                    {
-                        "config": config_name,
-                        "epoch": epoch,
-                        "ic_mean": ic_mean,
-                        "ic_std": ic_std,
-                        "ic_n_days": ic_n_days,
-                    }
-                )
-                complete_slices.append((config_name, int(epoch)))
-                epoch_scores.append((epoch, ic_mean, ic_std, ic_n_days))
+        for epoch in sorted(cfg_shards):
+            ep_df = _read_prediction_shards(cfg_shards[epoch])
+            fold_ids = sorted(ep_df["fold_id"].unique().to_list())
+            if fold_ids != expected_fold_ids:
+                del ep_df
+                continue
+            metrics = _decision_time_checkpoint_metrics(
+                ep_df,
+                date_col=date_col,
+                entity_col=entity_col,
+            )
+            del ep_df
+            ic_mean = float(metrics["ic_mean"])
+            ic_std = float(metrics["ic_std"])
+            ic_n_days = int(metrics["ic_n_days"])
+            all_curves.append(
+                {
+                    "config": config_name,
+                    "epoch": epoch,
+                    "ic_mean": ic_mean,
+                    "ic_std": ic_std,
+                    "ic_n_days": ic_n_days,
+                }
+            )
+            complete_slices.append((config_name, int(epoch)))
+            epoch_scores.append((epoch, ic_mean, ic_std, ic_n_days))
 
         if epoch_scores:
             full_coverage = max(item[3] for item in epoch_scores)
@@ -2788,16 +2811,16 @@ def run_dl_cv(
         # aggregation finishes. Registering only the raw-IC peak would prevent a
         # reader from applying the checkpoint-level coverage guard when that peak
         # has undefined daily IC on part of the validation surface.
-        if register and case_study and epoch_scores and cfg_preds.height > 0:
+        if register and case_study and epoch_scores:
             try:
                 from case_studies.utils.registry import register_prediction_set
 
                 arch = resolve_arch_name(config_name)
                 cfg_curves_df = pl.DataFrame([c for c in all_curves if c["config"] == config_name])
                 epoch_ic = {epoch: ic for epoch, ic, _std, _days in epoch_scores}
-                epochs = sorted(cfg_preds["epoch"].unique().to_list())
+                epochs = sorted(cfg_shards)
                 first_ep = best_cp if best_cp in epochs else epochs[0]
-                first_slice = cfg_preds.filter(pl.col("epoch") == first_ep).drop("config", "epoch")
+                first_slice = _read_prediction_shards(cfg_shards[first_ep]).drop("config", "epoch")
                 t_hash = _register_dl_config(
                     case_study=case_study,
                     label=label_col,
@@ -2816,10 +2839,11 @@ def run_dl_cv(
                     prediction_split=prediction_split,
                     identity_params=_config_identity_params(cfg),
                 )
+                del first_slice
                 for epoch, _ic, _epoch_std, _days in epoch_scores:
                     if epoch == first_ep:
                         continue
-                    epoch_preds = cfg_preds.filter(pl.col("epoch") == epoch).drop("config", "epoch")
+                    epoch_preds = _read_prediction_shards(cfg_shards[epoch]).drop("config", "epoch")
                     register_prediction_set(
                         case_study,
                         training_hash=t_hash,
@@ -2829,6 +2853,7 @@ def run_dl_cv(
                         predictions=epoch_preds,
                         metrics={"ic_mean": epoch_ic[epoch]},
                     )
+                    del epoch_preds
                 print(
                     f"    registered {config_name} incrementally "
                     f"({len(epoch_scores)} per-epoch slices)"
@@ -2841,25 +2866,16 @@ def run_dl_cv(
     del config_acc
     gc.collect()
 
-    # Cut in the order the loop recorded them, so the row order is the one the accumulating list
-    # produced. The cuts are lazy and collected once, so the slices are never all materialised
-    # alongside the frame they came from and the result they go into. `all_predictions` is not
-    # read after this and is the largest thing alive.
-    complete_predictions = (
-        pl.concat(
-            [
-                all_predictions.lazy().filter(
-                    (pl.col("config") == slice_config)
-                    & (pl.col("epoch").cast(pl.Int64) == slice_epoch)
-                )
-                for slice_config, slice_epoch in complete_slices
-            ],
-            how="diagonal_relaxed",
-        ).collect()
-        if complete_slices
-        else pl.DataFrame()
+    # Read in the order the loop recorded, which is the order a single frame cut by
+    # (config, checkpoint) produced: configuration, then checkpoint, then fold. A prediction
+    # set is registered content-addressed, so the row order is a result.
+    complete_predictions = _read_prediction_shards(
+        [
+            shard
+            for slice_config, slice_epoch in complete_slices
+            for shard in shards_by_config[slice_config][slice_epoch]
+        ]
     )
-    del all_predictions
     gc.collect()
 
     learning_curves = pl.DataFrame(all_curves) if all_curves else pl.DataFrame()

--- a/case_studies/utils/deep_learning.py
+++ b/case_studies/utils/deep_learning.py
@@ -1204,6 +1204,29 @@ def _predict_reconstructed_sequence(
     return np.concatenate(parts)
 
 
+def _sorted_by_checkpoint(
+    frames: dict[int, list[pl.DataFrame]],
+    context: SequenceResearchContext,
+) -> pl.DataFrame:
+    """Concatenate reconstructed folds, each checkpoint sorted, one checkpoint at a time.
+
+    The whole frame used to be sorted at once by (entity, date, fold, checkpoint). Its only
+    reader is `_publish_sequence_predictions`, which cuts one checkpoint out of it, and
+    inside one checkpoint the fourth key is a constant - so sorting each checkpoint's rows
+    by the first three gives every published slice the same rows in the same order. What it
+    does not do is sort 160 million rows in one go: a sort costs about three times its input
+    (measured 0.69 GB in, 2.13 GB of growth, and the streaming engine is no cheaper), which
+    on a nasdaq reconstruction - twenty checkpoints over two folds of four million
+    validation rows - is around 21 GB to produce a 7 GB frame.
+    """
+    ordered: list[pl.DataFrame] = []
+    for checkpoint in sorted(frames):
+        parts = frames[checkpoint]
+        ordered.append(pl.concat(parts).sort(context.entity_col, context.date_col, "fold_id"))
+        parts.clear()
+    return pl.concat(ordered)
+
+
 def _reconstruct_pytorch_predictions(
     model_root: Path,
     context: SequenceResearchContext,
@@ -1212,7 +1235,7 @@ def _reconstruct_pytorch_predictions(
     from case_studies.utils.deep_model_state import deep_checkpoint_path, restore_deep_model
     from case_studies.utils.sequence_dataset import materialize_sequences
 
-    frames = []
+    frames: dict[int, list[pl.DataFrame]] = {}
     lookback = int(context.config["params"].get("lookback", 60))
     calendar_id = str(computation["preprocessing"]["calendar_id"])
     device = torch.device(str(computation["numerics"]["device"]))
@@ -1292,7 +1315,7 @@ def _reconstruct_pytorch_predictions(
                 device,
                 batch_size=int(context.config["batch_size"]),
             )
-            frames.append(
+            frames.setdefault(int(value), []).append(
                 pl.DataFrame(
                     {
                         context.date_col: timestamps,
@@ -1307,7 +1330,7 @@ def _reconstruct_pytorch_predictions(
             )
     if not frames:
         raise ValueError("locked sequence fitted state produced no predictions")
-    return pl.concat(frames).sort(context.entity_col, context.date_col, "fold_id", "epoch")
+    return _sorted_by_checkpoint(frames, context)
 
 
 def _reconstruct_darts_predictions(
@@ -1352,7 +1375,7 @@ def _reconstruct_darts_predictions(
         label_col=context.label_col,
         config=config,
     )
-    frames = []
+    frames: dict[int, list[pl.DataFrame]] = {}
     has_temporal = bool(
         context.temporal_by_fold is not None
         and context.temporal_keys
@@ -1412,10 +1435,10 @@ def _reconstruct_darts_predictions(
                 pl.lit(config["config_name"]).alias("config"),
                 pl.lit(value).alias("epoch"),
             )
-            frames.append(frame)
-    if not frames or any(frame.is_empty() for frame in frames):
+            frames.setdefault(int(value), []).append(frame)
+    if not frames or any(part.is_empty() for parts in frames.values() for part in parts):
         raise ValueError("locked Darts fitted state produced incomplete predictions")
-    return pl.concat(frames).sort(context.entity_col, context.date_col, "fold_id", "epoch")
+    return _sorted_by_checkpoint(frames, context)
 
 
 def _reconstruct_sequence_predictions(

--- a/case_studies/utils/latent_factors/cv.py
+++ b/case_studies/utils/latent_factors/cv.py
@@ -694,6 +694,7 @@ def run_latent_factor_cv(
         state[model_name] = {
             "fold_ics": [],
             "pred_frames": [],
+            "pred_files": [],
             "fold_extras": [],
         }
         log(f"  {model_name} (K={n_factors}):")
@@ -781,6 +782,7 @@ def run_latent_factor_cv(
             if not checkpoint_preds:
                 raise ValueError(f"{model_name} produced no physical checkpoints")
         checkpoint_ics: dict[int, float] = {}
+        fold_frames: list[pl.DataFrame] = []
         for epoch, predictions in checkpoint_preds.items():
             frame = _build_prediction_frame(
                 predictions=predictions,
@@ -811,7 +813,7 @@ def run_latent_factor_cv(
                 }
             )
             if frame is not None:
-                state[model_name]["pred_frames"].append(frame)
+                fold_frames.append(frame)
         best_epoch, reported_ic = _select_epoch_from_values(
             checkpoint_ics,
             checkpoint_selection_policy=metric_policy["checkpoint_selection_policy"],
@@ -821,13 +823,20 @@ def run_latent_factor_cv(
             f"      fold {split['fold']}: reported_epoch={best_epoch}, "
             f"IC={reported_ic:+.4f}, {fold_elapsed:.1f}s"
         )
-        _write_incremental_fold(
+        # This fold's predictions leave memory here. They used to be kept for the whole run
+        # in `pred_frames` and, separately, rebuilt from `checkpoint_preds` to be written -
+        # every fold of every model resident while the later folds were still fitting, and
+        # every prediction frame built twice.
+        fold_path = _write_incremental_fold(
             model_dir=model_dirs[model_name],
             fold_id=split["fold"],
-            predictions=checkpoint_preds,
-            model_input=model_input,
-            model_name=model_name,
+            frames=fold_frames,
         )
+        if fold_path is None:
+            state[model_name]["pred_frames"].extend(fold_frames)
+        else:
+            state[model_name]["pred_files"].append(fold_path)
+        fold_frames.clear()
 
     if fold_workers > 1 and active_models:
         prepared_folds: list[tuple[dict[str, Any], dict[str, Any]]] = []
@@ -947,11 +956,15 @@ def run_latent_factor_cv(
 
     for model_name in active_models:
         fold_ics_df = pl.DataFrame(state[model_name]["fold_ics"])
-        preds_df = (
-            pl.concat(state[model_name]["pred_frames"])
-            if state[model_name]["pred_frames"]
-            else pl.DataFrame()
-        )
+        # Read back in the order the folds were fitted, which is the order the accumulating
+        # list produced. A registered prediction set is content-addressed, so that is a
+        # result and not a presentation detail.
+        if state[model_name]["pred_files"]:
+            preds_df = pl.read_parquet(state[model_name]["pred_files"])
+        elif state[model_name]["pred_frames"]:
+            preds_df = pl.concat(state[model_name]["pred_frames"])
+        else:
+            preds_df = pl.DataFrame()
         best_epoch, mean_ic = _select_reporting_epoch(
             fold_ics_df,
             checkpoint_selection_policy=metric_policy["checkpoint_selection_policy"],
@@ -1575,30 +1588,21 @@ def _write_incremental_fold(
     *,
     model_dir: Path | None,
     fold_id: int,
-    predictions: dict[int, np.ndarray],
-    model_input: dict[str, Any],
-    model_name: str,
-) -> None:
-    if model_dir is None:
-        return
+    frames: list[pl.DataFrame],
+) -> Path | None:
+    """Persist one fold's checkpoint predictions and return where they went.
+
+    Takes the frames the caller already scored rather than rebuilding them from the raw
+    predictions, which is what it used to do: every fold's predictions were constructed
+    twice, once to score and once to write.
+    """
+    if model_dir is None or not frames:
+        return None
     incremental_dir = model_dir / "_incremental"
     incremental_dir.mkdir(parents=True, exist_ok=True)
-    frames: list[pl.DataFrame] = []
-    for epoch, preds in predictions.items():
-        frame = _build_prediction_frame(
-            predictions=preds,
-            returns_val=model_input["returns_val"],
-            eval_returns_val=model_input.get("eval_returns_val"),
-            val_dates=model_input["val_dates"],
-            val_entities=model_input["val_entities"],
-            fold_id=fold_id,
-            model_name=model_name,
-            epoch=epoch,
-        )
-        if frame is not None:
-            frames.append(frame)
-    if frames:
-        pl.concat(frames).write_parquet(incremental_dir / f"fold{fold_id}.parquet")
+    path = incremental_dir / f"fold{fold_id}.parquet"
+    pl.concat(frames).write_parquet(path)
+    return path
 
 
 def _select_epoch_from_values(

--- a/case_studies/utils/latent_factors/cv.py
+++ b/case_studies/utils/latent_factors/cv.py
@@ -957,8 +957,7 @@ def run_latent_factor_cv(
     for model_name in active_models:
         fold_ics_df = pl.DataFrame(state[model_name]["fold_ics"])
         # Read back in the order the folds were fitted, which is the order the accumulating
-        # list produced. A registered prediction set is content-addressed, so that is a
-        # result and not a presentation detail.
+        # list produced.
         if state[model_name]["pred_files"]:
             preds_df = pl.read_parquet(state[model_name]["pred_files"])
         elif state[model_name]["pred_frames"]:

--- a/case_studies/utils/registry/store.py
+++ b/case_studies/utils/registry/store.py
@@ -1289,8 +1289,10 @@ def incremental_prediction_shards(
 
     The order is the one a single file per fold produced: folds by the lexicographic
     order of ``<config>_fold<fold>``, and inside a fold the checkpoints ascending, which
-    is the order they were fitted in. Prediction sets are registered content-addressed,
-    so this is a result, not a presentation detail.
+    is the order they were fitted in. Registry identity does not depend on it -
+    ``published_prediction_digest`` sorts its row hashes - but every artifact these
+    runners write does, and holding the order is what let the change be compared against
+    the implementation it replaced.
     """
     pattern = "*.parquet" if config_name is None else f"{config_name}_fold*.parquet"
     shards: list[tuple[str, int, Path]] = []

--- a/case_studies/utils/registry/store.py
+++ b/case_studies/utils/registry/store.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 import sqlite3
 import subprocess
 from collections.abc import Mapping
@@ -1256,6 +1257,66 @@ def _save_parquet(path: Path, frame) -> None:
 # ---------------------------------------------------------------------------
 
 
+_INCREMENTAL_SHARD = re.compile(r"^(?P<stem>.+)_ep(?P<epoch>\d+)\.parquet$")
+
+
+def incremental_shard_path(incr_dir: Path, config_name: str, fold: int, epoch: int) -> Path:
+    """The one file a (config, fold, checkpoint) triple ever writes."""
+    return incr_dir / f"{config_name}_fold{int(fold)}_ep{int(epoch)}.parquet"
+
+
+def clear_fold_predictions(incr_dir: Path, config_name: str, fold: int) -> None:
+    """Drop whatever an earlier attempt at this (config, fold) left behind.
+
+    A shard is written once and never rewritten, so a re-fit that produces fewer
+    checkpoints than the attempt before it would otherwise read the leftovers back as
+    its own. Rewriting one file per fold used to truncate them implicitly.
+    """
+    if not incr_dir.exists():
+        return
+    for path in incr_dir.glob(f"{config_name}_fold{int(fold)}_ep*.parquet"):
+        path.unlink()
+    legacy = incr_dir / f"{config_name}_fold{int(fold)}.parquet"
+    if legacy.exists():
+        legacy.unlink()
+
+
+def incremental_prediction_shards(
+    incr_dir: Path,
+    config_name: str | None = None,
+) -> list[tuple[str, int, Path]]:
+    """Return ``(stem, checkpoint, path)`` in the order their rows concatenate.
+
+    The order is the one a single file per fold produced: folds by the lexicographic
+    order of ``<config>_fold<fold>``, and inside a fold the checkpoints ascending, which
+    is the order they were fitted in. Prediction sets are registered content-addressed,
+    so this is a result, not a presentation detail.
+    """
+    pattern = "*.parquet" if config_name is None else f"{config_name}_fold*.parquet"
+    shards: list[tuple[str, int, Path]] = []
+    legacy: list[str] = []
+    for path in incr_dir.glob(pattern):
+        match = _INCREMENTAL_SHARD.match(path.name)
+        if match is None:
+            legacy.append(path.name)
+            continue
+        shards.append((match["stem"], int(match["epoch"]), path))
+    if legacy:
+        raise ValueError(
+            f"{incr_dir} holds {len(legacy)} prediction file(s) written one-per-fold by an "
+            f"earlier version ({', '.join(sorted(legacy)[:3])}). They carry every checkpoint "
+            f"the fold reached and would be counted a second time alongside the per-checkpoint "
+            f"shards beside them. Delete the directory and re-fit."
+        )
+    shards.sort(key=lambda item: (item[0], item[1]))
+    return shards
+
+
+def incremental_prediction_files(incr_dir: Path, config_name: str | None = None) -> list[Path]:
+    """The shard paths from :func:`incremental_prediction_shards`, in the same order."""
+    return [path for _stem, _epoch, path in incremental_prediction_shards(incr_dir, config_name)]
+
+
 def flush_fold_predictions(
     incr_dir: Path,
     config_name: str,
@@ -1270,10 +1331,19 @@ def flush_fold_predictions(
     eval_actual: np.ndarray | None = None,
     eval_col: str = "eval_actual",
 ) -> None:
-    """Write one fold's checkpoint predictions to parquet for crash safety.
+    """Write each checkpoint's fold predictions to its own parquet shard.
 
     Shared by deep_learning, tabular_dl, and darts_forecasting runners.
     Handles Object-typed date columns from pandas datetime arrays.
+
+    One shard per (config, fold, checkpoint), written once. The sequence runner calls
+    this at every checkpoint with every checkpoint fitted so far, and this used to
+    rewrite one file per fold from all of them, so both the frames it built and the bytes
+    it wrote grew with the square of the schedule. A nasdaq fold is 3,993,874 validation
+    rows, which is a measured 172 MB a checkpoint: at the twentieth checkpoint of twenty
+    the writer built 3.8 GB of frames to write a file it had already written nineteen
+    times, and wrote 210 checkpoints' worth of parquet over the fold where 20 were new. A
+    shard that already exists is left alone.
     """
     import numpy as np
     import polars as pl
@@ -1284,8 +1354,10 @@ def flush_fold_predictions(
             strict=False
         )
 
-    frames = []
     for ep, preds in checkpoint_preds.items():
+        shard = incremental_shard_path(incr_dir, config_name, fold, ep)
+        if shard.exists():
+            continue
         n = len(preds)
         entities = val_entities if val_entities is not None else np.array(["unknown"] * n)
         df = pl.DataFrame(
@@ -1301,10 +1373,8 @@ def flush_fold_predictions(
         )
         if eval_actual is not None:
             df = df.with_columns(pl.Series(eval_col, eval_actual.astype(np.float64)))
-        frames.append(df)
-
-    if frames:
-        _save_parquet(incr_dir / f"{config_name}_fold{fold}.parquet", pl.concat(frames))
+        _save_parquet(shard, df)
+        del df
 
 
 def flush_fold_training_log(

--- a/case_studies/utils/tabular_dl.py
+++ b/case_studies/utils/tabular_dl.py
@@ -1960,7 +1960,11 @@ def _train_tabm_fold(
 # ---------------------------------------------------------------------------
 
 
-from case_studies.utils.registry.store import flush_fold_predictions
+from case_studies.utils.registry.store import (
+    clear_fold_predictions,
+    flush_fold_predictions,
+    incremental_prediction_files,
+)
 
 
 def _decision_time_checkpoint_metrics(
@@ -2051,11 +2055,17 @@ def _checkpoint_prediction_frame(
 
 
 def _load_incremental_preds_for_config(incr_dir: Path, config_name: str) -> pl.DataFrame:
-    """Reassemble one config's predictions from its per-fold incremental saves."""
-    parquet_files = sorted(incr_dir.glob(f"{config_name}_fold*.parquet"))
+    """Reassemble one config's predictions from its per-checkpoint incremental saves.
+
+    The shards are read in the order :func:`incremental_prediction_files` defines - folds
+    by the lexicographic order of ``<config>_fold<fold>``, checkpoints ascending inside a
+    fold - which is the order one file per fold produced. A registered prediction set is
+    content-addressed, so that order is a result and not a presentation detail.
+    """
+    parquet_files = incremental_prediction_files(incr_dir, config_name)
     if not parquet_files:
         return pl.DataFrame()
-    return pl.concat([pl.read_parquet(f) for f in parquet_files])
+    return pl.read_parquet(parquet_files)
 
 
 def _load_cached_tabm_config(
@@ -2847,21 +2857,29 @@ def run_tabm_cv(
                         min_obs=5,
                     )["ic_mean"]
                     state["fold_checkpoint_ics"].setdefault(1, []).append(ic)
-                    fold_prediction_frame = _checkpoint_prediction_frame(
-                        candidate_key,
-                        fd["fold"],
-                        {1: preds},
-                        fd["val_dates"],
-                        fd["val_entities"],
-                        fd["y_val"],
-                        date_col,
-                        entity_col,
-                        eval_actual=fd["y_eval_val"] if eval_col else None,
-                        eval_col=eval_col or "eval_actual",
+                    # Built only where something reads it. On the incremental path the
+                    # writer builds the same rows again, so building it here was a second
+                    # copy of the fold nothing looked at.
+                    fold_prediction_frame = (
+                        _checkpoint_prediction_frame(
+                            candidate_key,
+                            fd["fold"],
+                            {1: preds},
+                            fd["val_dates"],
+                            fd["val_entities"],
+                            fd["y_val"],
+                            date_col,
+                            entity_col,
+                            eval_actual=fd["y_eval_val"] if eval_col else None,
+                            eval_col=eval_col or "eval_actual",
+                        )
+                        if (_recovery is not None or incr_dir is None)
+                        else None
                     )
                     if _recovery is not None:
                         state["prediction_frames"].append(fold_prediction_frame)
                     elif incr_dir is not None:
+                        clear_fold_predictions(incr_dir, candidate_key, fd["fold"])
                         flush_fold_predictions(
                             incr_dir,
                             candidate_key,
@@ -2976,21 +2994,26 @@ def run_tabm_cv(
                     continue
                 for ep, ic in checkpoint_ics.items():
                     state["fold_checkpoint_ics"].setdefault(ep, []).append(ic)
-                fold_prediction_frame = _checkpoint_prediction_frame(
-                    candidate_key,
-                    fd["fold"],
-                    checkpoint_preds,
-                    fd["val_dates"],
-                    fd["val_entities"],
-                    fd["y_val"],
-                    date_col,
-                    entity_col,
-                    eval_actual=fd["y_eval_val"] if eval_col else None,
-                    eval_col=eval_col or "eval_actual",
+                fold_prediction_frame = (
+                    _checkpoint_prediction_frame(
+                        candidate_key,
+                        fd["fold"],
+                        checkpoint_preds,
+                        fd["val_dates"],
+                        fd["val_entities"],
+                        fd["y_val"],
+                        date_col,
+                        entity_col,
+                        eval_actual=fd["y_eval_val"] if eval_col else None,
+                        eval_col=eval_col or "eval_actual",
+                    )
+                    if (_recovery is not None or incr_dir is None)
+                    else None
                 )
                 if _recovery is not None:
                     state["prediction_frames"].append(fold_prediction_frame)
                 elif incr_dir is not None:
+                    clear_fold_predictions(incr_dir, candidate_key, fd["fold"])
                     flush_fold_predictions(
                         incr_dir,
                         candidate_key,
@@ -3242,6 +3265,9 @@ def run_tabm_cv(
                 if strict:
                     raise
                 print(f"    WARN: incremental registration failed for {artifact_name}: {exc}")
+        # One configuration's predictions at a time. Without this the last configuration's
+        # frame is still alive when every configuration's is read back below.
+        del cfg_all_preds, prediction_parts
         gc.collect()
 
     failures = {
@@ -3252,11 +3278,17 @@ def run_tabm_cv(
     direct_failure = next(iter(failures.values()), None) if _recovery is None else None
     prediction_frames = [*cached_prediction_frames, *in_memory_prediction_frames]
     if incr_dir is not None and _recovery is None:
-        for candidate_key in completed_candidate_keys:
-            frame = _load_incremental_preds_for_config(incr_dir, candidate_key)
-            if frame.height:
-                prediction_frames.append(frame)
+        # One read across every completed configuration's shards, in the order one file per
+        # fold produced.
+        shard_paths = [
+            path
+            for candidate_key in completed_candidate_keys
+            for path in incremental_prediction_files(incr_dir, candidate_key)
+        ]
+        if shard_paths:
+            prediction_frames.append(pl.read_parquet(shard_paths))
     all_predictions = pl.concat(prediction_frames) if prediction_frames else pl.DataFrame()
+    del prediction_frames
     execution_diagnostics = {
         "base_fold_preparation_s": preparation_elapsed_s,
         "base_fold_preparations": preparation_count,

--- a/case_studies/utils/tabular_dl.py
+++ b/case_studies/utils/tabular_dl.py
@@ -2059,8 +2059,7 @@ def _load_incremental_preds_for_config(incr_dir: Path, config_name: str) -> pl.D
 
     The shards are read in the order :func:`incremental_prediction_files` defines - folds
     by the lexicographic order of ``<config>_fold<fold>``, checkpoints ascending inside a
-    fold - which is the order one file per fold produced. A registered prediction set is
-    content-addressed, so that order is a result and not a presentation detail.
+    fold - which is the order one file per fold produced.
     """
     parquet_files = incremental_prediction_files(incr_dir, config_name)
     if not parquet_files:

--- a/tests/test_darts_state.py
+++ b/tests/test_darts_state.py
@@ -651,3 +651,149 @@ def test_the_reconstruction_asks_for_the_terminal_step_on_a_lagged_label(
     )
 
     assert seen == ["terminal"]
+
+
+def _tiny_darts_cv_inputs(n_dates: int = 40, n_symbols: int = 6):
+    dates = mcal.get_calendar("NYSE").valid_days("2024-01-02", "2024-04-15")[:n_dates]
+    dates = dates.tz_localize(None)
+    dataset = pd.DataFrame(
+        [
+            {
+                "timestamp": timestamp,
+                "symbol": f"S{symbol}",
+                "feature": symbol + day / 10,
+                "fwd_ret_1d": np.sin(day / 3) + symbol / 100,
+            }
+            for symbol in range(n_symbols)
+            for day, timestamp in enumerate(dates)
+        ]
+    )
+    config = {
+        "family": "deep_learning",
+        "library": "darts",
+        "config_name": "tsmixer_probe",
+        "params": {
+            "architecture": "tsmixer",
+            "lookback": 4,
+            "hidden_dim": 4,
+            "n_blocks": 1,
+            "dropout": 0.0,
+            "darts_target": "lagged_label",
+            "darts_output_chunk_length": 2,
+        },
+        "n_epochs": 3,
+        "batch_size": 32,
+        "checkpoint_interval": 1,
+        "seed": 7,
+    }
+    splits = [
+        {
+            "fold": 0,
+            "train_start": dates[0],
+            "train_end": dates[14],
+            "val_start": dates[15],
+            "val_end": dates[26],
+        },
+        {
+            "fold": 1,
+            "train_start": dates[0],
+            "train_end": dates[26],
+            "val_start": dates[27],
+            "val_end": dates[-1],
+        },
+    ]
+    return dataset, config, splits
+
+
+def test_darts_runner_does_not_keep_a_checkpoint_it_has_written(tmp_path, monkeypatch) -> None:
+    """A checkpoint's frame is written and dropped, not held to the end of the run.
+
+    Every checkpoint used to be appended to a per-config list and a per-run list right
+    after being flushed, so a run held one copy of every checkpoint of every fold of every
+    config until it finished, of something already on disk. At the nasdaq schedule that is
+    twenty 172 MB frames per fold.
+    """
+    import weakref
+
+    from case_studies.utils import darts_forecasting
+
+    dataset, config, splits = _tiny_darts_cv_inputs()
+
+    written: list[weakref.ReferenceType] = []
+    flush = darts_forecasting._flush_darts_fold_preds
+
+    def tracking_flush(incr_dir, config_name, fold, epoch, frame):
+        path = flush(incr_dir, config_name, fold, epoch, frame)
+        written.append(weakref.ref(frame))
+        return path
+
+    monkeypatch.setattr(darts_forecasting, "_flush_darts_fold_preds", tracking_flush)
+
+    alive_at_each_scoring: list[int] = []
+    score = darts_forecasting.cross_sectional_ic
+
+    def tracking_score(*args, **kwargs):
+        alive_at_each_scoring.append(sum(ref() is not None for ref in written))
+        return score(*args, **kwargs)
+
+    monkeypatch.setattr(darts_forecasting, "cross_sectional_ic", tracking_score)
+
+    result = darts_forecasting.run_darts_cv(
+        dataset,
+        splits,
+        configs=[config],
+        feature_names=["feature"],
+        label_col="fwd_ret_1d",
+        date_col="timestamp",
+        entity_col="symbol",
+        device="cpu",
+        save_dir=tmp_path / "run",
+        max_train_sequences=0,
+        register=False,
+        case_study="etfs",
+        notebook=None,
+    )
+
+    assert result["all_predictions"].height > 0
+    assert len(written) == len(splits) * config["n_epochs"]
+    assert max(alive_at_each_scoring) <= 1, (
+        f"a scoring call found {max(alive_at_each_scoring)} flushed checkpoint frames "
+        "alive; the runner is holding checkpoints it has already written"
+    )
+
+
+def test_darts_all_predictions_is_its_shards_in_order(tmp_path) -> None:
+    """The assembled frame is the shards concatenated in the order they were written.
+
+    It used to be a concatenation of the in-memory copies, which is what made holding them
+    look necessary. Reading them back has to give the same frame, rows and order alike, or
+    a registered prediction set moves.
+    """
+    dataset, config, splits = _tiny_darts_cv_inputs()
+    save_dir = tmp_path / "run"
+
+    result = run_darts_cv(
+        dataset,
+        splits,
+        configs=[config],
+        feature_names=["feature"],
+        label_col="fwd_ret_1d",
+        date_col="timestamp",
+        entity_col="symbol",
+        device="cpu",
+        save_dir=save_dir,
+        max_train_sequences=0,
+        register=False,
+        case_study="etfs",
+        notebook=None,
+    )
+
+    shards = sorted(
+        (save_dir / "_incremental").glob("*.parquet"),
+        key=lambda path: (
+            int(path.stem.split("_fold")[1].split("_ep")[0]),
+            int(path.stem.split("_ep")[1]),
+        ),
+    )
+    assert len(shards) == len(splits) * config["n_epochs"]
+    assert result["all_predictions"].equals(pl.read_parquet(shards))

--- a/tests/test_deep_learning_adapter.py
+++ b/tests/test_deep_learning_adapter.py
@@ -840,3 +840,150 @@ def test_run_dl_cv_assembles_predictions_in_config_then_epoch_order(tmp_path) ->
     assert len(parts) == len(config_names) * 4
 
     assert result["all_predictions"].equals(pl.concat(parts, how="diagonal_relaxed"))
+
+
+def test_flush_writes_one_shard_per_checkpoint_and_never_rewrites_one(tmp_path) -> None:
+    """A checkpoint's predictions are written once, to a file of their own.
+
+    The sequence runner reaches a checkpoint and hands the writer every checkpoint fitted
+    so far, so a writer that keeps one file per fold rebuilds and rewrites the whole fold
+    at every checkpoint: quadratic in the schedule, and on a nasdaq fold - four million
+    validation rows over twenty checkpoints - about ten gigabytes resident to write a file
+    it had already written nineteen times.
+    """
+    import numpy as np
+
+    from case_studies.utils.registry.store import (
+        flush_fold_predictions,
+        incremental_prediction_shards,
+    )
+
+    incr_dir = tmp_path / "_incremental"
+    incr_dir.mkdir()
+    n = 8
+    dates = np.array(["2024-01-02"] * n, dtype="datetime64[us]")
+    entities = np.array(list("ABCDEFGH"))
+    y_val = np.arange(n, dtype=np.float64)
+
+    reached: dict[int, np.ndarray] = {}
+    written_at: dict[int, int] = {}
+    for epoch in (1, 2, 3):
+        reached[epoch] = np.full(n, float(epoch))
+        flush_fold_predictions(
+            incr_dir, "nlinear", 2, reached, dates, entities, y_val, "timestamp", "symbol"
+        )
+        written_at[epoch] = (incr_dir / f"nlinear_fold2_ep{epoch}.parquet").stat().st_mtime_ns
+
+    shards = incremental_prediction_shards(incr_dir, "nlinear")
+    assert [(stem, epoch) for stem, epoch, _path in shards] == [
+        ("nlinear_fold2", 1),
+        ("nlinear_fold2", 2),
+        ("nlinear_fold2", 3),
+    ]
+    for _stem, epoch, path in shards:
+        frame = pl.read_parquet(path)
+        assert frame["epoch"].unique().to_list() == [epoch]
+        assert path.stat().st_mtime_ns == written_at[epoch], (
+            f"checkpoint {epoch}'s shard was rewritten by a later checkpoint"
+        )
+
+
+def test_run_dl_cv_holds_one_checkpoint_slice_at_a_time(tmp_path, monkeypatch) -> None:
+    """Post-processing reads a checkpoint back, scores it, and drops it.
+
+    It used to reassemble every incremental save into one frame and cut slices out of
+    that, so the whole prediction set stayed resident with a per-config copy and a
+    per-epoch copy beside it.
+    """
+    import weakref
+
+    import numpy as np
+    import pandas as pd
+
+    rng = np.random.default_rng(1)
+    dates = pd.bdate_range("2024-01-01", periods=120)
+    symbols = ("A", "B", "C", "D", "E", "F", "G", "H", "I", "J")
+    frames = []
+    for symbol in symbols:
+        first = rng.normal(size=len(dates))
+        frames.append(
+            pd.DataFrame(
+                {
+                    "symbol": symbol,
+                    "timestamp": dates,
+                    "f1": first,
+                    "f2": rng.normal(size=len(dates)),
+                    "target": 0.1 * first + 0.01 * rng.normal(size=len(dates)),
+                }
+            )
+        )
+    dataset = pd.concat(frames, ignore_index=True)
+    splits = [
+        {
+            "fold": 0,
+            "train_start": dates[0],
+            "train_end": dates[59],
+            "val_start": dates[60],
+            "val_end": dates[79],
+        },
+        {
+            "fold": 1,
+            "train_start": dates[0],
+            "train_end": dates[79],
+            "val_start": dates[80],
+            "val_end": dates[119],
+        },
+    ]
+    configs = [
+        {
+            "family": "deep_learning",
+            "config_name": name,
+            "n_epochs": 4,
+            "checkpoint_interval": 1,
+            "batch_size": 16,
+            "params": {"architecture": architecture, "lookback": 5},
+        }
+        for name, architecture in (("nlinear", "nlinear"), ("lstm_h64", "lstm"))
+    ]
+
+    slices: list[weakref.ReferenceType] = []
+    read_shards = deep_learning._read_prediction_shards
+
+    def tracking_read(paths):
+        frame = read_shards(paths)
+        if frame.height:
+            slices.append(weakref.ref(frame))
+        return frame
+
+    monkeypatch.setattr(deep_learning, "_read_prediction_shards", tracking_read)
+
+    alive_at_each_scoring: list[int] = []
+    score = deep_learning._decision_time_checkpoint_metrics
+
+    def tracking_score(frame, **kwargs):
+        alive_at_each_scoring.append(sum(ref() is not None for ref in slices))
+        return score(frame, **kwargs)
+
+    monkeypatch.setattr(deep_learning, "_decision_time_checkpoint_metrics", tracking_score)
+
+    result = deep_learning.run_dl_cv(
+        dataset,
+        splits,
+        configs=configs,
+        n_features=2,
+        feature_names=["f1", "f2"],
+        label_col="target",
+        date_col="timestamp",
+        entity_col="symbol",
+        device="cpu",
+        register=False,
+        save_dir=tmp_path,
+        seed=0,
+    )
+
+    assert result["all_predictions"].height > 0
+    assert len(alive_at_each_scoring) == len(configs) * 4
+    assert alive_at_each_scoring == [1] * len(alive_at_each_scoring), (
+        f"a scored checkpoint found {max(alive_at_each_scoring)} prediction frames alive; "
+        f"post-processing is holding slices across checkpoints"
+    )

--- a/tests/test_deep_learning_adapter.py
+++ b/tests/test_deep_learning_adapter.py
@@ -749,10 +749,11 @@ def test_run_dl_cv_assembles_predictions_in_config_then_epoch_order(tmp_path) ->
 
     Post-processing used to hold the whole prediction set three times over: the frame read back
     from the incremental parquet files, a filtered copy per configuration, and every eligible
-    epoch slice appended to a list that was then concatenated. Cutting the slices lazily from
-    one frame removes two of those copies, and the thing that could go wrong is order: a single
-    filter over the whole frame returns file order, not configuration-then-epoch order, and the
-    registered prediction set is order-bearing.
+    epoch slice appended to a list that was then concatenated. Reading one slice back at a time
+    removes those copies, and the thing that could go wrong is order: a single pass over the
+    whole set returns file order, not configuration-then-epoch order. Registry identity does
+    not depend on the order - `published_prediction_digest` sorts its row hashes - but every
+    artifact the runner writes does.
     """
     import numpy as np
     import pandas as pd

--- a/tests/test_deep_learning_adapter.py
+++ b/tests/test_deep_learning_adapter.py
@@ -988,3 +988,52 @@ def test_run_dl_cv_holds_one_checkpoint_slice_at_a_time(tmp_path, monkeypatch) -
         f"a scored checkpoint found {max(alive_at_each_scoring)} prediction frames alive; "
         f"post-processing is holding slices across checkpoints"
     )
+
+
+def test_checkpoint_sorted_reconstruction_matches_a_whole_frame_sort() -> None:
+    """Sorting each checkpoint gives every published slice the rows a whole-frame sort gave.
+
+    The reconstruction's only reader cuts one checkpoint out of the frame, and inside one
+    checkpoint the `epoch` key is a constant, so the two orders can only differ on rows the
+    published slice does not contain. Sorting the whole frame instead costs about three
+    times its input; on a nasdaq reconstruction that is roughly 21 GB to produce a 7 GB
+    frame.
+    """
+    import numpy as np
+
+    from case_studies.utils.deep_learning import _sorted_by_checkpoint
+
+    rng = np.random.default_rng(4)
+    entities = np.array(["C", "A", "B", "A", "C", "B"])
+    stamps = np.array(
+        ["2024-01-03", "2024-01-02", "2024-01-02", "2024-01-03", "2024-01-02", "2024-01-03"],
+        dtype="datetime64[us]",
+    )
+    frames: dict[int, list[pl.DataFrame]] = {}
+    for checkpoint in (10, 5):
+        for fold in (1, 0):
+            frames.setdefault(checkpoint, []).append(
+                pl.DataFrame(
+                    {
+                        "timestamp": stamps,
+                        "symbol": entities,
+                        "fold_id": fold,
+                        "y_score": rng.normal(size=len(entities)),
+                        "y_true": rng.normal(size=len(entities)),
+                        "config": "nlinear",
+                        "epoch": checkpoint,
+                    }
+                )
+            )
+    whole = pl.concat([part for parts in frames.values() for part in parts]).sort(
+        "symbol", "timestamp", "fold_id", "epoch"
+    )
+    context = SimpleNamespace(entity_col="symbol", date_col="timestamp")
+
+    by_checkpoint = _sorted_by_checkpoint(frames, context)
+
+    assert sorted(by_checkpoint["epoch"].unique().to_list()) == [5, 10]
+    for checkpoint in (5, 10):
+        assert whole.filter(pl.col("epoch") == checkpoint).equals(
+            by_checkpoint.filter(pl.col("epoch") == checkpoint)
+        ), f"checkpoint {checkpoint} publishes a different slice than a whole-frame sort"

--- a/tests/test_tabular_dl_runtime.py
+++ b/tests/test_tabular_dl_runtime.py
@@ -158,7 +158,7 @@ def test_fold_persistence_keeps_fit_and_evaluation_targets(tmp_path) -> None:
         eval_col="eval_actual",
     )
 
-    saved = pl.read_parquet(tmp_path / "tabm_probe_fold0.parquet")
+    saved = pl.read_parquet(tmp_path / "tabm_probe_fold0_ep25.parquet")
     assert saved["y_true"].to_list() == [0.0, 1.0]
     assert saved["eval_actual"].to_list() == [-0.1, 0.3]
 
@@ -789,7 +789,7 @@ def test_direct_registered_batch_preserves_completed_sibling_on_later_failure(
         )
 
     assert registered == ["tabm_s"]
-    assert (tmp_path / "return" / "_incremental" / "tabm_s_fold0.parquet").exists()
+    assert (tmp_path / "return" / "_incremental" / "tabm_s_fold0_ep1.parquet").exists()
 
 
 def test_saved_artifact_message_does_not_leak_absolute_path(


### PR DESCRIPTION
#908 took gradient boosting's fold predictions off the heap. The same shape is
in every remaining modeling runner, and the two sequence writers are worse,
because they also rewrite what they have already written. nasdaq 08-11 and
every us_equities modeling notebook run on this code.

**The writer, and it is quadratic.** `flush_fold_predictions` kept one parquet
file per fold, and the sequence runner calls it at every checkpoint with every
checkpoint fitted so far, so the K-th checkpoint rebuilt the fold from K frames
and wrote the whole file again. A nasdaq fold is 3,993,874 validation rows, a
measured 172 MB per checkpoint: at the twentieth checkpoint of twenty the
writer built 3.8 GB of frames to write a file it had already written nineteen
times, and wrote 210 checkpoints' worth of parquet over the fold where 20 were
new. It now writes one shard per (config, fold, checkpoint), once.
`_flush_darts_fold_preds` had the same shape and gets the same treatment.

**The trainer.** `_train_one_config` accumulated every checkpoint's validation
predictions and returned them. Its one caller persists each checkpoint through
the callback and deleted the returned dict on the next line: 639 MB held to the
end of a nasdaq fold for nothing.

**The post-processing.** `run_dl_cv` reassembled every incremental save into
one frame and cut slices out of it, so the whole prediction set was resident
while a per-config copy and a per-epoch copy stood beside it, and the assembled
result made a fourth. Three of those four are filters, and a filter copies. It
now reads one (config, checkpoint) slice back from its own shards, scores it,
and drops it.

**The Darts runner held every checkpoint it had written.** `run_darts_cv`
appended each checkpoint's predictions to a per-config list and a per-run list
immediately after flushing them to their shard, then concatenated the per-config
list and cut a filter out of it per checkpoint and a second filter per fold
inside that. `us_equities_panel`'s `11_dl_tsmixer` and `12_dl_weekly` are the
production notebooks on that path. It now keeps the shard's path, scores a
checkpoint by reading back only that checkpoint's shards, and assembles the run
with one multi-file read.

`run_tabm_cv` builds the fold frame only where something reads it, and holds
one configuration's predictions at a time. The latent-factor CV kept every fold
of every model for the whole run and separately rebuilt each frame to write it;
it now writes the frames it scored and reads them back per model. `causal.py`
accumulates floats and needed nothing: its walk-forward DML rebinds the fold's
nuisance models each iteration and its placebo draws keep one scalar apiece.

**Row order.** The shards are read in the order one file per fold produced -
folds by the lexicographic order of `<config>_fold<fold>`, checkpoints ascending
inside a fold - and `incremental_prediction_shards` is the single place that
decides it. Registry identity does not depend on that order:
`published_prediction_digest` sorts its row hashes, so a frame, its reverse and
a shuffle of it all digest to `2b4321c1748d635a`. What the order guarantees is
that every artifact these runners write is what the implementation they replace
produced, which is what makes the A/B below a real check. A directory holding
files from the old one-per-fold layout raises rather than counting them twice.

**The reuse path sorted 160 million rows to publish them 4 million at a time.**
Rebuilding a completed run's predictions from its persisted checkpoints sorted
the whole frame by (entity, date, fold, checkpoint). A sort costs about three
times its input - measured, 0.69 GB in and 2.13 GB of growth, and the streaming
engine is no cheaper at 3.33 GB against 3.32 GB peak for the same rows - so a
nasdaq reconstruction spent around 21 GB to produce a 7 GB frame, on the path
every re-run of a completed 08-11 config takes. The frame's only reader cuts one
checkpoint out of it, and inside a checkpoint the fourth key is a constant, so
`_sorted_by_checkpoint` sorts each checkpoint by the first three and frees its
inputs as it goes. A test asserts slice-for-slice equality against the
whole-frame sort and fails if the keys are reordered.

## Verification

Two A/Bs, both on real fits, both comparing content and row order.

The pytorch path against unmodified `origin/main` (2 configs, 2 folds, 4
checkpoints, 10 symbols, cpu): `predictions.parquet`, `all_predictions.parquet`
and `learning_curves.parquet` equal, training log equal excluding its timing
column.

The Darts path against this branch's previous commit (2 tsmixer configs, 2
folds, 4 checkpoints, 8 symbols, cpu): `all_predictions` (1920, 7),
`predictions` (240, 6), `learning_curves` (8, 5) and the training log excluding
its timings all equal including schema, and the 16 shard names are identical.

Four new tests. Three fail against the code they replace: one holds the writer
to a shard per checkpoint that a later checkpoint does not rewrite; one holds
`run_dl_cv` to a single prediction frame alive at each checkpoint it scores; one
weakrefs every frame the Darts runner flushes and finds 6 alive before the fix,
which is that run's two folds times three checkpoints. The fourth pins the
Darts assembly to its shards in order. 314 tests green across the sequence,
tabular, darts, latent-factor and gbm suites, plus 145 across the darts,
sequence and deep-learning suites after the Darts change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sy1WqyZZTXcoyFYAjVbyiu
