### PR TITLE
us_equities_panel: the GARCH refit comment counted the wrong universe

### DIFF
--- a/case_studies/us_equities_panel/config/setup.yaml
+++ b/case_studies/us_equities_panel/config/setup.yaml
@@ -196,9 +196,11 @@ model_based:
     # sensitive to - is estimated from too few volatility cycles.
     burnin: 504
     # How often the variance model is re-estimated. A quarter, which on this panel is
-    # 3,178 series re-estimated about 110 times each. Section 4b measures what the cadence
-    # buys: the fitted persistence of a US equity moves slowly, so a faster cadence would
-    # multiply the fits without moving the emitted volatility.
+    # 3,160 series - the rest carry less than the burn-in above and take the market-level
+    # volatility - re-estimated 58 times each on average, 110 times for a series that
+    # spans the whole sample, and about 183,000 times in all. Section 4b measures what the
+    # cadence buys: the fitted persistence of a US equity moves slowly, so a faster cadence
+    # would multiply the fits without moving the emitted volatility.
     refit_every: 63
     # The specification the maximum-likelihood fit estimates, declared here rather than
     # written into the notebook's call, so what "the GARCH feature" names on this panel is


### PR DESCRIPTION
`model_based.garch.refit_every`'s comment read "3,178 series re-estimated about 110 times each",
which prices the notebook at 350,000 GARCH estimations. Both halves are wrong, and the number is
load-bearing: it is what a reader costs a stage-04 run from, and it is the only place the schedule's
size is stated.

- **3,178 is the label file's universe.** The GARCH walk runs on the full session panel, where the
  eligibility screen decides which rows leave the notebook rather than which series are fitted.
  3,160 of 3,199 stocks carry more than the 504-session burn-in; the rest take the market-level
  volatility.
- **110 is the maximum, not the typical.** The schedule freezes at the 2016-01-01 holdout and most
  stocks are younger than the sample, so the mean is 58 refits.

Measured 2026-09-10 on the production panel through `refit_boundaries(n, 504, 63)` with the holdout
freeze applied: **183,298 estimations**, 58 per fitted series, 110 at most.

Comment only. The parsed configuration is unchanged, so no digest, identity or hash moves.

Measured alongside it, and recorded on ml4t/agent-workspace#1020 rather than here: a fit costs
14.9 ms including the filter pass, so the whole schedule is 0.76 CPU-hours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P1tBf8pMZ74NrdVfCzz76s
