### PR TITLE
us_equities_panel: the Wasserstein regime estimator moves into case_studies/utils/temporal.py

### DIFF
--- a/case_studies/us_equities_panel/04_model_based_features.ipynb
+++ b/case_studies/us_equities_panel/04_model_based_features.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "073f0f6c",
+   "id": "0606981d",
    "metadata": {},
    "source": [
     "# US Equities Panel: Model-Based Features\n",
@@ -69,7 +69,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1bd658b5",
+   "id": "5f1d540f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -78,7 +78,6 @@
     "import multiprocessing\n",
     "import os\n",
     "from concurrent.futures import ProcessPoolExecutor\n",
-    "from dataclasses import dataclass\n",
     "from datetime import date\n",
     "\n",
     "import matplotlib.pyplot as plt\n",
@@ -99,9 +98,12 @@
     "from case_studies.utils.coverage import assert_sessions_complete\n",
     "from case_studies.utils.cv_window import modeling_fold_boundaries\n",
     "from case_studies.utils.temporal import (\n",
+    "    fit_wasserstein_kmeans,\n",
     "    garch11_conditional_volatility,\n",
+    "    lift_stream,\n",
     "    refit_boundaries,\n",
     "    walk_forward_feature,\n",
+    "    wasserstein_distance_1d,\n",
     "    write_model_based,\n",
     ")\n",
     "from data import load_us_equities\n",
@@ -129,13 +131,12 @@
     "\n",
     "FDR_ALPHA = 0.05\n",
     "\n",
-    "FloatArray = NDArray[np.float64]\n",
-    "IntArray = NDArray[np.int64]"
+    "FloatArray = NDArray[np.float64]"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "402c9516",
+   "id": "1c51a3f8",
    "metadata": {},
    "source": [
     "### The values a run can be given\n",
@@ -181,7 +182,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0e1094e0",
+   "id": "2c4b3da6",
    "metadata": {
     "tags": [
      "parameters"
@@ -202,7 +203,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9ba8267d",
+   "id": "1206cd15",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -211,7 +212,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "12b7d842",
+   "id": "2b7a0c26",
    "metadata": {},
    "source": [
     "## Configuration\n",
@@ -235,7 +236,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9d9f19dd",
+   "id": "9b0ba4cd",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -288,7 +289,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "01a1c36e",
+   "id": "f6fca69d",
    "metadata": {},
    "source": [
     "## Why this panel is given regime and volatility features\n",
@@ -320,7 +321,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "363390af",
+   "id": "8dc2af26",
    "metadata": {},
    "source": [
     "## 1. Load the panel and screen it\n",
@@ -361,7 +362,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f9b2add2",
+   "id": "a48759d0",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -386,7 +387,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "beafa50b",
+   "id": "d4f29f47",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -437,7 +438,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e3cc9c1b",
+   "id": "b9244a5a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -467,7 +468,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6eed770c",
+   "id": "d6016cf6",
    "metadata": {},
    "source": [
     "Those two totals are sums over twenty-eight years, and what every transform below actually\n",
@@ -486,7 +487,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "633af381",
+   "id": "1455326a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -528,7 +529,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "653bfb8a",
+   "id": "f936b096",
    "metadata": {},
    "source": [
     "## 1b. What bounds an estimate, and what selects a row\n",
@@ -562,7 +563,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b415a05e",
+   "id": "d0bd2e56",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -616,7 +617,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d1d8630d",
+   "id": "fc8bba2c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -635,7 +636,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d2338c87",
+   "id": "05237b32",
    "metadata": {},
    "source": [
     "Each row of the figure is one fold: the filled bar is the span it trains on, the open bar\n",
@@ -650,7 +651,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "eb1f3450",
+   "id": "a5bb0ae1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -690,7 +691,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e7072994",
+   "id": "4d62d924",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -720,136 +721,20 @@
     "The centroids are re-estimated on the schedule: fitted on the market history up to a\n",
     "boundary, held fixed while the next quarter of windows is scored against them, then fitted\n",
     "again on everything up to the following boundary. Every stock carries the same value on a\n",
-    "date, because the series being clustered is market-wide."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "bdac5160",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "@dataclass(frozen=True)\n",
-    "class LiftedStream:\n",
-    "    \"\"\"Overlapping windows of cross-sectional return distributions.\"\"\"\n",
+    "date, because the series being clustered is market-wide.\n",
     "\n",
-    "    segments: FloatArray  # (n_segments, window_len)\n",
-    "    sorted_segments: FloatArray  # Sorted per window\n",
-    "    starts: IntArray  # Start indices\n",
-    "    window_len: int\n",
-    "    step: int\n",
-    "\n",
-    "\n",
-    "def lift_stream(\n",
-    "    returns: FloatArray,\n",
-    "    window_len: int,\n",
-    "    overlap: int,\n",
-    ") -> LiftedStream:\n",
-    "    \"\"\"Lift a 1D return stream into overlapping windows.\"\"\"\n",
-    "    step = window_len - overlap\n",
-    "    windows_view = np.lib.stride_tricks.sliding_window_view(returns, window_shape=window_len)\n",
-    "    windows_view = windows_view[::step]\n",
-    "    segments = np.ascontiguousarray(windows_view, dtype=np.float64)\n",
-    "    sorted_segments = np.sort(segments, axis=1)\n",
-    "    starts = np.arange(0, segments.shape[0] * step, step, dtype=np.int64)\n",
-    "\n",
-    "    return LiftedStream(\n",
-    "        segments=segments,\n",
-    "        sorted_segments=sorted_segments,\n",
-    "        starts=starts,\n",
-    "        window_len=window_len,\n",
-    "        step=step,\n",
-    "    )"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "be3816eb",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "def wasserstein_distance_1d(\n",
-    "    sorted_a: FloatArray, sorted_b: FloatArray, p: float = 1.0\n",
-    ") -> FloatArray:\n",
-    "    \"\"\"1D p-Wasserstein distance between equal-weight empirical measures.\n",
-    "\n",
-    "    Reduces over the last axis and broadcasts over the rest, so a stack of sorted windows\n",
-    "    against one sorted centroid returns one distance per window.\n",
-    "    \"\"\"\n",
-    "    return (np.abs(sorted_a - sorted_b) ** p).mean(axis=-1) ** (1.0 / p)\n",
-    "\n",
-    "\n",
-    "def wasserstein_barycenter_1d(sorted_members: FloatArray, p: float = 1.0) -> FloatArray:\n",
-    "    \"\"\"Wasserstein barycenter: median (p=1) or mean (p=2) of sorted atoms.\"\"\"\n",
-    "    if p == 1.0:\n",
-    "        return np.median(sorted_members, axis=0).astype(np.float64)\n",
-    "    return sorted_members.mean(axis=0).astype(np.float64)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "c15bc1e3",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "def fit_wasserstein_kmeans(\n",
-    "    sorted_segments: FloatArray,\n",
-    "    n_clusters: int = 2,\n",
-    "    max_iter: int = 50,\n",
-    "    n_init: int = 5,\n",
-    "    random_state: int = 42,\n",
-    ") -> tuple[IntArray, FloatArray]:\n",
-    "    \"\"\"Fit Wasserstein k-means on sorted 1D segments.\n",
-    "\n",
-    "    Returns (labels, centroids).\n",
-    "    \"\"\"\n",
-    "    rng = np.random.default_rng(random_state)\n",
-    "    n_samples = sorted_segments.shape[0]\n",
-    "    best_labels = None\n",
-    "    best_centroids = None\n",
-    "    best_inertia = float(\"inf\")\n",
-    "\n",
-    "    for _ in range(n_init):\n",
-    "        # Random initialization\n",
-    "        idx = rng.choice(n_samples, size=n_clusters, replace=False)\n",
-    "        centroids = sorted_segments[idx].copy()\n",
-    "\n",
-    "        for _ in range(max_iter):\n",
-    "            # Assignment: compute distance to each centroid\n",
-    "            dists = np.zeros((n_samples, n_clusters))\n",
-    "            for k in range(n_clusters):\n",
-    "                dists[:, k] = wasserstein_distance_1d(sorted_segments, centroids[k][None, :])\n",
-    "\n",
-    "            labels = dists.argmin(axis=1)\n",
-    "\n",
-    "            # Update centroids\n",
-    "            new_centroids = np.zeros_like(centroids)\n",
-    "            for k in range(n_clusters):\n",
-    "                members = sorted_segments[labels == k]\n",
-    "                if len(members) > 0:\n",
-    "                    new_centroids[k] = wasserstein_barycenter_1d(members, p=1.0)\n",
-    "                else:\n",
-    "                    new_centroids[k] = centroids[k]\n",
-    "\n",
-    "            if np.allclose(centroids, new_centroids, atol=1e-6):\n",
-    "                break\n",
-    "            centroids = new_centroids\n",
-    "\n",
-    "        inertia = sum(dists[i, labels[i]] for i in range(n_samples))\n",
-    "        if inertia < best_inertia:\n",
-    "            best_inertia = inertia\n",
-    "            best_labels = labels\n",
-    "            best_centroids = centroids\n",
-    "\n",
-    "    return best_labels, best_centroids"
+    "The estimator itself - the lifting, the distance, the barycenter and the k-means around them -\n",
+    "is `lift_stream`, `wasserstein_distance_1d`, `wasserstein_barycenter_1d` and\n",
+    "`fit_wasserstein_kmeans` in `case_studies/utils/temporal.py`, beside the HMM helpers the other\n",
+    "case studies fit their regimes with. This notebook composes them on the schedule below.\n",
+    "[`09_model_based_features/12_wasserstein_regimes`](../../09_model_based_features/12_wasserstein_regimes.ipynb)\n",
+    "builds the same four objects from nothing, for a reader who wants to see the algorithm rather\n",
+    "than use it."
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "93e54c00",
+   "id": "e0d4ff65",
    "metadata": {},
    "source": [
     "### The series the clustering reads\n",
@@ -862,7 +747,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d4745f65",
+   "id": "cafa475b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -889,7 +774,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "64bdb786",
+   "id": "e999b019",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -915,7 +800,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3e5360dd",
+   "id": "90decf09",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -966,7 +851,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4ff96ae8",
+   "id": "54d4681b",
    "metadata": {},
    "source": [
     "The walk is driven once over the whole market series. `freeze_after` is the count of\n",
@@ -980,7 +865,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ffb864c0",
+   "id": "b03e4161",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1075,7 +960,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "90682b78",
+   "id": "2e322edd",
    "metadata": {},
    "source": [
     "### What the clustering inferred, on the sessions a model is scored over\n",
@@ -1111,7 +996,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "58320b93",
+   "id": "7e541100",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1185,7 +1070,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cc4f9d11",
+   "id": "203f1de2",
    "metadata": {},
    "source": [
     "`wass_dist_ratio` is the second thing the clustering yields: the distance to the nearer\n",
@@ -1203,7 +1088,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f915c6a5",
+   "id": "52b81da2",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1233,7 +1118,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c90d44f0",
+   "id": "9548ce1b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1286,7 +1171,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0c85cd1c",
+   "id": "826ed26a",
    "metadata": {},
    "source": [
     "The sweep runs on a sample of stocks - every symbol with a long enough eligible history,\n",
@@ -1306,7 +1191,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "972f4e21",
+   "id": "25364330",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1355,7 +1240,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "86556696",
+   "id": "a4fa6bcd",
    "metadata": {},
    "source": [
     "The two curves cross, and where they cross is the whole argument for a fractional order.\n",
@@ -1367,7 +1252,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0c19caf6",
+   "id": "92d2af03",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1418,7 +1303,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3c4224f7",
+   "id": "fa2a1fc5",
    "metadata": {},
    "source": [
     "### Apply the transform to the panel\n",
@@ -1431,7 +1316,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bf31ed72",
+   "id": "3e2f5705",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1442,7 +1327,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "df0f20ae",
+   "id": "8233c34b",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1476,7 +1361,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9aff95c8",
+   "id": "6a4b8962",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1585,7 +1470,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0a259f66",
+   "id": "510f527a",
    "metadata": {},
    "source": [
     "Each stock is an independent walk, so they are spread across processes. Within one walk the\n",
@@ -1598,7 +1483,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "10e62f30",
+   "id": "2b9e250b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1697,7 +1582,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "39b77258",
+   "id": "f013e1b8",
    "metadata": {},
    "source": [
     "The market-level series takes the same walk. It is what a stock too short to pay the\n",
@@ -1708,7 +1593,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "baf246bd",
+   "id": "a8b4f1db",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1727,7 +1612,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dc5f2b50",
+   "id": "c5ad9d7f",
    "metadata": {},
    "source": [
     "## 4b. What re-estimating moves\n",
@@ -1761,7 +1646,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0a385251",
+   "id": "5425ba70",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1821,7 +1706,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3a6290c1",
+   "id": "5952434d",
    "metadata": {
     "tags": [
      "results"
@@ -1837,7 +1722,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "91dceff4",
+   "id": "71f19c94",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1864,7 +1749,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c6dde671",
+   "id": "0ffe52b6",
    "metadata": {},
    "source": [
     "## 5. Assemble the panel\n",
@@ -1881,7 +1766,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "002927ce",
+   "id": "eb4db9ec",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1910,7 +1795,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e145ff86",
+   "id": "bbe2b409",
    "metadata": {},
    "source": [
     "A missing value has to be a null and not a NaN. `ffdiff` returns a float NaN where the log\n",
@@ -1923,7 +1808,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "98236b8e",
+   "id": "e2e812b7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1946,7 +1831,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dd99109d",
+   "id": "8d813269",
    "metadata": {},
    "source": [
     "### What the assembled panel holds\n",
@@ -1970,7 +1855,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2d7cc08b",
+   "id": "0c8c9101",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2001,7 +1886,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a901acca",
+   "id": "75dde096",
    "metadata": {},
    "source": [
     "## 6. Write the artifact\n",
@@ -2034,7 +1919,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "782b4325",
+   "id": "0ff0d4d9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2078,7 +1963,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b20e5825",
+   "id": "58ad6d63",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2117,7 +2002,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "35e9f0b2",
+   "id": "9ce88c59",
    "metadata": {},
    "source": [
     "## 7. What each column ranks on its own\n",
@@ -2175,7 +2060,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9f43b581",
+   "id": "5de2d67a",
    "metadata": {},
    "source": [
     "The endpoint of a label is the `LABEL_HORIZON`-th next session in the stock's own series,\n",
@@ -2192,7 +2077,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "01f831f3",
+   "id": "3d592f14",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2230,7 +2115,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8ebec3e6",
+   "id": "fa91a9cd",
    "metadata": {},
    "source": [
     "The narrowest cross-section a correlation is computed over is half the median date's, rather\n",
@@ -2242,7 +2127,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "220110ad",
+   "id": "2f5d15d8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2252,7 +2137,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "47737f9a",
+   "id": "ca241774",
    "metadata": {},
    "source": [
     "Which columns vary across a cross-section is measured, not declared. A feature whose\n",
@@ -2265,7 +2150,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e8ebc45c",
+   "id": "85dcf121",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2296,7 +2181,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cbeafb78",
+   "id": "277a1bc2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2340,7 +2225,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "745a69ab",
+   "id": "b38cf22d",
    "metadata": {
     "tags": [
      "results"
@@ -2356,7 +2241,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ed9207cc",
+   "id": "cd597176",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2371,7 +2256,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0f1f983d",
+   "id": "14990960",
    "metadata": {},
    "source": [
     "The bars are signed, because a column the panel ranks one way and a column it ranks the\n",
@@ -2386,7 +2271,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9860e374",
+   "id": "a8e22325",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2428,7 +2313,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8663661d",
+   "id": "18df40a4",
    "metadata": {},
    "source": [
     "## Key takeaways\n",

--- a/case_studies/us_equities_panel/04_model_based_features.py
+++ b/case_studies/us_equities_panel/04_model_based_features.py
@@ -80,7 +80,6 @@
 import multiprocessing
 import os
 from concurrent.futures import ProcessPoolExecutor
-from dataclasses import dataclass
 from datetime import date
 
 import matplotlib.pyplot as plt
@@ -101,9 +100,12 @@ from case_studies.utils.artifact_digest import read_digest, value_digest
 from case_studies.utils.coverage import assert_sessions_complete
 from case_studies.utils.cv_window import modeling_fold_boundaries
 from case_studies.utils.temporal import (
+    fit_wasserstein_kmeans,
     garch11_conditional_volatility,
+    lift_stream,
     refit_boundaries,
     walk_forward_feature,
+    wasserstein_distance_1d,
     write_model_based,
 )
 from data import load_us_equities
@@ -132,7 +134,6 @@ FFD_THRESHOLD = 1e-5
 FDR_ALPHA = 0.05
 
 FloatArray = NDArray[np.float64]
-IntArray = NDArray[np.int64]
 
 # %% [markdown]
 # ### The values a run can be given
@@ -609,112 +610,14 @@ show_with_alt(
 # boundary, held fixed while the next quarter of windows is scored against them, then fitted
 # again on everything up to the following boundary. Every stock carries the same value on a
 # date, because the series being clustered is market-wide.
-
-
-# %%
-@dataclass(frozen=True)
-class LiftedStream:
-    """Overlapping windows of cross-sectional return distributions."""
-
-    segments: FloatArray  # (n_segments, window_len)
-    sorted_segments: FloatArray  # Sorted per window
-    starts: IntArray  # Start indices
-    window_len: int
-    step: int
-
-
-def lift_stream(
-    returns: FloatArray,
-    window_len: int,
-    overlap: int,
-) -> LiftedStream:
-    """Lift a 1D return stream into overlapping windows."""
-    step = window_len - overlap
-    windows_view = np.lib.stride_tricks.sliding_window_view(returns, window_shape=window_len)
-    windows_view = windows_view[::step]
-    segments = np.ascontiguousarray(windows_view, dtype=np.float64)
-    sorted_segments = np.sort(segments, axis=1)
-    starts = np.arange(0, segments.shape[0] * step, step, dtype=np.int64)
-
-    return LiftedStream(
-        segments=segments,
-        sorted_segments=sorted_segments,
-        starts=starts,
-        window_len=window_len,
-        step=step,
-    )
-
-
-# %%
-def wasserstein_distance_1d(
-    sorted_a: FloatArray, sorted_b: FloatArray, p: float = 1.0
-) -> FloatArray:
-    """1D p-Wasserstein distance between equal-weight empirical measures.
-
-    Reduces over the last axis and broadcasts over the rest, so a stack of sorted windows
-    against one sorted centroid returns one distance per window.
-    """
-    return (np.abs(sorted_a - sorted_b) ** p).mean(axis=-1) ** (1.0 / p)
-
-
-def wasserstein_barycenter_1d(sorted_members: FloatArray, p: float = 1.0) -> FloatArray:
-    """Wasserstein barycenter: median (p=1) or mean (p=2) of sorted atoms."""
-    if p == 1.0:
-        return np.median(sorted_members, axis=0).astype(np.float64)
-    return sorted_members.mean(axis=0).astype(np.float64)
-
-
-# %%
-def fit_wasserstein_kmeans(
-    sorted_segments: FloatArray,
-    n_clusters: int = 2,
-    max_iter: int = 50,
-    n_init: int = 5,
-    random_state: int = 42,
-) -> tuple[IntArray, FloatArray]:
-    """Fit Wasserstein k-means on sorted 1D segments.
-
-    Returns (labels, centroids).
-    """
-    rng = np.random.default_rng(random_state)
-    n_samples = sorted_segments.shape[0]
-    best_labels = None
-    best_centroids = None
-    best_inertia = float("inf")
-
-    for _ in range(n_init):
-        # Random initialization
-        idx = rng.choice(n_samples, size=n_clusters, replace=False)
-        centroids = sorted_segments[idx].copy()
-
-        for _ in range(max_iter):
-            # Assignment: compute distance to each centroid
-            dists = np.zeros((n_samples, n_clusters))
-            for k in range(n_clusters):
-                dists[:, k] = wasserstein_distance_1d(sorted_segments, centroids[k][None, :])
-
-            labels = dists.argmin(axis=1)
-
-            # Update centroids
-            new_centroids = np.zeros_like(centroids)
-            for k in range(n_clusters):
-                members = sorted_segments[labels == k]
-                if len(members) > 0:
-                    new_centroids[k] = wasserstein_barycenter_1d(members, p=1.0)
-                else:
-                    new_centroids[k] = centroids[k]
-
-            if np.allclose(centroids, new_centroids, atol=1e-6):
-                break
-            centroids = new_centroids
-
-        inertia = sum(dists[i, labels[i]] for i in range(n_samples))
-        if inertia < best_inertia:
-            best_inertia = inertia
-            best_labels = labels
-            best_centroids = centroids
-
-    return best_labels, best_centroids
+#
+# The estimator itself - the lifting, the distance, the barycenter and the k-means around them -
+# is `lift_stream`, `wasserstein_distance_1d`, `wasserstein_barycenter_1d` and
+# `fit_wasserstein_kmeans` in `case_studies/utils/temporal.py`, beside the HMM helpers the other
+# case studies fit their regimes with. This notebook composes them on the schedule below.
+# [`09_model_based_features/12_wasserstein_regimes`](../../09_model_based_features/12_wasserstein_regimes.ipynb)
+# builds the same four objects from nothing, for a reader who wants to see the algorithm rather
+# than use it.
 
 
 # %% [markdown]

--- a/case_studies/utils/temporal.py
+++ b/case_studies/utils/temporal.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import os
 from collections.abc import Callable, Mapping, Sequence
 from contextlib import contextmanager
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, NamedTuple
 
@@ -34,18 +35,23 @@ from case_studies.utils.artifact_digest import write_artifact
 
 __all__ = [
     "HmmFit",
+    "LiftedStream",
     "arima_one_step_forecast",
     "chain_worker_pool",
     "filtered_state_probs",
     "fit_hmm_kmeans_init",
     "fit_hmm_restarts",
+    "fit_wasserstein_kmeans",
     "fold_feature_geometry",
     "garch11_conditional_volatility",
+    "lift_stream",
     "refit_boundaries",
     "relabel_states",
     "sort_states_by_mean",
     "sort_states_by_variance",
     "walk_forward_feature",
+    "wasserstein_barycenter_1d",
+    "wasserstein_distance_1d",
     "write_model_based",
 ]
 
@@ -548,6 +554,160 @@ def _cluster_covariance(cluster: np.ndarray, pooled: np.ndarray) -> np.ndarray:
     if cluster.shape[0] < 2:
         return pooled.copy()
     return np.atleast_2d(np.cov(cluster.T))
+
+
+@dataclass(frozen=True)
+class LiftedStream:
+    """Overlapping windows of a return series, each held both raw and sorted.
+
+    A distribution-based regime estimator does not read a return series point by point; it
+    reads a window of it as an empirical measure. Lifting is that reshaping, done once:
+    ``segments`` holds the windows in time order and ``sorted_segments`` holds each window's
+    values ascending, which is the form every 1D optimal-transport quantity below takes.
+    Sorting once here rather than inside the distance is most of what makes the k-means
+    affordable, since each window is re-scored against every centroid on every iteration.
+    """
+
+    segments: np.ndarray  # (n_segments, window_len)
+    sorted_segments: np.ndarray  # Each row of `segments`, ascending
+    starts: np.ndarray  # Index into the input series where each window opens
+    window_len: int
+    step: int
+
+
+def lift_stream(returns: np.ndarray, window_len: int, overlap: int) -> LiftedStream:
+    """Lift a 1D return stream into overlapping windows of ``window_len``.
+
+    Consecutive windows advance by ``window_len - overlap``, so ``overlap`` is how many
+    sessions two neighbouring windows share. A trailing partial window is dropped rather
+    than padded: a short window is a different measure, not a shorter view of the same one.
+    """
+    step = window_len - overlap
+    windows_view = np.lib.stride_tricks.sliding_window_view(returns, window_shape=window_len)
+    windows_view = windows_view[::step]
+    segments = np.ascontiguousarray(windows_view, dtype=np.float64)
+    sorted_segments = np.sort(segments, axis=1)
+    starts = np.arange(0, segments.shape[0] * step, step, dtype=np.int64)
+
+    return LiftedStream(
+        segments=segments,
+        sorted_segments=sorted_segments,
+        starts=starts,
+        window_len=window_len,
+        step=step,
+    )
+
+
+def wasserstein_distance_1d(
+    sorted_a: np.ndarray, sorted_b: np.ndarray, p: float = 1.0
+) -> np.ndarray:
+    """1D p-Wasserstein distance between equal-weight empirical measures.
+
+    Two equal-sized samples in one dimension are matched by rank - the smallest of one to
+    the smallest of the other, and so on up - so the transport cost is a mean over the
+    sorted arrays and needs no optimizer. Both arguments must already be sorted ascending;
+    that is what :class:`LiftedStream` stores.
+
+    Reduces over the last axis and broadcasts over the rest, so a stack of sorted windows
+    against one sorted centroid returns one distance per window.
+    """
+    return (np.abs(sorted_a - sorted_b) ** p).mean(axis=-1) ** (1.0 / p)
+
+
+def wasserstein_barycenter_1d(sorted_members: np.ndarray, p: float = 1.0) -> np.ndarray:
+    """Wasserstein barycenter of sorted 1D measures: median at ``p=1``, mean at ``p=2``.
+
+    Taken rank by rank, which is what makes the result a distribution rather than an
+    average of numbers: the barycenter's smallest atom is the median of the members'
+    smallest atoms.
+    """
+    if p == 1.0:
+        return np.median(sorted_members, axis=0).astype(np.float64)
+    return sorted_members.mean(axis=0).astype(np.float64)
+
+
+def _wasserstein_assignments(
+    sorted_segments: np.ndarray, centroids: np.ndarray
+) -> tuple[np.ndarray, np.ndarray]:
+    """Distance from every segment to every centroid, and each segment's nearest."""
+    dists = np.stack(
+        [
+            wasserstein_distance_1d(sorted_segments, centroids[k][None, :])
+            for k in range(centroids.shape[0])
+        ],
+        axis=1,
+    )
+    return dists, dists.argmin(axis=1)
+
+
+def fit_wasserstein_kmeans(
+    sorted_segments: np.ndarray,
+    n_clusters: int = 2,
+    max_iter: int = 50,
+    n_init: int = 5,
+    random_state: int = 42,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Fit k-means on sorted 1D segments under the Wasserstein distance.
+
+    Ordinary Lloyd's algorithm with the two Euclidean quantities replaced by their
+    optimal-transport counterparts: :func:`wasserstein_distance_1d` for the assignment step
+    and :func:`wasserstein_barycenter_1d` for the update. A cluster is therefore a
+    distribution that the windows assigned to it are close to *as distributions*, which is
+    what separates a calm month from a turbulent one when both may have the same mean.
+
+    An empty cluster keeps its previous centroid rather than being re-seeded, so a restart
+    that collapses to fewer than ``n_clusters`` occupied clusters stays reproducible instead
+    of consuming draws from ``rng``.
+
+    Restarts are scored by inertia - the summed distance from each segment to the centroid
+    it was assigned - and the lowest wins. The distances that score a restart are computed
+    against the centroids that restart returns. That is not a restatement of the loop: the
+    scoring used to reuse the last assignment pass, which runs *before* the final centroid
+    update, so a restart that exhausted ``max_iter`` was scored against centroids one update
+    older than the ones it returned, and the wrong restart could win. A restart that
+    converges is unaffected, because the update it broke on moved the centroids by less than
+    ``atol``.
+
+    Returns
+    -------
+    tuple of ndarray
+        The labels and centroids of the lowest-inertia restart. Centroids come back in
+        whatever order the winning restart produced; a caller emitting a feature named for
+        one of them has to impose an order, the way ``sort_states_by_*`` does for an HMM.
+    """
+    rng = np.random.default_rng(random_state)
+    n_samples = sorted_segments.shape[0]
+    best_labels = None
+    best_centroids = None
+    best_inertia = float("inf")
+
+    for _ in range(n_init):
+        idx = rng.choice(n_samples, size=n_clusters, replace=False)
+        centroids = sorted_segments[idx].copy()
+
+        for _ in range(max_iter):
+            _, labels = _wasserstein_assignments(sorted_segments, centroids)
+
+            new_centroids = np.zeros_like(centroids)
+            for k in range(n_clusters):
+                members = sorted_segments[labels == k]
+                if len(members) > 0:
+                    new_centroids[k] = wasserstein_barycenter_1d(members, p=1.0)
+                else:
+                    new_centroids[k] = centroids[k]
+
+            if np.allclose(centroids, new_centroids, atol=1e-6):
+                break
+            centroids = new_centroids
+
+        dists, labels = _wasserstein_assignments(sorted_segments, centroids)
+        inertia = float(dists[np.arange(n_samples), labels].sum())
+        if inertia < best_inertia:
+            best_inertia = inertia
+            best_labels = labels
+            best_centroids = centroids
+
+    return best_labels, best_centroids
 
 
 def fold_feature_geometry(

--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -27,12 +27,16 @@ from case_studies.utils.temporal import (
     arima_one_step_forecast,
     filtered_state_probs,
     fit_hmm_kmeans_init,
+    fit_wasserstein_kmeans,
     garch11_conditional_volatility,
+    lift_stream,
     refit_boundaries,
     relabel_states,
     sort_states_by_mean,
     sort_states_by_variance,
     walk_forward_feature,
+    wasserstein_barycenter_1d,
+    wasserstein_distance_1d,
     write_model_based,
 )
 
@@ -1256,3 +1260,90 @@ def test_the_arima_filter_walks_forward_without_reading_its_future() -> None:
         n_features=1,
     )
     assert np.allclose(values[:240, 0], shorter[:, 0], equal_nan=True)
+
+
+# ---------------------------------------------------------------------------
+# The Wasserstein regime estimator.
+# ---------------------------------------------------------------------------
+
+
+def test_lift_stream_advances_by_the_window_less_the_overlap() -> None:
+    """Windows share `overlap` observations, and a trailing partial window is dropped."""
+    returns = np.arange(100, dtype=float)
+    lifted = lift_stream(returns, window_len=21, overlap=5)
+
+    assert lifted.step == 16
+    assert lifted.segments.shape[1] == 21
+    assert np.array_equal(lifted.starts, np.arange(0, lifted.segments.shape[0] * 16, 16))
+    assert np.array_equal(lifted.segments[0], returns[:21])
+    assert np.array_equal(lifted.segments[1], returns[16:37])
+    # 100 observations hold five complete windows opening at 0, 16, 32, 48 and 64; the sixth
+    # would open at 80 and run to 101.
+    assert lifted.segments.shape[0] == 5
+    assert np.array_equal(lifted.sorted_segments, np.sort(lifted.segments, axis=1))
+
+
+def test_the_wasserstein_distance_between_a_sample_and_its_shift_is_the_shift() -> None:
+    """Equal-sized 1D samples match by rank, so a pure translation costs exactly the shift."""
+    rng = np.random.default_rng(0)
+    a = np.sort(rng.normal(size=64))
+    assert wasserstein_distance_1d(a, a) == pytest.approx(0.0)
+    assert wasserstein_distance_1d(a, a + 0.25) == pytest.approx(0.25)
+    assert wasserstein_distance_1d(a, a + 0.25, p=2.0) == pytest.approx(0.25)
+
+
+def test_the_barycenter_is_taken_rank_by_rank() -> None:
+    """The barycenter's smallest atom is the members' smallest atoms combined, not a mean."""
+    members = np.array([[0.0, 1.0, 2.0], [10.0, 11.0, 12.0], [20.0, 21.0, 22.0]])
+    assert np.array_equal(wasserstein_barycenter_1d(members, p=1.0), [10.0, 11.0, 12.0])
+    assert np.array_equal(wasserstein_barycenter_1d(members, p=2.0), [10.0, 11.0, 12.0])
+
+
+def test_a_restart_is_scored_against_the_centroids_it_returns() -> None:
+    """The assignment pass that scores a restart runs after its last centroid update.
+
+    It used to run before: the loop scored `dists` and `labels` from the pass at the top of
+    the final iteration, while the centroids returned were the ones that iteration went on to
+    produce. A restart that converged was unaffected, because the update it broke on moved the
+    centroids by less than `atol` - but one that stopped on `max_iter` returned labels that
+    were the nearest centroids of a set it did not return, and an inertia describing that same
+    stale set, so the wrong restart could win.
+
+    `max_iter=1` makes every restart stop that way, and one unstructured blob makes the
+    partition move on every update rather than settling immediately. Under the previous
+    implementation these labels disagree with the returned centroids.
+    """
+    rng = np.random.default_rng(0)
+    segments = np.sort(rng.normal(size=(40, 12)), axis=1)
+
+    labels, centroids = fit_wasserstein_kmeans(
+        segments, n_clusters=2, max_iter=1, n_init=3, random_state=1
+    )
+    nearest = np.stack(
+        [wasserstein_distance_1d(segments, centroids[k][None, :]) for k in range(2)], axis=1
+    ).argmin(axis=1)
+
+    assert np.array_equal(labels, nearest)
+
+
+def test_wasserstein_kmeans_separates_two_distributions_and_is_reproducible() -> None:
+    """Two well-separated blobs come back as two clusters, identically on the same seed."""
+    # Same mean, so the two are told apart by their spread and not by their level, which is
+    # what the feature claims. The gap is wide because a narrow one is genuinely ambiguous: at
+    # 0.5 against 4.0 one draw of sixteen from the wide blob is calmer than the calm ones and
+    # clusters with them, which is the estimator being right about that window.
+    rng = np.random.default_rng(7)
+    calm = rng.normal(0.0, 0.2, size=(30, 16))
+    turbulent = rng.normal(0.0, 10.0, size=(30, 16))
+    segments = np.sort(np.concatenate([calm, turbulent]), axis=1)
+
+    labels, centroids = fit_wasserstein_kmeans(segments, n_clusters=2, random_state=42)
+
+    assert centroids.shape == (2, 16)
+    assert len(np.unique(labels[:30])) == 1
+    assert len(np.unique(labels[30:])) == 1
+    assert labels[0] != labels[30]
+
+    again, again_centroids = fit_wasserstein_kmeans(segments, n_clusters=2, random_state=42)
+    assert np.array_equal(labels, again)
+    assert np.array_equal(centroids, again_centroids)

--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -1293,10 +1293,18 @@ def test_the_wasserstein_distance_between_a_sample_and_its_shift_is_the_shift() 
 
 
 def test_the_barycenter_is_taken_rank_by_rank() -> None:
-    """The barycenter's smallest atom is the members' smallest atoms combined, not a mean."""
-    members = np.array([[0.0, 1.0, 2.0], [10.0, 11.0, 12.0], [20.0, 21.0, 22.0]])
+    """Rank by rank, and the median at ``p=1`` against the mean at ``p=2``.
+
+    The members are spaced asymmetrically so the two disagree: rank 0 draws from 0, 10 and
+    50, whose median is 10 and whose mean is 20. Evenly spaced members would let an
+    implementation that always took the mean pass both assertions.
+    """
+    members = np.array([[0.0, 1.0, 2.0], [10.0, 11.0, 12.0], [50.0, 51.0, 52.0]])
     assert np.array_equal(wasserstein_barycenter_1d(members, p=1.0), [10.0, 11.0, 12.0])
-    assert np.array_equal(wasserstein_barycenter_1d(members, p=2.0), [10.0, 11.0, 12.0])
+    assert np.array_equal(wasserstein_barycenter_1d(members, p=2.0), [20.0, 21.0, 22.0])
+    # Each output atom is built from one rank of the members, so the result is a
+    # distribution and not a pooled average of the nine numbers, which is 21.0.
+    assert wasserstein_barycenter_1d(members, p=2.0)[0] != pytest.approx(members.mean())
 
 
 def test_a_restart_is_scored_against_the_centroids_it_returns() -> None:

--- a/tests/test_us_equities_panel_model_based_schedule.py
+++ b/tests/test_us_equities_panel_model_based_schedule.py
@@ -24,9 +24,12 @@ import pytest
 import yaml
 
 from case_studies.utils.temporal import (
+    fit_wasserstein_kmeans,
     garch11_conditional_volatility,
+    lift_stream,
     refit_boundaries,
     walk_forward_feature,
+    wasserstein_distance_1d,
 )
 
 NOTEBOOK = (
@@ -93,12 +96,12 @@ def _garch_kwargs() -> dict:
     return {key: declared[key] for key in keys}
 
 
+# What the notebook composes, not what it imports. The Wasserstein estimator moved into
+# `case_studies.utils.temporal` beside the HMM helpers, so it is injected below the way
+# `walk_forward_feature` and `garch11_conditional_volatility` already were: these tests are
+# about whether a value reads the sessions before it, and that is a property of the walk the
+# notebook builds rather than of the estimator it calls.
 DEFINITIONS = (
-    "LiftedStream",
-    "lift_stream",
-    "wasserstein_distance_1d",
-    "wasserstein_barycenter_1d",
-    "fit_wasserstein_kmeans",
     "fit_regime_centroids",
     "assign_regime_features",
     "garch_walk",
@@ -121,6 +124,9 @@ def _load(arch_model) -> dict:
         "arch_model": arch_model,
         "walk_forward_feature": walk_forward_feature,
         "garch11_conditional_volatility": garch11_conditional_volatility,
+        "lift_stream": lift_stream,
+        "fit_wasserstein_kmeans": fit_wasserstein_kmeans,
+        "wasserstein_distance_1d": wasserstein_distance_1d,
         "FloatArray": np.ndarray,
         "IntArray": np.ndarray,
         "WASSERSTEIN_WINDOW": REGIME["window"],


### PR DESCRIPTION
Stage 04 was the only case study that defined its regime estimator inside the notebook. `etfs` and `crypto_perps_funding` call `fit_hmm_restarts`, `cme_futures` calls `fit_hmm_kmeans_init`, and all three take their state ordering from `sort_states_by_*` in `case_studies/utils/temporal.py`. `us_equities_panel` imported four helpers from that module and hand-rolled a fifth estimator beside them: `LiftedStream`, `lift_stream`, `wasserstein_distance_1d`, `wasserstein_barycenter_1d` and `fit_wasserstein_kmeans`, 106 lines across three cells. The first four were also defined a second time in `09_model_based_features/12_wasserstein_regimes`, so one estimator had two implementations in the repository.

All five move into `temporal.py` beside the HMM helpers and are imported. The notebook keeps `fit_regime_centroids` and `assign_regime_features`, which compose them on this case study's schedule and read its own constants. The teaching notebook is deliberately untouched - its job is to build the algorithm from nothing for a reader - and the notebook's markdown now points at both.

## The defect fixed on the way

`fit_wasserstein_kmeans` scored each restart's inertia from the assignment pass at the top of its final iteration, while the centroids it returned were the ones that iteration went on to produce:

```python
for _ in range(max_iter):
    dists = ...            # against `centroids`
    labels = dists.argmin(axis=1)
    new_centroids = ...
    if np.allclose(centroids, new_centroids, atol=1e-6):
        break
    centroids = new_centroids      # <- the returned set

inertia = sum(dists[i, labels[i]] for i in range(n_samples))   # <- the previous set
```

A restart that converged was unaffected, because the update it broke on moved the centroids by less than `atol`. One that stopped on `max_iter` returned labels that were the nearest centroids of a set it did not return, and an inertia describing that same stale set, so the wrong restart could win. The scoring pass now runs after the last update, and takes `dists[arange, labels]` rather than a Python loop over every sample.

## No emitted value moves on this case study

Measured rather than argued. The notebook's market series was rebuilt at production scale - 14,498,930 panel rows over 3,199 symbols, screened to the 5,062 dates carrying at least 50 eligible stocks - and both implementations were fitted at all 69 refit boundaries of the regime schedule:

| | |
|---|---|
| boundaries fitted | 69 |
| restarts that reached `max_iter` | 0 of 345 |
| boundaries whose centroids moved | 0 |
| largest absolute difference | 0.000e+00 |

Every restart converged, which is why the fix is invisible here. It would not be on data that does not converge within fifty iterations.

## Tests

`tests/test_temporal.py` gains five tests for the promoted estimator. One of them fails against the previous implementation: at `max_iter=1` on an unstructured blob, the returned labels must be the nearest of the returned centroids.

`tests/test_us_equities_panel_model_based_schedule.py` parsed the five objects out of the notebook's AST and asserted they were defined there. It now injects them the way it already injected `walk_forward_feature` and `garch11_conditional_volatility`, and asserts on what the notebook composes.

Verified: 93 passed across both unit modules, and the notebook executes end to end at preview tier (`tests/test_case_studies.py -k "us_equities_panel and 04_"`, 1 passed in 1m42s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P1tBf8pMZ74NrdVfCzz76s
