### PR TITLE
test-unit-data: the two deselected artifact-spec tests were never waiting on a rebuild

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1012,21 +1012,30 @@ jobs:
           # CI job, which is a real gap and is stated in that file's docstring.
           # The other three tests in the same file assert relations that hold on any
           # extract - they collect as six cases - and are what this job gates.
-          # The two deselects below are not quarantine entries: the quarantine file
-          # describes what test-unit does not run, and both of these are inside a
-          # file this job DOES run. They need the stage 01-05 artifacts of
-          # us_equities_panel and nasdaq100_microstructure, the two case studies
-          # whose rebuild has not produced them, so they fail on any checkout -
-          # here and on a workstation alike. Take them out when those two rebuild.
           #
-          # The artifact dependency was true and was not the whole reason. Until
-          # 2026-09-06 the microstructure test also asserted `label_buffer ==
-          # "15min"` against a config that has declared 16min since #737, and that
-          # assertion reads the repo config and no data, so it failed two lines
-          # before the artifacts were ever touched. The rebuild alone would not have
-          # made the test pass, and whoever lifted this deselect afterwards would
-          # have read the red as the rebuild being wrong. The literal is corrected,
-          # so this deselect now blocks only on the artifacts, which is what it says.
+          # Two tests in test_artifact_specs.py were deselected here until 2026-09-10
+          # on the stated grounds that they needed stage 01-05 artifacts of
+          # us_equities_panel and nasdaq100_microstructure "whose rebuild has not
+          # produced them", and would come back when those two case studies rebuilt.
+          # That reason was wrong in a way worth recording, because it pointed at a
+          # workstation run that this job never reads and would never have fixed it.
+          #
+          # ml4t/third-edition-test-data carries the features and labels both tests
+          # need, under intermediates/<case study>/. What neither test did was ask
+          # for them. conftest's seeded_output_dir fixture is what copies the
+          # fixture's intermediates into the directory get_case_study_dir resolves
+          # to; it is not autouse, and both tests took no fixtures at all, so the
+          # loader looked in the checked-out source tree, found no features/ or
+          # labels/ there, and raised. A rebuild on the workstation puts artifacts
+          # in ~/ml4t/artifacts, which is not on any path this container can see.
+          #
+          # Both tests now request seeded_output_dir and both pass, so the deselects
+          # are gone and this job gates 97 tests rather than 95. The fixture is
+          # session-scoped and exports ML4T_OUTPUT_DIR for the rest of the run, so
+          # the order it lands in relative to test_eoa_universe_roster.py decides
+          # whether that file reads a redirect or the source tree. Both orders were
+          # measured before this change landed and both are green: the roster tests
+          # read a SEEDED redirect, which is the case the unset above never covered.
           .venv/bin/python -m pytest \
             tests/test_eoa_universe_roster.py \
             tests/test_fixture_registry_identity.py \
@@ -1037,8 +1046,6 @@ jobs:
             tests/test_etf_baseline_parity.py \
             tests/test_sp500_options_research.py::test_official_population_is_snapshotted_before_option_execution \
             tests/test_us_firm_research_workflow.py::test_open_study_writes_canonical_results_to_output_dir \
-            --deselect tests/test_artifact_specs.py::test_us_equities_pilot_helpers_preserve_current_outputs \
-            --deselect tests/test_artifact_specs.py::test_microstructure_pilot_helpers_preserve_current_outputs \
             -m "not production_extract" \
             -v --tb=short -rs --junitxml=unit-data.xml
       # A skip here is a failure: these tests run in this job and nowhere else,

--- a/tests/test_artifact_specs.py
+++ b/tests/test_artifact_specs.py
@@ -64,7 +64,16 @@ def test_crypto_modeling_splits_use_label_clock_before_feature_join(
     assert captured["minimum"] == datetime(2020, 1, 1)
 
 
-def test_us_equities_pilot_helpers_preserve_current_outputs() -> None:
+def test_us_equities_pilot_helpers_preserve_current_outputs(seeded_output_dir) -> None:
+    """The pilot helpers still return what the case study declares.
+
+    ``seeded_output_dir`` is required, not incidental. It is the fixture that copies
+    ml4t/third-edition-test-data's ``intermediates/<case study>/`` into the directory
+    ``get_case_study_dir`` resolves to. Without it the loaders look in the source tree,
+    find no ``features/`` or ``labels/`` there, and raise - which is what kept both of
+    these deselected in the ``test-unit-data`` job until 2026-09-10 under the mistaken
+    reading that they were waiting on a workstation rebuild.
+    """
     bt = get_backtest_config("us_equities_panel")
     prices = load_backtest_prices("us_equities_panel", max_symbols=2)
     mds = load_modeling_dataset("us_equities_panel", "fwd_ret_1d", max_symbols=2)
@@ -89,7 +98,16 @@ def test_us_equities_pilot_helpers_preserve_current_outputs() -> None:
     assert mds.task_type == "regression"
 
 
-def test_microstructure_pilot_helpers_preserve_current_outputs() -> None:
+def test_microstructure_pilot_helpers_preserve_current_outputs(seeded_output_dir) -> None:
+    """The pilot helpers still return what the case study declares.
+
+    ``seeded_output_dir`` is required, not incidental. It is the fixture that copies
+    ml4t/third-edition-test-data's ``intermediates/<case study>/`` into the directory
+    ``get_case_study_dir`` resolves to. Without it the loaders look in the source tree,
+    find no ``features/`` or ``labels/`` there, and raise - which is what kept both of
+    these deselected in the ``test-unit-data`` job until 2026-09-10 under the mistaken
+    reading that they were waiting on a workstation rebuild.
+    """
     bt = get_backtest_config("nasdaq100_microstructure")
     prices = load_backtest_prices("nasdaq100_microstructure", max_symbols=2)
     mds = load_modeling_dataset("nasdaq100_microstructure", "fwd_ret_15m", max_symbols=2)
@@ -100,10 +118,11 @@ def test_microstructure_pilot_helpers_preserve_current_outputs() -> None:
     # last bar of every training window inside the first validation label's window. #737 made
     # that the declared value and this assertion was not moved with it.
     #
-    # It went unreported because `test-unit-data` deselects this test by node id - it is one of
-    # the "6 deselected" that job reports - on the grounds that it needs stage 01-05 artifacts
-    # the nasdaq rebuild has not produced. That reason is true of the two lines below and was
-    # never true of this one, which reads the repo config and no data.
+    # It went unreported because `test-unit-data` deselected this test by node id, on the
+    # grounds that it needed stage 01-05 artifacts the nasdaq rebuild had not produced. That
+    # was never true of this line, which reads the repo config and no data, and the deselect
+    # itself is gone as of 2026-09-10: the fixture had the artifacts all along and the test
+    # was not asking for them. See the docstring above.
     assert bt.label_buffer == "16min"
     assert bt.calendar == "NYSE"
     assert bt.cadence == "15_minute"


### PR DESCRIPTION
Two tests in `tests/test_artifact_specs.py` have been deselected by node id in the `test-unit-data` job. The recorded reason was that they need the stage 01-05 artifacts of `us_equities_panel` and `nasdaq100_microstructure`, "the two case studies whose rebuild has not produced them", and that they come back when those two rebuild.

That reason pointed at the wrong machine, and waiting on the rebuild would never have lifted either deselect.

`ml4t/third-edition-test-data` already carries what both tests need, under `intermediates/<case study>/features/financial.parquet` and `intermediates/<case study>/labels/<label>.parquet`. Neither test asked for it. `conftest.py`'s `seeded_output_dir` is the fixture that copies those into the directory `get_case_study_dir` resolves to; it is not autouse, and both tests took no fixtures at all. So both loaders read the checked-out source tree, found no `features/` there, and raised `FileNotFoundError`. A workstation rebuild writes to `~/ml4t/artifacts`, which no CI container can see.

Both tests now request `seeded_output_dir`. Both pass. The two `--deselect` lines are gone and the job gates 97 tests instead of 95.

## What was measured

In a worktree with no case-study symlinks, under the job's own environment (`ML4T_DATA_PATH` at the fixture, `ML4T_OUTPUT_DIR` unset, `-m "not production_extract"`), against `ml4t/third-edition-test-data` at `eb75ed95`, which is the commit CI checks out:

```
97 passed, 4 deselected in 45.70s
```

Zero skipped, which that job treats as a failure.

## The measurement that was wrong first

Worth naming, because the trap is general rather than specific to these two tests. Run inside a `--case-study` worktree, the microstructure test passes and the `us_equities_panel` one fails. That reads as "nasdaq has rebuilt, us_equities has not", which is exactly the claim this PR removes, and it is an artifact of the worktree: `scripts/new-worktree.sh --case-study` symlinks `case_studies/nasdaq100_microstructure/features` to the production artifacts, so the test never reaches the fixture at all. In a tree without those symlinks both tests fail, and both fail for the fixture reason.

## One ordering note

`seeded_output_dir` is session-scoped and exports `ML4T_OUTPUT_DIR` for the remainder of the run, so whether `test_eoa_universe_roster.py` reads a redirect or the source tree now depends on collection order. Both orders were measured before this landed and both are green. The roster tests read a *seeded* redirect, which is the case the `unset ML4T_OUTPUT_DIR` above them was never covering; that unset is left in place unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sy1WqyZZTXcoyFYAjVbyiu
