### PR TITLE
Take gpu: true off 25 test overrides that do not need a card, and document the four that keep it

### DIFF
--- a/tests/fixtures/seed_results.py
+++ b/tests/fixtures/seed_results.py
@@ -1934,11 +1934,19 @@ def _seed_demo_predictions(cs_dir: Path, cs_id: str, primary_label: str) -> None
 def _seed_news_features(output_dir: Path) -> None:
     """Seed a minimal news_features.parquet for Ch10/08_text_feature_evaluation.
 
-    The panel is produced by 10/07_news_return_signals, which declares `gpu: true` and so
-    skips on a CI runner. 08 is the only chapter-10 notebook that runs there, so without this
-    seed it fails on a missing input rather than exercising anything. The notebook is right to
-    raise on the missing file - a notebook that tolerates absent input reports success for a
-    run that computed nothing - which is why the fixture supplies it instead.
+    The panel is produced by 10/07_news_return_signals, which is marked `skip` because the
+    FNSPID fixture sample (2020-2023) does not overlap the us_equities fixture (ends
+    2018-03-27), so its price join drops every row. 08 is then the only chapter-10 notebook
+    that runs on a CI runner, and without this seed it fails on a missing input rather than
+    exercising anything. The notebook is right to raise on the missing file - a notebook that
+    tolerates absent input reports success for a run that computed nothing - which is why the
+    fixture supplies it instead.
+
+    This seed cited 07's `gpu: true` until 2026-09-10. That flag was wrong: 07 runs to
+    completion on CPU in 28s. Removing it made 07 execute ahead of 08 and overwrite this panel
+    with the empty one its own join produces, which is how the real reason surfaced. Once the
+    fixture's news and price windows overlap (ml4t/agent-workspace#1116), 07 runs, writes a
+    real panel, and this seed can go - `if path.exists()` already yields to it.
 
     The notebook loads from get_output_dir(10, "fnspid") / "news_features.parquet"; in test
     mode that is {ML4T_OUTPUT_DIR}/ch10_fnspid/news_features.parquet. This directory name is

--- a/tests/overrides.yaml
+++ b/tests/overrides.yaml
@@ -383,9 +383,22 @@
     SAMPLE_SIZE: 1500
   timeout: 300
 10_text_feature_engineering/07_news_return_signals:
+  # Not a GPU notebook - it ran to completion on CPU in 28s with the card hidden. What it cannot
+  # do is produce a row against this fixture: the news sample spans 2020-01-02..2023-12-28 and
+  # `load_us_equities` ends 2018-03-27, so the join at line 981 drops all 109 feature rows and
+  # the notebook writes an empty news_features.parquet. It reports that ("Overlapping dates: 0",
+  # "Observations: 0") and still exits 0, so with the GPU flag off it silently replaced the panel
+  # `tests/fixtures/seed_results.py::_seed_news_features` puts there for 08, which then failed on
+  # the empty file. Production overlaps for nine years (news 2009-02..2020-06, prices to
+  # 2018-03), so this is the fixture's sampling window, not the notebook.
+  # ml4t/agent-workspace#1116.
   parameters:
     MAX_ARTICLES: 500
     MAX_TICKERS: 5
+  skip: true
+  skip_reason: >-
+    The FNSPID fixture sample (2020-2023) has no overlap with the us_equities fixture
+    (ends 2018-03-27), so every feature row drops at the price join. ml4t/agent-workspace#1116.
   timeout: 600
 10_text_feature_engineering/08_text_feature_evaluation:
   parameters:

--- a/tests/overrides.yaml
+++ b/tests/overrides.yaml
@@ -360,10 +360,10 @@
   # No CUDA requirement in the source - the flag is a cost decision, not a hardware one. The cell
   # that fine-tunes all three checkpoints takes 637s against the 600s per-cell limit on CPU (645s
   # under load 16.8, so contention is not what fails it). MAX_TRAIN_STEPS already applies; what
-  # remains is the model count, and no parameter bounds it. Adding one would be clean - line 495
-  # derives `model_names` from the results dict, so nothing downstream names a checkpoint - but it
-  # is a parameters-cell edit, which invalidates the committed .ipynb and costs a production GPU
-  # run to regenerate. ml4t/agent-workspace#1097 carries that decision.
+  # remains is the model count, and no parameter bounds it. Adding one would be clean - the figure
+  # cells derive `model_names` from `results.keys()`, so nothing downstream names a checkpoint -
+  # but it is a parameters-cell edit, which invalidates the committed .ipynb and costs a
+  # production GPU run to regenerate. ml4t/agent-workspace#1097 carries that decision.
   gpu: true
   parameters:
     MAX_TRAIN_STEPS: 20
@@ -376,17 +376,18 @@
 10_text_feature_engineering/06_finbert_cross_dataset:
   # FinBERT inference over the whole split - the SAMPLE_SIZE default of 10,000 exceeds its 8,142
   # rows, so it never binds - overruns the 300s per-cell limit on CPU: measured 334s idle, 353s
-  # under load 9.5. The notebook picks its device with a CPU fallback at line 102 and has no CUDA
-  # guard, so what it needed was a reduction, not a card. At 1,500 it passes in 160s and the
-  # majority-class rate it benchmarks against moves 43.1% -> 42.9%. ml4t/agent-workspace#1097.
+  # under load 9.5. The notebook picks its device with a plain `0 if torch.cuda.is_available()
+  # else -1` fallback and has no CUDA guard, so what it needed was a reduction, not a card. At
+  # 1,500 it passes in 160s and the majority-class rate it benchmarks against moves
+  # 43.1% -> 42.9%. ml4t/agent-workspace#1097.
   parameters:
     SAMPLE_SIZE: 1500
   timeout: 300
 10_text_feature_engineering/07_news_return_signals:
   # Not a GPU notebook - it ran to completion on CPU in 28s with the card hidden. What it cannot
   # do is produce a row against this fixture: the news sample spans 2020-01-02..2023-12-28 and
-  # `load_us_equities` ends 2018-03-27, so the join at line 981 drops all 109 feature rows and
-  # the notebook writes an empty news_features.parquet. It reports that ("Overlapping dates: 0",
+  # `load_us_equities` ends 2018-03-27, so the price join drops all 109 feature rows and the
+  # notebook writes an empty news_features.parquet. It reports that ("Overlapping dates: 0",
   # "Observations: 0") and still exits 0, so with the GPU flag off it silently replaced the panel
   # `tests/fixtures/seed_results.py::_seed_news_features` puts there for 08, which then failed on
   # the empty file. Production overlaps for nine years (news 2009-02..2020-06, prices to
@@ -406,12 +407,12 @@
   timeout: 300
 10_text_feature_engineering/09_filing_text_signals:
   # No CUDA requirement in the source - the flag is a cost decision. FinBERT chunks each ~6,500
-  # word MD&A section into ~16 windows of 512 tokens and costs over 15s per filing on CPU, so the
-  # scoring cell at line 317 overran the 600s per-cell limit at both sizes measured: 639s idle
-  # with MAX_SYMBOLS 5 (75 filings), and again with MAX_FILINGS 40. Reducing further is blocked,
-  # not merely slow: the IC loop needs 20 surviving observations per signal-horizon pair
-  # (line 654) and at 12 filings it gets none, at which point line 721 raises NameError because
-  # the else branch at 707 never binds `ic_summary`. That is ml4t/agent-workspace#1115; a usable
+  # word MD&A section into ~16 windows of 512 tokens and costs over 15s per filing on CPU, so its
+  # FinBERT scoring cell overran the 600s per-cell limit at both sizes measured: 639s idle with
+  # MAX_SYMBOLS 5 (75 filings), and again with MAX_FILINGS 40. Reducing further is blocked,
+  # not merely slow: the IC loop skips any signal-horizon pair with `valid.height < 20`, at 12
+  # filings that is every pair, and the figure cell's `len(ic_summary)` then raises NameError
+  # because the `if ic_results:` else branch never binds it. ml4t/agent-workspace#1115; a usable
   # reduction here needs it fixed first. ml4t/agent-workspace#1097.
   gpu: true
   parameters:
@@ -1052,10 +1053,10 @@
   tier: weekly
   timeout: 300
 22_rag_financial_research/06_esg_rag_vs_finetune:
-  # `REQUIRE_GPU = True` at line 77 is a module constant, not a papermill parameter, and line 83
-  # raises unless `torch.cuda.is_available()`. Line 230 raises again if the loaded FinBERT
-  # parameters are not on cuda. There is no CPU path. Measured: fails in 28s with the card
-  # hidden. ml4t/agent-workspace#1097.
+  # `REQUIRE_GPU = True` is a module constant, not a papermill parameter, and the guard on
+  # `torch.cuda.is_available()` raises. The later `parameter_device.type != "cuda"` check raises
+  # again if the loaded FinBERT weights are not on the card. There is no CPU path. Measured: fails
+  # in 28s with the card hidden. ml4t/agent-workspace#1097.
   gpu: true
   parameters:
     MAX_HEADLINES: 50
@@ -1086,9 +1087,9 @@
   tier: on_demand
   timeout: 600
 23_knowledge_graphs/06_gnn_feature_engineering:
-  # Line 73 raises unless `torch.cuda.is_available()`, and line 75 pins `DEVICE = "cuda"` for
-  # every tensor the fold loop builds (402-404). There is no CPU path. Measured: fails in 28s
-  # with the card hidden. ml4t/agent-workspace#1097.
+  # It raises unless `torch.cuda.is_available()`, then pins `DEVICE = torch.device("cuda")` for
+  # every tensor the fold loop builds. There is no CPU path. Measured: fails in 28s with the card
+  # hidden. ml4t/agent-workspace#1097.
   gpu: true
   timeout: 600
 23_knowledge_graphs/03_graph_rag_qa:

--- a/tests/overrides.yaml
+++ b/tests/overrides.yaml
@@ -162,7 +162,6 @@
   gpu: true
   timeout: 600
 05_synthetic_data/02_tailgan_tail_risk:
-  gpu: true
   parameters:
     BATCH_SIZE: 64
     LATENT_DIM: 32
@@ -182,7 +181,6 @@
   requires_import: signatory
   timeout: 900
 05_synthetic_data/04_gtgan_irregular:
-  gpu: true
   parameters:
     BATCH_SIZE: 4
     HIDDEN_DIM: 4
@@ -194,7 +192,6 @@
     SEQ_LENGTH: 4
   timeout: 120
 05_synthetic_data/05_diffusion_ts:
-  gpu: true
   parameters:
     BATCH_SIZE: 8
     CLASSIFIER_EPOCHS: 1
@@ -211,7 +208,6 @@
     WARMUP_STEPS: 1
   timeout: 180
 05_synthetic_data/06_llm_tabular_great:
-  gpu: true
   parameters:
     BATCH_SIZE: 8
     EPOCHS: 1
@@ -361,21 +357,32 @@
   requires_import: gensim
   timeout: 300
 10_text_feature_engineering/04_bert_finetuning:
+  # No CUDA requirement in the source - the flag is a cost decision, not a hardware one. The cell
+  # that fine-tunes all three checkpoints takes 637s against the 600s per-cell limit on CPU (645s
+  # under load 16.8, so contention is not what fails it). MAX_TRAIN_STEPS already applies; what
+  # remains is the model count, and no parameter bounds it. Adding one would be clean - line 495
+  # derives `model_names` from the results dict, so nothing downstream names a checkpoint - but it
+  # is a parameters-cell edit, which invalidates the committed .ipynb and costs a production GPU
+  # run to regenerate. ml4t/agent-workspace#1097 carries that decision.
   gpu: true
   parameters:
     MAX_TRAIN_STEPS: 20
   timeout: 600
 10_text_feature_engineering/05_financial_ner_finetuning:
-  gpu: true
   parameters:
     N_EPOCHS: 1
     N_SAMPLES: 100
   timeout: 600
 10_text_feature_engineering/06_finbert_cross_dataset:
-  gpu: true
+  # FinBERT inference over the whole split - the SAMPLE_SIZE default of 10,000 exceeds its 8,142
+  # rows, so it never binds - overruns the 300s per-cell limit on CPU: measured 334s idle, 353s
+  # under load 9.5. The notebook picks its device with a CPU fallback at line 102 and has no CUDA
+  # guard, so what it needed was a reduction, not a card. At 1,500 it passes in 160s and the
+  # majority-class rate it benchmarks against moves 43.1% -> 42.9%. ml4t/agent-workspace#1097.
+  parameters:
+    SAMPLE_SIZE: 1500
   timeout: 300
 10_text_feature_engineering/07_news_return_signals:
-  gpu: true
   parameters:
     MAX_ARTICLES: 500
     MAX_TICKERS: 5
@@ -385,6 +392,14 @@
     MIN_ASSETS_PER_DAY: 3
   timeout: 300
 10_text_feature_engineering/09_filing_text_signals:
+  # No CUDA requirement in the source - the flag is a cost decision. FinBERT chunks each ~6,500
+  # word MD&A section into ~16 windows of 512 tokens and costs over 15s per filing on CPU, so the
+  # scoring cell at line 317 overran the 600s per-cell limit at both sizes measured: 639s idle
+  # with MAX_SYMBOLS 5 (75 filings), and again with MAX_FILINGS 40. Reducing further is blocked,
+  # not merely slow: the IC loop needs 20 surviving observations per signal-horizon pair
+  # (line 654) and at 12 filings it gets none, at which point line 721 raises NameError because
+  # the else branch at 707 never binds `ic_summary`. That is ml4t/agent-workspace#1115; a usable
+  # reduction here needs it fixed first. ml4t/agent-workspace#1097.
   gpu: true
   parameters:
     MAX_SYMBOLS: 5
@@ -444,7 +459,6 @@
     MAX_SYMBOLS: 3
   timeout: 900
 12_gradient_boosting/03_dl_vs_gbm:
-  gpu: true
   parameters:
     MAX_FOLDS: 2
     MAX_SYMBOLS: 15
@@ -520,7 +534,6 @@
 12_gradient_boosting/12_case_study_insights:
   timeout: 300
 13_dl_time_series/01_core_architectures:
-  gpu: true
   parameters:
     BATCH_SIZE: 64
     EPOCHS: 2
@@ -528,7 +541,6 @@
     LOOKBACK: 10
   timeout: 300
 13_dl_time_series/02_nbeats_interpretable:
-  gpu: true
   parameters:
     BATCH_SIZE: 64
     EPOCHS: 2
@@ -538,7 +550,6 @@
     N_LAYERS: 2
   timeout: 300
 13_dl_time_series/03_great_debate:
-  gpu: true
   parameters:
     BATCH_SIZE: 64
     D_MODEL: 16
@@ -548,7 +559,6 @@
     N_LAYERS: 1
   timeout: 300
 13_dl_time_series/04_transformers:
-  gpu: true
   parameters:
     BATCH_SIZE: 64
     D_MODEL: 16
@@ -559,7 +569,6 @@
     PATCH_SIZE: 6
   timeout: 300
 13_dl_time_series/05_tcn:
-  gpu: true
   parameters:
     BATCH_SIZE: 64
     EPOCHS: 2
@@ -567,7 +576,6 @@
     N_CHANNELS: 16
   timeout: 300
 13_dl_time_series/06_tsmixer:
-  gpu: true
   parameters:
     BATCH_SIZE: 64
     D_MODEL: 16
@@ -576,7 +584,6 @@
     N_LAYERS: 1
   timeout: 300
 13_dl_time_series/07_mamba_ssm:
-  gpu: true
   parameters:
     BATCH_SIZE: 64
     D_MODEL: 16
@@ -589,7 +596,6 @@
     N_LAYERS: 1
   timeout: 300
 13_dl_time_series/08_cnn_image_encoding:
-  gpu: true
   parameters:
     BATCH_SIZE: 64
     EPOCHS: 2
@@ -600,7 +606,6 @@
     MAX_VAL_SAMPLES: 2000
   timeout: 300
 13_dl_time_series/09_foundation_models:
-  gpu: true
   parameters:
     BATCH_SIZE: 64
     CHRONOS_NUM_SAMPLES: 3
@@ -612,7 +617,6 @@
     PREDICTION_LENGTH: 5
   timeout: 300
 13_dl_time_series/10_uncertainty:
-  gpu: true
   parameters:
     BATCH_SIZE: 64
     EPOCHS: 2
@@ -623,7 +627,6 @@
     N_ENSEMBLE: 2
   timeout: 300
 13_dl_time_series/11_library_landscape:
-  gpu: true
   parameters:
     BATCH_SIZE: 64
     EPOCHS: 2
@@ -666,7 +669,6 @@
     TOP_N_STOCKS: 50
   timeout: 900
 14_latent_factors/07_stochastic_discount_factor:
-  gpu: true
   parameters:
     ADVERSARIAL_ROUNDS: 1
     BETA_EPOCHS: 8
@@ -679,7 +681,6 @@
     UNCONDITIONAL_EPOCHS: 8
   timeout: 360
 14_latent_factors/08_supervised_autoencoder:
-  gpu: true
   parameters:
     N_EPOCHS: 5
     N_SPLITS: 2
@@ -823,18 +824,15 @@
 17_portfolio_construction/09_allocator_comparison:
   timeout: 600
 17_portfolio_construction/11_dl_portfolio_allocation:
-  gpu: true
   parameters:
     N_EPOCHS: 2
   timeout: 600
 17_portfolio_construction/12_vlstm_portfolio:
-  gpu: true
   parameters:
     MAX_SYMBOLS: 10
     N_EPOCHS: 2
   timeout: 600
 17_portfolio_construction/13_deepm_regime_robust:
-  gpu: true
   parameters:
     MAX_ITERS: 40
     MAX_SYMBOLS: 10
@@ -974,7 +972,6 @@
     TOTAL_TIMESTEPS: 1000
   timeout: 600
 21_rl_execution_hedging/03_market_making_ppo:
-  gpu: true
   parameters:
     EVAL_EPISODES: 2
     TOTAL_TIMESTEPS: 1000
@@ -1042,6 +1039,10 @@
   tier: weekly
   timeout: 300
 22_rag_financial_research/06_esg_rag_vs_finetune:
+  # `REQUIRE_GPU = True` at line 77 is a module constant, not a papermill parameter, and line 83
+  # raises unless `torch.cuda.is_available()`. Line 230 raises again if the loaded FinBERT
+  # parameters are not on cuda. There is no CPU path. Measured: fails in 28s with the card
+  # hidden. ml4t/agent-workspace#1097.
   gpu: true
   parameters:
     MAX_HEADLINES: 50
@@ -1072,6 +1073,9 @@
   tier: on_demand
   timeout: 600
 23_knowledge_graphs/06_gnn_feature_engineering:
+  # Line 73 raises unless `torch.cuda.is_available()`, and line 75 pins `DEVICE = "cuda"` for
+  # every tensor the fold loop builds (402-404). There is no CPU path. Measured: fails in 28s
+  # with the card hidden. ml4t/agent-workspace#1097.
   gpu: true
   timeout: 600
 23_knowledge_graphs/03_graph_rag_qa:


### PR DESCRIPTION
`gpu: true` in `tests/overrides.yaml` means "torch, with a CUDA device it can see"
(`tests/pm_helpers.py:283`), so an entry carrying one is never executed by a runner without a card.
38 entries declared it. This measures every one that can run from the repo venv and removes the flag
where the notebook does not need the hardware.

## Method

Each entry ran through the CI harness with the card hidden, against the CI fixture:

```
ML4T_DATA_PATH=~/ml4t/test-data/data CUDA_VISIBLE_DEVICES="" \
  uv run pytest tests/test_chapter_notebooks.py -k <stem>
```

one at a time, six threads each. `timeout` in `overrides.yaml` is papermill's **per-cell** limit
(`pm_helpers.py:1616` passes it as `execution_timeout`), not a notebook budget, so PASS/FAIL is the
decision variable rather than elapsed-against-budget: `05_synthetic_data/06_llm_tabular_great`
passes at 177s of wall clock against a declared 120s because no single cell takes 120s.

## What changed

**25 flags come off** (38 `gpu: true` entries become 13). 24 on the measurement alone - each notebook ran to completion on CPU with no
cell over its declared limit, which is exactly what its CI job asserts. None of them gets there by
skipping work when no card is visible: every `cuda.is_available()` reference across the 24 is a
device selection, a CUDA-only seeding block, or an `empty_cache()` call.

The 25th, `06_finbert_cross_dataset`, comes off on a reduction. It picks its device with a CPU
fallback at line 102 and has no CUDA guard, so what overran its 300s cell was unbounded work: its
`SAMPLE_SIZE` default of 10,000 exceeds the split's 8,142 rows and never binds, and the entry never
lowered it. At 1,500 it passes in 160s, and the majority-class rate the notebook benchmarks its
accuracy against moves 43.1% -> 42.9%, so the smaller sample does not starve a label class.

**Four keep the flag, and each entry now carries the reason above it** in the form #862 established.

| entry | why |
|---|---|
| `22_rag_financial_research/06_esg_rag_vs_finetune` | `REQUIRE_GPU = True` at line 77 is a module constant, not a papermill parameter; line 83 raises unless `torch.cuda.is_available()`, line 230 raises again if the loaded weights are not on cuda. Fails in 28s with the card hidden. |
| `23_knowledge_graphs/06_gnn_feature_engineering` | Line 73 raises unless `torch.cuda.is_available()`; line 75 pins `DEVICE = "cuda"` for every tensor the fold loop builds at 402-404. Fails in 28s. |
| `10_text_feature_engineering/04_bert_finetuning` | No CUDA requirement in the source - a cost decision. One cell fine-tunes three checkpoints: 637s against a 600s per-cell limit. `MAX_TRAIN_STEPS: 20` already applies; the model count has no parameter. |
| `10_text_feature_engineering/09_filing_text_signals` | No CUDA requirement either. FinBERT chunks each ~6,500-word MD&A section into ~16 windows and costs >15s per filing on CPU, overrunning 600s at both sizes measured. |

The last two say plainly that the flag is about cost rather than hardware, which is a thing a reader
of this file could not previously tell apart from a real requirement.

**Nine entries are untouched** because they cannot run from this venv: `docker_env: py312` (four),
py312 + gensim (one), `ml4t+neo4j+gpu` (two), `requires_import: pfhedge` (one), and one
`tier: on_demand` entry excluded before the GPU guard is reached.

## One removal turned ch10 red, and that is the useful part

`10_text_feature_engineering/07_news_return_signals` also needs no card - it runs on CPU in 28s.
But with the flag off it executed in CI for the first time and **wrote an empty
`news_features.parquet`**, which `08_text_feature_evaluation` then refused with
`ValueError: Empty dataset ... Notebook 07 ran but produced no usable rows`.

The cause is the fixture, not the notebook. Its news sample spans 2020-01-02..2023-12-28 and
`load_us_equities` ends 2018-03-27, so the price join at line 981 drops all 109 feature rows. 07
prints `Overlapping dates: 0` and `Observations: 0` and still exits 0. Production overlaps for nine
years (news 2009-02..2020-06 against prices to 2018-03), so a reader is unaffected.

`tests/fixtures/seed_results.py` had been seeding a synthetic panel for 08 and yields to a real one
with `if path.exists()`; 07 running first overwrote it. That seed's docstring gave 07's `gpu: true`
as its justification, so it is corrected to the real reason and now says what makes it removable.

07 therefore loses the flag and gains `skip` + `skip_reason` naming the fixture gap. It was already
skipping in CI - this makes the stated reason true. Filed as ml4t/agent-workspace#1116, together
with the second half: 07 already computes the overlap and warns on zero, and that branch should
raise rather than write an empty file.

## Two things worth knowing

**A FAIL under load settles nothing, and here it settled the same way anyway.** A run under load
that passes inside its per-cell limit is an upper bound on the same run idle, so only overruns need
a quiet machine. All three were re-measured idle and each came in *faster* than its loaded run by
8-19s (637 vs 645 at load 16.8, 334 vs 353 at load 9.5, 639 vs 649 at load 10.4). Contention was
never the factor.

**Reducing `09_filing_text_signals` is blocked, not merely slow.** Its IC loop needs 20 surviving
observations per signal-horizon pair (line 654); at 12 filings it gets none, and line 721 then
raises `NameError` because the `else` at 707 never binds `ic_summary`. Same displaced line means the
notebook never writes `ic_summary.parquet` on any run, including the shipped one - the committed
`.ipynb` carries the neighbouring save's output and never the IC summary's. Filed separately; a
usable reduction here needs that fixed first.

## Verification

`151 passed` across `tests/test_workspace_prerequisites.py`, `tests/test_invocation_fanout.py`,
`tests/test_pm_helpers.py` and `tests/test_seoa_sweep_universe.py`.

Removing a `gpu` field has no other CI effect: `tests/notebook_catalog.py:239` is its only other
consumer, no workflow or test reads what that produces, and its `GPU_KEYWORDS` set matches the
notebook text anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WLnJJCNVmBibLcmzZR9cak
