### PR TITLE
us_equities_panel enrolls in the case-study matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -362,24 +362,8 @@ jobs:
           if [[ "$all" == "true" ]] || [[ "${{ steps.filter.outputs.cs-sp500opt }}" == "true" ]]; then
             add_cs "sp500_options"
           fi
-          # us_equities_panel is DEFERRED and does not enroll, even on a push to
-          # main. It is the most expensive case study in the corpus - the runtime
-          # reference puts one tabular_dl configuration at 4.1 hours - and its
-          # rebuild is scheduled after the other eight complete. Until then its
-          # notebooks fail CI for reasons nobody is working on, which trains
-          # readers of this workflow to expect a red job and to stop reading it.
-          #
-          # A deferred case study must not also be a permanently red one. Enroll
-          # it again by deleting CS_DEFERRED below; nothing else needs changing,
-          # and the notice in the log names the condition so the skip cannot be
-          # forgotten silently.
-          CS_DEFERRED="us_equities_panel"
           if [[ "$all" == "true" ]] || [[ "${{ steps.filter.outputs.cs-usequity }}" == "true" ]]; then
-            if [[ " $CS_DEFERRED " == *" us_equities_panel "* ]]; then
-              echo "::notice title=us_equities_panel deferred::case-study job skipped by design while its rebuild is descheduled; re-enroll by clearing CS_DEFERRED in .github/workflows/test.yml"
-            else
-              add_cs "us_equities_panel"
-            fi
+            add_cs "us_equities_panel"
           fi
 
           echo "case_matrix=$cases" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
`us_equities_panel` has not enrolled in the case-study matrix since the deferral
went in: `CS_DEFERRED` made the job emit a notice and skip, so `cs-us_equities_panel`
was absent from the check runs rather than red, and a green PR asserted nothing
about these notebooks.

The condition the deferral named has been met. The stage 01-05 and stage 06+
review passes are complete, every `us_equities_panel` notebook is at `ready` in
the register, and the notebooks execute.

## Evidence

Ran what the cs job runs - `pytest tests/test_case_studies.py -k us_equities_panel`,
22 notebooks at preview tier - on this workstation before opening this PR:

```
21 passed, 1 skipped, 195 deselected in 1374.23s (0:22:54)
```

The skip is `20_strategy_analysis`, which declares in its own skip reason that it
needs a registered holdout refit the CI fixture does not produce. The job's
budget is 90 minutes; this PR's own `cs-us_equities_panel` run is the check on
whether the runner needs more wall clock than this machine did.

The enrollment block now reads exactly like the other eight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P1tBf8pMZ74NrdVfCzz76s
