### PR TITLE
backtest_runner: say why the whole-second gap measurement is safe

### DIFF
--- a/case_studies/utils/backtest_runner.py
+++ b/case_studies/utils/backtest_runner.py
@@ -83,6 +83,16 @@ def observed_periods_per_year(daily_returns) -> float:
     if n <= 2:
         return 0.0
     all_ts = daily_returns["timestamp"].unique().sort()
+    # `total_seconds()` returns whole seconds, so a gap under one second truncates to 0 and the
+    # filter below deletes it. That is safe here because of the grids this is called on, not
+    # because of the unit: the finest return grid any case study evaluates on is minute-level,
+    # so the smallest real gap is 60. It would go false the day something evaluates on seconds,
+    # and it would fail quietly - every gap zeroed, the array emptied, 0.0 returned, and
+    # `reconcile_periods_per_year` keeping the declared constant with nothing saying why.
+    # Switch to `dt.total_nanoseconds()` at that point rather than widening the filter.
+    # Found 2026-09-10 by the sweep behind
+    # 03_market_microstructure/04_itch_order_lifecycle_analysis, where the same pair of calls
+    # zeroed every sub-second order lifetime and then dropped the whole population.
     gaps = all_ts.diff().drop_nulls().dt.total_seconds().to_numpy().astype(float)
     gaps = gaps[gaps > 0]
     if gaps.size == 0:


### PR DESCRIPTION
`_infer_periods_per_year` measures spacing with `dt.total_seconds()`, which returns whole seconds, then filters `gaps > 0`. That pair is what zeroed every sub-second order lifetime in `03_market_microstructure/04_itch_order_lifecycle_analysis` and then dropped the entire sub-second population from the figure the section is about.

This call site is safe, but contingently rather than structurally: the finest return grid any case study evaluates on is minute-level, so the smallest real gap is 60 seconds. Nothing said so at the call site, and the argument goes false the day something evaluates on seconds - quietly, because every gap zeroes, the array empties, 0.0 returns, and `reconcile_periods_per_year` keeps the declared constant with nothing recording that a measurement was replaced by a default.

Found by a corpus sweep of `dt.total_seconds()`: nine call sites in five files. Two nasdaq sites take a market session and divide by 60, so truncation cannot bite; six in `17_databento_bar_sampling.py` are genuinely exposed and belong to the chapter-3 pass; this one is the only shared-library site.

Comment only, no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sy1WqyZZTXcoyFYAjVbyiu