### PR TITLE
Run 04_bert_finetuning in CI, and take its gpu: true off

### DIFF
--- a/10_text_feature_engineering/04_bert_finetuning.ipynb
+++ b/10_text_feature_engineering/04_bert_finetuning.ipynb
@@ -2,13 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "9de86aa9",
+   "id": "c0832887",
    "metadata": {
     "papermill": {
-     "duration": 0.001925,
-     "end_time": "2026-09-09T21:28:01.132010+00:00",
+     "duration": 0.002226,
+     "end_time": "2026-09-10T21:01:54.587594+00:00",
      "exception": false,
-     "start_time": "2026-09-09T21:28:01.130085+00:00",
+     "start_time": "2026-09-10T21:01:54.585368+00:00",
      "status": "completed"
     }
    },
@@ -69,19 +69,19 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "320c1325",
+   "id": "e83ffd75",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T21:28:01.135394Z",
-     "iopub.status.busy": "2026-09-09T21:28:01.135233Z",
-     "iopub.status.idle": "2026-09-09T21:28:05.841960Z",
-     "shell.execute_reply": "2026-09-09T21:28:05.841244Z"
+     "iopub.execute_input": "2026-09-10T21:01:54.591163Z",
+     "iopub.status.busy": "2026-09-10T21:01:54.591002Z",
+     "iopub.status.idle": "2026-09-10T21:01:58.654638Z",
+     "shell.execute_reply": "2026-09-10T21:01:58.654011Z"
     },
     "papermill": {
-     "duration": 4.70941,
-     "end_time": "2026-09-09T21:28:05.842736+00:00",
+     "duration": 4.066214,
+     "end_time": "2026-09-10T21:01:58.655198+00:00",
      "exception": false,
-     "start_time": "2026-09-09T21:28:01.133326+00:00",
+     "start_time": "2026-09-10T21:01:54.588984+00:00",
      "status": "completed"
     }
    },
@@ -139,13 +139,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b08dc4f5",
+   "id": "256f45de",
    "metadata": {
     "papermill": {
-     "duration": 0.001672,
-     "end_time": "2026-09-09T21:28:05.847237+00:00",
+     "duration": 0.001421,
+     "end_time": "2026-09-10T21:01:58.658959+00:00",
      "exception": false,
-     "start_time": "2026-09-09T21:28:05.845565+00:00",
+     "start_time": "2026-09-10T21:01:58.657538+00:00",
      "status": "completed"
     }
    },
@@ -160,19 +160,19 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "db4b5a6a",
+   "id": "42dd7cd8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T21:28:05.850868Z",
-     "iopub.status.busy": "2026-09-09T21:28:05.850695Z",
-     "iopub.status.idle": "2026-09-09T21:28:05.853321Z",
-     "shell.execute_reply": "2026-09-09T21:28:05.852725Z"
+     "iopub.execute_input": "2026-09-10T21:01:58.661950Z",
+     "iopub.status.busy": "2026-09-10T21:01:58.661769Z",
+     "iopub.status.idle": "2026-09-10T21:01:58.664018Z",
+     "shell.execute_reply": "2026-09-10T21:01:58.663691Z"
     },
     "papermill": {
-     "duration": 0.005238,
-     "end_time": "2026-09-09T21:28:05.853678+00:00",
+     "duration": 0.004384,
+     "end_time": "2026-09-10T21:01:58.664429+00:00",
      "exception": false,
-     "start_time": "2026-09-09T21:28:05.848440+00:00",
+     "start_time": "2026-09-10T21:01:58.660045+00:00",
      "status": "completed"
     },
     "tags": [
@@ -182,19 +182,23 @@
    "outputs": [],
    "source": [
     "SEED = 42\n",
-    "MAX_TRAIN_STEPS = -1"
+    "MAX_TRAIN_STEPS = -1\n",
+    "# How many sentences to score in the validation and test splits; 0 means all of them.\n",
+    "# This is the knob that decides whether CI can run this notebook - see the comment above\n",
+    "# the split below.\n",
+    "MAX_EVAL_SAMPLES = 0"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "e4f2ecbc",
+   "id": "7327ee85",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.001136,
-     "end_time": "2026-09-09T21:28:05.856308+00:00",
+     "duration": 0.001095,
+     "end_time": "2026-09-10T21:01:58.666833+00:00",
      "exception": false,
-     "start_time": "2026-09-09T21:28:05.855172+00:00",
+     "start_time": "2026-09-10T21:01:58.665738+00:00",
      "status": "completed"
     }
    },
@@ -207,20 +211,20 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "cd341c82",
+   "id": "9e826b27",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T21:28:05.859515Z",
-     "iopub.status.busy": "2026-09-09T21:28:05.859349Z",
-     "iopub.status.idle": "2026-09-09T21:28:05.896643Z",
-     "shell.execute_reply": "2026-09-09T21:28:05.896152Z"
+     "iopub.execute_input": "2026-09-10T21:01:58.669825Z",
+     "iopub.status.busy": "2026-09-10T21:01:58.669675Z",
+     "iopub.status.idle": "2026-09-10T21:01:58.721843Z",
+     "shell.execute_reply": "2026-09-10T21:01:58.721343Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.039477,
-     "end_time": "2026-09-09T21:28:05.896947+00:00",
+     "duration": 0.054168,
+     "end_time": "2026-09-10T21:01:58.722125+00:00",
      "exception": false,
-     "start_time": "2026-09-09T21:28:05.857470+00:00",
+     "start_time": "2026-09-10T21:01:58.667957+00:00",
      "status": "completed"
     }
    },
@@ -319,13 +323,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3a8d31af",
+   "id": "305bb9a5",
    "metadata": {
     "papermill": {
-     "duration": 0.001473,
-     "end_time": "2026-09-09T21:28:05.899793+00:00",
+     "duration": 0.001321,
+     "end_time": "2026-09-10T21:01:58.724909+00:00",
      "exception": false,
-     "start_time": "2026-09-09T21:28:05.898320+00:00",
+     "start_time": "2026-09-10T21:01:58.723588+00:00",
      "status": "completed"
     }
    },
@@ -341,19 +345,19 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "0d256136",
+   "id": "aa2c66ae",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T21:28:05.903263Z",
-     "iopub.status.busy": "2026-09-09T21:28:05.903149Z",
-     "iopub.status.idle": "2026-09-09T21:28:05.911116Z",
-     "shell.execute_reply": "2026-09-09T21:28:05.910209Z"
+     "iopub.execute_input": "2026-09-10T21:01:58.728056Z",
+     "iopub.status.busy": "2026-09-10T21:01:58.727961Z",
+     "iopub.status.idle": "2026-09-10T21:01:58.738417Z",
+     "shell.execute_reply": "2026-09-10T21:01:58.737879Z"
     },
     "papermill": {
-     "duration": 0.010268,
-     "end_time": "2026-09-09T21:28:05.911453+00:00",
+     "duration": 0.012549,
+     "end_time": "2026-09-10T21:01:58.738783+00:00",
      "exception": false,
-     "start_time": "2026-09-09T21:28:05.901185+00:00",
+     "start_time": "2026-09-10T21:01:58.726234+00:00",
      "status": "completed"
     }
    },
@@ -374,20 +378,20 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "96134882",
+   "id": "52c6450b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T21:28:05.914774Z",
-     "iopub.status.busy": "2026-09-09T21:28:05.914664Z",
-     "iopub.status.idle": "2026-09-09T21:28:05.924167Z",
-     "shell.execute_reply": "2026-09-09T21:28:05.923753Z"
+     "iopub.execute_input": "2026-09-10T21:01:58.742318Z",
+     "iopub.status.busy": "2026-09-10T21:01:58.742173Z",
+     "iopub.status.idle": "2026-09-10T21:01:58.751036Z",
+     "shell.execute_reply": "2026-09-10T21:01:58.750661Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.011659,
-     "end_time": "2026-09-09T21:28:05.924554+00:00",
+     "duration": 0.011272,
+     "end_time": "2026-09-10T21:01:58.751586+00:00",
      "exception": false,
-     "start_time": "2026-09-09T21:28:05.912895+00:00",
+     "start_time": "2026-09-10T21:01:58.740314+00:00",
      "status": "completed"
     }
    },
@@ -424,14 +428,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d3b64823",
+   "id": "340e8ab9",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.001203,
-     "end_time": "2026-09-09T21:28:05.927171+00:00",
+     "duration": 0.001256,
+     "end_time": "2026-09-10T21:01:58.754563+00:00",
      "exception": false,
-     "start_time": "2026-09-09T21:28:05.925968+00:00",
+     "start_time": "2026-09-10T21:01:58.753307+00:00",
      "status": "completed"
     }
    },
@@ -443,19 +447,19 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "00a61e97",
+   "id": "d2df6601",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T21:28:05.930224Z",
-     "iopub.status.busy": "2026-09-09T21:28:05.930106Z",
-     "iopub.status.idle": "2026-09-09T21:28:05.941861Z",
-     "shell.execute_reply": "2026-09-09T21:28:05.941281Z"
+     "iopub.execute_input": "2026-09-10T21:01:58.758969Z",
+     "iopub.status.busy": "2026-09-10T21:01:58.758430Z",
+     "iopub.status.idle": "2026-09-10T21:01:58.775494Z",
+     "shell.execute_reply": "2026-09-10T21:01:58.775108Z"
     },
     "papermill": {
-     "duration": 0.013928,
-     "end_time": "2026-09-09T21:28:05.942290+00:00",
+     "duration": 0.020327,
+     "end_time": "2026-09-10T21:01:58.776100+00:00",
      "exception": false,
-     "start_time": "2026-09-09T21:28:05.928362+00:00",
+     "start_time": "2026-09-10T21:01:58.755773+00:00",
      "status": "completed"
     }
    },
@@ -477,18 +481,45 @@
     "    )\n",
     "\n",
     "\n",
-    "dataset = create_dataset_dict(train_df, val_df, test_df)"
+    "dataset = create_dataset_dict(train_df, val_df, test_df)\n",
+    "\n",
+    "# Scoring, not training, is what this notebook spends its time on, and MAX_TRAIN_STEPS\n",
+    "# does not touch it. Each model is scored on the validation split every `eval_steps`\n",
+    "# during training and once on the test split at the end, and a full pass costs 183s on\n",
+    "# one CPU thread against 727 sentences. Under `MAX_TRAIN_STEPS: 20` that is two\n",
+    "# in-training evaluations plus two passes over the test split, so twenty training steps\n",
+    "# sit behind about twelve minutes of inference per model. Bounding the scored splits is\n",
+    "# the knob that reaches that; bounding the model count would leave a three-way\n",
+    "# comparison with one entry.\n",
+    "#\n",
+    "# 0 means score everything, which is what a real run does. The splits are already\n",
+    "# shuffled and stratified by `train_test_split`, so a prefix of each is class-balanced\n",
+    "# in expectation.\n",
+    "if MAX_EVAL_SAMPLES > 0:\n",
+    "    dataset = DatasetDict(\n",
+    "        {\n",
+    "            \"train\": dataset[\"train\"],\n",
+    "            \"validation\": dataset[\"validation\"].select(\n",
+    "                range(min(MAX_EVAL_SAMPLES, len(dataset[\"validation\"])))\n",
+    "            ),\n",
+    "            \"test\": dataset[\"test\"].select(range(min(MAX_EVAL_SAMPLES, len(dataset[\"test\"])))),\n",
+    "        }\n",
+    "    )\n",
+    "    print(\n",
+    "        f\"Scored splits bounded to {MAX_EVAL_SAMPLES}: \"\n",
+    "        f\"val {len(dataset['validation'])}, test {len(dataset['test'])}\"\n",
+    "    )"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "5fe468e0",
+   "id": "9c0ed4c8",
    "metadata": {
     "papermill": {
-     "duration": 0.001541,
-     "end_time": "2026-09-09T21:28:05.945246+00:00",
+     "duration": 0.001252,
+     "end_time": "2026-09-10T21:01:58.779676+00:00",
      "exception": false,
-     "start_time": "2026-09-09T21:28:05.943705+00:00",
+     "start_time": "2026-09-10T21:01:58.778424+00:00",
      "status": "completed"
     }
    },
@@ -510,20 +541,20 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "52c2756e",
+   "id": "accaa3d1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T21:28:05.948424Z",
-     "iopub.status.busy": "2026-09-09T21:28:05.948271Z",
-     "iopub.status.idle": "2026-09-09T21:28:05.951385Z",
-     "shell.execute_reply": "2026-09-09T21:28:05.950505Z"
+     "iopub.execute_input": "2026-09-10T21:01:58.785033Z",
+     "iopub.status.busy": "2026-09-10T21:01:58.784512Z",
+     "iopub.status.idle": "2026-09-10T21:01:58.787601Z",
+     "shell.execute_reply": "2026-09-10T21:01:58.787189Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.005405,
-     "end_time": "2026-09-09T21:28:05.951899+00:00",
+     "duration": 0.007027,
+     "end_time": "2026-09-10T21:01:58.787934+00:00",
      "exception": false,
-     "start_time": "2026-09-09T21:28:05.946494+00:00",
+     "start_time": "2026-09-10T21:01:58.780907+00:00",
      "status": "completed"
     }
    },
@@ -541,14 +572,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5424d1c4",
+   "id": "e5553b60",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.001531,
-     "end_time": "2026-09-09T21:28:05.955777+00:00",
+     "duration": 0.001281,
+     "end_time": "2026-09-10T21:01:58.790866+00:00",
      "exception": false,
-     "start_time": "2026-09-09T21:28:05.954246+00:00",
+     "start_time": "2026-09-10T21:01:58.789585+00:00",
      "status": "completed"
     }
    },
@@ -561,19 +592,19 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "9d642ef4",
+   "id": "0f11b741",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T21:28:05.959195Z",
-     "iopub.status.busy": "2026-09-09T21:28:05.959023Z",
-     "iopub.status.idle": "2026-09-09T21:28:05.961611Z",
-     "shell.execute_reply": "2026-09-09T21:28:05.961088Z"
+     "iopub.execute_input": "2026-09-10T21:01:58.794349Z",
+     "iopub.status.busy": "2026-09-10T21:01:58.794254Z",
+     "iopub.status.idle": "2026-09-10T21:01:58.796243Z",
+     "shell.execute_reply": "2026-09-10T21:01:58.795913Z"
     },
     "papermill": {
-     "duration": 0.004876,
-     "end_time": "2026-09-09T21:28:05.961944+00:00",
+     "duration": 0.004495,
+     "end_time": "2026-09-10T21:01:58.796644+00:00",
      "exception": false,
-     "start_time": "2026-09-09T21:28:05.957068+00:00",
+     "start_time": "2026-09-10T21:01:58.792149+00:00",
      "status": "completed"
     }
    },
@@ -590,13 +621,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8939bb86",
+   "id": "f5506e51",
    "metadata": {
     "papermill": {
-     "duration": 0.001295,
-     "end_time": "2026-09-09T21:28:05.964980+00:00",
+     "duration": 0.001183,
+     "end_time": "2026-09-10T21:01:58.799118+00:00",
      "exception": false,
-     "start_time": "2026-09-09T21:28:05.963685+00:00",
+     "start_time": "2026-09-10T21:01:58.797935+00:00",
      "status": "completed"
     }
    },
@@ -609,19 +640,19 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "17d9edee",
+   "id": "48ad284c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T21:28:05.968725Z",
-     "iopub.status.busy": "2026-09-09T21:28:05.968545Z",
-     "iopub.status.idle": "2026-09-09T21:28:06.370294Z",
-     "shell.execute_reply": "2026-09-09T21:28:06.369670Z"
+     "iopub.execute_input": "2026-09-10T21:01:58.802421Z",
+     "iopub.status.busy": "2026-09-10T21:01:58.802320Z",
+     "iopub.status.idle": "2026-09-10T21:01:59.211081Z",
+     "shell.execute_reply": "2026-09-10T21:01:59.210459Z"
     },
     "papermill": {
-     "duration": 0.404832,
-     "end_time": "2026-09-09T21:28:06.371145+00:00",
+     "duration": 0.411154,
+     "end_time": "2026-09-10T21:01:59.211530+00:00",
      "exception": false,
-     "start_time": "2026-09-09T21:28:05.966313+00:00",
+     "start_time": "2026-09-10T21:01:58.800376+00:00",
      "status": "completed"
     }
    },
@@ -642,19 +673,19 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "15a3dc28",
+   "id": "64f7b056",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T21:28:06.376287Z",
-     "iopub.status.busy": "2026-09-09T21:28:06.376106Z",
-     "iopub.status.idle": "2026-09-09T21:28:06.384012Z",
-     "shell.execute_reply": "2026-09-09T21:28:06.383404Z"
+     "iopub.execute_input": "2026-09-10T21:01:59.217636Z",
+     "iopub.status.busy": "2026-09-10T21:01:59.217501Z",
+     "iopub.status.idle": "2026-09-10T21:01:59.222812Z",
+     "shell.execute_reply": "2026-09-10T21:01:59.222402Z"
     },
     "papermill": {
-     "duration": 0.010672,
-     "end_time": "2026-09-09T21:28:06.384394+00:00",
+     "duration": 0.009258,
+     "end_time": "2026-09-10T21:01:59.223368+00:00",
      "exception": false,
-     "start_time": "2026-09-09T21:28:06.373722+00:00",
+     "start_time": "2026-09-10T21:01:59.214110+00:00",
      "status": "completed"
     }
    },
@@ -766,7 +797,12 @@
     "    train_result = trainer.train()\n",
     "    train_time = time.time() - start_time\n",
     "\n",
-    "    # Evaluate on test set\n",
+    "    # `evaluate` and `predict` both make a full forward pass over the test split and\n",
+    "    # report the same accuracy and macro F1, so this scores it twice. Collapsing them\n",
+    "    # into a single `predict(..., metric_key_prefix=\"eval\")` is correct and saves a\n",
+    "    # pass per model, but it moves the two models fine-tuned after it - DeBERTa-v3 to\n",
+    "    # 96.8% and ModernBERT to 97.9%, which puts ModernBERT above FinBERT and makes the\n",
+    "    # \"scores highest\" in takeaway 2 false. ml4t/agent-workspace#1121 carries it.\n",
     "    test_results = trainer.evaluate(tokenized[\"test\"])\n",
     "\n",
     "    # Get predictions for confusion matrix\n",
@@ -789,13 +825,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cde2510c",
+   "id": "81e31fbf",
    "metadata": {
     "papermill": {
-     "duration": 0.001693,
-     "end_time": "2026-09-09T21:28:06.388350+00:00",
+     "duration": 0.001237,
+     "end_time": "2026-09-10T21:01:59.226537+00:00",
      "exception": false,
-     "start_time": "2026-09-09T21:28:06.386657+00:00",
+     "start_time": "2026-09-10T21:01:59.225300+00:00",
      "status": "completed"
     }
    },
@@ -827,19 +863,19 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "33a9f74f",
+   "id": "bc5f454e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T21:28:06.392607Z",
-     "iopub.status.busy": "2026-09-09T21:28:06.392400Z",
-     "iopub.status.idle": "2026-09-09T21:28:06.395547Z",
-     "shell.execute_reply": "2026-09-09T21:28:06.394891Z"
+     "iopub.execute_input": "2026-09-10T21:01:59.229842Z",
+     "iopub.status.busy": "2026-09-10T21:01:59.229748Z",
+     "iopub.status.idle": "2026-09-10T21:01:59.231772Z",
+     "shell.execute_reply": "2026-09-10T21:01:59.231369Z"
     },
     "papermill": {
-     "duration": 0.006382,
-     "end_time": "2026-09-09T21:28:06.396322+00:00",
+     "duration": 0.004262,
+     "end_time": "2026-09-10T21:01:59.232085+00:00",
      "exception": false,
-     "start_time": "2026-09-09T21:28:06.389940+00:00",
+     "start_time": "2026-09-10T21:01:59.227823+00:00",
      "status": "completed"
     }
    },
@@ -851,19 +887,19 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "852f3d55",
+   "id": "141d579d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T21:28:06.401146Z",
-     "iopub.status.busy": "2026-09-09T21:28:06.400981Z",
-     "iopub.status.idle": "2026-09-09T21:29:58.967013Z",
-     "shell.execute_reply": "2026-09-09T21:29:58.965920Z"
+     "iopub.execute_input": "2026-09-10T21:01:59.235339Z",
+     "iopub.status.busy": "2026-09-10T21:01:59.235246Z",
+     "iopub.status.idle": "2026-09-10T21:03:09.923301Z",
+     "shell.execute_reply": "2026-09-10T21:03:09.922442Z"
     },
     "papermill": {
-     "duration": 112.569597,
-     "end_time": "2026-09-09T21:29:58.968033+00:00",
+     "duration": 70.690679,
+     "end_time": "2026-09-10T21:03:09.924187+00:00",
      "exception": false,
-     "start_time": "2026-09-09T21:28:06.398436+00:00",
+     "start_time": "2026-09-10T21:01:59.233508+00:00",
      "status": "completed"
     }
    },
@@ -878,7 +914,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "5ffff2bacb274f16a5e13a206ee18d86",
+       "model_id": "6ce0a2b2c04e4afdb95acb3f14ead172",
        "version_major": 2,
        "version_minor": 0
       },
@@ -892,7 +928,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "896ec209f406410cb446d3c06a06bee6",
+       "model_id": "1c464221cc364672af91504b2c5b927f",
        "version_major": 2,
        "version_minor": 0
       },
@@ -906,7 +942,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "2d18d8cff8b14c2192ad64546c826e01",
+       "model_id": "98f501a4018346afa99d07111701ba14",
        "version_major": 2,
        "version_minor": 0
       },
@@ -935,14 +971,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'loss': 0.1859, 'grad_norm': 20.997940063476562, 'learning_rate': 3.6446886446886445e-05, 'epoch': 1.0}\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "{'eval_loss': 0.1439751833677292, 'eval_accuracy': 0.9529411764705882, 'eval_f1': 0.9268183846497099, 'eval_runtime': 0.3427, 'eval_samples_per_second': 991.994, 'eval_steps_per_second': 32.094, 'epoch': 1.0}\n"
+      "{'loss': 0.1859, 'grad_norm': 20.997940063476562, 'learning_rate': 3.6446886446886445e-05, 'epoch': 1.0}\n",
+      "{'eval_loss': 0.1439751833677292, 'eval_accuracy': 0.9529411764705882, 'eval_f1': 0.9268183846497099, 'eval_runtime': 0.1665, 'eval_samples_per_second': 2042.398, 'eval_steps_per_second': 66.078, 'epoch': 1.0}\n"
      ]
     },
     {
@@ -963,14 +993,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'loss': 0.0871, 'grad_norm': 5.250923156738281, 'learning_rate': 1.8315018315018315e-05, 'epoch': 2.0}\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "{'eval_loss': 0.12193191796541214, 'eval_accuracy': 0.9588235294117647, 'eval_f1': 0.9480815595024367, 'eval_runtime': 0.3057, 'eval_samples_per_second': 1112.34, 'eval_steps_per_second': 35.987, 'epoch': 2.0}\n"
+      "{'loss': 0.0871, 'grad_norm': 5.250923156738281, 'learning_rate': 1.8315018315018315e-05, 'epoch': 2.0}\n",
+      "{'eval_loss': 0.12193191796541214, 'eval_accuracy': 0.9588235294117647, 'eval_f1': 0.9480815595024367, 'eval_runtime': 0.1678, 'eval_samples_per_second': 2026.781, 'eval_steps_per_second': 65.572, 'epoch': 2.0}\n"
      ]
     },
     {
@@ -991,28 +1015,16 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'loss': 0.0248, 'grad_norm': 0.12807831168174744, 'learning_rate': 1.8315018315018315e-07, 'epoch': 3.0}\n"
+      "{'loss': 0.0248, 'grad_norm': 0.12807831168174744, 'learning_rate': 1.8315018315018315e-07, 'epoch': 3.0}\n",
+      "{'eval_loss': 0.07449578493833542, 'eval_accuracy': 0.9852941176470589, 'eval_f1': 0.9749612971712637, 'eval_runtime': 0.18, 'eval_samples_per_second': 1889.038, 'eval_steps_per_second': 61.116, 'epoch': 3.0}\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'eval_loss': 0.07449578493833542, 'eval_accuracy': 0.9852941176470589, 'eval_f1': 0.9749612971712637, 'eval_runtime': 0.3166, 'eval_samples_per_second': 1073.904, 'eval_steps_per_second': 34.744, 'epoch': 3.0}\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "{'train_runtime': 27.3573, 'train_samples_per_second': 173.702, 'train_steps_per_second': 10.856, 'train_loss': 0.2775794105096297, 'epoch': 3.0}\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "{'eval_loss': 0.12166436016559601, 'eval_accuracy': 0.9705882352941176, 'eval_f1': 0.9550596536507691, 'eval_runtime': 0.2844, 'eval_samples_per_second': 1195.415, 'eval_steps_per_second': 38.675, 'epoch': 3.0}\n"
+      "{'train_runtime': 18.1496, 'train_samples_per_second': 261.824, 'train_steps_per_second': 16.364, 'train_loss': 0.2775794105096297, 'epoch': 3.0}\n",
+      "{'eval_loss': 0.12166436016559601, 'eval_accuracy': 0.9705882352941176, 'eval_f1': 0.9550596536507691, 'eval_runtime': 0.1855, 'eval_samples_per_second': 1832.588, 'eval_steps_per_second': 59.29, 'epoch': 3.0}\n"
      ]
     },
     {
@@ -1025,7 +1037,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "9983648dd8ee4cb8936cbb616df79935",
+       "model_id": "2538acb6bddd466db9ede300d2a9d3ec",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1039,7 +1051,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "ff4a8db7bc9841ee8adc1d222f00ffa3",
+       "model_id": "ba9d337bce4343a1a5d09027657571e3",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1053,7 +1065,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "cc6139dcfa504b94a362328f270af45a",
+       "model_id": "6c3f5f2dc62d4be39bf582491bba07f2",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1082,14 +1094,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'loss': 0.4664, 'grad_norm': 12.67860221862793, 'learning_rate': 3.6446886446886445e-05, 'epoch': 1.0}\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "{'eval_loss': 0.30372530221939087, 'eval_accuracy': 0.8411764705882353, 'eval_f1': 0.5731024440040834, 'eval_runtime': 0.2483, 'eval_samples_per_second': 1369.496, 'eval_steps_per_second': 44.307, 'epoch': 1.0}\n"
+      "{'loss': 0.4664, 'grad_norm': 12.67860221862793, 'learning_rate': 3.6446886446886445e-05, 'epoch': 1.0}\n",
+      "{'eval_loss': 0.30372530221939087, 'eval_accuracy': 0.8411764705882353, 'eval_f1': 0.5731024440040834, 'eval_runtime': 0.1627, 'eval_samples_per_second': 2090.276, 'eval_steps_per_second': 67.627, 'epoch': 1.0}\n"
      ]
     },
     {
@@ -1110,14 +1116,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'loss': 0.1409, 'grad_norm': 0.33492574095726013, 'learning_rate': 1.8315018315018315e-05, 'epoch': 2.0}\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "{'eval_loss': 0.10770367085933685, 'eval_accuracy': 0.9676470588235294, 'eval_f1': 0.95728117986791, 'eval_runtime': 0.342, 'eval_samples_per_second': 994.115, 'eval_steps_per_second': 32.163, 'epoch': 2.0}\n"
+      "{'loss': 0.1409, 'grad_norm': 0.33492574095726013, 'learning_rate': 1.8315018315018315e-05, 'epoch': 2.0}\n",
+      "{'eval_loss': 0.10770367085933685, 'eval_accuracy': 0.9676470588235294, 'eval_f1': 0.95728117986791, 'eval_runtime': 0.1429, 'eval_samples_per_second': 2380.057, 'eval_steps_per_second': 77.002, 'epoch': 2.0}\n"
      ]
     },
     {
@@ -1138,28 +1138,16 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'loss': 0.0462, 'grad_norm': 0.25122660398483276, 'learning_rate': 1.8315018315018315e-07, 'epoch': 3.0}\n"
+      "{'loss': 0.0462, 'grad_norm': 0.25122660398483276, 'learning_rate': 1.8315018315018315e-07, 'epoch': 3.0}\n",
+      "{'eval_loss': 0.08874943852424622, 'eval_accuracy': 0.9764705882352941, 'eval_f1': 0.9572292009652467, 'eval_runtime': 0.1426, 'eval_samples_per_second': 2383.458, 'eval_steps_per_second': 77.112, 'epoch': 3.0}\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'eval_loss': 0.08874943852424622, 'eval_accuracy': 0.9764705882352941, 'eval_f1': 0.9572292009652467, 'eval_runtime': 0.2982, 'eval_samples_per_second': 1140.312, 'eval_steps_per_second': 36.892, 'epoch': 3.0}\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "{'train_runtime': 31.8734, 'train_samples_per_second': 149.09, 'train_steps_per_second': 9.318, 'train_loss': 0.3111513519929314, 'epoch': 3.0}\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "{'eval_loss': 0.22998805344104767, 'eval_accuracy': 0.9441176470588235, 'eval_f1': 0.9323938475285921, 'eval_runtime': 0.335, 'eval_samples_per_second': 1014.868, 'eval_steps_per_second': 32.834, 'epoch': 3.0}\n"
+      "{'train_runtime': 21.0992, 'train_samples_per_second': 225.221, 'train_steps_per_second': 14.076, 'train_loss': 0.3111513519929314, 'epoch': 3.0}\n",
+      "{'eval_loss': 0.22998805344104767, 'eval_accuracy': 0.9441176470588235, 'eval_f1': 0.9323938475285921, 'eval_runtime': 0.1474, 'eval_samples_per_second': 2306.945, 'eval_steps_per_second': 74.636, 'epoch': 3.0}\n"
      ]
     },
     {
@@ -1172,7 +1160,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "5b729d847f5049afa664a7f967f6563a",
+       "model_id": "ef25279ae93446cca323aca03bf0d637",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1186,7 +1174,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "2dd67e74752f45d9a8403238e43be181",
+       "model_id": "f36cfe70ee5144799aaaf0e5165faff9",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1200,7 +1188,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "3150b47912df4279948ba3acb948d481",
+       "model_id": "bcc8b90b59ad4cc19b2f62120a49ab8c",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1236,7 +1224,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'eval_loss': 0.14586132764816284, 'eval_accuracy': 0.9529411764705882, 'eval_f1': 0.9437384465630204, 'eval_runtime': 0.4588, 'eval_samples_per_second': 741.064, 'eval_steps_per_second': 23.976, 'epoch': 1.0}\n"
+      "{'eval_loss': 0.14586132764816284, 'eval_accuracy': 0.9529411764705882, 'eval_f1': 0.9437384465630204, 'eval_runtime': 0.2486, 'eval_samples_per_second': 1367.597, 'eval_steps_per_second': 44.246, 'epoch': 1.0}\n"
      ]
     },
     {
@@ -1264,7 +1252,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'eval_loss': 0.19364973902702332, 'eval_accuracy': 0.9676470588235294, 'eval_f1': 0.9530266343825665, 'eval_runtime': 0.5173, 'eval_samples_per_second': 657.281, 'eval_steps_per_second': 21.265, 'epoch': 2.0}\n"
+      "{'eval_loss': 0.19364973902702332, 'eval_accuracy': 0.9676470588235294, 'eval_f1': 0.9530266343825665, 'eval_runtime': 0.2423, 'eval_samples_per_second': 1403.038, 'eval_steps_per_second': 45.392, 'epoch': 2.0}\n"
      ]
     },
     {
@@ -1292,21 +1280,21 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'eval_loss': 0.1012372151017189, 'eval_accuracy': 0.9794117647058823, 'eval_f1': 0.9692561720946445, 'eval_runtime': 0.4582, 'eval_samples_per_second': 741.989, 'eval_steps_per_second': 24.006, 'epoch': 3.0}\n"
+      "{'eval_loss': 0.1012372151017189, 'eval_accuracy': 0.9794117647058823, 'eval_f1': 0.9692561720946445, 'eval_runtime': 0.2473, 'eval_samples_per_second': 1374.879, 'eval_steps_per_second': 44.481, 'epoch': 3.0}\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'train_runtime': 44.3239, 'train_samples_per_second': 107.211, 'train_steps_per_second': 6.701, 'train_loss': 0.19385443572644834, 'epoch': 3.0}\n"
+      "{'train_runtime': 24.8208, 'train_samples_per_second': 191.452, 'train_steps_per_second': 11.966, 'train_loss': 0.19385443572644834, 'epoch': 3.0}\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'eval_loss': 0.15171849727630615, 'eval_accuracy': 0.9647058823529412, 'eval_f1': 0.9617135876506192, 'eval_runtime': 0.4586, 'eval_samples_per_second': 741.399, 'eval_steps_per_second': 23.986, 'epoch': 3.0}\n"
+      "{'eval_loss': 0.15171849727630615, 'eval_accuracy': 0.9647058823529412, 'eval_f1': 0.9617135876506192, 'eval_runtime': 0.2531, 'eval_samples_per_second': 1343.156, 'eval_steps_per_second': 43.455, 'epoch': 3.0}\n"
      ]
     }
    ],
@@ -1316,13 +1304,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f118bc58",
+   "id": "41c6cdb3",
    "metadata": {
     "papermill": {
-     "duration": 0.481989,
-     "end_time": "2026-09-09T21:29:59.454755+00:00",
+     "duration": 0.001925,
+     "end_time": "2026-09-10T21:03:09.928913+00:00",
      "exception": false,
-     "start_time": "2026-09-09T21:29:58.972766+00:00",
+     "start_time": "2026-09-10T21:03:09.926988+00:00",
      "status": "completed"
     }
    },
@@ -1337,19 +1325,19 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "65a2f9d2",
+   "id": "d4051f84",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T21:29:59.464452Z",
-     "iopub.status.busy": "2026-09-09T21:29:59.463760Z",
-     "iopub.status.idle": "2026-09-09T21:29:59.469583Z",
-     "shell.execute_reply": "2026-09-09T21:29:59.469042Z"
+     "iopub.execute_input": "2026-09-10T21:03:09.934418Z",
+     "iopub.status.busy": "2026-09-10T21:03:09.933782Z",
+     "iopub.status.idle": "2026-09-10T21:03:09.939203Z",
+     "shell.execute_reply": "2026-09-10T21:03:09.938806Z"
     },
     "papermill": {
-     "duration": 0.011639,
-     "end_time": "2026-09-09T21:29:59.470195+00:00",
+     "duration": 0.008636,
+     "end_time": "2026-09-10T21:03:09.939479+00:00",
      "exception": false,
-     "start_time": "2026-09-09T21:29:59.458556+00:00",
+     "start_time": "2026-09-10T21:03:09.930843+00:00",
      "status": "completed"
     }
    },
@@ -1364,7 +1352,7 @@
        "  white-space: pre-wrap;\n",
        "}\n",
        "</style>\n",
-       "<small>shape: (3, 6)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>Model</th><th>Accuracy</th><th>F1 (macro)</th><th>Parameters</th><th>Train Time</th><th>Test split held out?</th></tr><tr><td>str</td><td>str</td><td>str</td><td>str</td><td>str</td><td>str</td></tr></thead><tbody><tr><td>&quot;FinBERT&quot;</td><td>&quot;97.1%&quot;</td><td>&quot;0.955&quot;</td><td>&quot;109.5M&quot;</td><td>&quot;28s&quot;</td><td>&quot;no, checkpoint saw it&quot;</td></tr><tr><td>&quot;DeBERTa-v3&quot;</td><td>&quot;94.4%&quot;</td><td>&quot;0.932&quot;</td><td>&quot;141.8M&quot;</td><td>&quot;32s&quot;</td><td>&quot;yes&quot;</td></tr><tr><td>&quot;ModernBERT&quot;</td><td>&quot;96.5%&quot;</td><td>&quot;0.962&quot;</td><td>&quot;149.6M&quot;</td><td>&quot;45s&quot;</td><td>&quot;yes&quot;</td></tr></tbody></table></div>"
+       "<small>shape: (3, 6)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>Model</th><th>Accuracy</th><th>F1 (macro)</th><th>Parameters</th><th>Train Time</th><th>Test split held out?</th></tr><tr><td>str</td><td>str</td><td>str</td><td>str</td><td>str</td><td>str</td></tr></thead><tbody><tr><td>&quot;FinBERT&quot;</td><td>&quot;97.1%&quot;</td><td>&quot;0.955&quot;</td><td>&quot;109.5M&quot;</td><td>&quot;19s&quot;</td><td>&quot;no, checkpoint saw it&quot;</td></tr><tr><td>&quot;DeBERTa-v3&quot;</td><td>&quot;94.4%&quot;</td><td>&quot;0.932&quot;</td><td>&quot;141.8M&quot;</td><td>&quot;22s&quot;</td><td>&quot;yes&quot;</td></tr><tr><td>&quot;ModernBERT&quot;</td><td>&quot;96.5%&quot;</td><td>&quot;0.962&quot;</td><td>&quot;149.6M&quot;</td><td>&quot;25s&quot;</td><td>&quot;yes&quot;</td></tr></tbody></table></div>"
       ],
       "text/plain": [
        "shape: (3, 6)\n",
@@ -1373,9 +1361,9 @@
        "│ ---        ┆ ---      ┆ ---        ┆ ---        ┆ ---        ┆ ---                   │\n",
        "│ str        ┆ str      ┆ str        ┆ str        ┆ str        ┆ str                   │\n",
        "╞════════════╪══════════╪════════════╪════════════╪════════════╪═══════════════════════╡\n",
-       "│ FinBERT    ┆ 97.1%    ┆ 0.955      ┆ 109.5M     ┆ 28s        ┆ no, checkpoint saw it │\n",
-       "│ DeBERTa-v3 ┆ 94.4%    ┆ 0.932      ┆ 141.8M     ┆ 32s        ┆ yes                   │\n",
-       "│ ModernBERT ┆ 96.5%    ┆ 0.962      ┆ 149.6M     ┆ 45s        ┆ yes                   │\n",
+       "│ FinBERT    ┆ 97.1%    ┆ 0.955      ┆ 109.5M     ┆ 19s        ┆ no, checkpoint saw it │\n",
+       "│ DeBERTa-v3 ┆ 94.4%    ┆ 0.932      ┆ 141.8M     ┆ 22s        ┆ yes                   │\n",
+       "│ ModernBERT ┆ 96.5%    ┆ 0.962      ┆ 149.6M     ┆ 25s        ┆ yes                   │\n",
        "└────────────┴──────────┴────────────┴────────────┴────────────┴───────────────────────┘"
       ]
      },
@@ -1404,13 +1392,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "39e66f89",
+   "id": "d3a85523",
    "metadata": {
     "papermill": {
-     "duration": 0.004581,
-     "end_time": "2026-09-09T21:29:59.479612+00:00",
+     "duration": 0.002718,
+     "end_time": "2026-09-10T21:03:09.945293+00:00",
      "exception": false,
-     "start_time": "2026-09-09T21:29:59.475031+00:00",
+     "start_time": "2026-09-10T21:03:09.942575+00:00",
      "status": "completed"
     }
    },
@@ -1425,26 +1413,26 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "id": "6a242ffe",
+   "id": "d8ee9fc0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T21:29:59.489572Z",
-     "iopub.status.busy": "2026-09-09T21:29:59.489435Z",
-     "iopub.status.idle": "2026-09-09T21:29:59.739963Z",
-     "shell.execute_reply": "2026-09-09T21:29:59.739370Z"
+     "iopub.execute_input": "2026-09-10T21:03:09.950689Z",
+     "iopub.status.busy": "2026-09-10T21:03:09.950474Z",
+     "iopub.status.idle": "2026-09-10T21:03:10.072772Z",
+     "shell.execute_reply": "2026-09-10T21:03:10.072179Z"
     },
     "papermill": {
-     "duration": 0.256773,
-     "end_time": "2026-09-09T21:29:59.741065+00:00",
+     "duration": 0.125967,
+     "end_time": "2026-09-10T21:03:10.073338+00:00",
      "exception": false,
-     "start_time": "2026-09-09T21:29:59.484292+00:00",
+     "start_time": "2026-09-10T21:03:09.947371+00:00",
      "status": "completed"
     }
    },
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAkgAAAFBCAYAAACM+VD6AAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjksIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvJkbTWQAAAAlwSFlzAAAPYQAAD2EBqD+naQAARilJREFUeJzt3Xd0FFUfxvHvphESAgkQCBBC6EUiTXoTMCC9SJPeRKo0ERBQkSIKiCBFlCJNpHdRUJAiRXpHegkklDQgkL7vH4F9YVNoSTYJz+ccj+zM7Mxv7+7cPHtndsYQHh5mRERERERMrCxdgIiIiEhKo4AkIiIiYkYBSURERMSMApKIiIiIGQUkeWUTp81n8syFli7DInoNHsOvq363dBnxet73ZuPmHXTo+WkyVJS2hYdH0KHnp/x37pKlS3mmPkPG8c++w5YuI5aKddpx9sIV4NU+l0+u52XNXriSIV9MfuHn3fYPpM0HQ7jtH/hK20/I6ImzUnS/u3j5xudqu0NHT+HdrHsyVPTibCxdwIsYP2UOm7fuBuBhaBh2trZYW8dkvLWLp+KUwfGF17lx8w4OHTvNyI8/TNRaJeU7dPQUvT8ZR3r7dE9N37R8JtHR0fw4fwV/bt9HsUL5+PqLARaqUlKiXoPHcPzUOWxt/t+Ftm5Wl+4dm7Ng5rgk2WZi91XTvlYgTiyzF64EoFv79wBwzeLCLz99bcmSJBGkqoA0tF9XhvbrCkDTDv3p36Md1Su9ZeGqJDXL4OjAllU/xpr+4GEouXPloFD+PBaoSlKD3l3fp3Wzdy1dhogkkVQVkJ7FaDSyYt0Wfl21idCwcOq+U4WenVthbW3Fzj0HmfrjLwQF3+ONIvn55KPObN62hzmLVmGMNrJt57/06tqa5o28Teu7H/KA+UvWsXPvIfwDgihb6g2GD+qOo0N6AP49dIIf5i3lqo8f+Tzd+XTAB3h65CQgMJgpsxbz76HjpLe3p32rBjStX4vRE2eRwdGBAT3bA7B87Wa27fqXGRNGADFDwrO+/YyJ036mcMG8DO7TiSWrNvHn33vxvXmbooXy8fknPciaxQWA/85dYsqPizl34So5smfl4z6d2HPgKDd8bzNqaC/T62jbfSh9PnifimVLmKZdu+7HnEWrOHriPx6GhtGswTt079gciPk29OBhGDbWVvyxdTc2NtZ8NrgHJYoXBsDX7zZfT53LyTMXKJDPA1sbG/LmyRXr/di4eQd7Dxwjv2duVm/8i0yZnPj8kx4cPnaGX1dtIjIyik8HdKNcGS8A/tqxj2Vr/uDSFR+yZHZmWP9uvPlGIYB423T2wpWER0QSFhbGH1t3M2fql2TN4syP81ewedseAOrUrMQHHd4jnZ3dc3+WHNLb06xBLQICgzh34WqCy1674ceA4d9w8sx5CubLw4hB3cnmmoX3Og546vWdPnuRwZ9PYu2i700jnxAT9gf2bM/S1X9w4fI16nlXpWXjOnzz/VyOnzpH2VLFGTW0FzaPRis2/LGdBUvXExR8j7dKFmNArw64PvpMPOu9OXjkFFN/Woyv321KvVmUYf274ZzJ6bnbRZ7t3RY9GDfiI0qXKPZc+9KEaT9z4vQ53HNmZ0i/rhQu4BlrnT8vWRurr6pcriTNOg5g88pZptHzF9l25z4jad7Im/q1q5n21SIF87J641+EhoUxqFdHalQtB8T0F19Pifk8hkdEYGNjTY7sriybO9FU4/AxU8mVMzu9urQCoHmngRQvWoAvhsT0RYNGTqRKhVI0qVeT1Rv+YsPm7Vz18cPDPQefDe6Bp0fOl2rvLX/v4edf1nLrTgBvFMnPyI8/JEtm51jLJbTfxNe/PCk0LJweA7+kTs1KvP9ePdP08VPmsOH37RisDPyy4jdGDetNmRLFqNWkG6vmTyaHmyujJ84ib55cXLzsw579Rx/15T35acFKtu7Yh1v2rIwd8RE5smcFnn8/DQgMZsTY7/n30Aly5cjGsAHdKJQ/Dz0Gfkndd6rSuF4N03JNO/Rnw5JpTx1p6TV4DPW9q7H9nwMcO3WWimVL0L9HOyZNX8C+g8cpXMCTsSP6mp7zz77D/DBvOX637lCscD4G9Oxget+Cgu8xcdrP/HvoBDndXMnp5vpUrecuXGHS9PlcuOxD4QKefDqwGzndsr3o252s0tQ5SJu37WHZmj+YOn4Yy+ZM4Oz5K2zeFnNIbtzk2bRv1ZBNy2bQoXUjMmV0otP7jenYuhF1alVm69o5T4UjACsrK7JkdmbGxOGsWjCZy1dvsGbjVgDOX7zKJ198S7uWDfl9+Ux6dmlF1izOREVFM2TUd1hZGVg2dyI/Tv6MQvk9n/s1fP/TL3z9+QCG9e+KtbU1dna2TPhyIBt+nY4RIz8vWQfAHf9A+g79ihpVyrHx1+kMH9Sd7K5ZqO9djV17D/EwNBSI6dhu+wdSttQbT20nNDSMKuVLs/jHr/lh0kgW/LqO02cvmuav/W0rBfJ5sHzeJMqWKs7MuUsBHr2+yeTI7sq6X6YytF8XAoPuxvt6/v5nPxkyOLBs3kTyuOeg56Ax3A95wKJZ4/F+uyJTf/rFtGxYWDgDe3Xgt6UzeLtKWb6eMveJbcbfpqs3/EV216xsWDKNnG6uzJq3nOOnzvHztNH8PG00x0+d48f5K577PXhRJ06fo88H77N28VSyuWZm/JQ5WFtbUb92NdPnD2DH7oPUrFr+qXD02Pxf1/HpwG7MmDCCX1b8xsivptGnWxuW/PQNew8cY9femHNFdu49xIw5S/lyWG/WLZ6Ka1YXho76jqio6Ge+Nz43bjL0y+/o3fV9fls6g3x53Jk+59ckaxeJEd++FBERyaCRE3nzjUL8tnQGH3RozmdfTSMqKjrWOp7VV73otuPy9z/7sbGxZtGs8bzX0Jvvflhkmjdm0o94uOdgw6/T+KDDe3gVK/hUOAIoW7o4R46fAeDWbX/s7dNx5Ph/GI1GoqKiOXbyLG+VfAODwYARI59/0pNNy2aSN08uvn+iH3gRe/Yf5Zup8xjQqz2bls3g/ffqkSljhljLPXu/SbjPNhqNTJo+Hw/3HLRuVvepeUP7daVOrcp0bN2IrWvnULVC6ThrXbJyE/W9q7Fi3iSu+vjSqfdwyr/lxepF32Fra8OSlb8BL7afnjxzgRZN6rB+yfeULV2ckeOmER0dTYM61Z/qe3btPUS50sXjPA1l/q/r+KDDeyyeNZ4duw/Sc9AY3mvkzar533LD7xYb/tgOwH/nL/PZV9Pp88H7bPx1OmVLF2fA8K9Nf2vGTPqRsPBwVs7/lm9GDeTu/RDTNu7eC6Hfp1/TuF5NNi2fyTtvV2Dc5NlxvqaUJE0FpFUb/qR9ywbkypENR0cHmtavyZ79RwHI5pqZ/85fJjQsnNJvFjWNAiXEIb09rZu9SzpbWy5e9iFrFhf+O38ZgDW/baNGlbLUrFoOGxsbSnkVIYOjA2cvXObshct83KcTThkcyZrFhTeK5H/u19ClbVNyuLliZWWFtbUV7zeri3NGJy5cukrWzM6m7f+xdTf58rjTonFt7OxsKVzAk+zZsuCeMztFCuZlx+5DAOzcc4i3q7xlGn14rGD+PLzzdgUePHiI3y1/XFwymdYNUKZEMWrXqISdnS0V3nqTqz5+AJw5d5Fr12/S78O2pLe3J0/unBQtnDfe1+OZOxfNG3mTzs6OimVL4OhgT6f3G2Ofzo5K5Uty5doN07L1vKtSIK8HV3x8cUyfnotXfAgPj3hmm3q45+D99+piY2OD0WhkzW9b6dWlFVkyO5MlszO9urZmzcatGI2xLxp/P+QB3s26m/5b/6gzeBF1a1Ulv2du0tvb06FVI/YfPklERCT1a1dl++6DhIaFA7Bjz0FqVSsf5zratWxATrds5M2Ti5xurjR6923y5slFlszOFC2Uj8uP2mnNxr9o3tibIgXzYm+fjl5dW3P56nXOXrj8zPdm4+YdVC5fknKli2NjY0PrZu+y99H+IS9u5rylps9Nyy4fx7tcfPvS4eNnuP/gAR1bN8LGxoaKZUtgY2PDdd+biVZjfNuOi2fuXLRq+m7Mvlm2BLfuBBAaGgbA+UtXqeddFacMjjR6923OnI19EnrZUsU5ffYioaFhHD5+hrdKvoFDent8btzkwuVrZHBMj3vO7AC819CbnG7ZuHjFh4xOjpx9ou95ESvWbaF5Y2/eKvkGNjY2lC/jFauvg4T3m+fps9du2saJ0+cYNqArBoPhpWp9p3p5ypQshqOjAyW9ilDqzaJUrVCadHZ2lCvtZeoLX2Q/rVqxNCXeKEQ6Ozs6vd+Yqz6+XPe9Rc1q5fnv/GVu3fYHYMeeQ/H2PU0b1KJg/jymvqZG1XKUeKOQqc4r13wBWPf739SsVp7yZbyws7OlbfP62Nrasmf/MQICg/ln32EG9uqIUwZHsmXNTJkSxUzb+HvXv+TO5Ubdd6pgY21N47o1+O/cZcLCw1+qLZNLmjrEdsP3Ft/9sIjvf1oCQHR0NCW9YoaTJ4/9hEXLNvL+B0Oo904VurRr+sxDLmHh4UyaPp/9h07gVaxgzLRHf+xu+N0yHf550nXfW2R3zfJcASwuTw4NR0dH88O8ZWz5ew+F8ntibW1FWFiYafueHrEPawE0fLc6m7f9Q52aldi55yCd2jSJtYyv323GfvsTt/0DKVOiGOnsbAkN/f+H9clOIKOTIxGRkY+ed4dsrpmxNzuxOT5P9iUZnTI8NSGjkyORkVGmx39s/YfZC1fhmtWFAnk9gJj34FltmjWzs6neoLv3eBgaZuqIAXLnys6Dh6EEBd/DxTnjU8+N7xykl+WcyQmj0ci9kBByumWjSMG8/LPvMEUK5uXuvRDT58jc0+2dIVb7Rz5q/xt+t6lTs7JpXjo7O7K5ZuaG322M0cYE35vrvrfY/s8B/tkX84sRo9EYZ2iU59Ozc6vnOgcpvn3pht8tAgKCqf3e/0+6Do+IIPjufb74egY7dh8EoG2LBnRt1/Slaoxv23EvyxPLxozCRERGYk86ypf2Yt3v28idKzurNvxFscKxv/TlypGN7K5ZOHHmPIePnaFMyWKEPHjI4WOneRgaRplHo0cAS1ZtYvmazXi4u5E1i4vpS0RC9uw/yvAxUwHImsWFZXMncsPvFrVrVHrmcxPcb4zGBPuXi1d8OHX2ItHR0YSGhpPe3v6Z24vb0/t48N17Tzz+/3vzsvupQ3p77NOl4+69EHLncqNmtXJs/nsP7zV8h2Mn/2PUkJ7xVPX0Z8T8c/C4Tl+/26bDsxDz2XLPmZ0bfrfI7poZO1tb3LJliXMb131vceq/C0/9Wi08PIK790LiXD6lSFMByS27K80a1KLuO1VizcvsnImPureh0/uNGfLFtyxZsYlObRpjMBiIjo77w/frqt+5es2X5fMmYWNjw+yFK03no7hly4rP9djfxnJkz8rtO4GEhobF+kNla2Pz1AcirqH0J/25fS/bdu1n8Y9f45Deno2bd7B09e+m7e89cCzO571duSxTZi3muu8trl73o0yJorGW+XrqXIoVyW86X6DX4DEJ1vJY5syZ8A8IIjIyMs5vai/r1p0AvpzwA4tnjcfTIxe+frdZvnYzkHCbmnPO6ER6+3Rc971lOlfL5/pNHNLbJ8u5Nld9fHFIb49Lppgg1qBOdf7avpeAwGBqVi2HldWrDdrmdHPluu8t0+Ow8HBu3Qkgp5srD0PDEnxvcmTPSu2alRg+8INXqkESR47srrhlz8ryeZNijUrEFaTN+yob25j3+O69EJwyOGI0GomOTrhPeVmVy5fi5yVradN9KHk9cjG0f9c4lytbqjgnTp3n6Mn/6NKuKWFh4Rw8eprIyEiqVCgFwPFT55i7aDVL50wgs0smDh09xfZ/DjyzhoplS7B17Zynprlly4rPjfhHxR5LaL+Jjo5OsH/xvXmHqeOHsnPPQabPXsKIOH5FaIB4/468qJfdT2/d9ic0LIxcOWLO62lQuzqTZy4kT+6clPIqiqOjw6vV5eb61Oim0Wjkuu9NGtSpTmYXZ8IjIuL8Evr4uSWKF47zl5PXfHxfqa6klKYOsTWtX5OfFqzk7IUrREREcujoKe74B3LHP5BfVvxG8N37GI1GrKysCIuI+caS2SUT/527xP2QB4SHRzy1vuDge0RFG4mIjOT8xats/+egaV6DOtXYsn0vO3YfJDIykqMnz3L+0jUKF8xLbnc3Js1YQEjIAwICg9m2818A3HNl58iJMwQG3eXQsdMsX/tHgq8n+O59IiMjiYyM4rrvLTb9ucs0z7tGRU6fvcia37YSERHJ+UvXOHriPwDs7dNRo0o5Jnw/j6oVS8f5xzIo+B4RERGEh0ewc+8hzl9M+ETkx94okh8HB3t+XrKW8PAIjp08G29QexF374UQHW0kNCyce/dD+HX1/68tlFCbmrOysqJJvZrMmLuUgMBgAoKCmTl3KY3r1XzpofFn2X/4OP4BQQQG3WXm3KU0qFPdtK3qld/i+Onz/LV9L+9Ur/DK22pSrybL1242HS6eOXcZedxzUii/5zPfm/q1q7F15z7+3rWfyKgozl+8arpOjJ2dLWHhERpRSkalvIpgbW3NrJ+XExoaxs1b/hw4cjLe5c37KhfnjDg42LNjz0ECgoKZOH0+YWER8T7/VSxfu5ne3VqzYck0pn3z6VMjtE8qW7o4B46cJDIyimxZM1OieGFOnjnP6bMXTYdcgu7eIzIyioiISAICg1n96LzOx+xsbU198bM+l43r1mDZms0cPfEfkZGR/LPvMLfuBMRaT0L7zbP6lwpvvUnpN4vSpW1Tdu8/ajrP6kmZMztz4vR5QkPDYv0deVEJ7afmjp86h8+Nm4Q8eMiUWYupVrGM6YugV7GCPAwNY+W6LdSqHvfhtRfR6N23+Wv7PvYfPkFERCRLVm4iPDyCimXfxC1bFooWysvMeUsJDQ3j4mUf/vx7r+m5b1cuy8VLPqxcv4WIiEiuXffj+KlzANjZ2RERGfnMAQNLSFMBqe47VWjboh7Dx0zl3ZY9mDV/Bf4BQWRwdOBOQBCd+oygeaeBZHTKQNvm9QGoVa0CGZ0cadahP8vMAkuLxrWJjIykcduPmLt4NXVq/n8ot1jh/Hw5rDez5i/n3RY9+WHeMjAasbG2ZsIXAwkOvkfTDgPoPmAU/oHBADSsU50c2bPSssvHrFr/Jz0fjd7E591alcmVIzvNOvRnwvfzqF2jommeW7asTB77Ces2/U3dlj0ZO+lHoqL+f7iqQZ1q7Dt4PN7jzj06t2Trjn95r9NADh87Q+XypZ6rjdPZ2TH+s/7s2nuYBu/35tdVm+LdxovI7+lO80be9B48lj5DxlG6RFHsbG0BEmzTuHzYuQVvFClAh16f0qHnpxQtnJ8POzV/oXp+nL+Cmo27Mv/Xdezad4iajbsyZ9HqOJctXCAvg0ZOpHW3T8iTOyc9O7c0zbNPZ0e1SmXwu+X/QueixadqxTL07NKKEWO/p1GbPvjdusP4z/tjbW31zPfGwz0HE74YyIKl66jz3oeMGDeNy1evA1DSqwhgZOX6P1+5Rnk+dna2TB47mAuXr9GobV+6DxjFvgPH4w0D5n2VjbU1/Xu0Z/6StfQcNIZSXkUoFMcv4BJD5fKlGPX1D9Rs3I1aTbrRovMgVm/8K9ZyZUoU4/Dx05R4dPqBe87sPHj4EDtbW9OIboUyb1KxXAnadB/CsNFTeLtK2afW0aBONb77IeYCiM/6XFav/BY9u7RkzKQfqdeqF6s2/GX6Q/vkehLab57Vv1g/GvV1yuBIj84tmfD9z6ZD3o81rVeTwKC7NGnfj2279r9o8z4lof3UnFexAoz99ieatu+H0Whk2IBupnkGg4EGdapx+Pjz9+8JKVzAk1FDe/PdD4uo27Ine/YfZfLYIaS3t8dgMDBqaG+uXb9JwzZ9mTJrEe+8/f8vhM6ZnJjy1RD+2rGPui170v/Trzl55gIAhfLnIa9HLmbMTXk/GDGEh4fpK2MadPGyD/0+/ZrVC7/Dxtra0uW81r7/6ResDFb07tba0qWIvLD7IQ/4cOCX/DBpJE4ZHImIiGT9738zY+5S/lz9k6XLkwSsWLeFI8fPMGZ4X0uXkiqlqREkiTmxO/juPab+uJiu7ZoqHFlQdHQ0J89cYPPW3bRpXu/ZTxBJge74B+IfEMTFK9cJD4/ght8tTpw5T4nisX+kIilDdHQ0V67dYPGKjXRt18zS5aRaaeokbYF9B48zctw0qlUqQ4Pa1Sxdzmtt9MQfOXDkJP16tIvzxEWR1CBP7px0er8JX34zkzsBQbhkykiVCqXp36O9pUuTePy0YCVrfttKp/cbx3kRX3k+OsQmIiIiYkaH2ERERETMKCCJiIiImFFAEhERETGTagKS0WgkMjJSF7ITEYtRPyTy+kg1ASkqKoqq9Ts9dTFEEZHkpH5IJH4Llq6j1+AxbN99gGYdBtBr8Bg+fXT/vNRIP/MXERGRV3LD7xbnL14zPW7RpDbvN6trwYpeXaoZQRIREZGUx2g0MmPOUnp0bmGalsHs5rhrf9tGj4Ff0nvwWEJCHiR3iS9FI0giIiLy0v7etZ+ihfKR0y2badr63/9m9YY/qVWtAm1b1OfP7XsZPbwvLpmc4ryBekqUOqoUERGRFGnbrv1ERkYyctw0Ll+5QUBgMBNGDcLGxpoufUfyTvUKfPJRZ37+ZQ2ZXTLRsXWjVBGSUn6FIiIikmJ9Oay36d+9Bo+hlFdRMjo5Eh1txMbGBmtrKzLYOTC4b2e+mTqPvQeOU6VCKQtW/HwUkERERCTRHDp6iu9+WMjN2/40evdtnDM58c3387jhe5v06dNRukRRS5f4XBSQREREJFHMmDACgGYN33lq+qcDPrBEOa9Ev2ITERERMaMRJJFE4OxeIlHXF+RzNMH54eERNG73EV8O603ZUsUTddsiIqIRJJFU6dCx07xbqzI79xyydCkiImmSApJIKrRzz0GaN6rNuQtXMBqN/Pn3Xrr0/YwufT/j8tXr3LsfwpBRk+k+YBSTZy4EoG33oQAEBd+j1+AxAPT/9GvmLFrN2G9/4tp1P/oO+Yr2PT5l6qzFAERGRjJ64iy6DxjFiLHfs2P3QeYsWg3Atet+fDnhBwu8ehGRpKdDbCKpjNFo5PLVG+TKkY08uXNy9vxlZs5byuJZ47GxtcHKYOCHecso6VWE95vVJSIiMt51hUdE4OmRk67tmhIWHs5Xn/XDIb093fp9Tnh4BBs27yCDY3p+nPw5ERGRGAywZNUmurRtwo7dB6lVrXwyvnIRkeSjgCSSypw5d4lbdwIYOW4at+8EsGvfYYoWyoe9fTrTMucvXeMj76oA2NomvJuXKVEMgIDAu/yyYiN2draEPAjFPyCIC5euUqVC6afWU6xwPs6cu8SRE2do2aROUrxEEUkknmWaWroEi7p8cPVLP1cBSSSV2bHnIIN6d6TCW2/y4GEoHXp+itFoJCw8HCuDFVHR0eTJnYP9h0/i6ZGL+yEPyODogNFoxGg0cu26X5zrXb7mD8qXeZMKZd/k2MmzAOTJnZP9h05QsWwJ03oa1qnOkpWbcHHO+MzwJSKSWql3E0kEz/rVWWLaf+gEHVs3BsAhvT3ZXbNQukRRegwcjZWVFQN7daBj68Z8OeEHNm/bQ948Ofl0wAdULl+KD/p/QZUKpbGztY213qqVyjB11mK2/L0H+3Qxo1GN6tZgzKNzkJwzOjFu5Ed4euTi0tXrdG7TJNles4hIcjOEh4cZLV3E84iMjKRq/U7s3PhzqriHi0haFRUVzaCRE5gwatBrN4KkfkhSGx1ie/lDbPoVm4g8t2vX/egzZBxNG9R67cKRiLxe1MOJyHPLncuNmRNHWLoMEZEkpxEkERERETMKSCIiIiJmFJBEREREzCggibwGfP1uExkVlWzb87lxM9m2JSKSFHSStkgiOLuqWaKur1CzVfHO8/W7Tac+I8mf1x2A6pXeop531Zgra/sHsnjW+FjPmfvLGob175qoNSbkj627qfdOFXK4uSbbNkVEEpNGkERSoeJFCzBjwghmTBhBq6bvkj69PUM+6gJxXNXs4mUfcufKjpVV8u3uDWpXY/VvW5NteyIiiU0jSCJpgI21dbyjNcdPnaNMiTcA6DdsPMWLFmTXvkO8Xbks9+6F8M+/R+jcpjHv1qrCzr2HWLh0PUHB9+jesTnvVK+A3607fDV5Ng8ehlK98lvUqlqeabOXEB4RQe0alfDI5cbkmQuJio6meuW3aNeiAdmzZSE4+F5yNoGISKJSQBJJhU6cPk+vwWMA+GJIL7JlzRzvstd9b1K1UswNZyMiI6lYtgQdWjekXqteLJ41nhaNazN+yhzerVWFN4sVYsaE4QQF3+PLCbN4p3oFps/+laYNavF25bJERERyxz+QYyfPsmT2N2RwdKBL38/4bHAPPNzd6DFoNJXLlSJvnlxERUcnS1uIiCQFBSSRVKh40QJMGv3xcy0b8jCU9PbpTI/dc2YnnZ0d2bNmwS1bVoxGI3f8gwA4d/EKO/ccxD5dOvxu3QFiDtF9OrAbgOnq2YUKeJLB0QGAu/fu4+mRE4CSxQtz8YoPefPkwmhMFXcxEhGJk85BEknjcmZ35eYt/1jTDQbDU/8HmD77V7p3aE6b5vVN03O7u3HgyCkA7oc8iLWejE6OXPXxJTo6mqMnz5LXIxdAsp7zJCKS2DSCJJIIEvrVWXL4Z99h1m36G79bdxjyxWSGDeiGcyYnAPLkzsnFK9fxfBRcElKnZmUGjJhA4QKeuDx6fp9u7zNu8k8s+HUd5Up70aB2taeeM+SjLoz79ieioqOpVrEM+TzdiYyMxOqJ4CUiktoYwsPDUsU4uO6iLfJywsMjmDR9PsMGdEu2bf61Yx92drZUrVA62baZHNQPSWrjWaappUuwqMsHV7/0czUGLpLG2dnZ8uYbhYiIiEy2bYaEPKBS2ZLJtj0RkcSmr0Air4H6ZofFklqjujWSdXsiIolNI0giIiIiZhSQRERERMwoIImIiIiYUUASERERMaOAJCIiImImSQPSklWbaPh+HxYv3xhrns+Nm3Tr9zltPxzK73/tSsoyREQA8PW7TfWGnTl09BRBwffoO+Qr2nYfyqLlGyxdmoikMEkakEp7FaFcGa84502ZtYjObZrw47efMevn5XHewkBEJDFNn/MruXO5ATB38WqqV36L+TPGsOnPXVz18bVwdSKSkiRpQCpcMC85smeNNT0qKpq9B45RsnhhHB0d8HDPwaGjp5OyFBF5zR05fobo6GgKF/AEYPe/RyjpVQQbGxu8ihZkz/6jli1QRFIUi1woMvjePZwzOuH46G7gHu45uOMfaIlSROQ1EBUVzYy5Sxk1pBezF8XcNy8gMBj3nNmBx31QUJzPXbFuCyvXbwHAaEwVd2YSkURgkYBkwED0Ex1NtNGIwSr2jS3VMYlIYti4ZQflShcnh5uraZrBYIBH/Uq0MTrOPgigeSNvmjfyBv5/LzYRSfssEpAyZczAvfsh3A95QAZHB675+FHhrTdjLaeOSUQSw/Z/9uMfEMzeA8e47nuLU/9d4MHDUHxu3KRAPg+u+fhRIJ+HpcsUkRQkWQPS4uUbcc3qQu0alahYtgSHj5+hlFcRrl33pfSbRZOzFBF5jUwaPdj079ETZ1Hfuyo79hzi8PEzeHrk5MTp87Rv1dCCFYpISpNkAem2fyCDRkzAPzAYK4OBPQeOki+Pe8ywNtD/w3Z8Nn46P8xbRs8urXB0SJ9UpYiIxNK5TRNGjpvGmo1baVCnmul8JBERAEN4eFiqOLnn8SG2nRt/xsbGIkcGReQ1p35IUhvPMk0tXYJFXT64+qWfqytpi4iIiJhRQBIRERExk2bHiJ3dSyT7NoN8dKE5ERGRtCDNBiSRlEjBXUQkdVBAEknjzq5qZpHtFmq2yiLbFRFJDApIicgSf4j0R0hERCTx6SRtERERETMKSCIiIiJmdIhNnkknFouIyOtGI0giIiIiZhSQRERERMzoEJukSPpFoIiIWJJGkERERETMKCCJiIiImFFAEhERETGjgCQiIiJiRgFJRERExIwCkoiIiIgZBSQRERERMwpIIiIiImYUkERERETMKCCJiIiImFFAEhERETGjgCQiIiJiRgFJRERExIwCkoiIiIgZBSQRERERMzaWLkBERMSSzl64wtRZiwkMvot39YpUqVCKabOX4HvzDs0bedOicW1LlygWoIAkIiKvNUeH9Iwd8RFOGRxo0XkQRQrlZezwvtjY2tCi8yCa1q+JjY3+XL5u9I6LiMhrLVeObBiNRi5duU6GDA6UL+OFwWAAwDlTRgBOnjnPtNm/Eh4ewcd9OlK0UD5LlizJQAFJRERee7+s+I1ps5fwzRcDTOFo/+ETFCnoiY2NDfsOHqdp/Zq8U70CRqOFi5VkoZO0RUTktde2RX3W/fI9y9du4dadAG7dCWDeL2vo3bU1AC2b1OHS1etMnrmQgKBgC1cryUEBSUREXmvHT50jIiKSrJmdcXCwx+fGTUZ9PZNP+nYmU0YnACIiIvmwYwtKvFGYJSs3WbhiSQ46xCYiIq+1e/dDGDhiAsH37lOscD42b92N7807TPj+Z4wYadu8Pleu+bJn/1GMGOn7QRtLlyzJQAFJRERea5XKlaRSuZIJLlO5fCnaNK+XPAVJiqBDbCIiIiJmFJBEREREzCggiYiIiJhJsnOQ1vy2leVrN5PB0YHRw3qTzTWLad6lK9f5fPx0Qh48pFb1CvTq0iqpyhARERF5YUkSkAICg1m4dD2LZ41n595DTJ+zlFFDe5nmz128mnYtG1CjSjn6fTqea9f9yJ3LLSlKERGRVMqzTFNLl2Bxlw+utnQJr60kOcS27+BxCuX3xN4+HSW9irBn/5Gn5js6pMc5U0ZsbW3wzJ0LG2vrpChDRERE5KUkyQiSf0AQHu4xI0JZMzsTFR1NaFg49unsAOjUpjH9ho2nbq2qRBujyeHmmhRliIiIiLyUpDkHyQDGJ25WY4w28ujWNgBs3LyTVk3rcvtOAOcuXOV+yAMyODrEWs2KdVtYuX5LzDp08xsRERFJJkkSkFyzuHDi9HkAbvsHYmtrSzq7mNGj0NAwduw5wPzpY2Meh4WxY/dB6nlXjbWe5o28ad7IG4DIyEiq1u+UFOWKiIiIPCVJzkEqV9qLcxeuEBoaxuFjZ6hUriSLl29k87bdWFlZ4et3B58bN4mMiuKqj29SlCAiIiLy0pJkBMnFOSOd2jSha7/PcXJ0YPTwvixcuh6DwYCdnS0jBnVnwPBviI6OptSbRaldo2JSlCEiIiLyUpLsOkgN61SnYZ3qpscDe3Uw/btapTJUq1QmqTYtIiIi8kp0JW0RERERMwpIIiIiImaS7BCbiEhKcetOAJOmz+eajx+2djZ8NrgHWVycGTluGgGBwdT1rkK7Fg0sXaaIpCAKSCKS5hkMBj5o/x4F8nmwfO1mFi/fSAZHB6pXfosm9WrQsfcIqlUsg4d7DkuXKiIphA6xiUia55rFhQL5PAgMuovPDT8K5fdk979HKOlVBBsbG7yKFmTP/qOWLlNEUhAFJBF5LRw9eZaG7/fh0pUbtGhcm4DAYNxzZgfAwz0Hd/yDLFugiKQoOsQmIq+FEm8UYtu6uSxYuo6vJv+EwWCAR7cwijZGY7AyxPk83fJI5PWkgCQirw1bWxtaNqlDq66DyeySCZ8bNymQz4NrPn4UyOcR53NSwy2P/G7dYeK0+fj63aZyhVJ0aduUEWO/59adAPJ75mbkx92xstIBA5EXoT1GRNK81Rv/4r9zlzAajWzbtZ88uXNSuXwpDh8/Q2RkJCdOn6di2RKWLvOl3b4TyCcfdWbBzHHs3X+UbTv/pUhBTxbMGEtUVCTnL12zdIkiqY5GkEQkzSvlVZTJMxfgd8sfRwd7Rn7cg8wumRg5bhprNm6lQZ1qpvORUiOvYgVN/87skons2bKwbee/3L0XQmRUNLncXDl55jzTZv9KeHgEH/fpSNFC+SxYsUjKp4AkImmep0dOpnw1NNb0qeNjT0vNLl+9gcFgoHiRAqRLZ0fPj0dTsnhhHB0d2HfwOE3r1+Sd6hXQqVQiz6ZDbCIiaUBIyAMmTvuZQb07snbTNup5V2X+9DHcux/C8VPnaNmkDpeuXmfyzIUEBAVbulyRFE8BSUQklYuMiuKLb2bSpV1T3HNmx/fmHe6HPMDGxgbXrJm5cu0GERGRfNixBSXeKMySlZssXbJIiqdDbCIiqdwvKzZy6r+LzF28mtkLV1KulBer1v/JouUbcM2SmW7tm7F6w1b27D+KESN9P2hj6ZJFUjwFJBGRVK5Dq0Z0aNXoqWmd2jR+6nGb5vVo07xecpYlkqrpEJuIiIiIGQUkERERETMKSCIiIiJmFJBEREREzOgkbRGRJOJZpqmlS7CoywdXW7oEkZemESQRERERMwpIIiIiImYUkERERETMKCCJiIiImFFAEpFUKyoq2tIliEgapYAkIqnG4uUb8Q8IAmDQyInUaNyFNb9ttWxRIpImKSCJSKqx/o/tZMqYgX8PncDO1paFM8exaNkGS5clImmQApKIpBph4eGEPHjILys20r1jc/LkzomjY3pLlyUiaZACkoikGu/Wqkzdlr1wcc5E3jy5OH/pGm7Zslq6LBFJg3QlbRFJNT7s2IL3m9Ujo5MjAK5ZXOjfo72FqxKRtEgBSURSvMPHzyQ4P0d2jSKJSOJKMCAFBt3l5m1/ihTMm1z1iIjEMnnmQgDu3r2PwcqAU4aYEST/gCA8crkxc9JIS5YnImlQvAFpwx/bWbR8IxEREaycPxlfv9v8tHAlnw3ukZz1iYiwYMZYAIZ8MZlPB35ApowZALjhd4vZC1dZsjQRSaPiPUl74bIN/Dx9DI6ODgDkcHPl4mWfZCtMRMTcdb9bpnAEkNMtGxcuX7NgRSKSVsUbkKysDNinszM9DnnwkIehoclSlIhIXLJmdmbR8g1EREQSHR3Nhj+2Y22lH+OKSOKL9xBbhbfeZNbPywkLC2fX3sMsXLaeKhVKJ2dtIiJPGda/G6MnzuKHecsxGCBvHndGDupu6bJEJA2KNyD17tqaxSt+wymDA/N+WUOVCqVo37JBctYmIvKU7NmyMO2bT3kYGkp0VLTpFAARkcQWb0BavXErHVs3omPrRslZj4hIgq5d98M/IAjjE9NKeRWxWD0ikjbFG5A2b9tD0wa1sLG2fqkVr/ltK8vXbiaDowOjh/Umm2sW07yQBw/5avJsLl+7QXbXLHw5tJe+CYrIM43/bg4bt+zAI1cOrG1i+iaDAeZPH2vhykQkrYk3IDWu+zZ9h3xFqyZ1sLb+/0mQVSuWeeZKAwKDWbh0PYtnjWfn3kNMn7OUUUN7mebPWbSaIoXyMmZ4Xy5e9sHBQfdSEpFn++ffI2xYMo1MGZ0sXYqIpHHxBqRNf+7CymBg+drNpmkGg+G5AtK+g8cplN8Te/t0lPQqwoTv5z01/8/te1g6ZwIA+TzdX7Z2EXnNFC7gSXp7e0uXISKvgXgD0vQJw196pf4BQXi4uwExP8uNio4mNCwc+3R2PAwNxcpgxS8rNrH9n/1UKFuCXl1axbmeFeu2sHL9FgCMRmOcy4jI6+PNNwoybPQUypfxemp6yyZ1LFSRiKRVCd5q5NjJs+zadxgDMYfWihct8HxrNTwdaIzRRgyGmH8/eBBKYPBdShQvRPuWDejW/wtqVClL0UL5Yq2meSNvmjfyBiAyMpKq9Ts93/ZFJE26es0Xl0xOnD1/+f8TH3cuIiKJKN6AtHHzDub9sgbvGhUxYGDUNzPp3KYJ9byrPnOlrllcOHH6PAC3/QOxtbUlnV3MRSedM2XE1saGN4sVws7OlpLFC3Pd91acAUlE5EkjPv7Q0iWIyGsi3oC0dPXvzJ4yCudMMSdDtmxSh4+GfvVcAalcaS9+nL+C0NAwDh87Q6VyJVm8fCOuWV2oXaMSZUoUY/f+I1R4qwRHT/5Hk3o1E+8ViUiatuXvPezccxAwUK1iGd55u4KlSxKRNCjea/RHRUebwhGAcyYnoqKjn2ulLs4Z6dSmCV37fc7qDX/Sq2srbt72545/EAD9e7Zn6arfaffhUN6uXFYnaovIc1mwdB3L1vzBW6WKU7Z0cZau+YNFyzZYuiwRSYPiHUEqWjAvk2cuoFXTdwFYtmYzRQrmfe4VN6xTnYZ1qpseD+zVwfTvHNmzMnPSyJepV0ReY5u37WH2d19gb58OgHeql+eD/qNop6v8i0gii3cEaUDP9oSGhtOt3xd80H8UoaFhDOzZPjlrExF5ijHaiJ2dremxna0dxmj9wlVEEl+8I0iOjg4MG9CNYclZjYhIAsqX8WL4mO9Nv25dueFPypUpbuGqRCQtincE6fuffiEgKNj0+Np1P76dsSBZihIRiUuvrq0oVCAPM+YuZcbcpRTKl4feXVtbuiwRSYPiHUE6cOQkfT9oY3qcO5cbx0+dS5aiRETiYmNjQ+c2TejcpolpWnh4hOUKEpE0K94RpIjwSO6HPDA9Dgl5wIOHoclSlIhIXL74egaBQXdNj69d92Pc5J8sWJGIpFXxjiA1fLc6vT8Zy3sNvTEYDKze8Bd1alZKztpERJ5y6ep1XJwzmh7nzuXG5as3LFiRiKRV8Qak99+rR5bMzuzcc4h790No2qDWUz/bFxFJbtFRRm77B+KaxQWAO/6BOsQmIkkiVkDauecgjg7pKV2iGLVrVOLkmQts3bmPsxeukC9PLt4o8pz3YxMRSWTtWtane/8vePedKhgw8Ptf/9CxdSNLlyUiaVCsc5AWLN2Ap0cuAI6ePMuWv/fw6+wJjBrai8kzFyZ7gSIij9WpWZkvhvYmKjKK8IgIRgz6gMb1ali6LBFJg2KNID0MDSWzSyYAfl25idbN3iV3Ljdy53Jj0nT9zF9ELMsjlxvpqpV/oSv7i4i8qFgjSFYGA2cvXOHAkZMcPHqSxnVjvp1FRkY+dQVbEZHktuGP7fT8eAwjxn4PgK/fbb6c8IOFqxKRtCjWCFKvrq3p9fEYwiMiGNqvK5kyxtywdunqPyhf2ivZCxQReWzhsg3MnzGW7gNGAZDDzZWLl30sXJWIpEWxAlKFt95k07KZREZFkt7e3jS9TMlieObOmazFiYg8ycrKgH06O9PjkAcPeRiq67OJSOKL82f+trY22No+PUvH+0XE0iq89Sazfl5OWFg4u/YeZsHSdVSpUNrSZYlIGhTvdZBERFKa3l1bs3jFbzhlcOD7n36hbq0qtGvV4JnPu3svhPFT5nDNx49MGTPw5bDeWFlZMXLcNAICg6nrXYV2LZ69HhF5fcR7qxERkZRi556DHDp6ChsbGzq2bsQbRQrgc8OPZWv/4L9zl575/BOnz9GicW0W/jCOwgU9WbxiI3MXr6Z65beYP2MMm/7cxVUf32R4JSKSWiggiUiK96rXZ6tUriSlvIoA4FWsILfvBLL73yOU9CqCjY0NXkULsmf/0SR9DSKSuugQm4ikeIl5fbaDR07x5huF2LX3EO45swPg4Z6DO/5BcS6/Yt0WVq7fAoDRaHz5FyEiqYoCkoikeI+vz3b33n0OHj3J0P5dgBe/PtuFy9fYf/gkfT54n5lzl8KjwBNtjMZgZYjzOc0bedO8kbdpe1Xrd3q1FyMiqYICkoikeIlxfbbAoLt8Pn4GY4b3JZ2dHZldMuFz4yYF8nlwzcePAvk8kvIliEgqo4AkIineq16fLTw8gk9HT+GDDu9RIG9uACqXL8Xh42fw9MjJidPnad+qYZLVLyKpjwKSiKQKr3J9toXLNvDf+cvMX7KWOQtXATBpzGBGT5jFmo1baVCnmul8JBERUEASkddA13ZN6dquaazpU8cPtUA1IpIa6Gf+IiIiImYUkERERETMKCCJiIiImFFAEhERETGjgCQiIiJiRgFJRERExIwCkoiIiIgZBSQRERERMwpIIiIiImYUkERERETMKCCJiIiImFFAEhERETGjgCQiIiJiRgFJRERExIwCkoiIiIiZJAtIa37bStsPh/LhwC+5dds/zmUGjpjA6ImzkqoEERERkZeSJAEpIDCYhUvXM2fKKJo38mb6nKWxltn97xFu3wlMis2LiIiIvJIkCUj7Dh6nUH5P7O3TUdKrCHv2H3lqfmRkJLMXrqRdywZJsXkRERGRV2KTFCv1DwjCw90NgKyZnYmKjiY0LBz7dHYArFj3JzWqlMM1i3OC61mxbgsr128BwGg0JkWpIiIiIrEkSUDC8HSgMUYbMRhi/h0UfI8tf+9h5sQRnDh9LsHVNG/kTfNG3kDMqFPV+p2SpFwRERGRJyVJQHLN4sKJ0+cBuO0fiK2tLensYkaP/tl3mPshD+g1eAwhDx4SFHyPhUvX075Vw6QoRUREROSFJUlAKlfaix/nryA0NIzDx85QqVxJFi/fiGtWF+rXrkb92tUAOHT0FBu37FQ4EhERkRQlSU7SdnHOSKc2Teja73NWb/iTXl1bcfO2P3f8g5JicyIiIiKJKmnOQQIa1qlOwzrVTY8H9uoQa5nSJYpRukSxpCpBRERE5KXoStoiIiIiZhSQRERERMwoIImIiIiYUUASERERMaOAJCIiImJGAUlERETEjAKSiIiIiBkFJBEREREzCkgiIiIiZhSQRERERMwoIImIiIiYUUASERERMaOAJCIiImJGAUlERETEjAKSiIiIiBkFJBEREREzCkgiIiIiZhSQRERERMwoIImIiIiYUUASERERMaOAJCIiImJGAUlERETEjAKSiIiIiBkFJBEREREzCkgiIiIiZhSQRERERMwoIInIa2PJqk00fL8Pi5dvBCAo+B59h3xF2+5DWbR8g4WrE5GURAFJRF4bpb2KUK6Ml+nx3MWrqV75LebPGMOmP3dx1cfXgtWJSEqigCQir43CBfOSI3tW0+Pd/x6hpFcRbGxs8CpakD37j1qwOhFJSWwsXYCIiKUEBAbjnjM7AB7uObjjHxRrmRXrtrBy/RYAjEZjcpYnIhakgCQiry2DwQCPQk+0MRqDlSHWMs0bedO8kTcAkZGRVK3fKTlLFBEL0SE2EXltZXbJhM+NmwBc8/HDNYuLhSsSkZRCAUlEXluVy5fi8PEzREZGcuL0eSqWLWHpkkQkhdAhNhF5Ldz2D2TQiAn4BwZjZTCw58BRxg7/iJHjprFm41Ya1KlmOh9JREQBSUReC65ZXFgwc1ys6VPHD7VANSKS0ukQm4iIiIgZBSQRERERMwpIIiIiImaS7BykNb9tZfnazWRwdGD0sN5kc81imvfrqt/ZvO0fQh6E0qdba6pWLJNUZYiIiIi8sCQZQQoIDGbh0vXMmTKK5o28mT5nqWleyIOHhIWH89N3o/hqZD/GTZ6tq9OKiIhIipIkAWnfweMUyu+JvX06SnoVYc/+I6Z5jg7p6di6EdbWVuTNk4uoqCjCwiOSogwRERGRl5Ikh9j8A4LwcHcDIGtmZ6KiowkNC8c+nd1Ty/13/jLuObPHmv6Y7oEkIiIilpA05yAZng40xmgjBrNbHEVGRTFl1mI+7NQy3tXoHkgiIiJiCUlyiM01iwtXr/sBMVevtbW1JZ3d06NE381cRJkSRSlfxispShARERF5aUkSkMqV9uLchSuEhoZx+NgZKpUryeLlG9m8bTcQc+jMPyCILm2bJsXmRURERF5Jkhxic3HOSKc2Teja73OcHB0YPbwvC5eux2AwcN33Ft/NXEjePO506j0CgPatGuL9dsWkKEVERETkhSXZdZAa1qlOwzrVTY8H9upg+veuTQuSarMiIiIir0xX0hYRERExo4AkIiIiYkYBSURERMSMApKIiIiIGQUkERERETMKSCIiIiJmFJBEREREzCggiYiIiJhRQBIRERExo4AkIiIiYkYBSURERMSMApKIiIiIGQUkERERETMKSCIiIiJmFJBEREREzCggiYiIiJhRQBIRERExo4AkIiIiYkYBSURERMSMApKIiIiIGQUkERERETMKSCIiIiJmFJBEREREzCggiYiIiJhRQBIRERExo4AkIiIiYkYBSURERMSMApKIiIiIGQUkERERETMKSCIiIiJmFJBEREREzCggiYiIiJhRQBIRERExo4AkIiIiYkYBSURERMSMApKIiIiIGQUkERERETM2SbXiNb9tZfnazWRwdGD0sN5kc81imudz4yZffD2Dh6FhtG/ZgHdrVUmqMkREEpRQXyUir68kGUEKCAxm4dL1zJkyiuaNvJk+Z+lT86fMWkTnNk348dvPmPXzcu6HPEiKMkREEvSsvkpEXl9JEpD2HTxOofye2Nuno6RXEfbsP2KaFxUVzd4DxyhZvDCOjg54uOfg0NHTSVGGiEiCEuqrROT1liSH2PwDgvBwdwMga2ZnoqKjCQ0Lxz6dHcH37uGc0QlHRwcAPNxzcMc/8JnrNBqNAERGRiZFyYkiMsoC20zB7fEq1JaJxxJtCS/entbW1hgMhiSqJm4J9VVxSQ39UEqidnp1asNX8yr9UNKcg2T4f0cCYIw28rjfM2Ag+ol50UYjBqu4O8UV67awcv2WmOWiowGo0bjbc5VQ9A2vl6n8lXSdneybhNmdknwTasvE89q0Jbxwe+7c+DM2Nkl2WmTcEuirHnuVfihHVsfEqTOVqlq/0ys9/3VvP1AbvqoXbb8n+6Ek6Y1cs7hw4vR5AG77B2Jra0s6u5hvZJkyZuDe/RDuhzwgg6MD13z8qPDWm3Gup3kjb5o38gZiOqbw8HCLfMt8Xu16DGPRD19Zuow0QW2ZeFJLW1pbWyf7NhPqqx5Lbf3Qk1LLe5+SqQ1fTWprvyf7oSQJSOVKe/Hj/BWEhoZx+NgZKpUryeLlG3HN6kLtGpWoWLYEh4+foZRXEa5d96X0m0WfuU4rKyvs7e2TotxEYzAYkv8bcBqltkw8asv4xdVXJSQ19ENP0nv/6tSGryY1t1+SVO3inJFObZrQtd/nODk6MHp4XxYuXW/6xtX/w3Z8Nn46P8xbRs8urXB0SJ8UZYiIJCiuvkpEBMAQHh5mfPZi8jxWrNtiGoqXV6O2TDxqy9eX3vtXpzZ8Nam5/RSQRERERMzoViMiIiIiZhSQRERERMwoIImIiIiYSZ2/vUtkvn636dRnJPnzugNQpkQxPNxz4P12xTiXn71wJVt3/Iu9vR02NjZ8Oaw3btmy0mvwGCIjo7CxsSadnR2Tx37C6ImzuHDpGlZWVlhbWzNqaE82bt7J4eOnOXfhKnnz5MLGxpqp44fx8GEo8xavoVObJmR0StkX93rcZvny5MJoNNK1fTPKlioea7lDR0/x+dczccuWlQcPH9Kve1vKlfEytaGzsxMAQz7qwonT55n3yxoyu2TiwcNQenVpRXhEBMvW/IHvzTukT5cOZ2cn+vdoT6H8eV6o3rMXrjB11mICg+/iXb0indo0TpR2eFW+frdp1nEAaxdPJVvWzISGhVO3RU8mjR5E6RLFEnzuoJET+bh3R3K4ub7Uth9/NqONRjI7Z2TM8L5kcHSgeaeBZHPNDEDO7K6M+PhD02c7LDwc54xOfDmsDzPnLeWqjy+n/7tE0cJ5yeLizOhP+7xULRK3lNA3zZgwIjlf8gtRP/Ty1Pc8mwLSI8WLFmDS6I+fe/luHd6jZtVyLFvzB+s2/U33js0B+OaLgThncnpq2SH9ulC0UD7W/f43K9Zu4aMP2wLQa/AYxo3oh3MmJ0IePOTrKXPZs/8oxYsVpGbVcon34pLI4za74x9I/+HfMPWroWR2yRRrueqV3uLjPh05f/Eqk6bPp1yZmKtJP27Dx06cPk/T+rVo26I+16778dlX05k3bTRvVy7L7IUryeeZ+6XbxdEhPWNHfIRTBgdadB5Em+b1sLOzfbkXnsjyeuRi556DvNfQm38PHsc1q0uybfvxZ3PKrEVs27WfhnWqk87OLs4/io8/27PmL2fztt0M7dcVgLbdh6boP6KpnaX7ppRO/dDLU9+TMAWkOGzcvIOg4Hu0bVGfbv0+J79nbo6cOEPH1o2p513VtFxkVBR3/ANxz5n9meuMiorG7+Yd3LJnjXO+o0N6ihTKS/GiBcmXJ1eivZbkkDWLC7VrVGTPgaMcP3WOM2cvkSWzM2NHfGRaxmg0cvO2P9mzZXnm+oxGI7437yS47Lrf/2bDH9sJDLrL8IEfUNKriGneqf8usO73vxnaryshDx4yfMxUvhs3BKPRyKUr18mQwQFb25Tz0S9SKC/7DhznvYbe7Nx7CK9iBQFYtGwD23cfwNrKigG9OlC4gCfHT51jzKQfyeySCf+AIAAehoYyeuKP3PC9RT5Pd0Z+/CFzFq0iPCKSE6fPMbBXR2bOXYpTBgeOnzrH0P5dn/qWHR4eQWDQXbK7Pvu9iYiI5PbtAIoVypckbSEJs0TflFqoH3px6nsSlnL+SljYidPn6TV4DADlSnmZPrh+t+4wafRgHjwMZfx3s02d0OwFK5k5dynh4RH88O1npvV88sW32NhYU9+7GvVrVwPg6ylz8Q8Mplzp4rRtXi/eGtq1aJBULy/JuWbJzG3/AGxtbPh5+hgWL9/I37v+JVvWzGzffYCTZ85z7uLVp74Jz16wkhXrNlMwXx4G9GwPwOqNf7Fx8w7Sp7fniyE9491e1QqlaVC7Gqf+u8i637c91TEVLZSPyTMXEhUVzd4Dx6hSoTQAv6z4jWmzl/DNFwNS1G0iDAYD6dLZERAUzP37D8iS2ZmLV66zY89BZn37GVd9/BgzaRazp4xi0vT5jPm0D3k93en7yTgAlq/dTPEiBRg34iMmTpvPsZNnAQh58JAZE0bg63ebW7cDGDviI079d4HNW3ebOqmvp8wlMOguzs5OpsMFYeHhpn2hfcuGVCxbAoj5bF+55kvjum9T4a0Syd1Mr62U0DelFuqHXoz6noQpID3y5DD2429pAJmcnMiUMQMZnRy54x9kWr5bh/eoUaUsV67dYMzEWUyfMByIfxj7qo8f5y5ewdHRIXleUDK7edufdZv+Jr19OnoNHkNYWATv1qpMtqyZTUPbd++FMHDEN7xRJD8Qe2gboGn9WtSsWo4vvpmZ4Lffg0dPceL0eawMBnxu3CT47n2Gjf4OgC+G9KJk8SKcOH2OXXsP0btrawDatqhP7ZqVGD1hFoUL5iVb1sxJ0xgvoVqlMsxdtIYyJYtx+eoNnDM5UdKrCFZWVnh65DR9Hu/dD6Hgo87E4dEV6M9fvMa1637s2neIBw9CKVv6DSDmfJXHsrlmxj6dHW7ZsnDbP9A0fUi/LhQpmJfDx07z7Yz5fDmsT4LD3Gt+24pTCvjm+zpR3/T81A+9OPU98VMv95ziSvoGg4GMj26++yzvVK/A4hUbCQgMjvP4eGp22z+QLX/voVv7Zpw4fZ7BfTthNBoxGAwcPnbatJyDQ8w9rB48DE1wfTncXPFwz8E/+45QpUKpOJf5acFKlvz0NVeu+XJm2iUyZczw1I71TvXy/L71Hx48DCVrFheOnzpHkYJ5yZrZGQcHe3xu3LR4x/SkSuVKMn7KHH6dPYHLV9cRGHSXoyf+Izo6mmvX/ciUMeYPm42NDTdv+ZM1iwvBd2M6rnye7hTM50H7Vg2JiorG2tqKcxeuxLkdA3F/jjNlciL47v1n1tmikTfdB35Jg0fnC4jlqW+KoX7o5ajviZ8C0kuavWAlv6zYSFhYBB992MY0/fEwNsC3Yz4xTbe2tqJV0zosWLqe/j3aJXu9SeHE6fP0GPglRmBgzw6U9CrC8VPn6NhrOI6ODnz+SQ8Atu8+wPmLVwgMvkfT+rVMHcLjoW2Anp1bPbXuDq0a8vn4GVQuXzLOPwBVKpSiz5BxvFmsELZx3AixUAFPRk/6kSb1agIx334GjphA8L37FCucj5LFCydmU7wyR4f0TPv6U1yzxJwkmd/TndDQUnw48EusrKz4pG8nAD7q3oZBn03EI5ebqZNo1bQOoyf+SOc+I3HK4Mj4z/s/93a/njIXKysrDAYDQ/p1AZ4e5s7g4MA3owb+v05HB2pWLceajVtp1fTdRHjlkthet75J/dCrUd8TP91qRERERMSMLhQpIiIiYkYBSURERMSMApKIiIiIGQUkERERETMKSCIiIiJm/gcGwNcj0qNC9AAAAABJRU5ErkJggg==",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAkgAAAFBCAYAAACM+VD6AAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjksIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvJkbTWQAAAAlwSFlzAAAPYQAAD2EBqD+naQAARkdJREFUeJzt3Xd0FFUfxvHvppMQkpAEAoTekY70JmDoVREQadKkKe1VuoIUQUBEKaIU6dK7KCgiHRGQ3pFOKCEJkJCyyb5/BFaySahJNgnP5xyP7M7szG9nd26euXN3xhAREW5CRERERMxsrF2AiIiISEqjgCQiIiJiQQFJRERExIICkoiIiIgFBSR5aROmzGXS9PnWLsMqenw8ip9W/mLtMhL0rJ/Nhk3baNd9cDJUlLZFRETSrvtgTp3519qlPFWvAWPYufegtcuIo2KdNpw+dxF4ue/l48t5UTPnr2DA8EnP/bpbAYG07jKAWwGBL7X+Jxk5YUaKbncXLtvwTNvuwKHj+L3VNRkqen521i7geYydPItNW3YB8CAsHAd7e2xtYzLemoXf4Jre5bmXuWHTNg4cPsGw/32QqLVKynfg0HF6fjKGdE6OsZ7fuGw60dHRfD93Ob/9uZciBfIwbnhfK1UpKVGPj0dx5PgZ7O3+a0JbvVWPru2bM2/6mCRZZ2K3VVPGKRAnlpnzVwDQue3bAHh7erDoh3HWLEkSQaoKSAN7d2Jg704ANGvXhz7d2lC90utWrkpSs/Quzmxe+X2c50MfhJE9WxYK5M1phaokNejZ6V1avVXX2mWISBJJVQHpaUwmE8vXbuanlRsJC4+g3ptV6P5+S2xtbdi+ez/ffL+IoOB7vFYoL5989D6b/tjNrAUrMUWb+GP7X/To1Irmjf3My7sfEsrcxWvZvucAAXeCKFvqNYb074qLczoA/jpwlO/mLOHSFX/y5PJlcN8u5MqRlTuBwUyesZC/DhwhnZMTbVs2pFmDWoycMIP0Ls707d4WgGVrNvHHjr+YNn4oENMlPOOrT5kw5UcK5s/Nx706sHjlRn7buofrN25RuEAePvukG16eHgCcOvMvk79fyJlzl8iS2Yv/9erA7r8Pce36LUYM7GF+H+91HUivLu9SsWwJ83OXr/oza8FKDh09xYOwcN5q+CZd2zcHYo6GQh+EY2drw69bdmFnZ8unH3ejRNGCAFz3v8W4b2Zz7OQ58uXJgb2dHblzZovzeWzYtI09fx8mb67srNrwO25urnz2STcOHj7JTys3YjRGMbhvZ8qVKQbA79v2snT1r/x78QqeGd0Z1KczxV8rAJDgNp05fwURkUbCw8P5dcsuZn3zOV6e7nw/dzmb/tgNQJ2alejS7m0cHRye+bvknM6JtxrW4k5gEGfOXXrivJev+dN3yJccO3mW/HlyMrR/VzJ5e/J2+76x3t+J0+f5+LOJrFnwrbnnE2LCfr/ubVmy6lfOXbhMfb+qtGhShy+/nc2R42coW6ooIwb2wO5hb8X6X/9k3pJ1BAXf4/WSRejbox3eD78TT/ts9v9znG9+WMh1/1uUKl6YQX064+7m+szbRZ6u7jvdGDP0I0qXKPJM+9L4KT9y9MQZfLNmZkDvThTMlyvOMn9cvCZOW1W5XEneat+XTStmmHvPn2fd7/caRvPGfjSoXc28rxbKn5tVG34nLDyc/j3aU6NqOSCmvRg3Oeb7GBEZiZ2dLVkye7N09gRzjUNGfUO2rJnp0bElAM079KNo4XwMHxDTFvUfNoEqFUrRtH5NVq3/nfWb/uTSFX9y+Gbh04+7kStH1hfa3pu37ubHRWu4efsOrxXKy7D/fYBnRvc48z1pv0mofXlcWHgE3fp9Tp2alXj37frm58dOnsX6X/7EYGNg0fKfGTGoJ2VKFKFW086snDuJLD7ejJwwg9w5s3H+whV27zv0sC3vzg/zVrBl2158MnsxeuhHZMnsBTz7fnonMJiho7/lrwNHyZYlE4P6dqZA3px06/c59d6sSpP6NczzNWvXh/WLp8Q609Lj41E08KvGnzv/5vDx01QsW4I+3dowceo89u4/QsF8uRg99EPza3buPch3c5bhf/M2RQrmoW/3dubPLSj4HhOm/MhfB46S1cebrD7esWo9c+4iE6fO5dyFKxTMl4vB/TqT1SfT837cySpNjUHa9Mdulq7+lW/GDmLprPGcPnuRTX/EnJIbM2kmbVs2YuPSabRr1Ri3DK50eLcJ7Vs1pk6tymxZMytWOAKwsbHBM6M70yYMYeW8SVy4dI3VG7YAcPb8JT4Z/hVtWjTil2XT6d6xJV6e7kRFRTNgxNfY2BhYOnsC30/6lAJ5cz3ze/j2h0WM+6wvg/p0wtbWFgcHe8Z/3o/1P03FhIkfF68F4HZAIB8O/IIaVcqx4aepDOnflczenjTwq8aOPQd4EBYGxDRstwICKVvqtVjrCQsLp0r50iz8fhzfTRzGvJ/WcuL0efP0NT9vIV+eHCybM5GypYoyffYSgIfvbxJZMnuzdtE3DOzdkcCguwm+n60795E+vTNL50wgp28Wuvcfxf2QUBbMGIvfGxX55odF5nnDwyPo16MdPy+ZxhtVyjJu8uzH1pnwNl21/ncye3uxfvEUsvp4M2POMo4cP8OPU0by45SRHDl+hu/nLn/mz+B5HT1xhl5d3mXNwm/I5J2RsZNnYWtrQ4Pa1czfP4Btu/ZTs2r5WOHokbk/rWVwv85MGz+URct/ZtgXU+jVuTWLf/iSPX8fZseemLEi2/ccYNqsJXw+qCdrF36Dt5cHA0d8TVRU9FM/myvXbjDw86/p2eldfl4yjTw5fZk666ck2y4SI6F9KTLSSP9hEyj+WgF+XjKNLu2a8+kXU4iKio6zjKe1Vc+77vhs3bkPOztbFswYy9uN/Pj6uwXmaaMmfk8O3yys/2kKXdq9TbEi+WOFI4CypYvyz5GTANy8FYCTkyP/HDmFyWQiKiqaw8dO83rJ1zAYDJgw8dkn3dm4dDq5c2bj28fageexe98hvvxmDn17tGXj0mm8+3Z93DKkjzPf0/ebJ7fZJpOJiVPnksM3C63eqhdr2sDenahTqzLtWzVmy5pZVK1QOt5aF6/YSAO/aiyfM5FLV67ToecQyr9ejFULvsbe3o7FK34Gnm8/PXbyHO80rcO6xd9StnRRho2ZQnR0NA3rVI/V9uzYc4BypYvGOwxl7k9r6dLubRbOGMu2Xfvp3n8Ubzf2Y+Xcr7jmf5P1v/4JwKmzF/j0i6n06vIuG36aStnSRek7ZJz5b82oid8THhHBirlf8eWIfty9H2Jex917IfQePI4m9Wuycdl03nyjAmMmzYz3PaUkaSogrVz/G21bNCRblky4uDjTrEFNdu87BEAm74ycOnuBsPAIShcvbO4FehLndE60eqsujvb2nL9wBS9PD06dvQDA6p//oEaVstSsWg47OztKFStEehdnTp+7wOlzF/hfrw64pnfBy9OD1wrlfeb30PG9ZmTx8cbGxgZbWxvefase7hlcOffvJbwyupvX/+uWXeTJ6cs7TWrj4GBPwXy5yJzJE9+smSmUPzfbdh0AYPvuA7xR5XVz78Mj+fPm5M03KhAa+gD/mwF4eLiZlw1QpkQRateohIODPRVeL86lK/4AnDxznstXb9D7g/dI5+REzuxZKVwwd4LvJ1f2bDRv7IejgwMVy5bAxdmJDu82wcnRgUrlS3Lx8jXzvPX9qpIvdw4uXrmOS7p0nL94hYiIyKdu0xy+WXj37XrY2dlhMplY/fMWenRsiWdGdzwzutOjUytWb9iCyRT3ovH3Q0Lxe6ur+b91DxuD51GvVlXy5spOOicn2rVszL6Dx4iMNNKgdlX+3LWfsPAIALbt3k+tauXjXUabFg3J6pOJ3DmzkdXHm8Z13yB3zmx4ZnSncIE8XHi4nVZv+J3mTfwolD83Tk6O9OjUiguXrnL63IWnfjYbNm2jcvmSlCtdFDs7O1q9VZc9D/cPeX7T5ywxf29adPxfgvMltC8dPHKS+6GhtG/VGDs7OyqWLYGdnR1Xr99ItBoTWnd8cmXPRstmdWP2zbIluHn7DmFh4QCc/fcS9f2q4prehcZ13+Dk6biD0MuWKsqJ0+cJCwvn4JGTvF7yNZzTOXHl2g3OXbhMepd0+GbNDMDbjfzI6pOJ8xevkMHVhdOPtT3PY/nazTRv4sfrJV/Dzs6O8mWKxWnr4Mn7zbO02Ws2/sHRE2cY1LcTBoPhhWp9s3p5ypQsgouLMyWLFaJU8cJUrVAaRwcHypUuZm4Ln2c/rVqxNCVeK4CjgwMd3m3CpSvXuXr9JjWrlefU2QvcvBUAwLbdBxJse5o1rEX+vDnNbU2NquUo8VoBc50XL18HYO0vW6lZrTzlyxTDwcGe95o3wN7ent37DnMnMJidew/Sr0d7XNO7kMkrI2VKFDGvY+uOv8iezYd6b1bBztaWJvVqcOrMBcIjIl5oWyaXNHWK7dr1m3z93QK+/WExANHR0ZQsFtOdPGn0JyxYuoF3uwyg/ptV6Nim2VNPuYRHRDBx6lz2HThKsSL5Y557+Mfumv9N8+mfx129fpPM3p7PFMDi83jXcHR0NN/NWcrmrbspkDcXtrY2hIeHm9efK0fc01oAjepWZ9MfO6lTsxLbd++nQ+umcea57n+L0V/9wK2AQMqUKIKjgz1hYf99WR9vBDK4uhBpND583W0yeWfEyWJgc0Ieb0syuKaP9UQGVxeMxijz41+37GTm/JV4e3mQL3cOIOYzeNo29crobq436O49HoSFmxtigOzZMhP6IIyg4Ht4uGeI9dqExiC9KHc3V0wmE/dCQsjqk4lC+XOzc+9BCuXPzd17IebvkaXY2zt9nO1vfLj9r/nfok7NyuZpjg4OZPLOyDX/W5iiTU/8bK5ev8mfO/9m596YX4yYTKZ4Q6M8m+7vt3ymMUgJ7UvX/G9y504wtd/+b9B1RGQkwXfvM3zcNLbt2g/Ae+80pFObZi9UY0Lrjn9eHps3phcm0mjECUfKly7G2l/+IHu2zKxc/ztFCsY96MuWJROZvT05evIsBw+fpEzJIoSEPuDg4RM8CAunzMPeI4DFKzeybPUmcvj64OXpYT6IeJLd+w4xZNQ3AHh5erB09gSu+d+kdo1KT33tE/cbk+mJ7cv5i1c4fvo80dHRhIVFkM7J6anri1/sfTz47r3HHv/32bzofuqczgknR0fu3gshezYfalYrx6atu3m70ZscPnaKEQO6J1BV7O+I5ffgUZ3X/W+ZT89CzHfLN2tmrvnfJLN3Rhzs7fHJ5BnvOq5ev8nxU+di/VotIiKSu/dC4p0/pUhTAcknszdvNaxFvTerxJmW0d2Nj7q2psO7TRgw/CsWL99Ih9ZNMBgMREfH/+X7aeUvXLp8nWVzJmJnZ8fM+SvM41F8Mnlx5Wrco7Esmb24dTuQsLDwOH+o7O3sYn0h4utKf9xvf+7hjx37WPj9OJzTObFh0zaWrPrFvP49fx+O93VvVC7L5BkLuXr9Jpeu+lOmROE484z7ZjZFCuU1jxfo8fGoJ9bySMaMbgTcCcJoNMZ7pPaibt6+w+fjv2PhjLHkypGN6/63WLZmE/DkbWrJPYMr6ZwcuXr9pnms1pWrN3BO55QsY20uXbmOczonPNxigljDOtX5/c893AkMpmbVctjYvFynbVYfb65ev2l+HB4Rwc3bd8jq482DsPAnfjZZMntRu2YlhvTr8lI1SOLIktkbn8xeLJszMU6vRHxB2rKtsrOP+Yzv3gvBNb0LJpOJ6OgntykvqnL5Uvy4eA2tuw4kd45sDOzTKd75ypYqytHjZzl07BQd2zQjPDyC/YdOYDQaqVKhFABHjp9h9oJVLJk1nowebhw4dJw/d/791Boqli3BljWzYj3nk8mLK9cS7hV75En7TXR09BPbl+s3bvPN2IFs372fqTMXMzSeXxEaIMG/I8/rRffTm7cCCAsPJ1uWmHE9DWtXZ9L0+eTMnpVSxQrj4uL8cnX5eMfq3TSZTFy9foOGdaqT0cOdiMjIeA9CH722RNGC8f5y8vKV6y9VV1JKU6fYmjWoyQ/zVnD63EUiI40cOHSc2wGB3A4IZNHynwm+ex+TyYSNjQ3hkTFHLBk93Dh15l/uh4QSEREZa3nBwfeIijYRaTRy9vwl/ty53zytYZ1qbP5zD9t27cdoNHLo2GnO/nuZgvlzk93Xh4nT5hESEsqdwGD+2P4XAL7ZMvPP0ZMEBt3lwOETLFvz6xPfT/Dd+xiNRozGKK5ev8nG33aYp/nVqMiJ0+dZ/fMWIiONnP33MoeOngLAycmRGlXKMf7bOVStWDreP5ZBwfeIjIwkIiKS7XsOcPb8kwciP/Jaobw4Ozvx4+I1REREcvjY6QSD2vO4ey+E6GgTYeER3Lsfwk+r/ru20JO2qSUbGxua1q/JtNlLuBMYzJ2gYKbPXkKT+jVfuGv8afYdPELAnSACg+4yffYSGtapbl5X9cqvc+TEWX7/cw9vVq/w0utqWr8my9ZsMp8unj57KTl9s1Igb66nfjYNaldjy/a9bN2xD2NUFGfPXzJfJ8bBwZ7wiEj1KCWjUsUKYWtry4wflxEWFs6NmwH8/c+xBOe3bKs83DPg7OzEtt37uRMUzISpcwkPj0zw9S9j2ZpN9OzcivWLpzDly8GxemgfV7Z0Uf7+5xhGYxSZvDJSomhBjp08y4nT582nXILu3sNojCIy0sidwGBWPRzX+YiDvb25LX7a97JJvRosXb2JQ0dPYTQa2bn3IDdv34mznCftN09rXyq8XpzSxQvT8b1m7Np3yDzO6nEZM7pz9MRZwsLC4/wdeV5P2k8tHTl+hivXbhAS+oDJMxZSrWIZ84FgsSL5eRAWzoq1m6lVPf7Ta8+jcd03+P3Pvew7eJTISCOLV2wkIiKSimWL45PJk8IFcjN9zhLCwsI5f+EKv23dY37tG5XLcv7fK6xYt5nISCOXr/pz5PgZABwcHIg0Gp/aYWANaSog1XuzCu+9U58ho76hbotuzJi7nIA7QaR3ceb2nSA69BpK8w79yOCanveaNwCgVrUKZHB14a12fVhqEVjeaVIbo9FIk/c+YvbCVdSp+V9XbpGCefl8UE9mzF1G3Xe6892cpWAyYWdry/jh/QgOvkezdn3p2ncEAYHBADSqU50smb1o0fF/rFz3G90f9t4kpG6tymTLkpm32vVh/LdzqF2jonmaTyYvJo3+hLUbt1KvRXdGT/yeqKj/Tlc1rFONvfuPJHjeudv7Ldiy7S/e7tCPg4dPUrl8qWfaxo4ODoz9tA879hyk4bs9+WnlxgTX8Tzy5vKleWM/en48ml4DxlC6RGEc7O0BnrhN4/PB++/wWqF8tOsxmHbdB1O4YF4+6ND8uer5fu5yajbpxNyf1rJj7wFqNunErAWr4p23YL7c9B82gVadPyFn9qx0f7+FeZqTowPVKpXB/2bAc41FS0jVimXo3rElQ0d/S+PWvfC/eZuxn/XB1tbmqZ9NDt8sjB/ej3lL1lLn7Q8YOmYKFy5dBaBksUKAiRXrfnvpGuXZODjYM2n0x5y7cJnG731I174j2Pv3kQTDgGVbZWdrS59ubZm7eA3d+4+iVLFCFIjnF3CJoXL5UowY9x01m3SmVtPOvPN+f1Zt+D3OfGVKFOHgkROUeDj8wDdrZkIfPMDB3t7co1uhTHEqlitB664DGDRyMm9UKRtrGQ3rVOPr72IugPi072X1yq/TvWMLRk38nvote7By/e/mP7SPL+dJ+83T2hfbh72+ruld6PZ+C8Z/+6P5lPcjzerXJDDoLk3b9uaPHfued/PG8qT91FKxIvkY/dUPNGvbG5PJxKC+nc3TDAYDDetU4+CRZ2/fn6RgvlyMGNiTr79bQL0W3dm97xCTRg8gnZMTBoOBEQN7cvnqDRq1/pDJMxbw5hv/HRC6u7ky+YsB/L5tL/VadKfP4HEcO3kOgAJ5c5I7RzamzU55PxgxRESE65AxDTp/4Qq9B49j1fyvsbO1tXY5r7Rvf1iEjcGGnp1bWbsUked2PySUD/p9zncTh+Ga3oXISCPrftnKtNlL+G3VD9YuT55g+drN/HPkJKOGfGjtUlKlNNWDJDEDu4Pv3uOb7xfSqU0zhSMrio6O5tjJc2zasovWzes//QUiKdDtgEAC7gRx/uJVIiIiueZ/k6Mnz1KiaNwfqUjKEB0dzcXL11i4fAOd2rxl7XJSrTQ1SFtg7/4jDBszhWqVytCwdjVrl/NKGznhe/7+5xi9u7WJd+CiSGqQM3tWOrzblM+/nM7tO0F4uGWgSoXS9OnW1tqlSQJ+mLeC1T9vocO7TeK9iK88G51iExEREbGgU2wiIiIiFhSQRERERCwoIImIiIhYSDUByWQyYTQadSE7EbEatUMir45U8yu2qKgoqjbowPYNPybqLS5ERJ6V2iGRuPxv3mbClLlc979F5QqleLN6BfoN/ZIcvlkA+HbsYGxtU01/jJn2cBEREXlht24H8slH7+Pp4c77vYZSqWwJalUrT9/u7axd2ktRQBIREZEX9vjNlTN6uGGwscHFOfbNcbfvOcCiZRswRkXz+aCeZMnsldxlPjcFJBEREXlpFy5dw2Aw4OTowI69B/nrwBGKv1aQD7u8y7Zd++nRqRWFC+TGNpXc4SH1nRQUERGRFCUkJJQJU36kf8/25M+Tg69Hf8LU8UM4ffYCh4+d5oP2zflj+1989+MyQkMfWLvcZ6KAJCIiIi/MGBXF8C+n07FNM3yzZubKtRu4u7niYG+Pvb0ddna22Nra8tEH7+Hmmp6ff9th7ZKfiU6xiYiIyAtbtHwDx0+dZ/bCVcycv4Iq5Uvz14Ej3L4TRLlSRSlSMC9TZ/3EyTP/Ymdry6A+na1d8jNJNfdiMxqN+nmtiFiV2iGRV4dOsYmIiIhY0CGQSCJw9y2RaMsKunLoqfNERETSpM1HfD6oJ2VLFU20dYuISAz1IImkQgcOn6Burcps333A2qWIiKRJCkgiqdD23ftp3rg2Z85dxGQy8dvWPXT88FM6fvgpFy5d5d79EAaMmETXviOYNH0+AO91HQhAUPA9enw8CoA+g8cxa8EqRn/1A5ev+vPhgC9o220w38xYCMSMuRk5YQZd+45g6Ohv2bZrP7MWrALg8lV/Ph//nRXevYhI0tMpNpFUxmQyceHSNbJlyUTO7Fk5ffYC0+csYeGMsdjZ22FjMPDdnKWULFaId9+qR2SkMcFlRURGkitHVjq1aUZ4RARffNob53ROdO79GRERkazftI30Lun4ftJnREYaMRhg8cqNdHyvKdt27adWtfLJ+M5FRJKPApJIKnPyzL/cvH2HYWOmcOv2HXbsPUjhAnlwcnI0z3P238t85FcVAHv7J+/mZUoUAeBO4F0WLd+Ag4M9IaFhBNwJ4ty/l6hSoXSs5RQpmIeTZ/7ln6MnadG0TlK8xUR3914IYyfP4vIVf9wypOfzQT1Zuf431mzcioebKwDDB/QgTy5fK1cqkrhylWlm7RKs6sL+VS/8WgUkkVRm2+799O/ZngqvFyf0QRjtug/GZDIRHhGBjcGGqOhocmbPwr6Dx8iVIxv3Q0JJ7+KMyWTCZDJx+ap/vMtdtvpXypcpToWyxTl87DQAObNnZd+Bo1QsW8K8nEZ1qrN4xUY83DM8NXylFEdPnOGdJrUpVawQ3/6wiIXLN5DOyZGu7ZvTqE51a5cnIilQ6mjdRFK4Z/nlWWLZd+Ao7Vs1AcA5nROZvT0pXaIw3fqNxMbGhn492tG+VRM+H/8dm/7YTe6cWRnctwuVy5eiS5/hVKlQGgd7+zjLrVqpDN/MWMjmrbtxcozpjWpcrwajHo5Bcs/gyphhH5ErRzb+vXSV91s3Tbb3/LIqlStp/nexIvnZsu0vcvj64J4hvfWKEpEUTReKFJHnEhUVTf9h4xk/on+q6UF63MSpc8mZPStBwXf5++Ax7t4LoUzJIvTu1ga7eG6iuXztZlas2wzEjP+6ePm62iFJNXSKTafYRCQZXL7qz5hJM2n1Vt1UGY7OXbjMvoPH6NXlXQKD7lK3VhWcnZ0YMHwSv/6+kwa1q8V5TfPGfjRv7Af8d6AmImlf6mvhRMRqsmfzYfqEodYu44UEBt3ls7HTGDXkQxwdHPDJ5GWeVrNqOS5evmbF6kQkpdF1kEQkzYuIiGTwyMl0afc2+XJnJzwigjU//0FUVDQhoQ/Yd/AYBfPntnaZIpKCqAdJRNK8+UvXc+rsBeYuXsOs+SuJio7Gr3pFuvT5jMCgu9SsVp6aVctZu0wRSUEUkEQkzevUphmd2sQdrNqhdRMrVCMiqYFOsYm8Aq7738IYFZVs67ty7UayrUtEJCmoB0kkEZxe+VaiLavAWyufOP26/y069BpG3twxV32uXul16vtVjbmydkAgC2eMjfOa2YtWM6hPp0Sr8Wl+3bKL+m9WIYuPd7KtU0QkMakHSSQVKlo4H9PGD2Xa+KG0bFaXdOmcGPBRR4jnqmbnL1whe7bM2Ngk3+7esHY1Vv28JdnWJyKS2NSDJJIG2NnaJthbc+T4GcqUeA2A3oPGUrRwfnbsPcAblcty714IO//6h/dbN6FurSps33OA+UvWERR8j67tm/Nm9Qr437zNF5NmEvogjOqVX6dW1fJMmbmYiMhIateoRI5sPkyaPp+o6GiqV36dNu80JHMmT4KD7yXnJhARSVQKSCKp0NETZ+nx8Sgg5iarmbwyJjjv1es3qFop5oazkUYjFcuWoF2rRtRv2YOFM8byTpPajJ08i7q1qlC8SAGmjR9CUPA9Ph8/gzerV2DqzJ9o1rAWb1QuS2SkkdsBgRw+dprFM78kvYszHT/8lE8/7kYOXx+69R9J5XKlyJ0zG1HR0cmyLUREkoICkkgqVLRwPiaO/N8zzRvyIIx0To7mx75ZM+Po4EBmL098MnlhMpm4HRAEwJnzF9m+ez9Ojo7437wNxJyiG9yvM4D56tkF8uUivYszAHfv3SdXjqwAlCxakPMXr5A7ZzZMplRxFyMRkXhpDJJIGpc1szc3bgbEed5gMMT6P8DUmT/RtV1zWjdvYH4+u68Pf/9zHID7IaFxlpPB1YVLV64THR3NoWOnyZ0jG0CyjnkSEUls6kESSQRP++VZUtu59yBrN27F/+ZtBgyfxKC+nXF3cwUgZ/asnL94lVwPg8uT1KlZmb5Dx1MwXy48Hr6+V+d3GTPpB+b9tJZypYvR0OJ+ZQM+6siYr34gKjqaahXLkCeXL0ajEZvHgpeISGpjiIgITxX94I9uEqm7aIs8n4iISCZOncugvp2TbZ2/b9uLg4M9VSuUTrZ1Jge1Q5La5CoT9wKpr5IL+1e98GvVBy6Sxjk42FP8tQJERhqTbZ0hIaFUKlsy2dYnIpLYdAgk8gpoYHFaLKk1rlcjWdcnIpLY1IMkIiIiYkEBSURERMSCApKIiIiIBQUkEREREQsKSCIiIiIWkjQgLV65kUbv9mLhsg1xpl25doPOvT/jvQ8G8svvO5KyDBEREZHnkqQ/8y9drBBnz1+Kd9rkGQt4v3VTShYtSJtug6hSobT53k4iIiIi1pSkPUgF8+cmS2avOM9HRUWz5+/DlCxaEBcXZ3L4ZuHAoRNJWYqIiEi8/G/e5n+fTuS9rgOZNntJnMfyarLKGKTge/dwz+CKy8Meoxy+WbgdEGiNUkRE5BV363Ygn3z0PvOmj2HPvkP437gd63F8N3uWtM8qV9I2YCDa9N8t4KJNJgw2cW9suXztZlas2wyAyZQqbhknIiKpTLEi+c3/zujhRtYsmcjkldH82GBj4Or1m3wxaSYPwsJ5v3VTqlQoZa1yJZlYJSC5ZUjPvfsh3A8JJb2LM5ev+FPh9eJx5mve2I/mjf2A/24SKSIikhQuXLqGwWDA29MjzuNfft9J2dJFadeyEVFRUVauVJJDsp5iW7hsA5v+2IWNjQ0Vy5bg4JGT3A8J5fLV65QuXjg5SxERETELCQllwpQf6d+zPQaDIc7jWtXKY2MwMG7ybK5ev2ntciUZJFkP0q2AQPoPHU9AYDA2BgO7/z5Enpy+GAwxp9L6fNCGT8dO5bs5S+nesSUuzumSqhQREZEEGaOiGP7ldDq2aYZv1sxxHgOEhD6gTYuGHD91jhk/LmPMsN5WrlqSWpIFJG9PD+ZNH5Pg9Cw+3vzw9fCkWr2IiMgzWbR8A8dPnWf2wlXMnL+CcqWKxXpct1YVHB0cWPfrVkzRJtq2bGTtkiUZWGUMkoiISErRrmVj2rVsHOu5Dq2bxJmvTs1KyVWSpAC61YiIiIiIhTTbg+TuWyLZ1xl05VCyr1NEREQSX5oNSCIpkYK7iEjqoIAkksadXvmWVdZb4K2VVlmviEhiUEBKRNb4Q6Q/QiKSVuUq08zaJVjdhf2rrF3CK0uDtEVEREQsKCCJiIiIWNApNnkqDSwWEZFXjXqQRERERCwoIImIiIhY0Ck2SZH0i0AREbEm9SCJiIiIWFBAEhEREbGggCQiIiJiQQFJRERExIICkoiIiIgFBSQRERERC/qZv4ikeXfvhTB28iwuX/HHLUN6Ph/UExsbG4aNmcKdwGDq+VWhzTsNrV2miKQgCkgikuYdPXGGd5rUplSxQnz7wyIWLt9AZKSR6pVfp2n9GrTvOZRqFcuQwzeLtUsVkRRCp9hEJM2rVK4kpYoVAqBYkfzcuh3Irr/+oWSxQtjZ2VGscH5279P9/0TkP+pBEpFXyv5/jlP8tQLs2HMA36yZAcjhm4XbAUHxzr987WZWrNsMgMlkSq4yRcTKFJBE5JVx7sJl9h08Rq8u7zJ99hJ4GHiiTdEYbAzxvqZ5Yz+aN/YDwGg0UrVBh+QqV0SsSKfYROSVEBh0l8/GTmPUkA9xdHAgo4cbV67dAODyFX+8PT2sXKGIpCQKSCKS5kVERDJ45GS6tHubfLmzA1C5fCkOHjmJ0Wjk6ImzVCxbwspVvpzBIydT++2uAJw9f4n3ew2j00efcfTEWStXJpI6KSCJSJo3f+l6Tp29wNzFa2jXfTDtug/mvXcasH33Adr3GErDOtXM45FSqw+7tMbD3Q2A735cxoiBPRg+oDtffjvHypWJpE4agyQiaV6nNs3o1KZZnOe/GTvQCtUkjSw+3tjZ2gIQFHzXfMmC8PBwwsLC+XXLLjb+th1bW1u+HN4XFxdna5YrkuIpIImIpDHpXZy5cOka9vZ23L0XQuiDMH77cw8jh3yIh5srdnZq+kWeRnuJiEga0/39FoybPIs8ubOTPZsP7m6ufPLR+/y4aDUZPdxo36qxQpLIU2gMkohIGpM7py/TJw6j9dv1yeSVERsbG9K7OPPxh+8TcCeYPX8fsXaJIimeDiFERFK546fOMXfxWvxv3mbA8EmUKVmEzVv3kM7JkQG9O2I0Gpk+ZwnXrt8iXTpHSpcobO2SRVI8BSQRkVSuSMG8jBveN9ZzLZrWifV4cN8uyVmSSKqnU2wiIiIiFhSQRERERCwoIImIiIhYUEASERERsaBB2iIiSSRXmbhX736VXNi/ytoliLww9SCJiIiIWEiyHqTVP29h2ZpNpHdxZuSgnmTy9jRP+/fiVT4bO5WQ0AfUql6BHh1bJlUZIiIiIs8tSXqQ7gQGM3/JOmZNHkHzxn5MnbUk1vTZC1fRpkVDfpo5nqMnznD5qn9SlCEiIiLyQpIkIO3df4QCeXPh5ORIyWKF2L3vn1jTXZzT4e6WAXt7O3Jlz2a+A7WIiIhISpAkp9gC7gSRw9cHAK+M7kRFRxMWHoGTowMAHVo3ofegsdSrVZVoUzRZfLyTogwRERGRF5I0Y5AMYDKZzA9N0SYMhv8mb9i0nZbN6nHr9h3OnLvE/ZBQ0rs4x1nM8rWbWbFuc8wyHlueiIiISFJKkoDk7enB0RNnAbgVEIi9vT2ODjG9R2Fh4Wzb/Tdzp46OeRwezrZd+6nvVzXOcpo39qN5Yz8AjEYjVRt0SIpyRURERGJJkjFI5UoX48y5i4SFhXPw8EkqlSvJwmUb2PTHLmxsbLjuf5sr125gjIri0pXrSVGCiIiIyAtLkh4kD/cMdGjdlE69P8PVxZmRQz5k/pJ1GAwGHBzsGdq/K32HfEl0dDSlihemdo2KSVGGiIiIyAtJsusgNapTnUZ1qpsf9+vRzvzvapXKUK1SmaRatYiIiMhL0ZW0RURERCwoIImIiIhYUEASERERsaCAJCIiImJBAUlERETEggKSiIiIiAUFJBERERELCkgiIiIiFhSQRERERCwoIImIiIhYUEASERERsaCAJCIiImJBAUlERETEggKSiIiIiAUFJBERERELCkgiIiIiFhSQRERERCwoIImIiIhYUEASERERsaCAJCIiImJBAUlERETEggKSiIiIiAUFJBERERELdtYuQEQkuSxeuZFFyzbQ6q16vPdOA2bOX8GajVvxcHMFYPiAHuTJ5WvlKkUkJVBAEpFUKyoqGlvbZ+8IL12sEGfPX4r1XNf2zWlUp3pilyYiqZxOsYlIqrFw2QYC7gQB0H/YBGo06cjqn7c88+sL5s9NlsxesZ5zz5A+MUsUkTRCPUgikmqs+/VPWjarw18HjuJgb8/86WPoP2wCTevXfOFlLly2gemzl1KmZBF6d2uDna1trOnL125mxbrNAJhMppeqX0RSDwUkEUk1wiMiCAl9wKLlG+j9QRtyZs+Ki0u6F15ewzrVqVurCs7OTgwYPolff99Jg9rVYs3TvLEfzRv7AWA0GqnaoMPLvAURSSV0ik1EUo26tSpTr0UPPNzdyJ0zG2f/vYxPJq+nvzABPpm88M2amYzubtSsWo6Ll68lYrUikpqpB0lEUo0P2r/Du2/VJ4OrCwDenh706db2hZYVHhHBL7/tpGGd6oSFh7Pv4LE4vUci8upSQBKRFO/gkZNPnG458Do+twIC6T90PAGBwdgYDOz66x/KlipKlz6fERh0l5rVylOzarnEKllEUrknBqTAoLvcuBVAofy5k6seEZE4Jk2fD8Ddu/cx2BhwTR/TgxRwJ4gc2XyYPnHYU5fh7enBvOlj4jzfoXWTxC1WRNKEBAPS+l//ZMGyDURGRrJi7iSu+9/ih/kr+PTjbslZn4gI86aNBmDA8EkM7tcFt4c/zb/mf5OZ81daszQRSaMSHKQ9f+l6fpw6ChcXZwCy+Hhz/sKVZCtMRMTSVf+b5nAEkNUnE+cuXLZiRSKSViUYkGxsDDg5Opgfh4Q+4EFYWLIUJSISH6+M7ixYtp7ISCPR0dGs//VPbG30Y1wRSXwJnmKr8HpxZvy4jPDwCHbsOcj8peuoUqF0ctYmIhLLoD6dGTlhBt/NWYbBALlz+jKsf1drlyUiaVCCAalnp1YsXP4zrumdmbNoNVUqlKJti4bJWZuISCyZM3ky5cvBPAgLIzoq2jwEQEQksSUYkFZt2EL7Vo1p36pxctYjIvJEl6/6E3AniMdv+lGqWCGr1SMiaVOCAWnTH7tp1rBWnPsSPavVP29h2ZpNpHdxZuSgnmTy9jRPCwl9wBeTZnLh8jUye3vy+cAeOhIUkaca+/UsNmzeRo5sWbC1i2mbDAaYO3W0lSsTkbQmwYDUpN4bfDjgC1o2rYOt7X+DIKtWLPPUhd4JDGb+knUsnDGW7XsOMHXWEkYM7GGePmvBKgoVyM2oIR9y/sIVnJ1f/F5KIvLq2PnXP6xfPAW3DK7WLkVE0rgEA9LG33ZgYzCwbM0m83MGg+GZAtLe/UcokDcXTk6OlCxWiPHfzok1/bc/d7Nk1ngA8uTyfdHaReQVUzBfLtI5OVm7DBF5BSQYkKaOH/LCCw24E0QOXx8g5me5UdHRhIVH4OTowIOwMGwMNixavpE/d+6jQtkS9OjYMt7lLF+7mRXrNgNgMpninUdEXh3FX8vPoJGTKV+mWKznWzStY6WKRCSteuKtRg4fO82OvQcxEHNqrWjhfM+2VEPsQGOKNmEwxPw7NDSMwOC7lChagLYtGtK5z3BqVClL4QJ54iymeWM/mjf2A8BoNFK1QYdnW7+IpEmXLl/Hw82V02cv/Pfko8ZFRCQRJRiQNmzaxpxFq/GrUREDBkZ8OZ33Wzelvl/Vpy7U29ODoyfOAjE3iLS3t8fRIeaik+5uGbC3s6N4kQI4ONhTsmhBrl6/GW9AEhF53ND/fWDtEkTkFZFgQFqy6hdmTh6Bu1vMYMgWTevw0cAvnikglStdjO/nLicsLJyDh09SqVxJFi7bgLeXB7VrVKJMiSLs2vcPFV4vwaFjp2hav2bivSMRSdM2b93N9t37AQPVKpbhzTcqWLskEUmDErxGf1R0tDkcAbi7uRIVHf1MC/Vwz0CH1k3p1PszVq3/jR6dWnLjVgC3A4IA6NO9LUtW/kKbDwbyRuWyGqgtIs9k3pK1LF39K6+XKkrZ0kVZsvpXFixdb+2yRCQNSrAHqXD+3EyaPo+WzeoCsHT1Jgrlz/3MC25UpzqN6lQ3P+7Xo53531kyezF94rAXqVdEXmGb/tjNzK+H4+TkCMCb1cvTpc8I2ugq/yKSyBLsQerbvS1hYRF07j2cLn1GEBYWTr/ubZOzNhGRWEzRJhwc7M2PHewdMEXrF64ikvgS7EFycXFmUN/ODErOakREnqB8mWIMGfWt+detK9b/RrkyRa1clYikRQn2IH37wyLuBAWbH1++6s9X0+YlS1EiIvHp0aklBfLlZNrsJUybvYQCeXLSs1Mra5clImlQgj1If/9zjA+7tDY/zp7NhyPHzyRLUSIi8bGzs+P91k15v3VT83MREZHWK0hE0qwEe5AiI4zcDwk1Pw4JCSX0QViyFCUiEp/h46YRGHTX/PjyVX/GTPrBihWJSFqVYA9So7rV6fnJaN5u5IfBYGDV+t+pU7NSctYmIhLLv5eu4uGewfw4ezYfLly6ZsWKRCStSjAgvft2fTwzurN99wHu3Q+hWcNasX62LyKS3KKjTNwKCMTb0wOA2wGBOsUmIkkiTkDavns/Ls7pKF2iCLVrVOLYyXNs2b6X0+cukidnNl4r9Iz3YxMRSWRtWjSga5/h1H2zCgYM/PL7Ttq3amztskQkDYozBmnekvXkypENgEPHTrN5625+mjmeEQN7MGn6/GQvUETkkTo1KzN8YE+ijFFEREYytH8XmtSvYe2yRCQNitOD9CAsjIwebgD8tGIjrd6qS/ZsPmTP5sPEqfqZv4hYV45sPjhWK/9cV/YXEXlecXqQbAwGTp+7yN//HGP/oWM0qRdzdGY0GmNdwVZEJLmt//VPuv9vFENHfwvAdf9bfD7+OytXJSJpUZwepB6dWtHjf6OIiIxkYO9OuGWIuWHtklW/Ur50sWQvUETkkflL1zN32mi69h0BQBYfb85fuGLlqkQkLYoTkCq8XpyNS6djjDKSzsnJ/HyZkkXIlT1rshYnIvI4GxsDTo4O5schoQ94EKbrs4lI4ov3Z/729nbY28eepPP9ImJtFV4vzowflxEeHsGOPQeZt2QtVSqUtnZZIpIGJXglbRGRlKZnp1Y4OTnimt6Zb39YRKWyJenesaW1yxKRNEgBSURSvO2793Pg0HHs7Oxo36oxrxXKx5Vr/ixd8yunzvxr7fJEJA1SQBKRFE/XZxOR5KaAJCIpXkLXZytbqij3Qx5YuToRSYsUkEQkxdP12UQkuSV4s1oRkZRC12cTkeSmgCQiKZ6uzyYiyU0BSURSBV2fTUSSk8YgiYiIiFhQQBIRERGxoIAkIiIiYkEBSURERMSCApKIiIiIBQUkEXllLF65kUbv9mLhsg0ABAXf48MBX/Be14EsWLbeytWJSEqigCQir4zSxQpRrsx/F5acvXAV1Su/ztxpo9j42w4uXbluxepEJCVRQBKRV0bB/LnJktnL/HjXX/9Qslgh7OzsKFY4P7v3HbJidSKSkiggicgr605gML5ZMwOQwzcLtwOCrFuQiKQYupK2iLyyDAYDmEwARJuiMdgY4syzfO1mVqzbDIDp4bwikvYpIInIKyujhxtXrt0gX54cXL7iT748OeLM07yxH80b+wFgNBqp2qBDMlcpItagU2wi8sqqXL4UB4+cxGg0cvTEWSqWLWHtkkQkhVAPkoi8Em4FBNJ/6HgCAoOxMRjY/fchRg/5iGFjprB6wxYa1qlmHo8kIqKAJCKvBG9PD+ZNHxPn+W/GDrRCNSKS0ukUm4iIiIgFBSQRERERC0kWkFb/vIX3PhjIB/0+5+atgHjn6Td0PCMnzEiqEkREREReSJIEpDuBwcxfso5Zk0fQvLEfU2ctiTPPrr/+4dbtwKRYvYiIiMhLSZKAtHf/EQrkzYWTkyMlixVi975/Yk03Go3MnL+CNi0aJsXqRURERF5KkvyKLeBOEDl8fQDwyuhOVHQ0YeERODk6ALB87W/UqFIOb0/3Jy5HV7AVERERa0ian/kbYgcaU7QJw8Mr+AcF32Pz1t1MnzCUoyfOPHExuoKtiIiIWEOSBCRvTw+OnjgLxFyczd7eHkeHmN6jnXsPcj8klB4fjyIk9AFBwfeYv2QdbVs2SopSRERERJ5bkgSkcqWL8f3c5YSFhXPw8EkqlSvJwmUb8PbyoEHtajSoXQ2AA4eOs2HzdoUjERERSVGSZJC2h3sGOrRuSqfen7Fq/W/06NSSG7cCuB0QlBSrExEREUlUSXarkUZ1qtOoTnXz43492sWZp3SJIpQuUSSpShARERF5IbqStoiIiIgFBSQRERERCwpIIiIiIhYUkEREREQsKCCJiIiIWFBAEhEREbGggCQiIiJiQQFJRERExIICkoiIiIgFBSQRERERCwpIIiIiIhYUkEREREQsKCCJiIiIWFBAEhEREbGggCQiIiJiQQFJRERExIICkoiIiIgFBSQRERERCwpIIiIiIhYUkEREREQsKCCJiIiIWFBAEhEREbGggCQiIiJiQQFJRERExIICkoiIiIgFBSQRERERCwpIIiIiIhYUkEREREQsKCCJiIiIWFBAEhEREbGggCQiIiJiQQFJRERExIKdtQsQEbGWyvXakjdXdgBKFC1I/57trVyRiKQUCkgi8sry9szIvOljrF2GiKRAOsUmIq8sN7f01i5BRFIo9SCJyCsr4E4QXfqMAEz06tKaEq8VsHZJIpJCKCCJyCtr9NDeFMqfi6079jF83DRWzfs6zjzL125mxbrNAJhMpmSuUESsRQFJRF5Zj3qM/N6oyIQpcwkLj8DJ0SHWPM0b+9G8sR8ARqORqg06JHeZImIFSRaQVv+8hWVrNpHexZmRg3qSydvTPO2nlb+w6Y+dhISG0atzK6pWLJNUZYiIxGvn3oPk8M1C9mw+7D90nExeGeOEIxF5dSVJQLoTGMz8JetYOGMs2/ccYOqsJYwY2AOAkNAHhEdE8MPXI7h4+Ro9PxnNzxVKYzAYkqIUEZF4ZfXJxMSpc7l56w72DnZ8+kk3a5ckIilIkgSkvfuPUCBvLpycHClZrBDjv51jnubinI72rRoDkDtnNqKiogiPiNSRm4gkq9w5s/H1mAHWLkNEUqgkCUgBd4LI4esDgFdGd6Kio+M9t3/q7AV8s2ZOMBxpcKSIiIhYQ9KMQTLEDjSmaBOWZ9CMUVFMnrGQDzq0SHAxGhwpIiIi1pAkF4r09vTg0lV/AG4FBGJvb4+jQ+xeoq+nL6BMicKUL1MsKUoQEREReWFJEpDKlS7GmXMXCQsL5+Dhk1QqV5KFyzaw6Y9dQMyps4A7QXR8r1lSrF5ERETkpSTJKTYP9wx0aN2UTr0/w9XFmZFDPmT+knUYDAauXr/J19PnkzunLx16DgWgbctG+L1RMSlKEREREXluSXYdpEZ1qtOoTnXz43492pn/vWPjvKRarYiIiMhL081qRURERCwoIImIiIhYUEASERERsaCAJCIiImJBAUlERETEggKSiIiIiAUFJBERERELCkgiIiIiFhSQRERERCwoIImIiIhYUEASERERsaCAJCIiImJBAUlERETEggKSiIiIiAUFJBERERELCkgiIiIiFhSQRERERCwoIImIiIhYUEASERERsaCAJCIiImJBAUlERETEggKSiIiIiAUFJBERERELCkgiIiIiFhSQRERERCwoIImIiIhYUEASERERsaCAJCIiImJBAUlERETEggKSiIiIiAUFJBERERELCkgiIiIiFhSQRERERCwoIImIiIhYUEASERERsaCAJCIiImJBAUlERETEgl1SLXj1z1tYtmYT6V2cGTmoJ5m8Pc3Trly7wfBx03gQFk7bFg2pW6tKUpUhIvJET2qrROTVlSQ9SHcCg5m/ZB2zJo+geWM/ps5aEmv65BkLeL91U77/6lNm/LiM+yGhSVGGiMgTPa2tEpFXV5IEpL37j1Agby6cnBwpWawQu/f9Y54WFRXNnr8PU7JoQVxcnMnhm4UDh04kRRkiIk/0pLZKRF5tSXKKLeBOEDl8fQDwyuhOVHQ0YeERODk6EHzvHu4ZXHFxcQYgh28WbgcEPnWZJpMJAKPRmBQlJwpjlBXWmYK3x8vQtkw81tiW8Pzb09bWFoPBkETVxO9JbVV8UkM7lJJoO708bcOX8zLtUNKMQTL815AAmKJNPGr3DBiIfmxatMmEwSb+RnH52s2sWLc5Zr7oaABqNOn8TCUUfq3Yi1T+UjrNTPZVwswOSb4KbcvE88psS3ju7bl9w4/Y2SXZsMj4PaGteuRl2qEsXi6JU2cqVbVBh5d6/au+/UDb8GU97/Z7vB1KktbI29ODoyfOAnArIBB7e3scHWKOyNwypOfe/RDuh4SS3sWZy1f8qfB68XiX07yxH80b+wExDVNERIRVjjKfVZtug1jw3RfWLiNN0LZMPKllW9ra2ib7Op/UVj2S2tqhx6WWzz4l0zZ8Oalt+z3eDiVJQCpXuhjfz11OWFg4Bw+fpFK5kixctgFvLw9q16hExbIlOHjkJKWKFeLy1euULl74qcu0sbHByckpKcpNNAaDIfmPgNMobcvEo22ZsPjaqidJDe3Q4/TZvzxtw5eTmrdfklTt4Z6BDq2b0qn3Z7i6ODNyyIfMX7LOfMTV54M2fDp2Kt/NWUr3ji1xcU6XFGWIiDxRfG2ViAiAISIi3PT02eRZLF+72dwVLy9H2zLxaFu+uvTZvzxtw5eTmrefApKIiIiIBd1qRERERMSCApKIiIiIBQUkEREREQup87d3iey6/y069BpG3ty+AJQpUYQcvlnwe6NivPPPnL+CLdv+wsnJATs7Oz4f1BOfTF70+HgURmMUdna2ODo4MGn0J4ycMINz/17GxsYGW1tbRgzszoZN2zl45ARnzl0id85s2NnZ8s3YQTx4EMachavp0LopGVxT9sW9Hm2zPDmzYTKZ6NT2LcqWKhpnvgOHjvPZuOn4ZPIi9MEDend9j3Jlipm3obu7KwADPurI0RNnmbNoNRk93Ah9EEaPji2JiIxk6epfuX7jNukcHXF3d6VPt7YUyJvzueo9fe4i38xYSGDwXfyqV6RD6yaJsh1e1nX/W7zVvi9rFn5DJq+MhIVHUO+d7kwc2Z/SJYo88bX9h03gfz3bk8XH+4XW/ei7GW0ykdE9A6OGfEh6F2ead+hHJu+MAGTN7M3Q/31g/m6HR0TgnsGVzwf1YvqcJVy6cp0Tp/6lcMHceHq4M3JwrxeqReKXEtqmaeOHJudbfi5qh16c2p6nU0B6qGjhfEwc+b9nnr9zu7epWbUcS1f/ytqNW+navjkAXw7vh7uba6x5B/TuSOECeVj7y1aWr9nMRx+8B0CPj0cxZmhv3N1cCQl9wLjJs9m97xBFi+SnZtVyiffmksijbXY7IJA+Q77kmy8GktHDLc581Su9zv96tefs+UtMnDqXcmVirib9aBs+cvTEWZo1qMV77zTg8lV/Pv1iKnOmjOSNymWZOX8FeXJlf+Ht4uKcjtFDP8I1vTPvvN+f1s3r4+Bg/2JvPJHlzpGN7bv383YjP/7afwRvL49kW/ej7+bkGQv4Y8c+GtWpjqODQ7x/FB99t2fMXcamP3YxsHcnAN7rOjBF/xFN7azdNqV0aodenNqeJ1NAiseGTdsICr7He+80oHPvz8ibKzv/HD1J+1ZNqO9X1TyfMSqK2wGB+GbN/NRlRkVF43/jNj6ZveKd7uKcjkIFclO0cH7y5MyWaO8lOXh5elC7RkV2/32II8fPcPL0v3hmdGf00I/M85hMJm7cCiBzJs+nLs9kMnH9xu0nzrv2l62s//VPAoPuMqRfF0oWK2SedvzUOdb+spWBvTsREvqAIaO+4esxAzCZTPx78Srp0ztjb59yvvqFCuRm799HeLuRH9v3HKBYkfwALFi6nj93/Y2tjQ19e7SjYL5cHDl+hlETvyejhxsBd4IAeBAWxsgJ33Pt+k3y5PJl2P8+YNaClUREGjl64gz9erRn+uwluKZ35sjxMwzs0ynWUXZERCSBQXfJ7P30zyYy0sitW3coUiBPkmwLeTJrtE2phdqh56e258lSzl8JKzt64iw9Ph4FQLlSxcxfXP+bt5k48mNCH4Qx9uuZ5kZo5rwVTJ+9hIiISL776lPzcj4Z/hV2drY08KtGg9rVABg3eTYBgcGUK12U95rXT7CGNu80TKq3l+S8PTNyK+AO9nZ2/Dh1FAuXbWDrjr/I5JWRP3f9zbGTZzlz/lKsI+GZ81awfO0m8ufJSd/ubQFYteF3NmzaRrp0Tgwf0D3B9VWtUJqGtatx/NR51v7yR6yGqXCBPEyaPp+oqGj2/H2YKhVKA7Bo+c9MmbmYL4f3TVG3iTAYDDg6OnAnKJj790PxzOjO+YtX2bZ7PzO++pRLV/wZNXEGMyePYOLUuYwa3IvcuXz58JMxACxbs4mihfIxZuhHTJgyl8PHTgMQEvqAaeOHct3/Fjdv3WH00I84fuocm7bsMjdS4ybPJjDoLu7urubTBeEREeZ9oW2LRlQsWwKI+W5fvHydJvXeoMLrJZJ7M72yUkLblFqoHXo+anueTAHpoce7sR8dpQG4ubriliE9GVxduB0QZJ6/c7u3qVGlLBcvX2PUhBlMHT8ESLgb+9IVf86cv4iLi3PyvKFkduNWAGs3biWdkyM9Ph5FeHgkdWtVJpNXRnPX9t17IfQb+iWvFcoLxO3aBmjWoBY1q5Zj+JfTn3j0u//QcY6eOIuNwcCVazcIvnufQSO/BmD4gB6ULFqIoyfOsGPPAXp2agXAe+80oHbNSowcP4OC+XOTyStj0myMF1CtUhlmL1hNmZJFuHDpGu5urpQsVggbGxty5chq/j7eux9C/oeNifPDK9CfPX+Zy1f92bH3AKGhYZQt/RoQM17lkUzeGXFydMAnkye3AgLNzw/o3ZFC+XNz8PAJvpo2l88H9XpiN/fqn7fgmgKOfF8lapuendqh56e2J2Fq5Z5RfEnfYDCQ4eHNd5/mzeoVWLh8A3cCg+M9P56a3QoIZPPW3XRu+xZHT5zl4w87YDKZMBgMHDx8wjyfs3PMPaxCH4Q9cXlZfLzJ4ZuFnXv/oUqFUvHO88O8FSz+YRwXL1/n5JR/ccuQPtaO9Wb18vyyZSehD8Lw8vTgyPEzFMqfG6+M7jg7O3Hl2g2rN0yPq1SuJGMnz+KnmeO5cGktgUF3OXT0FNHR0Vy+6o9bhpg/bHZ2dty4GYCXpwfBd2Marjy5fMmfJwdtWzYiKioaW1sbzpy7GO96DMT/PXZzcyX47v2n1vlOYz+69vuchg/HC4j1qW2KoXboxajtSZgC0guaOW8Fi5ZvIDw8ko8+aG1+/lE3NsBXoz4xP29ra0PLZnWYt2Qdfbq1SfZ6k8LRE2fp1u9zTEC/7u0oWawQR46foX2PIbi4OPPZJ90A+HPX35w9f5HA4Hs0a1DL3CA86toG6P5+y1jLbteyEZ+NnUbl8iXj/QNQpUIpeg0YQ/EiBbCP50aIBfLlYuTE72lavyYQc/TTb+h4gu/dp0jBPJQsWjAxN8VLc3FOx5Rxg/H2jBkkmTeXL2Fhpfig3+fY2NjwyYcdAPioa2v6fzqBHNl8zI1Ey2Z1GDnhe97vNQzX9C6M/azPM6933OTZ2NjYYDAYGNC7IxC7mzu9szNfjuj3X50uztSsWo7VG7bQslndRHjnkthetbZJ7dDLUduTMN1qRERERMSCLhQpIiIiYkEBSURERMSCApKIiIiIBQUkEREREQsKSCIiIiIW/g/Ne8LP3wRuDQAAAABJRU5ErkJggg==",
       "text/plain": [
        "<Figure size 583.3x320 with 2 Axes>"
       ]
@@ -1510,13 +1498,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dbafa0c6",
+   "id": "e2af5a1f",
    "metadata": {
     "papermill": {
-     "duration": 0.004894,
-     "end_time": "2026-09-09T21:29:59.752121+00:00",
+     "duration": 0.002282,
+     "end_time": "2026-09-10T21:03:10.078285+00:00",
      "exception": false,
-     "start_time": "2026-09-09T21:29:59.747227+00:00",
+     "start_time": "2026-09-10T21:03:10.076003+00:00",
      "status": "completed"
     }
    },
@@ -1534,19 +1522,19 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "id": "6fc4860e",
+   "id": "83499a07",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T21:29:59.760871Z",
-     "iopub.status.busy": "2026-09-09T21:29:59.760685Z",
-     "iopub.status.idle": "2026-09-09T21:30:00.109677Z",
-     "shell.execute_reply": "2026-09-09T21:30:00.109170Z"
+     "iopub.execute_input": "2026-09-10T21:03:10.086236Z",
+     "iopub.status.busy": "2026-09-10T21:03:10.085979Z",
+     "iopub.status.idle": "2026-09-10T21:03:10.293076Z",
+     "shell.execute_reply": "2026-09-10T21:03:10.292677Z"
     },
     "papermill": {
-     "duration": 0.35323,
-     "end_time": "2026-09-09T21:30:00.110204+00:00",
+     "duration": 0.213083,
+     "end_time": "2026-09-10T21:03:10.293633+00:00",
      "exception": false,
-     "start_time": "2026-09-09T21:29:59.756974+00:00",
+     "start_time": "2026-09-10T21:03:10.080550+00:00",
      "status": "completed"
     }
    },
@@ -1568,11 +1556,14 @@
    ],
    "source": [
     "n_models = len(results)\n",
-    "fig, axes = plt.subplots(1, n_models, figsize=FIGSIZE[\"triple_h_tall\"])\n",
+    "# `squeeze=False` so this cell does not depend on how many models ran. `n_models` is\n",
+    "# read from `results`, and without it a one-model dict gets a bare Axes rather than an\n",
+    "# array and the zip below raises `'Axes' object is not iterable`.\n",
+    "fig, axes = plt.subplots(1, n_models, figsize=FIGSIZE[\"triple_h_tall\"], squeeze=False)\n",
     "\n",
     "labels = [\"negative\", \"neutral\", \"positive\"]\n",
     "\n",
-    "for ax, (name, r) in zip(axes, results.items(), strict=True):\n",
+    "for ax, (name, r) in zip(axes[0], results.items(), strict=True):\n",
     "    cm = confusion_matrix(r[\"y_true\"], r[\"y_pred\"])\n",
     "    sns.heatmap(\n",
     "        cm,\n",
@@ -1605,13 +1596,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e36d1bcc",
+   "id": "d7247ac3",
    "metadata": {
     "papermill": {
-     "duration": 0.005064,
-     "end_time": "2026-09-09T21:30:00.121037+00:00",
+     "duration": 0.002113,
+     "end_time": "2026-09-10T21:03:10.299618+00:00",
      "exception": false,
-     "start_time": "2026-09-09T21:30:00.115973+00:00",
+     "start_time": "2026-09-10T21:03:10.297505+00:00",
      "status": "completed"
     }
    },
@@ -1656,19 +1647,19 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "id": "3a113c5c",
+   "id": "b84b72b0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T21:30:00.129830Z",
-     "iopub.status.busy": "2026-09-09T21:30:00.129599Z",
-     "iopub.status.idle": "2026-09-09T21:30:00.133054Z",
-     "shell.execute_reply": "2026-09-09T21:30:00.132588Z"
+     "iopub.execute_input": "2026-09-10T21:03:10.304929Z",
+     "iopub.status.busy": "2026-09-10T21:03:10.304755Z",
+     "iopub.status.idle": "2026-09-10T21:03:10.308604Z",
+     "shell.execute_reply": "2026-09-10T21:03:10.308048Z"
     },
     "papermill": {
-     "duration": 0.00916,
-     "end_time": "2026-09-09T21:30:00.133580+00:00",
+     "duration": 0.007368,
+     "end_time": "2026-09-10T21:03:10.309144+00:00",
      "exception": false,
-     "start_time": "2026-09-09T21:30:00.124420+00:00",
+     "start_time": "2026-09-10T21:03:10.301776+00:00",
      "status": "completed"
     }
    },
@@ -1678,11 +1669,11 @@
      "output_type": "stream",
      "text": [
       "FinBERT: accuracy 97.1%, macro F1 0.955 (NOT held out, checkpoint saw this corpus)\n",
-      "  109.5M parameters, 28s to fine-tune\n",
+      "  109.5M parameters, 19s to fine-tune\n",
       "DeBERTa-v3: accuracy 94.4%, macro F1 0.932 (held-out)\n",
-      "  141.8M parameters, 32s to fine-tune\n",
+      "  141.8M parameters, 22s to fine-tune\n",
       "ModernBERT: accuracy 96.5%, macro F1 0.962 (held-out)\n",
-      "  149.6M parameters, 45s to fine-tune\n"
+      "  149.6M parameters, 25s to fine-tune\n"
      ]
     }
    ],
@@ -1716,30 +1707,30 @@
    "version": "3.14.3"
   },
   "ml4t_provenance": {
-   "executed_at": "2026-09-09T21:30:11.432059+00:00",
+   "executed_at": "2026-09-10T21:03:21.963995+00:00",
    "executor": "local-uv",
-   "library_digest": "9ba6119c275c181c92be8c76fc667148f9a82dfb3b52aed131951753699249fb",
-   "outputs_digest": "07442c36503d34c56a5b131b2efa83f334dc53fadbe34723d5d1a3ae20f42a78",
+   "library_digest": "971331d685439acf1ad4447debf6e5a73ad0c5bf5e93cde94ff457c84a7d3551",
+   "outputs_digest": "cf5727b89e9797e67b6111a6cf9db02f1cd0d1dcf89605659f56b17f019e6cbb",
    "parameters": {},
    "production": true,
-   "source_py_blob": "8ed331452055c542ea3a03c68ba891e1843eaeee"
+   "source_py_blob": "454a1eef6684352ecef426458c479431d40b12b5"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 122.535853,
-   "end_time": "2026-09-09T21:30:02.954117+00:00",
+   "duration": 79.228384,
+   "end_time": "2026-09-10T21:03:13.131379+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "~/ml4t/public-teach-c/10_text_feature_engineering/.04_bert_finetuning.build.3905550.ipynb",
-   "output_path": "~/ml4t/public-teach-c/10_text_feature_engineering/.04_bert_finetuning.papermill.3905550.ipynb",
+   "input_path": "~/ml4t/public-gpu-flags/10_text_feature_engineering/.04_bert_finetuning.build.3355454.ipynb",
+   "output_path": "~/ml4t/public-gpu-flags/10_text_feature_engineering/.04_bert_finetuning.papermill.3355454.ipynb",
    "parameters": {},
-   "start_time": "2026-09-09T21:28:00.418264+00:00",
+   "start_time": "2026-09-10T21:01:53.902995+00:00",
    "version": "2.7.0"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {
     "state": {
-     "010402e17bfc43b58a0bd85be8794d27": {
+     "0157a81c2f884fc5a32a8cd4cee4af33": {
       "model_module": "@jupyter-widgets/base",
       "model_module_version": "2.0.0",
       "model_name": "LayoutModel",
@@ -1792,30 +1783,7 @@
        "width": null
       }
      },
-     "07200605cb5d4956a94e1d05355e8236": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "2.0.0",
-      "model_name": "HTMLModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "@jupyter-widgets/controls",
-       "_model_module_version": "2.0.0",
-       "_model_name": "HTMLModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/controls",
-       "_view_module_version": "2.0.0",
-       "_view_name": "HTMLView",
-       "description": "",
-       "description_allow_html": false,
-       "layout": "IPY_MODEL_657fbc1eb5e24c0a82dca9cf550a1381",
-       "placeholder": "​",
-       "style": "IPY_MODEL_24ded93d563549b089b9c09c9b7310a3",
-       "tabbable": null,
-       "tooltip": null,
-       "value": "Map: 100%"
-      }
-     },
-     "081ff1d02d184ba7abb60f97e3e8c4be": {
+     "0239a070c539412b9cc1e33d9a45dfbd": {
       "model_module": "@jupyter-widgets/base",
       "model_module_version": "2.0.0",
       "model_name": "LayoutModel",
@@ -1868,30 +1836,60 @@
        "width": null
       }
      },
-     "0903cbff24f8486591f3a50e1fa1d1a0": {
-      "model_module": "@jupyter-widgets/controls",
+     "05416887147d411ca9e6d4e8dc4042b1": {
+      "model_module": "@jupyter-widgets/base",
       "model_module_version": "2.0.0",
-      "model_name": "HTMLModel",
+      "model_name": "LayoutModel",
       "state": {
-       "_dom_classes": [],
-       "_model_module": "@jupyter-widgets/controls",
+       "_model_module": "@jupyter-widgets/base",
        "_model_module_version": "2.0.0",
-       "_model_name": "HTMLModel",
+       "_model_name": "LayoutModel",
        "_view_count": null,
-       "_view_module": "@jupyter-widgets/controls",
+       "_view_module": "@jupyter-widgets/base",
        "_view_module_version": "2.0.0",
-       "_view_name": "HTMLView",
-       "description": "",
-       "description_allow_html": false,
-       "layout": "IPY_MODEL_54f8751af98846f2a5af59645d50761d",
-       "placeholder": "​",
-       "style": "IPY_MODEL_97dabe1bcf4a45d2b5deeed7de9fe97d",
-       "tabbable": null,
-       "tooltip": null,
-       "value": "Map: 100%"
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
       }
      },
-     "0eb518da682349cbb9ae331a934dffd8": {
+     "05ebf9e5285945758fd0d0bcda80b3fe": {
       "model_module": "@jupyter-widgets/controls",
       "model_module_version": "2.0.0",
       "model_name": "FloatProgressModel",
@@ -1907,17 +1905,17 @@
        "bar_style": "success",
        "description": "",
        "description_allow_html": false,
-       "layout": "IPY_MODEL_33e835b239864c748e14fb2183758a7c",
+       "layout": "IPY_MODEL_c812dfb756594161a8690105818f50bd",
        "max": 340.0,
        "min": 0.0,
        "orientation": "horizontal",
-       "style": "IPY_MODEL_b68068e48f4a432aa0a8453d2a5c9d4b",
+       "style": "IPY_MODEL_0b31871f2d884ff6b1ce05f3684b8ed4",
        "tabbable": null,
        "tooltip": null,
        "value": 340.0
       }
      },
-     "0f1375d4082540b698c939a620efbe31": {
+     "08146df81d884141b177a71caf4c79f4": {
       "model_module": "@jupyter-widgets/base",
       "model_module_version": "2.0.0",
       "model_name": "LayoutModel",
@@ -1970,318 +1968,7 @@
        "width": null
       }
      },
-     "0f570a41f52c417f814327baca5967a7": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "2.0.0",
-      "model_name": "LayoutModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/base",
-       "_model_module_version": "2.0.0",
-       "_model_name": "LayoutModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "2.0.0",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border_bottom": null,
-       "border_left": null,
-       "border_right": null,
-       "border_top": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "grid_area": null,
-       "grid_auto_columns": null,
-       "grid_auto_flow": null,
-       "grid_auto_rows": null,
-       "grid_column": null,
-       "grid_gap": null,
-       "grid_row": null,
-       "grid_template_areas": null,
-       "grid_template_columns": null,
-       "grid_template_rows": null,
-       "height": null,
-       "justify_content": null,
-       "justify_items": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "object_fit": null,
-       "object_position": null,
-       "order": null,
-       "overflow": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
-      }
-     },
-     "1092ea29b0ee4f68b2288ef07a37990e": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "2.0.0",
-      "model_name": "LayoutModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/base",
-       "_model_module_version": "2.0.0",
-       "_model_name": "LayoutModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "2.0.0",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border_bottom": null,
-       "border_left": null,
-       "border_right": null,
-       "border_top": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "grid_area": null,
-       "grid_auto_columns": null,
-       "grid_auto_flow": null,
-       "grid_auto_rows": null,
-       "grid_column": null,
-       "grid_gap": null,
-       "grid_row": null,
-       "grid_template_areas": null,
-       "grid_template_columns": null,
-       "grid_template_rows": null,
-       "height": null,
-       "justify_content": null,
-       "justify_items": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "object_fit": null,
-       "object_position": null,
-       "order": null,
-       "overflow": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
-      }
-     },
-     "146945e5f8f2483d8e07d5063ca27a70": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "2.0.0",
-      "model_name": "LayoutModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/base",
-       "_model_module_version": "2.0.0",
-       "_model_name": "LayoutModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "2.0.0",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border_bottom": null,
-       "border_left": null,
-       "border_right": null,
-       "border_top": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "grid_area": null,
-       "grid_auto_columns": null,
-       "grid_auto_flow": null,
-       "grid_auto_rows": null,
-       "grid_column": null,
-       "grid_gap": null,
-       "grid_row": null,
-       "grid_template_areas": null,
-       "grid_template_columns": null,
-       "grid_template_rows": null,
-       "height": null,
-       "justify_content": null,
-       "justify_items": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "object_fit": null,
-       "object_position": null,
-       "order": null,
-       "overflow": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
-      }
-     },
-     "14d0036ba35b4609986ebd87029c07d6": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "2.0.0",
-      "model_name": "HTMLModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "@jupyter-widgets/controls",
-       "_model_module_version": "2.0.0",
-       "_model_name": "HTMLModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/controls",
-       "_view_module_version": "2.0.0",
-       "_view_name": "HTMLView",
-       "description": "",
-       "description_allow_html": false,
-       "layout": "IPY_MODEL_72cba48a36454e7a875910da6201581b",
-       "placeholder": "​",
-       "style": "IPY_MODEL_3c62c7ebe92f4fb88fe2d8a4747d0d5c",
-       "tabbable": null,
-       "tooltip": null,
-       "value": " 340/340 [00:00&lt;00:00, 23618.53 examples/s]"
-      }
-     },
-     "16effb833d38464d8eec98c6b547e057": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "2.0.0",
-      "model_name": "LayoutModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/base",
-       "_model_module_version": "2.0.0",
-       "_model_name": "LayoutModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "2.0.0",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border_bottom": null,
-       "border_left": null,
-       "border_right": null,
-       "border_top": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "grid_area": null,
-       "grid_auto_columns": null,
-       "grid_auto_flow": null,
-       "grid_auto_rows": null,
-       "grid_column": null,
-       "grid_gap": null,
-       "grid_row": null,
-       "grid_template_areas": null,
-       "grid_template_columns": null,
-       "grid_template_rows": null,
-       "height": null,
-       "justify_content": null,
-       "justify_items": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "object_fit": null,
-       "object_position": null,
-       "order": null,
-       "overflow": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
-      }
-     },
-     "1cac11024dc543dcb1e796ca00f2f2f0": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "2.0.0",
-      "model_name": "LayoutModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/base",
-       "_model_module_version": "2.0.0",
-       "_model_name": "LayoutModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "2.0.0",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border_bottom": null,
-       "border_left": null,
-       "border_right": null,
-       "border_top": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "grid_area": null,
-       "grid_auto_columns": null,
-       "grid_auto_flow": null,
-       "grid_auto_rows": null,
-       "grid_column": null,
-       "grid_gap": null,
-       "grid_row": null,
-       "grid_template_areas": null,
-       "grid_template_columns": null,
-       "grid_template_rows": null,
-       "height": null,
-       "justify_content": null,
-       "justify_items": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "object_fit": null,
-       "object_position": null,
-       "order": null,
-       "overflow": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
-      }
-     },
-     "1d5e7cfdb77a4d3fb9ef1dff07da2fa6": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "2.0.0",
-      "model_name": "HTMLModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "@jupyter-widgets/controls",
-       "_model_module_version": "2.0.0",
-       "_model_name": "HTMLModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/controls",
-       "_view_module_version": "2.0.0",
-       "_view_name": "HTMLView",
-       "description": "",
-       "description_allow_html": false,
-       "layout": "IPY_MODEL_0f570a41f52c417f814327baca5967a7",
-       "placeholder": "​",
-       "style": "IPY_MODEL_cd17cb0883f3467a8472e405d1b93def",
-       "tabbable": null,
-       "tooltip": null,
-       "value": "Map: 100%"
-      }
-     },
-     "1f1c0f5e7f2944fe8e11fa21db9addac": {
+     "0a2eca661a894a3683d5856b17ad9749": {
       "model_module": "@jupyter-widgets/controls",
       "model_module_version": "2.0.0",
       "model_name": "HTMLStyleModel",
@@ -2299,280 +1986,7 @@
        "text_color": null
       }
      },
-     "20d7dc0cb5244d7ab34dd02688e68e54": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "2.0.0",
-      "model_name": "HTMLStyleModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/controls",
-       "_model_module_version": "2.0.0",
-       "_model_name": "HTMLStyleModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "2.0.0",
-       "_view_name": "StyleView",
-       "background": null,
-       "description_width": "",
-       "font_size": null,
-       "text_color": null
-      }
-     },
-     "24ded93d563549b089b9c09c9b7310a3": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "2.0.0",
-      "model_name": "HTMLStyleModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/controls",
-       "_model_module_version": "2.0.0",
-       "_model_name": "HTMLStyleModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "2.0.0",
-       "_view_name": "StyleView",
-       "background": null,
-       "description_width": "",
-       "font_size": null,
-       "text_color": null
-      }
-     },
-     "27a0f51a50014efa9a9c35563b3536ca": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "2.0.0",
-      "model_name": "HTMLStyleModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/controls",
-       "_model_module_version": "2.0.0",
-       "_model_name": "HTMLStyleModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "2.0.0",
-       "_view_name": "StyleView",
-       "background": null,
-       "description_width": "",
-       "font_size": null,
-       "text_color": null
-      }
-     },
-     "29ffffe8500041a9b2d6a96fe7408a3f": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "2.0.0",
-      "model_name": "LayoutModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/base",
-       "_model_module_version": "2.0.0",
-       "_model_name": "LayoutModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "2.0.0",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border_bottom": null,
-       "border_left": null,
-       "border_right": null,
-       "border_top": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "grid_area": null,
-       "grid_auto_columns": null,
-       "grid_auto_flow": null,
-       "grid_auto_rows": null,
-       "grid_column": null,
-       "grid_gap": null,
-       "grid_row": null,
-       "grid_template_areas": null,
-       "grid_template_columns": null,
-       "grid_template_rows": null,
-       "height": null,
-       "justify_content": null,
-       "justify_items": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "object_fit": null,
-       "object_position": null,
-       "order": null,
-       "overflow": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
-      }
-     },
-     "2d18d8cff8b14c2192ad64546c826e01": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "2.0.0",
-      "model_name": "HBoxModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "@jupyter-widgets/controls",
-       "_model_module_version": "2.0.0",
-       "_model_name": "HBoxModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/controls",
-       "_view_module_version": "2.0.0",
-       "_view_name": "HBoxView",
-       "box_style": "",
-       "children": [
-        "IPY_MODEL_b5143fb4b2ab44dab48045759f14f79b",
-        "IPY_MODEL_0eb518da682349cbb9ae331a934dffd8",
-        "IPY_MODEL_613425ebff3440458da9fe4e07d78bf2"
-       ],
-       "layout": "IPY_MODEL_b0d905bc3a91468a99e22269e71d7d1a",
-       "tabbable": null,
-       "tooltip": null
-      }
-     },
-     "2d4b86dd83594f85b7c97f1724a9af52": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "2.0.0",
-      "model_name": "HTMLModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "@jupyter-widgets/controls",
-       "_model_module_version": "2.0.0",
-       "_model_name": "HTMLModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/controls",
-       "_view_module_version": "2.0.0",
-       "_view_name": "HTMLView",
-       "description": "",
-       "description_allow_html": false,
-       "layout": "IPY_MODEL_081ff1d02d184ba7abb60f97e3e8c4be",
-       "placeholder": "​",
-       "style": "IPY_MODEL_51f4b359b7214bb181a13f893a2d07b3",
-       "tabbable": null,
-       "tooltip": null,
-       "value": " 340/340 [00:00&lt;00:00, 22065.38 examples/s]"
-      }
-     },
-     "2dd67e74752f45d9a8403238e43be181": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "2.0.0",
-      "model_name": "HBoxModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "@jupyter-widgets/controls",
-       "_model_module_version": "2.0.0",
-       "_model_name": "HBoxModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/controls",
-       "_view_module_version": "2.0.0",
-       "_view_name": "HBoxView",
-       "box_style": "",
-       "children": [
-        "IPY_MODEL_1d5e7cfdb77a4d3fb9ef1dff07da2fa6",
-        "IPY_MODEL_8e99232d5abf4bcdba816018115e9abf",
-        "IPY_MODEL_fef42a3f32aa4e9e8f08d19980fb130f"
-       ],
-       "layout": "IPY_MODEL_b13c300161cc4676922abffd98aeda3e",
-       "tabbable": null,
-       "tooltip": null
-      }
-     },
-     "3150b47912df4279948ba3acb948d481": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "2.0.0",
-      "model_name": "HBoxModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "@jupyter-widgets/controls",
-       "_model_module_version": "2.0.0",
-       "_model_name": "HBoxModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/controls",
-       "_view_module_version": "2.0.0",
-       "_view_name": "HBoxView",
-       "box_style": "",
-       "children": [
-        "IPY_MODEL_38b762ca11244086b780d6417c1a9d59",
-        "IPY_MODEL_5b569b6608734ce6b3d463a605e3f10f",
-        "IPY_MODEL_9589290a9947471ba06f3e6b1abcda3e"
-       ],
-       "layout": "IPY_MODEL_9e203567e7f8449f963ea326c00f0d0b",
-       "tabbable": null,
-       "tooltip": null
-      }
-     },
-     "33bd62493dcd4e87b46b6eced87219be": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "2.0.0",
-      "model_name": "HTMLStyleModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/controls",
-       "_model_module_version": "2.0.0",
-       "_model_name": "HTMLStyleModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "2.0.0",
-       "_view_name": "StyleView",
-       "background": null,
-       "description_width": "",
-       "font_size": null,
-       "text_color": null
-      }
-     },
-     "33e835b239864c748e14fb2183758a7c": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "2.0.0",
-      "model_name": "LayoutModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/base",
-       "_model_module_version": "2.0.0",
-       "_model_name": "LayoutModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "2.0.0",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border_bottom": null,
-       "border_left": null,
-       "border_right": null,
-       "border_top": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "grid_area": null,
-       "grid_auto_columns": null,
-       "grid_auto_flow": null,
-       "grid_auto_rows": null,
-       "grid_column": null,
-       "grid_gap": null,
-       "grid_row": null,
-       "grid_template_areas": null,
-       "grid_template_columns": null,
-       "grid_template_rows": null,
-       "height": null,
-       "justify_content": null,
-       "justify_items": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "object_fit": null,
-       "object_position": null,
-       "order": null,
-       "overflow": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
-      }
-     },
-     "35981dee7e944d7c8cf57fb7ef0525d1": {
+     "0b31871f2d884ff6b1ce05f3684b8ed4": {
       "model_module": "@jupyter-widgets/controls",
       "model_module_version": "2.0.0",
       "model_name": "ProgressStyleModel",
@@ -2588,30 +2002,25 @@
        "description_width": ""
       }
      },
-     "38b762ca11244086b780d6417c1a9d59": {
+     "0c99c9d2ad7e47efae6f6a98723b206f": {
       "model_module": "@jupyter-widgets/controls",
       "model_module_version": "2.0.0",
-      "model_name": "HTMLModel",
+      "model_name": "HTMLStyleModel",
       "state": {
-       "_dom_classes": [],
        "_model_module": "@jupyter-widgets/controls",
        "_model_module_version": "2.0.0",
-       "_model_name": "HTMLModel",
+       "_model_name": "HTMLStyleModel",
        "_view_count": null,
-       "_view_module": "@jupyter-widgets/controls",
+       "_view_module": "@jupyter-widgets/base",
        "_view_module_version": "2.0.0",
-       "_view_name": "HTMLView",
-       "description": "",
-       "description_allow_html": false,
-       "layout": "IPY_MODEL_edec085419494d2fba52c97a9cefd0b4",
-       "placeholder": "​",
-       "style": "IPY_MODEL_b688a9adc4014ceb8068c2b41bea2344",
-       "tabbable": null,
-       "tooltip": null,
-       "value": "Map: 100%"
+       "_view_name": "StyleView",
+       "background": null,
+       "description_width": "",
+       "font_size": null,
+       "text_color": null
       }
      },
-     "3ab279eb89e140b0a8d04158333f0ea5": {
+     "11c06aee43f84b998f6ef8fbd4ddb080": {
       "model_module": "@jupyter-widgets/base",
       "model_module_version": "2.0.0",
       "model_name": "LayoutModel",
@@ -2664,7 +2073,30 @@
        "width": null
       }
      },
-     "3c62c7ebe92f4fb88fe2d8a4747d0d5c": {
+     "1a9dc5ddd027439bb7ddfbca0c38a13d": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "HTMLModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "2.0.0",
+       "_view_name": "HTMLView",
+       "description": "",
+       "description_allow_html": false,
+       "layout": "IPY_MODEL_11c06aee43f84b998f6ef8fbd4ddb080",
+       "placeholder": "​",
+       "style": "IPY_MODEL_5085770cf2424578ac0588ec6421dec6",
+       "tabbable": null,
+       "tooltip": null,
+       "value": " 340/340 [00:00&lt;00:00, 34802.41 examples/s]"
+      }
+     },
+     "1b09d5c9bf114baeaf2463ac298ddfc5": {
       "model_module": "@jupyter-widgets/controls",
       "model_module_version": "2.0.0",
       "model_name": "HTMLStyleModel",
@@ -2682,7 +2114,283 @@
        "text_color": null
       }
      },
-     "3ce97a8e2c8e44b8ad926d44b46809f6": {
+     "1c464221cc364672af91504b2c5b927f": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "HBoxModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "2.0.0",
+       "_view_name": "HBoxView",
+       "box_style": "",
+       "children": [
+        "IPY_MODEL_568d59db637b4b7f98cbd6c4e253c66e",
+        "IPY_MODEL_8f5daab01b0f4dac9de60be3e66d8819",
+        "IPY_MODEL_1a9dc5ddd027439bb7ddfbca0c38a13d"
+       ],
+       "layout": "IPY_MODEL_6ed605da5c0548f9bf4975b52da48eda",
+       "tabbable": null,
+       "tooltip": null
+      }
+     },
+     "1cef94c9f7764a3cbedbd2efdb459308": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "HTMLModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "2.0.0",
+       "_view_name": "HTMLView",
+       "description": "",
+       "description_allow_html": false,
+       "layout": "IPY_MODEL_8aeb27407fcc475986d04b2b67cbe571",
+       "placeholder": "​",
+       "style": "IPY_MODEL_51757ceaefa14c7aa291b7183ffb5280",
+       "tabbable": null,
+       "tooltip": null,
+       "value": " 340/340 [00:00&lt;00:00, 25066.59 examples/s]"
+      }
+     },
+     "1da594bf4c204c7fbd1fcd060bc36ef2": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "1df7295c147f414dae38d45e96ca456a": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "HTMLModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "2.0.0",
+       "_view_name": "HTMLView",
+       "description": "",
+       "description_allow_html": false,
+       "layout": "IPY_MODEL_24c5f4fd378f460eb2aa684abd778066",
+       "placeholder": "​",
+       "style": "IPY_MODEL_65b637aa92c5415fb97c036afc826871",
+       "tabbable": null,
+       "tooltip": null,
+       "value": "Map: 100%"
+      }
+     },
+     "1e4d2709696743cfade6d43801426cbc": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "HTMLModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "2.0.0",
+       "_view_name": "HTMLView",
+       "description": "",
+       "description_allow_html": false,
+       "layout": "IPY_MODEL_3d62d565cbef461fa37c862e6f541f8e",
+       "placeholder": "​",
+       "style": "IPY_MODEL_ea0e1a31a7fc432097fb6d6bd8d9cbd0",
+       "tabbable": null,
+       "tooltip": null,
+       "value": "Map: 100%"
+      }
+     },
+     "1f2b40cef43a494e8b5ef4dcc7da7a6c": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "24c5f4fd378f460eb2aa684abd778066": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "2538acb6bddd466db9ede300d2a9d3ec": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "HBoxModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "2.0.0",
+       "_view_name": "HBoxView",
+       "box_style": "",
+       "children": [
+        "IPY_MODEL_1e4d2709696743cfade6d43801426cbc",
+        "IPY_MODEL_6d81daef3ff04558ba506b0aff3625bc",
+        "IPY_MODEL_5c7d7851d7bc4dc8a023f58f7b3b4a31"
+       ],
+       "layout": "IPY_MODEL_f4b8c4bc6eb542b7a2acc2221aeb5398",
+       "tabbable": null,
+       "tooltip": null
+      }
+     },
+     "27c398177f54467a87e19e6448613001": {
       "model_module": "@jupyter-widgets/controls",
       "model_module_version": "2.0.0",
       "model_name": "HTMLStyleModel",
@@ -2700,7 +2408,113 @@
        "text_color": null
       }
      },
-     "3cf1580521564248a45b5c00ea9af4dd": {
+     "2b06b665efa443a295b83964245d4153": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "2ed0605d45aa425ab10086c4e7d60651": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "31da59ecfe6f43da83f84b3de9d35e17": {
       "model_module": "@jupyter-widgets/controls",
       "model_module_version": "2.0.0",
       "model_name": "HTMLStyleModel",
@@ -2718,7 +2532,23 @@
        "text_color": null
       }
      },
-     "3f1a6e63ea7141a8ad1981fbf1caf7cd": {
+     "32a3f93058ae40e0811bae039290d5c1": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "ProgressStyleModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "StyleView",
+       "bar_color": null,
+       "description_width": ""
+      }
+     },
+     "39247128875b41c588d209cee2b92cf4": {
       "model_module": "@jupyter-widgets/controls",
       "model_module_version": "2.0.0",
       "model_name": "FloatProgressModel",
@@ -2734,17 +2564,747 @@
        "bar_style": "success",
        "description": "",
        "description_allow_html": false,
-       "layout": "IPY_MODEL_b052c62533a642d680c5f1eab0e61b3e",
+       "layout": "IPY_MODEL_a7aa36ed068c413782e8fb2242741615",
+       "max": 340.0,
+       "min": 0.0,
+       "orientation": "horizontal",
+       "style": "IPY_MODEL_39e96be02ad8498eb5e720170fb7e54a",
+       "tabbable": null,
+       "tooltip": null,
+       "value": 340.0
+      }
+     },
+     "39e96be02ad8498eb5e720170fb7e54a": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "ProgressStyleModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "StyleView",
+       "bar_color": null,
+       "description_width": ""
+      }
+     },
+     "3d62d565cbef461fa37c862e6f541f8e": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "43ca5a36321843249584ea63a1e89ecd": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "HTMLModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "2.0.0",
+       "_view_name": "HTMLView",
+       "description": "",
+       "description_allow_html": false,
+       "layout": "IPY_MODEL_e637fab5c5de49a59c7b2190c92a65b8",
+       "placeholder": "​",
+       "style": "IPY_MODEL_59ffa985df9b4f239f1287f5aa48df47",
+       "tabbable": null,
+       "tooltip": null,
+       "value": "Map: 100%"
+      }
+     },
+     "48b2e7b3b02845bd8c9fdb6ccf7be1e0": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "4c5b429d5e564b59b6b87f66d76938c9": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "503c1047356c472db3da4f0740eb6ddf": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLStyleModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "HTMLStyleModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "StyleView",
+       "background": null,
+       "description_width": "",
+       "font_size": null,
+       "text_color": null
+      }
+     },
+     "5085770cf2424578ac0588ec6421dec6": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLStyleModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "HTMLStyleModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "StyleView",
+       "background": null,
+       "description_width": "",
+       "font_size": null,
+       "text_color": null
+      }
+     },
+     "509d13e83f654b648b170ae8df32632b": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "51757ceaefa14c7aa291b7183ffb5280": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLStyleModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "HTMLStyleModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "StyleView",
+       "background": null,
+       "description_width": "",
+       "font_size": null,
+       "text_color": null
+      }
+     },
+     "5305c4ade7004cbf865fc91f51b77096": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "ProgressStyleModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "StyleView",
+       "bar_color": null,
+       "description_width": ""
+      }
+     },
+     "55554fa7122f4800aef921654c829c43": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLStyleModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "HTMLStyleModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "StyleView",
+       "background": null,
+       "description_width": "",
+       "font_size": null,
+       "text_color": null
+      }
+     },
+     "568d59db637b4b7f98cbd6c4e253c66e": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "HTMLModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "2.0.0",
+       "_view_name": "HTMLView",
+       "description": "",
+       "description_allow_html": false,
+       "layout": "IPY_MODEL_48b2e7b3b02845bd8c9fdb6ccf7be1e0",
+       "placeholder": "​",
+       "style": "IPY_MODEL_b529898deec7470fa258a1ff80d3fafd",
+       "tabbable": null,
+       "tooltip": null,
+       "value": "Map: 100%"
+      }
+     },
+     "5710ba27073d4034a9bbbb32bac20610": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "FloatProgressModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "2.0.0",
+       "_view_name": "ProgressView",
+       "bar_style": "success",
+       "description": "",
+       "description_allow_html": false,
+       "layout": "IPY_MODEL_b2f872db38754de6a074ec218ff60da1",
+       "max": 340.0,
+       "min": 0.0,
+       "orientation": "horizontal",
+       "style": "IPY_MODEL_df971a039a9846338feabb98289ce83a",
+       "tabbable": null,
+       "tooltip": null,
+       "value": 340.0
+      }
+     },
+     "59ffa985df9b4f239f1287f5aa48df47": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLStyleModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "HTMLStyleModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "StyleView",
+       "background": null,
+       "description_width": "",
+       "font_size": null,
+       "text_color": null
+      }
+     },
+     "5c7d7851d7bc4dc8a023f58f7b3b4a31": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "HTMLModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "2.0.0",
+       "_view_name": "HTMLView",
+       "description": "",
+       "description_allow_html": false,
+       "layout": "IPY_MODEL_ecf20189797f41c1a3d1f9d3457297d6",
+       "placeholder": "​",
+       "style": "IPY_MODEL_643c2dbfa5df408e80a6af1a38684390",
+       "tabbable": null,
+       "tooltip": null,
+       "value": " 1584/1584 [00:00&lt;00:00, 37711.45 examples/s]"
+      }
+     },
+     "5eff5f234ca94192ba9c99635d99031c": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "HTMLModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "2.0.0",
+       "_view_name": "HTMLView",
+       "description": "",
+       "description_allow_html": false,
+       "layout": "IPY_MODEL_d97f7acfd78f4c6dbfc8f98a46576170",
+       "placeholder": "​",
+       "style": "IPY_MODEL_55554fa7122f4800aef921654c829c43",
+       "tabbable": null,
+       "tooltip": null,
+       "value": " 340/340 [00:00&lt;00:00, 32239.08 examples/s]"
+      }
+     },
+     "643c2dbfa5df408e80a6af1a38684390": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLStyleModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "HTMLStyleModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "StyleView",
+       "background": null,
+       "description_width": "",
+       "font_size": null,
+       "text_color": null
+      }
+     },
+     "6550e5989c234ba9a1a07ae593ba6fcd": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "HTMLModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "2.0.0",
+       "_view_name": "HTMLView",
+       "description": "",
+       "description_allow_html": false,
+       "layout": "IPY_MODEL_1f2b40cef43a494e8b5ef4dcc7da7a6c",
+       "placeholder": "​",
+       "style": "IPY_MODEL_1b09d5c9bf114baeaf2463ac298ddfc5",
+       "tabbable": null,
+       "tooltip": null,
+       "value": " 1584/1584 [00:00&lt;00:00, 48097.31 examples/s]"
+      }
+     },
+     "65b637aa92c5415fb97c036afc826871": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLStyleModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "HTMLStyleModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "StyleView",
+       "background": null,
+       "description_width": "",
+       "font_size": null,
+       "text_color": null
+      }
+     },
+     "660ba4241f1441589b70534b47daa258": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "666645c3865f4522846801e2e0838aae": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "67fc9159ee6f437687db980649c8a922": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "HTMLModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "2.0.0",
+       "_view_name": "HTMLView",
+       "description": "",
+       "description_allow_html": false,
+       "layout": "IPY_MODEL_c4d730c92169495184377e2d03e0e989",
+       "placeholder": "​",
+       "style": "IPY_MODEL_503c1047356c472db3da4f0740eb6ddf",
+       "tabbable": null,
+       "tooltip": null,
+       "value": " 1584/1584 [00:00&lt;00:00, 45502.83 examples/s]"
+      }
+     },
+     "6c3f5f2dc62d4be39bf582491bba07f2": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "HBoxModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "2.0.0",
+       "_view_name": "HBoxView",
+       "box_style": "",
+       "children": [
+        "IPY_MODEL_f739c2701ced436d92bdae9e2ae0e4c1",
+        "IPY_MODEL_39247128875b41c588d209cee2b92cf4",
+        "IPY_MODEL_71c9bfa7a9da49d48ce726f45699dec2"
+       ],
+       "layout": "IPY_MODEL_05416887147d411ca9e6d4e8dc4042b1",
+       "tabbable": null,
+       "tooltip": null
+      }
+     },
+     "6ce0a2b2c04e4afdb95acb3f14ead172": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "HBoxModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "2.0.0",
+       "_view_name": "HBoxView",
+       "box_style": "",
+       "children": [
+        "IPY_MODEL_a8aff87449ef42c48ca44fa6460d0263",
+        "IPY_MODEL_ade416c5f9454796b626cbefd9c55dfc",
+        "IPY_MODEL_67fc9159ee6f437687db980649c8a922"
+       ],
+       "layout": "IPY_MODEL_f8683f843bbe4742854378db41586b00",
+       "tabbable": null,
+       "tooltip": null
+      }
+     },
+     "6d81daef3ff04558ba506b0aff3625bc": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "FloatProgressModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "2.0.0",
+       "_view_name": "ProgressView",
+       "bar_style": "success",
+       "description": "",
+       "description_allow_html": false,
+       "layout": "IPY_MODEL_fca90f4bc227418da02f46a0d0cc3f73",
        "max": 1584.0,
        "min": 0.0,
        "orientation": "horizontal",
-       "style": "IPY_MODEL_acd0d682335b45b6b87d8f289eb6e940",
+       "style": "IPY_MODEL_6dbb9a3692ab47d7822ef7f587d2dca1",
        "tabbable": null,
        "tooltip": null,
        "value": 1584.0
       }
      },
-     "414f8d23450342efaa0b9f4d92aad3bb": {
+     "6dbb9a3692ab47d7822ef7f587d2dca1": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "ProgressStyleModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "StyleView",
+       "bar_color": null,
+       "description_width": ""
+      }
+     },
+     "6ed605da5c0548f9bf4975b52da48eda": {
       "model_module": "@jupyter-widgets/base",
       "model_module_version": "2.0.0",
       "model_name": "LayoutModel",
@@ -2797,56 +3357,7 @@
        "width": null
       }
      },
-     "4269c1c2d635411e8cd05fb9472e1654": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "2.0.0",
-      "model_name": "FloatProgressModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "@jupyter-widgets/controls",
-       "_model_module_version": "2.0.0",
-       "_model_name": "FloatProgressModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/controls",
-       "_view_module_version": "2.0.0",
-       "_view_name": "ProgressView",
-       "bar_style": "success",
-       "description": "",
-       "description_allow_html": false,
-       "layout": "IPY_MODEL_16effb833d38464d8eec98c6b547e057",
-       "max": 340.0,
-       "min": 0.0,
-       "orientation": "horizontal",
-       "style": "IPY_MODEL_68afaa8c74b14530a0038e864026ea23",
-       "tabbable": null,
-       "tooltip": null,
-       "value": 340.0
-      }
-     },
-     "4cd767728b4d4199aed6c5d7bd06342e": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "2.0.0",
-      "model_name": "HTMLModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "@jupyter-widgets/controls",
-       "_model_module_version": "2.0.0",
-       "_model_name": "HTMLModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/controls",
-       "_view_module_version": "2.0.0",
-       "_view_name": "HTMLView",
-       "description": "",
-       "description_allow_html": false,
-       "layout": "IPY_MODEL_e27537283b6940648fa5a45dccf0fc50",
-       "placeholder": "​",
-       "style": "IPY_MODEL_725e5c16d87944829f1d88babc177dea",
-       "tabbable": null,
-       "tooltip": null,
-       "value": "Map: 100%"
-      }
-     },
-     "51f4b359b7214bb181a13f893a2d07b3": {
+     "700156664d8d46f39e8038cd42bcd99b": {
       "model_module": "@jupyter-widgets/controls",
       "model_module_version": "2.0.0",
       "model_name": "HTMLStyleModel",
@@ -2864,7 +3375,7 @@
        "text_color": null
       }
      },
-     "53633e33e7e44284b3ba905e26b6bdcc": {
+     "71c9bfa7a9da49d48ce726f45699dec2": {
       "model_module": "@jupyter-widgets/controls",
       "model_module_version": "2.0.0",
       "model_name": "HTMLModel",
@@ -2879,31 +3390,15 @@
        "_view_name": "HTMLView",
        "description": "",
        "description_allow_html": false,
-       "layout": "IPY_MODEL_1092ea29b0ee4f68b2288ef07a37990e",
+       "layout": "IPY_MODEL_ca658e5449884f39883cd2526673e8fa",
        "placeholder": "​",
-       "style": "IPY_MODEL_9c04c3d91cbd41758adace269cab89de",
+       "style": "IPY_MODEL_700156664d8d46f39e8038cd42bcd99b",
        "tabbable": null,
        "tooltip": null,
-       "value": " 1584/1584 [00:00&lt;00:00, 41261.60 examples/s]"
+       "value": " 340/340 [00:00&lt;00:00, 31972.36 examples/s]"
       }
      },
-     "538d514185584ad8a887c21fe9dd4101": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "2.0.0",
-      "model_name": "ProgressStyleModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/controls",
-       "_model_module_version": "2.0.0",
-       "_model_name": "ProgressStyleModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "2.0.0",
-       "_view_name": "StyleView",
-       "bar_color": null,
-       "description_width": ""
-      }
-     },
-     "54f8751af98846f2a5af59645d50761d": {
+     "826a745c913844808779159315b71f80": {
       "model_module": "@jupyter-widgets/base",
       "model_module_version": "2.0.0",
       "model_name": "LayoutModel",
@@ -2956,7 +3451,154 @@
        "width": null
       }
      },
-     "57194a1c63284f4296dffa8ebaf56c0e": {
+     "82e0689e99d8447da54267c9afefec07": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "HTMLModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "2.0.0",
+       "_view_name": "HTMLView",
+       "description": "",
+       "description_allow_html": false,
+       "layout": "IPY_MODEL_08146df81d884141b177a71caf4c79f4",
+       "placeholder": "​",
+       "style": "IPY_MODEL_0a2eca661a894a3683d5856b17ad9749",
+       "tabbable": null,
+       "tooltip": null,
+       "value": " 340/340 [00:00&lt;00:00, 28481.39 examples/s]"
+      }
+     },
+     "8473a2703a45460f863e6599c276ba28": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLStyleModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "HTMLStyleModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "StyleView",
+       "background": null,
+       "description_width": "",
+       "font_size": null,
+       "text_color": null
+      }
+     },
+     "8aeb27407fcc475986d04b2b67cbe571": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "8e2c2e1306d647a09ca6ded02bd410ac": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "8f5daab01b0f4dac9de60be3e66d8819": {
       "model_module": "@jupyter-widgets/controls",
       "model_module_version": "2.0.0",
       "model_name": "FloatProgressModel",
@@ -2972,17 +3614,85 @@
        "bar_style": "success",
        "description": "",
        "description_allow_html": false,
-       "layout": "IPY_MODEL_8f017f59f7344dbd869060572c1dbb43",
+       "layout": "IPY_MODEL_509d13e83f654b648b170ae8df32632b",
+       "max": 340.0,
+       "min": 0.0,
+       "orientation": "horizontal",
+       "style": "IPY_MODEL_d1768f39a8ff434aa51e5ba40059c935",
+       "tabbable": null,
+       "tooltip": null,
+       "value": 340.0
+      }
+     },
+     "98f501a4018346afa99d07111701ba14": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "HBoxModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "2.0.0",
+       "_view_name": "HBoxView",
+       "box_style": "",
+       "children": [
+        "IPY_MODEL_1df7295c147f414dae38d45e96ca456a",
+        "IPY_MODEL_05ebf9e5285945758fd0d0bcda80b3fe",
+        "IPY_MODEL_1cef94c9f7764a3cbedbd2efdb459308"
+       ],
+       "layout": "IPY_MODEL_826a745c913844808779159315b71f80",
+       "tabbable": null,
+       "tooltip": null
+      }
+     },
+     "9df105ad7cdb4d72b0419c5691de31c2": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "FloatProgressModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "2.0.0",
+       "_view_name": "ProgressView",
+       "bar_style": "success",
+       "description": "",
+       "description_allow_html": false,
+       "layout": "IPY_MODEL_c6d4505a912b43318228dc59335c5ba6",
        "max": 1584.0,
        "min": 0.0,
        "orientation": "horizontal",
-       "style": "IPY_MODEL_35981dee7e944d7c8cf57fb7ef0525d1",
+       "style": "IPY_MODEL_cf7d29d480874e13bccc4e96e0a39178",
        "tabbable": null,
        "tooltip": null,
        "value": 1584.0
       }
      },
-     "5879447f6fbe4679b4a98a22e5032911": {
+     "a675cca79170433da2cc5c05f1540b38": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLStyleModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "HTMLStyleModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "StyleView",
+       "background": null,
+       "description_width": "",
+       "font_size": null,
+       "text_color": null
+      }
+     },
+     "a7aa36ed068c413782e8fb2242741615": {
       "model_module": "@jupyter-widgets/base",
       "model_module_version": "2.0.0",
       "model_name": "LayoutModel",
@@ -3035,57 +3745,7 @@
        "width": null
       }
      },
-     "5b569b6608734ce6b3d463a605e3f10f": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "2.0.0",
-      "model_name": "FloatProgressModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "@jupyter-widgets/controls",
-       "_model_module_version": "2.0.0",
-       "_model_name": "FloatProgressModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/controls",
-       "_view_module_version": "2.0.0",
-       "_view_name": "ProgressView",
-       "bar_style": "success",
-       "description": "",
-       "description_allow_html": false,
-       "layout": "IPY_MODEL_85cb244704cb4aa38538579b6bb95d26",
-       "max": 340.0,
-       "min": 0.0,
-       "orientation": "horizontal",
-       "style": "IPY_MODEL_6f344a824f38447eaaeb58c8c1b18ab8",
-       "tabbable": null,
-       "tooltip": null,
-       "value": 340.0
-      }
-     },
-     "5b729d847f5049afa664a7f967f6563a": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "2.0.0",
-      "model_name": "HBoxModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "@jupyter-widgets/controls",
-       "_model_module_version": "2.0.0",
-       "_model_name": "HBoxModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/controls",
-       "_view_module_version": "2.0.0",
-       "_view_name": "HBoxView",
-       "box_style": "",
-       "children": [
-        "IPY_MODEL_b4c743b6f48649559f95f495ba3a8c8e",
-        "IPY_MODEL_6647c964810540f1b263846c6adf0b37",
-        "IPY_MODEL_53633e33e7e44284b3ba905e26b6bdcc"
-       ],
-       "layout": "IPY_MODEL_146945e5f8f2483d8e07d5063ca27a70",
-       "tabbable": null,
-       "tooltip": null
-      }
-     },
-     "5f519bf29da14387bab1129dc84c523b": {
+     "a8aff87449ef42c48ca44fa6460d0263": {
       "model_module": "@jupyter-widgets/controls",
       "model_module_version": "2.0.0",
       "model_name": "HTMLModel",
@@ -3100,39 +3760,15 @@
        "_view_name": "HTMLView",
        "description": "",
        "description_allow_html": false,
-       "layout": "IPY_MODEL_ffc15c2bbed946a2b69f81dcc13f6926",
+       "layout": "IPY_MODEL_666645c3865f4522846801e2e0838aae",
        "placeholder": "​",
-       "style": "IPY_MODEL_3cf1580521564248a45b5c00ea9af4dd",
+       "style": "IPY_MODEL_a675cca79170433da2cc5c05f1540b38",
        "tabbable": null,
        "tooltip": null,
        "value": "Map: 100%"
       }
      },
-     "5ffff2bacb274f16a5e13a206ee18d86": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "2.0.0",
-      "model_name": "HBoxModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "@jupyter-widgets/controls",
-       "_model_module_version": "2.0.0",
-       "_model_name": "HBoxModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/controls",
-       "_view_module_version": "2.0.0",
-       "_view_name": "HBoxView",
-       "box_style": "",
-       "children": [
-        "IPY_MODEL_7c22f9bd1a914086a73733541bd0a9a3",
-        "IPY_MODEL_3f1a6e63ea7141a8ad1981fbf1caf7cd",
-        "IPY_MODEL_6815c8269bcf4ae48deea2dadbb41751"
-       ],
-       "layout": "IPY_MODEL_8979a12dc82c47fd90d6e4a3b9a1601e",
-       "tabbable": null,
-       "tooltip": null
-      }
-     },
-     "613425ebff3440458da9fe4e07d78bf2": {
+     "ac6d2d9e86b6481890f415bb045e52b0": {
       "model_module": "@jupyter-widgets/controls",
       "model_module_version": "2.0.0",
       "model_name": "HTMLModel",
@@ -3147,121 +3783,15 @@
        "_view_name": "HTMLView",
        "description": "",
        "description_allow_html": false,
-       "layout": "IPY_MODEL_a7c0c1215af44d8981d8dee91de0da58",
+       "layout": "IPY_MODEL_e0de26a57cbd47e088b27d6b5e39847b",
        "placeholder": "​",
-       "style": "IPY_MODEL_3ce97a8e2c8e44b8ad926d44b46809f6",
+       "style": "IPY_MODEL_8473a2703a45460f863e6599c276ba28",
        "tabbable": null,
        "tooltip": null,
-       "value": " 340/340 [00:00&lt;00:00, 34601.43 examples/s]"
+       "value": "Map: 100%"
       }
      },
-     "63d1f0fcb39f40adbb049fd4850c849e": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "2.0.0",
-      "model_name": "LayoutModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/base",
-       "_model_module_version": "2.0.0",
-       "_model_name": "LayoutModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "2.0.0",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border_bottom": null,
-       "border_left": null,
-       "border_right": null,
-       "border_top": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "grid_area": null,
-       "grid_auto_columns": null,
-       "grid_auto_flow": null,
-       "grid_auto_rows": null,
-       "grid_column": null,
-       "grid_gap": null,
-       "grid_row": null,
-       "grid_template_areas": null,
-       "grid_template_columns": null,
-       "grid_template_rows": null,
-       "height": null,
-       "justify_content": null,
-       "justify_items": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "object_fit": null,
-       "object_position": null,
-       "order": null,
-       "overflow": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
-      }
-     },
-     "657fbc1eb5e24c0a82dca9cf550a1381": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "2.0.0",
-      "model_name": "LayoutModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/base",
-       "_model_module_version": "2.0.0",
-       "_model_name": "LayoutModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "2.0.0",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border_bottom": null,
-       "border_left": null,
-       "border_right": null,
-       "border_top": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "grid_area": null,
-       "grid_auto_columns": null,
-       "grid_auto_flow": null,
-       "grid_auto_rows": null,
-       "grid_column": null,
-       "grid_gap": null,
-       "grid_row": null,
-       "grid_template_areas": null,
-       "grid_template_columns": null,
-       "grid_template_rows": null,
-       "height": null,
-       "justify_content": null,
-       "justify_items": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "object_fit": null,
-       "object_position": null,
-       "order": null,
-       "overflow": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
-      }
-     },
-     "6647c964810540f1b263846c6adf0b37": {
+     "ac73c6d638044e2784c1c36c3e2e7341": {
       "model_module": "@jupyter-widgets/controls",
       "model_module_version": "2.0.0",
       "model_name": "FloatProgressModel",
@@ -3277,17 +3807,66 @@
        "bar_style": "success",
        "description": "",
        "description_allow_html": false,
-       "layout": "IPY_MODEL_3ab279eb89e140b0a8d04158333f0ea5",
+       "layout": "IPY_MODEL_cec0e4da5cbc46f39b824f8a23177278",
+       "max": 340.0,
+       "min": 0.0,
+       "orientation": "horizontal",
+       "style": "IPY_MODEL_32a3f93058ae40e0811bae039290d5c1",
+       "tabbable": null,
+       "tooltip": null,
+       "value": 340.0
+      }
+     },
+     "ade416c5f9454796b626cbefd9c55dfc": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "FloatProgressModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "2.0.0",
+       "_view_name": "ProgressView",
+       "bar_style": "success",
+       "description": "",
+       "description_allow_html": false,
+       "layout": "IPY_MODEL_f3b403668cc0425f9ba9cd0805f9224c",
        "max": 1584.0,
        "min": 0.0,
        "orientation": "horizontal",
-       "style": "IPY_MODEL_76387ff6c4f0453cae44935f262d920c",
+       "style": "IPY_MODEL_e1012e38c4624134ace42b58116f6092",
        "tabbable": null,
        "tooltip": null,
        "value": 1584.0
       }
      },
-     "66af94ef00714377911822e368317cc9": {
+     "b2035db5f6d04e0bbeac96078c0ff03c": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "HTMLModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "2.0.0",
+       "_view_name": "HTMLView",
+       "description": "",
+       "description_allow_html": false,
+       "layout": "IPY_MODEL_2b06b665efa443a295b83964245d4153",
+       "placeholder": "​",
+       "style": "IPY_MODEL_c1c01047a2b2472aac359d4a51a3d7d1",
+       "tabbable": null,
+       "tooltip": null,
+       "value": "Map: 100%"
+      }
+     },
+     "b2f872db38754de6a074ec218ff60da1": {
       "model_module": "@jupyter-widgets/base",
       "model_module_version": "2.0.0",
       "model_name": "LayoutModel",
@@ -3340,62 +3919,7 @@
        "width": null
       }
      },
-     "6815c8269bcf4ae48deea2dadbb41751": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "2.0.0",
-      "model_name": "HTMLModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "@jupyter-widgets/controls",
-       "_model_module_version": "2.0.0",
-       "_model_name": "HTMLModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/controls",
-       "_view_module_version": "2.0.0",
-       "_view_name": "HTMLView",
-       "description": "",
-       "description_allow_html": false,
-       "layout": "IPY_MODEL_63d1f0fcb39f40adbb049fd4850c849e",
-       "placeholder": "​",
-       "style": "IPY_MODEL_b4ca2896bc31471eb7c18feff1328533",
-       "tabbable": null,
-       "tooltip": null,
-       "value": " 1584/1584 [00:00&lt;00:00, 41953.63 examples/s]"
-      }
-     },
-     "68afaa8c74b14530a0038e864026ea23": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "2.0.0",
-      "model_name": "ProgressStyleModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/controls",
-       "_model_module_version": "2.0.0",
-       "_model_name": "ProgressStyleModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "2.0.0",
-       "_view_name": "StyleView",
-       "bar_color": null,
-       "description_width": ""
-      }
-     },
-     "6f344a824f38447eaaeb58c8c1b18ab8": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "2.0.0",
-      "model_name": "ProgressStyleModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/controls",
-       "_model_module_version": "2.0.0",
-       "_model_name": "ProgressStyleModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "2.0.0",
-       "_view_name": "StyleView",
-       "bar_color": null,
-       "description_width": ""
-      }
-     },
-     "725e5c16d87944829f1d88babc177dea": {
+     "b529898deec7470fa258a1ff80d3fafd": {
       "model_module": "@jupyter-widgets/controls",
       "model_module_version": "2.0.0",
       "model_name": "HTMLStyleModel",
@@ -3413,311 +3937,7 @@
        "text_color": null
       }
      },
-     "72cba48a36454e7a875910da6201581b": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "2.0.0",
-      "model_name": "LayoutModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/base",
-       "_model_module_version": "2.0.0",
-       "_model_name": "LayoutModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "2.0.0",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border_bottom": null,
-       "border_left": null,
-       "border_right": null,
-       "border_top": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "grid_area": null,
-       "grid_auto_columns": null,
-       "grid_auto_flow": null,
-       "grid_auto_rows": null,
-       "grid_column": null,
-       "grid_gap": null,
-       "grid_row": null,
-       "grid_template_areas": null,
-       "grid_template_columns": null,
-       "grid_template_rows": null,
-       "height": null,
-       "justify_content": null,
-       "justify_items": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "object_fit": null,
-       "object_position": null,
-       "order": null,
-       "overflow": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
-      }
-     },
-     "76387ff6c4f0453cae44935f262d920c": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "2.0.0",
-      "model_name": "ProgressStyleModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/controls",
-       "_model_module_version": "2.0.0",
-       "_model_name": "ProgressStyleModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "2.0.0",
-       "_view_name": "StyleView",
-       "bar_color": null,
-       "description_width": ""
-      }
-     },
-     "7c22f9bd1a914086a73733541bd0a9a3": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "2.0.0",
-      "model_name": "HTMLModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "@jupyter-widgets/controls",
-       "_model_module_version": "2.0.0",
-       "_model_name": "HTMLModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/controls",
-       "_view_module_version": "2.0.0",
-       "_view_name": "HTMLView",
-       "description": "",
-       "description_allow_html": false,
-       "layout": "IPY_MODEL_0f1375d4082540b698c939a620efbe31",
-       "placeholder": "​",
-       "style": "IPY_MODEL_a98b606c9b7845ae864bf339b7f70a23",
-       "tabbable": null,
-       "tooltip": null,
-       "value": "Map: 100%"
-      }
-     },
-     "7effc1309026430dbc436c2bfbabd5f8": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "2.0.0",
-      "model_name": "LayoutModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/base",
-       "_model_module_version": "2.0.0",
-       "_model_name": "LayoutModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "2.0.0",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border_bottom": null,
-       "border_left": null,
-       "border_right": null,
-       "border_top": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "grid_area": null,
-       "grid_auto_columns": null,
-       "grid_auto_flow": null,
-       "grid_auto_rows": null,
-       "grid_column": null,
-       "grid_gap": null,
-       "grid_row": null,
-       "grid_template_areas": null,
-       "grid_template_columns": null,
-       "grid_template_rows": null,
-       "height": null,
-       "justify_content": null,
-       "justify_items": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "object_fit": null,
-       "object_position": null,
-       "order": null,
-       "overflow": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
-      }
-     },
-     "8542c3c3af6442e98fb7bb754202100d": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "2.0.0",
-      "model_name": "LayoutModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/base",
-       "_model_module_version": "2.0.0",
-       "_model_name": "LayoutModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "2.0.0",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border_bottom": null,
-       "border_left": null,
-       "border_right": null,
-       "border_top": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "grid_area": null,
-       "grid_auto_columns": null,
-       "grid_auto_flow": null,
-       "grid_auto_rows": null,
-       "grid_column": null,
-       "grid_gap": null,
-       "grid_row": null,
-       "grid_template_areas": null,
-       "grid_template_columns": null,
-       "grid_template_rows": null,
-       "height": null,
-       "justify_content": null,
-       "justify_items": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "object_fit": null,
-       "object_position": null,
-       "order": null,
-       "overflow": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
-      }
-     },
-     "85cb244704cb4aa38538579b6bb95d26": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "2.0.0",
-      "model_name": "LayoutModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/base",
-       "_model_module_version": "2.0.0",
-       "_model_name": "LayoutModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "2.0.0",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border_bottom": null,
-       "border_left": null,
-       "border_right": null,
-       "border_top": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "grid_area": null,
-       "grid_auto_columns": null,
-       "grid_auto_flow": null,
-       "grid_auto_rows": null,
-       "grid_column": null,
-       "grid_gap": null,
-       "grid_row": null,
-       "grid_template_areas": null,
-       "grid_template_columns": null,
-       "grid_template_rows": null,
-       "height": null,
-       "justify_content": null,
-       "justify_items": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "object_fit": null,
-       "object_position": null,
-       "order": null,
-       "overflow": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
-      }
-     },
-     "89535c00a9d54c2ca428274e4db660f8": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "2.0.0",
-      "model_name": "LayoutModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/base",
-       "_model_module_version": "2.0.0",
-       "_model_name": "LayoutModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "2.0.0",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border_bottom": null,
-       "border_left": null,
-       "border_right": null,
-       "border_top": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "grid_area": null,
-       "grid_auto_columns": null,
-       "grid_auto_flow": null,
-       "grid_auto_rows": null,
-       "grid_column": null,
-       "grid_gap": null,
-       "grid_row": null,
-       "grid_template_areas": null,
-       "grid_template_columns": null,
-       "grid_template_rows": null,
-       "height": null,
-       "justify_content": null,
-       "justify_items": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "object_fit": null,
-       "object_position": null,
-       "order": null,
-       "overflow": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
-      }
-     },
-     "896ec209f406410cb446d3c06a06bee6": {
+     "ba9d337bce4343a1a5d09027657571e3": {
       "model_module": "@jupyter-widgets/controls",
       "model_module_version": "2.0.0",
       "model_name": "HBoxModel",
@@ -3732,16 +3952,58 @@
        "_view_name": "HBoxView",
        "box_style": "",
        "children": [
-        "IPY_MODEL_0903cbff24f8486591f3a50e1fa1d1a0",
-        "IPY_MODEL_4269c1c2d635411e8cd05fb9472e1654",
-        "IPY_MODEL_cadd20419ee34d15a743ceb0e9786abb"
+        "IPY_MODEL_ac6d2d9e86b6481890f415bb045e52b0",
+        "IPY_MODEL_5710ba27073d4034a9bbbb32bac20610",
+        "IPY_MODEL_db6adc99378c4d21a4c0a1fe945cb029"
        ],
-       "layout": "IPY_MODEL_414f8d23450342efaa0b9f4d92aad3bb",
+       "layout": "IPY_MODEL_1da594bf4c204c7fbd1fcd060bc36ef2",
        "tabbable": null,
        "tooltip": null
       }
      },
-     "8979a12dc82c47fd90d6e4a3b9a1601e": {
+     "bcc8b90b59ad4cc19b2f62120a49ab8c": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "HBoxModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "2.0.0",
+       "_view_name": "HBoxView",
+       "box_style": "",
+       "children": [
+        "IPY_MODEL_b2035db5f6d04e0bbeac96078c0ff03c",
+        "IPY_MODEL_db75ba4e06f04093867cad3d9c4e25e2",
+        "IPY_MODEL_5eff5f234ca94192ba9c99635d99031c"
+       ],
+       "layout": "IPY_MODEL_0157a81c2f884fc5a32a8cd4cee4af33",
+       "tabbable": null,
+       "tooltip": null
+      }
+     },
+     "c1c01047a2b2472aac359d4a51a3d7d1": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLStyleModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "HTMLStyleModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "StyleView",
+       "background": null,
+       "description_width": "",
+       "font_size": null,
+       "text_color": null
+      }
+     },
+     "c4d730c92169495184377e2d03e0e989": {
       "model_module": "@jupyter-widgets/base",
       "model_module_version": "2.0.0",
       "model_name": "LayoutModel",
@@ -3794,7 +4056,242 @@
        "width": null
       }
      },
-     "8caa361812964d178950f92ae486e144": {
+     "c6d4505a912b43318228dc59335c5ba6": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "c812dfb756594161a8690105818f50bd": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "ca658e5449884f39883cd2526673e8fa": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "ccb177ac2e9e41f79436e3da183b7445": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "HTMLModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "2.0.0",
+       "_view_name": "HTMLView",
+       "description": "",
+       "description_allow_html": false,
+       "layout": "IPY_MODEL_edb225e87ebc445a8140cdc6fbf42052",
+       "placeholder": "​",
+       "style": "IPY_MODEL_0c99c9d2ad7e47efae6f6a98723b206f",
+       "tabbable": null,
+       "tooltip": null,
+       "value": "Map: 100%"
+      }
+     },
+     "cec0e4da5cbc46f39b824f8a23177278": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "cf7d29d480874e13bccc4e96e0a39178": {
       "model_module": "@jupyter-widgets/controls",
       "model_module_version": "2.0.0",
       "model_name": "ProgressStyleModel",
@@ -3810,7 +4307,99 @@
        "description_width": ""
       }
      },
-     "8e99232d5abf4bcdba816018115e9abf": {
+     "d1768f39a8ff434aa51e5ba40059c935": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "ProgressStyleModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "StyleView",
+       "bar_color": null,
+       "description_width": ""
+      }
+     },
+     "d97f7acfd78f4c6dbfc8f98a46576170": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "db6adc99378c4d21a4c0a1fe945cb029": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "HTMLModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "2.0.0",
+       "_view_name": "HTMLView",
+       "description": "",
+       "description_allow_html": false,
+       "layout": "IPY_MODEL_0239a070c539412b9cc1e33d9a45dfbd",
+       "placeholder": "​",
+       "style": "IPY_MODEL_27c398177f54467a87e19e6448613001",
+       "tabbable": null,
+       "tooltip": null,
+       "value": " 340/340 [00:00&lt;00:00, 29191.50 examples/s]"
+      }
+     },
+     "db75ba4e06f04093867cad3d9c4e25e2": {
       "model_module": "@jupyter-widgets/controls",
       "model_module_version": "2.0.0",
       "model_name": "FloatProgressModel",
@@ -3826,17 +4415,33 @@
        "bar_style": "success",
        "description": "",
        "description_allow_html": false,
-       "layout": "IPY_MODEL_df683f63e84f450db007ce4e0538d07d",
+       "layout": "IPY_MODEL_8e2c2e1306d647a09ca6ded02bd410ac",
        "max": 340.0,
        "min": 0.0,
        "orientation": "horizontal",
-       "style": "IPY_MODEL_538d514185584ad8a887c21fe9dd4101",
+       "style": "IPY_MODEL_5305c4ade7004cbf865fc91f51b77096",
        "tabbable": null,
        "tooltip": null,
        "value": 340.0
       }
      },
-     "8f017f59f7344dbd869060572c1dbb43": {
+     "df971a039a9846338feabb98289ce83a": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "ProgressStyleModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "StyleView",
+       "bar_color": null,
+       "description_width": ""
+      }
+     },
+     "e0de26a57cbd47e088b27d6b5e39847b": {
       "model_module": "@jupyter-widgets/base",
       "model_module_version": "2.0.0",
       "model_name": "LayoutModel",
@@ -3889,7 +4494,76 @@
        "width": null
       }
      },
-     "942f6ef713d24a88b941979a98742ff0": {
+     "e1012e38c4624134ace42b58116f6092": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "ProgressStyleModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "StyleView",
+       "bar_color": null,
+       "description_width": ""
+      }
+     },
+     "e637fab5c5de49a59c7b2190c92a65b8": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "ea0e1a31a7fc432097fb6d6bd8d9cbd0": {
       "model_module": "@jupyter-widgets/controls",
       "model_module_version": "2.0.0",
       "model_name": "HTMLStyleModel",
@@ -3907,74 +4581,113 @@
        "text_color": null
       }
      },
-     "9589290a9947471ba06f3e6b1abcda3e": {
-      "model_module": "@jupyter-widgets/controls",
+     "ecf20189797f41c1a3d1f9d3457297d6": {
+      "model_module": "@jupyter-widgets/base",
       "model_module_version": "2.0.0",
-      "model_name": "HTMLModel",
+      "model_name": "LayoutModel",
       "state": {
-       "_dom_classes": [],
-       "_model_module": "@jupyter-widgets/controls",
+       "_model_module": "@jupyter-widgets/base",
        "_model_module_version": "2.0.0",
-       "_model_name": "HTMLModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/controls",
-       "_view_module_version": "2.0.0",
-       "_view_name": "HTMLView",
-       "description": "",
-       "description_allow_html": false,
-       "layout": "IPY_MODEL_8542c3c3af6442e98fb7bb754202100d",
-       "placeholder": "​",
-       "style": "IPY_MODEL_20d7dc0cb5244d7ab34dd02688e68e54",
-       "tabbable": null,
-       "tooltip": null,
-       "value": " 340/340 [00:00&lt;00:00, 26581.86 examples/s]"
-      }
-     },
-     "97dabe1bcf4a45d2b5deeed7de9fe97d": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "2.0.0",
-      "model_name": "HTMLStyleModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/controls",
-       "_model_module_version": "2.0.0",
-       "_model_name": "HTMLStyleModel",
+       "_model_name": "LayoutModel",
        "_view_count": null,
        "_view_module": "@jupyter-widgets/base",
        "_view_module_version": "2.0.0",
-       "_view_name": "StyleView",
-       "background": null,
-       "description_width": "",
-       "font_size": null,
-       "text_color": null
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
       }
      },
-     "981199f49b45480d8fed7d44815b9646": {
-      "model_module": "@jupyter-widgets/controls",
+     "edb225e87ebc445a8140cdc6fbf42052": {
+      "model_module": "@jupyter-widgets/base",
       "model_module_version": "2.0.0",
-      "model_name": "FloatProgressModel",
+      "model_name": "LayoutModel",
       "state": {
-       "_dom_classes": [],
-       "_model_module": "@jupyter-widgets/controls",
+       "_model_module": "@jupyter-widgets/base",
        "_model_module_version": "2.0.0",
-       "_model_name": "FloatProgressModel",
+       "_model_name": "LayoutModel",
        "_view_count": null,
-       "_view_module": "@jupyter-widgets/controls",
+       "_view_module": "@jupyter-widgets/base",
        "_view_module_version": "2.0.0",
-       "_view_name": "ProgressView",
-       "bar_style": "success",
-       "description": "",
-       "description_allow_html": false,
-       "layout": "IPY_MODEL_edd8d4af5e8249469eaacf7ba4b51b39",
-       "max": 340.0,
-       "min": 0.0,
-       "orientation": "horizontal",
-       "style": "IPY_MODEL_a00098b5c2774304ad24b7eac77c7473",
-       "tabbable": null,
-       "tooltip": null,
-       "value": 340.0
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
       }
      },
-     "9983648dd8ee4cb8936cbb616df79935": {
+     "ef25279ae93446cca323aca03bf0d637": {
       "model_module": "@jupyter-widgets/controls",
       "model_module_version": "2.0.0",
       "model_name": "HBoxModel",
@@ -3989,213 +4702,40 @@
        "_view_name": "HBoxView",
        "box_style": "",
        "children": [
-        "IPY_MODEL_07200605cb5d4956a94e1d05355e8236",
-        "IPY_MODEL_57194a1c63284f4296dffa8ebaf56c0e",
-        "IPY_MODEL_abdd5f61159b4db5b8d5d6b87b0d5c9e"
+        "IPY_MODEL_43ca5a36321843249584ea63a1e89ecd",
+        "IPY_MODEL_9df105ad7cdb4d72b0419c5691de31c2",
+        "IPY_MODEL_6550e5989c234ba9a1a07ae593ba6fcd"
        ],
-       "layout": "IPY_MODEL_89535c00a9d54c2ca428274e4db660f8",
+       "layout": "IPY_MODEL_2ed0605d45aa425ab10086c4e7d60651",
        "tabbable": null,
        "tooltip": null
       }
      },
-     "9c04c3d91cbd41758adace269cab89de": {
+     "f36cfe70ee5144799aaaf0e5165faff9": {
       "model_module": "@jupyter-widgets/controls",
       "model_module_version": "2.0.0",
-      "model_name": "HTMLStyleModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/controls",
-       "_model_module_version": "2.0.0",
-       "_model_name": "HTMLStyleModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "2.0.0",
-       "_view_name": "StyleView",
-       "background": null,
-       "description_width": "",
-       "font_size": null,
-       "text_color": null
-      }
-     },
-     "9e203567e7f8449f963ea326c00f0d0b": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "2.0.0",
-      "model_name": "LayoutModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/base",
-       "_model_module_version": "2.0.0",
-       "_model_name": "LayoutModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "2.0.0",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border_bottom": null,
-       "border_left": null,
-       "border_right": null,
-       "border_top": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "grid_area": null,
-       "grid_auto_columns": null,
-       "grid_auto_flow": null,
-       "grid_auto_rows": null,
-       "grid_column": null,
-       "grid_gap": null,
-       "grid_row": null,
-       "grid_template_areas": null,
-       "grid_template_columns": null,
-       "grid_template_rows": null,
-       "height": null,
-       "justify_content": null,
-       "justify_items": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "object_fit": null,
-       "object_position": null,
-       "order": null,
-       "overflow": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
-      }
-     },
-     "a00098b5c2774304ad24b7eac77c7473": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "2.0.0",
-      "model_name": "ProgressStyleModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/controls",
-       "_model_module_version": "2.0.0",
-       "_model_name": "ProgressStyleModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "2.0.0",
-       "_view_name": "StyleView",
-       "bar_color": null,
-       "description_width": ""
-      }
-     },
-     "a7c0c1215af44d8981d8dee91de0da58": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "2.0.0",
-      "model_name": "LayoutModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/base",
-       "_model_module_version": "2.0.0",
-       "_model_name": "LayoutModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "2.0.0",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border_bottom": null,
-       "border_left": null,
-       "border_right": null,
-       "border_top": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "grid_area": null,
-       "grid_auto_columns": null,
-       "grid_auto_flow": null,
-       "grid_auto_rows": null,
-       "grid_column": null,
-       "grid_gap": null,
-       "grid_row": null,
-       "grid_template_areas": null,
-       "grid_template_columns": null,
-       "grid_template_rows": null,
-       "height": null,
-       "justify_content": null,
-       "justify_items": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "object_fit": null,
-       "object_position": null,
-       "order": null,
-       "overflow": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
-      }
-     },
-     "a98b606c9b7845ae864bf339b7f70a23": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "2.0.0",
-      "model_name": "HTMLStyleModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/controls",
-       "_model_module_version": "2.0.0",
-       "_model_name": "HTMLStyleModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "2.0.0",
-       "_view_name": "StyleView",
-       "background": null,
-       "description_width": "",
-       "font_size": null,
-       "text_color": null
-      }
-     },
-     "abdd5f61159b4db5b8d5d6b87b0d5c9e": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "2.0.0",
-      "model_name": "HTMLModel",
+      "model_name": "HBoxModel",
       "state": {
        "_dom_classes": [],
        "_model_module": "@jupyter-widgets/controls",
        "_model_module_version": "2.0.0",
-       "_model_name": "HTMLModel",
+       "_model_name": "HBoxModel",
        "_view_count": null,
        "_view_module": "@jupyter-widgets/controls",
        "_view_module_version": "2.0.0",
-       "_view_name": "HTMLView",
-       "description": "",
-       "description_allow_html": false,
-       "layout": "IPY_MODEL_bfeb22e6b10547c4b9a0c24f2d3de839",
-       "placeholder": "​",
-       "style": "IPY_MODEL_1f1c0f5e7f2944fe8e11fa21db9addac",
+       "_view_name": "HBoxView",
+       "box_style": "",
+       "children": [
+        "IPY_MODEL_ccb177ac2e9e41f79436e3da183b7445",
+        "IPY_MODEL_ac73c6d638044e2784c1c36c3e2e7341",
+        "IPY_MODEL_82e0689e99d8447da54267c9afefec07"
+       ],
+       "layout": "IPY_MODEL_660ba4241f1441589b70534b47daa258",
        "tabbable": null,
-       "tooltip": null,
-       "value": " 1584/1584 [00:00&lt;00:00, 31687.28 examples/s]"
+       "tooltip": null
       }
      },
-     "acd0d682335b45b6b87d8f289eb6e940": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "2.0.0",
-      "model_name": "ProgressStyleModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/controls",
-       "_model_module_version": "2.0.0",
-       "_model_name": "ProgressStyleModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "2.0.0",
-       "_view_name": "StyleView",
-       "bar_color": null,
-       "description_width": ""
-      }
-     },
-     "b052c62533a642d680c5f1eab0e61b3e": {
+     "f3b403668cc0425f9ba9cd0805f9224c": {
       "model_module": "@jupyter-widgets/base",
       "model_module_version": "2.0.0",
       "model_name": "LayoutModel",
@@ -4248,7 +4788,7 @@
        "width": null
       }
      },
-     "b0d905bc3a91468a99e22269e71d7d1a": {
+     "f4b8c4bc6eb542b7a2acc2221aeb5398": {
       "model_module": "@jupyter-widgets/base",
       "model_module_version": "2.0.0",
       "model_name": "LayoutModel",
@@ -4301,60 +4841,7 @@
        "width": null
       }
      },
-     "b13c300161cc4676922abffd98aeda3e": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "2.0.0",
-      "model_name": "LayoutModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/base",
-       "_model_module_version": "2.0.0",
-       "_model_name": "LayoutModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "2.0.0",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border_bottom": null,
-       "border_left": null,
-       "border_right": null,
-       "border_top": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "grid_area": null,
-       "grid_auto_columns": null,
-       "grid_auto_flow": null,
-       "grid_auto_rows": null,
-       "grid_column": null,
-       "grid_gap": null,
-       "grid_row": null,
-       "grid_template_areas": null,
-       "grid_template_columns": null,
-       "grid_template_rows": null,
-       "height": null,
-       "justify_content": null,
-       "justify_items": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "object_fit": null,
-       "object_position": null,
-       "order": null,
-       "overflow": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
-      }
-     },
-     "b4c743b6f48649559f95f495ba3a8c8e": {
+     "f739c2701ced436d92bdae9e2ae0e4c1": {
       "model_module": "@jupyter-widgets/controls",
       "model_module_version": "2.0.0",
       "model_name": "HTMLModel",
@@ -4369,90 +4856,15 @@
        "_view_name": "HTMLView",
        "description": "",
        "description_allow_html": false,
-       "layout": "IPY_MODEL_5879447f6fbe4679b4a98a22e5032911",
+       "layout": "IPY_MODEL_4c5b429d5e564b59b6b87f66d76938c9",
        "placeholder": "​",
-       "style": "IPY_MODEL_33bd62493dcd4e87b46b6eced87219be",
+       "style": "IPY_MODEL_31da59ecfe6f43da83f84b3de9d35e17",
        "tabbable": null,
        "tooltip": null,
        "value": "Map: 100%"
       }
      },
-     "b4ca2896bc31471eb7c18feff1328533": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "2.0.0",
-      "model_name": "HTMLStyleModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/controls",
-       "_model_module_version": "2.0.0",
-       "_model_name": "HTMLStyleModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "2.0.0",
-       "_view_name": "StyleView",
-       "background": null,
-       "description_width": "",
-       "font_size": null,
-       "text_color": null
-      }
-     },
-     "b5143fb4b2ab44dab48045759f14f79b": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "2.0.0",
-      "model_name": "HTMLModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "@jupyter-widgets/controls",
-       "_model_module_version": "2.0.0",
-       "_model_name": "HTMLModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/controls",
-       "_view_module_version": "2.0.0",
-       "_view_name": "HTMLView",
-       "description": "",
-       "description_allow_html": false,
-       "layout": "IPY_MODEL_7effc1309026430dbc436c2bfbabd5f8",
-       "placeholder": "​",
-       "style": "IPY_MODEL_f291e25bad3747b08a3089df8ca49ccb",
-       "tabbable": null,
-       "tooltip": null,
-       "value": "Map: 100%"
-      }
-     },
-     "b68068e48f4a432aa0a8453d2a5c9d4b": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "2.0.0",
-      "model_name": "ProgressStyleModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/controls",
-       "_model_module_version": "2.0.0",
-       "_model_name": "ProgressStyleModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "2.0.0",
-       "_view_name": "StyleView",
-       "bar_color": null,
-       "description_width": ""
-      }
-     },
-     "b688a9adc4014ceb8068c2b41bea2344": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "2.0.0",
-      "model_name": "HTMLStyleModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/controls",
-       "_model_module_version": "2.0.0",
-       "_model_name": "HTMLStyleModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "2.0.0",
-       "_view_name": "StyleView",
-       "background": null,
-       "description_width": "",
-       "font_size": null,
-       "text_color": null
-      }
-     },
-     "bfeb22e6b10547c4b9a0c24f2d3de839": {
+     "f8683f843bbe4742854378db41586b00": {
       "model_module": "@jupyter-widgets/base",
       "model_module_version": "2.0.0",
       "model_name": "LayoutModel",
@@ -4505,428 +4917,7 @@
        "width": null
       }
      },
-     "c59096b323434c66abcae269aa6761ef": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "2.0.0",
-      "model_name": "FloatProgressModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "@jupyter-widgets/controls",
-       "_model_module_version": "2.0.0",
-       "_model_name": "FloatProgressModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/controls",
-       "_view_module_version": "2.0.0",
-       "_view_name": "ProgressView",
-       "bar_style": "success",
-       "description": "",
-       "description_allow_html": false,
-       "layout": "IPY_MODEL_1cac11024dc543dcb1e796ca00f2f2f0",
-       "max": 340.0,
-       "min": 0.0,
-       "orientation": "horizontal",
-       "style": "IPY_MODEL_8caa361812964d178950f92ae486e144",
-       "tabbable": null,
-       "tooltip": null,
-       "value": 340.0
-      }
-     },
-     "cadd20419ee34d15a743ceb0e9786abb": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "2.0.0",
-      "model_name": "HTMLModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "@jupyter-widgets/controls",
-       "_model_module_version": "2.0.0",
-       "_model_name": "HTMLModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/controls",
-       "_view_module_version": "2.0.0",
-       "_view_name": "HTMLView",
-       "description": "",
-       "description_allow_html": false,
-       "layout": "IPY_MODEL_da0413f0e168415cad70336ee4d8b074",
-       "placeholder": "​",
-       "style": "IPY_MODEL_27a0f51a50014efa9a9c35563b3536ca",
-       "tabbable": null,
-       "tooltip": null,
-       "value": " 340/340 [00:00&lt;00:00, 36785.50 examples/s]"
-      }
-     },
-     "cc6139dcfa504b94a362328f270af45a": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "2.0.0",
-      "model_name": "HBoxModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "@jupyter-widgets/controls",
-       "_model_module_version": "2.0.0",
-       "_model_name": "HBoxModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/controls",
-       "_view_module_version": "2.0.0",
-       "_view_name": "HBoxView",
-       "box_style": "",
-       "children": [
-        "IPY_MODEL_5f519bf29da14387bab1129dc84c523b",
-        "IPY_MODEL_c59096b323434c66abcae269aa6761ef",
-        "IPY_MODEL_14d0036ba35b4609986ebd87029c07d6"
-       ],
-       "layout": "IPY_MODEL_010402e17bfc43b58a0bd85be8794d27",
-       "tabbable": null,
-       "tooltip": null
-      }
-     },
-     "cd17cb0883f3467a8472e405d1b93def": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "2.0.0",
-      "model_name": "HTMLStyleModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/controls",
-       "_model_module_version": "2.0.0",
-       "_model_name": "HTMLStyleModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "2.0.0",
-       "_view_name": "StyleView",
-       "background": null,
-       "description_width": "",
-       "font_size": null,
-       "text_color": null
-      }
-     },
-     "da0413f0e168415cad70336ee4d8b074": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "2.0.0",
-      "model_name": "LayoutModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/base",
-       "_model_module_version": "2.0.0",
-       "_model_name": "LayoutModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "2.0.0",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border_bottom": null,
-       "border_left": null,
-       "border_right": null,
-       "border_top": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "grid_area": null,
-       "grid_auto_columns": null,
-       "grid_auto_flow": null,
-       "grid_auto_rows": null,
-       "grid_column": null,
-       "grid_gap": null,
-       "grid_row": null,
-       "grid_template_areas": null,
-       "grid_template_columns": null,
-       "grid_template_rows": null,
-       "height": null,
-       "justify_content": null,
-       "justify_items": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "object_fit": null,
-       "object_position": null,
-       "order": null,
-       "overflow": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
-      }
-     },
-     "df683f63e84f450db007ce4e0538d07d": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "2.0.0",
-      "model_name": "LayoutModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/base",
-       "_model_module_version": "2.0.0",
-       "_model_name": "LayoutModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "2.0.0",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border_bottom": null,
-       "border_left": null,
-       "border_right": null,
-       "border_top": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "grid_area": null,
-       "grid_auto_columns": null,
-       "grid_auto_flow": null,
-       "grid_auto_rows": null,
-       "grid_column": null,
-       "grid_gap": null,
-       "grid_row": null,
-       "grid_template_areas": null,
-       "grid_template_columns": null,
-       "grid_template_rows": null,
-       "height": null,
-       "justify_content": null,
-       "justify_items": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "object_fit": null,
-       "object_position": null,
-       "order": null,
-       "overflow": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
-      }
-     },
-     "e27537283b6940648fa5a45dccf0fc50": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "2.0.0",
-      "model_name": "LayoutModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/base",
-       "_model_module_version": "2.0.0",
-       "_model_name": "LayoutModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "2.0.0",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border_bottom": null,
-       "border_left": null,
-       "border_right": null,
-       "border_top": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "grid_area": null,
-       "grid_auto_columns": null,
-       "grid_auto_flow": null,
-       "grid_auto_rows": null,
-       "grid_column": null,
-       "grid_gap": null,
-       "grid_row": null,
-       "grid_template_areas": null,
-       "grid_template_columns": null,
-       "grid_template_rows": null,
-       "height": null,
-       "justify_content": null,
-       "justify_items": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "object_fit": null,
-       "object_position": null,
-       "order": null,
-       "overflow": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
-      }
-     },
-     "edd8d4af5e8249469eaacf7ba4b51b39": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "2.0.0",
-      "model_name": "LayoutModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/base",
-       "_model_module_version": "2.0.0",
-       "_model_name": "LayoutModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "2.0.0",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border_bottom": null,
-       "border_left": null,
-       "border_right": null,
-       "border_top": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "grid_area": null,
-       "grid_auto_columns": null,
-       "grid_auto_flow": null,
-       "grid_auto_rows": null,
-       "grid_column": null,
-       "grid_gap": null,
-       "grid_row": null,
-       "grid_template_areas": null,
-       "grid_template_columns": null,
-       "grid_template_rows": null,
-       "height": null,
-       "justify_content": null,
-       "justify_items": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "object_fit": null,
-       "object_position": null,
-       "order": null,
-       "overflow": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
-      }
-     },
-     "edec085419494d2fba52c97a9cefd0b4": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "2.0.0",
-      "model_name": "LayoutModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/base",
-       "_model_module_version": "2.0.0",
-       "_model_name": "LayoutModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "2.0.0",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border_bottom": null,
-       "border_left": null,
-       "border_right": null,
-       "border_top": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "grid_area": null,
-       "grid_auto_columns": null,
-       "grid_auto_flow": null,
-       "grid_auto_rows": null,
-       "grid_column": null,
-       "grid_gap": null,
-       "grid_row": null,
-       "grid_template_areas": null,
-       "grid_template_columns": null,
-       "grid_template_rows": null,
-       "height": null,
-       "justify_content": null,
-       "justify_items": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "object_fit": null,
-       "object_position": null,
-       "order": null,
-       "overflow": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
-      }
-     },
-     "f291e25bad3747b08a3089df8ca49ccb": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "2.0.0",
-      "model_name": "HTMLStyleModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/controls",
-       "_model_module_version": "2.0.0",
-       "_model_name": "HTMLStyleModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "2.0.0",
-       "_view_name": "StyleView",
-       "background": null,
-       "description_width": "",
-       "font_size": null,
-       "text_color": null
-      }
-     },
-     "fef42a3f32aa4e9e8f08d19980fb130f": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "2.0.0",
-      "model_name": "HTMLModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "@jupyter-widgets/controls",
-       "_model_module_version": "2.0.0",
-       "_model_name": "HTMLModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/controls",
-       "_view_module_version": "2.0.0",
-       "_view_name": "HTMLView",
-       "description": "",
-       "description_allow_html": false,
-       "layout": "IPY_MODEL_66af94ef00714377911822e368317cc9",
-       "placeholder": "​",
-       "style": "IPY_MODEL_942f6ef713d24a88b941979a98742ff0",
-       "tabbable": null,
-       "tooltip": null,
-       "value": " 340/340 [00:00&lt;00:00, 25025.68 examples/s]"
-      }
-     },
-     "ff4a8db7bc9841ee8adc1d222f00ffa3": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "2.0.0",
-      "model_name": "HBoxModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "@jupyter-widgets/controls",
-       "_model_module_version": "2.0.0",
-       "_model_name": "HBoxModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/controls",
-       "_view_module_version": "2.0.0",
-       "_view_name": "HBoxView",
-       "box_style": "",
-       "children": [
-        "IPY_MODEL_4cd767728b4d4199aed6c5d7bd06342e",
-        "IPY_MODEL_981199f49b45480d8fed7d44815b9646",
-        "IPY_MODEL_2d4b86dd83594f85b7c97f1724a9af52"
-       ],
-       "layout": "IPY_MODEL_29ffffe8500041a9b2d6a96fe7408a3f",
-       "tabbable": null,
-       "tooltip": null
-      }
-     },
-     "ffc15c2bbed946a2b69f81dcc13f6926": {
+     "fca90f4bc227418da02f46a0d0cc3f73": {
       "model_module": "@jupyter-widgets/base",
       "model_module_version": "2.0.0",
       "model_name": "LayoutModel",

--- a/10_text_feature_engineering/04_bert_finetuning.py
+++ b/10_text_feature_engineering/04_bert_finetuning.py
@@ -126,6 +126,10 @@ warnings.filterwarnings(
 # %% tags=["parameters"]
 SEED = 42
 MAX_TRAIN_STEPS = -1
+# How many sentences to score in the validation and test splits; 0 means all of them.
+# This is the knob that decides whether CI can run this notebook - see the comment above
+# the split below.
+MAX_EVAL_SAMPLES = 0
 
 # %% [markdown]
 # `set_global_seeds` covers Python, NumPy and Torch. The Trainer draws from its own generator
@@ -239,6 +243,33 @@ def create_dataset_dict(train_df: pl.DataFrame, val_df: pl.DataFrame, test_df: p
 
 
 dataset = create_dataset_dict(train_df, val_df, test_df)
+
+# Scoring, not training, is what this notebook spends its time on, and MAX_TRAIN_STEPS
+# does not touch it. Each model is scored on the validation split every `eval_steps`
+# during training and once on the test split at the end, and a full pass costs 183s on
+# one CPU thread against 727 sentences. Under `MAX_TRAIN_STEPS: 20` that is two
+# in-training evaluations plus two passes over the test split, so twenty training steps
+# sit behind about twelve minutes of inference per model. Bounding the scored splits is
+# the knob that reaches that; bounding the model count would leave a three-way
+# comparison with one entry.
+#
+# 0 means score everything, which is what a real run does. The splits are already
+# shuffled and stratified by `train_test_split`, so a prefix of each is class-balanced
+# in expectation.
+if MAX_EVAL_SAMPLES > 0:
+    dataset = DatasetDict(
+        {
+            "train": dataset["train"],
+            "validation": dataset["validation"].select(
+                range(min(MAX_EVAL_SAMPLES, len(dataset["validation"])))
+            ),
+            "test": dataset["test"].select(range(min(MAX_EVAL_SAMPLES, len(dataset["test"])))),
+        }
+    )
+    print(
+        f"Scored splits bounded to {MAX_EVAL_SAMPLES}: "
+        f"val {len(dataset['validation'])}, test {len(dataset['test'])}"
+    )
 
 # %% [markdown]
 # ## The three checkpoints, and which of them can be read as held out
@@ -406,7 +437,12 @@ def fine_tune_model(model_name: str, spec: dict, dataset: DatasetDict) -> dict:
     train_result = trainer.train()
     train_time = time.time() - start_time
 
-    # Evaluate on test set
+    # `evaluate` and `predict` both make a full forward pass over the test split and
+    # report the same accuracy and macro F1, so this scores it twice. Collapsing them
+    # into a single `predict(..., metric_key_prefix="eval")` is correct and saves a
+    # pass per model, but it moves the two models fine-tuned after it - DeBERTa-v3 to
+    # 96.8% and ModernBERT to 97.9%, which puts ModernBERT above FinBERT and makes the
+    # "scores highest" in takeaway 2 false. ml4t/agent-workspace#1121 carries it.
     test_results = trainer.evaluate(tokenized["test"])
 
     # Get predictions for confusion matrix
@@ -550,11 +586,14 @@ show_with_alt(
 
 # %%
 n_models = len(results)
-fig, axes = plt.subplots(1, n_models, figsize=FIGSIZE["triple_h_tall"])
+# `squeeze=False` so this cell does not depend on how many models ran. `n_models` is
+# read from `results`, and without it a one-model dict gets a bare Axes rather than an
+# array and the zip below raises `'Axes' object is not iterable`.
+fig, axes = plt.subplots(1, n_models, figsize=FIGSIZE["triple_h_tall"], squeeze=False)
 
 labels = ["negative", "neutral", "positive"]
 
-for ax, (name, r) in zip(axes, results.items(), strict=True):
+for ax, (name, r) in zip(axes[0], results.items(), strict=True):
     cm = confusion_matrix(r["y_true"], r["y_pred"])
     sns.heatmap(
         cm,

--- a/tests/overrides.yaml
+++ b/tests/overrides.yaml
@@ -375,11 +375,18 @@
   # comparison, so bounding the model count instead would leave figures and alt text describing
   # panels that were not produced.
   #
-  # Measured at 20 steps and 100 sentences, all three checkpoints, `-k 04_bert_finetuning`:
-  # 863s and 6.2 GB, PASS, taken under load average 9. The timeout is 1800 rather than the
-  # measurement because a GitHub-hosted runner is slower per thread than the machine that
-  # measured it, and the fine-tuning cell carries most of the 863s. The ch10 job's budget is
-  # 60 minutes and it currently finishes in 4-7, so the headroom is in the job.
+  # Measured at 20 steps and 100 sentences, all three checkpoints, through this harness with
+  # `-k 04_bert_finetuning`: 863s and 6.2 GB, PASS, under load average 9. That figure is from
+  # the CPU path the removal of `gpu: true` creates - `CUDA_VISIBLE_DEVICES=""` and
+  # `ML4T_DATA_PATH` on the CI fixture - and not from the card. The GPU renders in
+  # `notebook-runtimes.tsv` are 54-126s and size nothing here.
+  #
+  # `timeout` is papermill's per-cell limit, not a notebook budget, so 1800 is being compared
+  # against the fine-tuning cell rather than against the 863s. That cell carries most of the
+  # run, so the margin is closer to 2x than to the ratio against the whole notebook. It is set
+  # above the measurement because a GitHub-hosted runner is slower per thread than the machine
+  # that measured it. The ch10 job's budget is 60 minutes and it currently finishes in 4-7, so
+  # the headroom is in the job.
   #
   # ml4t/agent-workspace#1097.
   parameters:

--- a/tests/overrides.yaml
+++ b/tests/overrides.yaml
@@ -357,17 +357,35 @@
   requires_import: gensim
   timeout: 300
 10_text_feature_engineering/04_bert_finetuning:
-  # No CUDA requirement in the source - the flag is a cost decision, not a hardware one. The cell
-  # that fine-tunes all three checkpoints takes 637s against the 600s per-cell limit on CPU (645s
-  # under load 16.8, so contention is not what fails it). MAX_TRAIN_STEPS already applies; what
-  # remains is the model count, and no parameter bounds it. Adding one would be clean - the figure
-  # cells derive `model_names` from `results.keys()`, so nothing downstream names a checkpoint -
-  # but it is a parameters-cell edit, which invalidates the committed .ipynb and costs a
-  # production GPU run to regenerate. ml4t/agent-workspace#1097 carries that decision.
-  gpu: true
+  # Runs on CPU. The `gpu: true` this entry used to carry was a cost decision, not a hardware
+  # one - there is no CUDA requirement in the source - and the cost it named was not measured.
+  # The 637s and 645s the earlier version of this comment quoted are FAIL rows: the per-cell
+  # timeout plus harness overhead, not a runtime. The fine-tuning cell had never completed on
+  # CPU, so there was no number to compare against the limit.
+  #
+  # What costs here is scoring, not training. `tests/pm_helpers.py`'s KERNEL_THREAD_CAP pins the
+  # kernel to one thread, and a full pass over the 727-sentence validation or test split costs
+  # 183s there. MAX_TRAIN_STEPS bounds training only: at 20 steps, `eval_steps` resolves to 10,
+  # so each model still pays two in-training evaluations plus two passes over the test split -
+  # about twelve minutes of inference behind twenty training steps. Lowering MAX_TRAIN_STEPS
+  # further makes evaluation a larger share, not a smaller one.
+  #
+  # MAX_EVAL_SAMPLES bounds the scored splits, which is the knob that reaches that cost. All
+  # three checkpoints run: FinBERT is the contaminated one and the notebook is a three-way
+  # comparison, so bounding the model count instead would leave figures and alt text describing
+  # panels that were not produced.
+  #
+  # Measured at 20 steps and 100 sentences, all three checkpoints, `-k 04_bert_finetuning`:
+  # 863s and 6.2 GB, PASS, taken under load average 9. The timeout is 1800 rather than the
+  # measurement because a GitHub-hosted runner is slower per thread than the machine that
+  # measured it, and the fine-tuning cell carries most of the 863s. The ch10 job's budget is
+  # 60 minutes and it currently finishes in 4-7, so the headroom is in the job.
+  #
+  # ml4t/agent-workspace#1097.
   parameters:
     MAX_TRAIN_STEPS: 20
-  timeout: 600
+    MAX_EVAL_SAMPLES: 100
+  timeout: 1800
 10_text_feature_engineering/05_financial_ner_finetuning:
   parameters:
     N_EPOCHS: 1


### PR DESCRIPTION
`10_text_feature_engineering/04_bert_finetuning` carried `gpu: true` in
`tests/overrides.yaml` with a comment saying the fine-tuning cell takes 637s against a 600s
per-cell limit. There is no CUDA requirement anywhere in the source, and 637s was not a
measurement: every row behind it is a `FAIL`, so it is the per-cell timeout plus harness
overhead. The cell had never completed on CPU, so there was no runtime to compare against the
limit.

## What actually costs

Scoring, not training. `tests/pm_helpers.py`'s `KERNEL_THREAD_CAP` pins the kernel to one
thread, and a full pass over the 727-sentence validation or test split costs 183s there
(measured `eval_runtime` 183.05 and 177.53).

`MAX_TRAIN_STEPS` bounds training only. At 20 steps, `eval_steps` resolves to
`max(10, 20 // 5)` = 10, so each model still pays two in-training evaluations plus two passes
over the test split - roughly twelve minutes of inference sitting behind twenty training steps.
Lowering `MAX_TRAIN_STEPS` further makes evaluation a *larger* share of the cost, not a
smaller one.

## The change

`MAX_EVAL_SAMPLES` bounds the scored validation and test splits. It defaults to `0`, meaning
score everything, so a reader's run and the production render are untouched. The splits are
already shuffled and stratified by `train_test_split`, so a prefix of each is class-balanced in
expectation.

Measured at `MAX_TRAIN_STEPS: 20` and `MAX_EVAL_SAMPLES: 100`, all three checkpoints:
**863s and 6.2 GB, PASS**, under load average 9. The entry's timeout is 1800 rather than the
measurement because a GitHub-hosted runner is slower per thread than the machine that measured
it. The `ch10` job's budget is 60 minutes and it currently finishes in 4-7.

All three checkpoints run. Bounding the model count was tried first and is the wrong knob twice
over: two models still timed out past 900s, and FinBERT is the contaminated checkpoint the
notebook exists to compare against the other two, so a bounded run would leave figures and alt
text describing panels that were not produced.

`plt.subplots(1, n_models)` gets `squeeze=False`. `n_models` is read from `results`, and a
one-model dict returned a bare `Axes` rather than an array, so the `zip` below raised
`'Axes' object is not iterable`. Unreachable at the committed three, reachable the moment
anyone runs fewer.

## No number moves

The render was regenerated from this source and reproduces `main`'s committed outputs exactly,
checkpoint for checkpoint:

| | FinBERT | DeBERTa-v3 | ModernBERT |
|---|---|---|---|
| `main` | 97.1% / 0.955 | 94.4% / 0.932 | 96.5% / 0.962 |
| this branch | 97.1% / 0.955 | 94.4% / 0.932 | 96.5% / 0.962 |

## Found while measuring, not fixed here

`fine_tune_model` scores the test split twice, once through `trainer.evaluate` and once through
`trainer.predict`. Collapsing them into a single `predict(..., metric_key_prefix="eval")` is a
two-line change and it is correct - but it moves the two models fine-tuned *after* it, to
DeBERTa-v3 96.8% and ModernBERT 97.9%. That puts ModernBERT above FinBERT and makes takeaway
2's "the contaminated row ... scores highest" false. Tracked as ml4t/agent-workspace#1121,
because it needs a prose revision to the chapter rather than a cleanup commit.

This takes `gpu: true` on `main` from 13 entries to 12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
