### PR TITLE
Point 20 chapter READMEs at the test file that exists

### DIFF
--- a/01_process_is_edge/README.md
+++ b/01_process_is_edge/README.md
@@ -42,7 +42,7 @@ This section translates the workflow into real operating contexts. It explains h
 uv run python 01_process_is_edge/<notebook>.py
 
 # Test mode (reduced data via Papermill)
-uv run pytest tests/test_notebooks.py -v -k "01_process_is_edge"
+uv run pytest tests/test_chapter_notebooks.py -v -k "01_process_is_edge"
 ```
 
 ## References

--- a/02_financial_data_universe/README.md
+++ b/02_financial_data_universe/README.md
@@ -60,7 +60,7 @@ This section translates data discipline into infrastructure decisions. Rather th
 uv run python 02_financial_data_universe/<notebook>.py
 
 # Test mode (reduced data via Papermill)
-uv run pytest tests/test_notebooks.py -v -k "02_financial_data_universe"
+uv run pytest tests/test_chapter_notebooks.py -v -k "02_financial_data_universe"
 ```
 
 ### NB21 storage_benchmark_database prerequisites

--- a/04_fundamental_alternative_data/README.md
+++ b/04_fundamental_alternative_data/README.md
@@ -60,7 +60,7 @@ This section provides a concrete pipeline for turning SEC filing text into a mod
 uv run python 04_fundamental_alternative_data/<notebook>.py
 
 # Test mode (reduced data via Papermill)
-uv run pytest tests/test_notebooks.py -v -k "04_fundamental_alternative_data"
+uv run pytest tests/test_chapter_notebooks.py -v -k "04_fundamental_alternative_data"
 ```
 
 ### Required environment variables

--- a/07_defining_the_learning_task/README.md
+++ b/07_defining_the_learning_task/README.md
@@ -63,7 +63,7 @@ This section introduces causal thinking as a falsification layer for features th
 uv run python 07_defining_the_learning_task/<notebook>.py
 
 # Test mode (reduced data via Papermill)
-uv run pytest tests/test_notebooks.py -v -k "07_defining_the_learning_task"
+uv run pytest tests/test_chapter_notebooks.py -v -k "07_defining_the_learning_task"
 ```
 
 ### Memory and runtime callouts

--- a/08_financial_features/README.md
+++ b/08_financial_features/README.md
@@ -57,7 +57,7 @@ This is the chapter's second major contribution after the feature-design grammar
 uv run python 08_financial_features/<notebook>.py
 
 # Test mode (reduced data via Papermill)
-uv run pytest tests/test_notebooks.py -v -k "08_financial_features"
+uv run pytest tests/test_chapter_notebooks.py -v -k "08_financial_features"
 ```
 
 > Memory: `03_structural_cross_instrument_features` peaks at ~7.4 GB RSS scanning the AlgoSeek S&P-500 options surface — recommend ≥8 GB system RAM for §8.3.

--- a/09_model_based_features/README.md
+++ b/09_model_based_features/README.md
@@ -78,7 +78,7 @@ A conditional volatility of a quarter means one thing for a utility and another 
 uv run python 09_model_based_features/<notebook>.py
 
 # Test mode (reduced data via Papermill)
-uv run pytest tests/test_notebooks.py -v -k "09_model_based_features"
+uv run pytest tests/test_chapter_notebooks.py -v -k "09_model_based_features"
 ```
 
 > Runtime, measured on a workstation: `10_uncertainty_features` about three minutes, which is the sampler; every other notebook in the chapter finishes in under 40 seconds.

--- a/10_text_feature_engineering/README.md
+++ b/10_text_feature_engineering/README.md
@@ -40,7 +40,7 @@ This is the chapter's real practical core. It explains that a strong text model 
 uv run python 10_text_feature_engineering/<notebook>.py
 
 # Test mode (reduced data via Papermill)
-uv run pytest tests/test_notebooks.py -v -k "10_text_feature_engineering"
+uv run pytest tests/test_chapter_notebooks.py -v -k "10_text_feature_engineering"
 ```
 
 ### Docker image split (chapter-specific)

--- a/11_ml_pipeline/README.md
+++ b/11_ml_pipeline/README.md
@@ -108,7 +108,7 @@ more model complexity is only justified when the linear benchmark genuinely leav
 uv run python 11_ml_pipeline/<notebook>.py
 
 # Test mode (reduced data via Papermill)
-uv run pytest tests/test_notebooks.py -v -k "11_ml_pipeline"
+uv run pytest tests/test_chapter_notebooks.py -v -k "11_ml_pipeline"
 ```
 
 ## References

--- a/12_gradient_boosting/README.md
+++ b/12_gradient_boosting/README.md
@@ -67,7 +67,7 @@ This section provides the empirical payoff for the chapter. Instead of treating 
 uv run python 12_gradient_boosting/<notebook>.py
 
 # Test mode (reduced data via Papermill)
-uv run pytest tests/test_notebooks.py -v -k "12_gradient_boosting"
+uv run pytest tests/test_chapter_notebooks.py -v -k "12_gradient_boosting"
 ```
 
 ## References

--- a/13_dl_time_series/README.md
+++ b/13_dl_time_series/README.md
@@ -86,7 +86,7 @@ The aggregate picture from [`12_case_study_insights`](12_case_study_insights.ipy
 uv run python 13_dl_time_series/<notebook>.py
 
 # Test mode (reduced data via Papermill)
-uv run pytest tests/test_notebooks.py -v -k "13_dl_time_series"
+uv run pytest tests/test_chapter_notebooks.py -v -k "13_dl_time_series"
 ```
 
 > Every chapter-13 notebook except `12_case_study_insights` trains PyTorch on the GPU

--- a/16_strategy_simulation/README.md
+++ b/16_strategy_simulation/README.md
@@ -30,7 +30,7 @@ This section closes the chapter by restating backtesting as a falsification disc
 # From the repository root
 uv run python 16_strategy_simulation/<notebook>.py
 # Test mode (reduced data via Papermill)
-uv run pytest tests/test_notebooks.py -v -k "16_strategy_simulation"
+uv run pytest tests/test_chapter_notebooks.py -v -k "16_strategy_simulation"
 ```
 ## References
 - **Ashwin Alankar et al.** (2023). [Fairy Tails: Lessons from 150 Years of Drawdowns](https://doi.org/10.3905/jpm.2023.1.503). *The Journal of Portfolio Management*.

--- a/18_transaction_costs/README.md
+++ b/18_transaction_costs/README.md
@@ -82,7 +82,7 @@ The cross-case-study cost-survival comparison lives in Chapter 20: see [`20_stra
 uv run python 18_transaction_costs/<notebook>.py
 
 # Test mode (reduced data via Papermill)
-uv run pytest tests/test_notebooks.py -v -k "18_transaction_costs"
+uv run pytest tests/test_chapter_notebooks.py -v -k "18_transaction_costs"
 ```
 
 ## References

--- a/19_risk_management/README.md
+++ b/19_risk_management/README.md
@@ -81,7 +81,7 @@ The cross-case-study risk-overlay comparison lives in Chapter 20: see [`20_strat
 uv run python 19_risk_management/<notebook>.py
 
 # Test mode (reduced data via Papermill)
-uv run pytest tests/test_notebooks.py -v -k "19_risk_management"
+uv run pytest tests/test_chapter_notebooks.py -v -k "19_risk_management"
 ```
 
 ## References

--- a/20_strategy_synthesis/README.md
+++ b/20_strategy_synthesis/README.md
@@ -52,7 +52,7 @@ uv run python 20_strategy_synthesis/02_feature_evaluation.py
 MPLBACKEND=Agg PLOTLY_RENDERER=json uv run python 20_strategy_synthesis/03_signal_quality.py
 
 # Test mode (reduced data via Papermill)
-uv run pytest tests/test_notebooks.py -v -k "20_strategy_synthesis"
+uv run pytest tests/test_chapter_notebooks.py -v -k "20_strategy_synthesis"
 ```
 
 ## Dependencies

--- a/21_rl_execution_hedging/README.md
+++ b/21_rl_execution_hedging/README.md
@@ -72,7 +72,7 @@ The chapter's message is that reinforcement learning is most credible for sequen
 uv run python 21_rl_execution_hedging/<notebook>.py
 
 # Test mode (reduced data via Papermill)
-uv run pytest tests/test_notebooks.py -v -k "21_rl_execution_hedging"
+uv run pytest tests/test_chapter_notebooks.py -v -k "21_rl_execution_hedging"
 ```
 
 ## References

--- a/22_rag_financial_research/README.md
+++ b/22_rag_financial_research/README.md
@@ -72,7 +72,7 @@ This section positions RAG not as the endpoint, but as one tool inside broader m
 uv run python 22_rag_financial_research/<notebook>.py
 
 # Test mode (reduced data via Papermill)
-uv run pytest tests/test_notebooks.py -v -k "22_rag_financial_research"
+uv run pytest tests/test_chapter_notebooks.py -v -k "22_rag_financial_research"
 ```
 
 ## References

--- a/24_autonomous_agents/README.md
+++ b/24_autonomous_agents/README.md
@@ -112,7 +112,7 @@ Add keys to `.env` (see `.env.example`). Without API keys, notebooks auto-detect
 uv run python 24_autonomous_agents/<notebook>.py
 
 # Test mode (mock providers via Papermill)
-uv run pytest tests/test_notebooks.py -v -k "24_autonomous_agents"
+uv run pytest tests/test_chapter_notebooks.py -v -k "24_autonomous_agents"
 ```
 
 ## References

--- a/25_live_trading/README.md
+++ b/25_live_trading/README.md
@@ -84,7 +84,7 @@ After completing this chapter, you will be able to:
 uv run python 25_live_trading/01_unified_framework_demo.py
 
 # Test mode (reduced data via Papermill)
-uv run pytest tests/test_notebooks.py -v -k "25_live_trading"
+uv run pytest tests/test_chapter_notebooks.py -v -k "25_live_trading"
 
 # Headless (no display)
 MPLBACKEND=Agg PLOTLY_RENDERER=json uv run python 25_live_trading/01_unified_framework_demo.py

--- a/26_mlops_governance/README.md
+++ b/26_mlops_governance/README.md
@@ -65,7 +65,7 @@ Every notebook binds its settings in a `parameters` cell with a Settings section
 uv run python 26_mlops_governance/01_drift_monitoring.py
 
 # Test mode (reduced data via Papermill)
-uv run pytest tests/test_notebooks.py -v -k "26_mlops_governance"
+uv run pytest tests/test_chapter_notebooks.py -v -k "26_mlops_governance"
 
 # Execute a notebook and keep its outputs
 uv run jupyter nbconvert --to notebook --execute --inplace \

--- a/27_systematic_edge/README.md
+++ b/27_systematic_edge/README.md
@@ -31,5 +31,5 @@ This section shifts from knowledge to career design, recommending honest skills 
 uv run python 27_systematic_edge/<notebook>.py
 
 # Test mode (reduced data via Papermill)
-uv run pytest tests/test_notebooks.py -v -k "27_systematic_edge"
+uv run pytest tests/test_chapter_notebooks.py -v -k "27_systematic_edge"
 ```


### PR DESCRIPTION
Every chapter README's "Running the Notebooks" block told the reader to run

```bash
uv run pytest tests/test_notebooks.py -v -k "<chapter_dir>"
```

`tests/test_notebooks.py` is not in the repo. The command exits 4 with
`file or directory not found` before collecting anything. The file that collects chapter
notebooks is `tests/test_chapter_notebooks.py`, which `15_causal_estimation/README.md`,
`17_portfolio_construction/README.md` and `tests/README.md` already name correctly.

Checked rather than substituted blind - `-k "<chapter_dir>"` still selects under the corrected
path, because the ids are `<chapter_dir>::<stem>.py`:

```
$ uv run pytest tests/test_chapter_notebooks.py --collect-only -q -k "01_process_is_edge"
2 collected
$ uv run pytest tests/test_chapter_notebooks.py --collect-only -q -k "26_mlops_governance"
7 collected
```

## Four held back

`03_market_microstructure`, `05_synthetic_data`, `06_strategy_definition` and
`23_knowledge_graphs` each have a live teaching branch rewriting that README, two of them with
open PRs (#920, #922). Sweeping them here would either conflict with those rewrites or be
silently reverted by them, so they stay stale for now and ml4t/agent-workspace#1114 stays open
for them.

A guard that fails when a README names a path the repo does not have is what stops this
recurring, and it has to wait for the same four: added now it would turn those branches red for
a line they are already rewriting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
