### PR TITLE
Un-skip the five chapter 22 notebooks whose skip reasons were not true

### DIFF
--- a/tests/overrides.yaml
+++ b/tests/overrides.yaml
@@ -1052,33 +1052,53 @@
   tier: weekly
   timeout: 300
 22_rag_financial_research/02_domain_embeddings_comparison:
+  # Was skipped as "Requires RAG infrastructure (chromadb + embedding models) not
+  # provisioned in CI". It imports no chromadb, and chromadb is a core dependency
+  # (pyproject.toml `dependencies`), not an extra, so it is provisioned everywhere.
+  # What actually stopped it is `REQUIRE_GPU`, a declared parameter defaulting to
+  # True that nothing here set: the guard raises before any model loads. With
+  # REQUIRE_GPU false it passes on the CPU path with CUDA_VISIBLE_DEVICES="".
+  # Stays weekly for the one external thing that is real: it pulls
+  # BAAI/bge-large-en-v1.5 (~1.3 GB) and all-MiniLM-L6-v2 from HuggingFace at run
+  # time. The local pass was against a warm HF cache, so it is not a CI cost.
+  # ml4t/agent-workspace#1118.
   parameters:
     MAX_DOCUMENTS: 50
     MAX_QUERIES: 10
     USE_LOCAL_MODELS_ONLY: true
-  skip: true
-  skip_reason: Requires RAG infrastructure (chromadb + embedding models) not provisioned in CI
+    REQUIRE_GPU: false
   tier: weekly
   timeout: 300
 22_rag_financial_research/03_hybrid_retrieval:
+  # Same false reason as 02, same cause: `REQUIRE_GPU` defaulted True and nothing
+  # set it. Passes on CPU in 63s (warm HF cache, so not a CI cost). Stays weekly
+  # because it downloads all-MiniLM-L6-v2 and cross-encoder/ms-marco-MiniLM-L-6-v2.
+  # ml4t/agent-workspace#1118.
   parameters:
     MAX_DOCUMENTS: 50
     MAX_QUERIES: 10
     TOP_K: 5
-  skip: true
-  skip_reason: Requires RAG infrastructure (chromadb + embedding models) not provisioned in CI
+    REQUIRE_GPU: false
   tier: weekly
   timeout: 300
 22_rag_financial_research/04_ragas_evaluation:
+  # Was skipped as "Requires OpenAI API access for ragas evaluator LLM". It has no
+  # LLM client and no ragas import: the metrics are token overlap computed locally,
+  # which is the weakness 08_rag_security's prose says this notebook measures. It
+  # also carried tier: weekly, a second gate that would have kept it out of the
+  # per-commit run even with the skip gone. Both removed; 04 and 08 together pass in
+  # 38s against the CI fixture. ml4t/agent-workspace#1118.
   parameters:
     MAX_SAMPLES: 10
-  skip: true
-  skip_reason: Requires OpenAI API access for ragas evaluator LLM
-  tier: weekly
   timeout: 300
 22_rag_financial_research/05_10k_rag_assistant:
-  skip: true
-  skip_reason: Requires RAG infrastructure (chromadb + embedding models) not provisioned in CI
+  # Same false reason as 02. This one does import chromadb - and chromadb is a core
+  # dependency, so "not provisioned in CI" was wrong about the one package it names.
+  # `REQUIRE_GPU` defaulted True and nothing set it. RUN_LIVE_LLM defaults False, so
+  # no OpenAI call is reached. Passes on CPU in 81s (warm HF cache). Stays weekly for
+  # the HuggingFaceEmbedding download. ml4t/agent-workspace#1118.
+  parameters:
+    REQUIRE_GPU: false
   tier: weekly
   timeout: 300
 22_rag_financial_research/06_esg_rag_vs_finetune:
@@ -1097,6 +1117,9 @@
     NUM_QUARTERS: 2
   timeout: 300
 22_rag_financial_research/08_rag_security:
+  # Was skipped as "Requires RAG infrastructure (chromadb + embedding models) not
+  # provisioned in CI". It imports neither, and carried tier: weekly as well. Both
+  # removed. ml4t/agent-workspace#1118.
   # MAX_ATTACK_CASES is a cap that must not bind: the notebook raises on any
   # value between one and the fixture count, because dropping a fixture drops
   # an attack class and the two policies would then be compared on different
@@ -1104,9 +1127,6 @@
   # made six. 0 means all of them and cannot go stale as fixtures are added.
   parameters:
     MAX_ATTACK_CASES: 0
-  skip: true
-  skip_reason: Requires RAG infrastructure (chromadb + embedding models) not provisioned in CI
-  tier: weekly
   timeout: 300
 23_knowledge_graphs/08_8k_event_extraction:
   docker_env: ml4t+neo4j+gpu


### PR DESCRIPTION
`skip: true` in `tests/overrides.yaml` takes a notebook out of CI. All 56 entries carry a written `skip_reason`, and nothing checks whether any of them is still true - the suite is green whether a reason is sound, stale, or was never true. Five of the 56 belong to chapter 22, a completed chapter that nobody owns.

All five reasons are false. Each was found by un-skipping and running, which is the only thing that can find one: the reason is prose, and prose does not fail.

## Two named an LLM or a vector store the notebook never touches

| Notebook | Written reason | What is in the file |
|---|---|---|
| `04_ragas_evaluation` | "Requires OpenAI API access for ragas evaluator LLM" | no LLM client, no `ragas` import; the metrics are token overlap computed locally - the weakness `08_rag_security`'s own prose says this notebook measures |
| `08_rag_security` | "Requires RAG infrastructure (chromadb + embedding models) not provisioned in CI" | imports neither |

Both also carried `tier: weekly`. That is a **second, independent gate**: removing a skip changes nothing while the tier still holds the notebook out of the per-commit run. Both come off, and the two together pass in 38s against the CI fixture.

## Three named infrastructure that is present, and missed the parameter that was raising

`02_domain_embeddings_comparison`, `03_hybrid_retrieval` and `05_10k_rag_assistant` all carried "Requires RAG infrastructure (chromadb + embedding models) not provisioned in CI".

`chromadb` is a core dependency in `pyproject.toml`, not an extra, so it is provisioned in every environment the repo builds. 02 and 03 do not import it at all.

What actually stopped all three is `REQUIRE_GPU` - a parameter **declared in each notebook's parameters cell**, defaulting to `True`, that nothing in `tests/overrides.yaml` ever set:

```
RuntimeError: This production benchmark requires a CUDA-capable GPU.
```

The guard raises before any model loads. Their `MAX_DOCUMENTS` and `MAX_QUERIES` were already sized for CI, and then the notebooks were skipped anyway.

With `REQUIRE_GPU: false` all three pass on the CPU path with `CUDA_VISIBLE_DEVICES=""`: 02 and 03 in 63s, 05 in 81s.

They keep `tier: weekly`, because the one part of the reason that is real is the HuggingFace download at run time (`bge-large-en-v1.5` is ~1.3 GB). Those local times were measured against a warm HF cache, so they are **not** CI costs, and the entries say so rather than quoting a figure this machine cannot establish. `weekly-external.yml` is where a genuine external dependency belongs.

## Measured

Against the CI fixture at `ml4t/third-edition-test-data@8c773ef4`:

```
per-commit ch22    1 executed -> 3 executed     44.85s
weekly ch22        1 executed -> 4 executed    145.71s
```

Entries carrying `skip: true` go 56 -> 51.

## What generalizes

Every one of these five reasons named infrastructure the repo already provisions, while the real gate was a declared parameter left at its production default. Reading a reason cannot catch that. The `tier` key is also a silent second skip that a skip-count audit misses entirely: 23 rows carry `tier: weekly` and 5 carry `tier: on_demand` on top of the 51 skips.

No notebook source changed, so no render is affected and no committed output moves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)