### PR TITLE
Chapter 25: the two workable live-trading notebooks, and a reference tape that refused its own orders

### DIFF
--- a/25_live_trading/01_unified_framework_demo.ipynb
+++ b/25_live_trading/01_unified_framework_demo.ipynb
@@ -2,13 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "d62d7e51",
+   "id": "55b03d6f",
    "metadata": {
     "papermill": {
-     "duration": 0.006626,
-     "end_time": "2026-09-09T00:45:09.622890+00:00",
+     "duration": 0.001752,
+     "end_time": "2026-09-11T00:15:13.178190+00:00",
      "exception": false,
-     "start_time": "2026-09-09T00:45:09.616264+00:00",
+     "start_time": "2026-09-11T00:15:13.176438+00:00",
      "status": "completed"
     }
    },
@@ -41,13 +41,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a6a9004d",
+   "id": "c09e4e07",
    "metadata": {
     "papermill": {
-     "duration": 0.004516,
-     "end_time": "2026-09-09T00:45:09.634828+00:00",
+     "duration": 0.001245,
+     "end_time": "2026-09-11T00:15:13.181310+00:00",
      "exception": false,
-     "start_time": "2026-09-09T00:45:09.630312+00:00",
+     "start_time": "2026-09-11T00:15:13.180065+00:00",
      "status": "completed"
     }
    },
@@ -56,25 +56,30 @@
     "\n",
     "Everything below is arranged to make one thing vary. The strategy, the bars, the parameters and the\n",
     "fill convention are held fixed across the two runs so that a difference in output has one candidate\n",
-    "explanation left, which is the engine."
+    "explanation left, which is the engine.\n",
+    "\n",
+    "One warning filter is installed with the imports. The broker adapters pull in websockets' legacy\n",
+    "module, which deprecates itself on import; it is the library's business rather than this\n",
+    "notebook's and nothing in the result depends on it. The other import-time deprecation, from\n",
+    "`nest_asyncio`, is filtered inside `async_utils.run_async` where the call that triggers it lives."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "5801a0c3",
+   "id": "7070948a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T00:45:09.640701Z",
-     "iopub.status.busy": "2026-09-09T00:45:09.640507Z",
-     "iopub.status.idle": "2026-09-09T00:45:11.882924Z",
-     "shell.execute_reply": "2026-09-09T00:45:11.882414Z"
+     "iopub.execute_input": "2026-09-11T00:15:13.185196Z",
+     "iopub.status.busy": "2026-09-11T00:15:13.184989Z",
+     "iopub.status.idle": "2026-09-11T00:15:15.482573Z",
+     "shell.execute_reply": "2026-09-11T00:15:15.481900Z"
     },
     "papermill": {
-     "duration": 2.245841,
-     "end_time": "2026-09-09T00:45:11.883518+00:00",
+     "duration": 2.300514,
+     "end_time": "2026-09-11T00:15:15.483216+00:00",
      "exception": false,
-     "start_time": "2026-09-09T00:45:09.637677+00:00",
+     "start_time": "2026-09-11T00:15:13.182702+00:00",
      "status": "completed"
     }
    },
@@ -94,10 +99,6 @@
     "import polars as pl\n",
     "from async_utils import run_async\n",
     "\n",
-    "# The broker adapters pull in websockets' legacy module, which deprecates itself on import. It\n",
-    "# is the library's business rather than this notebook's and nothing in the result depends on it.\n",
-    "# The other import-time deprecation, from nest_asyncio, is filtered inside `async_utils.run_async`\n",
-    "# where the call that triggers it lives.\n",
     "warnings.filterwarnings(\"ignore\", category=DeprecationWarning, module=r\"websockets\\.legacy\")\n",
     "\n",
     "from ml4t.backtest import BacktestConfig, DataFeed, Engine, ExecutionMode, Strategy\n",
@@ -113,45 +114,18 @@
     "logging.basicConfig(\n",
     "    level=logging.WARNING,\n",
     "    format=\"%(asctime)s - %(name)s - %(levelname)s - %(message)s\",\n",
-    ")\n",
-    "import asyncio\n",
-    "import logging\n",
-    "from collections.abc import AsyncIterator\n",
-    "from datetime import datetime\n",
-    "from typing import Any\n",
-    "\n",
-    "import pandas as pd\n",
-    "import polars as pl\n",
-    "from async_utils import run_async\n",
-    "\n",
-    "# ml4t.backtest imports\n",
-    "from ml4t.backtest import BacktestConfig, DataFeed, Engine, ExecutionMode, Strategy\n",
-    "from ml4t.backtest.types import Order, OrderSide, OrderStatus, OrderType, Position\n",
-    "\n",
-    "# ml4t.live imports\n",
-    "from ml4t.live import (\n",
-    "    LiveEngine,\n",
-    "    VirtualPortfolio,\n",
-    ")\n",
-    "\n",
-    "from data import load_etfs\n",
-    "\n",
-    "# Configure logging for live mode\n",
-    "logging.basicConfig(\n",
-    "    level=logging.WARNING,  # Reduce noise for demo\n",
-    "    format=\"%(asctime)s - %(name)s - %(levelname)s - %(message)s\",\n",
     ")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "7bca5a77",
+   "id": "63e7e88f",
    "metadata": {
     "papermill": {
-     "duration": 0.002253,
-     "end_time": "2026-09-09T00:45:11.888685+00:00",
+     "duration": 0.002195,
+     "end_time": "2026-09-11T00:15:15.487912+00:00",
      "exception": false,
-     "start_time": "2026-09-09T00:45:11.886432+00:00",
+     "start_time": "2026-09-11T00:15:15.485717+00:00",
      "status": "completed"
     }
    },
@@ -168,9 +142,10 @@
     "conventional pairing and nothing here depends on it; the parity claim holds or fails at any\n",
     "setting, which is the point.\n",
     "\n",
-    "`MAX_SYMBOLS` caps how many of the three ETFs are loaded. Zero means all of them, and continuous\n",
-    "integration sets it lower to keep the run short. The strategy trades only SPY either way; the\n",
-    "other two are loaded so the data path carries more than one symbol.\n",
+    "`MAX_SYMBOLS` caps how many of the three ETFs are loaded, and zero means all of them. It exists so\n",
+    "a shorter run can be requested without editing the notebook. The strategy trades only SPY at any\n",
+    "setting; the other two are loaded so the data path carries more than one symbol, which is what\n",
+    "makes the feed's per-symbol handling part of what the comparison covers.\n",
     "\n",
     "`INITIAL_CASH` sizes the account. It scales the printed portfolio values and changes nothing about\n",
     "which signals fire, since the strategy trades a fixed hundred shares."
@@ -179,19 +154,19 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "ef2de8a8",
+   "id": "44b6e723",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T00:45:11.891954Z",
-     "iopub.status.busy": "2026-09-09T00:45:11.891846Z",
-     "iopub.status.idle": "2026-09-09T00:45:11.893406Z",
-     "shell.execute_reply": "2026-09-09T00:45:11.893190Z"
+     "iopub.execute_input": "2026-09-11T00:15:15.492986Z",
+     "iopub.status.busy": "2026-09-11T00:15:15.492880Z",
+     "iopub.status.idle": "2026-09-11T00:15:15.494829Z",
+     "shell.execute_reply": "2026-09-11T00:15:15.494450Z"
     },
     "papermill": {
-     "duration": 0.003667,
-     "end_time": "2026-09-09T00:45:11.893685+00:00",
+     "duration": 0.005304,
+     "end_time": "2026-09-11T00:15:15.495410+00:00",
      "exception": false,
-     "start_time": "2026-09-09T00:45:11.890018+00:00",
+     "start_time": "2026-09-11T00:15:15.490106+00:00",
      "status": "completed"
     },
     "tags": [
@@ -208,19 +183,19 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "d490fffd",
+   "id": "782573f0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T00:45:11.896705Z",
-     "iopub.status.busy": "2026-09-09T00:45:11.896640Z",
-     "iopub.status.idle": "2026-09-09T00:45:11.898569Z",
-     "shell.execute_reply": "2026-09-09T00:45:11.898324Z"
+     "iopub.execute_input": "2026-09-11T00:15:15.498992Z",
+     "iopub.status.busy": "2026-09-11T00:15:15.498916Z",
+     "iopub.status.idle": "2026-09-11T00:15:15.501416Z",
+     "shell.execute_reply": "2026-09-11T00:15:15.501034Z"
     },
     "papermill": {
-     "duration": 0.003851,
-     "end_time": "2026-09-09T00:45:11.898885+00:00",
+     "duration": 0.004601,
+     "end_time": "2026-09-11T00:15:15.501670+00:00",
      "exception": false,
-     "start_time": "2026-09-09T00:45:11.895034+00:00",
+     "start_time": "2026-09-11T00:15:15.497069+00:00",
      "status": "completed"
     }
    },
@@ -247,13 +222,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5be6a577",
+   "id": "8e141d2c",
    "metadata": {
     "papermill": {
-     "duration": 0.00127,
-     "end_time": "2026-09-09T00:45:11.901536+00:00",
+     "duration": 0.001302,
+     "end_time": "2026-09-11T00:15:15.504384+00:00",
      "exception": false,
-     "start_time": "2026-09-09T00:45:11.900266+00:00",
+     "start_time": "2026-09-11T00:15:15.503082+00:00",
      "status": "completed"
     }
    },
@@ -268,19 +243,19 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "d6697cc2",
+   "id": "c9421c21",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T00:45:11.904756Z",
-     "iopub.status.busy": "2026-09-09T00:45:11.904687Z",
-     "iopub.status.idle": "2026-09-09T00:45:11.937027Z",
-     "shell.execute_reply": "2026-09-09T00:45:11.936605Z"
+     "iopub.execute_input": "2026-09-11T00:15:15.507552Z",
+     "iopub.status.busy": "2026-09-11T00:15:15.507489Z",
+     "iopub.status.idle": "2026-09-11T00:15:15.538040Z",
+     "shell.execute_reply": "2026-09-11T00:15:15.537471Z"
     },
     "papermill": {
-     "duration": 0.034535,
-     "end_time": "2026-09-09T00:45:11.937415+00:00",
+     "duration": 0.032684,
+     "end_time": "2026-09-11T00:15:15.538388+00:00",
      "exception": false,
-     "start_time": "2026-09-09T00:45:11.902880+00:00",
+     "start_time": "2026-09-11T00:15:15.505704+00:00",
      "status": "completed"
     }
    },
@@ -336,14 +311,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9eb0ab57",
+   "id": "33375b75",
    "metadata": {
     "lines_to_next_cell": 0,
     "papermill": {
-     "duration": 0.001702,
-     "end_time": "2026-09-09T00:45:11.940792+00:00",
+     "duration": 0.001515,
+     "end_time": "2026-09-11T00:15:15.541555+00:00",
      "exception": false,
-     "start_time": "2026-09-09T00:45:11.939090+00:00",
+     "start_time": "2026-09-11T00:15:15.540040+00:00",
      "status": "completed"
     }
    },
@@ -354,14 +329,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "56fdfa2a",
+   "id": "6dfab75c",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.001671,
-     "end_time": "2026-09-09T00:45:11.944422+00:00",
+     "duration": 0.001305,
+     "end_time": "2026-09-11T00:15:15.544317+00:00",
      "exception": false,
-     "start_time": "2026-09-09T00:45:11.942751+00:00",
+     "start_time": "2026-09-11T00:15:15.543012+00:00",
      "status": "completed"
     }
    },
@@ -380,19 +355,19 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "71495e0d",
+   "id": "9883b9d0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T00:45:11.948061Z",
-     "iopub.status.busy": "2026-09-09T00:45:11.947938Z",
-     "iopub.status.idle": "2026-09-09T00:45:11.951687Z",
-     "shell.execute_reply": "2026-09-09T00:45:11.951384Z"
+     "iopub.execute_input": "2026-09-11T00:15:15.547644Z",
+     "iopub.status.busy": "2026-09-11T00:15:15.547559Z",
+     "iopub.status.idle": "2026-09-11T00:15:15.551292Z",
+     "shell.execute_reply": "2026-09-11T00:15:15.550909Z"
     },
     "papermill": {
-     "duration": 0.006074,
-     "end_time": "2026-09-09T00:45:11.952032+00:00",
+     "duration": 0.005872,
+     "end_time": "2026-09-11T00:15:15.551579+00:00",
      "exception": false,
-     "start_time": "2026-09-09T00:45:11.945958+00:00",
+     "start_time": "2026-09-11T00:15:15.545707+00:00",
      "status": "completed"
     }
    },
@@ -405,12 +380,12 @@
     "    property the rest of the notebook tests rather than assumes.\n",
     "\n",
     "    Attributes:\n",
-    "        fast_period: Fast MA lookback (default: 10)\n",
-    "        slow_period: Slow MA lookback (default: 30)\n",
+    "        fast_period: Sessions in the shorter average\n",
+    "        slow_period: Sessions in the longer average\n",
     "        signal_log: Records all signals for verification\n",
     "    \"\"\"\n",
     "\n",
-    "    def __init__(self, symbol: str, fast_period: int = 10, slow_period: int = 30):\n",
+    "    def __init__(self, symbol: str, fast_period: int, slow_period: int):\n",
     "        self.symbol = symbol\n",
     "        self.fast_period = fast_period\n",
     "        self.slow_period = slow_period\n",
@@ -485,13 +460,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6097c288",
+   "id": "846c95d5",
    "metadata": {
     "papermill": {
-     "duration": 0.001355,
-     "end_time": "2026-09-09T00:45:11.955049+00:00",
+     "duration": 0.00135,
+     "end_time": "2026-09-11T00:15:15.554438+00:00",
      "exception": false,
-     "start_time": "2026-09-09T00:45:11.953694+00:00",
+     "start_time": "2026-09-11T00:15:15.553088+00:00",
      "status": "completed"
     }
    },
@@ -504,20 +479,20 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "8f6cacac",
+   "id": "8f8f7153",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T00:45:11.958292Z",
-     "iopub.status.busy": "2026-09-09T00:45:11.958209Z",
-     "iopub.status.idle": "2026-09-09T00:45:12.382525Z",
-     "shell.execute_reply": "2026-09-09T00:45:12.382074Z"
+     "iopub.execute_input": "2026-09-11T00:15:15.557614Z",
+     "iopub.status.busy": "2026-09-11T00:15:15.557463Z",
+     "iopub.status.idle": "2026-09-11T00:15:15.989652Z",
+     "shell.execute_reply": "2026-09-11T00:15:15.989058Z"
     },
     "lines_to_next_cell": 0,
     "papermill": {
-     "duration": 0.426398,
-     "end_time": "2026-09-09T00:45:12.382819+00:00",
+     "duration": 0.434196,
+     "end_time": "2026-09-11T00:15:15.989999+00:00",
      "exception": false,
-     "start_time": "2026-09-09T00:45:11.956421+00:00",
+     "start_time": "2026-09-11T00:15:15.555803+00:00",
      "status": "completed"
     }
    },
@@ -554,14 +529,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "755b85b9",
+   "id": "26b95097",
    "metadata": {
     "lines_to_next_cell": 0,
     "papermill": {
-     "duration": 0.001403,
-     "end_time": "2026-09-09T00:45:12.385862+00:00",
+     "duration": 0.00141,
+     "end_time": "2026-09-11T00:15:15.993040+00:00",
      "exception": false,
-     "start_time": "2026-09-09T00:45:12.384459+00:00",
+     "start_time": "2026-09-11T00:15:15.991630+00:00",
      "status": "completed"
     }
    },
@@ -575,19 +550,19 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "37822243",
+   "id": "9e1877e1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T00:45:12.389253Z",
-     "iopub.status.busy": "2026-09-09T00:45:12.389170Z",
-     "iopub.status.idle": "2026-09-09T00:45:12.401549Z",
-     "shell.execute_reply": "2026-09-09T00:45:12.401148Z"
+     "iopub.execute_input": "2026-09-11T00:15:15.996613Z",
+     "iopub.status.busy": "2026-09-11T00:15:15.996465Z",
+     "iopub.status.idle": "2026-09-11T00:15:16.010685Z",
+     "shell.execute_reply": "2026-09-11T00:15:16.010290Z"
     },
     "papermill": {
-     "duration": 0.014593,
-     "end_time": "2026-09-09T00:45:12.401882+00:00",
+     "duration": 0.016592,
+     "end_time": "2026-09-11T00:15:16.011041+00:00",
      "exception": false,
-     "start_time": "2026-09-09T00:45:12.387289+00:00",
+     "start_time": "2026-09-11T00:15:15.994449+00:00",
      "status": "completed"
     }
    },
@@ -634,13 +609,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b1d99375",
+   "id": "5f4587d2",
    "metadata": {
     "papermill": {
-     "duration": 0.001469,
-     "end_time": "2026-09-09T00:45:12.405020+00:00",
+     "duration": 0.001452,
+     "end_time": "2026-09-11T00:15:16.014104+00:00",
      "exception": false,
-     "start_time": "2026-09-09T00:45:12.403551+00:00",
+     "start_time": "2026-09-11T00:15:16.012652+00:00",
      "status": "completed"
     }
    },
@@ -655,14 +630,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5fadc09f",
+   "id": "781ea5e9",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
      "duration": 0.00136,
-     "end_time": "2026-09-09T00:45:12.407835+00:00",
+     "end_time": "2026-09-11T00:15:16.016916+00:00",
      "exception": false,
-     "start_time": "2026-09-09T00:45:12.406475+00:00",
+     "start_time": "2026-09-11T00:15:16.015556+00:00",
      "status": "completed"
     }
    },
@@ -682,20 +657,20 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "95f5c8dd",
+   "id": "17609a1d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T00:45:12.411464Z",
-     "iopub.status.busy": "2026-09-09T00:45:12.411369Z",
-     "iopub.status.idle": "2026-09-09T00:45:12.416632Z",
-     "shell.execute_reply": "2026-09-09T00:45:12.416289Z"
+     "iopub.execute_input": "2026-09-11T00:15:16.020754Z",
+     "iopub.status.busy": "2026-09-11T00:15:16.020662Z",
+     "iopub.status.idle": "2026-09-11T00:15:16.026017Z",
+     "shell.execute_reply": "2026-09-11T00:15:16.025637Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.007716,
-     "end_time": "2026-09-09T00:45:12.417003+00:00",
+     "duration": 0.007736,
+     "end_time": "2026-09-11T00:15:16.026397+00:00",
      "exception": false,
-     "start_time": "2026-09-09T00:45:12.409287+00:00",
+     "start_time": "2026-09-11T00:15:16.018661+00:00",
      "status": "completed"
     }
    },
@@ -780,8 +755,15 @@
     "            side = OrderSide.BUY if quantity > 0 else OrderSide.SELL\n",
     "            quantity = abs(quantity)\n",
     "\n",
-    "        # Get fill price\n",
-    "        price = limit_price or self._current_prices.get(asset, 100.0)\n",
+    "        if limit_price is not None:\n",
+    "            price = limit_price\n",
+    "        elif asset in self._current_prices:\n",
+    "            price = self._current_prices[asset]\n",
+    "        else:\n",
+    "            raise KeyError(\n",
+    "                f\"No price for {asset}: the feed has not delivered a bar for it. \"\n",
+    "                \"Filling at a default would put a price into the tape that no bar carried.\"\n",
+    "            )\n",
     "\n",
     "        self._order_count += 1\n",
     "        fill_timestamp = self._current_timestamp or datetime.min\n",
@@ -819,41 +801,46 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0815dd34",
+   "id": "f4ddf832",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.001351,
-     "end_time": "2026-09-09T00:45:12.419823+00:00",
+     "duration": 0.001423,
+     "end_time": "2026-09-11T00:15:16.029357+00:00",
      "exception": false,
-     "start_time": "2026-09-09T00:45:12.418472+00:00",
+     "start_time": "2026-09-11T00:15:16.027934+00:00",
      "status": "completed"
     }
    },
    "source": [
     "### Historical Replay Feed\n",
     "\n",
-    "The historical replay feed is the notebook's stand-in for a real streaming source. Its job is to preserve\n",
-    "live-engine semantics while holding the market data constant."
+    "The historical replay feed is the notebook's stand-in for a real streaming source. Its job is to\n",
+    "preserve live-engine semantics while holding the market data constant.\n",
+    "\n",
+    "A missing bar raises here rather than being skipped. The parity claim rests on both engines\n",
+    "reading the same tape, so a feed that quietly dropped a symbol on some dates would hand the live\n",
+    "engine a shorter history, move its moving averages, and report the difference as an engine\n",
+    "disagreement."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "236e45e8",
+   "id": "7eae620f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T00:45:12.423254Z",
-     "iopub.status.busy": "2026-09-09T00:45:12.423152Z",
-     "iopub.status.idle": "2026-09-09T00:45:12.427579Z",
-     "shell.execute_reply": "2026-09-09T00:45:12.427202Z"
+     "iopub.execute_input": "2026-09-11T00:15:16.032819Z",
+     "iopub.status.busy": "2026-09-11T00:15:16.032731Z",
+     "iopub.status.idle": "2026-09-11T00:15:16.036648Z",
+     "shell.execute_reply": "2026-09-11T00:15:16.036266Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.00674,
-     "end_time": "2026-09-09T00:45:12.427993+00:00",
+     "duration": 0.006106,
+     "end_time": "2026-09-11T00:15:16.036927+00:00",
      "exception": false,
-     "start_time": "2026-09-09T00:45:12.421253+00:00",
+     "start_time": "2026-09-11T00:15:16.030821+00:00",
      "status": "completed"
     }
    },
@@ -915,45 +902,35 @@
     "        date = self._dates[self._index]\n",
     "        self._index += 1\n",
     "\n",
-    "        # Build bar data\n",
+    "        timestamp = date.to_pydatetime() if hasattr(date, \"to_pydatetime\") else date\n",
     "        data: dict[str, dict[str, Any]] = {}\n",
     "        for symbol in self._symbols:\n",
-    "            try:\n",
-    "                bar = {\n",
-    "                    \"open\": float(self._data[\"Open\"].loc[date, symbol]),\n",
-    "                    \"high\": float(self._data[\"High\"].loc[date, symbol]),\n",
-    "                    \"low\": float(self._data[\"Low\"].loc[date, symbol]),\n",
-    "                    \"close\": float(self._data[\"Close\"].loc[date, symbol]),\n",
-    "                    \"volume\": float(self._data[\"Volume\"].loc[date, symbol]),\n",
-    "                }\n",
-    "                data[symbol] = bar\n",
-    "\n",
-    "                # Update broker prices for fills\n",
-    "                if self._broker:\n",
-    "                    timestamp = date.to_pydatetime() if hasattr(date, \"to_pydatetime\") else date\n",
-    "                    self._broker.update_price(symbol, bar[\"close\"], timestamp)\n",
-    "            except (KeyError, ValueError):\n",
-    "                pass\n",
+    "            bar = {\n",
+    "                field.lower(): float(self._data[field.title()].loc[date, symbol])\n",
+    "                for field in (\"open\", \"high\", \"low\", \"close\", \"volume\")\n",
+    "            }\n",
+    "            data[symbol] = bar\n",
+    "            if self._broker:\n",
+    "                self._broker.update_price(symbol, bar[\"close\"], timestamp)\n",
     "\n",
     "        self._stats[\"bars_emitted\"] += 1\n",
     "\n",
-    "        # Small delay to simulate real-time (optional, can be 0)\n",
+    "        # Yield to the event loop, as a real feed would while waiting on the socket.\n",
     "        await asyncio.sleep(0)\n",
     "\n",
-    "        timestamp = date.to_pydatetime() if hasattr(date, \"to_pydatetime\") else date\n",
     "        return timestamp, data, {}"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "ffc4e1f7",
+   "id": "696d3131",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.001363,
-     "end_time": "2026-09-09T00:45:12.430830+00:00",
+     "duration": 0.0014,
+     "end_time": "2026-09-11T00:15:16.039852+00:00",
      "exception": false,
-     "start_time": "2026-09-09T00:45:12.429467+00:00",
+     "start_time": "2026-09-11T00:15:16.038452+00:00",
      "status": "completed"
     }
    },
@@ -967,20 +944,20 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "b5c0fddc",
+   "id": "e083c6a5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T00:45:12.434124Z",
-     "iopub.status.busy": "2026-09-09T00:45:12.434054Z",
-     "iopub.status.idle": "2026-09-09T00:45:13.120855Z",
-     "shell.execute_reply": "2026-09-09T00:45:13.120451Z"
+     "iopub.execute_input": "2026-09-11T00:15:16.043176Z",
+     "iopub.status.busy": "2026-09-11T00:15:16.043102Z",
+     "iopub.status.idle": "2026-09-11T00:15:16.689665Z",
+     "shell.execute_reply": "2026-09-11T00:15:16.689232Z"
     },
     "lines_to_next_cell": 0,
     "papermill": {
-     "duration": 0.688876,
-     "end_time": "2026-09-09T00:45:13.121137+00:00",
+     "duration": 0.648664,
+     "end_time": "2026-09-11T00:15:16.689957+00:00",
      "exception": false,
-     "start_time": "2026-09-09T00:45:12.432261+00:00",
+     "start_time": "2026-09-11T00:15:16.041293+00:00",
      "status": "completed"
     }
    },
@@ -989,14 +966,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-09-08 20:45:13,117 - ml4t.live.engine - WARNING - LiveEngine: Feed terminated\n"
+      "2026-09-10 20:15:16,686 - ml4t.live.engine - WARNING - LiveEngine: Feed terminated\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-09-08 20:45:13,118 - ml4t.live.engine - WARNING - LiveEngine: Runtime degraded (feed_terminated) and auto recovery disabled\n"
+      "2026-09-10 20:15:16,686 - ml4t.live.engine - WARNING - LiveEngine: Runtime degraded (feed_terminated) and auto recovery disabled\n"
      ]
     },
     {
@@ -1047,14 +1024,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f0c2cba4",
+   "id": "32ca05a1",
    "metadata": {
     "lines_to_next_cell": 0,
     "papermill": {
-     "duration": 0.011363,
-     "end_time": "2026-09-09T00:45:13.134180+00:00",
+     "duration": 0.001525,
+     "end_time": "2026-09-11T00:15:16.693223+00:00",
      "exception": false,
-     "start_time": "2026-09-09T00:45:13.122817+00:00",
+     "start_time": "2026-09-11T00:15:16.691698+00:00",
      "status": "completed"
     }
    },
@@ -1069,13 +1046,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "70a3f402",
+   "id": "0aa267f7",
    "metadata": {
     "papermill": {
-     "duration": 0.002214,
-     "end_time": "2026-09-09T00:45:13.138114+00:00",
+     "duration": 0.001467,
+     "end_time": "2026-09-11T00:15:16.696206+00:00",
      "exception": false,
-     "start_time": "2026-09-09T00:45:13.135900+00:00",
+     "start_time": "2026-09-11T00:15:16.694739+00:00",
      "status": "completed"
     }
    },
@@ -1089,19 +1066,19 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "08266d65",
+   "id": "cd6c1e09",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T00:45:13.144117Z",
-     "iopub.status.busy": "2026-09-09T00:45:13.143888Z",
-     "iopub.status.idle": "2026-09-09T00:45:13.147679Z",
-     "shell.execute_reply": "2026-09-09T00:45:13.147120Z"
+     "iopub.execute_input": "2026-09-11T00:15:16.699781Z",
+     "iopub.status.busy": "2026-09-11T00:15:16.699696Z",
+     "iopub.status.idle": "2026-09-11T00:15:16.702216Z",
+     "shell.execute_reply": "2026-09-11T00:15:16.701706Z"
     },
     "papermill": {
-     "duration": 0.00775,
-     "end_time": "2026-09-09T00:45:13.148202+00:00",
+     "duration": 0.004827,
+     "end_time": "2026-09-11T00:15:16.702529+00:00",
      "exception": false,
-     "start_time": "2026-09-09T00:45:13.140452+00:00",
+     "start_time": "2026-09-11T00:15:16.697702+00:00",
      "status": "completed"
     }
    },
@@ -1131,14 +1108,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d092c576",
+   "id": "4ed063fd",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.001897,
-     "end_time": "2026-09-09T00:45:13.152646+00:00",
+     "duration": 0.001465,
+     "end_time": "2026-09-11T00:15:16.705567+00:00",
      "exception": false,
-     "start_time": "2026-09-09T00:45:13.150749+00:00",
+     "start_time": "2026-09-11T00:15:16.704102+00:00",
      "status": "completed"
     }
    },
@@ -1152,20 +1129,20 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "075a2971",
+   "id": "704f2322",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T00:45:13.156346Z",
-     "iopub.status.busy": "2026-09-09T00:45:13.156273Z",
-     "iopub.status.idle": "2026-09-09T00:45:13.162521Z",
-     "shell.execute_reply": "2026-09-09T00:45:13.162263Z"
+     "iopub.execute_input": "2026-09-11T00:15:16.709021Z",
+     "iopub.status.busy": "2026-09-11T00:15:16.708956Z",
+     "iopub.status.idle": "2026-09-11T00:15:16.715169Z",
+     "shell.execute_reply": "2026-09-11T00:15:16.714919Z"
     },
     "lines_to_next_cell": 0,
     "papermill": {
-     "duration": 0.008629,
-     "end_time": "2026-09-09T00:45:13.162961+00:00",
+     "duration": 0.008377,
+     "end_time": "2026-09-11T00:15:16.715440+00:00",
      "exception": false,
-     "start_time": "2026-09-09T00:45:13.154332+00:00",
+     "start_time": "2026-09-11T00:15:16.707063+00:00",
      "status": "completed"
     }
    },
@@ -1267,14 +1244,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1b83da12",
+   "id": "a3079bbd",
    "metadata": {
     "lines_to_next_cell": 0,
     "papermill": {
-     "duration": 0.001562,
-     "end_time": "2026-09-09T00:45:13.166431+00:00",
+     "duration": 0.001585,
+     "end_time": "2026-09-11T00:15:16.718750+00:00",
      "exception": false,
-     "start_time": "2026-09-09T00:45:13.164869+00:00",
+     "start_time": "2026-09-11T00:15:16.717165+00:00",
      "status": "completed"
     }
    },
@@ -1287,14 +1264,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "724e583f",
+   "id": "2c7cd0db",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.001534,
-     "end_time": "2026-09-09T00:45:13.169583+00:00",
+     "duration": 0.001495,
+     "end_time": "2026-09-11T00:15:16.721858+00:00",
      "exception": false,
-     "start_time": "2026-09-09T00:45:13.168049+00:00",
+     "start_time": "2026-09-11T00:15:16.720363+00:00",
      "status": "completed"
     }
    },
@@ -1307,19 +1284,19 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "4c73c605",
+   "id": "7885d3a0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T00:45:13.173387Z",
-     "iopub.status.busy": "2026-09-09T00:45:13.173315Z",
-     "iopub.status.idle": "2026-09-09T00:45:13.175306Z",
-     "shell.execute_reply": "2026-09-09T00:45:13.175060Z"
+     "iopub.execute_input": "2026-09-11T00:15:16.725568Z",
+     "iopub.status.busy": "2026-09-11T00:15:16.725493Z",
+     "iopub.status.idle": "2026-09-11T00:15:16.727500Z",
+     "shell.execute_reply": "2026-09-11T00:15:16.727281Z"
     },
     "papermill": {
-     "duration": 0.004446,
-     "end_time": "2026-09-09T00:45:13.175693+00:00",
+     "duration": 0.004396,
+     "end_time": "2026-09-11T00:15:16.727861+00:00",
      "exception": false,
-     "start_time": "2026-09-09T00:45:13.171247+00:00",
+     "start_time": "2026-09-11T00:15:16.723465+00:00",
      "status": "completed"
     }
    },
@@ -1346,19 +1323,19 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "id": "cb4065f7",
+   "id": "fbf96f78",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T00:45:13.179612Z",
-     "iopub.status.busy": "2026-09-09T00:45:13.179534Z",
-     "iopub.status.idle": "2026-09-09T00:45:13.181920Z",
-     "shell.execute_reply": "2026-09-09T00:45:13.181645Z"
+     "iopub.execute_input": "2026-09-11T00:15:16.731644Z",
+     "iopub.status.busy": "2026-09-11T00:15:16.731565Z",
+     "iopub.status.idle": "2026-09-11T00:15:16.733737Z",
+     "shell.execute_reply": "2026-09-11T00:15:16.733507Z"
     },
     "papermill": {
-     "duration": 0.005022,
-     "end_time": "2026-09-09T00:45:13.182424+00:00",
+     "duration": 0.004561,
+     "end_time": "2026-09-11T00:15:16.734096+00:00",
      "exception": false,
-     "start_time": "2026-09-09T00:45:13.177402+00:00",
+     "start_time": "2026-09-11T00:15:16.729535+00:00",
      "status": "completed"
     }
    },
@@ -1403,19 +1380,19 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "id": "d649d590",
+   "id": "03943942",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T00:45:13.188697Z",
-     "iopub.status.busy": "2026-09-09T00:45:13.188614Z",
-     "iopub.status.idle": "2026-09-09T00:45:13.192233Z",
-     "shell.execute_reply": "2026-09-09T00:45:13.191045Z"
+     "iopub.execute_input": "2026-09-11T00:15:16.737923Z",
+     "iopub.status.busy": "2026-09-11T00:15:16.737863Z",
+     "iopub.status.idle": "2026-09-11T00:15:16.739906Z",
+     "shell.execute_reply": "2026-09-11T00:15:16.739648Z"
     },
     "papermill": {
-     "duration": 0.007242,
-     "end_time": "2026-09-09T00:45:13.192653+00:00",
+     "duration": 0.004383,
+     "end_time": "2026-09-11T00:15:16.740178+00:00",
      "exception": false,
-     "start_time": "2026-09-09T00:45:13.185411+00:00",
+     "start_time": "2026-09-11T00:15:16.735795+00:00",
      "status": "completed"
     }
    },
@@ -1459,13 +1436,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "387c5b81",
+   "id": "f7405880",
    "metadata": {
     "papermill": {
-     "duration": 0.001747,
-     "end_time": "2026-09-09T00:45:13.196629+00:00",
+     "duration": 0.001645,
+     "end_time": "2026-09-11T00:15:16.743574+00:00",
      "exception": false,
-     "start_time": "2026-09-09T00:45:13.194882+00:00",
+     "start_time": "2026-09-11T00:15:16.741929+00:00",
      "status": "completed"
     }
    },
@@ -1477,23 +1454,23 @@
   },
   {
    "cell_type": "markdown",
-   "id": "74c90350",
+   "id": "6c802c4f",
    "metadata": {
     "papermill": {
-     "duration": 0.001638,
-     "end_time": "2026-09-09T00:45:13.199991+00:00",
+     "duration": 0.001626,
+     "end_time": "2026-09-11T00:15:16.746897+00:00",
      "exception": false,
-     "start_time": "2026-09-09T00:45:13.198353+00:00",
+     "start_time": "2026-09-11T00:15:16.745271+00:00",
      "status": "completed"
     }
    },
    "source": [
     "## Where the Strategy Traded\n",
     "\n",
-    "The tables above show five signals of nine. The question they cannot answer is where the crossovers\n",
-    "fell across the year, which is a judgement about a shape: whether the strategy traded steadily or\n",
-    "clustered around a few reversals, and whether the two engines fired at the same moments or merely\n",
-    "the same number of times.\n",
+    "The tables above show the first rows of each log. The question they cannot answer is where the\n",
+    "crossovers fell across the year, which is a judgement about a shape: whether the strategy traded\n",
+    "steadily or clustered around a few reversals, and whether the two engines fired at the same\n",
+    "moments or merely the same number of times.\n",
     "\n",
     "Drawing the year answers both. The two moving averages cross where the signals sit, and each\n",
     "engine's markers are drawn separately: filled for the backtest, hollow rings on top for the live\n",
@@ -1504,33 +1481,33 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "id": "24cbb3b1",
+   "id": "2eb593b8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T00:45:13.204098Z",
-     "iopub.status.busy": "2026-09-09T00:45:13.203957Z",
-     "iopub.status.idle": "2026-09-09T00:45:13.307372Z",
-     "shell.execute_reply": "2026-09-09T00:45:13.306773Z"
+     "iopub.execute_input": "2026-09-11T00:15:16.750771Z",
+     "iopub.status.busy": "2026-09-11T00:15:16.750700Z",
+     "iopub.status.idle": "2026-09-11T00:15:16.849345Z",
+     "shell.execute_reply": "2026-09-11T00:15:16.848960Z"
     },
     "papermill": {
-     "duration": 0.106011,
-     "end_time": "2026-09-09T00:45:13.307711+00:00",
+     "duration": 0.101138,
+     "end_time": "2026-09-11T00:15:16.849735+00:00",
      "exception": false,
-     "start_time": "2026-09-09T00:45:13.201700+00:00",
+     "start_time": "2026-09-11T00:15:16.748597+00:00",
      "status": "completed"
     }
    },
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAkgAAAFVCAYAAAAUvhB3AAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjksIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvJkbTWQAAAAlwSFlzAAAPYQAAD2EBqD+naQAA6ghJREFUeJzs3WV0FEkXgOF3MnF3JwSCBwju7u6yyOKL++K2uOvi7u7u7u5BgoS4u2fk+zEwECIESJBv6zlnz5Lp7uo7PZPMneqqW5KkpEQlgiAIgiAIgprGzw5AEARBEAThVyMSJEEQBEEQhM+IBEkQBEEQBOEzIkESBEEQBEH4jEiQPmPq6MaAYRN/2vkPHj1DTtdK3Ln36KfF8L2mzl6CqaMb77x9v/rYngNGY+rolql9L1+7jamjGzv3Hvnq8wj/bX2GjMciZ4mfHUa2uXD5BqaObmzddfBnhyIIv63fOkEqUq4+po5umDq64ZCvHDUbdeDM+auZPn7i9IUUKVc/GyP8ejWrVWDrmoUULVzwh5yvW98RNGzV/Yec63vVatyRPkPG/+wwhN/My1dvMXV04/K12z87FEEQfiO/dYIEkC9PLjavns+ooX0ICQunffdBREREZerYwODQbI7u6xka6FOpfCm0tbV+yPkCg369a5CeX/H1En59gUEhPzsEQRB+Q799gmRuZkLj+jUZ0Lsz3Tq2JikpGW8/fwCSkpKZMW85hcvWI1fhKvQcOIbgENWHbMNW3dm++xDePn6YOrql6JmIjIpmwLCJ5C5SlbLVm/PY/UWq8yqVSjZt30fJyo3J6VqJngPHEBUdA8CMecvJ41aNw8fPUqlOG5wKVmTUP7PVx0ZERtGj3yhyFKig7gEzdXTjwuUbbN11UP3vD3H++ddQ5ixaRZFy9clXvAa79h392FZEFP3+nkCuwlUoXrERm7btU2/bd+gExSs2wjF/eRq26s79h09TPIci5epz9cYdrt64g6mjGzPmLeedty+mjm7sO3SCVh37kqtwFRITk9i9/xj1W3bFqVAlCpepm+I8sXFxDBoxmZyulahUp02q82QUY2hYOJ16/o1TwYrUa96Zt+980nydTR3d8PbxY/vuQ6luHbx89ZYWHXqTo0AFmrfvRURk1Bdfo09dvHqTCjVbYp+3LDUatufcxWsAnDl/lRYdepO7SFXyFa/BrAUr1Mf0GTKeGg3bs2bjTtwqNKBo+frsPXicg0dOU7Z6c/K4VWPHnsOZugaf8vELoGuf4eQqXIWCJWsxf8la9flqN/mT7XsOU6hUbRa8f/zi1ZvUaNgeh3zlqNGwPZeu3lK39ejpc2o17ohdnrJUqNlS/b5J73GlUsnqDTsoUakxTgUr0q7bIDzfvx7/TFuAWY5ihISGqfctUakxXXoPB8DXL5COPYbgVLAiZas358SZiyleu5XrttFzwGhyFKiAt69/utf8U8EhofQcOIZchatQpFx9Zs5fQXJyMvDx9uqBI6do+kdPchSoQIsOvdWv/Qdbdx2kcZseADRu0yPF7VulUsnmHfspW705zq6V+Xf5hq96vZRKJZNmLCJvserkLlKVHv1GERgUQlx8PPOXrKVi7dbY5y1LxdqtuXX3YYrrMW/xGnoOGI2za2Xqt+jCO29fho+dTu4iVanesD1ePn7q/W/eeUCtxh1xzF+eBi274fHaM81Ylq7eTKFStXEtXYdtuw+l2H777iM6dB9MgZK1cHatzLCx05HJZLx+8w5TRzcWLl2n3nfe4jVY5SpJRGRUuu8VQfgv+O0TJJlMTkREFDdu32f3geM42ttSMJ8LADPnL2f2wpW0bdGQMcP6cvLsJTr1GoZCoWDciH7ky5MLSwsztqxZQK9u7dVtHj5+FmNjQwb06sQLjzdMn7ss1XkPHDnFwOGTKFm8CFPH/82Va7eZOnuJentIaDgz5i2ne6fW5M+bmxVrt/LwyTMA/pm2kMMnzjJ8UE+aNaoDwL+z/8G1YN40n+Ph42e59/Apg/p0QSKRMGL8TORyOUqlkr8GjObIiXMM7tuVlk3rMXDEJB48cic2Lo5eg8Zib2fD9H+GY29rjVKZsiboolnjMTM1oWB+F7asWUDLpvXU2waNmIyjgy3LF05BR0eb67fuUbp4UaaOH4qFhRlDRk9VjzGaOG0hG7ftpfufbejeqTUvP/kDnlGMAH2HjOfEmYv8PaAHjRvU4vVbrzSvwcaV8wCoXKE0W9YsoErFMuptazbtpGa1ijSsV4Pzl26ok6cvvUYf9B44FiQSZk4eiWvBfCQmJQFw5/5jcjs7MXncEArmz8OMecu5fuue+rh7D5+y79BJ+vfsRFJSMr0Hj2P+0rX81eUPtLW0GDFhFjKZ7IvX4IP4+ASat+vFhcs3GT64J507tMIlV0719qfPXjJ30SpGDO5F88Z1cX/uQauOfTEw0GfOtDHo6enRsmMfnr14BcDwsTMICAxm5qQRVKpQmvj4hAwf37h1L8PHzaBqpTJMHf83j588p0WHPsTFx9O8cV2USqX6FrbHa0/eeHrRrFFtkpOTadO5P/cfPmXs8H6UL1Oczr2G4R8QpI596uwlJCQmsWDmeBztbdO95h8oFAr+/Gsop85eZuzwfrRqWo+Z85cza8HKFPsNHjmFOjUr07BeDc5dvJ5qzE2VimXo0bktAGOH92PLmgUpzrFt9yF6d2+PlaU5k2b+S0hoWKZfrwuXb7Bg6Toa1q3OyCG9UKJER1sbDYkGF6/cpHWz+kwYNZCg4BB6DRyb4vdv2pyl2NpY06ldC67fuk/pqk2RKxR07diK+w+fsvh9subp5UPzdr3Q0NBg+sThSCQSuvQenup3+dDRM4ydNJeSxYswbuQAfP0CU2x/9uIVhoYGjBvRn2qVy7Fm4072HjyBS+6clC9TnANHT6v3PXnmEjWqlMfUxDjd94og/Bdo/uwAvted+49xLlxZ/fP65bPR1NREoVCwesMOShUvwviRAwDw9vHn3xUbePT0BeXLlMDczIT4hEQa1auRos1mjWozbcIwQPUN1OPV21TnXbV+O7mdnZg9eRRIwOOVJ3sPHmf2lFEpYsmfNzdGhobcvvcIj1eeuBUuyO27D6lYriQD+3QhIDCYA0dOYW5uipWlRZrP0drKgm1rFyKRSHji/oINW/cSHBJGfHwCp89fYfignnTu0BKUsG3XQY6cPMewfH+hp6eHro42NapVoFP7FqnarVG1Anq6OpibmamvwYekp1zp4iyYOR6JRALA/BnjiI9P4P4jd0q4ufLw8TPuP3xKDgc7tu46SJ0alZkwaiAAr996sWTlJgA83/mkG6O9nQ0nz16mR+e2DOrbFYCbtx9w6NiZVLE2rFsNAEcHO3WsH3o3JowcSPdObQgIDGbHnsPq1yszrxGAkZEhWlqalC9Tgk7tPl6nUUN7k5yczINHzyhT0o2LV25y++4jypf5OLh375Zl6Onp8sLjDWs27mTVv9PJnzc3L16+ZvXGnQQEhZCclJzuNShWtJC6rdPnr+Dx2pPlC6fSrlXjVNcgLj6BVf9Op2TxIgAMHzeD5GQZ82eMI6+LMyXcXClXowXrt+xh9pRRGBkagESCW5GCqvN+eL7pPL5q/XZsrC2ZP2McEomEpORkho2dzpnzV2lcvya5cubg5NlL/NGqMSdOX0RPV5faNSpx7eY9nj57yb+z/6FJw1okJCSybfchTp+/or6eTjkcWLt0JlpaWhle8w8ePXnOjdsPGNKvmzrBuXjlJqvWb2fs8H7q/caPHJDma/9BDgc7iroWAFTv6coVSqfYvm/LcvT0dAmPiGLyzH954+lNdHRspl4vQwMDAExNjGnfpmmKL1kHd6wiNCyc+w/dyePizPWb9wgNC8fSwhyApg1rMXncEORyOes27yJ/3tzMnzEOhULBynXbePH+eWzZeYC4+AQWz52IjbUllhbmtH/fs5fLOYf6fJt37MfUxJjVi2egq6uDmakxV2/cUW/v1L4FHf9oxmP3F8TFxXPgyClu33tE25aNaN+mKQOGTeStpzfGxqq/VUvnT87wvSII/wW/fQ9Sofx5OLxrDRtXzOWvLn/Qtc8I5i1eQ1h4BNExsbgV+TjYubib6o/bu3Ru43ygpfkxb7S0MCMxKTnVPp7vfHjj6YVz4cqq7vkVGwh+f/vh83YsLcwA1N+SC7vm58GjZ9x78EQ9A8vBzibdeDSlUnWi8uEPbGJSEp5equcxZ9EqnF0r41y4Mn4BQYSEhKGrq8PxveuRSqW4lW9A78HjCPqKMTxuRQqqzwmwct02CpSqRYfug3n4WNUTFhUVQ0hoOHHxCeTO5ZRmOxnF6PU+GUvv2MxKfZ1Vr1dmXiOA3ZuXks8lF+VqtKBdt0G8ed+LdeDIKQqXrUfz9r3Ut64+v0WnpaU6t4W5WYpYzN//nJSY8ev0qQ8JX5FC+dN9rp++n995+aKvp0ue3Kpepvx5c6Ovp8u79+dbsWgq9WtVoU6zTjRo2U196zO9xz29fHAr/PF1L/4+GXjn5YtEIqFFk7qcvXCN5ORkTpy5RO0alTDQ11fHPXDEJJxdK1OgZC2SkpIJCQ1Xx+paII86OcromquvxfvnkPL315Wo6BjCwiM+Xv90XvvM+vD6Wb5/vRK/4vUqXbIo29Yt4tTZy7iWqcv0ucuQyWQkJSUzYNhE8peoxd9jp6mPi4r6+N75ELdUKsXMzFQdh4aGBmZmpiS9/1vx7p3qd+TDbcD23QYBpHofe/n44ehgh66uTprP88r1O5So3Ji6TTurv4BERUUD0KxRHQz09Th49DRnL1xDU1NKgzrVgPTfK4LwX/Db9yAZGxuqvxU2aViLnXuPcOPWfYb064aRoUGKbvH7D1X/zpnTEQANDSmJiYnfdN6cTg5oaWuxZO4k9QeKpqY0U8f27dGRXfuOUqNRBwC6dmyV4ptppmPI4QBAtz9b07xxXfXjH5It14J52bVpCU/cX9KgVTcAViycmqINDemXr8E7b19GTpjFhFEDGdy3K1dv3FWP6zA3M0FTU1N9+xBI0f2fUYya7z8UPiRcnx/7qQ/X+Gter8y+RjlzOLB6yQzGjxpAo9bd6T9sIvu2LqfXoLF0aNOU2VNG4esfiFv5Bpk+9+ftQ/qv0wdOOewBeOL+gsKF8mXq+Z06dxmP157ky5OLFx5viItPIKeT6v1taWHOnGljGDm0N390GcifPf/myc0T6T7u7OTIg8fuKJVKJBIJ99//7uR0UsXfvHFd5i1ew/lLN7h55wGrF09PsX3U0D5ULFdSHV9u5/QT37Su+bG9H8fBOL9/Dg8euatvQ99/+BRjI0PMzUy/eG0+pSFVfQ9MTEz6wp4fY4Mvv14ADepUo37tquzce4Teg8fhlMMeiUTC5h37OXlgI2VLFWPGvOUpxq99jQ/XdvPq+ZiaGKsfL1Qg5e14aysLbt55QHx8Anp6uql+j/oMGU+h/C7cPLcfHR3tFGOxjAwNaNqoNsdOXSBvHmf17TVI/z0kCP8Fv32CFBYeyZET5wgJCeP85RtERcdQqXwpNDQ0+KvLHyxYuo4psxZja2PFxu17KV+mOEVdVd/QnXM6cO3mXZat2ULp4kUpXbJops/bo/Mf9Og/itUbdlC7RiW8vP0oV7p4po5dumozBfLlpmnDOpiYGFGkUH5i4+IxNND/queeyzkHNaqWZ/f+Y5iaGOOc05FHT57zz+hB3H/4lJETZtGmRUMkEgmy5GSk0tQdhs5ODty6+5AtOw9QrEghjIwMUu3zYdzBg0fubNt9iLWbdqm3aWpq0rBudY6cOMfcf1ejr6/H5h0HMhWjoYE+xd1cOXL8LCuKFiIqOoaTZy+l+VylUilOOey5dPUWu/YdpdT720wZycxr9M7bl+59R9K8SV2MDA1ISlJdp2SZjORkGS883rJr/zF27//2wakZXYNP1apeCUcHO8ZMmktkVDQSiYTwiEhGDumdZrtdOrRiw9Y9/D1mGu1aN2HrzoNoaWnStWMrIiKj+KPLAGrXqIydrTUxsbFIpRrpPg7Qs2s7Bo+awtDRUyle1JWFS9eR29mJWtUrAqqEO1+eXEyetRgtTU3q1KwCQIWyJSmUPw8btu5BQ0OClaU5L195MnX80DTjTu+af6qIa37KlirGhq17cXSww9cvgHsPnzJs4F8pejYz40OytXrjDmJj42jSsFaG+2f29Vq1fjuXr92mXu2qvPR4A6jep7GxcYBqkP+9B09Zv2X3V8X7qfatm7B01WbmLV5D+9ZNSEhIREtLK9WtwqYNa3Pl+h2GjJ5KxXIlWbZ6c4rt8fHxePsGsPfQCc6cv5LqPB3aNKNR6+68fuvFlPevW0bvFUH4L/jt3+0vX72lY48hjJgwkyfuLxg3oj8DencGVN9ohw38ix17DjNtzlLqVK/MplXz0NBQPe2/+/fArUhBps1ewsZte7/qvC2b1mPx3Im8fPWWkeNncezUBWJiYzN1bM1qFXj1xov5S9YwZuIcGrfpgVv5BqkGVn6JRCJh7ZJZNG9cly07DzB+6nx8/AIIC48gj4szbkUKsmDJWiZOX0jVyuWYMHJgqjYmjh6Ek6M9o/+ZzcFPBmp+qkA+Fwb27sL5S9dZtmozfbp3SLF97rTR1KlZmUXL1nPwyGl6dv0jUzFKJBLWLZ1FsaKuTJuzlJu3H9C5ffrjHGZPGYWujg7Dx89IMVsrPZl5jexsrKlepTyrN+xg1IRZ5Mmdk/kzxmFkaMD0f4bx9NlL5ixcReP6NbGyNP/iOdOS0TX4lKGBPge2r6BkscJMm7OUpas3o6ujk26vmmvBvOzZvIyo6BiGjZlGbFwcezYvo2D+PBgbGdKsUR127TvK36Onoa+nx5rFM9N9HKBzh5bMmjyS85dvMHbyXFwL5WPf1uXo6+mpn0fzxnV54v6CWtUrqhN6bW0tdm1eStlSxVi+ZivT5iwlJCQsxS2lzFzzT0mlUrasmU+tahWZOnsJu/cfY8TgXowY3Ourr3/FciXp3L4l127c5Z8ZCwkIDM5w/8y+XrWrV0ImlzNm0hy27T5Enx4dadO8AX+0akytahVZtnozx09foH/PTl8d8we5czlxYMdKdLS1mTRjEas37iQsPCLVe6JLh5b079WJ0+eusHDpOrp3apti+5ypowkJDWPa7CUUzJ8nVY91hbIlcHZyJCo6Wn17LaP3iiD8F0iSkhLT/usrZAuZTEbRcvXp2/NP+vfshFwuZ//hU/ToP4rNq+fTuH7Nnx2iIAj/MQqFgkq1W5Mvb242rJjzs8MRhF/Cb3+L7XeTkJhEUEgYu/YdRU9XF5lMxrbdhzAzNaFsqWI/OzxBEP5jbt19yNadB3nx6i0bV8372eEIwi9D9CD9BPsOnWDWgpW8feeNmakJZUq6MfrvPqkGXgqCIGS3+i278vrNO0YO6U33Tm1+djiC8MsQCZIgCIIgCMJnfvtB2oIgCIIgCFntt06QmncaTNvuw+jUZwyd+oxh6DjV4MJ/V23jzgNVQbMpc1eyY5+qbsfRU5cYOXFBuu2lJTomlvJ1O2Zt4On4lvh+Jv+AYPoO/1hX6d5Ddzr1GfPN7TXvNJiXr99lRWjptnXvoTtT5q5M44jMmTJ3Jfceume4j39AMLVb9Pzqttds3suC5arp2d97LTPrtac3k2Yvz9ZzNO80OMXP5et2JDomczM+P/fp7/OdB0/5d9W27w0vS/xuv7uCIHzZbz9Ie8qYAeRzyZnisYE926eztyAIn3JxzsE/I/r87DC+SalirpQq5vqzwxAE4f/Ub58gpWXkxAVUqVCShnWqZLjfkZMX2brnKHK5gtIlCvN3305oaGhw79EzFi7fjERDQu73Vbc/t2bzXuITEvHxC+SFhyfVKpWmbMkibNl1hLdevgzv34XqlcsQn5DAohVbefn6HdExsVSrWJp+PVR1gvoOn0r9WpU5dPw8taqWS1Eo0uP1O0ZPWcSS2WOwtbZMN9b6bfrQq0trDhw9x9C+nfB4846tu4+hpSWlXCk3BvfumKKw3tbdRzl76SbxCQnY21oxeXR/DPT1WLN5LxKJhMfuHpiZmvDPiN7pnhMgICiEAaNmEBYeSac+Y+jWoTnGRgYkJcv4d+VWbt57DEqYPWkoDnbWxMbGMW/ZJtxfvEEigX7d21GpXOrCmkdPXWKex1tCQsNp0agWHVo3RKFQsGzdTu49dCc2Lp5C+fMw7u+eSKUaxMbFs3j1Nh4+eYGWpiZ/tm1M7Wrl1e0plUomz1mJjZU5lcqVYPKclcTFJ9CpzxhGDOxG/jzOLF27g+u3H6JUKunYphFN6lXD08uXSbNXEBsXj6mJEZNG9ePA0bOcv3yLh09e4GBnzaIZo1LF/4FCqWDDtoNcun6H8Mhopo0dQKH8LiiVSjbuOMTp89dRKpWUK1WUPt3aqpeaSM9jdw/+XbWVuPgEzE1N+LtfZ5yd7Bk5cQGVy5egUd2qXL5+lxETF3B0x1LMzUxYsHwTjva2tG5aR93OlLkryZ/HmfNXblO4QB5qVy/PyEkL2L9pIf4BwYyctICqFUtz5cY9IqNimDZuAAXz5SYmNo4pc1by8s07goPDMDY2pHxpN4b178zEmct57emNtpYWg3p3pGzJj0U8B42eSUBgCJ36jKF8aTf6dFPV5zl4/DyXr9/D2zeAsUP/omLZ4uprc/zMFZRKJfVrVaJr+2bpXpOL1+6wc/8J/p05mmYdB7Ji3gQc7VXVrvsNn0bXDs1wc82f5uv7qc9/D1s0qpXmMfceurNiw26cHGx5+cYLiQTGDu2Z6gtaer/zR05e5Nrth0wfp6pHdv/xc1Zv2sOyOSlrQAmC8Gv4v0yQMuPh05ecOHeV9UumoqWpyeQ5K7h0/S4lihZi3NTFzJgwCLfC+Xn28g0nzl5Ns417D5+xcPoIlEpo9Ec/NDQ0WDxrNMfPXmHN5n1Ur1wGXR0dGtWtimsBFxISE2naYSANalcmV07VEgJHT15k6eyxaGtrcfSUqop0WEQk46YvYdKovthaW6Yba7WKpYmIjMbHL5D1S6YgkUgYMm42S2ePJU9uJ0JCw1NVHS7hVpC2zesilUoZMnY2J85eoWXj2gDsOXSadYunYGeT8TkBbK0tGTOkB2u27FP/gb/30J2w8Ajq1qxI/7/aMXbqYg4dP0+fbm1ZvHo7RQrlZfywXkRERtNtwHjKl3ZLVZnX1saSwb07Eh4RReuuf1OudFFcnHNQvVJp+nZri0Kp5M/eo7l59xEVyhRj8eptyGRytqyYiUKhIC4+PkV7W3cfJSEhkZ6dW6mqq3dqyb1Hzxg/TFVwcMP2g+hoa7F99SySkpLp3G8clcoWZ9+RsxQumIe/+3XGPzAEGytz+nRry+NnHvTo2IISbhkvDZOYkESh/Lnp3K4J/67ayo59J5g8uh8nz13lyo17rPl3Ilqamoydtpite47SpV3TdNuKio5l1OSFzJ44BNcCeTh/+RajJi9k68qZlC1VlLsPn9GoblXuPHhKSbdC3H3oTu1q5bnzwJ0WjVJXjd5z6DRr/52EkaFBqtuQbzx96N+jHd06NOPfVVvZvvc4k0f3Y+/hM8jkMvZumM+zl2+ZMGMJ44f14sKV2/j4B7J7/TyiolNXWl40YxTl63Zk0/LpKR43MzFmxbzx7D54ig3bD1GxbHFOnb/OO28/tq6cgVIJA0fPpEJpN/LnzZXhtdaUSqlTrQLnLt+kU9smhIZF4OsfRPEiBdm863Car6+5mUmKNj79PUzvPQHg4xvImCF/4exkz97Dp5m5cC3rFk9O0VZ6v/O1q5dn1aY9hIVHYm5mwslzV7/4JU4QhJ/nt0+Qxk9fjI62NgCDenWkZLHMrWl25fo93nn50XPwREBVn6hQ/tw8eeZBDkdb3AqrliP58I00LUVd82FibASAk6MdlcoWQ0NDg6KF8rEodAugqsprZWHG1j1HefnKEwAfvwB1gtSmeT20tT8u4pmUnMyYyYso6VYI1wJ5Moz1g46tG6kToZaNazNv6Ubat2xAlQqlUsXs5GjHibNXefj0JT5+gfh8Ur27ZpVy2NlYZuqc6bG1tiR/HmcAXAu64Pl+sc1L1+/y2N2D/UfOAqBQKImIjMLC3DTF8SXdCiGRSDA3M8G1QB7cX7zBxTkHDnY27D18BvcXb4iJiVPHfenaXVbOn4BUqoFUqoGJlpG6ras377N2y372b16o7vn63OXr94iOieX67YeA6voHBIVQs0pZZi5ay9ot+2nRqGa6x6dHT0+XMu97UgoXzMu+w2fU52tSvzp6urqA6vVauWF3hgnSk2ce5LC3Ub8fqlcuw4IVm/H29adcqSJs2H4ApVLJgycv6NquGddvP6SkWyHi4hNwcrRL1V7T+tVVq7R/Rdy21hZcuxVPYlKSugo6QNHC+dDW0mLWonX80aIezu/XDvuSKhVKIpFIKFwwj3pM0eXrd3n64jXdBkwAIC4+Af/AkC8mSAD1a1Vi6vxVdGrbhPNXblOrWjmkUo10X9/PE6RPfw/TOwbA0sIUZyfVmnmVy5dk/rJNyGSyFG1l9DvfuG41jp66xB8t6nPzziMG9kxZlV4QhF/Hb58gpTUGKTOUKKlVrRyDeqUcgH3p2t1vWm/o00VQNaVSPqwE8PL1O8ZNW0zPTq2oX7MSIWFLUHyyTMDn57p59zF/tmnE2Us38fYNIIeDbbqxptVG325t8Q8IZuPOQ6zffpA1Cyeq//DHJyTQY9A/NKlXjY6tG2JtaU7M+3WjPm/nS+fM1DWRaqJ+pkqYNKoveXKnv4BpquM1pejp6BAUHEq/EdP5s23j9z1BEhQKVcvpLcMBcOjEBf5oUY+1m/cxanD3NPdRKpUM+KsdlcuXTLVtw9KpnDx7lc79xjJxZF9KFC2YRguZex5K0luEV/Xf15IgASTY21qjp6vLI3cPdLS1KV3clWXrdnL/8XPKFC+c5rplUmnmFlX+NO4KZYqxdst++g6bhpaWpnrckrmpCesWT+bGnUdMmLGU2tXK82fbxpl+HpqamupzKJVK2rWoT5tmdb9wVGp5XXIilyvw9g3g3OWbDO3TSd1meq/vp1K899M55vPB+ZqaUrS0tFIlzxn9zrdoVJOBo2eS29mRkm6F0NfT/ernKgjCj/Fbz2LLDAmgVCrUPyje/7ti2eIcO30FLx9/APwDQ5DLFRTMn5uXr97h6aXq+Xjs7vFd57/74Cm5cjpQq1o55AoFgUGhGe5fpFBeendtQ59ubZm5cC1KpTLdWD+XmJTEY3cP7GytGNCjHZ5evoSGRai3e3n7ExEZTeumdbCxtsQjgxljmTmnrY0lQcFhacaSqr1yxVm7ZT/JyTKUSiV+AUFp7uftGwCobvW4v3hNsSL5cX/xBj09XRrXrYqBvh6eXn7q/SuUKcbWPUdRKBTI5HJ8/T+2O3pwD3p3aY37i9fcfaD6cLO1tiQgMESdWFUqV5xNO4+oFxj9ENejpy+RIKFxvWoUK5xf/eFoa22Jf2DIF59veiqXL8HhExdISEhEJpez9/AZKpUrAah6HtQJn0Si/lAtXDAvPv6BPH3+GoALV2+jp6dLDgdbAMqVKsqu/ScoUbQgBgb6GBroc/HqbXVPUFa4fP0eJdwKsn7JFFYt+IcihVRFTd94+hAeGUX50m40b1ST63cepjrW1toC/4CM1z8DqFSuBLsOnFS/Z9N6j6T4ff5MvZoVOXj8PDGx8epEPL3XN+M40j8mOiaWiMhoAHYfOEX5Um6qBOmTvy0Z/c5bmJuSP48zKzfspmHdql+MRRCEn+e370H6kjIli7Bm8z5aNq5N4QJ5WL/1AE+fv6Z4kQIM+KsdIyctQFOqiYmxIf+M7IOVhRkjBnZlxMQFGBkaUKZk4e/6lle9chmu3nxAp75jyeeSk1zpDPr+wNTYCIlEQo3KZThy8iKHjl+gaYPq6cb6qYSERPYdOcvcpRuIio6lY+tG2L6/ZQbgkisHFcoUo0Ov0eR0tMPB3lrdE/O5jK7PB/a21rg456Bt92F069AcW2uLdJ/XoF4dWLh8Mx16jUJXV4eyJYqoB6t/6oXHW/W4ofHDemFpYUap4q4cO32Zjr1Gkyung/oWh6rdjsxftpF2f41ET1eHlk1q42BnrbqWJkZoamoyrH8Xps5bxaZl0yhSKC9Jycm07zmSwb3/5M82jYmJiaPrgAno6urg4uzIhOG98XjzjgXLNxMXH4+Vhbm6J61h7SpMnLWMY6cvs2jmKJav20kOB1uaNaiR4ev6Qd0aFQkICqXbgAlIJBLKlCxMh1YNVde8aEGmz19Nh1YNyZvbiaSkZC5eu0PVCqWYMX4wC5ZvIiExCVMTI2ZOGKzu9ShXqijDJsxlwbSRgOo25Y79x/m7X5dMxZQZhQvmYc7iDTx68hJNLU3sba2oWaUsFuamzP53HdHvk4kRA7qmOrZl49r0HDqZmlXKMrh3+j2S9WpWJDg0jL7Dp6KjrY2VpTnTxg5AV1dHvc+nv8+fq1O9Aq26DKVnp1bqx9J7fdPqWfvSMQByhYIZC9fg4xuIrY0FY4b8pbo+n/xt+dLvfP1alZi5cC1urvnSjUEQhJ9PVNIWhO/w3OMtB4+dZ+Sgbj87lGw1bf5qypUqSs0qZZHLFWzZfYRL1+6y9t9JPzu0H+beQ3cWrtiSasD511AoFEyfv5qirvloUr96FkYnCEJW+7/vQRKE7JKYlMTmnYcZ8B+ou1W1Qim27DrMxu0HSUqW4WBnxdihf/3ssH4rH0p3uBXOTyNxe00QfnmiB0kQvoNSqczwdo0gCILwe/q/H6QtCNlJJEeCIAj/n0SCJAiCIAiC8BmRIAmCIAiCIHzmt0yQlEolMpkswyKBgiAIgiAI3+q3TJDkcjmVG3ZBLpf/7FAEQRAEQfg/9FsmSIIgCIIgCNlJJEiCIAiCIAifEQmSIAiCIAjCZ0SCJAiCIAiC8BmRIAmCIAiCIHxGJEiCIAiCIAifEQmSIAiCIAjCZ0SCJAiCIAiC8BmRIAmCIAiCIHxGJEiCIAiCIAifEQmSIAiCIAi/JE8vP67ffvhTzq35U84qCIIgCIKQgSlzV3Ls9GUA1v47iUL5XX7o+UUPkiAIgiAIv5Szl25y7PRlBvfuiK2NJfuOnP3hMYgESRAEQRCEX8YLj7fMWbyeahVL06ZZXZo1qMHpC9eJjIr5oXGIBEkQBEEQhF/CtVsP6DNsKva21owc1A2JRELjelVRKBQcO3P5h8YiEiRBEARBEH6Ik+eu0bnf2DS3HTh2jhH/zKdUMVeWzhmDqYkRAOamJsyfOpxmDar/yFDFIG1BEARBEH6MG3ce8vLVO2QyGZqaqhREoVCwcsNuNu08TKsmtRnc+0+k0pT9N6WLF/7hsWZ7D5J/QDBVG3fl3kN3ZDIZcxavp0OvUfQdPpWg4FBAlTV26DWKXkMnqx8TBEEQBOH/y3OPtwCER0YDkJSUzKTZK9i08zADe7ZnaN9OqZIjAB+/AJRK5Q+NNdsTpKVrd5DDwRaA/UfPgUTClhUzGDWoO2amJoSFR7J552HWLppEqya1Wbp2Z3aHJAiCIAjCDxYXn8A7b38AwiOiAFixYTfnr9xi6tgBtGvZAIlEkuq4m3ceUKl2a6bMWvxD483WBOnB4+coFAry53EG4PiZK/zRvB4SiQQnRzu0tDS5efcx+Vyc0dXVoViRAly//SA7QxIEQRAE4SfweP1O3QsUHhHFa09vdu0/QfeOLahZpWyax1y9cZdmf/QiOTmZSuVL/chwsy9BkssVLFu3kwF/tVc/FhAUwq17j+ncbyzT5q9GJpcTGhaBk6Oqh8nS3BS5QkFCYlJ2hSUIgiAIwk/w3OMtmppSAMLCI1m1cQ/2dta0a1E/zf3DwyP5q/8opFINDu1cTY2qFX5kuNk3SPvo6UuUKVEYO1sr9WNx8QkYGhiwfvEUhv8zn0vX7oKEFPcVlQolafSwsefQafYePq3a5wffhxQEQRAE4fs89/Akb+6cvPP2IzwiildvvKhRuSza2lpp7j9ywkz8AoJYOn8yJYsX+cHRZmOCdPHqbULDIrlx5xG+/kG4v3hNUlIyxQrnR0NDg1LFCuHnH4SVpRlPnr0CIDg0HC0tLXS0tVO116pJbVo1qQ2ATCajcsMu2RW6IAiCIAhZKDIqmht3HlKnenmiomMICQ0nMCg0RSfKp/z8A9lz8ATVq5SjfesmPzhalWxLkOZNGa7+95S5K2lYuzIXr93l3JVbtG5ahzsP3GnZuBYF8+Vm1cY9JCQkcv/RcyqUKZZdIQmCIAiC8BMsXLEVuVxOp7ZNcH/xlhevPJErFNjZWKa5/5adB1AoFPzVpV2aA7d/hB9aKLJbh+bcuf+Udj1GYGNlQfnSbpiZGtOlfTO6D/qH/UfO0Ld72x8ZkiAIgiAI2ej67YecOHuFQb06YmFuirmpsXq6v30aPUjx8Qls2r4fOxsr6tSo9KPDVfshhSLHD+ul/ve8KcNSbW9ctyqN61b9EaEIgiAIgvCDxMbFM2vROsqWLEKD2pUBMDM1Ji4+AQDbz3qQ7t5/TO/B4/Dx9Wfs8H7qYpI/g1hqRBAEQRCELBMUEsbAUTN57enNsnU7iYqOYeTAbupbZWamxgBYWpipxxwnJiYxZdZiajftxDtvXyaNGczQ/t1/2nMAsdSIIAiCIAhZ6PCJC9y+/4S/x80lMDiUoX07pRiM/SFB+nB77bH7C3oPGsfTZy9xK1KQ5QumUKhA3p8S+6dED5IgCIIgCFlCoVBw9NRlShVzJTIqhiKF8tKyca0U+5ibmgCqBOnIiXPUaNieFx5vGDW0D2cObf4lkiMQPUiCIAiCIGSRe4+e4R8YzD8j+2BqbIiZqQkaGin7Yj70INnZWDF/8Rp0tLU5snstxYoW+hkhp0skSIIgCIIgZInrtx9iY2VB0UJ5052e/yFBQqng3sOntG/T5JdLjkDcYhMEQRAEIYuEhkVgZ2uVYe0ieztrypYswqvXbwBo27LRjwrvq4geJEEQBEEQskRYeBTmH3qI0qGro838qcMpWr4Bjva2VC5f+gdF93VED5IgCIIgCFkiLCISczOTL+539cZdfHz9ad28QaoxSr+KXzMqQRAEQRB+O2HhkR/HGGVg594jwK97ew1EgiQIgiAIQhaQyxVERkV/sQcpLj6eg0dPU6xoIQrkc/lB0X09kSAJgiAIgvDdIqOiUSiU6jpH6Tl28gLRMbH88Qv3HoFIkARBEARByAJh4ZEAX+xB2rn3CFKplJZN6/2IsL6ZSJAEQRAEQfhuHxOk9McgBQaFcPbiNWpVr4iVpcWPCu2biARJEARBEITvFhbxPkHK4BbbnoPHUSgUtGvV+EeF9c1EgiQIgiAIwncLC49CX08XXV2ddPc5dvIC+nq61K1Z5QdG9m1EgiQIgiAIwncLi8h4in9UdAw37zygcsUy6Onp/sDIvo1IkARBEARB+G5h4RkXibxw+QYymYza1Sv9wKi+nUiQBEEQBEH4bl9KkM5euAZArWoVf1RI30UkSIIgCIIgfLfwyKh0B2h7+fhx9OQ58uTOiXNOxx8c2bcRCZIgCIIgCN9FLlfgHxCMtaV5qm3vvH1p1Lo7oWERjBra55vaj/a9gUKW+L1hfhWRIAmCIAiC8F2ee7wlOiaO4m4FUzyuSo564O3jz5J5k2jVrP5Xtx0f9hL/m7MJvL8iq8LNFJEgCYIgCILwXW7de4yBvh6u+XOrH/uQHPn4qpKjDm2afnW7SqWcoAerQSLFPH+LrAz5i0SCJAiCIAjCd7l17wklixVCU1MTgMTEJJq36/1dyRFA5NszJEa8xixPI3SMc2RlyF8kEiRBEARBEL5ZbFw8j909KFuiiPqxnfuO8MbTi9F/9/nm5EieGEXI061Idc2xKNAmq8LNNJEgCYIgCILwTeRyBbMWrUMigfKl3d4/JmfRsvWYmBjRu3uHb247xH0biuQYrIt2QUNLL6tCzjSRIAmCIAiC8NUUCgUzFq7h3KWbTB7VDztbKwBOnLnE67de/NX5D4yNDL+p7eT4UCI9z6JnURBDh59TN0kkSIIgCIIgfBWlUsm8ZZs4dvoy44f3onrlMupt23cfQiKR0O3P1t/cfsTrY6CUY5avORKJJCtC/moiQRIEQRAEIdOUSiWLV29n3+EzjBrcnbo1PvbwhIVHcPLsJapWKou9nc03tR8X8pTItyfRMnTAwLZEVoX91TR/2pkFQRAEQfjt3Lr3hO17jzG0byea1KuWYtv+w6dITpbRtmWjr243MdKTkCdbiA28BxIpNiU6IJH8vH4ckSAJgiAIgpBpl67fxd7WilZNaqfatmPPYfT1dGlcv2am20uODSLk2XaivS4BSowcK2NRqB3ahrZZGPXXEwmSIAiCIAgA3Lr7GLlCoZ6R9jmlUsm1Ww+oVLZ4qrFBr9+84/a9R7Rp0RBDA/1MnS/a9zoBtxegVMjQty6GpWsHdM1cvvt5ZAWRIAmCIAiCAMDy9bt46+XLhiVTcHZySLX97TtfAgJDqFCmWKptO/cdBeCPTN5eUyqVhLpvRyLVwaHCOPSti35X7FlNDNIWBEEQBIGExCQ83nghS5YxYeYykpKSU+1z7fYDdHS0KV405ZprMpmMnfuOYGtjRdVKZTN1vviQpyRF+2Ccs8YvlxyBSJAEQRAEQQA8Xr9DLpczcnB33r7zYcWG3an2efzUg6KF8qGro53i8ZXrt/POy5dO7VoglUozdb6INycAMM1V9/uDzwYiQRIEQRAEgafPX6OtrUX9mhXp07Ut2/ce49bdxyn2eevli0suR/XPSqWScxevMX3OUpxzOjK4X9dMnSs5LogYvxvoW7uhbWSfpc8jq4gESRAEQRAE3F+8Jn8eZzQ1NfmjRT3KlCjMlLkriYiMBiAxKQlf/0ByOTkQFx/Phi17qFCrJS069CExKZmFM8ejr5e5JUHCPQ6DUoFZ3m9bp+1HEAmSIAiCIAi4v3hNofyqGWQaGhqMG9aLZJmMP/uMYdr81bx954tCoeStpxeupesyeNQUfP0C6dfzT+5cOki1yuUydR55YjSRnmfQMcmFvnXas+V+BWIWmyAIwg+WlJTMoRMX8PLxZ3DvjmhoiO+qws8VFBKGr38QhQvkUT9mZWHGohmjOHTiAvsOnyExMZGgwAD+mTYfaysLZk8ZRbvWTTAyNPiqc4V5HEQpT/ypy4hkhkiQBEEQfpCkpGSOnLzIxh2HCA4NR6lUUqFMMcqV+vVm8Aj/LZeu3UUqlVK2VJEUj+fN7UT5koXZsHkXS1esQy6XU8Q1P9vWLSKHg91Xn0eWEE7E66NoGzth5Fghq8LPFiJBEgRB+AFevfFi2IR5BIWEUbtaebq2b8bEWcvYse+4SJCEbKNQKHjj6cP9x895/dabyuVLUKFMsVQ9Nxeu3qZUsUIYGRqgVCq5fe8R+w6d5OCRU/gHBgOgra1DqZLFObprJZqa35Y+hL/vPbIo+MdPXUYkM7I9QfIPCOaPv0awYOpwSrgVAmDO4vW89fJl2ZxxABw4do7dB09haKDPlNH9sLayyO6wBEEQfqjTF66TmJTEtlUz1QX42javx+Q5K/D08k2zKJ8gfK+/x8/lxp1HaGpKsbGy4ODx8+TN7USnP5pQoUwxlq3diVwu58Gj5wwb0IX1W3Yzb/FafHz9AciVMwd/D+hBgXx5mLd8C/VqV/vm5EghSyDS8wzaRo4Y2meuVtLPlO0J0tK1O8jh8HE9lVdvvXny/BUG+qqR7mHhkWzeeZitK2dy+cY9lq7dyaRRfbM7LEEQhB/KLyCYXDkdUiRC1SuXYfKcFTx98VokSEKWkcnlxMbGExMbx407jxjYqwPNG9ZER1uL+4+esXHHIcZPX4K2thYSiQRtLVUqYKCnTdfR07CxtmRg7y60aFIXtyIFkUgkyORyDp28TKlihb45rijvyyiS4zAt1OGXHnv0QbYmSA8eP0ehUJA/jzOgqpeweNVWunVozs79qgJRN+8+Jp+LM7q6OhQrUoA5i9dnZ0iCIAg/hEwu5+4Dd6KjY6lWubQqQXJKWe9FV0cbI0N9wsOjflKUwv+juYs3cOnaXRrVq4qOjjZN61dXF3Ys4VaIEm6FcH/xmnOXb1GvRkWsLM146+VLrwGj0dLS5NDO1eTLkytFm5pSKZtXTP/mmJLjQgj3OICGph7GTtW+5+n9MNmWIMnlCpat28mkkX1Zs2UfoFoB2MHOhny5c6r3Cw2LwMlR1cNkaW6KXKEgITEpVZXOPYdOs/fwaUCVaAmCIPxMN+8+xi8giOYN0161fPGqrew6cAqAefrD8A8IpmLZYqn2MzM1ITQ8IhsjFf5LfP2DOHLyInKFgs07D1OtYmn09XRT7Vcov4t6Sr9CoWDR0rW88HjDhFEDUyVH3ys28AEBtxciT4rCsnAnNLQyVyvpZ8u2BOno6UuUKVEYO1srAJKSZWzacZj5U4cRF5fwcUdJyoRHqVCSVs9bqya1adWkNqBa86Vywy7ZFbogCEKGYuPimTxnBUqFkmYNaqS6XRAWEcmBY+fp0r4pew+d4cHj54RHRmH//u8hwNNnHmzYsptLly4RFRnOwJ6/x20H4de2ccdBTEyMaNGoJms276N65dIZ7q9UKhk/dT77D5+iacPaDO6buUrYmaFUygl9tpuw57vR0NLDruwIjBwyVyvpV5BtCdLFq7cJDYvkxp1H+PoH8fT5a955+/H3+LkkJcvw9Q9kwfLNFMqfmyfPXgEQHBqOlpYWOtraX2hdEATh59m04xBh4ZGA6u+WtaV5iu27D55CqqHBH83r8/ipBxev3QFUvUVbdx1kw5Y93L73CAAtLS2u37hNr4FjmDphmJikInwz/4Bgjp2+Qt9ubWndtA5WFmZUr1Qmw2Nmzl/B0lWbKVe6GMsXTsmymlxKpRK/67OIDbiDjmlu7MoMQ9vQ9ssH/kKyLUGaN2W4+t9T5q6kYe3K6lls/gHBTJm3kiF9/iQ8IopVG/eQkJDI/UfPqVCmWHaFJAiC8N0UCgV7Dp+mVtVynLl4g5ev3qVIkJ48e8W2Pcdo1aQ2JsaG5HPJyd2H7kRGRNCqYy+io2PR09WlQ9umdGnfijOXbrJ+80527T/GibOX2bZ2IZXKl/qJz1D4XW3ccQhjQwOaN6qBlpYmTepXz3D/kNAw5i9Zg2vBfOzatDTTy4RkRnzIU2ID7mBoXw7b0oPRkP5+HR8/vQiBmakxXdo3o/ugf9h/5Ax9u7f92SEJgiCkKyAohLi4BOrXqoSRoQEvX3uqt/kHBDNi4nwK5M1Fz86tAMiXJycJ8fH4+/lgqK/P7CmjeHb3NEvnTaZ0yaLY2Vjj4pKXjSvngVJJq459GTxyMhu37uXhk2ckJSX/pGcq/E78A0M4cuoSHVo3RE839ZijtOzYe4TkZBlD+3fD2MgwS+OJeH0MAMvCHX/L5Ah+UKHI8cN6pfjZztZKXQMJoHHdqjSuW/VHhCIIgvBdXnv6AODinIN8eXLy8vU7AKJjYvl7/Fz09XSZ9c8QdLS1USqVPHrsjpeXJwDb1i2iuJtrivbMzYyJjI6hYb3q5HRyoEvvYWzYupcNW/cCoKOjzcTRg+nTo8OPe5LCb2fjjoMYGxrQonHakwY+p1Qq2bx9P2amJjSsWyNLY0mOCybG7xb6NiXQNrT/8gG/KFFJWxAE4Su88fTBQF8Paytz8rk4c/HqbWQyGWOm/EtIWDirF07E1MQIgFXrtzN97lI0NTWpWqVSquQIwNzMFKVSSUREFMWKFOT+lSP4BwRx/5E79x89Ze+BE4yeOBs7WyuaNarzo5+u8BsICArh6KlL9OrcOlO9RwqFgmlzlvLC4w29urVHV1cnS+OJ8roAKDDNXS9L2/3RRIIkCILwFd6+8yG3syMSiYT8eXKyfe8xBo6eyaOnHiyaPpKcOVTfmAMCg5k2ZymODnZUr1aFYkUKptmeuZkxAGERUVhamCGRSLC3s8HezoaGdavTuX1LajXuSP+//6FsqWLY2Vqrj5XL5bz29CUsIgq5XIGJkQG5ctqrC/EK//8SEpOYsWANBvp6tGhc64v7R0ZF03PAaE6evUxxN1eGDeyRpfEolUqiva+goW2EgU2xLG37RxMJkiAIwld44+lDoQKq+jGlirlS0q0QiUnJTBzZh5KfVBmePncZUdExLF84lYZ10x8sa25mAqCeFfe5HA52LJg5nvbdBvHP9IWs+nc6oeGR7Dp4lq17T+LjF5RifwN9XVo0rEbHVvXInydnmm0K/x/iExIY/s98njx7xZxJQ9Osd/Spl6/e0r7bIF69eUe71k1YMGNclvceJUW9IynaG5NcdZFo/N4pxu8dvSAIwg8kk8vx9Pajcb1qAFiYm7Jk9phU+wUFh7Jj72HKlipGgzrVMmzTzFTVg5RRscj6tatSq1pFdu07ikJDj0s3HpGULMPSwpQeHZrgYGeFplRKeGQ0J87fYPPuE2zefYLKZd1YMHUwluam3/iMVeRyBW88vcnrIhKuX0V8QgJDxszG440XC6eNoFiRAhnu/8LjDbUadyQuPoGZk0bQq1v7bKm7FeV9GQCjHJWzvO0fTSRIgiAImeTl7U9ysozcOR0z3G/tpl0kJSXT968/v/ghpKOtjaFB+suNREbFYGSoz8zJI6ndsi9nLt8jd057hvRuR93qZdHW0kqx/4Aerbn/5CXrtx/h8MkrtOgyiq3LJ5HDwearnqtcrmDM1EXUrVERj9fv2LD9IK2a1GZQ745oSqVf1ZaQ9dZs3sfzV54snT0G1wJ5vrj/P9MXEh0Ty57Ny6hVvWK2xKRUKon2uYqmngV6FhknbL8DkSAJgiBkQlBIGBNmLsXE2JD8eZ3T3e/mnQesWLeVnE4ONKqXcR2aD8zNTNK8xRYRGU2rLkPp060t1+64o9TQJheJNI/3o26IN+zxJimN9goD84rYU1pRkn9O36Vznwns3TRH3VuVGY/dX3Lp2l2u336IXC6nXKmi7D9yFh+/QKaO6Y+BgX6m2/rA2zcAA3099W1F4du88fRh5/6T9PizRaaSo+u37nHi9EWaNaqTbckRQEK4B7K4IMzyNkEi+elVhL6bSJAEQRC+wNPLjyFjZ6FUwop54zFMJznYte8o/Yf9g6ZUyvzpY5FmsqfF3MyE4NDwVI8fOHqO2Lh4dh44xa0HHlQvUZBZfk8wUCaRvGXLF9ttCSSY6zDdN4hZizczc3y/TMUDcOnaXSzMTcjn4kx8QiJzJv/NvYfPGDv1X3oOmczcyX+rl5LKrHHTF1MgTy5GD8nagcH/NXsOncbKwpT2LRt8cV+lUsmkGYuQSqWMG5H51/9bRPtcAcDIIfuSsB/p90/xBEEQssGrt95cvn6XR09f0mvoZPT19Fi1YALOTg6p9lUoFEyds4SeA8dgZWHO8f0bqFkt8x8SJYoW5OrN+0RFx6ofS0pKZs/hU5gYG/LQ/Q2aUimzpg9DJ4/LVz2PP4vloVjhfBw4fonIqJhMHaNUKrl0/S6Vy5Vk3pRhLJ09Bk2plDIlCrN64T8kJiXRfdA/PHb3ACAxKZm3Xn48fOrB0xdv8Q8MSbWouEKhwNPLD//AkK+KX0gtLCKSnDns0dbW+uK+J85c5MbtB3Rq15w8uZ2zLSalUkGMzzW0DGzQMftyr9bvQCRIgiAIaVi6ZjsjJi6g19DJ5HKyZ/m88Wmuk6ZUKuk1cCxzF62mhJsrZ49sxa1w2lP609OycS1kcjmHjp9XP3bm4g1CwyLp1qEliUlyShTNh7WVOYYD+pGok8nKxCbGaPfqTsdWdUhITGLP4XOZOuzNOx98/YOoUqEkEokkxfpczk4OrFk0CScHW3oNncKgsfMpW68b1Zv3o2mnETRsP5TyDf6iQfuhbNt3iti4eEB1izIpKZng0LDMXxghTdHRsZmqfK1UKpkyawl6urqMGNzri/t/j/jQ58gSwjByqPh/s+iyuMUmCIKQBk8vX6pVLE3B/Llo06weuukkJddv3Wf3gWPUqVGZDSvnfNN6VuZmJtStUZFdB0/SrmUDNDQk7Nh/gnKlivLayx8Aa0tj4oIfE+K9BUPTZAj8cruJetH4PhpNAZkSIz3YtHk9NW3OomuWF32rwhjlqJLmWJHnL98CULxo2omeUqkkWSnFLziagycukzunPW2b1sLUxAiZTI6PXxBHz1xlzLTlzFi4kb7dWlKiSF5AlSgJ3yc6JhbnnKl7Mj/32P0F7s896NG5bYr6WdkS04fbazkqZet5fiSRIAmCIHwmLj6BgKBQ/urUiga1M56uvHrDdgCmTvj7uxb7bFS3KkdOXuTZyzckJibh8fod/aePZP3O4wDUzvEYn8u3kGhooteqMmy6C5/ckvuc0kAHWfOSGNnqg1JJ4dxPuPcyEoUsgah351T/eV3ApkRftPRTfniGhkdgZGiQZlLo6x/Mn/0m8uadH04O1liYGrBv47xUvQbjhnblryFTePnGl1mLN1PKLT9KpZK4uARi4+JFMcvvEB0Ti7GhwRf3O3zsLEC2V2BXKuTE+F5H28gBbeP/n1IQIkESBEH4zDtvPwByfeFbup9/IIePn6N6lXLky5Pru87pWsAFI0N9rt9+yMvXnuR2dqR0icIsXLkFPW0oaBePnl15bIt2QsvAhvgLI1A8fZpue1LnPFg3Hqv+2dJxHolPr5Cj5lIk8mhC3XcQ6Xkaz1MDMLArjY6xE9pG9mgbOhARHp7mTLPIqBg6D5jMWy9/Jg7vgY62BivW70KuUKin/l8L96KCmRO79h/j6tUrREdHY2Biw52HL5Anx2Gop0lwSDgGTiJB+lZR0bEYZSZBOn4GSwszypcpnq3xRPteQ54YiWnuev83t9dAjEESBEFIxdNLlSB9WDYkPas37EAmk/FXl3bffU7VIOgiHDt9ieu37tG9SQEC7y6GmFckJsPco9qEGTdFy0BVz0i7dy8wSWe6vImJavsn4uMT0dLURFNTiqauGTYl+uBQcQLaJjmJ8b1G6LMd+N+az7tzf1PL8jDdKwQS9nI/MX43iQ99RlK0H9Pmr+bVWx/GDulClz8akt8lJ0lJyXh5q24DPo4OoNWD7TQfOZK/R08hOioKY2NjBnRrBopkpFr6BAeHMGfRKqKiMzdgXEhJJpMRF5+AkVHGCdLLV295/vINDevWyPRsym8R43eLgDuLkWobY5wzaxe9/dlED5IgCMJn3nr5YmttkeHSDZFR0azdtIt8eXJRr1aVLDlvpVJ5yaG8TJkGcgwSDxHlBVbmRiiUUTzy1uTlK0/cXPMBIHVxQW5jgzQydf0kDUdHpC4fZ7spFApevPbC2tIsxTd8A5tiGNgUQyGLJynaj6QYX5KifXlw8wSOxrGEPNms3jcqXsmB41DQAaoa7eLtyROYSfVpVjIJj1cvcHay54/T65CZaXDZORkjY2PG/N2XTbuO0rhBHa7ecefxCx/0DM3YunM/ew8co07NyrRsWp86NSqh94VlMgSV6Jg4AIy/kCDtO3QSgKYNv7w+27eK8buJ3815SLX1caw0CS39ryv78KsTPUiCIAifeefll+Z0/k+t37ybqOgYBvXtmmKW17eKDXyAS/JOqheSodQyxdK1I851ltGx+0gApFo6vHz9Tr2/QqFgqUKfyM8GWYfI5ES2ap3iscs3HuLtG0jT+mknchqaeuiauWCcowqWhdqx/rodJ4Ma4lh5EralBmJVpAtX/IuQJIPWtfKia+aChqYeisQQmpeS4RCxilV7JhMsVZWt1HQ0o+c/fejRqTXa2lrcefCUsPAICuXLiVRLjyaN6lOyeBEOHz9L515/41qmLpeu3vrua/hfEB2jGneW0S02pVLJngPHsLI0p0rFMtkTh+8N/G7ORaptgGPlyeiY/P+MPfpAJEiCIAifeevli7NT+rfXEhISWbZmCw52NrRu9uVifRlRyJMJfrwB36uTkSiSkDu0o3CTFZjnb4G2oS2lihWkQJ6cBIVG8ezlG/VxOw+c5NCLd2g6OaVo71WCjBl7j6d4bPPu40gkEtq3zNxg3bCISExNzdG3KoKxUzXM8jbh8PUwzE2Nad9rKjkqTyJnzXnkrr+Wc565iYqVscc0GYxVvUAKQy2u54xGIo/BtUBuNmw7iEKhpF0L1fkTZBKO7lnL01snmTJ+KDKZjJYd+3DgyKnvuZT/CR9qZWU0SPvh42e8evOO5o3roqmZ9TeK4kOf4X9rHlJtI1VyZOz05YN+QyJBEgRB+ERiUhK+/oHkyqAHafueQwQFh9KvV6dMFetLT3J8KN4XRhHucQhd83w41ZxHwbKtU7QpkUjo2LoeyckyHjx9TcvOQxj+zzyWr9vJHy3qYTFsKBirlhBJ1NNjl6kN2/ccIiAwGIArNx9y7spdalQqiaPdl6d6y+RyIqNiMDf7uCyJUqnE09ufkm4FUsxsS0qWs3TXU5qsCeW5LOWMt1exQZw82Z8uZfww1Uti8uh+tG5cE4DAINVUf3s7Gwb06syJ/RuwMDejR//RnDhz8Ruv5n9DZnqQ1mzcCfDdyXt6wl8dBaUcx0oT0DHOkS3n+BWIBEkQBOET3r6BKBRKcqaTIMlkMv5dvhEzUxM6tWvxTedQKpUkhL/C59IEEiPfYp6/FTmqTEPbwDbN/Vs1rkHhArmJiUtGV88Ab99AcuV0oHfXNkhdXNDIofqQijQ0pkm/HiQlJbNy3TbuPnpOn+GzMdDXZfSgTpmKLSIiCqVSidkns9ji4hOQyxUYGX5cYkUmkzFuyjy8ffzQ6lKOJD2dlO1oaLHYtDCm0kBmtUumhI0XyaF3kWpIiI2LQ6lUkpSUzNt3vujq6nFwxypMjI3oO2QCsXFxX3tJ/zM+9CClN0h74dJ1bNl5gPJlS1CqRJEsP788OZZY/9voWRZCx8Q5y9v/lYhB2oIgCJ/wfOcLgHM6M9g2bd/H23fejP67T7prsqVFlRS9JMb3OjG+N0mOU1V6tC7WC9PcdTM8VldHm41LJtD2r3Fcvf2UNk1q0rtLc3S0Vb022r17ETNgEGdcCtG9dlVccjuzdtthth26ioaGBusWjSNPrsx90w+LiALA3PRjgvThPImJSYSHR7Jp+z5Wb9yJj68/heuVxTuHGfEoU7XlJdUnsuRQLF/sJPTZTuQKJXIFuNrG8GJfS5LlkCyDmAQJtvlqMXF4FwaMXsD6LXvo3zNzCd1/TXRMLJqaUvR0dVJt27h1LxNnLKJQgbxsX7soW6bcx/jeQKlIxjhH1Sxv+1eTZoKUkJDIwePnefj0Jd4+AcQnJCCVSrG3tSJPLidaNKr51YsUCoIg/A48vX0xNzPBxDj1Ug4REVHMmLccG2tL+n3FB7hSqSTw3lKi3qmW+tDUs8TUpSFGOaqgZ543U21YmJmwd90Meg2bxa5DZ9l16CxVyhendZMa2NtacsChAK99QnkzYyVRSdpoaGsgkcDO1VMpWijza2OFhatmxX1aB0lTU4qJsQGXrt+jUOk6xCckYG1lwaihfbhYSY/4WP802wpJjmNKqCcHa80nNuA+z1/7ApuQaOoRlGSBoZ4mukaaKMLfQdBpyhpqMqqdIytWb6JHp7boppEE/NdFx6hqIH2e/Bw8cpoho6finNORfVuXY2pqnE4L3yfK6zwSDS0MHSpkS/u/klQJ0r7DZzh+9ip1qpenZ6dW2NlaoqOtjUKhICgkjBevPJm9eD0WZiaMGtJDXRxMEATh/8Hbd76pxh95+fixav12Nm3fT1RUNP/O/uereo8iXh0h6t059K2LYlGoA7pmeb7p272JsSHbV07m2u3HbN59nNMXb3Hp+v0U+1y7+5zCBV0I8PXinecbEuLTr7adlo8J0scP2INHThMU4IeOvgm5cjkzuE8nmjWqw4vEUDY+3Jlhe6/iwngSG0YR+zIc2rwKgAFDJlDSrYB6n4dPnjN/0SQGNDGjRXkZLjYKDh/eR+vW319f6v9NVHRMqvFHF6/epMeAUVhbWXBg20psbbKnAyMx0pP4EHeMclRFqv3lQpW/u1QJUvnSbjRvVDPVL6+Ghga21pbYWltStUIpfP2DRHIkCMIvKyAohGs3H3D11gOevXhDnRoV6Nah+Rfrx3h6+1GsiOrDOzAohBHjZ3L4+FkUCgX58+Zm6vih/PlH80zHEel5luDHG9A2csCu7AikWplPrNIikUioWKYoFcsUJSAolEs3HhAREc3t+0958OQ5axZOwM01LzfvPKBR6+7Ua96F/j07MfrvPpmqNRQWEYmBvp76thrAouXr0VCqpvCXKVuONi0aAjDmyRlCk+MzbC8kOY6xHqfZlr8l+45eoGA+Z0oUzZ9iH7fCBXgbbsKdmNrUzBuMGyeIit9N6DNN9CwLoGuWFw1NUScJPixUm/I9PGbiXHS0tdm7ZTnOOR2z7dwRr1WzI01dsmfw968mVYL04daZXK7g8o27vH3ni4aGBrlzOlCxbHF1vQ+HTMyGEARB+NGiomMZOGoGL155IpVKKVY4P7WqlePwiQucOHuFwb07Uq9m2gtqyuRyvHz8ad5QNdtq5IRZHDx6mtrVK9GnRweqVyn/VT0/Mf53CLy3DE19KxwqTvju5OhzttYWtGmiijWnozVP3J+RJ5fqA7JsqWJcPL6D/n//w78rNnDs1HmWzJtEudLFkcnlREXHpBhn9EFYeFSK22sPnzzj3sOndGrXgsDIZI6evkaXPxoizWnMq7jQTMX5Ki6Mf5ZvJCY2nj9b10/zGjra2+DtF4xju54sPvuCCg6vCH2mWucOiQY6JrmwdO2AgU2xr7xK/1+iY+JSJEhPn3nw9NlLunRoiWvBzN2u/RayxEiivC+hY5Yn07eFf3dpzmILj4iiU98xbN19jIjIaELDIli/7QBd+o8nMkqUhxcE4df16q0XL155MmJgV07sXs6S2WMY2rcTO9fOwc01P9PmryY5WZbmsX7+Qchkcpyd7Hn09DkHjpyiXu2q7N68lBpVK3xVcpQcF0LA3X/R0DIgR+XsrzJsbWUOQFBwmPqxQgXycurgJiaNGYy3rz/1W3Tl8PGzHDt9mfZ/jUSpTD2wOiw8AvNPxq9s2LIHgC4dWjJmUGekUg16DJnO0Av7vth79EHE+Tfs3X4SN9c8tGiQ9uBeR3sbfP1UA9drNetDwwneDF8fTYJZLQxsS5IU44vfjdkkRrzN3AX5PxUVk3Idtt37jwLQunnDbD1v2LNdKOWJmOdtlq3n+ZWkmSCtWL+LujUqsHrhPwzp8ydD+3Zi3eIpVK1QkmVrd/zoGAVBEDItKFjVq1GvZsUU44QsLcxo17I+Mpkcb9+ANI996/VxBtvM+SsAGDOs71fHoBqUvQRFUgy2Jfur10/LTk4OqhIBHxba/UBTU5NBfbty+eQujIwMGTdlHq9evyMyKoaY2JTT6YNCwrh84x6F8quWKYmJjWP3/mMULVyA4m6uuLnm5d/pQwmPjMZj5jmkt4MhWZFuTJKIRLT2eaJ94B1Y6fH3lJ7pDrx2tLfB532CVDB/HlYuns2tZ1HU6bGB26ElcawwHpQyfK5NJTHS81sv028nLCKShIRE9c+fjkFSKBTsOXAcRwe7bF2QNinaj4i3p9A1y4uhQ/lsO8+vJs0E6emL1/zZpnGqx7u2b8aT56+yPShBEIRvFRQShpGhAXq6qces5MqpGnz9IRH63HOPt5ibmRARGcmxk+epX6caRV0LpLlvRqK8LhAX9AjjnDUxtM+epR4+92Hm3WtP7zS358uTiyF9u/LOy5djp86hVCoJDUu5jtvCFVvQ1dGha4dmAOw9cJyY2Di6dmyl7j2rU60sM+cOQVtDE52dbzCf8YRKV5R0Tnahp44rPaQFaRNmT5HdYehPf4jWtUDs8tvTY3ZXHCzN043f0d6GkLAI4hMSANUaYkf3rMXExIguvYezfMc1bEoNRpEUjffFcYS/OopSkZwFV+7XpVAoaNttOLVb9qTnkEksX7eTkNAIdYL08PEzfPwCaN6oTpYsd5Oe0Oe7QSnHqkiXbCkd8KtKc5q/hkSS5kXQ0NBAmo0vgiAIwvcKDA7DxsoizW0mxkaYm5nw9p0PUDbV9ucv31Igby5WrlONfen3159fdW5ZYiThLw8Q8fo4Uh1TrIp0/ur4v5VEIsHFOQevPX3S3ad39w5s2LaXO3cfoK2jg6eXj3pJlWu3HnD+8i0mjeqr/gBev3UPBvp6tGxaP0U7ratUovYRN/YcOc+W3Se4d+AW9w6kXEtNIpFQtUJxOraqR/WKJb64onyO9z1gvn5B5MmtWrqiRLHCnDm8hbadBzB55r/o6Ayja7MJBNxeSPCjtYS92ItRjkpoG+VA29AebUM7pLpm/zcf4lHRscTExtGwThUSEhI5cuoSUdEx2Fqr3t8nzlwCoF7t7KtJlBQbQLTPZfStiqJnWTDbzvMrSjNB8g8MYdTkhakeVyqVBASFZHdMgiD8hyQkJOLxxosihbJm4GdwcBjWVmbpbs/l5MCbd6l7kJRKJc9evqFh7crMnLuYIq75qViuZKbOKU+KIdzjEOGvjqCUJ6BtkhObYr2RaqeupZSdXHLl4Obdx+lu19PT5fzRbVSq1w4/Xz8WLV9PtUplSEhIZO6SjZQpUZja1VS3UK7fuseDR+50bt8SY6PUz8PUxIgeHZrQrV0jrt1+zJPnb4iMikFLSxMzEyNqVCpJzhx2mY7d0V51G9LHL1CdIAHkcLDj5IGNuJVvwPbdh+n3158411lKxJvjRLw+RsSrIyna0TJ0wKHCGLQNM3/uX1X4+6KdTepVo6hrPpRKJcEhYViYq97fp85dxsTEiLKl3LLl/EpFMiFPtoBSgXn+b6sa/ztLM0Ea3KdjugdUqZC5PxiCIAiZcer8NWYsXMueDfOzZHZsYEgohfK5pLs9V04H7j5wT/W4f2AwkVEx3Lx1l9i4eAb37Zqpngh5YhSeZ4ciTwhD28gBi4LtMHQoh0Ty43vbczs7svfwaRISk1KsmfYpQwMDjE3MiYyI4vzFaxw/fYG33oGEhkWwaMZI9XOeMW85GhoaDOidcUFMDQ0NKpV1o1LZ7/uQNjE2xNBAXz0O6VNGhgbUqVmZHXsO4+Xjh5OjPeb5mmGWtzHJsYEkRfuRHONPYpQXUe/O431xLPblRqBn8fW3R38l4RGqW6Bm7wfNSyQSrN/3jgYEBnP/4VNaNq2XLQvSJka+I+DOvyRGvkXf2g09q6xftuRXl+ZVbVi7yo+OQxCE/yj/973SR09domfnVt/dXnBwONYV0x/rksvJgf1Hz5GcLENL6+OfQPcXb0hIiOfYqfOUK12MFk3qZe58jzciTwjDskhnzPI0QiL5efXhXJxzoFAoeeftR/48zmnuExgcikQiwdbeAT+fd3Tq+TfWNnb069lRfZvrwuUbXLp6i3atm5And9rtZDWJRKKa6p/OAPoGdaqxY89hjp+6QK9u7d8fI31/a+3jsjAGtiUIuL0I74vjsHRt/1v3fHxY9sUsjarY5y5dB6BOjcpZek6lUk64x2FC3behVCowz98Ki4Kt/29uW36NNL/iPHzyguceH6dSbttzjNotetK1//hUMyQEQRC+R3BIOADHTl9GLk9/RlRmJCYlER4ZpZ7ynpZczo7I5fJUPRXPXr4hMjwMhULBzMmjMvWBEBf8mCiv8+hbF8MsT5OfmhwB5H4/CP3127QHaoMqQQKwsbakVYsmSKVSfH28mTh1Lq3/7MeSVZvo2mcEerq6jBjU84fE/YGttaU6vs/VqFoBHR1tjp++mGEbRg7lcaoxF23jHIQ83ULw443IEiKyIdrsFxEZjZaWJgb6eqm23b77EICK5Utl6Tn9b84j5MkmNPWtyVF1Opau7ZFoaGXpOX4XafYgrdq4h1GDuwPw6q03G7YfZMaEQfgFBDN3yUYWzxr9Q4MUBOH/V3BIGPa2VvgFBHPi3JXv6sH+kGxZZzBbKndOR6RSKVdv3idXTgeSkpLZuOMQ67fsJSwsjFZN61OsyJcHoyrkSQTeX4lEqo118Z6/xDdsAwN9bG0s05zJlpwsY9+RM3wofVQwXy7kcgVF3dywszYnKjKC85dvcPr8FTQ1Ndmx/l9yOWdugdusYmpilO44V0MDfapWLMu5S9eJjIrGxNgo3XZ0jB3JUWUKPlcmEe5xkHCPg0h1zdDSs0RT3wotA2sMbUuja1Hgl3jdPhUVHcv5K3cJCgnn8o17yORw8fp9Kpd1SzHQ/e6DJ9jaWOFgl3UlJOKCHhHjdwMD21LYlfkbDc3/9lp4aSZI0TGx6q7WHXuP0bxhDUoVcwVg6+6jPy46QRD+7wWHhFOpXHGiomOZMX8NOlra1KpW7pva+lADKb1ZbKAa69KkXjU27zqCS64czFq0hmfPPUiMj0UqlTL67z6ZOlfYi30kx/hh6doRbQPbb4o3O7g45+BNGjPZtu09xor1uzDQ18PC3ARbGysuXr1NdEw8owe3pHrlMkRERnHu4jVsrK0yPUA9K5maGBERFZ3u9vp1qnLq3GXOnL+Sambd56TahuSoOpUY3xvEBtwlOTaQ5LhgEsI9AAh/eQBds7zYlOiLjknOLH0e38L95Vs27z7BweOXiItPSLGty4ApONha0b5lXdo2q4m+ng5Pn3lQt1aVLEvwlEolIU+3gkQTa7ce//nkCNJJkJKSZYSEhhMTG8f5q7fZvmoWoKrJoK313+xqEwQhewSHhmNlYc7AnqrJIf/MWopCqaBO9a9fLTzwfRXpjHqQAFo3rc3mHftp2bEPcbGqxVwtzM2YOWkELrm//GGZFO1D+Mt9aBs7YZa3yVfHmZ1cnB05fvZKisf8A4JZv+0AluamhIRFkDOHPRZmJuo6SHldVM/Z1MQ402OvsoOJsRGRkeknSPVqVWUIUzl+6uIXEyQADakOxk5VMXb6OA1eIU8mKdqbSM8zRL45hdf5EdiVHYahXekseQ5fKzlZxoTZq9m+7xQAtlZm6GiCW+G86OloEx0bT8niRdi+7xRzlm5h0eqd9OzQCLlcTslihbMsjiiv8ySEe2Dq0gAtA7GUGKQzBqlLuyb80WMEnfuOo8sfTdWj5o+fuYJrwfRnhwiCIHyNuPgEYmLjsLI0RyrVYNzfvahXsxKTZi/nxGcf8pkRGByKsZFhutWaQbUyfZW6bfD2ekdSYgKN69dk27pFPL97mr+6/PHFcyiVSgLvr0SpkGFTvA8SjayfQfQ9XHLlIDgknKjoWPVjC1dswdjIgJULJqCjo42NlTkWZqYA6OvrYm+bvcugZJapiSHxCYkkJCalud3O1poSbq6cOn+F5ORvKxKpIdVC1zQ3NsV64lh1GhJNPfxuzCba5+r3hP5NkpNl9B4+i+37TlGxTFGmj+mFRJmEawFnQkPDCDaHvLlzMKTXH1w9soqlM4dhYWbMkvX70dYzzrIESRYfRvCj9Uh1zbAo+OXfgf+KNH+z69WsRPEiBUlITCRnjo+zA8xMjenTtc0PC04QhP9vwSGqHh8rS1VdF6lUgzFD/kIikTB5zkoUCiUNamd+ls69h8/I55J2D5CvXyBzFq1kw9a9WFtZMHHMYFo0rouZWeoFWzMS9e4c8SFPMclVFz2L/F8+4AfL/X7c0BtPb4oVKcDlG/e4dP0u08YNxN7Wmokj+mBuZkJktGpdzby5nLK1CvPXMDVRzdaKjIxG1zrt26QN6lZn6uwlXLt1j6oVUxf7/Bpn7wSw74A245pL8b+1gKQYPwzty6JtlIOXr99x94E7djaWVK+cPdXQJ8xaxdnLd2jeoCqzJ/Rn6Lg5FMibi/atGjBy3Vp8y0rJ56NK9rW0NGlYuyIl3QpQo3kflEoLQiPjvnCGL1PI4vG7MQtFciz2JQf88Npdv7J0v/rYpPHmrFCmWHbGIgjCf0xwqGpQtZXFx8KOqiSpB1INDabOW4VUqkHdGhW/2FZ4RBR3Hz5l+ICu6scSEhK5c/8xh46dYeO2vSQmJlG+bAnWLJ6Jg/3XD25Njgsh+MlGpDqmWLqmXy/uZ8rpaIdUKuW1pzcF8uZiwbLNlC1ZhOqVVLeQqr3/v/uL18DH22u/AlMT1cDriKjoND+DAGrXqMTU2Us4c+7qdydIJ85c4bl3HLKcg9DyWUOo+3ZC3bcj1THl8Vs5lx8l8eCdlGM7l6U51f57PH72mu37T1O5rBuzJ/Tn6s373HnwlClj+uPs5EBILTuUUgln7VLecrS1tkCbeOIlUmYv2UqTulVSlKv4GkpFMn435pAQ7oFZvhY/bFmc30WaV7VT37F8Ou5LQ6KBtZU55UoVpWn96r/Mtw1BEH5vH1aet/pszJCGhgYjB3UjMjqGtVv2ZypBunD1NhIkuOR0YNaCFVy+dpvb9x6R+P52jVuRgowb3p9a1St+9cBWpUJG+OujhD3bhUIWj12Zv5FqG3z5wJ9AS0uTnDnseP3Wh407DqUqAPmBpbkpAHk/qVr9s32YmRaRwTikoq4FsLG25MyFK0wZP/SbzxUeEcWDJ88BePo2kmb1FxEX/IS44MeEe9+mqH0ARe3huoeU4CD/LE+QNu06BkDXdg0ZPWURV2/ep2zJIlSrVJpHkf4kmat6jkK0kngcHUgRI1VCHx0Tyzsvb4oVL8lb3zDOXr5NvRpfv4CsQhZP4L1lxAU9wMS5NpauHbLuyf2fSLuSdu+U34yUCiUhYREcOn4e/4Bg+nYX9ygFQfh+waHhqjFDaVR91tDQoE71Coyd+i/+AcFMmLmUP9s0TrOa/407D1m2ZhsR4SFUqdcWpVKJvp4uFcuVpFL50lQqX4rSJYp+04yf2MAHBD9aS1K0L5r61tiWGvTLf9N2cXbk3OWbxMbF06ltE/Ws5E9ZWZozalB3alb9thmD2cHURHV7J6MESSKRUKNqBbbvPoSPXwCO9t82g/Dy9bsAONhZ8+T5K1o0roWhXSkM7Uqx8SI8enCLSX/aUj7vQ2QvFpDsOBkt/awZvBwRGc2hE5ext7Hgn5lLsDQ3Zdq4gVSvVBqJRMI/nhdQGKg+nqMlMsZ6nOZQCdXnsvtzD5RKJTUqlWDT3gts3n3iqxKk5LgQIt4cI/LtaRTJsRjal/tlylT8atJMkEoUTbsGSNWKpejWf/xXJUj+AcH88dcIFkwdTmh4JDv3nyAyKoYOrRvSrEENAA4cO8fug6cwNNBnyuh+6kHhgiD8fwsKCctwxtmHv0UrNuzmybNX3Lz3OEWClJCQyOiJc1i/ZTeg+vCsV7sqPTq1oUrFMmh956zbSM8zBN5bhkRDG4uCf2CWryka0l9/+nPFssV59cab1k3r8GebxmnuI5FIaNqg+g+OLGM62toolBJOX7yFl28wujraWFqYUrlcMQwNPhZLrF29Itt3H+Ls+at07tDym8518dod3ArnJ1dOR+7cf6p+PDEpidMXrtOsYU1yVGzBzLEdaVMuCO+L43CsPBltw+8v6XDq4i0Sk5KJj4ulf482dGjdUP0l4XF0AK/iUhbLfBUXpu5FevS+16t86WIEhMVz9PRVgkMjsLIwzfCcyXFBhDzdphqMrpSjZeiApWtHTJxr/vQCp7+qr7pxqaujjYb0626vLV27gxwOtsgVCrx8/Fk2ZxzxCQm06DyEGpXLIpPJ2LzzMFtXzuTyjXssXbuTSaP6ftU5BEH4/SgUCt54+qgHaKfF1MSIvLmdOHX+GgCPHj9n8cqNPH3mwRP3l7zweE1ysgwdXV1GD+1Ns0a1cXZyzJr4ZAmEPN2GVMcUp+ozs6z34EeoW6Nipm5L/iqiomPZf+wim3cfJzA0hj1HLgIfK2YbGujRomE1OraqRz4XJ6pXLo9UKuXIiXPflCDJZDLuP3pO1/bNsDA3Zd/hM0RFx2JsZMCla3eJjomjUZ0qaGlpcd3TghIl8pCXa/hcmUjOGnOQaqdfpDIzPhQ0dXaypXvH5im2jfE4Q2hyfIrHQpLj1L1Ij5++AKCIa37cX/m+T5DC002QlAo54a+PEOq+A6U8ET2rIpjlaYyBbYmfsl7g7yTTCVJiUhJ7D53JsADb5x48fo5CoSB/HmekGhp076haE0dbWwt7G2siIqN4+vw1+Vyc0dXVoViRAsxZvP7rn4UgCL8VpVLJxFnLefT0BZNG9stw35LFCuHxxgttLSnHTpzi8NHjADja21KjSnn0DQx55xvM4L5dM2zna0W8PoY8MQJrt79+q+Tod3P+yl0GjplPdGwcxkYGONiaU8w1L906NCMhMYnXnj5s23eaTbuOs2nXcdq3rMPkET2pVa0CZy5cIyg49KvvOri/eEN8QiIl3AphZKj//rHXlCtVlKOnLlHUNR9OjnYAWJib4h5iTsUGfxH0YCUBdxZjX27Ed5V3+FAI0v6zxZnT6j364EMv0mP3F1hbWWBjbYm+nqo3My4uIc1j5Mmx+F6dQkLYS7QMbLEu1hMDm2LfHPd/TZqvcJ2WPYGP9yOVSiUJiYmUdCvE6ME9MtWwXK5g2bqdTBrZlzVb9qXYFhIaTnRMLA52Nly6dhcnR1WXpaW5KXKFIsOVqAVB+P298/bj9IXrjBn61xerZlcqW4I9B0/h8fIFCoWC+TPG0bxRHfX0/DmL15OsyNrxE7KECMJe7ENT3xqTXLWytG3howPHLjL0n0UY62gxrW4pGhVw4vz562hF+lPE/T4ApYG2TUpz3y83C688YdveU/jff8yf9Stw8uxl9h06Qe/uXzfA+O5Ddwz09cifV/Xl3dzMhHsP3cnl5MCte0/US20BWJibEBoWgUmuzsSHPSfa6yKepwdgXqANxjmqINH4+ttTRoaqAf4falF9kFbv0QchyXGMeXkK9+ceVCqnWn8tKkY1zd/YKPWEAYU8Eb/rM0gIe4mpS0MsC3f8LW4P/0rSTJA2Lpue4mcNiQQLcxM0NTOfMR89fYkyJQpj91kBMqVSyb+rttG1fTOkUg2QqB5Tb1coSWus2J5Dp9l7+LS6DUEQfl/PXqoWw65W8csLbZYsVohq5Yvx+NFD7B1yULBAvhS1iwKCQrC1tszS+EKebkEhi8OmZP//7EKd2e3qrUcMm7gYW3MT1uhEkfPBNXhwjdrvtydvfpVi/yLACiVM0JVy6I0/Zo89MTI0YPOOA3Tp0CrD4qCfu/vQnWJFCqD5fm2z0sVduX3/Kfp6euhoa1OzysfyAZYWZjx++pzpc5dhbWlBi/LtCfc4SODdxYS92ItFwbYYOVb6qkHOdu9LGETHfEyGMuo9+uBRqC9JNvpUqaiaJHDrnjvaWprYflYSQamQ439rPvEh7pi6NMSqaDcxCPsbpMp4/ANDsLP58h8bv4Ag7G3T73a+ePU2oWGR3LjzCF//INxfvGbq2AHcuP0ILS1NmtSvBqjqnzx5pvpFCA4NR0tLCx3t1L1HrZrUplUT1a+OTCajcsMumXl+giD8gp57vCGHg636m3RGQkLDWLtpJwXz50HXwITXnt6UL+2m3h4QGEoJty8vLptZ8WEviXp3Dn3rohjaf1+dHSFtCoWC8TNXoqurzYZlk8ixYgmKp0+/eJyWBKYYywnTN2Lfpbs0rF+HHbv3067bQLasWYCBvv4X20hISOSxuwe9u7RWP1a6eGFOnb9OWHgk1SuXxkD/44Dwd++8OHnqLCdPnQUgx4Z/qV1vBeEeh4l4dYSA2wtIjg3AokDrVOdKT14XRzQkcP3uUxQKBRoaGhn2Hn0QrwXGvSrRp11HXr724sbdJzSrX0Xdg6RUyIjxu0X4q0MkhL3EKEdVrIp2FcnRN0o1Quv6rQf0HDKJPYdO4+XjT3KyDFD12gQFh3Lp2l2GjpvDui37kcnl6TY8b8pwNiydyppFk6hQphjD+3fBLyCYS9fvMmLgxxesTIkieLx+R0JCIvcfPRfFKAXhP+DZy7cUyOucqX0nTl9EXHwCo4b0JvdnC7Eqlcos7UFSKhUEPVgNEilWRXuID5Zscu32Y96886NDy7rkc3FCu3cvMMlcRXNNUxPGjlVN5NHRN6Hbn605f+kGLTv0ISIy6ovHr992AKVSSZUKH3svSxVzVX3GhYTRqE4V9eMnz15iz/4jaGlpsWnVPExMjBg4fBKvPAOxLPQHueouR8fEmVD37cT43cr08w8MDEFPV4uAoDAuXr+fqd6jD3ScLXiRGMaWPScA+LN1feRJMYQ+38PbE73xvzWXxIg3mOSqi23JfmIg9ndI1YPUonEt6tWqxKHjF1i+bhfefgEkJCQilUqxt7UiTy4nhvXvnGHvUVoSEpP4Z8ZSrK0s+GvwJFAqqV+rEu1aNqBL+2Z0H/QPRgb6TBk7IMuenCAIvx6ZXI7Hay+qVfzy4qBHTpxjy84D1KxagSYNa/HqnR8nz13l5et35HPJSVR0DHHxCdhmotc7M6I8z5IY8RqzPI3RMc6a2XBCapt3H0cikdChZV0ApC4uaDg6ooiM/OKxGo6OFKxWkbIlj3P87DWuHl2Fgb4+i1dupEnbv9i3dTmWFmmXjnjt6c3WPcfo2r4ZDp8MkLaxtsDJ0Q6ZTEaxIgXUjy9cth5NTSlOzrmpWqksC2eOp3u/UVSp15YJowbSp3sH7MuP5t25YQTeX46eZcFMzXDz9gvAytyIhIAIJs9di+7gkoQqMu49+iBCkcSgw1vx3nedQvlzUaygE96XRpMU5Y2mrjkWhdpj4lwLTV3TTLUnpC/NQUX6err80aIef7TImlWdxw/rBcC5g2vT3N64blUa162a5jZBEP6/vPP2IyExkQL5cqW7j/tzD2YtWMnBo6cxNjbi3zkTkUgk9OzciifPXjFo9EyWzB6D7H0Pd1b0IMmTYgh5uhWpjinmBdt+d3tC2qJj4jhz6TZVyhdTT9AB0O7di4Rx4yGDJClWSxuL3qrPkw4t63Lz7lNOnL3B5HFDMDIyYPrcZTRv35uLx3ekWvFBoVAwa9E6HO1t+LNNo1RtD+nzJ1Kphvq4l6/ecv3mPWrXqIxPYATBoRE0b1wXezsbeg8ax9hJczl+6gJL50/GumhXAu78S/CTzdiW+HKZGm/fQHLntKd7x1aMn7UK5l+AbnnB+MuTkzReR/Fm/Uv0dbSYN2kggfcWkxTljXmBNlgUaPXLLZ78OxN9b4Ig/FBP3FVjDvOnsQbYC483dOs7goq1W3Pw6Gnq1a7KiX3r1eumGRkasHD6SKwszBgwcgY37j4GyNS4yYwo5IkEPVyLPCkKq8J/ItX68lgW4duEhEUglyso+Nkt1g+9SBkJ0tZF6uICQKF8quMDQ8KQSCSMGNyLLh1a8vjpC54+90h17KETF3js7sHIQd3Q1k498L5cqaKULl4YALlczpKVmwDo2LYZAKFhEQCULVWMK6d30aNzW65cv0Ol2q3xibVHz6oIUZ5nSYr2SdX253z8At8navXp0r0p+MRgvfQVdZ/qM8iqNCNzVWZkrsoMcSiH9tGXaB1+TgdZLipckKG/+iVaEilTpvfHXtODGL+bGDlWxKJgW5EcZTGRIAmC8MMolUoOHj9H6eKFMTD4mIQkJSXTd+h4ytVowb5DJ6ldvRLnjmxlx/p/KVQgb4o2TIwN+XfmaMxMjVmxfhfa2lrfvE6WUqkk2vcanqcHEu19ET2rwhg5id7s7BQXnwio7lR8LqOxSHHa2mw1+tjjpK+nGkgd+0kNoCYNVCUZLly6keLY0LAIlq7ZQaO6VSn+yS20zykUCvYdOkH5mi3ZtH0fhQvlp26tyoCqPM0HBvr6zJ02hh0b/iU6JpZJsxZjWag9oCTsxf6Mnj4AEZFRmL+f4j+xbxfmThyAlgwurz/P5p6r8N9wD6NLwcTve0byodfk9tBi/6gdPDhyl7w5HTi0fhZNSuQj+PEGNHXNsS7WW4yXywYi3RQE4Yd5+OQFz16+Zf7U4Ske37X/KNt2HaJS+VJMHD2IUiWKZtiOqYkRi2eOpu/waUilGt/04ZAY5UXQgzXEhzxBQ0sfq6JdMc1dXwxqzWZGBh8Sm9RjbjIaixRjYs6juKSPP8fGpWgPoHyZEujoaHPu0jUG9O6sfnzRyi1oakrp3yP9ZbJOnLnIpBmLePbiNYYG+gwb+Bf9e3ZCV0cHC3MTfP2DUh1Tr1ZVWjSpy75DJ3n4phsOloWJ8r6ERaG2GRYX/VC1+4NWjWvQqE4ljp6+yubdJ9hz+Jx6m56ROX4BYTSsXZE/W9ejbAlXAHyvTvnlF07+3WWYID19/prZi9cRExPH3o0LCAgK4fL1e7RuWudHxScIwv+R7fuO4+xkT9mSRdSPKZVKlq/ZiqGBPlvXLlSv6P4l5mYmrF74D9ExsV8dhyw+DO+L41Akx2LiXBuLQu3EoNYfxMrCDB0dbW4/eJbm9jTHIpmY8LpGbSJ2HEUuVyCVanDnoWpNMkcHG/Vuenq6lC9Tgus37xMfn4Ceni6+/kGcvnCDMUP/SvO9FR+fwPBxM9iy8wD6eroM7tuVAb07Y2H+cQkcJ0c7vHz804x37LB+HDhymiUrN7Fyehd8r0wi9NlubEumXSFeqVQSFR2DsZFhisd1dbRp2ag6LRtVx9s3kOCwCKbNWcqFS9e5e/Egzjnt1ftGep4lLugBxjlrYGBbIs3zCN8vw69KcxavZ9LIfuqucGtLc46cupjRIYIgCGny8Qvk8vV7/NG8fooBtJeu3eLps5d0aNss08nRB0aGBl89o1apVBJ4fwWK5Bjsyv6NTYk+Ijn6gfT0dGhStxL3Hr3gyfM3qbanNRZJw9ER7bx5USiUREZFo1Qq2bTrOIYGejSoWSHFvtUrlyMhMZGrN+4C4OsXCKS9CHtERBQtOvRWz5S8e/kwE8cMTpEcQcYJkkvunJQtXYxzF6+hYZQfPcvCRL07T1K0b5r7xyckIpPJ06x+/UEOBxtKFMmPr483DnaWKZKj5PhQgh+vR6prjlWRrF1eR0gpwwQpKSkZZ6ePL4xEIiExMTnbgxIE4f/PrgMnMTE2pG7NlIuo7tx7BICeXdK//ZGVIt+eIjbgDkY5KmPkUOHLBwhZ7s/W9QHY+r6Wz+dSjEUyMUG7dy/M31dPDwuP5N6jFzz38KR8qcIYfnKLDaBx/ZoAbNl5AFAN4gZVz9XnhoyewvVb9+nfqxO7Ny/FLp1kO6ejHV6+ASgUijS3N6hdjbj4BC5fu42lawdAge+1aUT7Xku18kNUdIzqaX3hy0BcfDwvX3lS1FU1ZkqpkBMf5kHgncUokuOwKd5b3FrLZhkmSDkcbLl19zESCcTGxrFwxeYUCZMgCEJmREXHcuTkRVo0qpVinUWFQsGZ81cpmN8Fl9ypZ7VltfjQ5wQ/WouWvg3Wbn9l+/mEtBUtlAc317zsPnSOa7cepdr+aS+ShqMjUhcXzM1UA/F9/YMYM205AN7e3iQmJaU4NncuJ6pXKceRE+cICAwmKDgUczOTVDPXbt19yP7Dp6hXuypTx/+dqizAp5wc7UhMTCLofbL1ufp1VAP7j5++gJ5FfqyKdkWWGIH/zbl4XxhFXMjHKuGRUaoEKaMeJAD3Zx5IUNCsnB4+V6fy6sifeF8YSVzwI4xz1sDQ7svL9AjfJ8MEacTArmzbe4zXb32o27oPbzx9Gdavc0aHCIIgpHLo+HlkcjktG6dc+PXR0xcEBYdSu3rlbD2/Uqkk4vVxfC5PADSwKzsMqbbhF48Tss/sCf3Q09Wh17BZ3Lj7JNV27d69QFNT9X/A3NQEhULJ1IUbefHaC0N9LaJjYli2dgf3Hz/H2zeA+ATVjLZuf7ZBJpOxdtMuAoNDsbFKWThSLpcz+p/ZaGpqMmXc0C/G6uRoB4CXd9q32fLkdiZfnlycOH0RpVKJWZ7G5KqzDNPc9UmIeIPPpfEEPVTVAfzQg/T5GKRPKZVyPJ9dYsVAe4qaPyc++BG6prkxL9Aax0oTsSnR54sxC98vw0HaFuamLJw+Uv2m09NNPS1TEAQhIzKZjF0HT1K3RkX1bZIPTp+7DEDtGpWy7/zxYQQ9WkeM7zW09G2wK/s3umYu2XY+IXPy58nJ6gWj6TFkOn/2nUTXdg3p2Kqeunik1MUFnWlTkbq4EB+fyOFTlwmLSiAwzIfihfOgVCRRt3oFNu08zK4Dp9Ttli/txuyJQ3DJ5cSCpeuoWaMquZ1T9k6uWLeNuw+e0PevjuR1cf5irHa2VmhqSnnn40+ZTyYYfKpOzcosWbkJ9+evcC2YF01dU6yL/YVpnkYE3PmXiNdH0bcqTFS0av/0epDiQp4SeG8FRfV8Ibceuo51cCzRFQ3NzC/GK2SNDBOkk+euUq5UUUyMjZi3dCPXbj1gcO+OVC5f8kfFJwjCb+7E2asEh4SnWZn/9LkrGBkaUK50sSw/rywhnLCX+4l8cwqlIglD+7LYlOgvxm38QsqVLMzutdPpP2ouqzYfZPWWQ1StUJzK5YphZKhPYkISr0/cZN/RC0RFx6KhIaFaBTc0UJDDIRd9urXlz7aNCQmNIDQsgqOnL3Hlxj00NTXZsmYBdZp24uSpsxgZGXLsxEn1eCD/gCBy5czBuBH9MxWnplSKg50N3r4B6e5To0p5lqzcxLmL13At+LF2l7ahHfZlh+N5djAB95aSpGyAhoYEA309FMnxyJOjkSfFokiKIdr3GpFvTyLR0GLHpTg8Qk3ZvLn3911k4ZtlmCCt33aQqhVK8fT5a954+jBiYDfmL9skEiRBEDLF2zeABSs2U6d6BVycc6TYFhoWzu17j2hUrwZaWqkrG38rhTyJUPftRLw5jlKehI5JLiwKtsXArrQopvcLKpjXmdO7/+Xa7cds3n2c0xdvc+HqvRT75MnlyN992nPx6k1src25dO2uelFZQwN9DA30cXayJzg0jONnrpCQkEjB/HnYvXkp7boNxdhIHxNjQyQSCRKJhBwO9kwdP1RdbDIzcmYwkw3Sr8EEoKlnjl2pwfjdmEVO+X5GNJLgeaovsrjUtZX0LF0J0q7B/D2DGTYo9ZIowo+TYYKUnJyMlpYW2/ceo0+3thQumAedNEq0C4IgpGX2v+uxMDNlxIAuqbadu3gdpVKZ5bfXwp7vJtzjIDomzu8TozIiMfrFaWhoUKmsG5XKuhEUEs47b3+iomPR1dXB0tyEfC5OSCQSnr/w4PL1u8jlctyK5E/VjoW5KaBazsTR3oZCBfJha+/AlDH9qVW13HfFaGdrxY07qQeUf6Cnp0uFsiW4dvOeugbTpwxsS+BQcRwvL8wmt1UcEg1NjJyqoqltjIa2IVItQzT1rTCwLcGW+SsBqFWtYlqnEn6QDBOkksUK0aBtXwrmy0XhgnnwDwhONYZAEAQhLQmJSTx48pxBvTqmWFbkg9PnrwBQu3rWJUhJMQGEexxE2zgnTtXnINGQZlnbwo9hbWmGtWXqKfkAtaqVQyrVoEaVsql6JOHjVP7Q9wlSUHAokDWLGVtbmhMUHIpSqUw34a5RpQLnL93g+q171KiauoSEvlURjnpXwdPLl9ULJ6Z7rrMXrmJsbESp4mmPdxJ+jAwTpFGDutOyce2PU/slEvr/1f5HxCUIwm8gNi4ebS0ttLQ+/ikJi4jEPyAYmUyOTCanSKG8qY6Ty+WcvXCNIq75060987WUSiXBj9aiVMiwdusukqP/QzWrlKVmlbLpbrd8nyAFv183LfB9gmT92Sy2b2FtaU58QiKxcfEYppHwA1SvUh6Ac5eup5kgAURFxWQ4xT8sPIJ7D5/SqF4NNDXFamA/U4ZXX0NDAyNDfY6dvoxEIqFMicLkyZU6axcE4b+p+8B/iI2Lp33L+jRtUANdHW1GTlzIy9eetGtRHz1dHVzS+Jtx5/5jQsPC6dy+RZbFEu1zhdiAuxjlqIK+VeEsa1f4fRjo66Gjo01IaATrtu7n2q0HSKVSLN4vDPs9rN4nWUHBYekmSK4F82JtZcG5i9dhfNrtREXHYGuTfo/Whcs3UCgU4vbaLyDDOkjXbj2g55BJPHr6kodPXtJryGSu3374o2ITBOEXJpcr8PENwMTYkKVrd9L8z8GMnbqYJ888kMlkbN93nIL5cqMpTd2Ts+fAcQCaNKydNbEkRhH8cC1SbWOsi3bLkjaF349EIsHS3JSgkDC27DqCl48/RQrmQSr9/gWIrS3fJ0jpFIv8cP7qVcrj/twD/4DUA7Ah9UK1nztz4SoANaqJKu8/W4Y9SKs37WXl/H9wsFN1gfv6BzFu2mLKl3b7IcEJgvDrioyORq5Q0LNTK/Llycm2Pcc4dOICTepVIyIymkvX76Z5e00mk3HgyCnyujjjVrhAlsQS9Gg98qQobEsPRqpjnCVtCr8nKwszHj19QXxCIoumj0y3btHXsjQ3RSKRpJkgeXr5YmlhhqGBPjWqlGfn3iOcv3yD9q2bpNo3rYVqP1AqlZy7eJ0C+XLjaG+bJXEL3y7DtDpZJlMnRwAOdtYky2TZHpQgCL++0NAIACzMTbC1tmRo304c37WMEQO70bheNYA0E6RLV28RHBJGq2b1s2R2WWzAPaK9L2JgWxIjx+ytyC38+izMTXF/oVoEN4+LU5a1q6WlibmZMcGfJUhKpZI+w6ay68BJ4OM4pM3b95GcnJxqX1UPUtoJ0p17jwkIDE53/JLwY2WYIDnYWbNj3wlkMhkyuZyd+0/gkEUDKgVB+L2FhkcCYP7J+A49XV2kUg0qli3GnEl/U65Uyt7mW3cf0nfoBCQSCa2a1v/uGBTJ8QTeX4GGph7WxXqJ6fwClhZmKJVKLC3MMDfN2lnXqplsKROkwOBQIiKjCQz6MCDcgu6d2nD91n1GTpiVYrHaxMQkkpKT002QVm/YDkCHNs2yNG7h22SYIA3v34Vrtx5QvWl3ajTtzrVbDxieRj0TQRD+e0LDIwCwSKP0h0QioVK54uqxH0qlkvVbdtOwVTciI6NZvXjGdy1Oq1TKifG/g+/1acjiQ7B07YiW/vdP5RZ+f5YWpgDky8Leow+sLM1T3WJ79cYb+PiFAWDmpBFUrVSWdZt3s3LdNvXjEe/XGUlrDFJAYDD7j5yicoXSKSpxCz9PhmOQLC3M+HfmKLEWmyAIqYSGRWBkaJBqlfTPJSQkMnzcDDbv2E9OJwe2rFlAkUKpi/xlhiwxksg3J4n0PIMsPgTQwNipOia5635Te8L/H8v3xSLzfkcCnh5rS3PuPXqW4rFXb70A1fT8D7S0tNi4Yi61mnRkzKS5uOTKSe0alQgIDAHAxsoiRRvx8QkMHTON5GQZvbqJUjq/ijR7kGJj41L8p5ArUMgVRMfEsnTNjh8doyAIv6DQsEgszL98C2PCtAVs3rGfGlXLc+Ho9m9OjuRJsXhfGEPosx0olQrMC7QhV73l2JYagETy/bOUhP8PH2oh5cmd9T1I1pbmqcYgvXqjSpBCwyJTPG5qaszODYsxMTaiW98RuD/3wC8gGAA724+9nWHhETRv34tjJ8/Tsmk96teumuVxC98mzR6k2i17IZHAJ7dOAZBIoGqFUj8iLkEQfnFh4ZHqpR3SExcfz449h3EtmI/dm5YiTWPKf2YolUoC7iwiOdYfS9eOmOVtKgpBCmnKmzsnZUsWoYRbwSxv29rKnOiYOJ48e0XhgnkAePXWGx0dbcIiIlEoFGhofEzWXXLnZPPq+TRr14sR42fSvGlDzEyN1XdjPL18aP1nPzxee9K/Vycmjx2S4njh50ozQbp2YvOPjkMQhN9MaHgEVhYZVyg+cvwcUdExdGzb7JuTI4Cod2eJDbiDUY6qmOVrLgZjC+kyMTZk4fSR2dJ2CbdCONhZ89fgiRTK70LzhjXw9vWnbMmiXL/9kOiYWEyMjVIcU6l8KerVqsKxUxcoUqQw9rZWALg/96BZu14Eh4QxY+II+vTokC0xC98uw1T1/uPnJCQkqn8OCgkThSIFQQBUY5DSGqD9qa27DqKlpUmbFg2++TyyhHCCH29EqmuGdbEeIjkSfhorCzN2rp3L7ElDMTLUZ9r81SgUSsqUUNVa+vw22wdNGtRCoVBw9/5jdYI0dvJcQsMi2LBirkiOflEZJkj/rtya4mcTY0PWbtmXrQEJgvB7UI1BMk13e1BwKJeu3qJuzSpYmKe9+OiXKJUKAu4uQZEci7XbX0i10q9ALAg/glSqQeVyJVg4fSTbV89m9JAeVCxbDICQsIg0j6lTszJaWpq8ev0GOxsrXr56y/lLN2hcvyZNG9b6ccELXyXDWWxJScno6uqof9bR1iYuLiHbgxIE4deW8H7Rzv+1d9fRUR5rAId/u0k27q6EJAR3d2lxKLRY0VKKW2lxK1AohQIFChf34i5FihZ3awIBQgjE3XWzcv9YEggJECBC6Dzn3HPhk/nmm4bdNyPvvGmS9uG/T6NWq+nwntuJKNLiiHm0j5Tw25i4NMXYsc77VlcQCoSriwOuLg5ZIy0vr2R7mZmpCY3r1+bkPxdRKZWsXq/JdzTw2+6FVVXhPbwxQCpZwpG1m/fRp1t7JBLYuucIDvYiUaQg/NflliTyVYeOnkIm06Hl543yXK5apSA57Cbxz86QHHYT1EpkJs7YVOn/oVUWhAKjp6eLoYH+a4fYAL7p1ZmT/1xk3qLlxCckUqlCGerWqlqItRTe1RsDpB+H9uHneSto1vE7ACqXL81P4wYXSsUEQfh4ZQ4lvK4HKS4ugXMXr9OsUd3XZg1+mVqlJPr+NuKfnUSZngBIMbCtjGmJphja10KqJcvH2gtC/rO0MM2WLPJVtjY22NjaEREeRtXK5Vm//Dcxn+4j98YAycLclEWzx4tEkYIgZBMSqtmp3N7WOtfzu/YfQaFQ0K51szyVlxDwDzGP9qJjZI+5xxcYuzRGR9/y7TcKwkfCwtzstUNsAKFhkVhZW7N1zXwqliuNrq4I+j92bwyQMonASBCElwUEh2JlaY6Bfs7PBoVCwZKVG7EwN6NTh1ZvLUutUhLzcA9SHUNcms5DS8egIKosCAXK0tz0jUNsfk8DcXKwo0bVioVYK+FDiIxUgiC8lVqtJjk5hYjIaFQqFUHB4Tg72uZ67f6/ThAQGMLAb7tjaPD2YCcx6DwZyWGYe7QXwZFQbFlamBEVE/va894+jylfxqMQayR8qFx7kJav20HPLu1y3VBPEIRPX2BwGLN/X01MXDyJiSkkJCahVKkA+GFIbwKDwyjt4ZrjvpTUVGb+tgRDA30Gfvv1W5+jViuJfrAbqbYBZu5t8/s1BKHQ2OSykW2mtHQ5j/ye0bZFw0KulfAhcg2QMhRKeg2eQNvmjejeqY0IlAThP+b2vz7cvfeIr79qjYmxISbGRpgYGbJ931Gu3PiXwJAwPm+cfdm9Wq3m1/nLeRYQzC/TxrxxhVumxKBLZCSFYFG6M1oy8TkjFF+21pakpKSRlJyCkWH2ntCHj5+iVCqpIHqQipVcA6SRA3vQt3sH9v51kv7fT+PzxnUo61ky63zDutULrYKCILyftHQ5R09d4u8zV4mJTSA1LZ2g4DDq1KjAmGG9cXd1fO29EVExWFqYMXJg9p3Fg0LDWbdlHxkZCpyd7ABNYHTs5FnmL17NzTveVK5YlkF5yO+iUsqJ9tmBRFsPc4/2H/ayglDEbKw12+6ER0bnCJDu+TxGV1eGewFsoCsUnNdO0jYxNqRdi0bExSey/8hp7nprPkwlEokIkAThIxYRFcu6rYfYeeAUMXEJSKVSzEyMkEgkxCUkc/T0VY6evoqdjTkONuZoSaFdy8Z88/UXL5URg7VlzuzXVSuVJWPDLgCcHew4fuo8s+Yt5V/vB8hkOvT/phtjvx+Itvbb13/E+OwkIykEq/I90dI1fuv1gvAxs7PRrLoMj4jG3dU52zlvH1/Kerqh/QH7EQqFL9dPscDgMP7ceYhrN73p9mVL9m5cmC2jtiAIH6d7D/3p9/0swiNjcHW2Z+i3X9G5fTPMTI05evICM35bTqUKZbh59xHhkXGERcTiYGPOxau3swVIkVGxWb8Rv6ycpxu6ujLk8gwCg4Lp1ncEerq6DOnfi5GDv8HeLm+JZFOi7hPjux9dMzfMS3XIt/cXhKJiaWGOllRKeGR0tuMZGQpu3LlPp/ZiS5HiJtcAaeiYWfTo3IYfh/QRgZEgFBMPHz/j64FTSE+XM3/6CL5q2wSp9MVC1XNRT7C2NGfV71MBCI+MYfiE+Vy/40O6XI5arc5KXBcRFUO1SmVzPENHR5uKZUvxLDCYHybMQlcm4+yx7Xh6lMxxbW7UajXpcU8IvfIbEi0ZdjVGIpHmKduIIHzUtLSkWFuZEx6RPUC6cvNfEpOS+byJ2CqnuMl1mf+u9Qvo/EULYuLiUavVhV0nQRDeUUJiMt+OnEVampy1iybTuX2zbMGRV2IY661DMCprl3XM1tqCP5dNp7S7M9Fxyazb+lfWucioGGyscvYgAfTs0pa05ESePA1gyvjheQqO5IkhRPvs5NnJUQScGYtSnoB9jVHomog5GcKnw8bakvDI7CvZTpy5hHtJ5xzDbsLHL9df3e7ee8SkmYuRyXTQ05Wx8JdxuLq8fkKnIAhFa9eh04SERzFj3ADKlS7J+m1/ERQaQXJyKvr6ehzNeIa6jBYPqmZfKaanK2Pi933oN2o2y9bvpnfXViiVShKTUrC2yjkHCeDY8dNcu3mHju1aMLR/rzfWS61WEXFnFfH+xwHQkplgWrIlJiWaom/hmT8vLwgfCVtrCyJeGmJLSU3j3OVb9OvZsegqJby3XAOklRt2svCXcVQq78nJs1dYtXE3s6d+/14PCA2L5OsB41g4ayxurs5Mnb2UmNh4WjdvQK8u7QDYf+Q0uw4cx8jQgJkTh2FjLbYYEIS8UqlUbN51FCNDfW7efcAvC9cjz1DkuE5PCrHlLNhsfJaejRtlDae5uzphqKdNdGwCx89co1I5N4Bce5AO/32GRcvWU7NaJVYsmpWtl+pVarU6KzjSt6qARemvMLCuiEQqJqoKnyZbayvuP3yS9ffzl2+Rni6neeO6RVgr4X3l+ukWG5dApfKa3+4+b1yHwODw937A/9Zux9lR062/bss+GtevwcZlszh68gIBQaHExMbz545DrF08g85fNOd/a3e897MEoTgKCgknMSn5ve+/cPUu/gGhJCWncvDv81Sp6Mkfs3/k4l+ruHvmT8rMbU1631KoSpmCdwxTRi/ix58WI8/IADT5W/T1dNDW0mLTriNERmmyAVs/D5CiomP4c/s+uvf7nn5Dx2FhbsaGFfPfOj8xMfAc8f7HMbCpjGP9KRjaVhHBkfBJs7HWJItUPU+qevzMJSqWK4W9Xe57Fgoft1x7kIxf2X1bqvV+Ow7f8XqASqXKyrh76dodvmjdFG1tzUTPy9fvYmJshKe7K3p6ulSpWIZ5S9a/17MEoThKTEqm+4BxKJUqPNxcqFqxNFUrlqVBnap5WiqvVquZ9bvm30w5GzN+a10bT2tTiAmCf4IIT0/iszBv6ikVUN6AhBIybnglsu/IWaJ9HrJq/gT0XEtga2WOmZmEa7fuExwWgUqlYve+Ixw/fY4r1++gVqvR0tKibq2q/DRhJI4OuW8zkkmeHEbEndVo6ZphX/MHpFpiY07h02dnY0lGhoLYuAS0tLS4etOLUYPfPAwtfLxy/QQOCArlm2GTs/7+LDD73zf+75e3FqxUqli2bgczxg9lzea9AMTExuP0/IPVxcmeqOg4MjIUuDxPOGdlYYZSpSItXY7eKzsd7z54gj2HTgCIiePAs8AQwiKiqV393Tc+zJxjki7PwNjIAH093azhFqFwPXkWjEKhpH/vToSGRXDx6h127j/O5B8H0K5l47fev3Dldh49CQRgmSwe62OHyHjpvAUw9JV7lGqYpqfFPv8wpi3bxtzfJmBna01QmGbuxLOgUCLCQ5kxZzEG+nq0a9WMti2b0uKzhnnKjq3MSCbk0q+oFKk41voRLV2TvDWGIBRzTg6a7zI//0CCQiNAraZZo1pFXCvhfeUaIP0+a+wHF3z4xDlqVauQrWtRIpHA8+BGpVYhkUpAkj3gUavU5PZd3fmL5nT+ojmg2S28Ydu+H1zH4mzb3qNcvenFvk2L8nS9Wq3mxh0f/tx1jGOnL2ebo+Jga0X3r1rQrePn2LxmYq5QMJ4+C0YqldC7aztkMh0AOvb6nqCQtw9rR8XEsXz9XkxNjIhPSMLQrSQ8fPDW+7QkMN1ESZCeITtOXWWAfyDWVmZ4P3wKwD/nrhAbE0O7Vs1YveRX9PX18vw+yvREgi/PRp4YiFXFbzC0q5bnewWhuHN1ccDW2pILV2/j+ySAmtUqYGFmWtTVEt5TrgFSbvlPEpOSMTTQf+OkzJedvXid6Jh4rtz4l+DQCO4/9CMlNY2gkHA83FwIDArDw80FE2NDvH0eAxAZHYuOjg66MtEd/zZR0XFEREajUCjeOhRz7vIdZi/awIPHzwCoVbUc7q6O6MpkJCQlc+m6FwuWb2Xxqh20bV6f6WO/w9xM/Nb/rpJTUgkOjcDe1gpjo7ztK+YfEIyjvW1WcARgb2tFaHjUW+/dsf8UGQoF1SqV5syFmyR07orB0sUQH//We+MMtNFpVw7W3WLK7GVcvXyRdLUuMj0jTp0+i76eHovmTs1TcKRSpJIS4UVy+G2SQq+hTIvF3PNLzD2+eOu9gvApkUgkNKhTjRP/XCYuPpGfxg4u6ioJHyDXb9bzl29iaKBPtcrlAFi0YjO7DvyNqYkx82b8SPk8bLi3YOaLXqiZ81fStnlDzl2+xW2vB7i6OODt85je3dpjaKDPqo27SUtL5/a/D6hXq0r+vNknLiY2DpVKTVhEdNawZW627zvB5F9XoKcro2+3tvTq0hKPktnzcWRkKDh1/jobdxzhwLFzePk8ZuPSaTg75C0r8n+dSqVi0/ZDbNl9mKTkFLSkUjYs+yVHO+fmaUAwJV9JoWFna01IWMQb71MqlWzd8zfWluZ0bNWIMxdu8vejIL51ckKVhwDJz9KAs64StKRKLt+4jzw9A11jC2TaEpydHencsQ1WlrnnQcqqgzyJ8FvLSA67gVql6ZHUMbTFssogzNxavrUOgvApali3GnsOnUAm06FRvcLdluvUuaus2rgLbW1t3F2dGT2sD6YmxtRr1Rt3V2cSk5Ip4WzPxB/6s2n7IcqWdqP986H8Kb8sofXnDahfu+pryz98/Bw+j/wZM/ybwnqlIpVrd9CmHX9l5T26e+8Rx89cYvuaecyYMJSFy/9874d926Mj5y/f4puhU2jXshFODraYm5nQt0dHvvt+Gvv+OsnQ77q9d/n/JVExcQCEhOb8Il2+bgenz1/jr+MXmTBrGY521hzaPJ/p4/pn+9K+FBsAaLIjt2pWl20rZzJ9bH/8A0LpM2w6MbEJhfIuxUm6XM7Bo2dQKJUApKalMXHmYlZt2k27lo1YsWAqMpkOV67fzVN5/s+CcXVxyHbMztaS0PDIN97n/eAJwWGRdG7flNaf18Xa0pwte/5Ga+AAMH1zl36UvjYzmrmTYaCNViNnJFIpbdq2BYmEAb2/xMTMgqqVyr2xjLRYPwLPTSUp5Ar6luWwrtQP1+ZLcW2xTARHwn9atUplMTTQp37tqhga6Bfac9Plcn77Yz3L5k1hy8o5tGneMKtnWk9Xxp8rZrN300Ia1KnGsrU7NNuIHTqJWq0mKjqWp4Eh1K1ZudDqWxzk2oOUmpaGhbnmQ3b7nqN8/VUrnB3tcHa0Y8H/Nr3zQ6aOGZT15z/mTMhxvn3LxllRrPB2KpUqK3gJyeWL9MiJ8zz2D+TQyWvYWJmzbeVMHO2zLzP1Sgyjy93tHKv+DRWNX/RA9f26LVKphJ/mrmbS7OWsmDe+YF+mmLlx+x6/LlpLhkJBo3o1GDftd54FhjB3+g80rKOZb1OpvCc37tyjV9d2bywrOTmFiKgYSpbI3oNkb2udtYBBRyf34dPoGE0vUUkXe7S1tOj+5ef8sWYXpwOjqGFng/4bepH8LA3wsdWsVJWVtiL9nxC8fZ5o5v6pFahUalyd7UmP80eRHocyLQ5FejzK9DgUabGkxz1FnqiZGG5VvhcWpb/KU9sJwqcsLS2dZ4EhAIwc2ANLSzMe+vrn6zNKODu8Nr2GIkNBWno6KalpWAJ1alTKcY1UKqV65XL8ffoiJZwdsLQww9vnMdduedP5i+bZptAolSqWr9/Bpat30NWVZfseB00SzLmL1/HYPwATYyMm/dAfZ0c7rt3yZv7SDUgkEjq0bkqPzm0ICApl1oJVxCckUrt6JX4Y0rtYLAzK9dNXKpHwyO8ZCYlJ3Lx7jwmj+gGaydEvz5UQikZcQiLK5z0Yr/YgKRQKomPjueXli1yewezJQ3IERwCTfE+SoVYx2fcEB6tlX4bap2sbzly4xfF/rhEUGoGTvRhqyxQRpdlGYNXGPWzafgg1apYvmJqVygKgeuVyrN+6PyvAUavVBIdGcNvrAVpSKW2aNwTg6fMP01eH2OxtrVCr1YRHvhg+vffAj6MnL5CUnExiUgp+TzX3ymQ69P9+GiVLOGFkqM/4mcuo2qccMwL8sUrNmSwys/coUzxy9IDwqFjcHI1JCLhAp5pyDAMX8exR7sN82gbWmJRohpl7G/TM3N6vIQXhE/MsMIS+w6cW6DM2LJ1J6VK5b+1jaGjA8P7d+W7kNNq1bEyfbu0xMzXOdo1SqeLv0xcpV1rzGdD9q9bsPniCJ0+DWL14erZrD584R0BgKJtWzCY1NQ09XV18Hr1Igrlh637MzUzYsnIOF67cZub8laxaOI2d+/9m8LddaVS3GnHxiQDM/n01Y4b3pZSbC7MXruHeAz8qlH37VJ2ilvtmtd99zdAxs5BnZDDh++8wNdE08o59f1O72rsvKxfyV3R0HAAGBnqEhGXvQYqKiUOlUhEYEoWTgw1N6+dcReSVGMbjFM2S7hthz9h9+wqdq2bfSLFPt9acuXiTbXuPM3aYyOORKTIqFmMjQxRKBWZmlsybMTpHxunqVcqxbN0Otu45zJXrd7h525uo6GjS09JBAnv+XEqdmlV5GqAJclyc7bPuVavVWateQsMjswKknfv/5uLV23h6lMDY0BCZTPNP9/6DJ/g88sfnkT89OzVn9ea/+GfDbU466vF1alKO+r/ce4RChc4pTR0cbCQs7Z2IdmbOM2Ua5qW+QMfIAW1dM7T0TDX/r2uGVFtsYC0Iryrh7MCGpTML/Blv0qVDC+rVqsL6rfvpPWQSi2ePx83VibR0OX2GTEKlVlOhjAfDB3QHoFrlsixetYUGdavmSK1z5ca/fNX+c7S1tHJddHL99r2suUh1albi53nLSU5JpXmTuvy54xBSiYTG9WuQnJKKzyN/Zs1fCUBaupx6xWQoL9cAqU6NShzduRyFUoG+3otVLNWrlMP1Lf+BhIIXHasZPqlQxiPHZN6IyBjS5EoUShXdOnyGllbOzMWTfE8SnZEKgEJfiwVR1+lM9gCpcd2quDjasn3fCX4Y1B1tbZEBGTQrLZ0d7Zg7bRTGxoa5rrgs5V6C9LQUxkycRUaGPOu4TCZDnpFB66++5bs+XfHw8EAqgRGjp/M0IIjwyGgiI6NJS0/H0NCIm3fuUbNqBQDiExKpVb0is6eMBMD7gR/teo5h16FTSBQpONpbs3XHPho0r8W5k7eY+VDNWQMZPWUZ1JOpkUogSirhXHU7ekUG4nstkcc3k0lN0GT8HdijNOHIOHTqISY2HkybOg2JVPQWC0Je6enpvrZ3pzA52tswZfRA/li5hWOnLzK0Xzf0dGVsWj47x7USiYRSbi6UciuR45wm5c7rh8E06Xlynm/ZrB7VKpdl1cbdHDt9kamjB2JgoMfGZb8Ui2G1l712fbiOjnaO+Q9lPoL/+AJEP5+gXaFsKXYfPJHtXERUDAqF5kuvfOmc/728EsN4lJi91ymUVLwSw7PNRZJKpTRtUJ2NO44QFROHnY3YHw9e7HJvZZl7vqiU1FR+mDCLJ35+GBjoM2xgP2pUrUj5MqWIS0jiu5FTMTOUsWbjiy117nl74WBng7W1JWVKuSGRSDh++jzTf1lAwzrVKF+2FHHxiTjYvRjqrFDGHSsLE6Ji4kmIDOTJEz8A4vbHUbVKJWR6Rpy/+5BzKTrYS9U4aamRyiDur6c8DgOlCmwsTVBoJ1OudEn69v6Vqze9uLxmLp3KlhLBkSAUM4/8nuF935eObZuhUquJjI6lai4pe/KqWuWyHDhymhpVypOWno5cnvE8b6Hm+6Vm1QqcPHuZ8mXcuXrjX0o4O2BooI/XfV8qlPVgSL+ufP3dWAwNDXCws+HIyfO0bd6I8IhobKwtikWw9Pa9DISPTlRMHCbGRpRwtichMYmk5BSMDA0ATQ+H6nnizZTU1Bz3Tnp0klhVerZjKdq5z0UyNdEMxcQnJH1yAZJarebIyfNYW5hT6x2ykUdGxVK9Su4rvBISk+jWdwSXr96i5eeNWPb7z1havAikAoJC0dXV47dZE3js588fKzYRF5/AljW/U7Vy+WxlfdFjKBcuXKZzryEcP/gn8QmJmJpm3wKocZ1K7DlyASNTC3au/plbp9fgYhSGhXEAJoZaJJZXc/IvFaeTpTxSSkhPl2CSZkD92p707NSKgKAwflm0gd5dWgPg6a75LdLtlUnjgiB8/Jwdbfnr77P0GTqZtLR0alQpzxet3n/xU8c2zfB/FkzPQRMwNjLghyG9KVvKjQ1bDxCfkEjfHh2Yu3gtPQdNwMTIkKljBqFWq7l0/Q7z/7eBpKQUBn+rWZX+09hB/LpwDVt3H8HS3IzZU0dmfWd9zESAVAxFx8RhZWGWlYrh7KUbtG3eCIDIyBiMjQxJSYsnODR7T5FXYhgPknKfePs4JSZHL5Jcrtm0Qlf300rcqVKpWLJ6K9v3HqOsZ8l3CpAiomKwfqX3KCw8kuOnzvPbopUEhYQxdEAvfvlpTI7fkDJXhsbFJ/F15/bcvf+E1LS0HMERQI2qlUhLTefa9Rt06jmEdAV4e1uyccseVGoVGRkKDh0+glKph0zPmKDry/i8TDIqqQUpSkOiU1XE6GfQ0yaKHxMzCNSX4L5lMzp6ZgDce+jPjz8twtLchHbN6wNgbmbCotnjqVS+1Ls0pyAIHwF9PT1+HNon13OnD6x97X2vrk7LpKOjzbiR3+Y4vmv9gqw//zxxeI7zg77pwqBvumQ7VsLZgRW///TaOnysRIBUDEXFxGFpYYanewlaNK3HouWbqVG5PLY2lkRExWBuZkx4VDy+TwKy3TfJ9yTxKnnuZWak5OhFCggKA/iksmrL5RnMWrCKk2evULt6Ra7f9s7WA/cmqWlpJCWnYGNtwaWrt9j/13HOXbzKg+crO8xMTZg3ayL9v+mWa/exoYE+Mh0dYuM1KRoSEpOwtDDL9VmlPVw5dfYqM6f8yNRZvwPw51N//ty2J+samUyHeWMbMPfPf5m6NYkFY9vSqv03SLVeDI8pW/qRNGIk5ys3oczz4Oi21yP6//ALGRkK1v8xNduy4ffZ208QBOFTJAKkYigmJg775/NRRg/7httePsxasIrFv44nIiqGcp4lePA4iGu3fbLu8UoM43Fy9BvLfbkXKSomjhNnr1OnegVMjfO2bcbHLjk5hQk/L+buvYfMmjyC0h6udO77I7e9HmTlMMqUkaHAPyAY3yfP8HsSyLOgEJo20Gw6GRYWztfjf0atVmNva023Tu1o3KA2bZo3wewNwaREIsHczISY55Ps4xOTKFnCKddry3i6Ic/IoFXzJpRwcWTiz4sZ1LcLFcp6IJVKkQDOsnsogg8zp681U7cmM2LOUb64nUSvLq2oVrE0EokELXd3EkaNpmP1qtx76M/m3cfYe/gfJMCy38ZRq+qbE0IKgiD8V4kAqRiKiomjYjlPAEyMDZkyehDfT5zD7oMniIyOpVqlsjjaPSQwJIqIqFhsrMw1K9cUOeckZSv3pV6kzH2+endpVRivVChmL1yDz6MnLJo9nmqVyqJWq7GzseTW3fs0rFMNr/u+7P3rJL5PAngaEJKVa8rR3oaUlDQe+D5FpVLx+5I16Mpk/LVrDdWrVnynyYYW5ibExr3oQcqc5/UqT3cXpFIJPr7+lCldChNTU5o3a4CHkwlJIZdJDLxAWqQvuqYladN6MuWapzBp9nL2HTnLviNnKVe6JNUqlsbIUJ+U1DS8tx3n1r8PAahY1p2ZEwZSpYLnB7aoIAjCp0sESMWMSqXSzIOxejEPpla1CnTp0IL/rd2OUqHE2sqchnUqsn3/GZau3UWXoV/wKOntm58CXAvxZ9aDzRzaeRprS3NaNKldUK9S6B75PaNDm6ZZmzFLJBKqVirLzbs+qNVqfp63ArVaTc2qFfiq7Wd4uLngXtIZQwN9tu4+wpLVW4mJjiIyIpyZU36kRrWcmWrfxtzM9EUPUkISJq/pndPX08PV2ZEHj/yxs7GimqsCnadL8fd+qqm7li4mrp9jU6kfUm09PEpasHP1Lzx8/Cyrl+j+wxdZfHV1ZXRu34zeXVpRWcwxEgRBeCsRIBUzUdGxZGQocHwlu/XQft24etOLgKBQbKwsaNmkLnv+OsumnUfZl+xLbNO8rUJTSSWs3PQXWpHptG5SHXmG/LXbXRQnmv2G4rB+ZQPW2tUrcfTkBfYfOU1QSDhL5k6kRpWck6Y/b1ybxSs3ExsTjZOjPYO/6/Fe9TA3M+FpQDBp6XLk8ozX9iABlPEsyQPfJ9Qro8Pw5nLUqWEYOzfEyKEuhrZVc03YWNqjBDMnDGLamP7EJSSSlJyKgb4eZqZGyHTE0n1BEIS8ynWzWuHjFfR8axFHe9tsx/X0dJk2bjDWVua4l3TG2tIUZXoCai01iYcfo3PwGaTk3HriZZKgZPSW3kcrMh0MVWzbsYsKtVpx5tzlAnufwpKckkpaejpWlmbZjn/WqBbOjnbMX7oBGyuLrN6lV9lYW2Kop41CoeD7IX3Rec9gw8LclNi4BBISNVmuTYzfECCVKomNlh9WiQdISZfg0nQe9jV/wNixzluzWWtra2lWOjrbY2NlLoIjQRCEd1T8uwb+Y0JCI5BIJNjbWeU4V660Owe3LEGtVjP4+8nEREVg6uGAobENyefCkF0Mp0zj8lRoXgkzBwu0dbRIT5GzZfkeZGFyEoPjAKjfuxETe3fl2pGLTJ6xgDm/r6Bpo7qF/KYfRp6RwdFTV9h18BSBweHEJySRmJTCguXbCY2I48s2jTEy1EdbW5vB33Zl8qw/aNmsXrbNGl+mUCgICQnB3MyEXt06vne9NJO0E0hI0ARIr+tBSo9/SkW901RulEaSXMaaC+Ys7ynyEwmCIBQWESAVM8GhEVhbmue6xUWmv0+d49zFazg6OtK7Yyd6dGpD+14/YGlpgc9pb3xOe+e4R6mlRbcOn9O7a2sqlNFsQFqhd1cuXrnJngPHCAgKwcXp499mJiU1jeXr97Jt33GiYuKRyXRwd3VEX1+XpOQUngWFM3XOSuYu2cRXbZsw/LsuNG1Qk1GDe9G8yeuDwAOHTxAWHsnkscPQ19d77XVvY2FmSlp6OuGRmhWFufUgpUTdI/jiL0iV6Vzy1WbPTX1MLT6tRJ2CIOS/bXuPsnXXYb7+qjU9u7QFIC4+kamzlxITG0/r5g3o1aXdG8t45PeMRSv+ZNm8KYVR5Y+aCJCKmeDQCBxemX/0MpVKxU+zFmJooE+LzxsTEBzKqfNXsTQz5PDW3/F7GsKRk5eIiY0nLV2OsZEBt+7ep7S7E3N/GpajvM4dW7PnwDH2HjjGqGH9CvLVPlhEVCzfjfoFLx8/nB1tmfh9B7q0/wwLcxOOnrzAz/NWcHjHMv4+fYVNu46yaedRTp27wYYlU+n25etX66nVapas3IS+nh7f9en6QXW0MNekAcjcqPblSdqK1BhifPcT/+RvJFJtHBvN5PSJzUTFB1DC1TjX8gRBEDJVq1iGx6/kv1u3ZR+N69egY5umfDNsCo3qVsfFyf41JQgvEwFSMRMSFpGVQTs35y9f59Fjf0YO7ksJV1d27v+boJBwmjSoib6eHhXKuGX1EGXavOsvVqzbydOAEFxdsvcSfda4PmamJuzY+xcjh/R97RBUUYtPTKbX0Gk88gtkZP8ujBr0dba6RkbHgKclFmYmdP+qBV9/2Zxdh04zadZyug+ayt71c3Bxssu17ItXbnLn3/t816crFuZmH1RPczNNNu2ngSFIJBKMDA3JSIki5tE+Ep6eRK3KQNe0JLZVB6NnUYrSpUri+yTgjZO5BUEoel9/O5KnzwILrHzXEs5sX//HG68pXaok9rbZp19cunaHL1o3RVtbm4plS3H5+t0cAVJEZDQzfltBYlJytl/Aff2e8ceqrcTGJ2BhZsqcaaM4cuI8sXEJDOjTCYDh42czfmQ/nB01n5+h4VH8vmwj4RHR6OjoMGfaKLzv+3L1phcTRn0HwKz5K/m8SV0qlffk14VreOT3DHtbK36eOJzk5BQWLNuEmakxCoWCH4d+w/yl63kWFIpCoWTmxOG4uTrh8+gJsxasIjY2geSUVCqWL8XSuZO4cOU2y9ZuR6lS8m2PjrT6rMF7t/nH+W0nvFZwaESOFWwv27xtPwB9enyJq4sDCYlJJCQm07/3V6+9p0uHFthYW7Jk9ZYc52QyHXp93RGfh37s3n/0g+tfUMZM+4NHfoFMGNmHH4f0yBHIeSdF8qSDHV6J4YBmiX/XLz5j6ZwxRMcm8N0Ps1EolLmWvXTVJiQSCUP798r1/LuwsdKsovO674uRoQHy2Ic8PT6c+CdHkZm44FB3Ii7N5qNnoVmKX/b5BtGmJqIHSRCEdxcTG4+Tg2ZRj4uTPVHRcTmuWbRyC00a1GTT8tm0/vxFQGFhbspP4wazecWvmJuZcObCNVo0rcc/F6+jVquJT0giJSUtKzgCzbzKEQN6sGn5bGpWLc/Bo2eoU7MSN+/eR61Wo1Kp8PLxpXrlcmzcdoBK5T3ZsXYeLZrWY/+RUwBcvn6Hls3qMX38UAwN9OndtT0b//cLXTu0ZOvuwwAsX7eTAX06cXDbEtxcnRg/sh9x8YksX7+DNX/M4M/lv7Jz/3EUijcvTnoT0YNUjCQnp+TY1f1loWERHDx6krq1q+Hh5oq2tmaeUt/uHV57D4CuTMbAbzox47cVuQZgY0YMYMuOA8z4dTHtWjfDQF8//14qHzz2D+TE2Wu0bFqbQX065nrNUcto1FqSHNuptGpWhyF9v2LZ+j2cuXiT5o1rZbvvrrcPx06cpW3Lpri7lfjgupoYG1K5vCd37z2ivJslIVd/A4kUh7qTMLSrniPpZBnP5wGSqehBEoSP2dt6d4qKRCKB5xuYq9QqJFIJ2/Yc4ejJCwCsWzqT2//6MG3cYADsba2z7rUwN+XaLW82bN3Pw8dPcXGyx8TYEHdXZ+4/fEJAUChNGtTI9jwDfT0Sk5JZtGIzd70f4l7SGX09PdxLOvPo8VMUSiXlSrujo6PNtVvepKfLOXTsH5RKVdZWR86O9tSsWgEALS0p2traLFu3A6/7vmg9/+XX0sKUuPhE0tPSSUlNRSKR4O3zmKjoOAb/+DMAic+/M61e2T8zr0SAVIwEh2k2n3VyyB7AJCQm8b9Vf/K/VZtIT5fT//k8GVcXB5bNn0LFcm9PDNiwTjW0tLS4cuMundo3z3bOzMyEcaMGMXH6byxbvZkxIwfk0xvlj827/gagf88vcs1q7ZUYRqyeEpDkuinvN93asHLTPv7cdSwrQEpJTWXh0nX8sWIDEomE74fm3LTxfX3WuA7/3n9I95rRKNNTsK89FiP7Grle61HSBV1dWY78TYIgCHlhYW5KUEg4Hm4uBAaF4eHmQpcOLejeqU3WNQqFktTU9ByLf7bvPYqXz2N6d22Hk4MtySma3Rjat2rMiX8uExkVw9Dvvs52z5nz19h98AQD+nSiYrlSXLp2B4CmDWpy4eptFEoljetrPu/UajUzJw/H3dU56/7QsMisIAjA2+cx85duYEi/bjSsU43l63cA0LBudVZv2s2u/cfp2PYznBxs8Q8Ipnrlssye+n2+tJ0YYitGwiM02bBtrTUrmlQqFcvWbKZq/XbMXbgCO1trNqyYx1dfvJhwXLViGbS1tN5atqGhAZXKl+Ly9X9zPf9dn664l3Rh0f/WZdXjY5CSmsaev85QxqMENarknsNoku9J5LqawClzO5WX2Vpb0LJJbc5dvo1/QAh/HTtN7aZfMW/xKtxdXTi0cw21qlfOtzo3aVCTL6opcDZLwcy9LcaOr189J5PpsGHpTNo0b5hvzxcE4b+jfu2q3PZ6gEKhwNvnMXVr5vwsK1fajQtXbgFkbb4NcOPOfVo1q4+nuyuP/V/Mr6peuRw+j56QmJSSY8Th5l0fGtWrTuUKpXns/2LCeL1aVbhx5z53/n1AneqaXQhqVq3A9r3HUKlUJKekkpCYnKNud70fUqViGWpXr4h/QHDW8dPnrjJl9CC2rJpD969aA1C+jDt3vB7y9Pl14RFv3n/0bUSA9JE6cOQM2/Zmn/MTFROHVCrJmui7ecd+Jk2fh56ujD9+m8aV03vp2K7FO+0N9rK6NSpz88590uXyHOdkMh1mTP6BpOQUOvUaytUbd97rGfnt4eMAEpNTaNei/mt7jx6nZP9HktmL9LL2LTUBSL9hk+nV/wfi4uKZPX0sZ49tp0Hd3Ht33odarUIdvJ+vamSQkGGCVYW3z2tydXFET/f1aR0EQRAio2PpM2QS+w6fZvveowwfPxuAb3t05PzlW3wzdArtWjbKmo/0su8H9WLngeP0GzGVoJAXn40d2zZj+fod/DjlN4wMDbKOS6VSypfxyBoSe1mrz+pz+Pg5ho37BdQvjhsbGWKgr4e5mQl6eppEt317dCA9XU6PgRMYMf5XgkPDc5TXqF51vH18GTBqBjEx8VnHPT1KMHbaAnoPnsTw8bPZtucIFmamTPpxAJNnLaHPkEls2nHw3RvyJRK5PF399ss+LgqFgoZt+3L+8Aa0tT+9UcJngSH0HjIJHR1tjuxYltXtuebPPRw4coZD25YC0KZTP27d8ebBrZOYmb5+F/m88vV7Rp+hk1k8ezy1cvnBV6vVzJ6/jEXL1pGRoeDrzu2ZMWkUtjY5k1YqM1KQJwYhTwhEnhiEMj0BLT1ztPUtMLAsi65ZyQ+uL8CZizf5duQs5kwZytdfNs9xvv2tzVyND8pxvI6pU7a5SFdv3aPbgCmkJkbRoVVDfp78A3YvjcXnl6j724l5sBM9izLY1RqDzEAMnQmCULykpcsZOmYW82eOxuL5L+yFrd+In1g2fwq6Mh18Hj1hzNQFHNm5LF+f8elFF5+AeUs3YGpsRFRMHJev36VJ/ZqApgcpc7JZUEgYl67epGO7FvkSHAF4uLlgZWnOlRv/5hogSSQSJo8dRtev2jLhp7ls332Iw8dOs2rJbFo3bwKAWpVB+K0VJASceeOzjBzrYld9OFLtD5vwLZVoOkHV6pxxfm69R5lenYt0/8FjAOrXqcGqP2Z/UJ1yo1Yrifc/QcyDneiaueHUcBpSrTdvFyIIgvCx8brvy/S5y+jT7YsiC44A6taszJDRM5FnZKArk/HT80nm+UkESB+Z5OQUbt65z+QfB7DzwHFO/nPlRYAUHYelhRkAew8cA6DLl21eV9Q7k0gk1KlRics37jJyUM9s59LjnxL/9BSqjGSMVBksGeFGWFdDvO75EHT1D2JKxCHVMSTh2SnSYh6RquVIcJIFTyMUePsnITOw4LfJ/clIiSDO7yhJwZcJyUjBoe6EDwoUzJ6v7gqPis1xbpLvSaIzUnO9L3MuUmYv0pHj/wDQpEHt965LbtRqNclhN4m69yfyhEC0dM1wqD1OBEeCIBRLFcuVYs/GhUVdDQb06ZSVi6mgiADpIxPyfKVayRKONG9ch7Vb9pGSmoaBvh7RMXGU9nAF4NjJcxgZGvB5k/r5+vy6NSvz199nCQ2Pwt7WCqU8mWif7cQ9OQpqVbZrjSRa1PLUQ0uqJsp7k+agREqIogyTVj3D2lKCq4sDUj1Drt6+j1TfFkNjRwxsqhBxZyXx/sd5cmQAJi6NMXX9DF1T13eub2mPEpibGnPg6FlG9u+Slf/oTb1HmTJ7kUrpmHHtzkMkWrp0av/ZO9fhddITgoi4s4LUqPtItGRYlO6EuWdHtHQM336zIAiCUKREgPSRCQ6LAMDBzgZzMxOWrdvBxau3ad6kLlExcdSzMEOpVHLX6z7VqlRANx8n78oTQ6jokEr7qgoCLi9AbqpEnhCEWpmGnkVprCv1Q9fEBYmWNiBFIpFw/tJ1en07kAnDO9Hrq2boW5Vn74rdlPbQYv3SmQBcvHqbm3fvExOXgI2VBRKJBJsqA5AZOxPvf5w4v8PE+R1G19wDc4/2GDvVRyLJ2/oBPV0ZXTt+zsqN+7h03YsGtTUrNN7Ue5Qpsxep4z19kMpwL2GHo33+zDtSpMcTfPFnFKkxmLo2x7JsN7T1xXwjQRCE4kKsYvvIhIRGoq+ni5mpMQ52NpQv487Jf66gVKqIjY3HytKMR4/9SU5JpVrl8vn23OgHu3l6YjixdxfTuZYcc9VDFClR6Fl4YFt9BM6Nf0HfohRSbV0kEq2sFWP1aldD38iS1TuuYuRQF21dU2JjE7L2HAOyhgVjYl+sQJBItDD3aEuJzxfh3ORXTEp8hjwhiLDrCwk8OxmlPOdyz9fp+ZVm5d7KTfs1WVrz0HuU6XFKDEt3HUQikTByQLc8P/NNlBkphF6djyI1Ctvqw7CtNkQER4IgCMWMCJA+MiFhkTjY22QFIJ81rsPlG3cJDg1HqVJhZWHGrbv3AKiaTwFSekIQ0T47kRk7YVt9OP/K2/DjNjNcWqzCueHPmJZo+toeHS0tLTq2a8GTpwHc9fIBIDo2LisVAWgSlQFEx8TluF8ikaBvURq76sNwa7US05ItSYt5SNCF6SjS43NcnxsXJzs6tm7E+St3mLt0MxMfnXhr71Gm2ItPiQlOwFBPh/YtG+XpnjfJSIki8OwkUqPuYebeFtMSTT+4TEEQBKHwiQDpIxMSFoHjS9uCfNaoNgqFkj2HTgKa3pjb+RggqdVKIm4vB7US2+rDMC3RjIo1Pic6Qc7dew/zVEan54kp9zyfOB4Tm4Cl+UsBkpmmNyk69s0Bj5auMTZVBmJRpivpcX4EnpmAPDEkT3WYPWkIVSt6snLjPrw3XoYM1ZtvUKnRPhOC7k5/VGYyug/r8MEb8WakRBF0fhryhACsKvTGulK/DypPEAQhryKiYhg/YyE9Boznm2GT8XuqSewYF5/IiPG/0nPgBDbv+uut5Tzye8bQsbMKurrFggiQPjLBoRE4vDQPxsbKgsrlPfnr+FkArJ4HSJYW5rg4OXzw82Ie7iM12gcz9zboW5QGwNO9BJYWply+fjdPZdSoVhFnJwf2HfobpVJJTFx8Vq8RgLa2NmamxtmSfL2ORCLBqtzX2FYdQkZqJCFX56FSZrz1Pn19XTYs+Ymq1crAxVAsZnvT4LyKCnczqPgYxpdsyPiSDRlhXo1mt3Sw/c0H2eFAVAZSpBUM+bLV+/X0qNVq5IkhxPod4dmpH8lIDsWmyiAsPL9874SdgiAI70oikTCgdye2rp5LuxaN2bJLs6nrui37aFy/BhuXzeLoyQsEBIUWcU2LDzFJ+yOiUqkIDY/MsbHs503qcMf7IRKJBEMDfbzuP6Rx/dof/AWcnhBItM8OZCbO2TI6SyQSalevxJUb/zJiQI+3liORSOj0RUsWLVvP+YvXSE+XZwuQQDPMFh0bl+e6mZZsjiItlmif7UTcXoFl2a7oGObMAJvtHmNDdiz7mS27/+bPXUe5deA6AAb6uhw5FkRKahqRUXEolEpsrS2wdbHmxo1rrB83l/IWeQ821WoVcX5HSA6/TVqML6qMJAC0dM2wrz0OY8c6eS5LEAQhP1hbmmNtaU5sXAJBIWF4ursCcOnaHb5o3RRtbW0qli3F5et3cXGyz3ZvRGQ0M35bQWJSMg4vbR3i6/eMP1ZtJTY+AQszU+ZMG8WRE+eJjUvIWmI/fPxsxo/sh7OjHQCh4VH8vmwj4RHR6OjoMGfaKLzv+3L1phcTRn0HwKz5K/m8SV0qlffk14VreOT3DHtbK36eOJzk5BQWLNuEmakxCoWCH4d+w/yl63kWFIpCoWTmxOG4uTrh8+gJsxasIjY2geSUVCqWL8XSuZO4cOU2y9ZuR6lS8m2PjrT6rMF7t6kIkD4CarUaiURCVEwcGRkKHOyyr6Rq2qAWvy/bhKmJMVeu30Yuz6Be7Wof/Nzo+1s1Q2vVhuXIy1O3RmWOnDhPeEQ0tjaavd8yMhTo6OT+I/NVh1YsWraeHfuOAGQbYtP83SzbJO28sCjdieSIOyQEnCEh4Ay6Zu4YO9bF2KkBOoY2ud4j09Hh2+7t6Pt1Wy5d92L4+Lno6+trVs5ZmVOxrAcdWzfi4sVL/G/1nzRrXJeO7VrkuU5qlYKwm0tJDDyHRKqNrpkbehae6Jl7YmhbFS2ZWMIvCP9FwZdmk5Gcc6uM/KJjaItjvUlvvObuvUcMGzOLapXLMXKg5pfemNj4rO1FXJzsiYqOy3HfopVbaNKgJl06tODspRvs2KeZLmFhbspP4wZjbWnOtDnLOHPhGi2a1mPImJn07/0VCYnJpKSkZQVHAKYmRowY0AMXJ3tWrN/JwaNn6NG5DcvW7UCtVqNWq/Hy8WX899+x5s89VCrvycxJwzly4jz7j5yieeO6XL5+h0Wzx1OzagWUShW9u7anlHsJDhw5w9bdh5kyZhDL1+1kQJ9ONKhTjQHfT2f8yH7ExSeyfP0O1vwxA20tLQaPnsnnjeu8944bIkAqYknJKfQcOIH6tatSqXwpgByb/1mYm1K9cnniExM5dkIz1NaqeeMPem5qjC9JIVcxcqiNvoVnjvM1q1VAKpVw5ca/dGjTlLveD/l+0lz2blqYLXuqWq0mNS2dEi5OeLi5cuzEWWwdnHP0IFlamBIW/m6b3EqkWjg1mEFKxB2Sgi+TFHqNqHubibq/lQilJ7XbT0VHN/dM3BKJhLo1KmBkoM33g7rR+YvmWfWdMnMB/1v9J3VqVmHjygV57olTq9WE315BYuA5DO1rYV/zB6TaIuGjIAgfh8rlPTlzcB2bdhzk14WrmTJmkObz7flOAyq1ColUwrY9Rzh68gIA65bO5Pa/Pkx7nona/qUtlizMTbl2y5sNW/fz8PFTXJzsMTE2xN3VmfsPnxAQFEqTBtn3qjTQ1yMxKZlFKzZz1/sh7iWd0dfTw72kM48eP0WhVFKutDs6Otpcu+VNerqcQ8f+QalUZe3t5uxoT82qFQDQ0pKira3NsnU78Lrvi9bzuaKWFqbExSeSnpZOSmoqEokEb5/HREXHMfjHnwFITE4hLj4xaweKdyUCpCJ2+txVomJiOXziHPsOn8LczAR7u5y5eMaN/JaExCS69hlGCRdHyni6f9Bz4/2PAxIsy3XP9bypiRHly3hw+cZdOrRpytlLN0lPl/P0WTDmpiZcvu7Fn7uPcfqC5riGFIXUiLj4ZHR1swcOFuam3Hvg9871lGrpYGRfEyP7mqhVGSSH3+XZzT+xUT/A/+J8SjWd8toAJz4hCYVCiZWlGaAJcCbNmM/yNZupW7saOzcuxdgobz0+arWK6HtbSXh2GgPbajjUHotEqvXO7yMIwqfpbb07hUVHR5uuHVvS7buxgOazNygkHA83FwKDwvBwc6FLhxZ07/RiFwaFQklqanrWvp+Ztu89ipfPY3p3bYeTgy3JKZrVwe1bNebEP5eJjIph6HdfZ7vnzPlr7D54ggF9OlGxXCkuXbsDQNMGNblw9TYKpZLG9TVBlVqtZubk4bi7OmfdHxoWmRUEAXj7PGb+0g0M6deNhnWqsXz9DgAa1q3O6k272bX/OB3bfoaTgy3+AcFUr1yW2VO/z5e2FJO0i9jRkxeoWbUCW1fNZcWCqez/c3GOH1IAJwdbVEolQcGhtPq88QfPP7KtOhinhj+ja+Ly2mvq1qzM9dveKBQKrt3yAuCvE5f4vPMIegyZxtFTl6lc3oOv2jaha4fPqFujPFpaOqQpJDTvMpI5f2xCnqGZYG1pbvZOc5ByI5HqYGRfg4fq9lx/ogVxt4m+vy3XfdjgRVoB6+e/PUyfvYjlazZTr3Z1dm36X56DI6U8iZDLc4h5tBddMzccao0WwZEgCB+VfYdP8dDXH7VazZkL1ynhrJlXWb92VW57PUChUODt85i6NSvnuLdcaTcuXLkFwINHT7KO37hzn1bN6uPp7spj/8Cs49Url8Pn0RMSk1JyjHjcvOtDo3rVqVyhNI/9A7KO16tVhRt37nPn3wfUqV4JgJpVK7B97zFUKhXJKakkJObMf3fX+yFVKpahdvWK+AcEZx0/fe4qU0YPYsuqOXT/qjUA5cu4c8frIU+fXxcekbd8eK8jepCKUEhYBHe8HzJ9/BAc7W1y/KC9av4fqwFo16rZBz9bItXCwPrNaQLq1KjEqo27OXXuGn7+gSSlyFm37TAmxoYM6NWBHp1aUNIl++Tmzzv05d/7fqiUpqzYuI/te4/xRYtaqJQqoqNiOH32MhXLe2JtZfnedY+MjmXbGRmVSpkQ83A3Snki1hX6INXRz3EdaFIjxMUnsHTVn1SuWJadm5ZiZGjwxmeoMlJJi/MjLdaX+CfHyUgJx9ilMbZVBothNUEQPjpVK5Zl4fJNhEVEY2igx9QxmiGzb3t0ZOrspew/fJp2LRtlzUd62feDejH9t+Xs/eskNaq8+F7o2LYZy9ZuZ8+hE7i6OGYdl0qllC/jkWOuKUCrz+rz2x/rOHvpBpXLl846bmxkiIG+HroyHfT0NJ+hfXt0YO7idfQYOAEDfT3GjuiLmYlxtvIa1avOjN+WM2DUDOrXqpJ13NOjBGOnLcDS3AxTUyPq16pC905tmPTjACbPWoKWlpSK5UoxdsS379eggEQuT8/91++PmEKhoGHbvpw/vOG9J18VBLVaTUaGAplMJ0/Xr9uyjy27DvPX9qXo6+nlOJ+SmkpgUCiBQaFcu3mX3xat5Is2n7Nx5fxCWUKuUqnoMXACIWERxCWkkpAsx0lfh619WmJnnHuAce7yTfyeBKAr02ZvaBL/yrXQzkgjKuZFPiNLSwu8rxxFXz/nO+fFz/NWcPTkBX4Y1JW6VjdIjfJGS9cEfasK6Jm5aSZOm7lx5J/bzP59Nef+2sChoyfpN3Q8C+dM4dteXXKUqdlU9gZJIddIi/VFnhAEaHIpSaQyrCt9i2nJFmLpviAI/3lp6XKGjpnF/Jmjs81JLUz9RvzEsvlT0JXp4PPoCWOmLuDIzmX5+oyPJ7r4BKzfup/1W/dTvXI5GtevQcM61V47OUytVnP05AWaNqiZIzhSq9UMGjmJnc9XhGWysbZk/i+TCu1LWiqV8secCfQbMZ2A0HgsjfTZZJCI5f69vC4zUd3n/yMNOpvBzFRtdiTq0aZNW67fuIFcnk50dAzz/1jN1PEj3qteEVExAMTEp+H05TTin54m1vcgScGXSAq+lFl79DIqY25qjI6ONsdOngOgRbOc2bLlSWFE3F1DSrimi1lb3wojx9romZd6/j83pNq5TwYXBEH4L/G678v0ucvo0+2LIguOQDMFZMjomcgzMtCVyfjp+STz/CQCpHyiUCrZ99cpKpQthUKpZMHSjcxbsoHyZTxoUr8GXTq0yNaz5O3zmKCQcMZ/nzPb8uYd+9m57wi1qlemYb2aODna4ezoQLUq5bEwNyvEt9IkqnRzc8X7USBdvmpO9ImD2Krkb78RkEhgSnV3rvuncM83kDYtmxGfkMg/Z8+zePkGunVqh6dHyXeuU0SkJkCKjUtAItHCrGRzzEo2R5WRSoDfTW5fOYEFDyhhcpsBTYxJSwzjxOkLVKpQBseXupdVSjmxj/YT83APalUGxi6NsSrXAx2D/NmwVhAE4VNTsVwp9mxcWNTVYECfTlm5mApKgQVIEVExLPjfRgKDwtCRafPT2MGYGhsx+ZclREbFUqViaaaMHohUKuX8lVus3LALbS0tpoweiIfb6ycOf6yuXP+XqJg45v88mtKlShKfkMTFq7c5c+EaS9dso2QJR+q9NH569OQFbK0tqVapbLZyQsMimDxjPva21uzctBQzUxOKUkxsAsdOXaZWtXLUqFyWP478zXJzPSQJCW+/2dQUg6GD6Xn1PjMXrKNR/dqEh4cTHBLG9es3mDZ7EdvWLX6n+qjVasIjNRPvYuNe1OHaTS+27zvG5et3MTUxwsLEjo4VgqlSIpFnJ4YzsIUOFSvYEXJlLorUGBRpsSjSYkGtRGbsjE2VgW+dkyUIgiD8dxTYKrbc0p7v3P839WpVYfeGBahUKm7cvkdGhoIFSzfyx5wJjBnel9+WrC+oKhWoQ8f+wdOjBKVLaXpETE2MaNO8Ib9O/T4rCWQmuTyDk2ev0LJZvRz7f03+eT4JiUks+HVKkQdHALsPnUaeoaB3l9Y4OtjwGG1SzPO2M73UyQktd3c6t2uKnq6MzbuPYWpijBopX7ZvwdHj/7D/r+PvVJ+ExCTk8gwMDfSJjdcESA98/fl+0lyiY+OYMnogB7b8wYxJP/LHCUNOBVXFL1RBpwameJoFkhRynYzUKLR0TTG0rYp1xW8p8dl8ERwJgiAI2RRYgGRtaY6Hm0u2tOcGBvqYmxojlUpxd3VGW1uLew8eY2ZqjIWZKWU93Xj4+CmJSTmX+n3MoqJjuXj1Nl+0apLjnLa2NqYmRtmySF+6dofEpGRaf549BfqZc5fZe/Bv2rRsSpsWOcsqCvce+gPQvFHNrC1QJgQlEPe2Hx1TU2SDB2n+aGJErWrluf/oKWamxiSnpDJ57HDMzUzpO3gsE6b99lIupTcLfz68VtrDNasH6dZdH3R1ZaxdPIO2LRqhK5NRyr0Ec6eNwjdUSo9f/bmR+DklWy6nVMcduLdZS4lm83CsNwnzUu2RSPM2qV4QBCG/XIoNePtFQpEq0DxId+89on334fg/C6FLhxZ0av85uw+dZPWmPfg+CaBShdJExcRl7QujpSXFycE2K3/Ny3YfPEH3AePoPmAcvQZPLMhqv7MjJ8+jpa1Fi6b1cj1vYW6aLUA6evICZT1LZls2mZaWzpjJs9HX02POjHEFXue8ik9MQldXhp6eLqYmRthYWaB0ccGo1JsTVWb2HmUyMzEiPV2Ogb5msrOZqQnn/t5B3VpVWbF2C8079Obxk6fZyjh26kKOn4WIlwOk5z1I3j6+lCvtlmNFY9VKZdh78Bil3F3p1msQOoa2In+RIAhFzisxjC53t+OVWHBbkwgfrkADpMy055UrePLrwtWcvXiDxvVqYGigz5NnQURFxyKRSLIl+lOr1Lmu0ur8RXO2rf6Nbat/Y/OKXwuy2u9ErVZz6NhZmjWs9drEgxZmpllf9CmpaVy8doeWzepnu+aPFRvw8w9g3KiBuDjlfePUgqajrY1Cocj6b7Rp+S+sXTwDo5EjwPQ1Kxhe6j3KlKFQAGBhobknLiEJZ0d7Du1cw7hRg/C+/4jGrb5my84DqNVqFAoFM35bkZUOP1NEZDRaWlq4l3QmJSWNtHQ5Xvd9qVC2VI5q7Np7hLj4BAZ+2x0tLREYCYLwcZjke5IMtYrJvieKuirCGxR4Ju3MtOeXrt9l296jfPN1e3p0bsMXrZpw+Ph5rCzNCQgOBUCpVBEcFoGVhVlBVyvf+D4JICgknDbNG772GksLU2KeDwdFRceiVCop9dJE9Li4BP5YvoFS7q4MG9inwOv8LizMTFAqVYSEafZRMzUxRltbGy13d6ROTrne82rvEUBQSIRm8rSZZl5VfHwioBmCnDRmKAd3rMbUxJhhP/7EkB+mEhmlSfIYGh6ZrZyIqBisLc2wfP4z8uDRE6Ji4qhY1iPbdZrEkJswNjLk687tP6wRBEEQ8olXYhiPUzQLTR6nxORrL1K9Vr3pM2QSX/X5gQGjZvA0IOTtN73iyz6jiHv++fzq8feR23237t5n9NT571VeYSqwACm3tOdyeQb3HvihUqnwf6ZJBV6+tBsJicnExMZz78Fjynm6YfiWLMcfk+AQzQ93KbcSr73GwtyMmOfbbGT+4JmavsgWunrjdpKSUxgzckCek0wWluZNagGw8+CpHOdkgwfl6EWS6xvk6D2699AfLx8/mjeuhfnzACkuIfs/wAZ1a3DhxC5aftaQ7bsP0W/oOFKSkwkJexEgqdVqLl69Qym3ElnlnLusyV30cg9SYHAo7br0x9fvKT8M/y7PW4oIgiAUtEm+J4nO0OxpFpWRkq+9SHq6MjYtn82ejb/Tomld/tx5KN/K/i8qsACpasWyLFu3g6/7j2P/4VOMG/EtU8YM4rcl6+ny7WiiY+Lo9mVLtLW1GTu8LyMnzmHh8j8/KC14UQiLjEZXV4apidFrr7EwNyE6RjMHKTNAMn++Qi04JJwVa7fi4uxApw6tCr7C76hp/Wo42lmzbe9xMjIU2c7l1oskyaX3aPPuYwD07tIKQwN9tLS0iIvPmSbAwtyMLWsX0b3LF1y+dotnT59w/uKVrPNXbvzLY/8Avu7UOitAOnHmEi5O9ll/P3D4JA1adMH7/kN+mjCSH4blzDMlCIJQFF7uPcqU371IAOnpcgKDw7K2FfH1e8aI8b/Sa/BERk6YQ0pqGgAPff0ZMGo6vQdPYtGKzdnKiImNp8eA8YRHRDNg1AyiomPpM2QS1256kZKaxtTZS+n23VhGTZpLQmIyyckpjBj/K12+Hc33EzXPePW+V8uf8PMiun03lvlLN6JWqwkNi6TnwAlZ1wwdOwufR09Ysnorf/19FtD8otxz4ASSk1Pytc1yU2B5kFxdHFj864Qcx7esnJPjWL1aVbLlCCpOwiOisbW2fGN2a0tzM5JTUklLl2f1nJiYGHHwyElGjp1BXHwCM6f++FFtm5JJS0uLHp1aMO9/W9i+7wS9u7bOdl42eBBpU6ZCfDyYmmI8cni2888CQ9l/5CwVy7pTubyml8fM1Ii4+KRcn6etrc2y33+mQvmyzJi9iCdP/ImLT8DM1IQtuw5TrrQ7VSuWyQrWomLimPhNZ1JSU5k0fR4btuzB0sKcHRuX0PKznFmzBUEQisrLvUeZMnuRDlbr9cHlp6XL6TNkEsFhEZgYG7Fm0XRAs1Dop3GDsbY0Z9qcZZy5cI2WTesxZfZSpo0bQoWyHtnyyqnUKmbOX8mQ77pha2PJzxOGMnTcL2xaPhuA5et2UKm8JzMnDefIifPsP3IKZwc7ZDIddq1fQHhENAb6ejnue1lKairjRn6LiZEh/b+fzq27PjjY5Z6kt33Lxiz43ybatWyM39MgnJ3sCmWkqcDnIH3qwiOisbN588armRv6xcbGExefgIG+HmMm/UKfgaORSqVsW7+YHl2+KIzqvpeenVriaG/NjPlrOXPhZrZzL/civTr3KCIyhr4jZ5Iuz2D00B5Zx01NjIlPyDnGnUkikWBpYYGllRUqlYqV67Zy/6EfN+/ep1eXtkgkEmQyHYwMDXAr4UTVSmVo1rYHG7bsoXGD2lw8sUsER4IgfFRy6z3KlF+9SJlDbEd3LOfHoX34Yco8QBMgPXkaxLwl63n4+Clh4dEEBIVhZmpMhefzNzN74QG27T5KUnIqDetUy/U51255s++vU/QZMoktuw4TF5dIpfKeREbHsmrj7jzts+nkYIeFmSna2trUrFqBB77+r73W1cWRjIwMoqJjOXfpBp81qv0uzfLeRID0gcIjo7CzsXrjNRbPA6To2HhCw6N44HOfDVv20KRhHS6e2EXr5k0Koabvz8zUmA1/TMXQUJ8BP/7Kxh1HSJe/2I1NNngQaGtnzT1Sq9XcuOPDl99OwD8glBlj+9Ok3ot/aGYmxrlOAnxZbFw8JqZmaGtrs2DJWoaNnoadjSWN6tXIumZAn05MHj2AOQuW8eDRE6aMG86+rSuwsxVbhQiC8HHJrfcoU37PRZLJdGhYpxopKakkJCazfe9RDhw9Q7uWjenQuglqtQqVWg3kPvLh7eOLoYEed+89yvW8Wq1m5uThbFo+my2r5jByUE8sLcxYt+RnHOys6TtsCiFhEXmur7a2Fnp6MgAUSkWu17Rp0YhT565y/fY96teumueyP4QIkD5QWEQ0tm/pQcpc2h4TG8/Va7dITk7mh2H92LtlOfbPky9+7Eq5ObNn3WxsbSyY9ttq6rXpz29LN+MfEILSxQWdmT8Tb2HN9n0naNdzDJ2/m0R4RAzzp4/IMSxnavrmHiTQzNUq4eyAo7MLVpbm3L7jxZUrV1i0bB1nL1xlwZI1tGhSF10dbbbv/osGdWswZuSAHJnJBUEQitqbeo8y5fdcpHsP/FCr1RgbGXDjzn1aNauPp7srj/0DAXBxtCMqOoaHz3tuXg5oJv7Qn+EDerBk1RZUKhXmZiYkJ6cgf/6Lcc2qFdi+9xgqlYrk50GY/7NgUlPTaNuiESVLOPLI71mO+14WExtPWrqc5OQUzly4TvXK5TAxMSIsPJq4+ESePA3Czz8o6/rPGtXm79MXsTQ3xSAPPVT54eOb9FKMpKXLiY1LeGuAZGpsjJZUSnRsHN73H6Ctrc3oYvhl7lHSmSNbf2fH/pNs3n2MZev3sGz9HoBs+awMDfTo1bkVfbq2xtM957565qbGBIe++YMgNi4BZ0c7YmLjUSrNMTI2JT0tmZlzl2Rds2f/UQCUSiWTxgzLr9cUBEHIV2/qPcqUH3ORMucgKVUqzRygicOQSCR0bNuMZWu3s+fQiawExTKZDtMnDGP2ojWo1VCxrAdjhvcFwMTYCDNTY1xdHDl66gJtmzeiaYNa9Bg4nuH9u9O3RwfmLl5Hj4ETMNDXY+yIvqSly5m9cA0JiYm4ONlTp0Zl9HRl2e5r0qBmVl1NjA0ZP/13wiKi6NKhZVa9vmr/Gb0GT6BO9UrUrPpiCyhDA33sbKxoVkjDawASuTxd/fbLPi4KhYKGbfty/vCGIp3YHBgcRtd+Y1g6dxLVq5R747Xtug+jUd1qzP7tD8qW8eTyyV2FVMuCoVKpOHflDqfP3yA2PhGFQompsSHly7jTsXUjjI1eP4Fu1cbdHD5+jgNb/shxLjQsEoVSyc/zVlDC2YFHj5/i+ySAwd92pftXrdm26yAhYRGoVCrmLV6FTKbDD8O+Y+LoIQX5uoIgCO/FKzGMrnd3vDVAArDSMWBH5W5UNLYthJoVL3HxiYyaNJeVC39CVyYrlGeKHqQPEBahSZ74th4kAHMzU/46ehKAmtWrFGS1CoVUKqVJvWrZ5hbllZmpZg6SWp0za/ofq7YSFRNLbFwCVSuWwd7WmuDQCL5s+xkymQ7f9OyUdW2LZg2xt7fBycHug99HEAShIOToPUrMQJIgRyJXodaVojaVgaEm/11+rmj7lJw5f43/rd3OqMG9Cy04AhEgfZDwCM2Yso3Vm3e3V6vVPPDxwffxE4yMjKhZrVJhVO+jZWlhhjwjg6TklBxJHCOiYnj4+Cna2lqYmZpQv3ZVWjdvgIlxzmSPNav/t9tREISPm1diOPeSIkClRssnDu1L4Wg9jM92jVoCyvLmKOrZovIwwTspAq/EcNGL9JKmDWvRtGGtQn+uCJA+QFhEFJYWpm/Nfn3yzEV8Hz/BxMQUe0enrG0y/qusLM0BiIqOyxEgxcTFo1QqUSqVmJuZULlC6aKooiAIwgczkGrTPsaW0yuOkxiZgEQqoWQtD2zcbdHRkyFPlRP2MIRnd/zR9o7FzMGcz4e1wkAqvpo/BuK/wgfw8w/Cxcn+jdcolUqmzV6ETKaDjZ09UqkUs5e2GfkvsrY0AyAyKoaSJRyzjqvVamJiXvx29XJeDkEQhOLm7j9e/DV7Lwb6eozs34XuX7XA3jZnWpiAoDC27D3OnzuPcnDGbprPLoF707dP3RAKVvFaRvWRuffwMeVLe7zxmgOHT3D/gS8D+36N7PnY6X89QMrsQYuMic12PDklFXlGBtraWoAIkARBKL5OnbvOmOlLsLOxZN+GOfw4pEeuwRGAi5MdE0f2YefqWZgYGzJi4nyu3b5fyDUWXiUCpPcUERVDZFQs5cu4v/G69q0/Y+GcKYz5fmBWb9N/PUDSlWn2rouKjst2PCZW03tUq1oFQJMOQBAEobhJTknlh58WY2psyOZl0/Eo6Zyn+yqUdWfDH1PR0dFmxMQFOfa/FAqXCJDe0/2HfgCUK+32xut0dHT4tlcXzExNKOtZEgAzU9EzYmVpTmRU9h6k6OcB0tdftab7V62z5ioJgiAUJweOnSchMZkfh/SgpIvDO91boYwbQ7/tRHhkDCfOXnune5t1+C7HscUrN/P4ScA7lZPp1c1j/2tEgPSe7j/ww8rSHBvrvI8TV61YBnMzE/T1dAuwZsWDlYUZUa8MsWX2IJX2KMnIQT2LXSJNQRAEtVrNpp1HMTLU58s2jd+rjK4dPkdHW5s/dx394Pp8P6gXHm45E/YKbycmaefR6KnzCIuIxt7WGgc7a67e9Hrr8Nqr2rVsTJMGtXLk/vkvsraywP9ZULZjMbHx6OhovzHJpCAIwsfMy8ePB75P+aZbG4wM9d+rDGtLM1p/VpeDf5/naWAors5vXgz0JkPHzmLEgB4cOXGeCmVL0bJZPdRqNV/3H8faP2YQExvPrAWriE9IpHb1SvwwpHe276iUtDR+nreCh75PKVnCkaljB6Erk9Gsw3ecPrAWgJnzV1K/dlViYuOJjUtgQB9Nvrrh42czfmQ/nB2LZ6468St6HqjVaq7e8MLEyBC1Ws3NO/eJjol75w3zpFJprvl8/ousLM1yDLHFxMZjYWYqAkhBEIot/2chANStUeGDysm8/2lg6AfXCaBJ/ZpcvHobAP9nwTg52GBkaMDs31czZnhftq+ZR2paOvce+GW7LzU1jX49v2Tzyl/JyFBw4szl1z6jRdN6/HPxOmq1mviEJFJS0optcASiBylPUlJSUapUdGrfnM+b1Cnq6nwSrC3MiY6JQ6VSZQ2lxcTGY2Eu5mcJglB8JSSlAGBk+GE94Zk54hKfl/ehKlcszW9L1qFQKrl49TaN69ckOSUVn0f+zJq/EtDs5VavZuVs91mam+HkoElaWbt6RR74PqVdy9yHDk2MDXF3deb+wycEBIXSpEGNfKl7UREBUh5k/sAbi96ffGNlaY5SpSIuPhELc1NAkyTSwtysaCsmCILwAfT1NOlcUtPSP6iclLQ0AAzyac6qtpYWVSqU4d97j7h84y6/TB4JajUGBnpsXPZLnnrutbW10Hv+fkqVKtftotq3asyJfy4TGRXD0O++zpe6FxUxxJYHiUnJAGJuTD6yttKsUIuMisk6Fh0jepAEQSjeMreeeuQX+EHl+D6/3+p5Yt380KRBTU7+cwVtLW3MzUwwNDTAwc6GIyfPA5rts9Tq7PvXJyYnk5CYTEaGgqOnLlKjSnkADPX18fMPJCIqhrveD7Our165HD6PnpCYlIKjvU2+1b0oiAApDxITMwMk0YOUXzKX8K/+cy//XLhOaloasXGaOUiCIAjFVZ0a5bGyMGX7/hMolcr3KiMtXc7uQ6dxdbanYtm8LwZKTUunc98fs/4XGh6V7XyNKuU5ff4qDeu+2GT8p7GDOHT0H3oOmsAvv68mOSU12z1WFmbMmr+S3kMmUbm8J7WrVwSg99ftGTlhDr8v20S9WlWyrpdKpZQv45F1XXEmhtjyILMHSUywzj9WFmYM6deVv09fYuLMxchkOmRkKP7z+9QJglC8yXR0+PrL5ixdu5tzl+/QtEH1dy7jyMlLxMYnMqxfp3dKd3L57805ji2bNyXrzzo62hzbtSLb+RLODqz4/adcy7O3s2bdkpm5nuv+PF/dq9LS5dzxesD8maPzXO+PlehByoOE5wGSkaEIkPKLRCKhT7cv2LJyDjvXzWdAn07UrVmJapXLFnXVBEEQPkj3L1sglUpZsHwrqanvNhcpPiGJpWt3o6sro3P7ZgVUw4Lhdd+XngPH06F1009iNEAESHmQkJiEoYE+WlqiuQqCs6Mdvbq0Y8HMsbi75i0lvyAIwsfK0d6aYd92wvvBE4ZNmEdaHidsJyalMODHX3nyLJixQ3sUu22pKpYrxZ6NC+nQpmlRVyVfiG/8PEhMTBYr2ARBEIQ8+3FIdzq3b8bpCzf5etBPXL99P8cE6ExqtZqL1/6ly3eTuHb7Pv16tOe7nl8Uco2FV4k5SG+w68BxomPiSExKERO0BUEQhDyTSCT89tMwrC3NWL5hL136T6aMRwl6dm5FxbJuGBnqk5iUym2vh2ze/TdPngUjkUgYN7wXQ/p+JRLmfgREgPQGf5++SHxCEmVKlRQTtAVBEIR3og4J4Qcrbfr0a8Wde4+4/9CfoCX/I+iV69rr6lKhXikqlffAXE+OKjgYLSenIqmz8IIIkF5DoVTi+yQApVKFnY0VJqIHSRAEQXgX6elk7N6DSWoqjYBGukCueR9Twe8e+N0jQ18frVq1CreeQq7EHKTXeBoQglyegVKpxO9poBhiEwRBEN6Jlrs7Uje3d7pH6uaGlvu7bYQuFAwRIL3GQ1//rD/HxiWISdqCIAjCO5MNHgSmeVzybmqquf491WvVmz5DJvFVnx8YMGoGTwNC3rmML/uMIi4+Mdfj7+N97wMIDYuk58AJANy6e5/RU+e/d1nvQwRIr/Hw8VPsba2zJsqJHiRBEAThXWm5uyPN43wiqZPTB/Ue6enK2LR8Nns2/k6LpnX5c+eh9y5LEHOQXuuBrz8VynqgUqkIj4wWAZIgCILwXmSDB5E2ZSrEx7/+og/sPXpZerqcwOAwnBxsAfD1e8Yfq7YSG5+AhZkpc6aNwkBfj4e+/sz/30bS0uRUr1KOUYN7ZZURExvP8HGzWfjLOKbMXkpUdCx9hkxieP/uVChXil8XruGR3zPsba34eeJwtKQSJvy8mLCIKBzsrPn1p1F8P3FutvtqPd9+JCIymgk/LyYpOYUypVyZNm4o6XJ5jjKLmgiQcqFUqvD1C6BxvRpERscSHhktJmkLgiAI7yWzF0n1hgDpQ3uPQLPNR58hkwgOi8DE2Ig1i6YDYGFuyk/jBmNtac60Ocs4c+EaLZvWY8rspUwbN4QKZT2IjUvIKkelVjFz/kqGfNcNWxtLfp4wlKHjfmHT8tkALF+3g0rlPZk5aThHTpxn/5FTODvYIZPpsGv9AsIjojHQ18txX6aTZ69SrrQ7o4f1ITwyGi0tKRu3HchRZvPGdT+oPT6UGGLLhRo1MycNp0mDmjjaWQOIOUiCIAjCe3vjXKR86j3KHGI7umM5Pw7tww9T5gGaAOnJ0yDmLVnPw8dPCQuPJiAoDDNTYyqU9QDA3Mwkq5xtu4+SlJxKwzrVcn3OtVve7PvrFH2GTGLLrsPExSVSqbwnkdGxrNq4G319vTfWs06NStzxfsD2vUcxMzF+bZlFTfQg5UJbS4sGdaoC4GBvA4CxkUFRVkkQBEEoxt7Ui5QfvUcvk8l0aFinGotXbCYhMZnDx8/i5fOY3l3b4eRgS3JKKiq1Gsg9GaW3jy+GBnrcvfeIyuU9c5xXq9XMnDw8x9ZQ65b8zLGTF+g7bApLf5uI5DXlu7k6sWbRdPYdOU3vIZNYv3RmrmWGhkW+fyPkA9GD9BaOWQGS6EESBEEQ3l+uvUj5OPfoZfce+KFWqzE2MuDGnfu0alYfT3dXHvsHAuDiaEdUdEzWiu2QsIiseyf+0J/hA3qwZNUWVCoV5mYmJCenIJdnAFCzagW27z2GSqUiOSWVhMRk/J8Fk5qaRtsWjShZwpFHfs9y3Jfp4eOnSKQSunVsiUymQ3BoRK5lIpGgUqs0N0kkr92qpaCIHqS3qFOjEr26tMPBzqaoqyIIgiAUY7n1IuVn71HmHCSlSqWZAzRxGBKJhI5tm7Fs7Xb2HDqBq4sjoOllmj5hGLMXrUGthoplPRgzvC8AJsZGmJka4+riyNFTF2jbvBFNG9Six8DxDO/fnb49OjB38Tp6DJyAgb4eY0f0JS1dzuyFa0hITMTFyZ46NSqjpyvLdl+TBjUBCAmNYO7itSQkJlOtcllKubng5GCbo0xPd1e0tbS5dssbT/cSBIeG8+RpEG6uhZNlXCKXpxduSJYPFAoFDdv25fzhDWhrixhPEARBKB6Ufn4vVrSZmqI3a6ZIDPmREkNsgiAIglBIXs6LlN9zj4T8JQIkQRAEQShEssGDQFu7QOYeCflHBEiCIAiCUIi03N3R/WWW6D36yIkASRAEQRAKmXbFikVdBeEtCmyGc0RUDAv+t5HAoDB0ZNr8NHYwJZzsWbj8T+54P8TUxIjp44ZgY23J/iOn2XXgOEaGBsycOAwba8uCqpYgCIIgCMJbFViAJJFIGNC7Ex5uLuw6cJwtuw5T1tMNJBI2r/iVwOAwzM1MiYmN588dh9iycg7nr9zif2t3MGPC0IKqliAIgiAIwlsV2BCbtaU5Hm4uxMYlEBQShqe7K0dPXuDrL1shkUhwcbJHR0ebqze98HR3RU9PlyoVy3D5+p2CqpIgCIIgCEKeFGgSobv3HjFszCyqVS7HyIG92LTjINdueTFl9hI83V0Z/30/omPicHGyA8DKwgylSkVauhw9XVm2snYfPMGeQycACj2bpiAIgiAI/y0FGiBVLu/JmYPr2LTjIL8uXE1KahpGhoasXzKTsdN+59ylmyDJHvCoVWokuWzf0vmL5nT+ojnwIlGkIAiCIAhCQSjwNNQ6Otp07diSbt+NxdLclCoVSiOVSqlRpRwhoRFYW5nj7fMYgMjoWHR0dNCVyd5YZmZApVAoCrr6giAIgiD8R2hpaSF53ktTYAHSvsOnKOfphqeHK2cuXKeEswOe7iU4feEaXTq04Mad+3Rq/zllPd1YtXE3aWnp3P73AfVqVXlr2UqlEoCmHfoXVPUFQRAEQfiPeXkLswLbi+1pQAgLl28iLCIaQwM9po4ZjIW5KT/PW0FAUCg1q1Zg7Ii+SCQSDv19lu17j2JsaMDMySOwtjR/Y9kqlQq5XJ4t0ssvvQZPZPOKX/O1zP8S0X75Q7Rj/hDtmH9EW+Yf0Zb5oyDasVB6kFxdHFj864QcxxfMHJPjWPuWjWnfsnGey5ZKpejp6X1Q/V5HIpGIDXA/gGi//CHaMX+Idsw/oi3zj2jL/FHQ7SgyaQuCIAiCILxCBEiv6NS+eVFXoVgT7Zc/RDvmD9GO+Ue0Zf4RbZk/CrodC2wOkiAIgiAIQnElepAEQRAEQRBeIQIkQRAEQRCEV4gASRAEQRAE4RWfzDrDhMRk5ixeS2BQGKYmRvw8cRhSqZSps5cSExtP6+YN6NWlXa7XWZibcuDIGQ4cPU1sXALNm9ZjyLddc+RYiotPzFEewLa9R9m66zBff9Wanl3aFsXrf7Ciar+IqBgW/G8jgUFh6Mi0+WnsYNxdnYuoFT5cUf4c1m/dO6vtKlcozehh3xT6++eXomrHQ3+fZdf+vwFQq8E/IJiDW//Awsy0KJohXxRVW6rVan5ftomrN71wsLNm6phBWFqYFU0j5JPCaMvg0AjmL93Av/cfcWrfmqzjn8L3TKYPbcdM85asxz8gmGXzpuR4Rn58X38yk7QvXbuDvr4eVSuWYcnqrQBkZChwcbKnY5umfDNsCr9O/Z6gkPAc140Y0IPrt72pWrEMSpWKzt/8yMqFP+FgZ5PtGb8v25SjPBcnex76+rPzwHHcSjgV2x/como/fX094uMT8XBzYdeB4/g8esJPYwcX+vvnl6L8OezY63v2b15c6O9cEIqyHTOdvXSDu14PGTmoZ+G9eAEoqrYMCglnz6ETzJ3+I0eOn+PuvUdMHTOo0N8/PxVGW8YnJOHnH8CYnxZw+sDarOOfwvdMpg9tR4DH/oHMnL8CQwP9XAOk/Pi+/mSG2OrVqkLVimUAqFiuFJFRsVy6docqFcugra1NxbKluHz9bq7XAdSsWgEkEvz8AzE0NMDa0iLHM3IrD6B0qZLY21oV0psWjKJqP2tLczzcXIiNSyAoJAxPd9dCe+eCUJQ/h6amRoX0lgWvKNsRQKlUsXHbAfr36VQIb1uwiqot/fwDqVGlPNpaWjRtWItL1+4U2jsXlMJoS1MTI6pVLpfj+KfwPZPpQ9tRrVazZNUW+vX88rXPyI/v608mQHrZzTv3qVTek5jYeJwcbAFwcbInKjou1+syjZv2OwNGTWfs8L7o6OQcfXxbeZ+Kwm6/u/ce0b77cPyfhdClQ4uCeakiUNjtGB0Tx4BRMxgwajp37z0qmJcqAkXx7/naLS/KlfbAQL9gMvYXlcJsSwd7G27e9UGlUnHz7n2SklNITUsruJcrZAXVlv8179OO5y7fxNHeFk+3Eq8tNz++rz+5AMnvaSDXb9+jfavGmrFdtWYEUaVWIZFKcr0u0++zxrJt9W8s+N9GngYEs23PEfoMmUSfIZNQKJVvLO9TURTtV7m8J2cOrqNyBU9+Xbi6EN+24BRFO/4y5XuW/jaRzl80Z/rcZYX4tgWnqP49n714g3q1KhfSWxaOwm7LxvVrYGFuQt/hUwkNi8TY0BCZjqxwX7qAFGRb/pe8TzvK5Rls2n6IQX07ZyurIL6vP6nwNTYugWlzljFr8gh0ZTIszE0JCgnHw82FwKAwPNxccr3uZS5O9tSsVoFbd33o3qkN3Tu1yTr3uvI+FUXZfjo62nTt2JJu340tnJctQEXVjpWf/3bVvEld5i/dSFq6HD3d4vuFVJQ/jz6+T+jXs2OhvGdhKIq21NbSYtIPA7LK3Xf4NFpaxf938oJuy/+K923H67e9SUhMYvTU+cgzFASHhrNw+Z/8MKR3vn9fF/+f1ufk8gwmzVzMgD6d8CipWclTv3ZVbns9QKFQ4O3zmLo1K+d6XWJSMis37iIjQ0FycgrXb3lTwtkhxzNyK+9TUVTtt+/wKR76+qNWqzlz4Xqu9xUnRdWOF6/eJjA4DICbd+9jY2VRrIOjov73HB4RjUUxX3GVqajaUi7P4GlACKD57b5N84aF99IFpDDa8r/gQ9qxZtUK7Fq/gDWLZzD3p1GU9nDlhyG9czwjP76vP5lVbGs372PLrr9wdXFAodB0Uy6YNZaZ81YSHRNHu5aN6N6pTa7XrVo4je17j3Hm4jXi45No3bwBA/t0zrH8Mj4hiamzl2YrLzI6ltFT5hEdG49UIqGEiwNL504q9Pf/UEXVfk8DQli4fBNhEdEYGugxdcxgSpZwLPT3zy9F1Y7+z4JZvHIzEZEx6Mi0mfTDAEp7uBb26+ebomrHTJ917M+p/Wv4FBRVW4ZFRDHjtxUkJCZR1tONsSP65uhJKW4Koy1XbdzNhSu3eOwfiEdJZ77p3oFK5T0/ie+ZTB/ajnp6ugCEhkUyc8HKXFex5cf39ScTIAmCIAiCIOSXT2aITRAEQRAEIb+IAEkQBEEQBOEVIkASBEEQBEF4hQiQBEEQBEEQXiECJEEQBEEQhFeIAEkQBEEQBOEVIkASBEEQBEF4xSe11YggCP8NX/YZhUxHG21tbfT1dOnZuS1NGtTMkXTvZWv+3IO9rTVtWzQqxJoKglBciQBJEIRiaeakEXi6lyAgKJTxMxaiUCpp3qRuUVdLEIRPhAiQBEEo1lyc7Bk5sCdL12yjWqWyLF65maCQcBISk+nasSVdO7Zk14Hj7Nx/HAN9PXbsO8a6pTOJi0vgtz/WExAchkymw7gR31KhrEdRv44gCB8JESAJglDslS/jQUBQKCbGRvTs3JbSpUoSERlN529H0/rzBnTp0IIHvv5Uq1Q2a4ht1oJVfP1Va+rUqMTTgGB+mrOMTct+KeI3EQThYyECJEEQij21WoVEIkEqlaKnp8vazfvwexqIBAnhEdEYGxlmuz4lNY0bt+8RExvPsrXbAc1u64IgCJlEgCQIQrHndf8xrs4OXLvlxf/WbmfQN53p/EVz+j6agkqd+37catT8b97kHMGTIAgCiGX+giAUc08DQvhj1Rb69ujI5et3qVGlPA3rVic2Lp7ExBe9QnY2VoSGRwJgoK9H1UplWb1pDyqVCqVSRWh4VFG9giAIHyGJXJ6e+69XgiAIH6nMZf5aUi309fXo3bUdTRrU5KGvP/P/txGlUkXFcqXwuu/LhFHf4elegidPgxj903zMTU2YP3M0SqWK+Us38DQgBF2ZDm1bNKLbl62K+tUEQfhIiABJEARBEAThFWKITRAEQRAE4RUiQBIEQRAEQXiFCJAEQRAEQRBeIQIkQRAEQRCEV4gASRAEQRAE4RX/B8R3Sj+aqWNAAAAAAElFTkSuQmCC",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAkgAAAFVCAYAAAAUvhB3AAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjksIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvJkbTWQAAAAlwSFlzAAAPYQAAD2EBqD+naQAA64xJREFUeJzs3XWYVNUbwPHvzGx398ICSy6wdHcjXSIhLY0iKgICUiqKioqooAjS3d3dHUssscB29/Tc3x8DI8sGCywL+Duf5/Fxmbn3nHMn3znxHplGo5YQBEEQBEEQTOSvuwGCIAiCIAhvGhEgCYIgCIIgPEUESIIgCIIgCE8RAZIgCIIgCMJTRID0gu4/jMDJL5gZ3/1a6HWHR0ZTrHwDfvtraaHX/Sb77a+lFCvfgPDI6NfdFOGRwaPG4+QXXCh1Dft4Eq5FqxRKXTlRqdSUq9acCVNnvXRZy1ZvwskvmINHTr50WQ1bv0efwZ+8dDnP4uQXzOBR4195PYJQWN7qAOle2EN6DhxN0aB6lK3ajIEjPifsQTjw7weMk18wLkUqU7pKU4Z89AUxsfGcPHMBJ79gZv+6wFTWwSMncfILZsnKDa/rcvLNx8uDZQt+4r0ubQFQKlU4+QWzbPWm5ypn74FjOPkFc/9hxKtoZqF7r0tbli34CV9vz9fdFOH/kJWVJUv+/JGRg/u8dFkKufGjWS5/+Y/o336czpTxH710OYLw/8bsdTfgRUmSxHv9PyQhMYnxY4Yhl8tZsnID5y5cIaCIn+m4cWOGUaJYEa5dv8UfC5YTHRPHppXzqVurGn/9s4qRQ/pgbm7O738txc/Xm+6d277Gq8ofuVxOnZr//lKOjU94oXJi4uILqklvBBdnpyyPiyAUtqqVKxRIOf5+PgAU8fd56bKCypZ86TIE4f/RW9uDlJScws3Qu9SpWZWhA3sxuH8PDu9cRZcOrbMcV6t6Jbp1eocpE0bTtFEdzpy7hCRJfPrhICKiYti26wB37t5n9/6jjB7eHwsL8yznS5LE0lUbqdWkE76latG6cz/uhT3MsU2Hjp2iSZue+JaqRZM2PTl87LTpvsvXbtCsXW+8A2tSp2kXVq/fBoBer+fHXxdQvmYrAoMbMe7L79BotHle+5PDe0eOnyG49jsAjBgz2dQj9CA8kg7vDcanZE2qNWjPr/MXI0n/prz65offGTFmMgDBtd+hQq3W7Np3GCe/YDZu3Q3AD3P+wskvmD8WLANg49bdOPkFc/najWde75Mq1GrN55O/ZeykmZSo2Ij6Ld/l2vVQvvnhd8pUbUb1hh24dPW66fiw++G81/9DipStS5V67fjrn1VIkkRySiruxaoydtJM07Gr12/DyS+YG7fu8M0Pv+PkF8zdew9M9X428RvGT5lF6SpNqVCrNYeOnjKde+zkORq06o5r0Sqm3sZy1ZpnabtOp+Ovf1bRpE1P/ErXpkq9duzYcxCAL7+ajbN/JeITEgHja6VKvXb0G/oZABGRMfQe9DFFytalZuNO7Nx7yFSuk18w8/5ezuBR4/EvU4eHEVHsPXCMzr2GUrxCQ0pVbsK3s/8wHZ+cksqgEePwL1PH1NYnh2B27DlInWZdKVK2Lt37jSI6Js50Xu9BH+Nfpg4Va7dm+rdznvn6WrNhO6279KdIuXqUr9GSxcvXm+5r03Ug738whlk/z6dCrdaUqtzE9FoGSEhMos/gTyhSti6tOvXl3v3wXOs5dfYizdr1xq90bd7pMoDQO2EAJCYl8+VXs6nZuBM+JWvSsmNf031gHGLuP+wzipVvQNmqzfjxiZ5gSZJYsnIDNRt3IiCoPr/8vijHum/cukOH9wbjV7o2DVu/x5lzl4F/31sLl66h18DRFClXj2btemcZtl24dA3la7bK8jw8Hlp68u/Hvdj7Dh6jefv38S9Th4EjPker1ZraunjFeqrWb0fRoHoM/nACqWnpABQP8MfMzAw/Hy8g98+PJ63fvJPKddviV7o2bboO5MKla4DxfdCqU998t//7X/5k2MeTKF6hIbWadOJKyE0AMpVKfvx1AXWbd8OnZE3qNu/G6XOXcnx8NRotoz6dQkBQfcpUbcYnE74iLT0jx2MF4U311gZIzk6OlC9Xms3b9zJwxOe5vlHTMzKJio5ly459nDxzkTKlSiCTyWhUvxZVgoNYsHg1f/6zCg93V3p375jt/OVrNjPyky8JLB7AN1PHElS2FJ6ebtmOC7kRStfew7G1tWHWVxOwtramS+9hXL95G4DPvviG6Jg4Zk4dS7061VEqVQD8Om8x02b+QpuWjRn/yXCWr97E/EUr8v04lCsTyLgxwwAY3L8HS/+ajbubC9NnzuH8xavMmPwJbVs1QaVSI5PJTOd16dCKDm2MwcBPMyfx87eTqF2jCgqFwvRYnj57EStLS06euQjAqbOXcHJ0oHzZUs+83qfN+3s5SqWKUUP6cDXkFo3b9OBm6F2GD+rNnXsP+HrWXMD4Idyp51CuhtxixuRPaFC3Op9+8TVLVmzAydGBJg3rsHv/EVOwt3PvIcqUKk6ZUiVyrPfPRStJTUvjo+H9SUxMYsLU7wHj66LXwNFIksTMqWMpWsSXcmVK8susKVnOVygUHDxykuZN6jNt4sdIksSQjyaSnpFJp3YtkSSJvQeOARB6J4y7YQ/o2LY5Wq2Wd/uO5MKla3zx2Qhq16hM3yGfEhUdayp7xne/olJrmD1zEn4+Xpy9cIXiAUWYNvFjypYO5JsffufE6fMAfPnVT2zZuY/PPhpMx7YtAPjluy8JKluS0+cu0XPAaPx8vPh6ymc8fBjJ6HHTAZjzxz9s332QcZ8Mo2e3DmRkKjE3z7vj+MTp81SvXJEZk8bg6urMx+NnZBmG3bJjH+cvXeOjYf2QyWSMnTQTvV4PwPCPJ7Fz7yE+GTWIdu80486jYPVpYQ/C6dRjCHK5nK+nfIZMJqPf0M+QJAm9Xs/ZC1fp16srY0cP4cq1G3z6xdeAcTi5U48hHDxyis9GD6Zvr66UKFbUVK7BYGD5ms0MHdgTdzcXps78xRTAPpackkrHHkOIiY1j+qQxFPHzoefAj8hUKk3HjP9yFhXLl6Fvj86cvXCFOX/8A8DJMxf4eNwMqlYqz/SJY7C0tKBrh9YMG9Q718fzo7HT6N6lLbVrVGHdpp3s3HsYMP7g+PCzqVStXIEZkz7h6PEzpjmN3l4exIedw8zM+Fzl9vnxWEZmJkM++gIfb0++/vIzfLw8svwgeiw/7f/6+99wcXZk1JA+3Lh1l6+//w0AuUzOoaOn6NaxNZPHfUhsXDxDPvwix3pWrNnMkpUbGNS3O8MH9UapUmFhbp7tOEF4k721Q2wymYwtq/5k4owfWLl2K+s27aR+nerM+X5KliG23oM+Nv1dtnQJ5v44zXT+Jx9+QK+Bozl7/goTPhuOlZVltnrmzl9C8YAi/DPvexQKRa7tWbh0LVqtjh+/mUjJEgFUCQ6iVpPOLFy6lu+mj8PezhZkMoIrlKVvry6m8+YvXEH9OtUZ/4kxyDl28izbdu7P9zwGVxdnalWvBEBwhbK0bdUEAHt7WwBKFC9K/97dsgRHAKUCi1GyRAAAjRvWpqi/LwBVgoM4c+4yBoOB0+cu07pFQ46fOo8kSZw5d4k6taoil8ufeb1Pq1qpPHO+nwLAynVbSExKYeHv3yGTyVixdjM3b98DYM/+Y9y7/5DZMyfSp0dnenfvyLZdB/jj7+X06dmZzu1aMuSjL7h1+x7FA/zZe/A4wwb2yvXxqVqpPHN/MD7new8c5eiJswDcvhNGckoq3381ga4dW5OWnsFPvy2kWeO6Wc6XyWQs/Ws2qWnpXLh8jfLlSrFlxz5uhd6lcnAQxYr6s2vfYd7r2o6dew5hbWVF8yb1OH7qPNeu3+KX776kfZtmqFRqlq/ZzJ4DR+nTozMARfx9WTB3JuaPvjjGjRmKVqvl4uXr1KgazKGjpzhz7jK1a1ThzLlL1K1VlQ+H9SM6Jo6NW3fj4uKEu5srX0z7ARtrK379YSoWFuZkZir5fPK3aDRa7O1skclk+Hp70rZ/E9MXbl5+/GYiSqWKC5dDqBIcxKUr17lw6ZrpNeLh7sryBT8hk8m4GnKTRcvWERefiFwuZ9e+Iwzq252PhvcH4NSZi2zevjdbHUtXbSRTqWLO91Pw9HDDzdWFngM+Iux+OMUC/Nm2dgGRUTFcunodfz8fU8/vngNHCb0Txu8/zaBH13Y5tn/90t+xtrYiKTmVaTN/4W7YQ9xcXUz3b96+l+iYOH77cRpVKpWnauUKNGjZnTPnLhNQ1PjZMWRADz7/eKipBzH0jvH1eea8safp22mf4+XpzoEjJ8hUqagcHJTr4zl75iSaN6lHxfJl2L3/iKk3bP7CFRQPKMJ308aBDEJvh7Fu044c3z+5fX48ppArsLa2xsrSgiaN6tCnZ+cc25Kf9ndo04yvJn8KGHvBQh+9N62sLNm0cj4JiUlcuBRCYIkATpw6T0JiUpbHF/79/HF3c6Fvzy45frYKwpvure1BAnB2dmTuD9O4cnIHI4f04eiJs9lWa0yfNIZta//m/JEtHN+7jrKlA033tW7ekBLFiiCXy+jfu1uOdYTdf0i5MoF5BkcA9x9EYGNtRWBx46/Z0iWLY2Ntxf1Hk8b/+HkGrZs1oEXHPrzTZQAXLl1Do9ESERXDkeNnCAiqT0BQfdZv3kVcfGJeVeXLtIljGDKwJ70Hfkz9lt05cPhEvs5rULcGl65eJ+TGbZKSU+jcvhUxsfHcun2Py9duUK92tXxd79Oe7LVwdXHBTKEwBW0uzs5o1JpH5RrPDy5fFjDOt6pUoZzp9tYtGmFpacGuvYc5cfoCqalpdGjTLNfrebJeNxdn0/BSieJFsbK0ZMuOfVy/eZs9B47i6+2R7XxJkpj+7RxKV27KkA+/4O6j4dXUtHRkMhmd27dk38HjaLVadu49TPMm9bC1sSHs0dDSh2OnmoYZNBot8QlJprKDygSagiMw9iiUr9mKTj2HmIYrHw+5lA8qzcXL1zl/8Sqr1m0FME1Gv/8ggoxMJaUqNyEgqD5jJ81EkiQSk5IZMfh9pkz4iE+/+JpqDTuwbtOOXB+rx+b9vZwy1ZrRa+BoLl0xDn2mpqab7n/yuXv8xajWaHjwqJepeLEiz6zj/n3jsY+HwnoOME4ijktIJDUtnZ4DR1O+Ziu+/OonMjKVZCpV6PV60+NaoVzpXMt+/Jy7uTgb2/botWWq+4Gx7s69hhEQVJ8GLbsb637ifff4eTEzM8PZyQG12vi6qRhUBoCVa7dw4dI1Ll6+jq9X9tdNftoTdj+cu2EPCChvfO//8sci4hJyfu/n9PnxJCsrS3asW4hCoSC49jsMHT2R2LjscxPz037zJ4JoN1dn1I/eM4+HzUpXacYnX3xF/KPH68nXxmOd2rXk1x+m8uv8JQTXeYd5fy/PsadJEN5kb3WA9PgDwMfbkxmTPqF2jSrcCr2X5Y1YoVxp6taqSvFiRbL1osjlcrw8PXB0sMfO1ibHOor4+3D95m3TEEJuihbxJVOpMv06vBl6l0yliqKPerPcXF2Y9dUEQs7sRqPR8P7gT7CwMMfHy4PqVSqyZfVfpv/+nPPNcz0Oj1e6qNVq0212tjZM/Gwk187spoi/Dz36Zx1CyHrev18gDerVQKPRsnHrbjw93GjWqC5mZmas3bgDjUZrCpCedb0v6vH5F6+EAMYhk4tXQky3O9jb0bxxPfYdOs6+g8coWSIgS9CbX/Z2tvTp2ZlN2/ZQu2kXroXcMv1qftLRE2f5Yc5f/DLrS66f3cPwD7IOpXRq15LUtHQOHD7JqbMX6di2+aPrMPa2jBszLMtzm9siAJVKzZCPvqBNy8aEXTvC/DlfZ7l/+KDeJCYl06RtL778+if69+5KpYrljHX5+2Bna8PGFfOy1OXm6oy5uTmjhvTl6qldNG1Yh4EjxuU6hw6Mc3A+n/wtHw3rz53LB5n6xce5Hvs0Dw/j0PPjoArI9Uvx8eOz5M8fs7S5XJmSzJ2/hP0Hj3P20CZOH9xI/TrVTec9nrR89dG8mBfxuCds9syJWepu3KDWM8+tV7sa5cuVZso3P9O4TU+cHB34aMSAF2tHEV+K+PuwedWfpjZsWjk/x2Nz+vx4WlDZkqxe/CuHdqxk++6DTP5qdoG2f83G7SxZuYFtaxdw6fh2OrdvleuxMpmM3t07cuHoFgb378Hnk7/lyPEz+apHEN4Ub+0Q29ETZ+nUcwjvdWlHzeqVeBgexZnzl2jVrGG2QOhlDHj/XcZOmsmA4Z/zTotGHD91no9HDMDd3QUzMzMuXLpGekYm/Xp1ZdGytXwy4St6dGvPslWbMDc3o3/vriSnpPJev1E0b1Ifby8P0jMyUCiMwcmgfu8xbeYvrFq3lVo1KnPj1h26PppoPmfePyxduZFlC2YTWDwg1zY+/rJZsWYLLs5ONG1Ul35DPqVSxXKULBFAYmISMpkMGVkfl8fDCT//vpAO7zSnRdP61KgSjKWlBWs2bqda5QpYW1tRvlwpVm/YZpp/BOR5vS+jWeM6BBT148df/8bMzIxzF64SF5/IpLGjTMd0bt+SoaMnEhkVQ4e2zV/o+c5UKlmweDU9urXHx8uDUoHFcHNzQZKkLOU9nutx4vR5MjIy+eXRXJTHgsqWpFRgMaZ9OwdzMzNaNG0AQJ2aVSlXOpBFy9Yil8twd3Ph1u0wZkwak2N7tDodWq2Om6H3WL1hO2s2ZJ2EO3f+EsqUKk6HNi1wdLSnQrnSZGQqsbO1YUCfd1mzcQc//rqAzu1aEhufQFF/XxQKBYNHjcfFxZlKFcoSGR2LTCZDrpBz9MRZRnwymekTx9D+nX974B5f78XLISxfs5kFi1fn+zH19/WmcnAQW3fs44+K5UhNS2fXvsM5HtuzW3vmzl/CD3P+ome39qhUaszNzan/aH6NSq1m9/4jZGQq2bpjn+m8Zo3r4efrzYSp35OSmoZMJiMpOYXPPx6a73a2a92UGbN+5dd5i+nXqyvm5mYkJadSv0510jMy8zz38LHTXA25ydjRQwDjsLZOp8t33U8a1Pc9Bo0cx5+LVtK8ST0ePIykVvXK2Y7L6/PjsQuXrvH55G95t3MbZDIZOq022zEv2/7Hr429B45x/uI1Fi5dk+V+b093boTeJTYugbnzFxOfmET92tVNAfmzeuEF4U3z1vYg1alZhe9nTODGrTuMm/wtS1as5/33OjHnqUm2L2tQ3+589eWnXL56g08mfMXDiEi0Oh22NjZ079KG46fOc+PmbYLKlmTtkt9ITUvn0wlfkZGZydolv1G2dCAO9nZ0bNuC1eu38cn4r7CxtuavOcaVWB8O7cuU8R9x9ORZxk78hhOnzpuGVZRKFbdu32PP/mN5trGovy/jxgwj9E4YE6bM4s7d+/R8tz279x/h43EzSElNY+Ef32FtbZXlvE5tW9C2VRM2btnNlK9/QqvVYm1tRY2qwdx/EEG1R0uWq1euwP0HEab5R0Ce1/sybG1s2LDsD4LKBPLF1O85fOw0300fx/s9OpmOadmsAWYKBaF3wujYpsUL1WNjbU3dWlXZuGU3P8z5iyEffUGDlt0ZNDLr/I+mjerwbuc2rFq3lSUrN/Dh0L5Z7pfJZHRq15KrITdp1riuqSfSwsKc1UvmUrNaJX7/axlfzZpLfHxijsMRYOzR+vrLT7l2/RazfppPu9ZNcXf7d15H00Z1uH33AT/++hcTpsyi3buDCK79DhGRMdSqXpnlf/9EUnIK46fMYtW6raYhwJ7vduDchSuMGT+D6zdvM+f7KRT190Wr1RIXl2AarnusTKkSfDi0HwcOn+C3+UvynN/1NJlMxt9zv6VSxSC+mjWXU2cu0rdn9vkyYByG27hyHpYWFkz95mf+/GcViUnJSJLEsEG9qFE1mK9mzeXcxasM6tvddJ6xp+wPqlYqz1ez5jL3zyVYWVo+1/CNs7Mjm1f9SdEivnz30zx+/m0h8QmJz1zdB1C5YhDOTo78Ou8fvvtpHr0GjqZSnTb8vST/geRjXTq0Ys73U7h1+x6fT/qW7bsPkp6RfaVXXp8fjwWWCCC4Qllm/7qAKV//RMP6tZj8+YcF2v73urajWaO6/PbnEnbsOZhtnuT7PToTejuM46fO0al9Kx6GR/HZxG/Yf+g4X477UKTgEN46Mo1GLQaG31CSJNGgVXc+HNqPbp3eed3N+U/Ze+AYPQZ8yJWTO/HydCcjM5NBI8dz7MRZHlzPOyAtbDqdjoq1WjN88PuMHNwHvV7Phi27GTRyHEv+/JF2rZu+ULnjp8wiM1PJz99NLuAW/3dN+fon9hw4xpFdq5DL5SQmJVOrSWeqVq7Air9/ft3Ne6a3vf2CUJje2iG2/weDR00AeOEvQCF34RFRaLU6vv7+N2rXrMKde/c5dOQkbd/Ax1ql1hAbn8jq9duwtrJCp9OxfM1mnJ0cqVmt0guV+dc/q1izYRvb1y0s2Mb+x4VHRHP7bhizfp6Pv58Px0+eIzYugdbNG77upuXL295+QShMogfpDbZp216aNKxtXOIrFCiVSs0X075n07Y9pKVn4OfjRef2rRgzcmC2ocg3wfrNO/l29jzu3X+Is5MjNaoGM/6TYZQr82JZko8cP0MRfx/ThGUhfx6ER/LJ+K84eeYCkiQRWCKAD/q9R693O7zupuXL295+QShMIkASBEEQBEF4yls7SVsQBEEQBOFVeasDpE59RtN94Kf0GTaBPsMmMGbiLAB+mb+csxeNidSmfz+Plet3ArBt92E+n5I9N0he0tIzqN0y920ECtKLtO91ioqOY/hnM0z/Pn8phD7DJrxweZ36jObWnfsF0bRcyzp/KYTp38974XKnfz+P85dC8jwmKjqO5p0HP3fZfy1Zx+zflwAv/1jm152wh0z97vdXWkenPqOz/Lt2y94vvC/Xk+/nsxev8cv85S/bvALxtr13BUF4trd+kvb0CaMoVaJolts+HNzzNbVGEN4uJQL8+XLssNfdjBdSrVIQ1SrlvsWHIAjCy3jrA6ScfD5lNg3qVKVNiwZ5Hrd11yGWrd2GXm+gepXyfDK8D3K5nPOXr/PT70uQyWUUL5pzZui/lqxDqVITHhnDzdAwGtWrTs2qFVi6eiv3HkTw2ch+NK5fA6VKxc9/LOPWnfukpWfQqG51Rgx6D4Dhn82gdbP6bN5xgGYNa2XJ5h165z7jp//Mr99NwMvDLde2tn53GEP6dWPjtv2MGd6H0Lv3WbZmO+bmCmpVC2b00N5ZEh8uW7ONfYdPoVSp8PFyZ9r4kdjaWPPXknXIZDKuhITi7OTIl2OH5lonQHRsPKPGfUNiUgp9hk1gQK9OONjbotHq+GXeMk6dvwISfDd1DL7eHmRkZPLDb4sJuXkXmQxGDOxBvVrZk+Jt232YH0LvEZ+QROe2zejVrQ0Gg4Hf/l7F+UshZGQqKVc6kImfDEahkJORqWTOn8u5dPUm5mZmvN+9Hc0b1TaVJ0kS02bNw9PdhXq1qjBt1jwylSr6DJvA2A8HUDowgLkLVnLijHGvr97vtqV9q0aEPYhg6nd/kJGpxMnRnqnjRrBx2z4OHDnNpas38fX24Odvsu+Z9ZhBMrBo+SYOnzhLUkoaX30xinKlSyBJEv+s3MyeAyeQJIla1SoybED3Z24geyUklF/mLyNTqcLFyZFPRvQloIgPn0+ZTf3aVWjbsiFHTpxj7JTZbFs5FxdnR2b/vhg/Hy+6dfg3V9T07+dROjCAA0fPUL5MIM0b1+bzqbPZsPgnoqLj+HzqbBrWrc7Rk+dJSU3nq4mjKFuqOOkZmUyfNY9bd+8TF5eIg4MdtasH8+nIvkyZ+Tt3wh5iYW7OR0N7U7NqBVN9H42fSXRMPH2GTaB29WCGDTDmNNq04wBHTpznYUQ0X4z5gLo1K5semx17jyJJEq2b1aN/z465PiaHjp9l1Yad/DJzPB17f8gfP0zGz8e4/cqIz76if6+OBAeVzvH5fdLT78PObZvleM75SyH8sWgNRXy9uHX3ATIZfDFmcLYfaLm957fuOsTxM5f4eqIxP9GFKzf4c/Fafps1Mc/nXhCE1+M/GSDlx6Vrt9i5/xgLf52BuZkZ02b9weET56hSsRwTZ8zhm8kfEVy+NNdv3WXnvpzz4py/dJ2fvh6LJEHb90Ygl8uZ8+14duw7yl9L1tO4fg2sLC1p27IhQWVKoFKr6dDrQ95pXp9iRY2rh7btOsTc777AwsKcbbuNWYcTk1OY+PWvTB03HC8Pt1zb2qhudZJT0giPjGHhr9ORyWR8PPE75n73BYHFixCfkJQty3SV4LJ079QShULBx198x859R+nSzrg9xtrNe/h7znS8PfOuE8DLw40JHw/ir6XrTR/w5y+FkJiUTMumdRn5QQ++mDGHzTsOMGxAd+b8uYIK5Uoy6dMhJKekMWDUJGpXD86W7dfL043RQ3uTlJxKt/6fUKt6RUoE+NO4XnWGD+iOQZJ4f+h4Tp27TJ0alZjz53J0Oj1L/5iJwWDItp3KsjXbUKnUDO7bFblczgd9unD+8nUmfWrMJLxoxSYsLcxZ8adxc9e+IyZSr2Zl1m/dR/mygXwyoi9RMfF4urswbEB3rlwPZVDvzlQJLpfn60ut0lCudHH69mjPL/OXsXL9TqaNH8Gu/cc4evI8f/0yBXMzM774ag7L1m6jX4/cVxGlpmUwbtpPfDflY4LKBHLgyGnGTfuJZfNmUrNaRc5duk7blg05e/EaVYPLce5SCM0b1ebsxRA6t82+T93azXtY8MtU7O1ssw1D3g0LZ+SgHgzo1ZFf5i9jxbodTBs/gnVb9qLT61i36Eeu37rH5G9+ZdKnQzh49AzhUTGsWfgDqWnZMzz//M04arfszeLfs26d4uzowB8/TGLNpt0sWrGZujUrs/vACe4/jGTZvG+QJPhw/EzqVA+mdMlieT7WZgoFLRrVYf+RU/Tp3p6ExGQiomKpXKEsS1ZvyfH5dXF2zFLGk+/D3F4TAOERMUz4+AMCiviwbsseZv60gL/nTMtSVm7v+eaNazN/8VoSk1JwcXZk1/5jz/wRJwjC6/PWB0iTvp6DpYUFAB8N6U3VSnl/cT129MR57j+IZPDoKYAx10y50sW5ej0Ufz8vgssbN8N8/Is0JxWDSuHoYA9AET9v6tWshFwup2K5UvycsBQwZhd2d3Vm2dpt3LodBkB4ZLQpQHq3UyssLP7dsFSj1TJh2s9UDS5HUJnAPNv6WO9ubU2BUJd2zflh7j/07PIODepUy9bmIn7e7Nx3jEvXbhEeGUN4ZIzpvqYNauHt6ZavOnPj5eFG6cAAAILKliDs0aakh0+c40pIKBu2GreNMBgkklNScXVxynJ+1eByyGQyXJwdCSoTSMjNu5QI8MfX25N1W/YScvMu6emZpnYfPn6OeT9ORqGQo1DIcTS3N5V17NQFFizdwIYlP5l6vp525MR50tIzOHHmEmB8/KNj42naoCYzf17AgqUb6Ny2aa7n58aYkdzYk1K+bEnWb9lrqq9968ZYWxlTCXRp15x5i9bkGSBdvR6Kv4+n6fXQuH4NZv+xhIcRUdSqVoFFKzYiSRIXr96kf4+OnDhziarB5chUqiji552tvA6tG+eaOiK3dnt5uHL8tBK1RkNiUrLp9VaxfCkszM359ue/ea9zKwKK5C9tQIM6VZHJZJQvG2iaU3TkxDmu3bzDgFHGxJWZShVRMfHPDJAAWjerx4wf59One3sOHD1Ds0a1UCjkuT6/TwdIT74PczsHwM3ViYAixv3g6teuyo+/Lc62VUde7/l2LRuxbfdh3uvcmlNnL/Ph4PxnKhcEoXC99QFSTnOQ8kNColmjWnw0JOsE7MPHz+W4h9GzmJn9u8+QmULB450Pbt25z8Sv5jC4T1daN61HfOKvGJ7YFuHpuk6du8L777Zl3+FTPIyIxt/XK9e25lTG8AHdiYqO459Vm1m4YhN//TTF9MGvVKkY9NGXtG/ViN7d2uDh5pJl76kny3lWnfl6TBRmmK5UgqnjhhNY/Nk7vZvON1NgbWlJbFwCI8Z+zfvd2z3qCZJhMBhLzmuLic07D/Je51YsWLKecaMH5niMJEmM+qAH9WtXzXbforkz2LXvGH1HfMGUz4dTpWLZfLf96euQyLmdMpnxv+dl3FdPho+XB9ZWVlwOCcXSwoLqlYP47e9VXLhygxqVy+e4T11+98R6st11alRiwdINDP/0K8zNzUzzllycHPl7zjROnr3M5G/m0rxRbd7v3i7f12FmZmaqQ5IkenRuzbsdW+b7/MdKliiKXm/gYUQ0+4+cYsywPqYyc3t+n5TltZ/LOU9PzjczU2Bubp4teM7rPd+5bVM+HD+T4gF+VA0uh80bmHNLEASjt3oVW37IAEkymP5hePR33ZqV2b7nKA/CowCIiolHrzdQtnRxbt2+T9gDY8/HlZDQl6r/3MVrFCvqS7NGtdAbDMTEJuR5fIVyJRna/12GDejOzJ8WIElSrm19mlqj4UpIKN5e7owa1IOwBxEkJCab7n/wMIrklDS6dWiBp4cboXmsGMtPnV6ebsTGJebYlmzl1arMgqUb0Gp1SJJEZHRsjsc9jIgGjEM9ITfvUKlCaUJu3sXa2op2LRtia2NN2INI0/F1alRi2dptGAwGdHo9EVH/ljt+9CCG9utGyM07nLto/HLz8nAjOibeFFjVq1WZxau2kvEoUHzcrsvXbiFDRrtWjahUvrTpy9HLw42omPhnXm9u6teuwpadB1Gp1Oj0etZt2Uu9WsY9qmQy2b8Bn0xm+lItX7Yk4VExXLtxB4CDx85gbW2Fv68XALWqVWT1hp1UqVgWW1sb7GxtOHTsjKknqCAcOXGeKsFlWfjrdObP/pIK5YwJKu+GhZOUkkrt6sF0atuUE2cvZTvXy8OVqOi4Z9ZRr1YVVm/cZXrN5vQayfJ+fkqrpnXZtOMA6RlKUyCe2/ObdztyPyctPYPklDQA1mzcTe1qwcYA6YnPlrze864uTpQODGDeojW0aSmyVwvCm+yt70F6lhpVK/DXkvV0adec8mUCWbhsI9du3KFyhTKM+qAHn0+djZnCDEcHO778fBjurs6M/bA/Y6fMxt7OlhpVy7/Ur7zG9Wtw7NRF+gz/glIlilIsl0nfjzk52COTyWhSvwZbdx1i846DdHinca5tfZJKpWb91n18P3cRqWkZ9O7WFq9HQ2YAJYr5U6dGJXoNGU9RP298fTxMPTFPy+vxeczHy4MSAf50H/gpA3p1wsvDNdfr+mhIL376fQm9hozDysqSmlUqmCarP+lm6D3TvKFJnw7BzdWZapWD2L7nCL2HjKdYUV/TEIex3N78+Ns/9Pjgc6ytLOnSvjm+3h7Gx9LRHjMzMz4d2Y8ZP8xn8W9fUaFcSTRaLT0Hf87ooe/z/rvtSE/PpP+oyVhZWVIiwI/Jnw0l9O59Zv++hEylEndXF1NPWpvmDZjy7W9s33OEn2eO4/e/V+Hv60XHd5rk+bw+1rJJXaJjExgwajIymYwaVcvTq2sb42NesSxf//gnvbq2oWTxImg0Wg4dP0vDOtX4ZtJoZv++GJVag5OjPTMnjzb1etSqVpFPJ3/P7K8+B4zDlCs37OCTEf3y1ab8KF82kFlzFnH56i3MzM3w8XKnaYOauLo48d0vf5P2KJgYO6p/tnO7tGvO4DHTaNqgJqOH5t4j2appXeISEhn+2QwsLSxwd3Phqy9GYWVlaTrmyffz01o0rkPXfmMY3Ker6bbcnt+cetaedQ6A3mDgm5/+IjwiBi9PVyZ8/IHx8Xnis+VZ7/nWzeox86cFBAeVyrUNgiC8fiKTtiC8hBuh99i0/QCffzTgdTfllfrqxz+pVa0iTRvURK83sHTNVg4fP8eCX6a+7qYVmvOXQvjpj6XZJpw/D4PBwNc//knFoFK0b924AFsnCEJB+8/3IAnCq6LWaFiyaguj/g/ybjWsU42lq7fwz4pNaLQ6fL3d+WLMB6+7WW+Vx6k7gsuXpq0YXhOEN57oQRKElyBJUp7DNYIgCMLb6T8/SVsQXiURHAmCIPw3iQBJEARBEAThKSJAEgRBEARBeMpbGSBJkoROp8szSaAgCIIgCMKLeisDJL1eT/02/dDr9a+7KYIgCIIg/Ae9lQGSIAiCIAjCqyQCJEEQBEEQhKeIAEkQBEEQBOEpIkASBEEQBEF4igiQBEEQBEEQniICJEEQBEEQhKeIAEkQBEEQBOEpIkASBEEQBEF4igiQBEEQBEEQniICJEEQBEEQhKeIAEkQBEEQhDdScmoGD6MSXkvdZq+lVkEQBEEQhDwcPHWdW2HRAHRsVhUPV4dCrV/0IAmCIAiC8Ea5+zCWW2HR1K4ciJ2NFSF3Igq9DSJAEgRBEAThjRGfmMaRs7cI8HOnfEk/ypbw4c6DWFRqbaG2QwRIgiAIgiC8ER5EJrD5wAUc7KxoUK0UMpmMMsW9kSTJNNxWWESAJAiCIAhCobh9P4Z1u87keN/1O5HsOnoFXw9n2jaujJWlBQDWVha0blCRsiV8CrOpYpK2IAiCIAiF40FUAgnJ6RgMBuRyYx+NJEmcuXKXi9cfEBToS+3KJZHLZVnO8/V0KfS2vvIepKjoOBq268/5SyHodDpmzVlIryHjGP7ZDGLjjEv3Nm7fT68h4xgyZprpNkEQBEEQ/lvik9IAUD6aT6TXGzhw8joXrz+gVqUS1KmSPTgCCI+MRpKkQm3rKw+Q5i5Yib+vFwAbtu0HmYylf3zDuI8G4uzkSGJSCktWbWHBz1Pp2r45cxesetVNEgRBEAShkGm1OpJTMwFQqjQAnLlyl7vhsTSrE0TF0kWQybIHR6fOXqRe825M/3ZOobb3lQZIF6/cwGAwUDowAIAde4/yXqdWyGQyivh5Y25uxqlzVyhVIgArK0sqVSjDiTMXX2WTBEEQBEF4DRKS001/q9RaEpPTuXIrnKpBxSju75HjOcdOnqPje0PQarXUq12tsJoKvMIASa838Nvfqxj1QU/TbdGx8Zw+f4W+I77gqx//RKfXk5CYTBE/Yw+Tm4sTeoMBlVrzqpolCIIgCMJrEJeUZho+y1RpOHv1Hg62VlQs7Z/j8UlJKXwwchwKhZzNq/6kScM6hdncVzdJe9uew9SoUh5vL3fTbZlKFXa2tiycM53PvvyRw8fPgYws44qSQSKHHjbWbt7Dui17jMcU8jikIAiCIAgvJz4xDVcnO5JTM1GpNCQkp1Pc3wOFIue+ms8nzyQyOpa5P06jauUKhdzaVxggHTp2hoTEFE6evUxEVCwhN++g0WipVL40crmcapXKERkVi7ubM1ev3wYgLiEJc3NzLC0sspXXtX1zurZvDoBOp6N+m36vqumCIAiCIBQglVrLw+hEAot4olJryVBqSM9UY29rlePxkVExrN20k8YNatGzW/tCbq3RKwuQfpj+menv6d/Po03z+hw6fo79R0/TrUMLzl4MoUu7ZpQtVZz5/6xFpVJz4fIN6tSo9KqaJAiCIAjCa3DiQigGg0SlskWIS0wlPjkNSZJyDZCWrtqIwWDgg349cpy4XRgKNVHkgF6dOHvhGj0GjcXT3ZXa1YNxdnKgX8+ODPzoSzZs3cvwgd0Ls0mCIAiCILxCD6ISCL0fQ+3KgdhYW2JlZUF8onG5v72tdbbjlUoVi1dswNvTnRZN6hV2c00KJVHkpE+HmP7+Yfqn2e5v17Ih7Vo2LIymCIIgCIJQSDRaHUfO3sTPy5lSAcYFWdaW5mh1egDsbC2zHH/uwhWGjp5IeEQUX3w2AjOz15fPWmw1IgiCIAhCgcnIVLPt4EUSk9M5ffkuao2O+tVKm4bKrK2M84xtrC0wUygAUKs1TP92Ds079OH+wwimThjNmJEDX9s1gNhqRBAEQRCEAnTjbiQRMUnsOHKZjEw1dSqXzDKUZv1oj7XHt10JucnQjyZy7fotgiuU5ffZ0ylXpuRrafuTRIAkCIIgCEKBkCSJW2HR+Ho6ExOfgqerA0ElfbMcY21lDoC9rRVbd+6n/7DPkCQYN2YYn4waiLm5+etoejYiQBIEQRAEoUBExiaTlqGicc2yWFlaYG1lnm0V2uMeJAdbK2ZM/wtLCwu2rllApYrlXkeTcyUCJEEQBEEQCsTDqARsbSzxdHPMdXm+1aM5SAnx8Zy/dI2e77Z/44IjEJO0BUEQBEEoIJkqDQ62VnnmLnKwtcLPy5kjR48C0L1L28Jq3nMRAZIgCIIgCAVCqdKYVqnlxsxMQav6Fdm4dTd+Pl7Ur129kFr3fESAJAiCIAhCgVCqNKY5Rnk5dvIc4RFRdOv0DnL5mxmKvJmtEgRBEAThrZOfHiSAVeu2Am/u8BqIAEkQBEEQhAJgMEioNNpnBkiZSiWbtu2hUsVylClVopBa9/xEgCQIgiAIwktTabRI0r95jnKzfddB0tIzeO8N7j0CESAJgiAIglAAlCoNwDPnIK1atxWFQkGXDq0Ko1kvTARIgiAIgiC8NFOAlMcQW0xsPPsOHadZ47q4u7kWVtNeiAiQBEEQBEF4aY8DJJs8AqS1m3ZgMBjo0bVdYTXrhYkASRAEQRCEl6ZUaTA3U2Bmpsj1mO27DmJjbUXLpg0KsWUvRgRIgiAIgiC8tEx13kv8U9PSOXX2IvXr1sDa2qoQW/ZiRIAkCIIgCMJLU6q0WFvmvoLt4JGT6HQ6mjeuV4itenEiQBIEQRAE4aU9K0nkvoPHAWjWqG5hNemliABJEARBEISXlleA9CA8km279hNYvCgBRf0KuWUvRgRIgiAIgiC8FINBIi1Dha2NZbb77j+MoG23gSQkJjNuzLAXKj8t4iQGnfplm/lcRIAkCIIgCMJLiU9KQ6PV4ePulOV2Y3A0iIfhUfz6w1S6dmz93GUrE28Rdeo7Yi78UUCtzR8RIAmCIAiC8FLCoxMxN1fg4epguu1xcBQeYQyOer3b4bnLlSQ9sRf/BJkCl9KdC7LJzyQCJEEQBEEQXkpETCK+Hs7I5cawQq3W0KnH0JcKjgBS7u1FnXwH58C2WDr4F2STn0kESIIgCIIgvDCNVkd0fCp+Xi6m21at38rdsAeM/2TYCwdHenUq8deWobBywbXMuwXV3HwTAZIgCIIgCC/EYJA4cvYmMhn4exsDJL1ez8+/LcTR0Z6hA3u9cNnxIcsxaNPxqNgPubl1QTU530SAJAiCIAjCc5MkicNnb3D3YRxNapXD3tYYxOzce5g79x7wQd/3cLC3e6GytcoEUsL2Ye1aFjvf15M3SQRIgiAIgiA8F0mSOHY+lFv3omlUowzF/T1M961YsxmZTMaA97u9cPnJd7aDpMe5VCdkMllBNPm5iQBJEARBEIR8kySJU5fuEHI7ggbVS1MywMt0X2JSMrv2HaZhvZr4eHu+UPmZ8ddIubcLcztfbL2qFFSzn5vZa6tZEARBEIS3TkRMEpdvPqRO5ZKUKe6T5b4NW3aj1ero3qXtc5erTgkj/upSMmLOg0yBZ5VeyGSvrx9HBEiCIAiCIORbWEQ89rZWBJX0zXbfyrVbsLG2ol3rpvkuT5sRS/z1FaQ9OAxI2PvVx7VcDyzsvJ557qskAiRBEARBEABjwkeDJFHE2zXH+yVJ4kFkAkV9XLPNDbpz9z5nzl/m3c5tsLO1yVd9aREniD4zG8mgw8ajEm5BvbByLvHS11EQRIAkCIIgCAIApy/fJSk1g84tquHsYJvt/qTUTNIzVRTxyR5ArVq/DYD38jm8JkkSCSErkCks8a0zERuPii/X+AImJmkLgiAIgoBOpychOR2DQWL/iRD0ekO2Yx5GJaBQyPF+as81nU7HqvVb8fJ0p2G9mvmqTxl/DU1aOA5Fm7xxwRGIAEkQBEEQBCAhOR1JkqhfrTRJqRmcuXI32zHR8Sl4uTliZqbIcvu8hSu4/yCCPj06o1Aosp2Xk+S7OwFwKtby5Rv/CogASRAEQRAEYhNSUSjklArwpEaF4ly++ZDw6MQsxySnZODi+O/QmyRJ7D90nK9nzSWgqB+jR/TPV13azFjSI09i4xGMhb3Ps094DUSAJAiCIAgCsYmpuDnZIZfLqVDaH19PZw6euo5KrQFAp9eTmqHE2cGWTKWSRUvXUqdZFzr3GoZao+WnmZOwsc7fliBJoVtAMuBc8sX2aSsMIkASBEEQBIHYhFTcXR0AkMlkNKpZFr1BYu2uMxw6fYOklEwkCU6eOk1Q9ZaMHjediMgYRgx+n7OHN9Gofq181aNXp5ESthdLx2LYeAS/ykt6KWIVmyAIQiHT6w3cuBtJclomdSqXfG1bKQjCYxmZatIyVHg+CpAAbK0tadMomBt3owi5HUGmUsmObVs4sH8fHu6ufDd9HD26tcfeLvtqt7wkhm5C0qtf6zYi+SECJEEQhEKi1xu4eS+KCyH3yVCqASji7Yp/LjlnBKGwhEXEIZPJ8PNyyXK7i6MtaFLZumkD586dJSMjgwpBpVn+98/4+3o/dz06VRLJd7Zh4VAEe786BdX8V0IESIIgCIUgITmdnUcuk5GpJrCIJ1WCirL/ZAhXboWLAEl4ZSRJIjElg6jYZBJT0gnwdcPfO3uSx3vhcfh6OmNpYY4kSZw5f5n1m3exaetuomLiAHB39+Ddbl2YNeUjzMxeLHxIetR75Fr2vde6jUh+vPIAKSo6jvc+GMvsGZ9RJbgcALPmLOTegwh+mzURgI3b97Nm027sbG2YPn4EHu7iw0IQhP+WOw9i0OsNdGtdw5SAr3wpfw6euk5SakaOSfkE4WXtPHyZh9GJyOUybK0tuXE3ClcnOyqVLUoRbxdOXb6LJElExaVQr2opFi5dww9zFhAeEQVAsaL+fDJqEHXr1iI0PI0KpfxfODgy6FSkhO3Fwt4PO5/85Up6nV55gDR3wUr8ff/dT+X2vYdcvXEbWxvjTPfEpBSWrNrCsnkzOXLyPHMXrGLquOGvulmCIAiFKjVdhbODbZZAqLifOwdPXScuIVUESEKBMRgMaLR6NFodD6MTqVUpkHIlfFAo5ETFJXMh5D77TlxDoTD24Cjkxv/HxkQwZvxXeHq48eHQfnRu35LgCmWRyWQYDAYSd5/Fx9P5hduV+vAIBm0mTuV6vdFzjx57pQHSxSs3MBgMlA4MAIxdfXPmL2NAr06s2mBMEHXq3BVKlQjAysqSShXKMGvOwlfZJEEQhEJhMBiIjE1GrdFSzM+dtEfLo59kZqbAwtyMTJXmNbVS+C86eu4WYRHxlCnujUIhp2xxb1NiRx8PZ3w8nIlNSOVueCwli3pha21JXEIKXXt9gLm5GZtX/UmpwGJZypTL5XRtVeOF26TNjCcpdCNyM2scijR6mcsrNK8sQNLrDfz29yqmfj6cv5auB+DwiXP4entSqnhR03EJickU8TP2MLm5OKE3GFCpNVhZWmQpb+3mPazbsgcwBlqCIAivU3h0IqnpSsoFZt/RHODkxTtcDQ0HoFX9iqRlqCjq45btOGsrC5QiQBIKSGq6kpv3opEkiYvXHxDg5465efaveg9XBzwerVgzGAxMnv4tN0PvMnnch9mCo5eVEXOR6DM/odek4la+D3Lz/OVKet1eWYC0bc9halQpj7eXOwAarY7FK7fw44xPycxU/XugLGvAIxkkcup569q+OV3bNweMe77Ub9PvVTVdEAQhTxqtjgOnriNJEmVL+GQbLlCqNFy/G0nlckUJuR1BVFwyKrUWe1sr0zHXroeyaOka1mzaxTutW1Kr0vi3YthBeLNdCLmPlaU55Ur4cO5aGMX93PM8XpIkJs34kQ1bdtOhTXNGD89fJuz8kCQ9CdfXkHhjDXJza7xrjsXeN3+5kt4EryxAOnTsDAmJKZw8e5mIqFiu3bjD/YeRfDLpezRaHRFRMcz+fQnlShfn6vXbAMQlJGFubo6lhcUzShcEQXh9Ll6/b+r1yVRqsLWxzHL/1dBwZDIZFUr5ExOfQliEcRWQmRyWrd7EoqVrOXP+MgBWVlYsX7EKnSqNGZM/FYtUhBeWlqHkVlg0NSsWJ6ikH7bWlhR7RoA088c/mDt/CbWqV+L3n6YjlxfMyjJJkog88S0Z0WexdCqOd41PsbDzevaJb5BXFiD9MP0z09/Tv59Hm+b1TavYoqLjmP7DPD4e9j5JyanM/2ctKpWaC5dvUKdGpVfVJEEQhJcmSRLXQiMo7u/B3YexxCenZQmQYuJTuHzzIUGBvlhZmuPqZE9kbDIXzp9jxpSJpKalY21lRa/uHejXsyvJSgPTvv6e1Ru2s3PfEZYv+Il6tau9xisU3lYXQu5jaWFG2UBfFAo5ZUrkvcdZfEIiP/76F0FlS7F68dx8bxOSH8r4a2REn8XOpxZe1UcjV7x9HR+vPQ+Ss5MD/Xp2ZOBHX2Jva8P0L0a97iYJgiDkKi1DhVanp1SAFxExiSQkpZvmFqVlKNl99ApuzvZUq2Ccx+HmbEdEeDhrVq3A3dWZiWNH8m7nNjg5Gud/nA8JY9AHQ3CyUDPq0y/p2ns473VtS+WKQVQKLkfZUoFYWJi/tusV3g5pGSpu3oumRsXimD+akP0sK9dtRavVMWbkABzs7Qq0Pcl3tgPgVr73WxkcQSEFSJM+HZLl395e7qYcSADtWjakXcuGhdEUQRCEl5KUkgGAi5Mtrk52xCelAaDWaNl5+DLm5ma0rFceM4UCSZLYuXsvC/6ahyRJLP/7ZyoHB2Upz8bSArVGR7sOTShaxJd+Qz9l0bJ1LFq2DgBLSwumjB/NsEG9CvdChbfK496j3BYNPE2SJJas2ICzkyNtWjYp0LZoM+NIjzyNjWcVLOzy7sV6k732HiRBEIS3SWJKBubmCmytLXFztudeeBwGg4G9x6+RodTQsVlV0yrc+QtXMGnaLOzs7BkxYmi24AjA2tp4rEqtpVKFslw4upWo6FguXA7hwuVrrNu4k/FTvsPby52ObVsU6rUKb4f0DBW3wqKoVr5YvnqPDAYDX82ay83QuwwZ0BMrK8tnnvM8Uh8cBAw4FW9VoOUWNhEgCYIgPIek1AxcHGyRyWS4Otlx+eZDth28RHR8Cm0aBuPkYANAdEwcX82ai5+vN9OmTqWov0eO5Vk/CqYyVRpsrC2RyWT4eHvi4+1Jm5aN6duzC83a9WbkJ19Ss1olvL3+LUev13MnLILE5FT0egOO9rYUK+pjSsQr/PfpdHoOnbmBuZkZQfnoPUpJTWPwqPHs2neEysFBfPrhoAJtjyRJpD08itzCHlvPSgVadmETAZIgCMJzSErJwN3FOH/I19MZHw8n9HoDTWqVy5Jl+OvvfyM1LZ3ff5pBm5a5b6tgY2UMkHLLheTv683smZPoOeAjvvz6J+b/8jUJSSms3rSPZet2ER4Zm+V4WxsrOrdpRO+urSgdWDTHMoX/Bq1Oz64jl4lJSKVV/Qo55jt60q3b9+g54CNu371Pj27tmf3NxALvPdKk3keT9hDHYi2Ryd/uEOPtbr0gCEIhMhgMJKVmULqYcRdzG2tL2jaunO242LgEVq7bQs1qlXinRaM8y7SyMk7AzitZZOvmDWnWqC6r12/DILfm8MnLaLQ63FydGNSrPb7e7pgpFCSlpLHzwEmWrNnJkjU7qV8zmNkzRuPm4vTC1wxgMEgkpWTg6lywE3mFF6fV6dlx6BIJyem80zAYb3enPI+/GXqXZu16k6lUMXPqWIYM6PlK8m6lPjwCgL1//QIvu7CJAEkQBCGfktOUGAwSLo5575u2YPFqNBotwz94/5lfQmaKvLcbUam1WFqYMXPa5zTvMpy9R85TvKgPHw/tQcvGNbEwz7rCbdSgbly4eouFK7ayZddROvcbx7Lfp+Lv6/lc12owSOw9fpXAop4kJKdzIeQ+QYG+1K4cWGC5coQXd+7qPeKS0mjXuBIero7PPP7Lr38iLT2DtUt+o1njuq+kTZIkkRZ+DDNrV6xdy7ySOgqTCJAEQRDyISNTzf4T17C0MMfN2T7X406dvcgffy+jaBFf2rZqnK+yjduNaLPdrlJrWLHtJDUqFOfvpZuQ5BYUQ00nZSQt4x/C2ofkFFaVB36o4EN1Q1W+3HOOvsMms27xLJydHPJ5tRCTkEJYRDwPohKQJAl/LxdC7kSSmq6kaZ0gLJ4xnJOTlLRMzM3NTMOKwotJTMngyq1wqpUPyFdwdOL0eXbuOUTHti1eWXAEoEoKRZcZi3PJ9shkb38QLQIkQRCEZ0hOzWD7oUtIQPumlbGwyPmjc/X6bYz89EvMFAp+/PoLFIr85aOxsTInQ6nOdnvInUi0Wj2bdh5l3dYDNK5Slm8jr2IradAuXfrMcrsAKhdLvo6I5ds5S5g5aUS+2gMQFh6PtZUFbs526HR6WtavQGRsMnuPX2PT3vO0alABe9vnmwy+9/g13F3saVD97e9deJ2uhYZja21BxdJFnnmsJElM/eZnFAoFE8fm//l/EWnhRwGw9311QVhhevtDPEEQhFcgMTmdsIh4ouNT2LTvPOZmZnRoWgVnh+zDawaDgRmzfmXwhxNwd3Vhx4ZFNG2U/y8Jbw9nHkQloNb824uk1xu4FhqBpYU5uw8cx0yh4NuvP8UysMRzXcf7lQKpVL4UG3ccJiU1PV/nSJJEWEQcAb5utKpfkbaNKyOXy/HzcqFDsyro9Ho27jlHTHwKYMwBde9BJJeuhXLt5j2iYuKzbSouSRLJaZmkZahyqlJ4DkqVBicHWxSKZ3+F79x7iJNnLtKnRycCiwe8sjZJkoH08OOY23pi6Rz4yuopTKIHSRAEIQenLt3hYXQiAF5ujrSsXwHLHDJaS5LEkA+/YM3G7VQJDmL53z/j5Zn3/ldPKxfoy8Xr97l+J5JKZY0rz+48iEWp0lAmwI2w+w9pVLcaHu4u6EeNIOWzz7BU5z6p28TRAYshA+l9PZxPp/zK2i37Gdir/TNPS0rJIC1DRYCvW7Y5VM4OtnRqXpXdR6+yeP1BkuKj2b73KMkpWYOvsqUCeL9bazq0qo+tjTUZmWr0ekOOPWXC81FrdfkappQkienf/oq1lRVjRw955vEvQ5lwA50qEZdSnf8zmy6LAEkQBCEHSakZBPi54+FiT/mSfpjlkoDvxOkLrNm4nRZN6rNo3qwX2s/KxsqCkkW9uBYaQcXSRZDJ4Mqth/h7uXDs1AUAateoTGbcFeIfLsXOSQsxzy5XbZ1GxOXxlNFJ2FvD4iULaeq5Dyvnkti4l8fev0GOc0XiHmUHz21llFKpYvPWnew9fAaA4kV96N6hGU6O9uh0esIjY9m29xgTvvqdb376h+EDutD20W4JGZkiQHpZGo0ux57Mp10JuUnIjVAG9e2eJX/Wq2AaXvOv90rrKUwiQBIEQXiKVqsjPVNNtfJulCqW9w7kfy5aAcCMyZ+81GafpYt5cfNeFHGJxqSPCcnp1GwYzOZtu5DJINhmH+FH7iGTm2HdtT4sPgdpGbmWJ9laoutUFXsvG5Akyhe/yvlbKRh0KlLv7zf+9+AgnlWGY26T9ctTqdJgaWGWY1AYERXH+yOmcPd+JJUrlqVWjcqMHdo1W6/BxDH9+e73Vezae4Rv5yzh3OVbVK9RA61Oj0are6FJ3oKRWmNc2fgsW7bvA3jlGdglg570iBNY2Pti4fDfyb0lXqGCIAhPSU7LBMDZ0SbP4yKjYtiyYz+NG9SiVGCxl6rTw9UBC3MzHkYnEp+UhrOjLb6ezqQkJ2BtDi7cw9anDh4V3sfc1hPlwbEYrl3LtTxFQCAe7b4w/dvN7wfU147i33QuMn0aCSErSQnbQ9juUdh6V8fSoQgW9j5Y2PmSqVSZMnw/KSU1nb6jpnHvQRRTPhtElcoVOXPlLpIkmQKk40kPqONchONnrnDwwAFuhVzG1tGTvYdOcfzkGerXrcG7rWuIAOklqDU6LPPx+G3ZsRc3V2dq18ieq6sgpUUcR69Owal4q//M8BqIAEkQBCGbpFRjgORkn3eA9Oeileh0Oj7o1+Ol63w8CfrWvSgyMjOpX1oi5twcSL+NSguXtG2pX6Iz5rZOAFgMHYJq4iRISclemKMjFkOzzjlRKtWYmxl7hWTmznhWGYadb23iQ5aTHnGc9IjjpmNdMMfazJ/EW5FY2PmgsHRAYeHIVz+u4va9cCaO6U+/99oQGZuEXm8gOU2Ji6MtV9Ki6XpxBbV2J3Ng6Q4kSaJcUHk6tKrPvKU7yFTDunXrcbZVMOGToQW+g/z/A4PBgFanxyKH+XBPunX7Hjdu3aVvzy75Xk35ItIjTxN9dg4KCwccihbsprevmwiQBEEQnpKcmoGdjWWeWzekpKaxYPFqSgUWo1WzBgVSr7+bOWYRO/Awv438rppUwN3FHoOUyu0ER8omp+P1aF6QokQJJG8fZDkESHI/PxQl/l3tZjAYuHnnAR5uzll+4dt6VsLWsxIGnRJNWiSa9Ag0aRE8vH0WG90D4q/eNR2bqpTYuAPK+kJD+9Xc27UTmbkdAXIX4uMDcLIvynt7/kbnLOdwETWly5Rl/CfDiEnR07FZVexci/L9L/NxdPbkj7+WsGjJalo0rU+XDq1p0aQe1tZWBfIY/tepNToArJ4xxLZ+8y4AOrRp9srakh55ishTP6CwsMGv3lTMbZ5vccKbTgRIgiAIT0lKzXzmJNiFS9aQmpbON1PHFkhm6YyYiyhCf8FHkYze0ge3wCbY+dahd7FENp34gmshN6hTLch0vCRJnKvZhAph97FUZZpuj9fpsezajSdnQx05eYmHETEM798lx7rlZtZYOZfAytkYVB24XwIfH1sqFzWgUyagV6eyfdNZNLordGtWEitnawyadHTKWAIUtzFcucL8cyWJswSwwqaEJ2Nm9aZthUos2nCEiJgkLKysqFapHGcvXmfwoAFcu3qZLTv2sXn7XlycnVj0xywa1K3x0o/jf51aawyQcsvFBcbXxtqN23F3c3llj2laxEmiTv+AwsIOv/pTsXR4dk6mt43IgyQIgvCU5JQMnBxyH15TqdT89tdSfL096dbxnZeqy6DXEndlERHHpoFejU2ZwZRq9QsupTtjYedFtUplKRNYlHMXrhARnWA678qtcG5ijdzfL0t5t1U6vlm3I8ttS9bsQCaT0bNL/ibrKtUarG1ssXGvgEORRjiXbM+WE4m4ODnQc8gM/OtPpWjTHyjeegERFq1JVxpY66QFB2MvkMpc4h/VGSRtKh7O9lwICUOSoFeXVkiShF5mzra1C7h2ehfTJ41Bp9PRpfcwNm7d/VKP5f8DtdqYKyunlBOPXbpyndt379OpXUvMzAq+H0SZcP1RcGSPX/1p/8ngCESAJAiCkIVOryc1Q5lnD9KKtZuJjUtgxJA+z5wLkhetMoGHB8eRFLoZK5dSFGn6A37lWmVJACiTyejdrRVKlZrNO/azYusJdh65zOnLd6hQyg/7D0eCg3ELEb2dPaudPFmxdjPRMXEAHD11if1Hz9GkXlX8vJ+91NtgMKBSa7F5YpK2JEmEPYyianAZrJ64XaPVM/b77bT6LYobuqyTukMzYtm1ayQltCuxkJJpUrscrRobezMeRhhzFPh4ezJqSF92bliEq4szg0aOZ+feQy/4aP5/eNyDlNcqtr/+WQXw0sF7bpJubwNJj1+9yVg6+L+SOt4EIkASBEF4QmqaEkki1x4knU7HL7//g7OTI316dH6hOiRJQpV0m/DDk1Gn3MOldFf8G3yFhW3OKQW6tmtCcFBJTp4+z5UrV0lNMwZw1SsWR1GiBHJ/45eU2t2D9iMGodFomff3cs5dvsGwz77D1saK8R/1yVfbVI96KKyfSESYqVSh1xuwt/v3MdHpdEyc/gOht+/iOLwJGmvLLOUky82Z41Qes8zb1LRYiXPGQbQJ5zBTyMnIyDD2JOkNJKVk4OXtw6aV83F0sGf4x5PJyMxEyJnm0Ryk3Fax/TT3b5au2kjtmlWoVqVCgdev12aQEXUGa7dyWDoGFHj5bxIxB0kQBOEJSanG3EJOufQgLV6xnnv3HzL+k2HY2ea9yu1JxqDoFukRJ0iPOIU209iL4lFpCE7FW+Z5rpWlBX///AXdP5jI8rXb0WnUDOvfGbNHq5Mshg4h86PRhLXsQOvmDSlRPIAFy7ewfPMx5HI5f/88kcBi+fuln6kyZuh+MkCytDD+rVZrSEpKYfGK9fz5zyrCI6Io36om0V52kMO2uQ8UNqRUHYPbzVUkXF+F3iCh04Ob7A63NnTBIJlhQIEWa1wDGjDls36MGj+bhUvXMnJw/gK6/zdqjRa5XJZjjqp/lq1jyjc/U65MSVYs+PmVLLlPjziJZNDi4N+wwMt+0+QYIKlUajbtOMCla7d4GB6NUqVCoVDg4+VOYLEidG7bFG+v/9ZsdUEQBDBO0La2ssDKMvvQWXJyKt/88DueHm6MeI4vcEmSiDk/l9T7+wEws3bDqUQb7P0bYO1SMl9luDo7su7vbxjy6bes3ryP1Zv30aB2Zbq1b4KPlxs3GnckKjKJ9d/MI1VjgdxCjkwGq/6cQcVy+d8bS5lDgGRmpsDRwZbDJ85TrnoLlCoVHu6ujBszjEP1rLmVEZVjWfHaTKYnhLGp2Y9kRF/gxp0IYDF2jm5obbwxV0hYyA1IKeEo72+mpp0Z43r48cefixnUpztWVpY5lvv/7HEOpKeDn01b9/Dx+BkEFPVj/bLfcXJyeCX1pz44gExujp1vnVdS/pskW4C0fsteduw7RovGtRncpyveXm5YWlhgMBiIjU/k5u0wvpuzEFdnR8Z9PMj0C0YQBOG/IDk1A+enhtcehEcyf+EKFq/YQGpqGr989+Vz9R4l395K6v392HhUxLVcL6ycA1/o172jgx0r5k3j+JkrLFmzgz2HTnP4xIVsx5UvW4LoiAfcD7uLSpl7tu2cKFWPh9j+DRA3bd1DbHQkljaOFCsWwOhhfejYtgU31Qn8c2lVnuXdzkzkakYiFXxqsHnJfAAGDP6E8sFlTMdExSZy/OBGKjpeoXPt+5TwNLBly3q6dXv5/FL/NWqNNtu8t0PHTjFo1Dg83F3ZuHzec+8FmO+6U8JQxodg798QhcWztzp522ULkGpXD6ZT26bZ3rxyuRwvDze8PNxoWKcaEVGxIjgSBOGNlZ6h4kFUAg8iE4hNTCWwqCdVgwLyXP0Dxh6kx3uQxcTGM3bSTLbs2IfBYKB0yeLMmDSG99/rlO92pITtI+7KIizsffGuORaFef4Dq5zIZDLq1qhI3RoViY5N4PDJiyQnp/EgKp6kVBWDe7YkOKgkp85epG23gbTq1I+Rg/sw/pNh+co1pFRrMDdXZPl8//n3hcglY89SjZq1eLdzGwAmXN1LglaZZ3nx2ky+CN3D8tJdWL/tIGVLBVClYuksx3h7uJBuXpJ0v4a4K/cRzE5SlWtIuG6GtVsZrJxLIjcTeZLgUQ/SUxO0J0z5HksLC9Yt/Z2Aon65nPnyku8YV0c6lXg1k7/fNNkCpMdDZ3q9gSMnz3HvfgRyuZziRX2pW7OyKd+Hbz5WQwiCIBQ2tUbLtoMXiU9KRyaT4e3uSIkiHty8G0VoWAx1KgdSMiDnydAGg4GUtEzKlfAB4PPJ37Jp2x6aN67HsEG9aNyg9nP1/KRHnSXm/G+Y2bjjW3fySwdHT/PycOXd9k0BuH0/hv0nQyhbyrjlSc1qlTi0YyUjP/mSX/5YxPbdB/j1h6nUql4Zg8GAWqPLMoz2mFKlybKC7dLV65y/dI0+PToTk6Jl257j9HuvDYqiDtzOTMh2fk5uZyby5e//kJ6h5P1urXN8DB3srEnJ0FC5xmDm7LtJHd/bJFw37nOHTI6lYzHcgnph61npOR+l/xa1NmuAdO16KNeu36Jfry4Elc3fcO2L0KlTSH14GEvnwHwPC7/tclzFlpScSp/hE1i2ZjvJKWkkJCazcPlG+o2cREpqemG3URAEId8SktOJT0qnXtVS9O1Yj7aNK1O3Sim6v1MTL3dHDp25gV5vyPHc1AwVBoOEk4Mtl6/dYOPW3bRq3pA1S+bSpGGd5wqOtJnxRJ/7Bbm5Lf71X32WYdtHq8gyMtWm28qVKcnuTYuZOmE0DyOiaN25P1t27ONWWDSrd5xGkqRs5WSqNFkCp0VL1wLQr1cXJnzUF4VCzqCPv2bMwfXP7D16LPnAXdat2EVwUCCd38l5cq+jnQ2p6cbymnUcRpvJD/lsYRoq52bYelVFkx5B5MnvUCffy98D8h+l0Wiz9IKu2bANgG6d2rzSehOvr0bSq3Ep2fGV1vMmyTFA+mPhalo2qcOfP33Jx8PeZ8zwPvw9ZzoN61TltwUrC7uNgiAI+fY4QCgZ4JUl27CNtSUVS/tjMEikpOf8xZ6cYpyv4+xgw8wf/wBgwqfDn7sNxknZv2LQpONVdSTmtp7PXcbzcrQ35s5+vNHuY2ZmZnw0vD9Hdq3G3t6OidN/ICY+BbVGi+ZRTp3HMjLV3I+Ix93FOME3PSOTNRu2U7F8GSoHBxEcVJJfvh5DUkoaoTP3ozgTB9qcg00AWbIa8/VhWGy8D+7WfDJ9cK4Trx3srUlNMz4vZUsHMm/Od5y+nkqLQYs4k1AVvzqTQNIRfnwG6pSwF32Y3jpKlQadTm/6t+qJjWoNBgNrN+7Az9f7lW5Iq0mLJPnebqycS2LnW/uV1fOmyTFAunbzDu+/2y7b7f17duTqjduvvFGCIAgvKkOpxtLCDPMclkE/Tv6YnJrzxOW4pDSsrSyIjIpi+64DtG7RiIpBZXI8Ni+pDw6SGXsZh6JNsfMpnO0zrK0ssLQwJzE5517+UoHF+Hh4f+4/iGDxslXo9XrTirXHjl8IxcxMQZWgogCs27iD9IxM+vfuauo9a9GoJjO//xgLuRmWq+7i8s1V6h2V6KstwWDLIAYpyvJuog8V1iRi8/UlzI/H4F3ah0Hf9cfXzSXX9jvYWZOp0qB9FAx0aNOMbWsX4OhoT7+hn/H7yuN4VhuNQZPGw0MTSbq9DcmgLYiH7o0lSRKrtp9i0YYjbNp7jtOX75D56PUNxozZ4ZHRdGrbokC2u8lNwo01IOlxr9DvlaQOeFPluMxfLpPl+CDI5XIUr/BJEARBeFnpmWrTcNPTrCzNsbayIDElg+I5pAWKT0zD3dmeeX8b576M+OD956pbp04h6dZGku/sQGHphHuFvs/d/hclk8lwcbIlMSX3VWtDB/Zi0fJ1rFu3gaNHT9Cw+nxTvqcHkQncC4+jSa1ypiGchcvWYmtjTZcOrbOU061BPZpvDWbt1gMsXbOT8xtPc37j6WztaVinMr27tqJx3SrP3FHe0c7YA5aarsTVyQ6AKpXKs3fLUrr3HcW0mb9gafkp/TtOJvrMT8RdXkDizXXY+9fDwt4fCzsfLOy8UVg5/2e+xB/38pUq5oVOZ+DmvWjUGh12NsYJ6zv3HgagVfNXl5NIkxFNWvgRbNwrYu1W9pXV8ybKMUCKioln3LSfst0uSRLRsfGvuk2CIPwf0en0JCSn4+nmWCDlZWSqsbXJPX+Os4MNSTkEEZIkEZuYRhEvB5av3kSFoNLUrVU1X3XqNekkhW4m6fZWJL0KC8eieFYaisLC7oWv40W4ONoSHp2U6/3W1lYc2LacgR9N48D+fcz8YS6L//gOnU7PsfO38PV0pkQR4wKcE6fPc/FyCH17dsHBPvt1ODnaM6hXewb0aMvxM1e4euMuKanpmJub4exoT5N6VSnq753vtj8eInwyQALw9/Vm18Z/CK79DivWbGHEB+8T0GIuyXd3kHxnO8m3t2Ypx9zOF986E7Cwy3/db6rHKRfKFPfBy80RSZLIUKqxeTRMuXv/ERwd7alZLfiV1C8ZtMRfXQqSAZfSL5Y1/m2WY4A0eljvXE9oUCd/HxiCIAj5cft+DIfP3uS9NrVwsLN+9gnPkJ6pwsM19yR5zg62RMZmDyLSMlSoNVpWrV5LRqaS0cP756snQq9OJWzfGPSqRCzsfXEt2wM731rIZIXf2+7iaEfI7Qh0On2OmZYBHB0caPVOWyLCw9m8dRc79ryDq6c/mUoN7zQMNl3zNz/8jlwuZ9TQvBNiyuVy6tUMpl7Nl/uStrQwx8LcjJS07NuM2NvZ0qJpfVau3cKD8EiK+PngUqojziXboc2IQZMWiTY9CnXqA1LvH+DhoS/wqTUWa9fnHx59kyjVj5J2PkpaKpPJTL1H0TFxXLh0jS4dWr2SDWnVKfeJPvsL6pR72HgEY+1e8NuWvOlyfFTbNG9Q2O0QBOH/VFqmCoBb96KoVqH4S5eXocx9iA3A2dGWkDuR6PWGLJvCxiWmERUZyep1W6hVvRKd27fKV31xV/5Br0rErUJfnAPbIpO9vvxwLo62SJJxorabs32Ox6RnqpDJZHTu+i5z58ym7+BP6dC5K33fa4+jvTENwcEjJzl87DQ9urUnsHhAobRdJpPhYGdtWsn2tHdaNGLl2i3s2H2QIQN6PjpH8Whozcd0nK1XFaLP/MzDQxNxC+r5Vvd8mJJ2WmZPx7D/8AkAWjSpX6B1SpKepNAtJIQsR5IMuJTuimvZbv+ZYcvnkeNPnEtXb3Ij9N+llMvXbqd558H0HzmJ+w8jC61xgiD892UojavOboZFYzBkX3b+PHR6PSq1Frs8h9hskSQp2xdxXGIqu3Zuw2AwMHPauHx9IWTGXSH1wQFsPCrhHNj+tQZHYAz+ABKTc5+HlP5olZ+vjxfTpkzC0sqKNatW0Ll7H7q9P4Jf5y+m/7CxWFtZMfajwYXS7sfsbK1M7Xtak4Z1sLS0YMeeQ3mWYe9bmyJNvsfCwZ/4a0uJu/IPOlXyK2jtq6dSa5DLZZibZ39dnTl3CYC6tasVaJ1Rp34g/upizGw88G/4NW5BPZHJ806u+l+VYw/S/H/WMm70QABu33vIohWb+GbyR0RGx/H9r/8w59vxhdpIQRD+uzIy1djbWpGWoeL2/WhKFXvxuSOZSuOQRJ5zkBxtkclk3I+Mx9nRFr3ewIXr99my6xAh167RtUNrKlV49mRUg15DzIV5yBQWeFQe/Eb8wrYwN8POxorElOwr2fR6AyF3IuBRDOrmYo8k2TNuwhdEPbzDtatXOHDkJHsOHMXMzIyVC3+hWED+NrgtKNaW5sRlqHK8z87WhoZ1a7L/8AlSUtNwdMi5hwzA0sEP/wbTCT86laTQTSSFbkJh5Yy5tRtmNu6Y23pg51UdK9cyb8Tz9qTUtAwOHD1HbHwStx9Ek56p4ZCvA/VrBmeZ6H7u4lW8PN3x9S64FBKZsZdJjzyJrVc1vGt8gtzs/3svvBwDpLT0DPx9jZlmV67bTqc2TahWKQiAZWu2FV7rBEH4z8tUqinq44ZKo+XQmZsoFHJKFHmxD/30R8N1tja5b0thZWlOmeLeXLrxAFcnO7btP82hQ0c5e+YkCoWC8Z8My1ddiTfXo02PxC2oNxa2OWfmfh1cnGxznIR++eZDzly5i7m5AmsrC+xtrbkXHoe5hRUD3n+X4v4jSU5JZf+h43h6uOd7gnpBsrI0R6XOfel+6xYN2b3/CHsPHM22su5pCgs7/BvOID3iJBnR59BmxKDNjEOVFApA0q2NWDmXxLPKcCwdixbodbyIkFv3WLJmJ5t2HCZTmTVI3LZzP75e7vTs0pLuHZtiY23JteuhtGzWoMACPEmSiL+2DGRmeAQP+r8PjiCXAEmj1RGfkER6RiYHjp1hxfxvAWNSKgvz/8+uNkEQXo0MpQYbawtqVTLuOL//ZAiSBIFFnz9Iejw8Y5fHHCSAUkXdWbZqE3N+/pk7d24jSRKuLs7MnDqWEsWf/WWpSQsn6dZ6LByK4Fyy/XO381VycbQlNCwmy21pGUrOh4RhY2VBpkqDk70NNlYWpjxIj+crOTk65Hvu1atgZWGOSpN7gNSqWUM+ZgY7dh96ZoAEIFdY4lCkIQ5F/l0Gb9Br0aQ9JCVsLyl3d/PgwFi8a36KnXf1ArmG56XV6pj83Z+sWL8bgOIBfpQpU5qg0gFYWVqSnpGJQatkxfrdzJq7lJ//XMXgXm3R6/VUrVS+wNqR+uAAqqRQnEq8g7mt2EoMcgmQ+vVoz3uDxqLV6hj0fmc83F0B2LH3KEFlSxRqAwVB+O/SanVotMa8LnK5jEY1yiKXyThwKgRJknLdMy03GZkqLC3Mcl3BBcad6Ud++iVp6RmYm5vRtlVTenRrR/PGdTHPxw9ASZKIuTAPyaDDs/IwZPKCX0H0Mlwc7chQPkD9xJYUxy/cxsrCnHZNKrNm52nsbKxM24mYmymwt30zNoK1sjRHp9PnugrP28uDKsFB7D5wFK1Wm6/n62lyhTlWTsWxqjQYe/+GRJ74hsiT3+FdfTT2fnUL4jLyTavVMfSzb9l35Cx1a1SkX4/23ItKxcXRFpVaS5S9kmpFS9K4VjlGDujK7oOnmDF7Ib8u3ICFtUOBBUg6ZSJxlxeisHLGtex7BVLmf0GO7+xWTetRuUJZVGo1Rf3/XR3g7OTAsP7vFlrjBEH4b8t4NGfIxtr4ZS2Xy2hQvQzI4MCp60gSlCqW/yApMjY519VbEZExzPp5HouWrcPD3ZUpE0bTuV1LnJ2fL/9S6v39KOOv4VisJdaupZ99QiFzeTxROyUDb3cn7kfEcz8inmZ1gnCws6ZJrXJYW1mgfjSU5epk98bMw7F6tJxdpdFil0uQ+07Lxsz47leOnz5Pw7o1X6q+BykOXNZ2oqrlZqJOz0aTHomdT00s7P1JSE4nMiYJO1srivu/mh6Vyd/OZ9+Rs3R6pyHfTR7J7mNXcXO2p2IZf5aeOcM8rvG9wgkAc3Mz2jSvS9XgMjTpNAxJciUhJXtKhOdl0CmJPPktBm0GPlVHFXrurjdZrok6PD1cswRHAHVqVMpzYpwgCMLzeLyC7cll+XK5jIbVy1CmuDcHT18nNCw6X2UpVRoiY5OyfJmpVGqOnjjL2EkzqVK/LYuWraN2zSoc2LaCgX3efe7gSJsZT9zVf1BYOuEWlHu+uNfJ0d4GmUxGYnIGOp2e4xdC8fNyoZifcbPcYn7ueLk5mnqQnkzK+LpZPVrOntc8pOZN6gGwd/+xl64v9H40yRoH7CqOx8zGlYSQFdzfO5q72wdy5/C3hF7Zy97j17JtyVIQrly/w4oNe6hfM5jvJo8kPCaJiJgkgssUwcXBlm12YehlEgvUl7Kc5+XhigVK5DL47tdlaJ/aT+95SAYtkSdnoUoKxblU50LbFudtkWMPUp/hX/DkDwq5TI6Huwu1qlWkQ+vGr3TPF0EQ/n883lj26bxFMpmM+tVKo1JrOX8tLF9DbffC4wAZCknDt7P/4MjxM5w5fxn1o2R7wRXKMvGzkTRrXPe5e0wkg46kO9tIvL4ag06Jd41PUFjYPlcZhUWhkOPkYENiSjoXrt/PlgDysce9dm9WgPSoBymPAKliUBk8PdzYe/Ao0yeNeeG6lCoN0XHJACSorCnT7Gcy464aUzdEXcBZHYKzIoQYWSnS08pjbeX+wnXlZPHq7QCMHPQu+06G8CAy4VEg68bltBjiFcaJ2uH6VK6kxVDB3jgnLy09g/sPHlKpclXuRSSy78gZWjV5/g1kDTolMed/IzP2Io4BzXEL6lVwF/cfkXMm7aFZfxlJBon4xGQ27zhAVHQcwweKMUpBEF7e441lc5pvIpPJCCzqyd7j10jLULLvRAiVyhYhwDf7F9Xte+EsX7uD48ePMfaTi0iShI21FXVrVaVe7erUq12N6lUqvtBQUkbMReIuL0CTFoGZjQde1T56439puzjacvdhHFqdjkpli5oSQD7J1tqS+tVKU7zImzMhNz8Bkkwmo0nDOqxYs5nwyGj8fF5sBeH9COO2Wfa2VsQkpFIu0Bc772rYeVfjlqYOkaq71HQ9j2fsOZLPTsOp4STMbQrmsUpOSWPzrqOULFGUK3disbGyoFmdIIr5uSOTyZh0Zx8ZCmPPULJBzRehe9hcxfi9HHIjFEmSaFKvCovXHWTJmp3PFSBpM+NJvrudlHt7MGgzsPOp9cakqXjT5BggVamYcw6QhnWrMWDkpOcKkKKi43jvg7HMnvEZCUkprNqwk5TUdHp1a0PHd5oAsHH7ftZs2o2drQ3Tx48wTQoXBOG/7VlZr308nAA4c/kesQmphEcnZQmQVCo1U2fOYd7fyzAYDMhkMlo1b8igPu/SoG6NF5rE+6SUsL3EnP8NmdwC17Lv4VyqA3LFm7/8uYi3K4nJ6RT396VS2ZxX5clkMsqW8MnxvtdFIZcRGRXN5p3x2NtYYGVpgZurE/VrVcLO9t9taJo3rsuKNZvZd+AYfXt1eaG67kXE4eXmhLOjLREx/249o9Pruf0glnKBpfALasHu9bMprjzBw0MT8as/DQu7l0/psPvQadRqDWVKl6JyuaIEly5i+pFwJS2a25kJWY6/nZlo6kW6fPUGALWrVyI6Ucm2PceIS0jG3dUpzzq1mbHEX1tOWvgxkPSY2/niFtQbx4Cmrz3B6ZvquZZfWFlaIFc83/Da3AUr8ff1Qm8w8CA8it9mTUSpUtG578c0qV8TnU7HklVbWDZvJkdOnmfuglVMHTf8ueoQBOHtI0kSSSnpeSZ1tLK0wNXJjtsPjMvWb96+x4WzJ7h2PZSrIbe4GXoHrVaHj68fwwe+R9tWjQko4lcg7TPoVMRfW47C0okijWcWWO9BYSgZ4PXcKwBfp9S0DDZsP8SSNTu4fS882/12ttZ0btOI3l1bUapEERrXr41CoWDrzv0vFCAZDAai4lKoUq4oNlaWhNyOMK36C4uIR6PVUaqYNwqFgjjzWvh6BiCLWkn40SkUbTILhcXLzcWNizcGZIHF/KkaVCzLfRNC95KgzZrlPV6baepFunLtJgAVgkoTcjviUYCUlGuAJBn0JN3ZSkLISiS9Gmv3CjgHtsPWq8pr2S/wbZLvAEmt0bBu8148n6N35+KVGxgMBkoHBqCQyxnY27gnjoWFOT6eHiSnpHLtxh1KlQjAysqSShXKMGvOwue/CkEQ3iqSJLH/ZAjR8Sk0qVUuz2N9PJxISE4nLjaauXN+ITPTuHLHz8eLJg1qUyKwJMXLVGRQt8YF2sbkO9vRq5PxCP7grQqO3jYHjp7jwwk/kpaRiYO9LQ3q1qB65XLUqVIalVrDnbBwlq/fw+LVO1i8egc9u7Rg2tjBNGtUh70HjxMbl/Dcow6xiWnodHp8PJyxsDB+DcYmpOLv7cqte1F4ujni9GhY0sbKglSLihSpZE/sxXlEn52DT62xL5Xe4XEiSOen5n/l1Hv02ONepCshN/Fwd8XTww2bR72vmZk5Zx/XazOIODYdVeItzG298Kg0GFvPSi/c7v83OT7DLboMBv4dj5QkCZVaTdXgcowfPShfBev1Bn77exVTPx/OX0vXZ7kvPiGJtPQMfL09OXz8HEX8jL903Fyc0BsMqNQa02oGQRD+e5LTMrnzIJYG1cs8M2t2UR83zly+xR+//YpGo2Xuj9N5p3lD0wq0o2dvEh2fUqDt06mSSby5HjMbDxyLNSvQsoV/bdx+iDFf/oyDpTlftaxG2zJFeBAej1lMGCVCjIFwdaB7++pciCzOT0evsnzdbqIuXOH91nXYte8I6zfvZOjA55tgHBmThLm5AjdnY4oDaysLImOTcXa0JTw6iQbV/03fYGNtSaZSjWOVFigTb5D24BBhe0bhUuZdHPwbIJM///CUvZ1xgr+ZPOu8n5x6jx6L12Yy4dZuQm6EUq+Wcf+11HTjY+Rgn33BgEGvJvLEN6gSb+FUog1u5Xu/FcPDb5IcA6R/fvs6y7/lMhmuLo6YmeU/Yt625zA1qpTH2yvrhEpJkvhl/nL69+xo3ElbZrzNdL9BIqe5Yms372Hdlj2mMgRBeHvFJaYBUMzP7ZnH+ng6E/fwFmlp6fTo9T4N6tfNsjw/LVOFXQEnOoy/thSDLhPPqiP/bzfqfNWOnb7Mp1Pm4OXiyF+WqRS9eBwuHqf4o/ufnqZdAfhDgslWCjbfjcL5Shj2drYsWbmRfr26YmWV/y//yNgkvN2dTCuyfT2diXgUNJkp5FlSRdhYW3DteihnThzGw82VzrV7khS6iZhzc0i8uQ7Xst2x96v3XJOc/byN5d8Ne2C6La/eo8cuJ0Sg8bShQV3jIoHT50OwMDfDyyNrD5pk0BN1+keU8SE4lWiDe8UBYhL2C8gW8UTFxOPt+ewPrcjoWHy8cu92PnTsDAmJKZw8e5mIqFhCbt5hxhejOHnmMubmZrRv3QgAd1dnrl6/DUBcQhLm5uZYWmTvPeravjld2zcHQKfTUb9Nv/xcnyAIb6D4xDQc7axNmZ7zPDYhkQX/rKRs6UCqVqtGYkoG/t7/fiGkZ6hNk7kLgjLxFqn392PjURE7n5dLRCjkzGAwMGnmPKysLFj021T8//gVw7VrzzzPXAbTHfQk2tiz/vA52rRuwco1G+gx4EOW/jUbW5vsq/WeptPpiUlIpXqFf+f++Ho6c/t+DEqVhmL+HliY//vVeOzYcb7/cY7ph7n/ol9o3uoPkkK3kHx7K9FnZqPNiMa1TLd8X3+1SuWwsbFmx96jTPiwN3K5PM/eo8eU5uAwpB7DevTm1p0HnDx3lY6tG5h6kCSDjvTI0yTd3owq8Rb2/g1xr9hfBEcvKNsMrROnLzL446ms3byHB+FRpiRUkiQRG5fA4ePnGDNxFn8v3YBOr8+14B+mf8aiuTP46+ep1KlRic9G9iMyOo7DJ84x9sN/n7AaVSoQeuc+KpWaC5dvUKdGpVdzpYIgvDHiElNxc8nfRNcpX/9MplLFuI+H4upkR+ITG7FKkkR6AfYgSZKB2It/gkyBe8VB4ovlFTl+5gp370fSq0tLSpUogsXQIeCYv6SdZk6OfPGFcSGPpY0jA97vxoHDJ+nSaxjJKanPPP98SBiSJGVZDenr6QwYV1WWfiJz+659h/n+xzk4OjmxeP4PODra8+FnU7kdFoNbufco1vJ3LB0DSAhZQXrk6Xxff6ZaS6WKQURExXHoxIV89R49Zhngyk11IkvX7gTg/W6t0WvSSbixlns7hxJ1+nvUyXdxLNYSr6ojxETsl5CtB6lzu2a0alaPzTsO8vvfq3kYGY1KpUahUODj5U5gsSJ8OrJvnr1HOVGpNXz5zVw83F35YPRUkCRaN6tHjy7v0K9nRwZ+9CX2tjZM/2JUgV2cIAhvHoPBQEJyuimzc1627tzP0lUbadqwDu3bNOP4+VBC78cQn5SGm7M9ao0OrU5fYHuJpYbtQ518B+fAdlg6FMxqOCG7JWt2IJPJ6NWlJQCKEiWQ+/lhSHn2XDK5nx9lG9WlZtUd7Nh3nGPb5mNrY8Ocef/QvvsHrF/2O26uLjmem5iczqUbD6kSVBQHu3/TBtjZWOFob4PBYMDb3cl0+0+/LcTc3Iyhw0fSomlDfpo5iYEjxtGgVXcmj/uQYQN74VN7PPf3f0rMhd+xdiubrxVuqelKalSrxKkz55n2/QKsRlclwZB379FjyQYNH21ZxsP1JyhXuhiVyhbh4eHxaFIfYmblgmu5njgGNMPMyumZZQl5k2k06rduQs/jIbYj2xY917woQRBev8TkdNbuOkPbxpXw8XDO8ZiQG6F8O3sem7btwcHBnhN71+Hr44lao2XbwUukZ6po26gSBoPE+j1n6disKh6uDi/VLr0mnbDdI0EmJ6DFryjMnz1cIzy/tPRMKjV5n3o1g/lnzmTT7fo7d1BNnAR5BElaG1vsv/0GRYkSbN51hA8n/Mj0zwfTu1srZv08n6+//40KQaU5tGNlth0fJEli877zqDU6urSsbpwD+4SHUQnI5TJ8PY3B1a3b96jRqCPt3mlO/aZt6NqyOi5Odpw6e5GhH03k3v2H1Ktdjbk/TsNZCiX67C84BDTDq8qz09QcOn2DxOR00pPjmPTtfPCzI3NASXB49uIk+Z1UrBbewkZhzroF3+CYsIr0yFO4lHkX1zJd37jNk99mou9NEIRCFZNgHAbJaVPZm6F3GTB8LHWbd2PTtj20at6QnesX4utjXOlmaWHOOw2DsbW2ZNvBizyMTgR46SE2g15N7KUF6DWpuJd/XwRHr1B8YjJ6vYGyJQOy3P64FykvGS5uKEqUAKBcKeP5MfGJyGQyxo4eQr9eXbhy7SbXboRmO/fG3ShiElKpX610tuAIwN/b1RQc6fV6fp23GID3e3QCIPPRfmw1q1Xi6J7VDOrbnaMnzlKveTfCM3ywdq9Aatg+NGnZ8zg9LTU9Ewd7a95/tzX9BnaA8HQ85t6m5TUbPnKvzufF6vN5sfp87FsLi223MN9yg166YtQ5qMPmz1uYyxRM/3okPmahpEeewt6vLq5lu4vgqICJAEkQhEIjSRI37kTi6+mcZSKsRqNl+JhJ1GrSmfWbd9G8cT32b13GyoW/UK5MySxlWFma06ZRMFZWFpy5cheFQo615YutNJMkibSI44Tt+ZC0h4ewdi+PfZGGL3WNQt4yH21QbGOdPajNay6S1taOq/Vbmf5tY20cIst4IgdQ+3eMKRkOHj6Zrc5Tl+5Qupg33nlM6DcYDKzfvJPaTbuweMV6ypcrTeP6xon6jzdWBrC1seH7ryawctEvpKVnMPXbObiV6wlIJN7ckMfVGynVWtNmwVOG9+P7KaMw18GRhQdYMng+UYvOY384DuX662g336F4qDkbxq3k4tZzlCzqy+aF39K+SinirizCzMoFj0pDxXy5V0CEm4IgFJro+BTiktJo1aBilttXb9jG8tWbqVe7GlPGf0S1KhVzKcHIytKCNo0qsXX/BWRy2Qt9OahTHxB78S+U8VeRm9vgXrE/TsVbi0mtr5i97ePAJvucm7zmImk9vIh1eHL1YmaW8gBq16iCpaUF+w8fZ9TQvqbbT1y8jVwuo2ZwiVzbtXPvIaZ+8zPXb97BztaGTz/8gJGD+2BuZoa1lQVp6dnb26pZQzq3b8n6zbu4dHcAvm7lSX14GNdy3fNMLqrW6LB6YgVn13ZNaNuiHtv2HGPJmp2s3bLfdJ+1vQuR0Ym0aV6X97u1omaVIAAijk1/4zdOftvlGSBdu3GH7+b8TXp6Juv+mU10bDxHTpynW4cWhdU+QRD+Q67cfIiTgw3+Xv9OopUkid//WoadrQ3LFvyEo0P+VrfZWFnQoVkV1Brdc7dDp0zk4aGJGLQZOAY0x7VcDzGptZC4uzpjaWnBmYvXc7zfYuiQ7HORHB1JebcHqhglBoOEXC7j7CXjnmR+vv8mGrW2tqJ2jSqcOHUBpVKFtbUVqelKU1JSqxx6GpVKFZ9N/IalqzZiY23F6OH9GTW0L64u/86Pc7K3ITkt50nUX3w6go1b9/DrvMXM+7ofEUenknB9DV5VR+R4vCRJj7Y1yfr1a2VpQZe2jenStjEPI2KIS0zmq1lzOXj4BOcObSKg6L/75qWE7SMz9iIORZtg61Ulx3qEl5fnT6VZcxYy9fMR2Noax+M93FzYuvtQoTRMEIT/ltR0JWER8VQo5Z+lx+fw8dNcu36LXt075js4eszSwjzLaqT8kCSJmAt/YNCm413zEzyrDBPBUSGytrakfct6nL98k6s37ma7P6e5SHI/P8wCSyBJoNJokSSJxat3YGdrzTtN62Q5tnH9WqjUao6dPAcYX3dAjrmykpNT6dxrqGml5LkjW5gyYXSW4AjA0d6GlLTMHK+nRPGi1Kxeif2HjiO3L421W3lS7x9AkxaR4/E6nR6DQcozB5i/rydVKpQmIvwhvt5uWYIjrTKBuCsLUVi54F6hf65lCC8vzwBJo9ESUOTfJ0Ymk6FWP53fVBAE4dmu3HqIlaU5JYtm3Vpk1bqtAAzu916htCPl3m4yos9i718fe986zz5BKHDvd2sNwLJHuXyelmUukqMjFkOHYP1o+ymlSsP5yze5ERpG80a1sLPNGiC3a90UgKWrNgKQnmmcO2RrnT3T9sfjp3Pi9AVGDunDmiVz8c4lfY2TgzXJaZm57uLwTvNGZCpVHDl+BregXoCBiONfkRZxPNs5j3s8c+rNelKmUsmt22FUDCoDGLNjKxNDiTk7B4M2E8/KQ8XQ2iuWZ4Dk7+vF6XNXkMkgIyOTn/5YkiVgEgRByA+1RsvNe9GUC/TFzOzfvasMBgN7DxyjbOkSlChe9JW3Q5lwg7jLCzC38cQj+INXXp+Qs4rlAgkOKsmazfs5fvpytvuf7EWS+/mhKFHCNKk5ITGFL76ZB0CRogHZEhYXL1aExg1qsXXnfqJj4sjIVGFtZZFt5drpc5fYsGU3rZo3ZMakT7KlBXiSk70Ner2BjEx1jve3bmGc2L9jz0GsXUvjXrE/OnUyUae+5+HBcWTG/5slXKUxdjI8PcT2tJDrocgw0LGWNeHHZnB76/s8PPg5mXGXcSjaBDvvanmeL7y8PAOksR/2Z/m67dy5F07LbsO4GxbBpyP65nWKIAhCNtfvRGIwGCgX6Jvl9svXbhIbl0DzxvVfaf2SJJF8ZwfhRyYDcrxrforCwu6Z5wmvzneTR2BtZcmQT7/l5Lmr2e63GDoEzMyM/8c450ylUvPplJ+5ERpGg3q1sLO35/Slu0TFJpOSlolWZwyWBrz/LjqdjgWLV5Oeqcbuqd4jvV7P+C+/w8zMjOkTxzyzrY72xmkmybkMswUWD6BUYDF27jmEJEk4B7ajWIvfcCreGlXyXcIPTyL20gLA+GMByHOITZL0hF0/zB8f+lDR5QbKuMtYORXHpUw3/OpNwbPKsGe2WXh5eYawri5O/PT15yhVxmWU1lYFuyGkIAj/fQaDgWuhEZQs6oWNVdZEeHv2HwGgeZN6r6x+nTKR2Mt/kx5xHHMbT7xrfoKVc+6rmYTCUTqwKH/OHs+gj7/m/eFT6d+jDb27tqKIn3GrD0WJElh+NQNFiRIolWq27D7CoqWrSExMplWzetSvW5uSAZ5cvP6Aq6H/5h7y93ahdfOGlChWhNlz/8bC1oXg4ApZ6v7j7+Wcu3iV4R/0pmSJgGe21d7WCrlcRnJaJn5eOWfpbtG0Pr/OW0zIjdsElS2JmZUTHpU+wCmwLdFnfyH5zjZs3Muj1hv3gMutBykz/hox5/+gonUEFLfGyq8FflX6IzfL/2a8QsHIM0Datf8YtapVxNHBnh/m/sPx0xcZPbQ39WtXLaz2CYLwlgsNiyFDqaZCqexJAPfsP4q9nS21qlcq8Hp1qiQSb20g5e5uJIMGO5+aeFYZKeZtvEFqVS3PmgVfM3Lc98xfsok/l26mYZ3K1K9VCXs7G9QqDXd2nmL9toOkpmVgYWHO+++1o3JwBZzsbalRsQSVyhQlU6UmU6nhZlg09yPiMTMzY+lfs2nRoQ9ffT0TV1cX7GytTfOBoqJjKVbUn4ljR+arnXK5HAdb61wnagM0aVCbX+ctZv+h4wSV/Td3l4WdNz41PyNs32iiz89FU3QEMhlYmJth0CrRa9PQazIwaNJJizhOyr1dyOTmrDycSWiCE0uWDH25B1l4YXkGSAuXb6JhnWpcu3GHu2HhjP1wAD/+tlgESIIg5EtKWibHL4QSWMQTF6esQ1oJiUmcOX+Ztq2aYG7+Yokec2LQa0gIWUHy3R1Ieg2WjsVwLdsdW+/qIpneG6hsyQD2rPmF42eusGTNDvYcOsPBY+ezHBNYzI9PhvXE0tYJV2cHwiLiKVPcOB/WwsIMCwsznBxsyVCqCQ2LRqfTU7Z0IGuWzGX8tF9QZqZhYa5AJjPmzPL39WHGpDGmZJP54eiQ+0o2yD0HE4CZtQve1UYTefJbFHd+JtjMk3u7VqHLjM1WjrVbELEWTfhx7Wg+/ahtvtsnFLw8AyStVou5uTkr1m1n2IDulC8bmOe4qSAIwpOOnruFjZUF9aqVynbf/kMnkCSpwIfXEm+sISl0E5aOAY8CoxoiMHrDyeVy6tUMpl7NYGLjk7j/MIrUtAysrCxxc3GkVIkiyGQydh+7yv3IeCRJwsste8ZtG2vjEG6mSoODnTWVg8vTo3cfmtYOokSR59tg/Wn2tlaERyXmer+1tRV1albh+KnzphxMT7L1qoJv3YncP/EL9oZIZHJ37Is0xMzCAbmFHQpzO8xs3LH1qsLSH42T0Js1qvtSbRZeTp4BUtVK5Xin+3DKlipG+bKBREXH4eKccxp4QRCEJ+l0eqLikqldKTDLtiKP7TlwFIDmjQsuQNKkR5MUugkLh6IUaTwLmVzx7JOEN4qHmzMebjlvYhxYxAO5TEZxf/dsPZIANo8mY2cq1TjYWZuW+NvZvPz8HTtrS9KVaiRJyjXgbtKgDgcOn+TE6fM0aZg9hYSNewVivT4hKTWDjs1yH4nZd/AYDg72VKtcIddjhFcvzwBp3EcD6dKu+b9L+2UyRn7QszDaJQjCW0Cj1aGQy7MsoVaqNKRlGDMeGwwSnjn80tfr9ew7eJwKQaVzzT3zvCRJIu7yAiSDDo/ggSI4+g8q7u9Bcf/cXy+2VsZAKENp3Fj28T5tdjYvv8DI1sYSnU6PVqvHIpcJ1o0b1AZg/+ETOQZIYFzmn9cS/8SkZM5fukbbVk0wMxO7gb1OeT76crkcezsbtu85gkwmo0aV8gQW8y+stgmC8IbbuOccGp2OiqX9KVvcBzMzBbuPXiE+OZ0KpfwxM1Pg4ph9UvTZC1dISEyib8/OBdaWtPCjZESfw96/ATbu5QusXOHtYW6uQKGQk6lUc/5aGA8iE5DJZKYcSi/jcaLJdKUal1wCnKCyJfFwd2X/oRMwKedy1BptngHbwSMnMRgMYnjtDZBnHqTjpy8y+OOpXL52i0tXbzHk42mcOHOpsNomCMIbzGCQSElXYmVhzqlLd1m+9QR7jl8jJiEVg8HAlVsPcXexzzEB39qNOwBo36Z5gbRFr04l7tICFBYOeFQcUCBlCm8fmUyGrbUlGUo1F288IDktE083B+Tyl5+DZvsoqHncK5Vb/Y0b1CbkRihR0dknYAOo1Vk3qn3a3oPHAGjSSGR5f93y7EH6c/E65v34Jb7exi7NiKhYJn41h9rVgwulcYIgvLnUj/bEqlahGG5O9ly6+YAbd6MoU9wbpVrL/Yh4PF2zD6/pdDo2bt1NyRIBBJcvUyBtib28EL0mFa/qo1FYOhRImcLbycbagui4FHQ6Pe80DM41b9Fzl/uoFypDmT2bdlJqBrZWllhYmNGkQW1WrdvKgSMn6dmtfbZjc9qo9jFJkth/6ARlShXHz8erQNotvLg8e5C0Op0pOALw9fZAq3v+nbMFQfjvyXw0z8PGygI7WyvqVilFn471qFe1NGWKewPg5ZY9WDl87DRx8Yl07di6QFaXZUSfJ+3hIWy9qmLv92ozcgtvPhsrS2ITUwFwzWEi94tSKORYW1lk225EkiS27L9gSlb5eB7SkhXr0Wq12Y5Va3S5rgY/e/4K0TFxuc5fEgpXngGSr7cHK9fvRKfTodPrWbVhJ74FNKFSEIS3W6bK+EVhbfXvCiFzMwVyuYwi3q60rF8BPy/XLOecPneJ4WMmI5PJ6Nqh9Uu3waBVEnPhD+Rm1nhUGiKW8wumpf421hYFMvfoSXaPhu+elJGpRqXWkv5o6M3D3ZWBfd7lxOkLfD752yyb1er1BvQGQ64b1f65aAUAvd7tWKDtFl5MngHSZyP7cfz0RRp3GEiTDgM5fvoin43qV0hNEwThTaZU/duD9DSZTEZRHzfT3A9Jkli4dA1tug4gJSWNP+d881Kb00qSnvSos0Sc+AqdMh63oN6Y27i9cHnCf8fjydQF2XtkKtvGMlsPUkJKOmDMvfTYzKljaVivJn8vWcO8v5ebblepc9+oNjomjg1bd1O/TvUsmbiF1yfPOUhurs78MnOc2ItNEIRsMlUaLC3Msu2S/jSVSs1nE79hycoNFC3iy9K/ZlOhXOkXqlOnTiHl7i5SwvaiU8YDchyKNMaxeMsXKk/473kcsLs62Rd42bbWlkTGJWe5LTHZGCAplf8GSObm5vzzx/c0a9+bCVO/p0SxojRvUo+0R71Mtk+tYlMqVYyZ8BVarY4hA0QqnTdFjp9sGRmZWf4z6A0Y9AbS0jOY+9fKwm6jIAhvoEylJl9DGJP/195dx1dd9QEc/9y+62YsGdvobgkppVNCFAFRRFIsQETAALHgwUBKBUFUSkIlJKWlQXrEYBsr1tvt+D1/XDYYG70APO/X63k9cu8vzu8wdr/3e875no9n8NOSVbRu0Zi/1/5638GRzawj9u/xpJ5egiTZ8a78LOXbz6Zs/deQyW4fpAn/Hc4lnUHK0AH5M0gAnp7uLP3xGzzc3Xh5+FhOnTlHdo4jQHJzuR4gpaVn8EzfIaz7axs9u7WnQ5sWRd5u4f4UmkFq03MIMhncMHQKgEwGLZrUL4l2CYLwkNMbzYUOr+U7xmBgyYo/qFalIssXfYtCcX/FGyVJIvHgV1h0CfhW64dXhW6iEKRQKB9PV4LLehNYxrPIr+3ipMFssZKUkplXADUtIweFQo7BZC5QZTsivBw/ffc/uj8/hLETP+XD9yfgpFGhUjp+di/FxNG7/wjOXbjEyCED+Oi9NwstiyGUjkIDpD0bfirpdgiC8IgxGM158z1u5c/1W8nKzqFfn+73HRwBZF3egi7xIG4hLfCq+IyYjC3cklajomOL4ilFE+jvhburE2u2HMbP242qEUFk5ugJLutNbEIaJrO1wATsZo3r0/7p5qzb+Dex8Um4uTg2yD115hzdnx/C1ZQ0PvlgLMNeeaFY2izcv9uGqkeOn8FovJ5OTE5JE4UiBUEAHKvY7jTE9vOyNahUSp7t0fG+72M1pnP1+EIUWi/K1H5FBEdCqXFx0vBsh0a0a1YDjVrJ9gNnkCQI9nfUWrp5mC1X145PY7fb2bFzL26ujuG19z6aRmpaBj/OmSaCo4fUbQOkr+f+nO/PHu6u/LB4ZbE2SBCER4PeaM5bUl2Y5Kup7Ni9n3ZPNcfHu/DNR+9EkuwkHpqJ3aKjTK3BKFQFty0RhJIkl8soF+RLxxa1ebZDQ5o3qERooKOchb6QIpIAbZ96EpVKyT/79uPmoiXqfDTbdvxDlw5P0a3T0yXZfOEe3HYVm9lsQXtDjRONWo3+NmXWBUH4b8jdtPN2c5DW/rUVSZLodp/biViNGaRFrUKfdAT30Fa4BT1xv80VhGLh6e6Cp7sLVqsNuF76osBxHu60aNaIrdv3kpyUxPK//wbg1ZeeL6mmCvfhtgFS+XJB/LB4FQP6dEEmg19+W0dggCgUKQj/dblDCbcbYvtj/RbUahXtnm5+19eV7FZ0iYfIvLwNXeIhkGyo3UMoU/uVB26zIBQXpVKBSqW45RAbwPDBL7J1+15GvT2e9PQMalavTOOGdUqwlcK9um2A9NbwAXz0xRxadx8EQK1qlZg0dmiJNEwQhIdX7lDCrTJIGRlZ7Nh9gNbNG+Pudufl1pLdRuqpX8m8vBmbKQuQ4+xfC49yrXAJaIhcUbQVkQWhqDlr1bfMIAFUrFiBDp26sPaPNdSpVY0Fsz8X8+kecrcNkLy9PPhy6juiUKQgCPlk6QrWc7nR8tXrsFqtdO7Q+u6uF/M3aVErUbkG4BXZFbfQFqicfO58oiA8JJy16ttmkLJ1Rlq0bMnbQ56lWpWKaDQi6H/Y3TZAyiUCI0EQbpSZrcfZSY1KVfBXiNVq5Zu5C/H28qRnt/Z3vJZkt5F29jfkKhdCW32BQuVcHE0WhGLlpNXcNoOUlpmDh6szdWtXL8FWCQ9CVKQSBOGOJEnCbLGSozciSRKZ2QY8XAsPZFb/uYmY2Hhefel5XJzvHOxkx+3EokvEK7KLCI6ER5azVl1gI9sbJadmUcbHvQRbJDyoQjNIs+cv5YXenXF3E0tqBeG/KDNbz/YDZzAYzZjMVkxma96u5E3qVCArR4+vV8G9rvQGA5M//wYXZydefem5O95HkmyknlmBXOmMZ0SnIn8OQSgphW1DkstqtZGSnkPFsIASbpXwIAoNkCxWG/2GjqNTm+Y837OjCJQE4T8mITmDxKuZ1KwUgkatRKNWoVErOX42jtjEVDKzDYSH5F/RKkkSn0ybzeWYK3z8/mi8vTzveJ/suD1YcuLxrtQLhVr8nhEeXa7OGixWG2azFbU6/0drSno2kiThLzJIj5RCA6RRr/Zl4PPdWPnnZl55/X2ebvEEVSqWz3v/ycb1SqyBgiDcH6PJzPote/hr2z7S0rMwmswYLTZqV41kyIBuRIQF3fLcHIMJZyc1T9SOzPd6Vo6BQycvYbdLeLo5hsMkSWLD5u1M++o7Dh09Qa0aVRhyF/Vd7DYzqaeXIlNq8Yrs8mAPKwilzMXZMVc3R2/EW51/5WZyahYKhRxvT/El4FFyy0na7m4udG7bnIzMbFav28qxE45fpjKZTARIgvAQS05JZ/4vf7BszRbSMrKQy+V4uruiUCrIyMwh6lw0y9ZsokqlCJo1qU9E+TAqlQ+gTtVyedfQ6U2F7rMW4OeJ3e4YanN3c2bjlp1M+WIm/544g1qt4pUX+zDm9VdRKu+8/iPt9DIsOfH4VnsBhabgcJ0gPEpcnR3/XnL0Jrw98wdISalZlPF2ExvRPmIK/S0WeyWRn5b9wf5DJ+jzTDtWLpyRr6K2IAgPp5Nno3n59SkkXU0jLCSA4S/1oFeX1nh6uBF1KZFt/5zCZtazYctuTpyK4vTZCzzZpAGaru3yBUh6Q+EBkp+3OwqFHJvNzslTp+gz8DW0Gg3DXunHqKEvElD27grJ6lNOkXZuNRrPcLwqdCuy5xeE0uKs1SCTyci5abcJm81OfHI6VSNvnbEVHk6FBkjDR0+hb6+OvDVsgAiMBOERcfb8ZZ57dQImk5lpH7xGj04t831j3Z16CRcnDf2ea83wAZ1JuprGyHHT2LnnAEaTme5P180rXJdjMBHo51ngHgqFnLK+HlxNzeD1MR+hUavZvmEJFSPLFzi2MJIkYcq4SMI/nyNTqClbfxQy+V1VGxGEh5pcLsPFSU3OTRO14xLTMJmtRISIXSgeNYXm+5YvmE6vrm1Jy8jMW7kiCMLDKytbx0ujpmA0mvnhy/fo1aV1vuDoeHYi47O2k+lmyXvN38+bn2Z9QJ0alTlw6BgLfl2b955Ob8LFufAvRzUqBvPHqhVcvBTDhHdG3lVwZM6OJ/X0Mi5vfoOYbWOwmbMIqP8GGvfQB3hqQXi4uDhr0d2UQTofk4S3h0uBYTfh4VfoV7djJ6MYP/kr1GoVWo2aGR+PJSxUpAcF4WG1/I+txCel8OHYwVStVJ4Fv/5JXEIyOp0BJyct6y2XsVdWsMz7HCNomXeeVqPm00kj6f3yOGYt+I1+vdshk8kxW6yFDrEBzP9xMVv+3kn3zm0Z/kq/27ZLkuwkH51HZvRGABRqdzzKt8O9XCucvCsW2fMLwsPA1VlDzg21kCwWK5eupFCvWljpNUq4b4UGSHN/XMaMj8dSs1pFNm//h3kLVzB14uv3dYOExKs8N3gsM6aMITwshIlTZ5KWnkmHNs3o17szAKvXbWX5mo24ujgz+d0RlPETWwwIwt2y2+0sXr4eVxcnDh07w8czFmC2WAscp5VDTLU4FksVeaFF87zhtLJ+XtStU5O/d+xh47b9NGvs2ECzsAzS2r+28eWsBTSoW5M5X0657aRTSZLygiMn3+p4V+qBs18NZHJFET25IDxcXJ21JKdm5f35cnwqNpudiFAxvPYoKvS3W3pGFjWrOb7dPd3iCWKvJN33Db79YQkhQWUBmP/zKlo0rc/CWVNYv3kXMXEJpKVn8tPSP/jhqw/p1bUN3/6w9L7vJQiPoqwcAyaz5c4H3sKufceIjkkgR2fg9792UrtGRb6e+ha7/5zHsW0/UfmzDpgGVsBewQPpeAoT3v6StyZ9hdniuKers5ZaNaqiUipZtHwd+mtzKHIzSCmpafy0ZBXPv/w6Lw8fi7eXJz/OmXbH+YnZsTvIjN6Ic5laBDWdgIt/bREcCY81F2cNOoMpb2rK+ctJ+Pu44+biVMotE+5HoRkkt5t235Yr7m/H4aPHz2C326kUGQbAnv1H6dqhFUqlkhpVKrD3wDHc3VypGBGGVquhdo3KfPHNgvu6lyA8ikxmC8vW78Nul/DxdCXAz5OAMp6UC/S5qyXBkiQx5X+OfzNVy3jyeYdGVPTzgLQ4+DuOJFMOTyWeoInNCtWcySqn5uDxbFat207q6bPMmzYObVg5/Hw8qV2zMvsPnyAtKwez2cyPi5exYdPf/HPgKJIkoVAoaNywDpPGjSIo0P+27TLrEkk++h0KjScBDd5ErhAbcwqPP1dnLXa7hMFoRi6XEZuYRpM6kXc+UXgoFRogxcQl8OKI9/L+fDk2/58XfvvxHS9ss9mZNX8pH74znO8XrwQgLT2T4Gu/WEODA0hJzcBisRIa7Mgw+Xp7YrPbMZrMaG/a6XjF75v47Y9NAGLiOJCRpSdHbyS4rPc9n2uz2cjO0WMyW3Bzdcbp2vJUoeSlZ+qw2yXqVQ8jO8fI5fgUTpyLo0WDylQKv/O2BDPmLiHqYiwAs9SZ+G34gxtzUd7A8JvOsUnwvlbBquhE3p/1K599Pg43F23eF6Ok5HRWLP2Vo0eP4OykpXP71nRq14q2Tz15V9WxbRYd8Xs+wW41ENTwLRQaUT1Y+G/wcHVkitIydWTlGAAKVJwXHh2FBkj/mzLmgS+8dtMOGtatTkBZv7zXZDIZXAtu7JIdmVwGsvwBj2SXKOyzulfXNvTq2gZw7Bb+ZKeBD9zGR9m/Z2OJS0yjb5fGd3W8JEkcPHqan5ZvYMPWvfnmqAT6+/J8j7b06f40ZXy9iqvJQiHSs/TIZFC7cjkUCkfG6Oc/9pB57Zfr7aSkZTB7wUo83F3JzMrBJbw8nD1zx/MUMvjA3Uac1oWlW/YxODoWjVpBVlYOAGs3bOLo0SN0bt+a7775BCcn7V0/j82UzZW9UzFnx+Jb40Vcyta963MF4VHn6e6Mi7OGy/EppGXkEOzvhZNWZE8fVYUGSHVrVinwWnaODhdnp7uuBLp99wFS0zL55+C/XElI5tTZC+gNRuLik4gMDyU2LpHI8FDc3Vw4cfo8AFdT01GpVGjU4gfqTvRGEzqDEbvdfse/kx17jzL1yx85c/4yAA3rVCUiLAiNWk1Wjo49B44zffYvfDVvKZ3aNOWDMYPw8hTf+u+V2WIlK8eAm4sWjVp1V+ekZ+lwd3HKC44A3Fy05OiMtznLYenqLVisVurWrMS2XYfI6vUszjO/gszMO56b4axE1bkqzD/MhKmzOHL4INlGUGtdmb/gJzw8PPjys4l3FRzZrQb0ycfRJR0hJ2E/NmM6XhWfwSuy6x3PFYTHiUwmo1ygLxdikjGaLLRsVPCzVHh0FBog7dx7CBdnJ+rWqgrAl3MWs3zNX3i4u/HFh29RrfKdx1SnT76ehZo8bS6d2jzJjr2HOXL8DGGhgZw4fZ7+fbrg4uzEvIUrMBpNHPn3DE0a1i6aJ3vMGQxmJMlR1t7d9dYTAJes2sR7n8xBq1EzsE8n+vVuR2T5kHzHWCxWtuw8wMKl61izYQfHT59n4cz3CQkUqeG7IUkSR05f5t8zsZgtVmQyGT3b1r+ruicZWTo8PfLvz+TmrCXrDgGSzWbjl9/+ws/Hi+7tm7Nt1yH+iorjpeBg7HcRIF3wcWZ7mAyF3Mbeg6ew6fVo3fxRKqBV61a8+EJvfH1uP3xrM+eQdHgWusSDSHZHRlLl4o9P7SF4hre7YxsE4XEUFuTLqfNXUCjkhAX5lui9t+zYx7yFy1EqlUSEhfD2iAF4uLvRpH1/IsJCyM7RUS4kgHfffIVFS/6gSqVwurRrAcCEj7+hw9PNaNqozi2vv3bjDk5HRTN65Isl9UilqtDUw6Klf+bVPTp2MoqN2/aw5Psv+HDccGbM/um+b/ZS3+7s3HuYF4dPoHO75gQH+uPl6c7Avt0Z9Pr7rPpzM8MH9bnv6/+X6I1mgLxx7hvt//cCF2OT+XPjbsZNmUVQWT/+WDyND8a+ki842pMeA4BKpaR968b8OncyH4x5heiYBAaM+IC09KwC1/6vs9psnLkQj91uB8BitbFp9wkOHo+mUvmydG1dB4VCTkxC6l1dLz1Tj5e7c77XXO8ig3TizEWuJF6lV5dWdHi6MX4+Xvz8218oXh0MHh63PTfFScmHrSOwOCtRNA9BJpfzTI8e2CWJN4cPoGPnrlS+trDiVozpF4jdMZGc+H9w8qmKX82XCWszk7C2s0RwJPynBfh5olIpCA3wQa0quSrxJrOZz79ewKwvJvDz3E/p2OZJ1Ncy2VqNmp/mTGXlohk0e6Ius35Y6thG7I/NSJJESmo6l2LjadygVom191FQ6N+ewWjE28vxS3bJb+t5rkd7QoLKEhJUlunfLrrnm0wcPSTvv7/+dFyB97u0a5EXxQp3JklSXoCUXcgHaVR0Ipfjknhv8leU8fXi17mTCQrwy3fM8exEeh9bwoZ6L1LD7fqKpIHPdUIulzHps+8YP3U2c754p3gf5hETn5TOjoNnsdklwoJ9+WvncTKy9bRrVoNy174tlvX1ID45g9pVyt32WmaLFZ3BhJf7TRkkFy06gwmbzZ5v6O1GqWmOLFH50ABUSiXPP/M0X3+/nK2xKdQvWwan22SRLvg4c9rfkd1SV/LF9Hc8+4+cQq1WUaliBOdjUvBwd8KUEY3VlIHNmIHVlInNlIHVmI4p4xLmbMfEcN9q/fCu1OPuOk8QHmNWq42MLD0AT9SOxEWrJiUtu0jv4enujFJZeKkMq8WK0WRCbzDiAzxRv2aBY+RyOfVqVeWvrbspFxKIj7cnJ06fZ//hE/Tq2ibfdA2bzc7sBUvZs+8oGo063+c4gN5g5LOv5nM+OgZ3N1fGv/kKIUFl2X/4BNNm/ohMJqNbh1b07dWRmLgEpkyfR2ZWNo3q1eTNYf0fiYVBhQZIcpmMqAuXycrO4dCxk4x742XAMTlafZdzK4TiYzRZ8ia235xBstvt6I1mduw6jNlsYep7wwoERwDjz23GItl579wmfq+bvxrygGc7sm3XYTb+vZ+4hGSCA8RQW67cfZYOnrjI0dOOOV1dW9fB1+v6bvSBZTw5fOpyXoAjSRLZOiPxyRnIZTIqlnes2szI0gEUGiAB6AzXh0+TU7OIupSI2WLFbLay//BZANRqFas3HaJixYq4ujjxzuRZ1BlQlQ9jovE1FCwWmZs9ypWJGS2QdDWN1k1qYEzcT3l5EoZDy7isL7z+mdLZD/dyrfGM6IjWM/ye+1AQHkcZWXpWbjpYrPfo0aY+vt5uhb7n4uLMyFeeZ9Co9+ncrgUD+nTB0yP/sTabnb+27qZqJcfvgOd7dGDF75u4eCmO7776IN+xazftICY2gUVzpmIwGNFqNJyOupj3/o+/rMbL052f537Krn+OMHnaXObNeJ9lq/9i6EvP0rxxXTIyHQHi1P99x+iRA6kQHsrUGd9z8swFqld5+MsfFL5Z7aDnGD56CmaLhXGvD8LD3dHJS1f9RaO6NUq0gUJBeoMje6RSKgpkkPQGMzabjT37DhMcWIZWTQuuIjqench5vWMI6ER6Etsun6dVufw/rAP6dGDb7kP8unIjY0bcfjuJ/xK9wYRGrcRul9A6q2j/ZM0CFacDy3ix/9+LHD1zmYNHTvDvibPExMSQmJCAhMS3X0ygUf3apF/7tulxwxCbJEmolI5vcdk6Q16AdCIqjssJKfh6uqFWK3F2dgRRsfEpaFwdw33jXn+ZSZ/O5u8fj7A5SMtzhpwC7b8xe4TVjmpL/LU2yxjd/DhK6QQoQLK641WhKyrXQJQaTxRaD8f/azyRK8UG1oJwM093Z3q0qV/s97id3t3a0qRhbRb8spr+w8bz1dR3CA8LxmgyM2DYeOySRPXKkYwc/DwAdWtV4at5P9OscZ0CpXX+OfgvPbo8jVKhwM3VpcC9Dhw5mTcX6YkGNfnoi9no9AbatGzMT0v/QC6T0aJpfXR6A6ejopkybS4ARpOZJo/IUF6hAdIT9WuyftlsrDYrTtrrq1jq1a5KWEhgiTVOKJze6MhilPFxJ/umDFKOwUTU+Yvk6PQMG/gMCkXBdOz4c5tJtTjOy5FbmBK3vUCA1KJxHUKD/FmyahNvDnn+lmnd/xqdwYy7qxPtmtVArVaiLKR/fTxdOHH8GJ9OnUxa6vW5SFqtBovFSvtnBjJowLN06dqF1KvJDHv9PS7FxJF0NZWrV1MxmkxUqFiJ0DJvE+TfCACj2UywvzdtmlYHoEKIL9/O+5l1W/6hYkQwVmMOCo0r/Qb3YPH8VUyJsrHdSc0LagtN1BJyGaTIZeyoV5Z+V2M5tz+b84d0GLIcwdWrfSshlQnmVJICF69yPP3U08jkIlssCHdLqVTcMrtTkoICyjDh7Vf5eu7PbNi6m+Ev90GrUbNo9tQCx8pkMiqEh1IhvOB0AEfJnVsPgzlGMQq+3651E+rWqsK8hSvYsHU3E99+FWdnLQtnffxIDKvd6JYzyFQqJaqbJphVrnDnXbuF4pc7/8jf14OT5+LyvafTm0hOdnwoN6xXvcC5x7MTOafLP4E4xpLJ8eykfHOR5HI5rZrVY+HSdaSkZVC2jNgfD0BnMOLirMX5Fhu56g0G3hw3haW//YmrqwtvjHiZ+nVqUK1yBTROLsxfupHtW9bx/cKlfL9wKTKZDEmSCCxbBj8/HypXCEcmk7Fx604GDX2DjasXUa1KBYwmS77tCsLLBVCtcgVOnI5i366t2K+tIqtZqzbd2jQjLj6JnUfPsEOvIkAuEayQkKsh489LnE8Em90RYFuVOqpWKs/A/p8Ql5hGcuIxqnoHieBIEB4xURcuc+LUObp3ao1dkriamk6dQkr23K26taqwZt1W6teuhtFkwmy2XKtb6PhS1aBOdTZv30u1yhHsO/gv5UICcXF24vipc1SvEsmwl5/luUFjcHFxJrBsGdZt3kmnNs1JSk6ljJ/3IxEsldwUe6HI6A1mNGolnm7OmMyOOSlqteOvUmcwYTI5MkxyecG/3vFRm0mz5s86ZUrmQuciebg7hmIys3IeuwBJkiTOXUrE2UlzT9XIdXozgf6Fp7mzsnPoM/A19u47TLunmzPrfx/h43298GZGtp4y/v4smDuDXbv28OvK9WTnGJg+eTR1alXLd60pXy7kyy+/ole/YWz8/SeMJgtaTf6g5anm9TlxOgo3T1+WzvuAw1u/J9Q1EW+3rbjXUJBdVWLzn3a26uRE2WSYTDLcjc40bVSRF3q2JyYukY+//JH+vTsA4HOtLIG3R8F0uiAID7eQIH/+/Gs7A4a/h9Foon7tanRtf/+Ln7p3bE305Su8MGQcbq7OvDmsP1UqhPPjL2vIzMpmYN9ufPbVD7wwZBzuri5MHD0ESZLYc+Ao0779kZwcPUNfcqxKnzRmCJ/M+J5fVqzDx8uTqRNH4epy++HCh4EIkB5BeqMJZ60mbzz60pWrVCzv2JZCpzflZTcysvLPQTmenUiULqXQa57XpxXIIpmvbaCq0TxehTslSeKfo+c5HhWHn5fbvQVIBlPeJq65EpOusnHLTj7/ci5x8YkMH9yPjyeNLvANyflaP5rMVp7r1QXvgPJYrbYCwRFA08YNyckZxJw58+j5wjAaNH6Sy+c9OfXvEeySHYvFypy587FZ1ag1LsQdmMXTlXXY5d7obS6kGuykOVnoVyaFt7ItJLipKbdwASqtJwAnz0bz1qQv8fFyp3ObpgA4adV0bFELf9/blwkQBOHh46TV8tbwAYW+t3XND7c87+bVablUKiVjR71U4PXlC6bn/fdH744s8P6QF3sz5MXe+V4rFxLInP9NumUbHlYiQHoE6Q1mnJ3U+Hq5ERnqz54j5wn098LV2bE83MvTMQ5+8XI8TzWtnXfe+HObSbcVXl8nxaIvkEWKiUsEeKyqattsdv7ef5oLMckEl/XmSlJavgzc7VisNswWKy5OGvbsO8zqPzeyY/c+zlxb2eHp4c4XU97llRf7FJo+VqkUKORyDEZH4GkyW3C+xTYEvl6uVKhUnSmT3mbCR9OJOh9d4Bi1WsUXYzrx2U//MvGXHKaP6UT7Li8iV1zPNNnaXUD/+hukvzCSyGvB0ZHjUbzy5sdYLFYWfD0RrfZ6wHc/e/sJgiA8jkSA9AgyGM15S8Gb1qtAwoYMtu8/Q8cWtdDpjTSqV4M1a7ewcdteBvftCFxbuaa7ffHCG7NIKWkZbNp+gCfqVcfD7fEYcjFbrGzafYKEqxk83aQavl5uLFn7DwlXM/JqGOWy2eykZ+lIy8ghNUNHRraO8GBHuYMzZ88y4JXXkSSJAH8/+vTsTItmjejYpiWetwkmZTIZWq0Kg8kxh8xkshRY4p/Lz8sNm93O8717UCEynD82H6BJ3UqU9fNELpcjA0LUJ7FeWcunA/2Y+IuO1z5dT9cjOfTr3Z66NSohk8lQRERgfW8iVWvX4uTZaBav2MDKtX8jA2Z9PpaGdaoWSd8KgiA8bkSA9AjSG815wyAatYoWDSuzbvsxTp67gs5gJrJ8CFUrR3D42CmSU9Ip4+vlWLlmvf0GqDdmkXL3+erfu31JPFKJ2HHgDMlpWXRsUYvAMl5IkoSrs4b45HTKBfmSlJLJyfNXSMvIIT1Ln1drys1Fi8VqIyU9B7PZzKSPvkGjVvPn8u+pV6fGPU02dNaoMVybZG8yWwvMK8rl4+WGTAZX07OoV6cWl69aaNO6Hp5aMznxe8mO3YXx6jk0HuXp2OE9qrbRM37qbFat286qddupWqk8dWtUwtXFCb3ByIl5Kzn8r6N2Uo0qEUwe9yq1q1d8wB4VBEF4fIkA6REjSRI5emO+eTDBZb2pViGIff9ewG6XcHHS0KVdc06ducDMH5bTe3hXonIKn3t0s/3x0Uw5s5g/lm3Fz8eLti0bFdejlLiU9ByqhAcSWMYxcVomkxFQxov45AwkSWLbvtNIkkRwWW+qRgbh7emKt4cLapWSf8/E8M+xC+zasZ3oy7FMnvAW9esWrFR7J05add4Qm9FsQXOLoT2VUoGnmwtX07JxddbiK7tAzuF1pGddcLRdocE97GnK1HwZuVJLZHlvln33MWfPX87LEp06e31YTqNR06tLa/r3bk+tahXuud2CIAj/NSJAesToDCbsdgl31/y7rDeqGUFcYjqZ2XpcnDW0admQn1dsYNGy9azSnSO91d2tQrPLZcxd9CeKqyY6tKyH2WIuUO7hUSRJEvpCJliHlPXm3KVETl+IJyvHQKeWtQny9ypwfnhoGXYcOM3OndsJDgpg6KC+99UOrVZFRqYeq9WGzWZHe5vK9H7ebqSkZROgjqWaYj1WnQa3kCdxDWyMi3+dQgs2Voosx+RxQ3h/9CtkZGWTozPg7KTF08MVtUos3RcEQbhbhW/0JDy0crcWya2wnEupVNCqURVcnDR4e7igkkn4uGtBIZG99jyq3y+DvuDWEzeSxenQzjyF4qoJXOz8unQ51Ru2Z9uOvcX2PCXFYrFhtdkL1C8KD/HDw9WJ3YejcHHSEFjGs9DzXZ21nDl5FF1ODq8PG4jqPoMNZ60ag8mMyez4u9DcJkDy9XZDmbUf24XvsKAhtNUXBDR4E7egJ+5YzdpRtM6TsJAAyvh6ieBIEAThHj36qYH/mOwcxyo0VxdtgffK+LjzQtcmSJJE/0GT2L57P96VQ3Fy8ka3IxHNnqtUal6F6m1q4hnojVKlwKQ3s3PdQVIPXyLt0lUAmvZvzrv9n2X/ut289+F0Pv3fHFo1b1yiz/mgzBYL67f8w/LftxB7JYmsHD12Cf7805/eXVvzTMcWuLo4IZfLaVAznM17ThJZzv+W84msVitbt2zBx9uLfn2633e7tNfmIBmvlVDQagr/J2jKvIRz3A9Ukp/EKnMnStGV6u5B931fQRAE4d6IAOkRk6Uz4OKkKXSLi1x/bdnB9t37adz4Cd4Z/QY1KwXzwf8Wc/78eU5tPcHprScKnKNWq+jT7Wn6P9uB6pUdG5BW7/8su/85xG9rNhATF09o8MO/zYzeYGT2gpX8umojKWmZqNUqIsKC8PBwI+lqBhcuxTHx07l89s0ienRqychBvSkf7EfjOpFEhPrf8rpr1m4iPiGJ98aMwMmpYHB6t5y1aqw2Ozq9I9AtLIOkTznJld0fI9lMJNorc0lqgbNLwWE/QRCEG/26cj2/LF/Lcz068ELvTgBkZGYzcepM0tIz6dCmGf16d77tNaIuXObLOT8x64sJJdHkh5oIkB4xWTmGAvOPbmS325k0ZQYuzk689GJ/snVGLl1JpXatakyf9Cpnz19m3eY9pKVnYjSZcXN1xmCBpo3q8EzbhgWu16t7B35bs4GVazbwxoiXi/PRHlhySjqD3viY46cvEBLkz7uvd6N3l6fw9nIn6lIif+87zXMdG7J2024WLV/PomXr2bLjID9+M5EaFUNueV1Jkvhm7iKctFoGDXj2gdropHUERLkb1d4YIFkNaaSdW03mxb+QyZUENZ/M8UM6jBk5eN9itZsgCEKuujUqc/5iTL7X5v+8ihZN69O9YyteHDGB5o3rERocUEotfLSIAOkRk51jxNPj1iXad+49QNT5aEYNHUhE+SBORMWRlWOgfLAfKqWC6pXD8zJEuY6diWH/vxfJyNLheVNdnqdaNMXTw52lK/9k1LCByOUP57S1zGwd/Ya/T9SFWEa90ps3hjyXr616g4k4pxzc3Vx4vkdbnnumDcv/2Mr4KbN5fshEVi74lNDgsoVee/c/hzj67ykGDXgWby/PB2qn07Vq2hnXAiS1SolFn0Ja1CqyLm1GslvQeJTHv85QtN4V8PU6Q2pGzi3LAQiC8HB47qVRXLocW2zXDysXwpIFX9/2mEoVyhPgn7+m2579R+naoRVKpZIaVSqw98CxAgFS8tVUPvx8Dtk5OgIDyuS9fu7CZb6e9wvpmVl4e3rw6ftvsG7TTtIzshg8oCcAI9+ZyjujXiYkyPH7MyEphf/NWkhScioqlYpP33+DE6fOse/Qcca9MQiAKdPm8nTLxtSsVpFPZnxP1IXLBPj78tG7I9Hp9EyftQhPDzesVitvDX+RaTMXcDkuAavVxuR3RxIeFszpqItMmT6P9PQsdHoDNapVYOZn49n1zxFm/bAEm93GS3270/6pZvfd5w/np51wS1k6A+4uTrd8f/GvqwEY0PcZvNxdMJmtGM0W6lULu+U51SoE4eqsYe/R8wXeU6tV9HuuO6fPXmDF6vUP2vxiM/r9r4m6EMu4UQN4a1jfAoHc8ZwkvnM9xfHsJMCxxP/Zrk8x89PRpKZnMejNqVittkKvPXPeImQyGcNf6Vfo+/fCxdkxuTopJRONWokp7QyXNo4k8+J61O6hBDZ+l9DW09B6O5bi+13bHfx2k7kFQRBuJS09k+BAx/SB0OAAUlIzChzz5dyfadmsAYtmT6XD09cDCm8vDyaNHcriOZ/g5enOtl37aduqCX/vPoAkSWRm5aDXG/OCI3Ds4fna4L4smj2VBnWq8fv6bTzRoCaHjp1CkiTsdjvHT5+jXq2qLPx1DTWrVWTpD1/QtlUTVq/bAsDeA0dp17oJH7wzHBdnJ/o/24WF337Ms93a8cuKtQDMnr+MwQN68vuv3xAeFsw7o14mIzOb2QuW8v3XH/LT7E9YtnojVuvtFyfdjsggPULMFitGk6XACrZcCYnJ/L5+M40b1SUyPIyMLB0AdauWu+U5AEqFgvrVy7Nt3+lrQ3j5jx392mB+XrqGDz/5is4dWuPsdOtrlYbz0bFs2r6fdq0aMWRA90KPmas7gk0mFdhOpX3rJxg2sAezFvzGtt2HaNMi/zDjsROn2bBpO53atSIivNwDt1WjVlHW14PElEx8XCzE7/scZHICG4/HpWy9ApPEfb0cAZLIIAnCw+1O2Z3SIpPJ4FrRW7tkRyaX8etv61i/eRcA82dO5si/p3l/7FAAAvz98s719vJg/+ET/PjLas6ev0RocADubi5EhIVw6uxFYuISaNmsfr77OTtpyc7R8eWcxRw7cZaI8iE4abVElA8h6vwlrDYbVStFoFIp2X/4BCaTmT82/I3NZqdRvRoAhAQF0KBOdQAUCjlKpZJZ85dy/NQ5FNe+/Pp4e5CRmY3JaEJvMCCTyThx+jwpqRkMfesjALJ1ejIys/H1ub85nCJAeoRcX+Kffw5SVnYO3877iW/nLcJkMvPKtXkynu4udGlVB3/fO++lVi7IF5lMRmxCGtUq5F8t5enpztg3hvDuB58z67vFjB41uIieqGgsXv4XAK+80LXQVWjHsxOJt+eArPBNeV/s05G5i1bx0/INeQGS3mBgxsz5fD3nR2QyGa8PL7hp4/0KDylDYko64bY/sdkyCWg0BteA+oUe6+PpikIhL1C/SRAE4W54e3kQF59EZHgosXGJRIaH0rtbW57v2THvGKvVhsFgQqPOvzfkkpXrOX76PP2f7UxwoD86veMzqEv7Fmz6ey9XU9IYPui5fOds27mfFb9vYvCAntSoWoE9+48C0KpZA3btO4LVZqNFU8fvO0mSmPzeSCLCrs8BTUi8mhcEAZw4fZ5pM39k2Mt9ePKJusxesBSAJxvX47tFK1i+eiPdOz1FcKA/0TFXqFerClMnvl4kfSeG2B4hOXoT4KjJA44J2bO+X0ydpp35bMYcyvr78eOcL+jR9fr2IAFlPO9q3pBapaSsrwexiYXv1zZowLNElA/ly2/nk5R8d1W5S4LeYOS3P7dRObIc9WtXKfSY8ec2kyNzLKvP3U7lRv5+3rRr2Ygde48QHRPPnxu20qhVD774ah4RYaH8sex7GtarVWRtLh/iRzn5QVxscXhGdMIt6NYlFBQKOT3a1qdiWOHzowRBEG6naaM6HDl+BqvVyonT52ncoODvsqqVwtn1z2GAvM23AQ4ePUX71k2pGBHG+ejr86vq1arK6aiLZOfoCbphzhLAoWOnad6kHrWqV+J89PUJ400a1ubg0VMc/fcMT9Rz7ELQoE51lqzcgN1uR6c3kJWtK9C2YyfOUrtGZRrVq0F0zJW817fu2MeEt4fw87xPeb5HBwCqVY7g6PGzXLp2XFLy7fcfvRMRID2kTl+I59+z+Sf86Q0mZDJHLR2AxUtXM/6DL9Bq1Hz9+fv8s3Ul3Tu3vae9wW4UEuBNfFI6VlvBuThqtYoP33uTHJ2env2Gs+/g0fu6R1E7ez6GbJ2ezm2b3jJ7dF6f/x9JbhbpRl3aPQnAyyPeo98rb5KRkcnUD8awfcMSmjUuPLtzPyTJju7cL5RX7MOq8se3+p3nNXm5u6BU3rqsgyAIwtXUdAYMG8+qtVtZsnI9I9+ZCsBLfbuzc+9hXhw+gc7tmufNR7rR60P6sWzNRl5+bSJx8dd/N3bv1JrZC5by1oTPcXW5vjhILpdTrXJk3pDYjdo/1ZS1G3cwYuzHIF1/3c3VBWcnLV6e7mi1joz4wL7dMJnM9H11HK+98wlXEpIKXK95k3qcOH2OwW98SFpaZt7rFSPLMeb96fQfOp6R70zl19/W4e3pwfi3BvPelG8YMGw8i5b+fu8deQOZ2WyS7nzYw8VqtfJkp4HsXPsjSuXjN0qYkaVnxV/7Ucjl9O/eNK/m0cET0Zy5EE+/bk0B6NjzZQ4fPcGZw5vx9LjzMNqdpKbn8NvGA3RsUYvgst4F3pckianTZvHlrPlYLFae69WFD8e/gX8Z3wLH2ix6zNlxmLNiMWfHYTNlodB6oXTyxtmnChrP8g/cXoBtuw/x0qgpfDphOM8906bA+10OL2ZfZlyB15/wCM43F2nf4ZP0GTwBQ3YK3do/yUfvvUnZG8bii0rKqSWknVmG1qcyAQ3HoHIS9Y0EQXi0GE1mho+ewrTJb+Pt6VEqbXj5tUnMmjYBjVrF6aiLjJ44nXXLZhXpPR6/6OIxsOvQWbRqFXqjmdiENMoHOz6o9QZz3lYZcfGJ7Nl3iO6d2xZJcATg7emCs5Oa2IS0QgMkmUzGe2NG8GyPToyb9BlLVvzB2g1bmffNVDq0aQmAZLeQdHgOWTHbbnsv16DGlK03ErnywSZ8y2WOJKgkFYzzC8se5bp5LtKpM44VfE2fqM+8r6c+UJsKI0k2MqM3kXZmGRrPcIKbvY9cIeYVCYLwaDl+6hwffDaLAX26llpwBNC4QS2GvT0Zs8WCRq1m0rVJ5kVJBEgPGbPFSnxyBi0aVObEuTguxCRfD5CMJpydHMNrK9dsAKD3Mx1vea17JZPJCCnrQ2xiKo2JzPeeKfMSmZe2YLfocLVb+Oa1cBKfdeH4ydPE7fuatHIZyFUuZF3egjEtClwjMagjybZ5kmJwQ+XkSZuGoVj0yWRcWE/Olb3EW/QENh73QIGCp4crAEkp6QXeG39uM6kWQ6Hn5c5Fys0irdv4NwAtmzW677YURpIkdImHSDn5E+asWBQaTwIbjRXBkSAIj6QaVSvw28IZpd0MBg/omVeLqbiIAOkhk7vXmpeHMxGhZTh08hIWixWVSoneYMbXyxEQbNi8A1cXZ55u2bRI7x8S4M3Z6ASydUbcXLTYzDpSTy8h4+J6kOz5jnWVKWhYUYtCLpFyYpHjRZkcs+eT7LlaExcnJzzdnVG6SFxJzkDpEoDaLQjnMrVJPjqXzOiNXFw3GPfQFniEPYXGI+ye21spshxeHm6sWb+dUa/0zpuQfrvsUa7cLFIFlSf7j55FptDQs8tT99yGWzFlxZF8dA6GlFPIFGq8K/XEq2J3FCqXO58sCIIglCoRID1ksnSOjIebixPhIWr2/3uRywmpRIb6X8sg+WCz2Th2/BR1a1dHo1Hf4Yp3z5wdj5c9mlD5Qa7s34cTaZiz4pBsRrTelfCr+TIa91BkCiUgRyaTsXPPAfq99CrjRvakX4/WOPlWY8+/ifhas+nR1jG5OSY+hfjkDAxGCy7OGmQyGWVqD0btFkJm9EYyLqwl48JaNF6ReEV2wS24KTLZ3a0f0GrUPNv9aeYuXMWeA8dp1sixQuN22aNcuVmk7iedQK4molxZggKKZt6R1ZTJld0fYTWk4RHWBp8qfVA6FRy2FARBEB5OIkB6yGTnGFAqFWg1Kpy0asp4u3MhJpnw4DIYjBactWqizkej0xuoW6takd039cwKUk/9AkC4AkgHq8YTrXck7qGtcA9tUWjQ0qRRXZxcffhu6T6GjnwPmUyGwRSTt+cYgNO1FQt6ozmvkrRMpsArshOeER0xpkeRGb2Z7LjdJB6YQcaFdQQ1mYBCfXeZlhd6tGXeotXMXbSaJg1qcFKXfMfsUa7z+jRmLj+ETCZj1OA+d3XOndgsehL2TcNqSMG/3mt4lGtVJNcVBEEQSo4IkB4yWToj7i7avCXr4aFl2P/vBbJ0BiRJwtlJw+7dBwGoU0QBkikrjtTTy1C7BeNVsTuXUuQcu2TmhfZPo1DcPpOjUCjo3rktc374mWPHT1O7ZlUMBnO+/eKctY4sl8FoAtzynS+TyXDyroSTdyX8qg8g5dQvZEb/RdyuDwhqOgGl5s6TAEODy9K9Q3NWrdvOZzMXs7up7I7Zo1zpuy+huZKFi1ZFl3bN7+qc27HoU7iyZwrmrBg8IzqJ4EgQBOERJeogPWSydQbcbtjqIyKkDHa7xKlzjsJXzlo1R46dBIomQJIkG8lHZoNkw7/eCDzKtSYovB5Gq4rElMw7XwDoea0w5W/XJo4bTOa8oAiu72CvN5pvex2Fxo0ytV/Fu/KzmDIuELttHObs+Ltqw9Txw6hToyJzF67ixMK9YLHf/gS7hHJbPJpl0dg91Tw/otsDb8Rr0acQt/N9zFkx+Fbvj1/Nlx/oeoIgCHcrOSWNdz6cQd/B7/DiiPe4cMlRRy8jM5vX3vmEF14dx+Llf97xOlEXLjN8zJTibu4jQQRID5msHEcGKZeLs4ayfh6cjU4AwNnJESD5eHsRGhz4wPdLO7sKQ+ppPCM64uRdCXBsb+GkVRObcHfDVPXr1iAkOJBVf/yFzWZDbzTjdEOAJJfL0WpUdwyQwJFR8q36HP51hmExXCV+3xfYbZY7nufkpOHHbyZRp25l2J2A99QTNNtpp0NaAM9QgXfKP8k75Z/kNa+6tD6swv/z06jXxmJ3liOv7sIz7e8v0yNJEubseNIvrOPylrew6BIoU3sI3hWfue+CnYIgCPdKJpMxuH9PfvnuMzq3bcHPyx2bus7/eRUtmtZn4awprN+8i5i4hFJu6aNDDLE9RCRJKpBBAogI8SfxqiObo5DB8VNnadG00QN/AJuyYkk9vRS1e0i+is6O5f7exCam8cRdXEcmk9Gzazu+nLWAPfuPYLPZ8wVIAE5aNQbDnQOkXB7l22A1ppN6egnJR+bgU+VZVC4FK8DmO8fNhaWzPuLnFX/x0/L1HF5zANnvB/Bwd+e8lxt6g5GrKRlYbTb8/bzxD/Xj4MH9LBj7GdW87z7YlCQ7GRfWoUs6gjHtHHZLDgAKjScBjcbiFnQ3vSYIglB0/Hy88PPxIj0ji7j4RCpGhAGwZ/9RunZohVKppEaVCuw9cIzQ4IB85yZfTeXDz+eQnaMj8IatQ85duMzX834hPTMLb08PPn3/DdZt2kl6RlbeEvuR70zlnVEvExLk2A4pISmF/81aSFJyKiqVik/ff4MTp86x79Bxxr0xCIAp0+bydMvG1KxWkU9mfE/UhcsE+Pvy0bsj0en0TJ+1CE8PN6xWK28Nf5FpMxdwOS4Bq9XG5HdHEh4WzOmoi0yZPo/09Cx0egM1qlVg5mfj2fXPEWb9sASb3cZLfbvT/qlm992nIkB6CEiShEwmQ28wY7dL+TJI4Ni7a8+RKLRqFXv2HcJsttCkUd0Hvm/qqV8cQ2t1RxSoyxMS4E3UpURy9Ma8vd9sNvst5yT16NaeL2ctYMXq9VSr2yzfEBs4hgYNprsPkAC8K/VEl3yUrJhtZMVsQ+MZgVtQY9yCm6FyKVPoOWqVipee78zA5zqx58BxPvt2CQaDHsluo4yvFzWqRNK9Q3N2797Dt9/9ROsWjeneue1dt0myW0k8NJPs2B3I5Eo0nuFovSui9aqIi3+du55YLgjC4+XKnqlYdAW3yigqKhd/gpqMv+0xx05GMWL0FOrWqsqoVx1fetPSM/O2FwkNDiAlNaPAeV/O/ZmWzRrQu1tbtu85yNJVjukS3l4eTBo7FD8fL97/dBbbdu2nbasmDBs9mVf69yArW4deb8wLjgA83F15bXBfQoMDmLNgGb+v30bfXh2ZNX8pkiQhSRLHT5/jndcH8f1Pv1GzWkUmjx/Juk07Wb1uC21aNGbvgaN8OfUdGtSpjs1mp/+zXagQUY4167bxy4q1TBg9hNnzlzF4QE+aPVGXwa9/wDujXiYjM5vZC5by/dcfolQoGPr2ZJ5u8cR977ghAqRSZjZbWb5hP6GBPpT1dUxIvjmD5KxVE1jGC6PJwoZNjo1W27dp8UD3NaSdIyd+H66BjXDyrljg/SB/b2QyiE1Io0pEIIlXM1i7/Rh9OzfOlx2SJAmD0US50GAiw8P4c/0WKtdqXGgGKUdvvKc2yuQKgpt9iD75KDlX9pKTsJ+Uk4tJOfULVs/GVGw6AqVaW/i5MhlNGtSga+c0GteOpFqF4Lz2Tpg8nW+/+4knGtRm4dzpd52JkySJpCNzyI7dgUtAQwIavIlcKQo+CoLwcKhVrSLbfp/PoqW/88mM75gweojj99u1nQbskh2ZXMavv61j/eZdAMyfOZkj/57m/WuVqANu2GLJ28uD/YdP8OMvqzl7/hKhwQG4u7kQERbCqbMXiYlLoGWz/HtVOjtpyc7R8eWcxRw7cZaI8iE4abVElA8h6vwlrDYbVStFoFIp2X/4BCaTmT82/I3NZs/b2y0kKIAGdaoDjg27lUols+Yv5fipcyiuzRX18fYgIzMbk9GE3mBAJpNx4vR5UlIzGPrWRwBk6/RkZGbj63N/WzqJAKmUXYxNRm80EXUpkdMX4nHSqHBzKfih/2T9ShhNZt6fNJFyoUFUrhjxQPfNjN4IyPCp+nyh72s1Ksp4uxObkEqViEAuXUnBZrOTnqVDq1Gx98Bxflqxga27DmHKywzJseLM5i1/06dj/orUzlo1V1Oz7rmdcoUK14AGuAY0QLJb0CUdI+HEUpTpu4nbb6Vc07G3DHCMJgt2u5S3PYskSYz/cBqzv19M40Z1WbZwJm6ud5fxkSQ7qSd/IevyVpz96xLYaAwyudhAVhAEhztld0qKSqXk2e7t6DNoDOAIcuLik4gMDyU2LpHI8FB6d2vL8z2v78JgtdowGExo1Pm/2C5ZuZ7jp8/T/9nOBAf6o9M7Vgd3ad+CTX/v5WpKGsMHPZfvnG0797Pi900MHtCTGlUrsGf/UQBaNWvArn1HsNpstGjqCKokSWLyeyOJCAvJOz8h8WpeEARw4vR5ps38kWEv9+HJJ+oye8FSAJ5sXI/vFq1g+eqNdO/0FMGB/kTHXKFerSpMnfh6kfSlmKRdyqIuJxLk70Xv9g3p2roOfbs0yduc9kburk4kJyURdyWB9k+3eOD5R/51hhL85Edo3ENveUxIgA9XktKx2+3EJaYBsHbTHp7u9Rp9h73P+i17qVUtkh6dWvJst6doXL8aCoWKQ0dP0rzrED79ehFmi2OCtbNWfVeTtG9HJlfhGlAfS9gortojMCfvI/XUr4XuwwbXV825XNue5YOpXzL7+8U0aVSP5Yu+vevgyGbOIX7vp6RFrUTjGU5gw7dFcCQIwkNl1dotnD0XjSRJbNt1gHIhjnmVTRvV4cjxM1itVk6cPk/jBrUKnFu1Uji7/jkMwJmoi3mvHzx6ivatm1IxIozz0bF5r9erVZXTURfJztETFJB/usOhY6dp3qQetapX4nx0TN7rTRrW5uDRUxz99wxP1KsJQIM61VmycgN2ux2d3kBWtq5A246dOEvtGpVpVK8G0TFX8l7fumMfE94ews/zPuX5Hh0AqFY5gqPHz3Lp2nFJyXe30OhWRAapFGXlGEi8mkmrRlVwd3XC3fX2G7dO+/o7ADq3b/3A95bJFTj73b5MQEiANwdPRHMx9ippmTp27z3A9p17cXdzYXC/bvTt2ZbyofknN/d5+W227dyP3ebBnIWrWLJyA13bNsTHx4/kTDM7djtRpVI4fr4+9912ndHCGdvT+LmaSTu7Aps5G7/qA5Cr8vef3mACwFmrISMzi5nzfqJWjSosWzQTVxfnwi6dx24xYMy4gDH9HJkXN2LRJ+EW2gL/2kPFsJogCA+dOjWqMGP2IhKTU3Fx1jJxtGPI7KW+3Zk4dSar126lc7vmefORbvT6kH588PlsVv65mfq1r38udO/Umlk/LOG3PzYRFhqU97pcLqda5Uh8vArWqWv/VFM+/3o+2/ccpFa1Snmvu7m64OykRaNWob1WPHhg32589tV8+r46DmcnLWNeG4ine/5aec2b1OPDz2cz+I0Padqwdt7rFSPLMeb96fh4eeLh4UrThrV5vmdHxr81mPemfINCIadG1QqMee2l++tQQGY2mwr/+v0Qs1qtPNlpIDvX/njfk6+KgyRJ2O3SHYsr5jp88hLHzsTQr1tTVMqCGQm9wUBsXAKxcQnsP3SMz7+cS9eOT7Nw7rQSWUIuSRLL1+8nS2fgn/2H2bx1J+GeLvzYpxVl3QoPMC5dSSHq3EVSriaxMiGHf80KlBYjKWnX6xkFBQVy8O9VODkVPn/oTrbtO825S4k0rhGEZ8piDCknUGjccfKtjtYz3DFx2jOcc1d07DhwhkG9WrBm7UZeHv4OMz6dwEv9ehf6rLrEg+TE78eYfg5zVhzgqKUkk6vxq/kSHuXbiqX7giD85xlNZoaPnsK0yW/j7XnnYr7F4eXXJjFr2gQ0ahWnoy4yeuJ01i2bVaT3eHiii8fAkVOXOXzqEoFlvAgL8iUsyDdv/svNJEki6lIi5YP9CgRHkiQxZNR4lq1al+/1Mn4+TPt4fIl9SMtkMjq1rM2cxevZsm0nQb5e/KhOx2f1Sm5VmSjo2v8AennCZIOSpdlaunXvjtlsJTk5iUMHDzDt6++Y+M5r99Uu3bXJ3garkupPvk/mpa2kn/udnCt7yLmy59pRciy+7dGqK6FQyNmweQcAbVsXrJZtzkkk+dj36JMcKWalky+uQY3QelW49r9w5MrbZ/cEQRD+C46fOscHn81iQJ+upRYcATRuUIthb0/GbLGgUauZdG2SeVESAVIRsdvtnDp/BX8fd+x2O7sPn2PXoSj8fdwJC/ajeoXgfJml5NQssnIMPFm/UoFrLV66mmWr1tGwXi2ebNKA4KCyhAQFUrd2Nby9PEvwqRyFKmNjopEkePuNQUjLFkFS3F2dK5PBhHoRHIjWc+zkRT5873UsFhuTk5P4avaP9OnZmYqR5e+5TTq9Y+jMaDIjkynwLN8Gz/JtsFsMpCacIfbiMRTpe3FKWUdlRTTG7Aps2rqLmtUrE3RDetluM5MetZq0s78h2S24hbbAt2pfVM5Fs2GtIAjC46ZG1Qr8tnBGaTeDwQN65tViKi7FFiAlp6Qx/duFxMYlolIrmTRmKB5urrz38TdcTUmndo1KTHj7VeRyOTv/OczcH5ejVCiY8ParRIbfeuLwwyo2MQ290Uz7J2vi6+2G0WQhJj6Vi3HJ7Dt2AS93F0IDr8+7ibqUiIuzhsAynvmuk5CYzHsfTiPA349li2bi6eFewk+SX1p6Fus276Fh3arUqhbJ/gat6LhjDWTdxYo0Dw+chw/lhX2nmDx9PlZjNiEhoTz73HN88fnnvD/1S36d/9U9tUeSJHKuzS0yGK/nseIS0zgeFUtsQgYadSRaZRihpjX4cJrLm0byalsVNaqXJf6fz7Aa0rAa07Ea00GyoXYLoUztV+84J0sQBEH47yi2VWyFlT1ftvovmjSszYofp2O32zl45CQWi5XpMxfy9afjGD1yIJ9/s6C4mlSszlxMwMfTFV9vxwQzrUZFxfJladvUUctBbzTlHWuz2bkYm0yFcv4Fhsve+2gaWdk5TP9kQqkHRwAr/tiK2WKlf+8OuLs6ke7jj8W/7J1PBOTBwSgiIujVuRVajZrFKzag1agIDA7hmS5tWb/xb1b/ufGe2mMyW7HZ7KhUirzCk1fTslm3/Rh6g5kWDSvzQtfGPN2sPifs3Uhw68eFBCs9m3lQ0TOWnPgDWAwpKDQeuPjXwa/GS5R7apoIjgRBEIR8ii2DVFjZc6PJhJeHG3K5nIiwEJRKBSfPnMfTww1vTw883Nw4e/4S2Tm6u16C/TDQG0zExKfSpE6FAu/l7kNmuGGJe0xCKiazlQph+QONbTv2svL3v+jYrhUd27Ys7mbflZNnowFo07wByBzx9JaqjWkZG4vWaLj1iR4eqIcOcfynuysN61Zj3+GTaDUqLBYbE8eO4u+d+xg4dAxDBx3lw/FvoNGob329a3KLTfp6uZGjc/x3QnI6CoWcZ9rUy9tw1sfLlXbNqjPn+4XMmhfNrI+H0LtXT5ROvmKJviAIpW5PegxNvB690ZL/kmKtg3TsZBRdnh9J9OV4endrS88uT7Pij818t+g3zl2MoWb1SqSkZeTtC6NQyAkO9Cc1LaPAtVb8vonnB4/l+cFj6Tf03eJs9j2LupSIXC4jslzh21843VQDKOpSIn5ebni5Xw8CjUYTo9+bipNWy6cfji32Nt+tzOwcNBo1Wq0GrUaFi5MGwsqjDit32/Nys0e5PN1dMZnM5Nb/Klu2DDv+WkrjhnWY88PPtOnWn/MXL+W7xrlLiXlL9XPprv3Z19MxjAmQlJpFGW/3vOAol6+XC78sXU2FiDD69BuCysVfBEeCIJS649mJ9D62hOPZxbc1ifDgijVAyi17Xqt6RT6Z8R3bdx+kRZP6uDg7cfFyHCmp6chksnyF/iS7VOgqrV5d2/Drd5/z63efs3jOJ8XZ7HsiSRJnLiZQPtgPjVpV6DHOWnVeBslisRITn0pkWP5aFF/P+ZEL0TGMfeNVQoPvfuPU4qZSKrFarXl/Rz3bNeCZNvVwHjEcPG6xguGG7FEui9UKgIvWsbTfaLIQEhTAH8u+Z+wbQzhxKooW7Z/j52VrrpVLsLNt32miLiXmu45Ob0Imk+Ht6YLFasNqtZGUkom/b8HhyOUr15GRmcWrLz2PopDim4IgCKVh/LnNWCQ7753bVNpNEW6j2Ctp55Y933PgGL+uXM+Lz3Whb6+OdG3fkrUbd+Lr40XMlQTAMTfnSmIyvt6exd2sIpOakUNWjoFK5W89L8fphgBJZzQjSRI+nq5572dkZPH17B+pEBHGiFcHFHub74W3pzs2m534xBTAMbdKLpejiIhAHhxc6Dk3Z48A4uKT8XB3xcXZUfYgN/ujVCoZP3o4vy/9Dg93N0a8NYlhb04kO8cxfJc7jJYrR2/CxUmdtxnu1fRs9EYzZXzyB2uOwpCLcHN14bleXR6wFwRBEIrG8exEzusdFZ7P69OKNIvUpH1/BgwbT48BbzL4jQ+5FBN/55Nu8syAN8jIzC709ftR2HmHj53i7YnT7ut6JanYAqTCyp6bzRZOnrmA3W4n+rKjFHi1SuFkZetIS8/k5JnzVK0Yjssdqhw/TLKufZDfGPDc7MZtNnIDA+0N2abvFi4hR6dn9KjBqG+RhSotbVo2BGDZ71sKvKceOqRAFsnm6lYge3TybDTHT1+gTYuGOF2bZ2Q056+k1KxxfXZtWk67p55kyYo/6D/4LaIvXiRLd32ekyRJxMSn4OPplrcZ7uUrjsDN3+d6Bin2SgKde7/CuQuXeHPkoEdqPpsgCI+38ec2k2px/F5LseiLNIuk1ahZNHsqvy38H21bNeanZX8U2bX/i4otQKpTowqz5i/luVfGsnrtFsa+9hITRg/h828W0Pult0lNy6DPM+1QKpWMGTmQUe9+yozZPz1QWfDSkKM3oVDIbzm8BvnnIBmvrbzSXvuAvxKfxJwffiE0JJCe3doXf4PvUaumdQkq68evKzdisVjzvVdYFkkWUjB7tHjFBgD6926PSqVAJpPlW6Kfy9vLk59/+JLne3dlx+5/mP3t1/yyZHne+3GJaaRl6qhRKTgv0Dp/OQkPN+e8gGnN2s00a9ubE6fOMmncKN4c8fKDd4IgCEIRuDF7lKuos0gAJpOZ2CuJeduKnLtwmdfe+YR+Q99l1LhP0Rscmfmz56IZ/MYH9B86ni/nLM53jbT0TPoOfoek5FQGv/EhKanpDBg2nv2HjqM3GJk4dSZ9Bo3hjfGfkZWtQ6fT89o7n9D7pbd5/V3HPW4+7+brj/voS/oMGsO0mQuRJImExKu88Oq4vGOGj5nC6aiLfPPdL/z513bA8UX5hVfHodPpi7TPClNsq9jCQgP56pNxBV7/ee6nBV5r0rA2TW7YY+VRkqM34uqsvW11ayetGovFMV/megZJye/rNjNqzIdkZGYxeeJbD9W2KbkUCgV9e7bli29/ZsmqTfR/tkO+99VDh2CcMBEyM6/VPRqW7/3LsQmsXredGlUiqFXNscpPq1FhNBe+ca1SqWTW/z6ifbs2jH53Mps2biIj8x08Pdw5diYGP283Avw8sdsdc6L0RjPNa5RHbzAw/oMv+PHn3/Dx9mLpwm9o91TBqtmCIAil5cbsUa7cLNLvdfs98PWNJjMDho3nSmIy7m6ufP/lBwB4e3kwaexQ/Hy8eP/TWWzbtZ92rZowYepM3h87jOpVIknPuF7bzi7ZmTxtLsMG9cG/jA8fjRvO8LEfs2j2VABmz19KzWoVmTx+JOs27WT1ui2EBJZFrVaxfMF0kpJTcXbSFjjvRnqDgbGjXsLd1YVXXv+Aw8dOE1i28CK9Xdq1YPq3i+jcrgUXLsUREly2REaain0O0uMuR2/C1fn2m5fmzpcxmMyOAEmy8da7Uxjw6tvI5XJ+XfAVfXt3LYnm3pcXerYjKMCPD6f9wLZdh/K9d2MW6ea5R8lX0xg4ajIms4W3h/fNe12rUeUFioWRyWSEly9Py9ZPYTKZmP/TcpJTs4hPzqBW5VBkMhkKhRy1SomXuwtuWjmtO/Xlx59/o0WzRuzetFwER4IgPFQKyx7lKqosUu4Q2/qls3lr+ADenPAF4AiQLl6K44tvFnD2/CUSk1KJiUvE08ON6lUiAfDyvD5N4dcV68nRGXjyibqF3mf/4ROs+nMLA4aN5+fla8nIyKZmtYpcTU1n3sIVd7XPZnBgWbw9PVAqlTSoU50z56JveWxYaBAWi4WU1HR27DnIU80b3Uu33DcRID0gnc6Im8vtfxhyh3/0BjMpqRnMmD6NH3/+jZZPPsHuTcvp0KZlCbT0/nl6uPHj1xNxcXFi8FufsHDpOkw3zCFSDx0CSmXe3CNJkjh49DTPvDSO6JgEPhzzCi2bXP+HdqcACRzBZJ269XBzd+ezGXMYM/EzlDI7YUHXv2HUr16eFg0rM3X6LM5EXWTC2JGs+mUOZf3FViGCIDxcCsse5SrquUhqtYonn6iLXm8gK1vHkpXrWbN+G53btaBbh5ZIkh27JAGFj3ycOH0OF2ctx05GFfq+JElMfm8ki2ZP5ed5nzJqyAv4eHsy/5uPCCzrx8ARE4hPTL7r9iqVirxpJ1abtdBjOrZtzpYd+zhw5CRNG9W562s/CBEgPaDcIbbbuTGD9NfmbSQkJPDmiJdZ+fNsAsoWXjvpYVMhPITf5k/Fv4w373/+HU06vsLnMxcTHROPLTQU1eSPyPT2Y8mqTXR+YTS9Bo0nKTmNaR+8VmBYTqu+c4BkNFnw8XSj/4CXCAoKZM3vfzJp0kRmfPsD23ftY/o33xNcxp3szHSWrPiTZo3rM3rU4AK1kARBEErb7bJHuYp6LtLJMxeQJAk3V2cOHj1F+9ZNqRgRxvnoWABCg8qSkprG2WuZmxsDmnfffIWRg/vyzbyfsdvteHm6o9PpMV/7YtygTnWWrNyA3W5Hdy0Ii758BYPBSKe2zSlfLoioC5cLnHejtPRMjCYzOp2ebbsOUK9WVdzdXUlMSiUjM5uLl+K4EH1938+nmjfir6278fHywPkuMlRF4eGb9PIIsVptGEyWOw6xadQqZDIZeoOZ7Tt2odFoePsR/DCPLB/Cul/+x9LVm1m8YgOzFvzGrAW/AeSrZ+XirKVfr/YMeLYDFSMKVop10qjyVv/disFowcPNmQoVIwmPeJPjx46yfesmJn/2Td4xv61eD4DNZmP86BFF9ZiCIAhF6nbZo1xFMRcpdw6SzW53zAF6dwQymYzunVoz64cl/PbHJsJCgwBHlumDcSOY+uX3SBLUqBLJ6JEDAXB3c8XTw42w0CDWb9lFpzbNadWsIX1ffYeRrzzPwL7d+Oyr+fR9dRzOTlrGvDYQo8nM1Bnfk5WdTWhwAE/Ur4VWo853XstmDfLa6u7mwjsf/I/E5BR6d2uX164eXZ6i39BxPFGvJg3qXN8CysXZibJlfGldQsNrADKz2STd+bCHi9Vq5clOA9m59sdSndicma1n6bp9dG5Zm0B/r9se+9Oa3Xi5KOg3cAjNn2zK77/OKqFWFg+73c6Of46ydedB0jOzsVpteLi5UK1yBN07NMfN9dYT6A4ev8jZ6ERe6NqkwHvZOgN2u8S2fafxdHcmNT2H1IwcGtQIp1pkIL8u/534xGTsdjtffDUPtVrFmyMG8e7bwwq5kyAIQuk6np3Is8eW3jFAAvBVObO0Vh9quPnf8dj/mozMbN4Y/xlzZ0xCo77ztlRFQWSQHkDuvmCud5iDBI5Vawt/+hWANk+1KNZ2lQS5XE7LJnXzzS26W1qNGqPJgiQVrJq+9+gF9AYTRpMFJ40aVxctWTkGqkYGolarePGFnnnHtm39JAEBZQgOvLvNcwVBEEpagexRtgVZlhmZ2Y6kkSN5qMHFUSamKFe0PU627dzPtz8s4Y2h/UssOAIRID2QHJ1jXzAXp9sPsUmSxIIF89mz5x/CIyJo+kSD2x7/uHN2UmOz2zFbrAXqR+n0RlLSc5DLZThpVJQLDKFiWNlC60w1qFezpJosCIJwz45nJ3EyJxnsEorTGSj3JKE4m5nvGEkGtmpeWJv4Y49050ROMsezk0QW6QatnmxIqycblvh9RYD0ALL1Rpy0ahSK288l2rxtN3v2/EPVatXpN2Agro9QpfDi4HzDqr6bAx+D0ZFZstkktFo1Zf08S6GFgiAID85ZrqRLmj9b52wk+2oWMrmM8g0jKRPhj0qrxmwwk3g2nstHo1GeSMcz0IunR7THWS4+mh8G4m/hAaRl6vB0u32wY7PZeH/ql2g0arr36IVSqUSrebi2EylpztcybjqDCS+P69uASJKUt2cdOCZzC4IgPKqO/X2cP6euxNlJy6hXevN8j7YE+PsWOC4mLpGfV27kp2Xr+f3DFbSZWo6IVj6l0GLhRo/WMqqHzNXULMr4FNxF/kZr1m7i1JlzDHm5L56engAiQHLKzSCZ8r1usdiw2e3I5Y55Sbn1owRBEB41W3YcYPQH31C2jA+rfvyUt4b1LTQ4AggNLsu7owaw7LspuLu58Nq709h/5FQJt1i4mQiQ7pNOb0JnMN0xQOrS4SlmfDqBt0YOyss2/dcDJKVCgUatQmfIv92I/to+dUHXVgT+1/tJEIRHk05v4M1JX+Hh5sLiWR8QWT7krs6rXiWCH7+eiEql5LV3pxfY/1IoWSJAuk/JaY59a/y83W57nEql4qV+vfH0cMf32rFi6AhcnNTobsogGa4FTDUrhVCjYsgdJ78LgiA8jNZs2ElWto63hvWlfGjgPZ1bvXI4w1/qSdLVNDZt339P57buNqjAa1/NXcz5izH3dJ1cN28e+18jAqT7lJyahbOT+o5VtG8U6OeJk0aFUqkoxpY9GpydNAWG2AzXMki+Xm40rhN52w2ABUEQHkaSJLFo2XpcXZx4puP9lXR5ttvTqJRKflq+/oHb8/qQfkSGFyzYK9yZCJDu0vodx1i+YT8bdv7L7sNRXLqSQhnv2w+v3axSeADPdmwkPvhxlEbQ3zzEZjQjl8tQq8TaAUEQHk3HT1/gzLlL9OzcClcXp/u6hp+PJx2easzegye4FJvwQO0ZPmYKp6MuMv3bhfy1dQ/gCOL6DBpDjk5PTFwCr775IX0GjeZ/sxbl7YiQS2808tEXc3jh1XFM+PgbTGbH7+0bs1WTp81l6879rPh9E98t+i3v9ZHvTCX2SuIDtb80iQDpLkiSRFxiOhq1EiSIT8pAbzQRGlj4hLtbkclkhdbz+S9yLmyIzWjGSasWAaQgCI+s6MvxADSuX/2BrpN7/oMGSLlaNm3A7n1HAIi+fIXgwDK4ujgz9X/fMXrkQJZ8/wUGo4mTZy7kO89gMPLyC8+weO4nWCxWNm3be8t7tG3VhL93H0CSJDKzctDrjYQEPbqFfMVX9btgsdqQJIlqkUFEhIriXUXBxUmD3mjOV03bYDTjrBEr1wRBeHRl5egBHrjenZurowRK9rXrPahaNSrx+Tfzsdps7N53hBZNG6DTGzgdFc2UaXMBx15uTRrUyneej5cnwYGOz71G9Wpw5twlOrcrfOjQ3c2FiLAQTp29SExcAi2b1S+StpcWESDdBZPZsZJAZH+KjrOT2lH3yGS5XjjSaMbJSQRIgiA8unLLkxiMpjsceXt6o2MrK2dt0SxWUSoU1K5emX9PRrH34DE+fm8USBLOzloWzvr4rjL3SqUC7bXns9nthW4X1aV9Czb9vZerKWkMH/RckbS9tIghtrtgMlsAxNyYIpS7Qk2vv/5LxGA04yQySIIgPMLK+HoDEHUh9oGuc+7a+b4+ng/apDwtmzVg89//oFQo8fJ0x8XFmcCyZVi3eScAScmpBeYgZet0ZGXrsFisrN+ym/q1qwHg4uTEhehYklPSOHbibN7x9WpV5XTURbJz9AQFlCmytpcG8Yl/F8x5GSTRXUUlt5r2wZPRVCofQHBZb0eA5C8CJEEQHl1P1K+Gr7cHS1ZvYuiL3VEo7n3VstFkZsUfWwkLCaBGlYi7Ps9gNNFr4Ft5f/7ms/H53q9fuxoffj6bQf165L02acwQPpnxPb+sWIePlydTJ47KNzzo6+3JlGlzibmSSMum9WlUrwYA/Z/rwqhxn1KzekWaNKydd7xcLqda5Uh8vDzu9bEfOuIT/y6YLGKIrag5a9U0rBnOuctJbNp9AoVCjs1mzxtuEwRBeBSpVSqee6YNM39YwY69R2nVrN49X2Pd5j2kZ2Yz4uWeyOV3P9Cz96/FBV6b9cWEvP9WqZRsWD4n3/vlQgKZ879JhV4voKwf87+ZXOh7z/fowPM9OhR43Wgyc/T4GaZNfvuu2/2wEkNsd0EMsRU9mUxG7Srl6N2+IX06NqJ+9fKEBHgTWMaztJsmCILwQJ5/pi1yuZzps3/BYLi3uUiZWTnM/GEFGo2aXl1aF1MLi8fxU+d44dV36NahFd6ej34GSQRId8FktqJSKfL2CBOKloebM7Uqh9KheS28PV1LuzmCIAgPJCjAjxEv9eTEmYuMGPcFxrucsJ2do2fwW59w8fIVxgzvi6fH7XdqeNjUqFqB3xbOoFvHVqXdlCIhAqS7YDJb0KjE8JogCIJwd94a9jy9urRm665DPDdkEgeOnCowATqXJEns3v8vvQeNZ/+RU7zctwuDXuhawi0WbibGjG7jxLk49AYzJrNVTNAWBEEQ7ppMJuPzSSPw8/Fk9o8r6f3Ke1SOLMcLvdpTo0o4ri5OZOcYOHL8LItX/MXFy1eQyWSMHdmPYQN7iIK5DwHxqX8b5y8lYTRb8PVyEwGSIAiCcE+k+Hje9FUy4OX2HD0Zxamz0cR98y1xNx3XRaOhepMK1KwWiZfWjP3KFRTBwaXSZuE68al/C3a7ndTMHOx2CTcXrVjBJgiCINwbkwnLit9wNxhoDjTXAIXWfTTAhZNw4SQWJycUDRuWbDuFQok5SLeQkaXHZnNUCk3LyBEZJEEQBOGeKCIikIeH39M58vBwFBF3X/tIKD4iQLqFq+nZef9tMFlQiwBJEARBuEfqoUPA4y6XvHt4OI6/T03a92fAsPH0GPAmg9/4kEsx8fd8jWcGvEFGZnahr9+P+z0PICHxKi+8Og6Aw8dO8fbEafd9rfshAqRbSEnPxs1Fm/dnsYpNEARBuFeKiAjkdzmfSB4c/EDZI61GzaLZU/lt4f9o26oxPy37476vJYg5SLeUkpZNGR937JKETm8SQ2yCIAjCfVEPHYJxwkTIzLz1QQ+YPbqRyWQm9koiwYH+AJy7cJmv5/1CemYW3p4efPr+Gzg7aTl7Lppp3y7EaDRTr3ZV3hjaL+8aaemZjBw7lRkfj2XC1JmkpKYzYNh4Rr7yPNWrVuCTGd8TdeEyAf6+fPTuSBRyGeM++orE5BQCy/rxyaQ3eP3dz/Kd1/DaNiXJV1MZ99FX5Oj0VK4Qxvtjh2Mymwtcs7SJT/1C2O0SqRk5hAX7oTeYRIAkCIIg3LfcLJL9NgHSg2aPwLHNx4Bh47mSmIy7myvff/kBAN5eHkwaOxQ/Hy/e/3QW23btp12rJkyYOpP3xw6jepVI0jOy8q5jl+xMnjaXYYP64F/Gh4/GDWf42I9ZNHsqALPnL6VmtYpMHj+SdZt2snrdFkICy6JWq1i+YDpJyak4O2kLnJdr8/Z9VK0UwdsjBpB0NRWFQs7CX9cUuGabFo0fqD8elBhiK5TEU02qUT7YDzcXJ0DswyYIgiDcv9vORSqi7FHuENv6pbN5a/gA3pzwBeAIkC5eiuOLbxZw9vwlEpNSiYlLxNPDjepVIgHw8nTPu86vK9aTozPw5BN1C73P/sMnWPXnFgYMG8/Py9eSkZFNzWoVuZqazryFK3By0hZ6Xq4n6tfk6IkzLFm5Hk93t1tes7SJtEgh5HI55QJ9AXB3dQRIYh82QRAE4X7dLotUFNmjG6nVKp58oi5fzVlMVraOtRu3c/z0efo/25ngQH90egN2SQIKL0Z54vQ5XJy1HDsZRa1qFQu8L0kSk98bSURYSL7X53/zERs272LgiAnM/PxdZLe4fnhYMN9/+QGr1m2l/7DxLJg5udBrJiRevf9OKAIig3QHuRO1xRCbIAiC8CAKzSIV4dyjG508cwFJknBzdebg0VO0b92UihFhnI+OBSA0qCwpqWmcPRcNQHxict657775CiMH9+WbeT9jt9vx8nRHp9NjvrZxe4M61VmycgN2ux2d3kBWto7oy1cwGIx0atuc8uWCiLpwucB5uc6ev4RMLqNP93ao1SquJCQXek1kMuyS3XGSTHbLrVqKi/jUv4OQAB9qVQ7NG2oTBEEQhPtRWBapKLNHuXOQbHa7Yw7QuyOQyWR079SaWT8s4bc/NhEWGgQ4skwfjBvB1C+/R5KgRpVIRo8cCIC7myueHm6EhQaxfssuOrVpTqtmDen76juMfOV5Bvbtxmdfzafvq+NwdtIy5rWBGE1mps74nqzsbEKDA3iifi20GnW+81o2awBAfEIyn331A1nZOurWqkKF8FCCA/0LXLNiRBhKhZL9h09QMaIcVxKSuHgpjvCwkqkyLjObTSUbkhUBq9XKk50GsnPtjyiVIsYTBEEQHg22Cxeur2jz8EA7ZbIoDPmQEkNsgiAIglBCbqyLVNRzj4SiJQIkQRAEQShB6qFDQKkslrlHQtERAZIgCIIglCBFRASaj6eI7NFDTgRIgiAIglDClDVqlHYThDsothnOySlpTP92IbFxiajUSiaNGUq54ABmzP6JoyfO4uHuygdjh1HGz4fV67ayfM1GXF2cmfzuCMr4+RRXswRBEARBEO6o2AIkmUzG4P49iQwPZfmajfy8fC1VKoaDTMbiOZ8QeyURL08P0tIz+WnpH/w891N2/nOYb39YyofjhhdXswRBEARBEO6o2IbY/Hy8iAwPJT0ji7j4RCpGhLF+8y6ee6Y9MpmM0OAAVCol+w4dp2JEGFqthto1KrP3wNHiapIgCIIgCMJdKdYiQsdORjFi9BTq1qrKqFf7sWjp7+w/fJwJU7+hYkQY77z+MqlpGYQGlwXA19sTm92O0WRGq1Hnu9aK3zfx2x+bAEq8mqYgCIIgCP8txRog1apWkW2/z2fR0t/5ZMZ36A1GXF1cWPDNZMa8/z927DkEsvwBj2SXkBWyfUuvrm3o1bUNcL1QpCAIgiAIQnEo9jLUKpWSZ7u3o8+gMfh4eVC7eiXkcjn1a1clPiEZP18vTpw+D8DV1HRUKhUatfq218wNqKxWa3E3XxAEQRCE/wiFQoHsWpam2AKkVWu3ULViOBUjw9i26wDlQgKpGFGOrbv207tbWw4ePUXPLk9TpWI48xauwGg0ceTfMzRpWPuO17bZbAC06vZKcTVfEARBEIT/mBu3MCu2vdguxcQzY/YiEpNTcXHWMnH0ULy9PPjoiznExCXQoE51xrw2EJlMxh9/bWfJyvW4uTgz+b3X8PPxuu217XY7ZrM5X6RXVPoNfZfFcz4p0mv+l4j+KxqiH4uG6MeiI/qy6Ii+LBrF0Y8lkkEKCw3kq0/GFXh9+uTRBV7r0q4FXdq1uOtry+VytFrtA7XvVmQymdgA9wGI/isaoh+LhujHoiP6suiIviwaxd2PopK2IAiCIAjCTUSAdJOeXdqUdhMeaaL/iobox6Ih+rHoiL4sOqIvi0Zx92OxzUESBEEQBEF4VIkMkiAIgiAIwk1EgCQIgiAIgnATESAJgiAIgiDc5LFZZ5iVrePTr34gNi4RD3dXPnp3BHK5nIlTZ5KWnkmHNs3o17tzocd5e3mwZt021qzfSnpGFm1aNWHYS88WqLGUkZld4HoAv65czy/L1/Jcjw680LtTaTz+Ayut/ktOSWP6twuJjUtEpVYyacxQIsJCSqkXHlxp/hw27dA/r+9qVa/E2yNeLPHnLyql1Y9//LWd5av/AkCSIDrmCr//8jXenh6l0Q1ForT6UpIk/jdrEfsOHSewrB8TRw/Bx9uzdDqhiJREX15JSGbazB/591QUW1Z9n/f64/A5k+tB+zHXF98sIDrmCrO+mFDgHkXxef3YTNLes/8oTk5a6tSozDff/QKAxWIlNDiA7h1b8eKICXwy8XXi4pMKHPfa4L4cOHKCOjUqY7Pb6fXiW8ydMYnAsmXy3eN/sxYVuF5ocABnz0WzbM1GwssFP7I/uKXVf05OWjIzs4kMD2X5mo2cjrrIpDFDS/z5i0pp/hx27/c6qxd/VeLPXBxKsx9zbd9zkGPHzzJqyAsl9+DFoLT6Mi4+id/+2MRnH7zFuo07OHYyiomjh5T48xelkujLzKwcLkTHMHrSdLau+SHv9cfhcybXg/YjwPnoWCZPm4OLs1OhAVJRfF4/NkNsTRrWpk6NygDUqFqBqynp7Nl/lNo1KqNUKqlRpQJ7Dxwr9DiABnWqg0zGhehYXFyc8fPxLnCPwq4HUKlCeQL8fUvoSYtHafWfn48XkeGhpGdkERefSMWIsBJ75uJQmj+HHh6uJfSUxa80+xHAZrOz8Nc1vDKgZwk8bfEqrb68EB1L/drVUCoUtHqyIXv2Hy2xZy4uJdGXHu6u1K1VtcDrj8PnTK4H7UdJkvhm3s+8/MIzt7xHUXxePzYB0o0OHT1FzWoVSUvPJDjQH4DQ4ABSUjMKPS7X2Pf/x+A3PmDMyIGoVAVHH+90vcdFSfffsZNRdHl+JNGX4+ndrW3xPFQpKOl+TE3LYPAbHzL4jQ84djKqeB6qFJTGv+f9h49TtVIkzk7FU7G/tJRkXwYGlOHQsdPY7XYOHTtFjk6PwWgsvocrYcXVl/8199OPO/YeIijAn4rh5W553aL4vH7sAqQLl2I5cOQkXdq3cIztSo4RRLtkRyaXFXpcrv9NGcOv333O9G8XcinmCr/+to4Bw8YzYNh4rDbbba/3uCiN/qtVrSLbfp9PreoV+WTGdyX4tMWnNPrx4wmvM/Pzd+nVtQ0ffDarBJ+2+JTWv+ftuw/SpGGtEnrKklHSfdmiaX28vdwZOHIiCYlXcXNxQa1Sl+xDF5Pi7Mv/kvvpR7PZwqIlfzBkYK981yqOz+vHKnxNz8ji/U9nMeW919Co1Xh7eRAXn0RkeCixcYlEhocWetyNQoMDaFC3OoePneb5nh15vmfHvPdudb3HRWn2n0ql5Nnu7egzaEzJPGwxKq1+rHXt21Wblo2ZNnMhRpMZrebR/UAqzZ/H0+cu8vIL3UvkOUtCafSlUqFg/JuD8667au1WFIpH/zt5cfflf8X99uOBIyfIys7h7YnTMFusXElIYsbsn3hzWP8i/7x+9H9arzGbLYyf/BWDB/QksrxjJU/TRnU4cvwMVquVE6fP07hBrUKPy87RMXfhciwWKzqdngOHT1AuJLDAPQq73uOitPpv1dotnD0XjSRJbNt1oNDzHiWl1Y+79x0h9koiAIeOnaKMr/cjHRyV9r/npORUvB/xFVe5SqsvzWYLl2LiAce3+45tniy5hy4mJdGX/wUP0o8N6lRn+YLpfP/Vh3w26Q0qRYbx5rD+Be5RFJ/Xj80qth8Wr+Ln5X8SFhqI1epIU06fMobJX8wlNS2Dzu2a83zPjoUeN2/G+yxZuYFtu/eTmZlDhzbNeHVArwLLLzOzcpg4dWa+611NTeftCV+Qmp6JXCajXGggMz8bX+LP/6BKq/8uxcQzY/YiEpNTcXHWMnH0UMqXCyrx5y8qpdWP0Zev8NXcxSRfTUOlVjL+zcFUigwr6ccvMqXVj7me6v4KW1Z/z+OgtPoyMTmFDz+fQ1Z2DlUqhjPmtYEFMimPmpLoy3kLV7Drn8Ocj44lsnwILz7fjZrVKj4WnzO5HrQftVoNAAmJV5k8fW6hq9iK4vP6sQmQBEEQBEEQispjM8QmCIIgCIJQVESAJAiCIAiCcBMRIAmCIAiCINxEBEiCIAiCIAg3EQGSIAiCIAjCTUSAJAiCIAiCcBMRIAmCIAiCINzksdpqRBCE/4ZnBryBWqVEqVTipNXwQq9OtGzWoEDRvRt9/9NvBPj70alt8xJsqSAIjyoRIAmC8EiaPP41KkaUIyYugXc+nIHVZqNNy8al3SxBEB4TIkASBOGRFhocwKhXX2Dm979St2YVvpq7mLj4JLKydTzbvR3Pdm/H8jUbWbZ6I85OWpau2sD8mZPJyMji868XEHMlEbVaxdjXXqJ6lcjSfhxBEB4SIkASBOGRV61yJDFxCbi7ufJCr05UqlCe5Kup9HrpbTo83Yze3dpy5lw0dWtWyRtimzJ9Hs/16MAT9WtyKeYKkz6dxaJZH5fykwiC8LAQAZIgCI88SbIjk8mQy+VotRp+WLyKC5dikSEjKTkVN1eXfMfrDUYOHjlJWnoms35YAjh2WxcEQcglAiRBEB55x0+dJywkkP2Hj/PtD0sY8mIvenVtw8CoCdilwvfjlpD49ov3CgRPgiAIIJb5C4LwiLsUE8/X835mYN/u7D1wjPq1q/Fk43qkZ2SSnX09K1S2jC8JSVcBcHbSUqdmFb5b9Bt2ux2bzU5CUkppPYIgCA8hmdlsKvzrlSAIwkMqd5m/Qq7AyUlL/2c707JZA86ei2batwux2ezUqFqB46fOMe6NQVSMKMfFS3G8PWkaXh7uTJv8NjabnWkzf+RSTDwatYpObZvT55n2pf1ogiA8JESAJAiCIAiCcBMxxCYIgiAIgnATESAJgiAIgiDcRARIgiAIgiAINxEBkiAIgiAIwk1EgCQIgiAIgnCT/wNKVwcDV9K9kQAAAABJRU5ErkJggg==",
       "text/plain": [
        "<Figure size 583.3x340 with 1 Axes>"
       ]
      },
      "metadata": {
       "image/png": {
-       "alt": "SPY close for 2023-01-01 to 2024-01-01 with its 10-day and 30-day moving averages. 9 crossover signals are marked, buys pointing up and sells pointing down, each with a hollow ring drawn from the live replay's own signal list. Every ring sits on a marker, so the two engines traded the same days at the same prices."
+       "alt": "SPY close for 2023-01-01 to 2024-01-01 with its 10-day and 30-day moving averages. 9 crossover signals are marked, buys pointing up and sells pointing down, each with a hollow ring drawn from the live replay's own signal list. Every ring sits on a marker."
       }
      },
      "output_type": "display_data"
@@ -1549,8 +1526,10 @@
     "\n",
     "\n",
     "fig, ax = plt.subplots()\n",
+    "# The close recedes: it is the backdrop the averages are read against, and drawing it in the same\n",
+    "# dark as the fast average makes the two indistinguishable at this line width.\n",
     "ax.plot(\n",
-    "    spy_close.index, spy_close.to_numpy(), color=COLORS[\"neutral\"], linewidth=1, label=\"SPY close\"\n",
+    "    spy_close.index, spy_close.to_numpy(), color=COLORS[\"recede\"], linewidth=1, label=\"SPY close\"\n",
     ")\n",
     "ax.plot(\n",
     "    fast_line.index,\n",
@@ -1587,11 +1566,7 @@
     "ax.set_ylabel(\"SPY close (USD)\")\n",
     "add_message_title(\n",
     "    ax,\n",
-    "    (\n",
-    "        \"Both engines traded the same crossovers on the same days\"\n",
-    "        if matches == len(backtest_signals)\n",
-    "        else \"The two engines disagree about when to trade\"\n",
-    "    ),\n",
+    "    \"SPY close, its two moving averages, and each engine's signals\",\n",
     "    subtitle=\"Filled markers are the backtest, hollow rings the live replay\",\n",
     ")\n",
     "ax.legend(loc=\"lower right\", fontsize=8)\n",
@@ -1601,22 +1576,22 @@
     "    f\"averages. {len(backtest_signals)} crossover signals are marked, buys pointing up and sells \"\n",
     "    \"pointing down, each with a hollow ring drawn from the live replay's own signal list. \"\n",
     "    + (\n",
-    "        \"Every ring sits on a marker, so the two engines traded the same days at the same prices.\"\n",
+    "        \"Every ring sits on a marker.\"\n",
     "        if matches == len(backtest_signals)\n",
-    "        else f\"{len(backtest_signals) - matches} of them do not coincide.\"\n",
+    "        else \"Some rings stand alone, with no marker underneath.\"\n",
     "    ),\n",
     ")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "04989079",
+   "id": "e0fcc741",
    "metadata": {
     "papermill": {
-     "duration": 0.00189,
-     "end_time": "2026-09-09T00:45:13.311713+00:00",
+     "duration": 0.001892,
+     "end_time": "2026-09-11T00:15:16.853766+00:00",
      "exception": false,
-     "start_time": "2026-09-09T00:45:13.309823+00:00",
+     "start_time": "2026-09-11T00:15:16.851874+00:00",
      "status": "completed"
     }
    },
@@ -1655,19 +1630,19 @@
   {
    "cell_type": "code",
    "execution_count": 17,
-   "id": "c4c520ec",
+   "id": "75020cf4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T00:45:13.316156Z",
-     "iopub.status.busy": "2026-09-09T00:45:13.316059Z",
-     "iopub.status.idle": "2026-09-09T00:45:13.318375Z",
-     "shell.execute_reply": "2026-09-09T00:45:13.318013Z"
+     "iopub.execute_input": "2026-09-11T00:15:16.858583Z",
+     "iopub.status.busy": "2026-09-11T00:15:16.858429Z",
+     "iopub.status.idle": "2026-09-11T00:15:16.860864Z",
+     "shell.execute_reply": "2026-09-11T00:15:16.860616Z"
     },
     "papermill": {
-     "duration": 0.005054,
-     "end_time": "2026-09-09T00:45:13.318661+00:00",
+     "duration": 0.005526,
+     "end_time": "2026-09-11T00:15:16.861233+00:00",
      "exception": false,
-     "start_time": "2026-09-09T00:45:13.313607+00:00",
+     "start_time": "2026-09-11T00:15:16.855707+00:00",
      "status": "completed"
     }
    },
@@ -1710,24 +1685,24 @@
    "version": "3.14.3"
   },
   "ml4t_provenance": {
-   "executed_at": "2026-09-09T00:45:19.645359+00:00",
+   "executed_at": "2026-09-11T00:15:25.584563+00:00",
    "executor": "local-uv",
-   "library_digest": "83bd06e0191f1e5a77e59dcf8691ded26c97b381e3db5784274fac61cf11e864",
-   "outputs_digest": "68452c0da3a85f70d311469a1f6bcf5610d21ad2cb88b81e4bf4fb3e2fd59fe1",
+   "library_digest": "a6b4265c351496fbe4ca572ca18a3e677b74fc31b98ef27bbcac63f021b5c638",
+   "outputs_digest": "e4fa94e6fbb9cb22265cca09938681a708ff79e53000167a18cae400238cb008",
    "parameters": {},
    "production": true,
-   "source_py_blob": "f18f0c1082c6a0d913bfb784b5276f606dc68b3b"
+   "source_py_blob": "fa178cd3984f3b4a16b4b92810254ad4f8a7cc0e"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 5.566057,
-   "end_time": "2026-09-09T00:45:14.536369+00:00",
+   "duration": 5.644836,
+   "end_time": "2026-09-11T00:15:18.178822+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "~/ml4t/public-teach-g/25_live_trading/.01_unified_framework_demo.build.2822835.ipynb",
-   "output_path": "~/ml4t/public-teach-g/25_live_trading/.01_unified_framework_demo.papermill.2822835.ipynb",
+   "input_path": "~/ml4t/public-teach-g/25_live_trading/.01_unified_framework_demo.build.523905.ipynb",
+   "output_path": "~/ml4t/public-teach-g/25_live_trading/.01_unified_framework_demo.papermill.523905.ipynb",
    "parameters": {},
-   "start_time": "2026-09-09T00:45:08.970312+00:00",
+   "start_time": "2026-09-11T00:15:12.533986+00:00",
    "version": "2.7.0"
   }
  },

--- a/25_live_trading/01_unified_framework_demo.py
+++ b/25_live_trading/01_unified_framework_demo.py
@@ -45,6 +45,11 @@
 # Everything below is arranged to make one thing vary. The strategy, the bars, the parameters and the
 # fill convention are held fixed across the two runs so that a difference in output has one candidate
 # explanation left, which is the engine.
+#
+# One warning filter is installed with the imports. The broker adapters pull in websockets' legacy
+# module, which deprecates itself on import; it is the library's business rather than this
+# notebook's and nothing in the result depends on it. The other import-time deprecation, from
+# `nest_asyncio`, is filtered inside `async_utils.run_async` where the call that triggers it lives.
 
 # %%
 """Verify backtest-to-live signal parity with a single strategy class."""
@@ -61,10 +66,6 @@ import pandas as pd
 import polars as pl
 from async_utils import run_async
 
-# The broker adapters pull in websockets' legacy module, which deprecates itself on import. It
-# is the library's business rather than this notebook's and nothing in the result depends on it.
-# The other import-time deprecation, from nest_asyncio, is filtered inside `async_utils.run_async`
-# where the call that triggers it lives.
 warnings.filterwarnings("ignore", category=DeprecationWarning, module=r"websockets\.legacy")
 
 from ml4t.backtest import BacktestConfig, DataFeed, Engine, ExecutionMode, Strategy
@@ -81,33 +82,6 @@ logging.basicConfig(
     level=logging.WARNING,
     format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
 )
-import asyncio
-import logging
-from collections.abc import AsyncIterator
-from datetime import datetime
-from typing import Any
-
-import pandas as pd
-import polars as pl
-from async_utils import run_async
-
-# ml4t.backtest imports
-from ml4t.backtest import BacktestConfig, DataFeed, Engine, ExecutionMode, Strategy
-from ml4t.backtest.types import Order, OrderSide, OrderStatus, OrderType, Position
-
-# ml4t.live imports
-from ml4t.live import (
-    LiveEngine,
-    VirtualPortfolio,
-)
-
-from data import load_etfs
-
-# Configure logging for live mode
-logging.basicConfig(
-    level=logging.WARNING,  # Reduce noise for demo
-    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
-)
 
 # %% [markdown]
 # ## 1. Settings
@@ -122,9 +96,10 @@ logging.basicConfig(
 # conventional pairing and nothing here depends on it; the parity claim holds or fails at any
 # setting, which is the point.
 #
-# `MAX_SYMBOLS` caps how many of the three ETFs are loaded. Zero means all of them, and continuous
-# integration sets it lower to keep the run short. The strategy trades only SPY either way; the
-# other two are loaded so the data path carries more than one symbol.
+# `MAX_SYMBOLS` caps how many of the three ETFs are loaded, and zero means all of them. It exists so
+# a shorter run can be requested without editing the notebook. The strategy trades only SPY at any
+# setting; the other two are loaded so the data path carries more than one symbol, which is what
+# makes the feed's per-symbol handling part of what the comparison covers.
 #
 # `INITIAL_CASH` sizes the account. It scales the printed portfolio values and changes nothing about
 # which signals fire, since the strategy trades a fixed hundred shares.
@@ -213,12 +188,12 @@ class DualMAStrategy(Strategy):
     property the rest of the notebook tests rather than assumes.
 
     Attributes:
-        fast_period: Fast MA lookback (default: 10)
-        slow_period: Slow MA lookback (default: 30)
+        fast_period: Sessions in the shorter average
+        slow_period: Sessions in the longer average
         signal_log: Records all signals for verification
     """
 
-    def __init__(self, symbol: str, fast_period: int = 10, slow_period: int = 30):
+    def __init__(self, symbol: str, fast_period: int, slow_period: int):
         self.symbol = symbol
         self.fast_period = fast_period
         self.slow_period = slow_period
@@ -451,8 +426,15 @@ class SimulatedBroker:
             side = OrderSide.BUY if quantity > 0 else OrderSide.SELL
             quantity = abs(quantity)
 
-        # Get fill price
-        price = limit_price or self._current_prices.get(asset, 100.0)
+        if limit_price is not None:
+            price = limit_price
+        elif asset in self._current_prices:
+            price = self._current_prices[asset]
+        else:
+            raise KeyError(
+                f"No price for {asset}: the feed has not delivered a bar for it. "
+                "Filling at a default would put a price into the tape that no bar carried."
+            )
 
         self._order_count += 1
         fill_timestamp = self._current_timestamp or datetime.min
@@ -491,8 +473,13 @@ class SimulatedBroker:
 # %% [markdown]
 # ### Historical Replay Feed
 #
-# The historical replay feed is the notebook's stand-in for a real streaming source. Its job is to preserve
-# live-engine semantics while holding the market data constant.
+# The historical replay feed is the notebook's stand-in for a real streaming source. Its job is to
+# preserve live-engine semantics while holding the market data constant.
+#
+# A missing bar raises here rather than being skipped. The parity claim rests on both engines
+# reading the same tape, so a feed that quietly dropped a symbol on some dates would hand the live
+# engine a shorter history, move its moving averages, and report the difference as an engine
+# disagreement.
 
 
 # %%
@@ -552,32 +539,22 @@ class HistoricalReplayFeed:
         date = self._dates[self._index]
         self._index += 1
 
-        # Build bar data
+        timestamp = date.to_pydatetime() if hasattr(date, "to_pydatetime") else date
         data: dict[str, dict[str, Any]] = {}
         for symbol in self._symbols:
-            try:
-                bar = {
-                    "open": float(self._data["Open"].loc[date, symbol]),
-                    "high": float(self._data["High"].loc[date, symbol]),
-                    "low": float(self._data["Low"].loc[date, symbol]),
-                    "close": float(self._data["Close"].loc[date, symbol]),
-                    "volume": float(self._data["Volume"].loc[date, symbol]),
-                }
-                data[symbol] = bar
-
-                # Update broker prices for fills
-                if self._broker:
-                    timestamp = date.to_pydatetime() if hasattr(date, "to_pydatetime") else date
-                    self._broker.update_price(symbol, bar["close"], timestamp)
-            except (KeyError, ValueError):
-                pass
+            bar = {
+                field.lower(): float(self._data[field.title()].loc[date, symbol])
+                for field in ("open", "high", "low", "close", "volume")
+            }
+            data[symbol] = bar
+            if self._broker:
+                self._broker.update_price(symbol, bar["close"], timestamp)
 
         self._stats["bars_emitted"] += 1
 
-        # Small delay to simulate real-time (optional, can be 0)
+        # Yield to the event loop, as a real feed would while waiting on the socket.
         await asyncio.sleep(0)
 
-        timestamp = date.to_pydatetime() if hasattr(date, "to_pydatetime") else date
         return timestamp, data, {}
 
 
@@ -751,10 +728,10 @@ live_log
 # %% [markdown]
 # ## Where the Strategy Traded
 #
-# The tables above show five signals of nine. The question they cannot answer is where the crossovers
-# fell across the year, which is a judgement about a shape: whether the strategy traded steadily or
-# clustered around a few reversals, and whether the two engines fired at the same moments or merely
-# the same number of times.
+# The tables above show the first rows of each log. The question they cannot answer is where the
+# crossovers fell across the year, which is a judgement about a shape: whether the strategy traded
+# steadily or clustered around a few reversals, and whether the two engines fired at the same
+# moments or merely the same number of times.
 #
 # Drawing the year answers both. The two moving averages cross where the signals sit, and each
 # engine's markers are drawn separately: filled for the backtest, hollow rings on top for the live
@@ -774,8 +751,10 @@ def _marker_series(signals: list[dict], side: str) -> tuple[list, list]:
 
 
 fig, ax = plt.subplots()
+# The close recedes: it is the backdrop the averages are read against, and drawing it in the same
+# dark as the fast average makes the two indistinguishable at this line width.
 ax.plot(
-    spy_close.index, spy_close.to_numpy(), color=COLORS["neutral"], linewidth=1, label="SPY close"
+    spy_close.index, spy_close.to_numpy(), color=COLORS["recede"], linewidth=1, label="SPY close"
 )
 ax.plot(
     fast_line.index,
@@ -812,11 +791,7 @@ ax.set_xlabel("Date")
 ax.set_ylabel("SPY close (USD)")
 add_message_title(
     ax,
-    (
-        "Both engines traded the same crossovers on the same days"
-        if matches == len(backtest_signals)
-        else "The two engines disagree about when to trade"
-    ),
+    "SPY close, its two moving averages, and each engine's signals",
     subtitle="Filled markers are the backtest, hollow rings the live replay",
 )
 ax.legend(loc="lower right", fontsize=8)
@@ -826,9 +801,9 @@ show_with_alt(
     f"averages. {len(backtest_signals)} crossover signals are marked, buys pointing up and sells "
     "pointing down, each with a hollow ring drawn from the live replay's own signal list. "
     + (
-        "Every ring sits on a marker, so the two engines traded the same days at the same prices."
+        "Every ring sits on a marker."
         if matches == len(backtest_signals)
-        else f"{len(backtest_signals) - matches} of them do not coincide."
+        else "Some rings stand alone, with no marker underneath."
     ),
 )
 

--- a/25_live_trading/02_etfs_deployment_loop.ipynb
+++ b/25_live_trading/02_etfs_deployment_loop.ipynb
@@ -2,13 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "44af5d0e",
+   "id": "2ce98e28",
    "metadata": {
     "papermill": {
-     "duration": 0.011017,
-     "end_time": "2026-09-11T00:32:32.565336+00:00",
+     "duration": 0.002809,
+     "end_time": "2026-09-11T00:38:48.784039+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:32:32.554319+00:00",
+     "start_time": "2026-09-11T00:38:48.781230+00:00",
      "status": "completed"
     }
    },
@@ -69,8 +69,9 @@
     "- ETF data downloaded under `ML4T_DATA_PATH/etfs/market`.\n",
     "- FRED macro data under `ML4T_DATA_PATH/macro` (for the yield-curve\n",
     "  regime feature).\n",
-    "- Forward-return label parquet at\n",
-    "  `case_studies/etfs/labels/fwd_ret_21d.parquet`.\n",
+    "- The ETFs case study's forward-return label parquet and its registry,\n",
+    "  both reached through `get_case_study_dir(\"etfs\")` so a run with\n",
+    "  `ML4T_OUTPUT_DIR` set reads the tree that run wrote.\n",
     "- Alpaca paper credentials in `ALPACA_API_KEY` / `ALPACA_SECRET_KEY`\n",
     "  (free at <https://app.alpaca.markets/paper>)."
    ]
@@ -78,19 +79,19 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "2b2393a9",
+   "id": "79af7f19",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:32:32.575668Z",
-     "iopub.status.busy": "2026-09-11T00:32:32.575521Z",
-     "iopub.status.idle": "2026-09-11T00:32:34.804752Z",
-     "shell.execute_reply": "2026-09-11T00:32:34.804275Z"
+     "iopub.execute_input": "2026-09-11T00:38:48.788081Z",
+     "iopub.status.busy": "2026-09-11T00:38:48.787964Z",
+     "iopub.status.idle": "2026-09-11T00:38:51.251469Z",
+     "shell.execute_reply": "2026-09-11T00:38:51.250979Z"
     },
     "papermill": {
-     "duration": 2.234045,
-     "end_time": "2026-09-11T00:32:34.805442+00:00",
+     "duration": 2.466203,
+     "end_time": "2026-09-11T00:38:51.252017+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:32:32.571397+00:00",
+     "start_time": "2026-09-11T00:38:48.785814+00:00",
      "status": "completed"
     }
    },
@@ -110,6 +111,8 @@
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
     "import polars as pl\n",
+    "from _etfs_features import build_yield_curve, compute_financial_features, feature_columns\n",
+    "from async_utils import run_async\n",
     "from ml4t.backtest import (\n",
     "    BacktestConfig,\n",
     "    DataFeed,\n",
@@ -124,13 +127,8 @@
     "from sklearn.preprocessing import StandardScaler\n",
     "\n",
     "from data import load_etfs, load_macro\n",
-    "from utils.paths import display_path, get_case_study_dir, get_chapter_dir, get_output_dir\n",
+    "from utils.paths import display_path, get_case_study_dir, get_output_dir\n",
     "from utils.style import COLORS, add_message_title, show_with_alt\n",
-    "\n",
-    "CHAPTER_DIR = get_chapter_dir(25)\n",
-    "\n",
-    "from _etfs_features import build_yield_curve, compute_financial_features, feature_columns\n",
-    "from async_utils import run_async\n",
     "\n",
     "# basicConfig is a no-op once a handler exists, and importing the feature libraries installs one,\n",
     "# so configuring the root logger here would leave two handlers attached and print every line\n",
@@ -149,19 +147,19 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "26f70bdf",
+   "id": "3b41de32",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:32:34.811856Z",
-     "iopub.status.busy": "2026-09-11T00:32:34.811775Z",
-     "iopub.status.idle": "2026-09-11T00:32:34.813610Z",
-     "shell.execute_reply": "2026-09-11T00:32:34.813337Z"
+     "iopub.execute_input": "2026-09-11T00:38:51.256348Z",
+     "iopub.status.busy": "2026-09-11T00:38:51.256237Z",
+     "iopub.status.idle": "2026-09-11T00:38:51.258460Z",
+     "shell.execute_reply": "2026-09-11T00:38:51.258132Z"
     },
     "papermill": {
-     "duration": 0.005431,
-     "end_time": "2026-09-11T00:32:34.814012+00:00",
+     "duration": 0.004792,
+     "end_time": "2026-09-11T00:38:51.258764+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:32:34.808581+00:00",
+     "start_time": "2026-09-11T00:38:51.253972+00:00",
      "status": "completed"
     },
     "tags": [
@@ -186,13 +184,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "65f99947",
+   "id": "bdb6f598",
    "metadata": {
     "papermill": {
-     "duration": 0.001423,
-     "end_time": "2026-09-11T00:32:34.817085+00:00",
+     "duration": 0.001451,
+     "end_time": "2026-09-11T00:38:51.261765+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:32:34.815662+00:00",
+     "start_time": "2026-09-11T00:38:51.260314+00:00",
      "status": "completed"
     }
    },
@@ -214,19 +212,19 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "92749bfe",
+   "id": "d62d79c7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:32:34.820446Z",
-     "iopub.status.busy": "2026-09-11T00:32:34.820374Z",
-     "iopub.status.idle": "2026-09-11T00:32:34.822565Z",
-     "shell.execute_reply": "2026-09-11T00:32:34.822333Z"
+     "iopub.execute_input": "2026-09-11T00:38:51.265120Z",
+     "iopub.status.busy": "2026-09-11T00:38:51.265045Z",
+     "iopub.status.idle": "2026-09-11T00:38:51.267910Z",
+     "shell.execute_reply": "2026-09-11T00:38:51.267491Z"
     },
     "papermill": {
-     "duration": 0.004331,
-     "end_time": "2026-09-11T00:32:34.822906+00:00",
+     "duration": 0.004954,
+     "end_time": "2026-09-11T00:38:51.268194+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:32:34.818575+00:00",
+     "start_time": "2026-09-11T00:38:51.263240+00:00",
      "status": "completed"
     }
    },
@@ -261,13 +259,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5f01084c",
+   "id": "572b29d4",
    "metadata": {
     "papermill": {
-     "duration": 0.001464,
-     "end_time": "2026-09-11T00:32:34.825930+00:00",
+     "duration": 0.001479,
+     "end_time": "2026-09-11T00:38:51.271322+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:32:34.824466+00:00",
+     "start_time": "2026-09-11T00:38:51.269843+00:00",
      "status": "completed"
     }
    },
@@ -287,19 +285,19 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "8168718f",
+   "id": "936c1e94",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:32:34.829817Z",
-     "iopub.status.busy": "2026-09-11T00:32:34.829681Z",
-     "iopub.status.idle": "2026-09-11T00:32:34.895774Z",
-     "shell.execute_reply": "2026-09-11T00:32:34.894945Z"
+     "iopub.execute_input": "2026-09-11T00:38:51.274875Z",
+     "iopub.status.busy": "2026-09-11T00:38:51.274800Z",
+     "iopub.status.idle": "2026-09-11T00:38:51.345488Z",
+     "shell.execute_reply": "2026-09-11T00:38:51.344949Z"
     },
     "papermill": {
-     "duration": 0.068797,
-     "end_time": "2026-09-11T00:32:34.896277+00:00",
+     "duration": 0.072931,
+     "end_time": "2026-09-11T00:38:51.345776+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:32:34.827480+00:00",
+     "start_time": "2026-09-11T00:38:51.272845+00:00",
      "status": "completed"
     }
    },
@@ -331,19 +329,19 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "5cd638eb",
+   "id": "970a4cc0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:32:34.903414Z",
-     "iopub.status.busy": "2026-09-11T00:32:34.903305Z",
-     "iopub.status.idle": "2026-09-11T00:33:01.146975Z",
-     "shell.execute_reply": "2026-09-11T00:33:01.146457Z"
+     "iopub.execute_input": "2026-09-11T00:38:51.349799Z",
+     "iopub.status.busy": "2026-09-11T00:38:51.349678Z",
+     "iopub.status.idle": "2026-09-11T00:39:19.280226Z",
+     "shell.execute_reply": "2026-09-11T00:39:19.279705Z"
     },
     "papermill": {
-     "duration": 26.247566,
-     "end_time": "2026-09-11T00:33:01.147303+00:00",
+     "duration": 27.933263,
+     "end_time": "2026-09-11T00:39:19.280810+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:32:34.899737+00:00",
+     "start_time": "2026-09-11T00:38:51.347547+00:00",
      "status": "completed"
     }
    },
@@ -352,14 +350,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2026-09-10 20:32:35 | mlquant.features.adx | INFO | [ADX] Starting calculation with parameters: period=14 (shape: (4,))\n"
+      "2026-09-10 20:38:51 | mlquant.features.adx | INFO | [ADX] Starting calculation with parameters: period=14 (shape: (4,))\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2026-09-10 20:32:35 | mlquant.features.adx | INFO | [ADX] Completed calculation (shape: (4,)) (0.04ms)\n"
+      "2026-09-10 20:38:51 | mlquant.features.adx | INFO | [ADX] Completed calculation (shape: (4,)) (0.05ms)\n"
      ]
     },
     {
@@ -378,13 +376,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "535378cb",
+   "id": "c6beaa78",
    "metadata": {
     "papermill": {
-     "duration": 0.001622,
-     "end_time": "2026-09-11T00:33:01.150777+00:00",
+     "duration": 0.003131,
+     "end_time": "2026-09-11T00:39:19.287462+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:33:01.149155+00:00",
+     "start_time": "2026-09-11T00:39:19.284331+00:00",
      "status": "completed"
     }
    },
@@ -420,19 +418,19 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "b49fc1ff",
+   "id": "8a2bda1e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:33:01.154876Z",
-     "iopub.status.busy": "2026-09-11T00:33:01.154770Z",
-     "iopub.status.idle": "2026-09-11T00:33:01.159711Z",
-     "shell.execute_reply": "2026-09-11T00:33:01.159208Z"
+     "iopub.execute_input": "2026-09-11T00:39:19.294457Z",
+     "iopub.status.busy": "2026-09-11T00:39:19.294354Z",
+     "iopub.status.idle": "2026-09-11T00:39:19.299264Z",
+     "shell.execute_reply": "2026-09-11T00:39:19.298799Z"
     },
     "papermill": {
-     "duration": 0.007564,
-     "end_time": "2026-09-11T00:33:01.159964+00:00",
+     "duration": 0.009058,
+     "end_time": "2026-09-11T00:39:19.299825+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:33:01.152400+00:00",
+     "start_time": "2026-09-11T00:39:19.290767+00:00",
      "status": "completed"
     }
    },
@@ -449,7 +447,9 @@
     }
    ],
    "source": [
-    "registry_path = get_case_study_dir(\"etfs\") / \"run_log\" / \"registry.db\"\n",
+    "etfs_dir = get_case_study_dir(\"etfs\")\n",
+    "labels_path = etfs_dir / \"labels\" / f\"{PRIMARY_LABEL}.parquet\"\n",
+    "registry_path = etfs_dir / \"run_log\" / \"registry.db\"\n",
     "# Read-only, but not `immutable=1`: the registry is a WAL database that sweeps write to\n",
     "# concurrently, and an immutable connection ignores the -wal file and reads the pre-WAL main\n",
     "# file, which shows up here as a stale leader or as a table that appears not to exist.\n",
@@ -506,13 +506,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a67fe3ed",
+   "id": "bebe441f",
    "metadata": {
     "papermill": {
-     "duration": 0.001537,
-     "end_time": "2026-09-11T00:33:01.163187+00:00",
+     "duration": 0.005868,
+     "end_time": "2026-09-11T00:39:19.310478+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:33:01.161650+00:00",
+     "start_time": "2026-09-11T00:39:19.304610+00:00",
      "status": "completed"
     }
    },
@@ -529,19 +529,19 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "88bf98b3",
+   "id": "ff439c67",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:33:01.166863Z",
-     "iopub.status.busy": "2026-09-11T00:33:01.166791Z",
-     "iopub.status.idle": "2026-09-11T00:33:01.225375Z",
-     "shell.execute_reply": "2026-09-11T00:33:01.224856Z"
+     "iopub.execute_input": "2026-09-11T00:39:19.318704Z",
+     "iopub.status.busy": "2026-09-11T00:39:19.318501Z",
+     "iopub.status.idle": "2026-09-11T00:39:19.412516Z",
+     "shell.execute_reply": "2026-09-11T00:39:19.411755Z"
     },
     "papermill": {
-     "duration": 0.06105,
-     "end_time": "2026-09-11T00:33:01.225838+00:00",
+     "duration": 0.09939,
+     "end_time": "2026-09-11T00:39:19.412829+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:33:01.164788+00:00",
+     "start_time": "2026-09-11T00:39:19.313439+00:00",
      "status": "completed"
     }
    },
@@ -555,22 +555,20 @@
     }
    ],
    "source": [
-    "labels = pl.read_parquet(\n",
-    "    CHAPTER_DIR.parent / \"case_studies\" / \"etfs\" / \"labels\" / f\"{PRIMARY_LABEL}.parquet\"\n",
-    ")\n",
+    "labels = pl.read_parquet(labels_path)\n",
     "panel = features.join(labels, on=[\"timestamp\", \"symbol\"], how=\"inner\")\n",
     "print(f\"Joined panel: {len(panel):,} rows over {panel['symbol'].n_unique()} symbols\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "4b3258ee",
+   "id": "97d1db54",
    "metadata": {
     "papermill": {
-     "duration": 0.001627,
-     "end_time": "2026-09-11T00:33:01.230114+00:00",
+     "duration": 0.001755,
+     "end_time": "2026-09-11T00:39:19.416510+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:33:01.228487+00:00",
+     "start_time": "2026-09-11T00:39:19.414755+00:00",
      "status": "completed"
     }
    },
@@ -587,19 +585,19 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "aaaf1c5d",
+   "id": "8dfc5295",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:33:01.233943Z",
-     "iopub.status.busy": "2026-09-11T00:33:01.233869Z",
-     "iopub.status.idle": "2026-09-11T00:33:01.241049Z",
-     "shell.execute_reply": "2026-09-11T00:33:01.240578Z"
+     "iopub.execute_input": "2026-09-11T00:39:19.421122Z",
+     "iopub.status.busy": "2026-09-11T00:39:19.420983Z",
+     "iopub.status.idle": "2026-09-11T00:39:19.430015Z",
+     "shell.execute_reply": "2026-09-11T00:39:19.429402Z"
     },
     "papermill": {
-     "duration": 0.009697,
-     "end_time": "2026-09-11T00:33:01.241462+00:00",
+     "duration": 0.011971,
+     "end_time": "2026-09-11T00:39:19.430351+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:33:01.231765+00:00",
+     "start_time": "2026-09-11T00:39:19.418380+00:00",
      "status": "completed"
     }
    },
@@ -634,19 +632,19 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "69963335",
+   "id": "c0ac2f84",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:33:01.246226Z",
-     "iopub.status.busy": "2026-09-11T00:33:01.246143Z",
-     "iopub.status.idle": "2026-09-11T00:33:03.340098Z",
-     "shell.execute_reply": "2026-09-11T00:33:03.339637Z"
+     "iopub.execute_input": "2026-09-11T00:39:19.435086Z",
+     "iopub.status.busy": "2026-09-11T00:39:19.434916Z",
+     "iopub.status.idle": "2026-09-11T00:39:22.087060Z",
+     "shell.execute_reply": "2026-09-11T00:39:22.086514Z"
     },
     "papermill": {
-     "duration": 2.096725,
-     "end_time": "2026-09-11T00:33:03.340493+00:00",
+     "duration": 2.655192,
+     "end_time": "2026-09-11T00:39:22.087459+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:33:01.243768+00:00",
+     "start_time": "2026-09-11T00:39:19.432267+00:00",
      "status": "completed"
     }
    },
@@ -677,13 +675,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1499cada",
+   "id": "c609fb48",
    "metadata": {
     "papermill": {
-     "duration": 0.001691,
-     "end_time": "2026-09-11T00:33:03.344104+00:00",
+     "duration": 0.001749,
+     "end_time": "2026-09-11T00:39:22.091211+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:33:03.342413+00:00",
+     "start_time": "2026-09-11T00:39:22.089462+00:00",
      "status": "completed"
     }
    },
@@ -700,19 +698,19 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "65dc7adb",
+   "id": "382679cc",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:33:03.348005Z",
-     "iopub.status.busy": "2026-09-11T00:33:03.347920Z",
-     "iopub.status.idle": "2026-09-11T00:33:03.352195Z",
-     "shell.execute_reply": "2026-09-11T00:33:03.351796Z"
+     "iopub.execute_input": "2026-09-11T00:39:22.095477Z",
+     "iopub.status.busy": "2026-09-11T00:39:22.095364Z",
+     "iopub.status.idle": "2026-09-11T00:39:22.100584Z",
+     "shell.execute_reply": "2026-09-11T00:39:22.100144Z"
     },
     "papermill": {
-     "duration": 0.006794,
-     "end_time": "2026-09-11T00:33:03.352586+00:00",
+     "duration": 0.008213,
+     "end_time": "2026-09-11T00:39:22.101201+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:33:03.345792+00:00",
+     "start_time": "2026-09-11T00:39:22.092988+00:00",
      "status": "completed"
     }
    },
@@ -770,13 +768,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "926ffc89",
+   "id": "cfc16664",
    "metadata": {
     "papermill": {
-     "duration": 0.003141,
-     "end_time": "2026-09-11T00:33:03.359097+00:00",
+     "duration": 0.00323,
+     "end_time": "2026-09-11T00:39:22.108190+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:33:03.355956+00:00",
+     "start_time": "2026-09-11T00:39:22.104960+00:00",
      "status": "completed"
     }
    },
@@ -794,19 +792,19 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "67e8c4ba",
+   "id": "7af73b18",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:33:03.365265Z",
-     "iopub.status.busy": "2026-09-11T00:33:03.365127Z",
-     "iopub.status.idle": "2026-09-11T00:33:03.388523Z",
-     "shell.execute_reply": "2026-09-11T00:33:03.388026Z"
+     "iopub.execute_input": "2026-09-11T00:39:22.114799Z",
+     "iopub.status.busy": "2026-09-11T00:39:22.114704Z",
+     "iopub.status.idle": "2026-09-11T00:39:22.138387Z",
+     "shell.execute_reply": "2026-09-11T00:39:22.137953Z"
     },
     "papermill": {
-     "duration": 0.026732,
-     "end_time": "2026-09-11T00:33:03.389060+00:00",
+     "duration": 0.027343,
+     "end_time": "2026-09-11T00:39:22.138841+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:33:03.362328+00:00",
+     "start_time": "2026-09-11T00:39:22.111498+00:00",
      "status": "completed"
     }
    },
@@ -843,14 +841,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8fd00834",
+   "id": "b51de843",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.003233,
-     "end_time": "2026-09-11T00:33:03.395930+00:00",
+     "duration": 0.001758,
+     "end_time": "2026-09-11T00:39:22.142586+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:33:03.392697+00:00",
+     "start_time": "2026-09-11T00:39:22.140828+00:00",
      "status": "completed"
     }
    },
@@ -876,19 +874,19 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "17e1df33",
+   "id": "f660e120",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:33:03.403326Z",
-     "iopub.status.busy": "2026-09-11T00:33:03.403232Z",
-     "iopub.status.idle": "2026-09-11T00:33:03.407606Z",
-     "shell.execute_reply": "2026-09-11T00:33:03.407182Z"
+     "iopub.execute_input": "2026-09-11T00:39:22.146632Z",
+     "iopub.status.busy": "2026-09-11T00:39:22.146538Z",
+     "iopub.status.idle": "2026-09-11T00:39:22.150897Z",
+     "shell.execute_reply": "2026-09-11T00:39:22.150505Z"
     },
     "papermill": {
-     "duration": 0.00884,
-     "end_time": "2026-09-11T00:33:03.408084+00:00",
+     "duration": 0.006878,
+     "end_time": "2026-09-11T00:39:22.151212+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:33:03.399244+00:00",
+     "start_time": "2026-09-11T00:39:22.144334+00:00",
      "status": "completed"
     }
    },
@@ -978,13 +976,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d705a5dc",
+   "id": "07db600e",
    "metadata": {
     "papermill": {
-     "duration": 0.002078,
-     "end_time": "2026-09-11T00:33:03.413666+00:00",
+     "duration": 0.00169,
+     "end_time": "2026-09-11T00:39:22.154726+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:33:03.411588+00:00",
+     "start_time": "2026-09-11T00:39:22.153036+00:00",
      "status": "completed"
     }
    },
@@ -1005,19 +1003,19 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "74a8e32b",
+   "id": "4aaa0a59",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:33:03.417650Z",
-     "iopub.status.busy": "2026-09-11T00:33:03.417573Z",
-     "iopub.status.idle": "2026-09-11T00:33:03.473918Z",
-     "shell.execute_reply": "2026-09-11T00:33:03.473434Z"
+     "iopub.execute_input": "2026-09-11T00:39:22.158596Z",
+     "iopub.status.busy": "2026-09-11T00:39:22.158523Z",
+     "iopub.status.idle": "2026-09-11T00:39:22.228121Z",
+     "shell.execute_reply": "2026-09-11T00:39:22.227478Z"
     },
     "papermill": {
-     "duration": 0.058872,
-     "end_time": "2026-09-11T00:33:03.474276+00:00",
+     "duration": 0.072035,
+     "end_time": "2026-09-11T00:39:22.228492+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:33:03.415404+00:00",
+     "start_time": "2026-09-11T00:39:22.156457+00:00",
      "status": "completed"
     }
    },
@@ -1063,13 +1061,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3416c0bb",
+   "id": "dfb5e0b1",
    "metadata": {
     "papermill": {
-     "duration": 0.001744,
-     "end_time": "2026-09-11T00:33:03.477986+00:00",
+     "duration": 0.001839,
+     "end_time": "2026-09-11T00:39:22.232699+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:33:03.476242+00:00",
+     "start_time": "2026-09-11T00:39:22.230860+00:00",
      "status": "completed"
     }
    },
@@ -1089,19 +1087,19 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "id": "d874e27b",
+   "id": "c2b10b2f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:33:03.482019Z",
-     "iopub.status.busy": "2026-09-11T00:33:03.481935Z",
-     "iopub.status.idle": "2026-09-11T00:33:03.484874Z",
-     "shell.execute_reply": "2026-09-11T00:33:03.484426Z"
+     "iopub.execute_input": "2026-09-11T00:39:22.237224Z",
+     "iopub.status.busy": "2026-09-11T00:39:22.237095Z",
+     "iopub.status.idle": "2026-09-11T00:39:22.242828Z",
+     "shell.execute_reply": "2026-09-11T00:39:22.239991Z"
     },
     "papermill": {
-     "duration": 0.005463,
-     "end_time": "2026-09-11T00:33:03.485180+00:00",
+     "duration": 0.008665,
+     "end_time": "2026-09-11T00:39:22.243159+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:33:03.479717+00:00",
+     "start_time": "2026-09-11T00:39:22.234494+00:00",
      "status": "completed"
     }
    },
@@ -1143,13 +1141,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b12c6c2b",
+   "id": "0348a854",
    "metadata": {
     "papermill": {
-     "duration": 0.001704,
-     "end_time": "2026-09-11T00:33:03.488646+00:00",
+     "duration": 0.001815,
+     "end_time": "2026-09-11T00:39:22.246941+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:33:03.486942+00:00",
+     "start_time": "2026-09-11T00:39:22.245126+00:00",
      "status": "completed"
     }
    },
@@ -1168,19 +1166,19 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "id": "9c3779de",
+   "id": "142f60c1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:33:03.492721Z",
-     "iopub.status.busy": "2026-09-11T00:33:03.492644Z",
-     "iopub.status.idle": "2026-09-11T00:33:03.614289Z",
-     "shell.execute_reply": "2026-09-11T00:33:03.613775Z"
+     "iopub.execute_input": "2026-09-11T00:39:22.251031Z",
+     "iopub.status.busy": "2026-09-11T00:39:22.250952Z",
+     "iopub.status.idle": "2026-09-11T00:39:22.382619Z",
+     "shell.execute_reply": "2026-09-11T00:39:22.382180Z"
     },
     "papermill": {
-     "duration": 0.124284,
-     "end_time": "2026-09-11T00:33:03.614711+00:00",
+     "duration": 0.134152,
+     "end_time": "2026-09-11T00:39:22.382903+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:33:03.490427+00:00",
+     "start_time": "2026-09-11T00:39:22.248751+00:00",
      "status": "completed"
     }
    },
@@ -1230,13 +1228,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "850921ef",
+   "id": "86dfbbe4",
    "metadata": {
     "papermill": {
-     "duration": 0.001931,
-     "end_time": "2026-09-11T00:33:03.618804+00:00",
+     "duration": 0.002011,
+     "end_time": "2026-09-11T00:39:22.387228+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:33:03.616873+00:00",
+     "start_time": "2026-09-11T00:39:22.385217+00:00",
      "status": "completed"
     }
    },
@@ -1257,19 +1255,19 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "id": "487617db",
+   "id": "3f8b6e83",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:33:03.623776Z",
-     "iopub.status.busy": "2026-09-11T00:33:03.623613Z",
-     "iopub.status.idle": "2026-09-11T00:33:03.629097Z",
-     "shell.execute_reply": "2026-09-11T00:33:03.628687Z"
+     "iopub.execute_input": "2026-09-11T00:39:22.391769Z",
+     "iopub.status.busy": "2026-09-11T00:39:22.391682Z",
+     "iopub.status.idle": "2026-09-11T00:39:22.396070Z",
+     "shell.execute_reply": "2026-09-11T00:39:22.395568Z"
     },
     "papermill": {
-     "duration": 0.008799,
-     "end_time": "2026-09-11T00:33:03.629597+00:00",
+     "duration": 0.00724,
+     "end_time": "2026-09-11T00:39:22.396411+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:33:03.620798+00:00",
+     "start_time": "2026-09-11T00:39:22.389171+00:00",
      "status": "completed"
     }
    },
@@ -1328,19 +1326,19 @@
   {
    "cell_type": "code",
    "execution_count": 17,
-   "id": "d3f9253b",
+   "id": "84246f35",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:33:03.638580Z",
-     "iopub.status.busy": "2026-09-11T00:33:03.638375Z",
-     "iopub.status.idle": "2026-09-11T00:33:03.642315Z",
-     "shell.execute_reply": "2026-09-11T00:33:03.641496Z"
+     "iopub.execute_input": "2026-09-11T00:39:22.400976Z",
+     "iopub.status.busy": "2026-09-11T00:39:22.400896Z",
+     "iopub.status.idle": "2026-09-11T00:39:22.403528Z",
+     "shell.execute_reply": "2026-09-11T00:39:22.403205Z"
     },
     "papermill": {
-     "duration": 0.009161,
-     "end_time": "2026-09-11T00:33:03.642952+00:00",
+     "duration": 0.005353,
+     "end_time": "2026-09-11T00:39:22.403874+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:33:03.633791+00:00",
+     "start_time": "2026-09-11T00:39:22.398521+00:00",
      "status": "completed"
     }
    },
@@ -1383,14 +1381,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "382d0957",
+   "id": "2b50fdcc",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.005182,
-     "end_time": "2026-09-11T00:33:03.653092+00:00",
+     "duration": 0.001951,
+     "end_time": "2026-09-11T00:39:22.407878+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:33:03.647910+00:00",
+     "start_time": "2026-09-11T00:39:22.405927+00:00",
      "status": "completed"
     }
    },
@@ -1408,19 +1406,19 @@
   {
    "cell_type": "code",
    "execution_count": 18,
-   "id": "c110fc9a",
+   "id": "0e914e75",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:33:03.659926Z",
-     "iopub.status.busy": "2026-09-11T00:33:03.659776Z",
-     "iopub.status.idle": "2026-09-11T00:33:03.664477Z",
-     "shell.execute_reply": "2026-09-11T00:33:03.664075Z"
+     "iopub.execute_input": "2026-09-11T00:39:22.412581Z",
+     "iopub.status.busy": "2026-09-11T00:39:22.412462Z",
+     "iopub.status.idle": "2026-09-11T00:39:22.416335Z",
+     "shell.execute_reply": "2026-09-11T00:39:22.415927Z"
     },
     "papermill": {
-     "duration": 0.008307,
-     "end_time": "2026-09-11T00:33:03.664839+00:00",
+     "duration": 0.006748,
+     "end_time": "2026-09-11T00:39:22.416617+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:33:03.656532+00:00",
+     "start_time": "2026-09-11T00:39:22.409869+00:00",
      "status": "completed"
     }
    },
@@ -1477,13 +1475,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fe40c6cb",
+   "id": "8e4b3a99",
    "metadata": {
     "papermill": {
-     "duration": 0.002091,
-     "end_time": "2026-09-11T00:33:03.669639+00:00",
+     "duration": 0.001966,
+     "end_time": "2026-09-11T00:39:22.420759+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:33:03.667548+00:00",
+     "start_time": "2026-09-11T00:39:22.418793+00:00",
      "status": "completed"
     }
    },
@@ -1503,19 +1501,19 @@
   {
    "cell_type": "code",
    "execution_count": 19,
-   "id": "6521159b",
+   "id": "f5ac3fff",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:33:03.674341Z",
-     "iopub.status.busy": "2026-09-11T00:33:03.674277Z",
-     "iopub.status.idle": "2026-09-11T00:33:03.676737Z",
-     "shell.execute_reply": "2026-09-11T00:33:03.676447Z"
+     "iopub.execute_input": "2026-09-11T00:39:22.425481Z",
+     "iopub.status.busy": "2026-09-11T00:39:22.425402Z",
+     "iopub.status.idle": "2026-09-11T00:39:22.428342Z",
+     "shell.execute_reply": "2026-09-11T00:39:22.428007Z"
     },
     "papermill": {
-     "duration": 0.005355,
-     "end_time": "2026-09-11T00:33:03.677071+00:00",
+     "duration": 0.00579,
+     "end_time": "2026-09-11T00:39:22.428618+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:33:03.671716+00:00",
+     "start_time": "2026-09-11T00:39:22.422828+00:00",
      "status": "completed"
     }
    },
@@ -1551,19 +1549,19 @@
   {
    "cell_type": "code",
    "execution_count": 20,
-   "id": "c2ee3a24",
+   "id": "37b3aa2c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:33:03.681573Z",
-     "iopub.status.busy": "2026-09-11T00:33:03.681510Z",
-     "iopub.status.idle": "2026-09-11T00:33:03.683979Z",
-     "shell.execute_reply": "2026-09-11T00:33:03.683696Z"
+     "iopub.execute_input": "2026-09-11T00:39:22.433211Z",
+     "iopub.status.busy": "2026-09-11T00:39:22.433141Z",
+     "iopub.status.idle": "2026-09-11T00:39:22.436331Z",
+     "shell.execute_reply": "2026-09-11T00:39:22.435829Z"
     },
     "papermill": {
-     "duration": 0.005137,
-     "end_time": "2026-09-11T00:33:03.684247+00:00",
+     "duration": 0.005936,
+     "end_time": "2026-09-11T00:39:22.436628+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:33:03.679110+00:00",
+     "start_time": "2026-09-11T00:39:22.430692+00:00",
      "status": "completed"
     }
    },
@@ -1619,13 +1617,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "027aa5f0",
+   "id": "2b02fc62",
    "metadata": {
     "papermill": {
-     "duration": 0.001988,
-     "end_time": "2026-09-11T00:33:03.688322+00:00",
+     "duration": 0.002046,
+     "end_time": "2026-09-11T00:39:22.440990+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:33:03.686334+00:00",
+     "start_time": "2026-09-11T00:39:22.438944+00:00",
      "status": "completed"
     }
    },
@@ -1647,14 +1645,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0de9867e",
+   "id": "139dd0d7",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.001972,
-     "end_time": "2026-09-11T00:33:03.692347+00:00",
+     "duration": 0.002022,
+     "end_time": "2026-09-11T00:39:22.445107+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:33:03.690375+00:00",
+     "start_time": "2026-09-11T00:39:22.443085+00:00",
      "status": "completed"
     }
    },
@@ -1670,19 +1668,19 @@
   {
    "cell_type": "code",
    "execution_count": 21,
-   "id": "a7c19bf8",
+   "id": "9b164e44",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:33:03.696941Z",
-     "iopub.status.busy": "2026-09-11T00:33:03.696881Z",
-     "iopub.status.idle": "2026-09-11T00:33:03.698978Z",
-     "shell.execute_reply": "2026-09-11T00:33:03.698570Z"
+     "iopub.execute_input": "2026-09-11T00:39:22.449968Z",
+     "iopub.status.busy": "2026-09-11T00:39:22.449872Z",
+     "iopub.status.idle": "2026-09-11T00:39:22.452241Z",
+     "shell.execute_reply": "2026-09-11T00:39:22.451849Z"
     },
     "papermill": {
-     "duration": 0.004921,
-     "end_time": "2026-09-11T00:33:03.699301+00:00",
+     "duration": 0.00534,
+     "end_time": "2026-09-11T00:39:22.452536+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:33:03.694380+00:00",
+     "start_time": "2026-09-11T00:39:22.447196+00:00",
      "status": "completed"
     }
    },
@@ -1700,19 +1698,19 @@
   {
    "cell_type": "code",
    "execution_count": 22,
-   "id": "e3e34491",
+   "id": "8f6bd4e5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:33:03.703920Z",
-     "iopub.status.busy": "2026-09-11T00:33:03.703860Z",
-     "iopub.status.idle": "2026-09-11T00:33:03.706787Z",
-     "shell.execute_reply": "2026-09-11T00:33:03.706356Z"
+     "iopub.execute_input": "2026-09-11T00:39:22.457333Z",
+     "iopub.status.busy": "2026-09-11T00:39:22.457249Z",
+     "iopub.status.idle": "2026-09-11T00:39:22.460477Z",
+     "shell.execute_reply": "2026-09-11T00:39:22.459926Z"
     },
     "papermill": {
-     "duration": 0.005709,
-     "end_time": "2026-09-11T00:33:03.707080+00:00",
+     "duration": 0.006089,
+     "end_time": "2026-09-11T00:39:22.460776+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:33:03.701371+00:00",
+     "start_time": "2026-09-11T00:39:22.454687+00:00",
      "status": "completed"
     }
    },
@@ -1756,13 +1754,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fb618e0d",
+   "id": "bb333fde",
    "metadata": {
     "papermill": {
-     "duration": 0.002098,
-     "end_time": "2026-09-11T00:33:03.711294+00:00",
+     "duration": 0.002079,
+     "end_time": "2026-09-11T00:39:22.465079+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:33:03.709196+00:00",
+     "start_time": "2026-09-11T00:39:22.463000+00:00",
      "status": "completed"
     }
    },
@@ -1779,19 +1777,19 @@
   {
    "cell_type": "code",
    "execution_count": 23,
-   "id": "a35a5312",
+   "id": "9194a4b1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:33:03.715938Z",
-     "iopub.status.busy": "2026-09-11T00:33:03.715876Z",
-     "iopub.status.idle": "2026-09-11T00:33:03.719191Z",
-     "shell.execute_reply": "2026-09-11T00:33:03.718807Z"
+     "iopub.execute_input": "2026-09-11T00:39:22.470331Z",
+     "iopub.status.busy": "2026-09-11T00:39:22.470236Z",
+     "iopub.status.idle": "2026-09-11T00:39:22.473891Z",
+     "shell.execute_reply": "2026-09-11T00:39:22.473516Z"
     },
     "papermill": {
-     "duration": 0.006119,
-     "end_time": "2026-09-11T00:33:03.719509+00:00",
+     "duration": 0.006946,
+     "end_time": "2026-09-11T00:39:22.474202+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:33:03.713390+00:00",
+     "start_time": "2026-09-11T00:39:22.467256+00:00",
      "status": "completed"
     }
    },
@@ -1800,7 +1798,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Run metadata: 25_live_trading/output/etfs_deployment/runs/run_20260911T003303Z.json\n"
+      "Run metadata: 25_live_trading/output/etfs_deployment/runs/run_20260911T003922Z.json\n"
      ]
     }
    ],
@@ -1848,13 +1846,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fad51d56",
+   "id": "ea100b5d",
    "metadata": {
     "papermill": {
-     "duration": 0.002057,
-     "end_time": "2026-09-11T00:33:03.723700+00:00",
+     "duration": 0.00211,
+     "end_time": "2026-09-11T00:39:22.478507+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:33:03.721643+00:00",
+     "start_time": "2026-09-11T00:39:22.476397+00:00",
      "status": "completed"
     }
    },
@@ -1920,24 +1918,24 @@
    "version": "3.14.3"
   },
   "ml4t_provenance": {
-   "executed_at": "2026-09-11T00:33:12.243179+00:00",
+   "executed_at": "2026-09-11T00:39:31.400309+00:00",
    "executor": "local-uv",
    "library_digest": "0af5dc39c6c29f1e215740139cdb8886b6f5894060fe3cbd08b809a63ae853aa",
-   "outputs_digest": "e83da8c9bc00ca15914225ffeca88da26c5392af5b0cb577d1b6660fa9ef39fb",
+   "outputs_digest": "26edb2f789f5bf544143568716a1ea8222ffadd9db62c767881c06840220693c",
    "parameters": {},
    "production": true,
-   "source_py_blob": "2351304a3d247afcafc49a898ccadced3682c8f4"
+   "source_py_blob": "779e71293b6e91127721fc5d37543ae4d006c818"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 33.029825,
-   "end_time": "2026-09-11T00:33:04.941896+00:00",
+   "duration": 35.764581,
+   "end_time": "2026-09-11T00:39:23.897457+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "~/ml4t/public-teach-g/25_live_trading/.02_etfs_deployment_loop.build.608378.ipynb",
-   "output_path": "~/ml4t/public-teach-g/25_live_trading/.02_etfs_deployment_loop.papermill.608378.ipynb",
+   "input_path": "~/ml4t/public-teach-g/25_live_trading/.02_etfs_deployment_loop.build.629375.ipynb",
+   "output_path": "~/ml4t/public-teach-g/25_live_trading/.02_etfs_deployment_loop.papermill.629375.ipynb",
    "parameters": {},
-   "start_time": "2026-09-11T00:32:31.912071+00:00",
+   "start_time": "2026-09-11T00:38:48.132876+00:00",
    "version": "2.7.0"
   }
  },

--- a/25_live_trading/02_etfs_deployment_loop.ipynb
+++ b/25_live_trading/02_etfs_deployment_loop.ipynb
@@ -2,13 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "9e62c686",
+   "id": "13c31e0d",
    "metadata": {
     "papermill": {
-     "duration": 0.001724,
-     "end_time": "2026-09-09T00:41:56.756126+00:00",
+     "duration": 0.007077,
+     "end_time": "2026-09-11T00:22:29.114909+00:00",
      "exception": false,
-     "start_time": "2026-09-09T00:41:56.754402+00:00",
+     "start_time": "2026-09-11T00:22:29.107832+00:00",
      "status": "completed"
     }
    },
@@ -78,19 +78,19 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "4d5f50cd",
+   "id": "6204f8db",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T00:41:56.759885Z",
-     "iopub.status.busy": "2026-09-09T00:41:56.759774Z",
-     "iopub.status.idle": "2026-09-09T00:41:59.060369Z",
-     "shell.execute_reply": "2026-09-09T00:41:59.059637Z"
+     "iopub.execute_input": "2026-09-11T00:22:29.120471Z",
+     "iopub.status.busy": "2026-09-11T00:22:29.120295Z",
+     "iopub.status.idle": "2026-09-11T00:22:31.367423Z",
+     "shell.execute_reply": "2026-09-11T00:22:31.367138Z"
     },
     "papermill": {
-     "duration": 2.303073,
-     "end_time": "2026-09-09T00:41:59.060790+00:00",
+     "duration": 2.250906,
+     "end_time": "2026-09-11T00:22:31.368484+00:00",
      "exception": false,
-     "start_time": "2026-09-09T00:41:56.757717+00:00",
+     "start_time": "2026-09-11T00:22:29.117578+00:00",
      "status": "completed"
     }
    },
@@ -102,6 +102,7 @@
     "import logging\n",
     "import os\n",
     "import pickle\n",
+    "import sqlite3\n",
     "import warnings\n",
     "from datetime import UTC, datetime\n",
     "from pathlib import Path\n",
@@ -115,7 +116,7 @@
     "from sklearn.preprocessing import StandardScaler\n",
     "\n",
     "from data import load_etfs, load_macro\n",
-    "from utils.paths import display_path, get_chapter_dir, get_output_dir\n",
+    "from utils.paths import display_path, get_case_study_dir, get_chapter_dir, get_output_dir\n",
     "from utils.style import COLORS, add_message_title, show_with_alt\n",
     "\n",
     "CHAPTER_DIR = get_chapter_dir(25)\n",
@@ -140,19 +141,19 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "5ef28896",
+   "id": "e02e8c20",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T00:41:59.064355Z",
-     "iopub.status.busy": "2026-09-09T00:41:59.064264Z",
-     "iopub.status.idle": "2026-09-09T00:41:59.066710Z",
-     "shell.execute_reply": "2026-09-09T00:41:59.066165Z"
+     "iopub.execute_input": "2026-09-11T00:22:31.373085Z",
+     "iopub.status.busy": "2026-09-11T00:22:31.372999Z",
+     "iopub.status.idle": "2026-09-11T00:22:31.374976Z",
+     "shell.execute_reply": "2026-09-11T00:22:31.374573Z"
     },
     "papermill": {
-     "duration": 0.00461,
-     "end_time": "2026-09-09T00:41:59.067009+00:00",
+     "duration": 0.005102,
+     "end_time": "2026-09-11T00:22:31.375714+00:00",
      "exception": false,
-     "start_time": "2026-09-09T00:41:59.062399+00:00",
+     "start_time": "2026-09-11T00:22:31.370612+00:00",
      "status": "completed"
     },
     "tags": [
@@ -161,11 +162,12 @@
    },
    "outputs": [],
    "source": [
-    "RIDGE_ALPHA = 1_000_000.0  # ridge_a1000000.0 from the ETF case study's CV sweep\n",
+    "EXPECTED_RIDGE_CONFIG = \"ridge_a1000000.0\"  # None reports the registry's pick instead of asserting\n",
     "PRIMARY_LABEL = \"fwd_ret_21d\"\n",
     "LIVE_WINDOW_START = \"2025-01-01\"  # cross-sections from here become \"live\" predictions\n",
     "FORWARD_HORIZON_DAYS = 21  # fwd_ret_21d label horizon (trading days)\n",
     "TOP_K = 5\n",
+    "CASH_BUFFER = 0.02  # share of the account left unallocated, so a next-bar fill is affordable\n",
     "REBALANCE_EVERY_N_DAYS = 21  # match the label horizon\n",
     "INITIAL_CASH = 100_000.0\n",
     "COMMISSION_RATE = 0.0005\n",
@@ -176,13 +178,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7b4eb1b7",
+   "id": "177ad62e",
    "metadata": {
     "papermill": {
-     "duration": 0.001311,
-     "end_time": "2026-09-09T00:41:59.069774+00:00",
+     "duration": 0.001455,
+     "end_time": "2026-09-11T00:22:31.379983+00:00",
      "exception": false,
-     "start_time": "2026-09-09T00:41:59.068463+00:00",
+     "start_time": "2026-09-11T00:22:31.378528+00:00",
      "status": "completed"
     }
    },
@@ -204,19 +206,19 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "19d84a2a",
+   "id": "7a27fcc0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T00:41:59.073229Z",
-     "iopub.status.busy": "2026-09-09T00:41:59.073084Z",
-     "iopub.status.idle": "2026-09-09T00:41:59.076593Z",
-     "shell.execute_reply": "2026-09-09T00:41:59.076104Z"
+     "iopub.execute_input": "2026-09-11T00:22:31.383482Z",
+     "iopub.status.busy": "2026-09-11T00:22:31.383418Z",
+     "iopub.status.idle": "2026-09-11T00:22:31.385724Z",
+     "shell.execute_reply": "2026-09-11T00:22:31.385390Z"
     },
     "papermill": {
-     "duration": 0.005746,
-     "end_time": "2026-09-09T00:41:59.076871+00:00",
+     "duration": 0.004538,
+     "end_time": "2026-09-11T00:22:31.386003+00:00",
      "exception": false,
-     "start_time": "2026-09-09T00:41:59.071125+00:00",
+     "start_time": "2026-09-11T00:22:31.381465+00:00",
      "status": "completed"
     }
    },
@@ -251,13 +253,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8cc6f2b4",
+   "id": "40fe2e5b",
    "metadata": {
     "papermill": {
-     "duration": 0.001359,
-     "end_time": "2026-09-09T00:41:59.079741+00:00",
+     "duration": 0.001601,
+     "end_time": "2026-09-11T00:22:31.389150+00:00",
      "exception": false,
-     "start_time": "2026-09-09T00:41:59.078382+00:00",
+     "start_time": "2026-09-11T00:22:31.387549+00:00",
      "status": "completed"
     }
    },
@@ -277,19 +279,19 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "3d7ce945",
+   "id": "c0cd102b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T00:41:59.083405Z",
-     "iopub.status.busy": "2026-09-09T00:41:59.083253Z",
-     "iopub.status.idle": "2026-09-09T00:41:59.150537Z",
-     "shell.execute_reply": "2026-09-09T00:41:59.149938Z"
+     "iopub.execute_input": "2026-09-11T00:22:31.393525Z",
+     "iopub.status.busy": "2026-09-11T00:22:31.393454Z",
+     "iopub.status.idle": "2026-09-11T00:22:31.479939Z",
+     "shell.execute_reply": "2026-09-11T00:22:31.479468Z"
     },
     "papermill": {
-     "duration": 0.069695,
-     "end_time": "2026-09-09T00:41:59.150843+00:00",
+     "duration": 0.089413,
+     "end_time": "2026-09-11T00:22:31.480511+00:00",
      "exception": false,
-     "start_time": "2026-09-09T00:41:59.081148+00:00",
+     "start_time": "2026-09-11T00:22:31.391098+00:00",
      "status": "completed"
     }
    },
@@ -321,19 +323,19 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "3ff70b5c",
+   "id": "d860922d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T00:41:59.154700Z",
-     "iopub.status.busy": "2026-09-09T00:41:59.154576Z",
-     "iopub.status.idle": "2026-09-09T00:42:25.622994Z",
-     "shell.execute_reply": "2026-09-09T00:42:25.622455Z"
+     "iopub.execute_input": "2026-09-11T00:22:31.489177Z",
+     "iopub.status.busy": "2026-09-11T00:22:31.488980Z",
+     "iopub.status.idle": "2026-09-11T00:22:57.889608Z",
+     "shell.execute_reply": "2026-09-11T00:22:57.889142Z"
     },
     "papermill": {
-     "duration": 26.471052,
-     "end_time": "2026-09-09T00:42:25.623526+00:00",
+     "duration": 26.405984,
+     "end_time": "2026-09-11T00:22:57.889893+00:00",
      "exception": false,
-     "start_time": "2026-09-09T00:41:59.152474+00:00",
+     "start_time": "2026-09-11T00:22:31.483909+00:00",
      "status": "completed"
     }
    },
@@ -342,14 +344,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2026-09-08 20:41:59 | mlquant.features.adx | INFO | [ADX] Starting calculation with parameters: period=14 (shape: (4,))\n"
+      "2026-09-10 20:22:31 | mlquant.features.adx | INFO | [ADX] Starting calculation with parameters: period=14 (shape: (4,))\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2026-09-08 20:41:59 | mlquant.features.adx | INFO | [ADX] Completed calculation (shape: (4,)) (0.04ms)\n"
+      "2026-09-10 20:22:31 | mlquant.features.adx | INFO | [ADX] Completed calculation (shape: (4,)) (0.05ms)\n"
      ]
     },
     {
@@ -368,13 +370,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ece245e9",
+   "id": "610c2869",
    "metadata": {
     "papermill": {
-     "duration": 0.001507,
-     "end_time": "2026-09-09T00:42:25.626733+00:00",
+     "duration": 0.001626,
+     "end_time": "2026-09-11T00:22:57.893343+00:00",
      "exception": false,
-     "start_time": "2026-09-09T00:42:25.625226+00:00",
+     "start_time": "2026-09-11T00:22:57.891717+00:00",
      "status": "completed"
     }
    },
@@ -389,29 +391,146 @@
     "\n",
     "The deployment fit is a **single Ridge regression on the full extended\n",
     "panel** - no walk-forward CV, no per-fold scaling, no hyperparameter\n",
-    "search. The hyperparameters come from the case study (`α = 10⁶` is the\n",
-    "highest-validation-IC Ridge configuration in the ETFs registry); we adopt it here\n",
-    "rather than re-deriving them. This separates the *research artefact*\n",
+    "search. The regularisation strength comes from the case study rather\n",
+    "than from a sweep here, which separates the *research artefact*\n",
     "(registry-stored, CV-evaluated, IC-reported) from the *deployment\n",
-    "artefact* (single fit, full history, governed path)."
+    "artefact* (single fit, full history, governed path).\n",
+    "\n",
+    "### Where the regularisation strength comes from\n",
+    "\n",
+    "A borrowed hyperparameter that sits in the parameters cell as a literal is a number nobody can\n",
+    "check: the registry's leader can move on the next sweep and nothing here would notice. The cell\n",
+    "below asks the registry which Ridge configuration leads on validation IC for this label, reads\n",
+    "the alpha out of that run's resolved specification, and checks the answer against\n",
+    "`EXPECTED_RIDGE_CONFIG`. Setting that pin to `None` reports the registry's pick instead of\n",
+    "asserting it, which is what to do when the case study is deliberately re-swept.\n",
+    "\n",
+    "The pin names a **configuration**, not a training hash. A refit re-keys the hash while selecting\n",
+    "the same configuration, so a hash pin would fire on runs where nothing had changed."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "b87c2caa",
+   "id": "eb225a87",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T00:42:25.630404Z",
-     "iopub.status.busy": "2026-09-09T00:42:25.630307Z",
-     "iopub.status.idle": "2026-09-09T00:42:25.694626Z",
-     "shell.execute_reply": "2026-09-09T00:42:25.694085Z"
+     "iopub.execute_input": "2026-09-11T00:22:57.897119Z",
+     "iopub.status.busy": "2026-09-11T00:22:57.897047Z",
+     "iopub.status.idle": "2026-09-11T00:22:57.901453Z",
+     "shell.execute_reply": "2026-09-11T00:22:57.901123Z"
     },
     "papermill": {
-     "duration": 0.066793,
-     "end_time": "2026-09-09T00:42:25.695032+00:00",
+     "duration": 0.006772,
+     "end_time": "2026-09-11T00:22:57.901704+00:00",
      "exception": false,
-     "start_time": "2026-09-09T00:42:25.628239+00:00",
+     "start_time": "2026-09-11T00:22:57.894932+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Registry leader on validation IC: ridge_a1000000.0  (IC 0.0434)\n",
+      "  alpha:        1e+06\n",
+      "  tuned on:     ['financial', 'model_based']\n",
+      "  deployed on:  ['financial']\n"
+     ]
+    }
+   ],
+   "source": [
+    "registry_path = get_case_study_dir(\"etfs\") / \"run_log\" / \"registry.db\"\n",
+    "registry_uri = f\"{registry_path.resolve().as_uri()}?mode=ro&immutable=1\"\n",
+    "with sqlite3.connect(registry_uri, uri=True) as conn:\n",
+    "    winner = conn.execute(\n",
+    "        \"\"\"SELECT tr.config_name, tr.spec_json, pm.ic_mean\n",
+    "           FROM training_runs tr\n",
+    "           JOIN prediction_sets ps ON ps.training_hash = tr.training_hash\n",
+    "           JOIN prediction_metrics pm ON pm.prediction_hash = ps.prediction_hash\n",
+    "           WHERE tr.family = 'linear'\n",
+    "             AND tr.label = ?\n",
+    "             AND tr.config_name LIKE 'ridge_%'\n",
+    "             AND ps.split = 'validation'\n",
+    "           ORDER BY pm.ic_mean DESC\n",
+    "           LIMIT 1\"\"\",\n",
+    "        (PRIMARY_LABEL,),\n",
+    "    ).fetchone()\n",
+    "if winner is None:\n",
+    "    raise RuntimeError(\n",
+    "        f\"The ETFs registry holds no validated Ridge run for {PRIMARY_LABEL}; \"\n",
+    "        \"the case study's linear stage has to run before this notebook can borrow from it.\"\n",
+    "    )\n",
+    "SOURCE_CONFIG, source_spec_json, source_ic = winner\n",
+    "source_spec = json.loads(source_spec_json)\n",
+    "\n",
+    "# Every fold of a sweep configuration is fitted at one alpha; a set with more than one member\n",
+    "# would mean the configuration name no longer identifies a single regularisation strength.\n",
+    "fold_alphas = {\n",
+    "    params[\"alpha\"]\n",
+    "    for params in source_spec[\"computation\"][\"model\"][\"effective_params_by_fold\"].values()\n",
+    "}\n",
+    "if len(fold_alphas) != 1:\n",
+    "    raise RuntimeError(f\"{SOURCE_CONFIG} was fitted at more than one alpha: {sorted(fold_alphas)}\")\n",
+    "RIDGE_ALPHA = float(fold_alphas.pop())\n",
+    "\n",
+    "# The artefacts the source run read are what its feature set was; \"label\" is the target, not a\n",
+    "# feature family.\n",
+    "SOURCE_FEATURE_SETS = sorted(set(source_spec[\"computation\"][\"feature_artifacts\"]) - {\"label\"})\n",
+    "\n",
+    "# `_etfs_features.compute_financial_features` builds exactly the financial families, so this names\n",
+    "# what was fitted above rather than restating an intention.\n",
+    "DEPLOYED_FEATURE_SETS = [\"financial\"]\n",
+    "\n",
+    "assert EXPECTED_RIDGE_CONFIG in (None, SOURCE_CONFIG), (\n",
+    "    f\"The registry now leads with {SOURCE_CONFIG}, not {EXPECTED_RIDGE_CONFIG}. \"\n",
+    "    \"Re-pin deliberately rather than following the leader silently.\"\n",
+    ")\n",
+    "print(f\"Registry leader on validation IC: {SOURCE_CONFIG}  (IC {source_ic:.4f})\")\n",
+    "print(f\"  alpha:        {RIDGE_ALPHA:g}\")\n",
+    "print(f\"  tuned on:     {SOURCE_FEATURE_SETS}\")\n",
+    "print(f\"  deployed on:  {DEPLOYED_FEATURE_SETS}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a2a927d1",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001531,
+     "end_time": "2026-09-11T00:22:57.904854+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T00:22:57.903323+00:00",
+     "status": "completed"
+    }
+   },
+   "source": [
+    "The two feature lists differ, and the difference is the cost of the transfer. The registry's\n",
+    "leader was tuned with the model-based families alongside the financial ones; this notebook fits\n",
+    "the financial families alone, because an HMM and a GARCH refit per symbol on every data update is\n",
+    "what the deployment declines to pay for. An alpha selected against one feature set is not\n",
+    "selected against another, so the number below is a starting point carried over from research,\n",
+    "not a tuned value for the model actually fitted here. Nothing in this notebook re-derives it, and\n",
+    "a deployment that wanted it re-derived would sweep on its own feature set."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "cb026485",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-11T00:22:57.908546Z",
+     "iopub.status.busy": "2026-09-11T00:22:57.908473Z",
+     "iopub.status.idle": "2026-09-11T00:22:57.968442Z",
+     "shell.execute_reply": "2026-09-11T00:22:57.967872Z"
+    },
+    "papermill": {
+     "duration": 0.062571,
+     "end_time": "2026-09-11T00:22:57.969125+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T00:22:57.906554+00:00",
      "status": "completed"
     }
    },
@@ -434,13 +553,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "77080719",
+   "id": "b1d41fdf",
    "metadata": {
     "papermill": {
-     "duration": 0.001514,
-     "end_time": "2026-09-09T00:42:25.698262+00:00",
+     "duration": 0.001693,
+     "end_time": "2026-09-11T00:22:57.972712+00:00",
      "exception": false,
-     "start_time": "2026-09-09T00:42:25.696748+00:00",
+     "start_time": "2026-09-11T00:22:57.971019+00:00",
      "status": "completed"
     }
    },
@@ -456,20 +575,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
-   "id": "bd66f514",
+   "execution_count": 8,
+   "id": "4092420b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T00:42:25.702121Z",
-     "iopub.status.busy": "2026-09-09T00:42:25.701953Z",
-     "iopub.status.idle": "2026-09-09T00:42:25.708738Z",
-     "shell.execute_reply": "2026-09-09T00:42:25.708330Z"
+     "iopub.execute_input": "2026-09-11T00:22:57.976472Z",
+     "iopub.status.busy": "2026-09-11T00:22:57.976390Z",
+     "iopub.status.idle": "2026-09-11T00:22:57.982398Z",
+     "shell.execute_reply": "2026-09-11T00:22:57.982027Z"
     },
     "papermill": {
-     "duration": 0.009509,
-     "end_time": "2026-09-09T00:42:25.709261+00:00",
+     "duration": 0.008547,
+     "end_time": "2026-09-11T00:22:57.982881+00:00",
      "exception": false,
-     "start_time": "2026-09-09T00:42:25.699752+00:00",
+     "start_time": "2026-09-11T00:22:57.974334+00:00",
      "status": "completed"
     }
    },
@@ -503,20 +622,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
-   "id": "affaa403",
+   "execution_count": 9,
+   "id": "123366f6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T00:42:25.714570Z",
-     "iopub.status.busy": "2026-09-09T00:42:25.714348Z",
-     "iopub.status.idle": "2026-09-09T00:42:28.378077Z",
-     "shell.execute_reply": "2026-09-09T00:42:28.377488Z"
+     "iopub.execute_input": "2026-09-11T00:22:57.987429Z",
+     "iopub.status.busy": "2026-09-11T00:22:57.987349Z",
+     "iopub.status.idle": "2026-09-11T00:23:00.192513Z",
+     "shell.execute_reply": "2026-09-11T00:23:00.191960Z"
     },
     "papermill": {
-     "duration": 2.666912,
-     "end_time": "2026-09-09T00:42:28.378461+00:00",
+     "duration": 2.207629,
+     "end_time": "2026-09-11T00:23:00.192995+00:00",
      "exception": false,
-     "start_time": "2026-09-09T00:42:25.711549+00:00",
+     "start_time": "2026-09-11T00:22:57.985366+00:00",
      "status": "completed"
     }
    },
@@ -547,13 +666,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "232020f2",
+   "id": "1c2b1f3b",
    "metadata": {
     "papermill": {
-     "duration": 0.001626,
-     "end_time": "2026-09-09T00:42:28.382009+00:00",
+     "duration": 0.003068,
+     "end_time": "2026-09-11T00:23:00.199390+00:00",
      "exception": false,
-     "start_time": "2026-09-09T00:42:28.380383+00:00",
+     "start_time": "2026-09-11T00:23:00.196322+00:00",
      "status": "completed"
     }
    },
@@ -569,20 +688,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
-   "id": "e8a95261",
+   "execution_count": 10,
+   "id": "86ec02b0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T00:42:28.386090Z",
-     "iopub.status.busy": "2026-09-09T00:42:28.385924Z",
-     "iopub.status.idle": "2026-09-09T00:42:28.392932Z",
-     "shell.execute_reply": "2026-09-09T00:42:28.392447Z"
+     "iopub.execute_input": "2026-09-11T00:23:00.206376Z",
+     "iopub.status.busy": "2026-09-11T00:23:00.206249Z",
+     "iopub.status.idle": "2026-09-11T00:23:00.212371Z",
+     "shell.execute_reply": "2026-09-11T00:23:00.211839Z"
     },
     "papermill": {
-     "duration": 0.009589,
-     "end_time": "2026-09-09T00:42:28.393206+00:00",
+     "duration": 0.010187,
+     "end_time": "2026-09-11T00:23:00.212787+00:00",
      "exception": false,
-     "start_time": "2026-09-09T00:42:28.383617+00:00",
+     "start_time": "2026-09-11T00:23:00.202600+00:00",
      "status": "completed"
     }
    },
@@ -626,8 +745,9 @@
     "    \"model_class\": \"sklearn.linear_model.Ridge\",\n",
     "    \"ridge_alpha\": RIDGE_ALPHA,\n",
     "    \"source_case_study\": \"etfs\",\n",
-    "    \"source_config_name\": f\"ridge_a{RIDGE_ALPHA:g}\",\n",
-    "    \"source_feature_sets\": [\"financial\"],  # deployment dropped model_based\n",
+    "    \"source_config_name\": SOURCE_CONFIG,\n",
+    "    \"source_config_feature_sets\": SOURCE_FEATURE_SETS,  # what the alpha was tuned on\n",
+    "    \"deployed_feature_sets\": DEPLOYED_FEATURE_SETS,  # what this fit used\n",
     "    \"intercept\": float(model.intercept_),\n",
     "    \"coef_l2_norm\": float(np.linalg.norm(model.coef_)),\n",
     "}\n",
@@ -639,13 +759,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "aa86d857",
+   "id": "2e963aff",
    "metadata": {
     "papermill": {
-     "duration": 0.001571,
-     "end_time": "2026-09-09T00:42:28.396529+00:00",
+     "duration": 0.001692,
+     "end_time": "2026-09-11T00:23:00.217861+00:00",
      "exception": false,
-     "start_time": "2026-09-09T00:42:28.394958+00:00",
+     "start_time": "2026-09-11T00:23:00.216169+00:00",
      "status": "completed"
     }
    },
@@ -662,20 +782,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
-   "id": "fab8b6dd",
+   "execution_count": 11,
+   "id": "521b76be",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T00:42:28.400647Z",
-     "iopub.status.busy": "2026-09-09T00:42:28.400495Z",
-     "iopub.status.idle": "2026-09-09T00:42:28.425438Z",
-     "shell.execute_reply": "2026-09-09T00:42:28.425131Z"
+     "iopub.execute_input": "2026-09-11T00:23:00.221909Z",
+     "iopub.status.busy": "2026-09-11T00:23:00.221793Z",
+     "iopub.status.idle": "2026-09-11T00:23:00.245746Z",
+     "shell.execute_reply": "2026-09-11T00:23:00.245290Z"
     },
     "papermill": {
-     "duration": 0.030906,
-     "end_time": "2026-09-09T00:42:28.429032+00:00",
+     "duration": 0.026472,
+     "end_time": "2026-09-11T00:23:00.246047+00:00",
      "exception": false,
-     "start_time": "2026-09-09T00:42:28.398126+00:00",
+     "start_time": "2026-09-11T00:23:00.219575+00:00",
      "status": "completed"
     }
    },
@@ -698,7 +818,13 @@
     "X_live = live_panel.select(fc).to_numpy()\n",
     "preds = model.predict(scaler.transform(imputer.transform(X_live)))\n",
     "predictions = live_panel.select([\"timestamp\", \"symbol\"]).with_columns(pl.Series(\"score\", preds))\n",
-    "assert predictions[\"timestamp\"].max() == live_panel[\"timestamp\"].max()\n",
+    "# The live window must reach the end of the feature panel: a prediction tape that stops short is\n",
+    "# how a deployment silently scores a stale cross-section. Comparing against `predictions` itself\n",
+    "# would compare the frame with a copy of its own column and could not fail.\n",
+    "assert predictions[\"timestamp\"].max() == features[\"timestamp\"].max(), (\n",
+    "    f\"Predictions stop at {predictions['timestamp'].max()} but features run to \"\n",
+    "    f\"{features['timestamp'].max()}; the newest cross-section carries no score.\"\n",
+    ")\n",
     "print(\n",
     "    f\"Predictions over live window: {len(predictions):,} rows on {predictions['timestamp'].n_unique()} dates\"\n",
     ")"
@@ -706,14 +832,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0e8c741b",
+   "id": "3b290ce3",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.008675,
-     "end_time": "2026-09-09T00:42:28.443320+00:00",
+     "duration": 0.001726,
+     "end_time": "2026-09-11T00:23:00.249741+00:00",
      "exception": false,
-     "start_time": "2026-09-09T00:42:28.434645+00:00",
+     "start_time": "2026-09-11T00:23:00.248015+00:00",
      "status": "completed"
     }
    },
@@ -724,25 +850,32 @@
     "weighted, rebalancing every `REBALANCE_EVERY_N_DAYS` trading days. The\n",
     "`on_data` interface is identical to every other strategy in this\n",
     "chapter: receive the bar dictionary, look up the prediction frame for\n",
-    "the current timestamp, compute target weights, route orders."
+    "the current timestamp, compute target weights, route orders.\n",
+    "\n",
+    "Positions are sized against the broker's current account value rather than `INITIAL_CASH`, so\n",
+    "leverage stays constant as profit and loss accrue, and against slightly less than all of it.\n",
+    "`CASH_BUFFER` is what the order is sized on the current bar's close but fills at the next bar's:\n",
+    "an overnight move against the position, plus commission, makes a basket sized at the full account\n",
+    "value unaffordable, and the broker answers that by rejecting the last leg rather than by filling\n",
+    "it smaller."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
-   "id": "463780f7",
+   "execution_count": 12,
+   "id": "f1204976",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T00:42:28.451803Z",
-     "iopub.status.busy": "2026-09-09T00:42:28.451661Z",
-     "iopub.status.idle": "2026-09-09T00:42:28.459558Z",
-     "shell.execute_reply": "2026-09-09T00:42:28.458839Z"
+     "iopub.execute_input": "2026-09-11T00:23:00.254041Z",
+     "iopub.status.busy": "2026-09-11T00:23:00.253944Z",
+     "iopub.status.idle": "2026-09-11T00:23:00.258321Z",
+     "shell.execute_reply": "2026-09-11T00:23:00.257905Z"
     },
     "papermill": {
-     "duration": 0.014519,
-     "end_time": "2026-09-09T00:42:28.460219+00:00",
+     "duration": 0.007101,
+     "end_time": "2026-09-11T00:23:00.258589+00:00",
      "exception": false,
-     "start_time": "2026-09-09T00:42:28.445700+00:00",
+     "start_time": "2026-09-11T00:23:00.251488+00:00",
      "status": "completed"
     }
    },
@@ -758,11 +891,13 @@
     "        top_k: int,\n",
     "        rebalance_every: int,\n",
     "        symbols: list[str],\n",
+    "        cash_buffer: float,\n",
     "    ):\n",
     "        self.predictions = predictions\n",
     "        self.top_k = top_k\n",
     "        self.rebalance_every = rebalance_every\n",
     "        self.symbols = symbols\n",
+    "        self.cash_buffer = cash_buffer\n",
     "        self._bars_seen = 0\n",
     "        self.signal_log: list[dict] = []\n",
     "        self.rebalance_log: list[dict] = []\n",
@@ -788,10 +923,7 @@
     "        self.rebalance_log.append({\"timestamp\": timestamp, \"targets\": targets})\n",
     "        prices = {s: data[s][\"close\"] for s in self.symbols if s in data}\n",
     "\n",
-    "        # Size positions against the broker's current account value rather\n",
-    "        # than INITIAL_CASH so leverage stays constant as PnL accrues across\n",
-    "        # rebalances.\n",
-    "        account_value = broker.get_account_value()\n",
+    "        account_value = broker.get_account_value() * (1.0 - self.cash_buffer)\n",
     "\n",
     "        for symbol in self.symbols:\n",
     "            position = broker.get_position(symbol)\n",
@@ -833,13 +965,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b707df1e",
+   "id": "8099c520",
    "metadata": {
     "papermill": {
-     "duration": 0.0024,
-     "end_time": "2026-09-09T00:42:28.465122+00:00",
+     "duration": 0.001696,
+     "end_time": "2026-09-11T00:23:00.262063+00:00",
      "exception": false,
-     "start_time": "2026-09-09T00:42:28.462722+00:00",
+     "start_time": "2026-09-11T00:23:00.260367+00:00",
      "status": "completed"
     }
    },
@@ -859,20 +991,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
-   "id": "0cac3d9e",
+   "execution_count": 13,
+   "id": "af1b9466",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T00:42:28.473108Z",
-     "iopub.status.busy": "2026-09-09T00:42:28.472612Z",
-     "iopub.status.idle": "2026-09-09T00:42:28.536343Z",
-     "shell.execute_reply": "2026-09-09T00:42:28.535803Z"
+     "iopub.execute_input": "2026-09-11T00:23:00.266242Z",
+     "iopub.status.busy": "2026-09-11T00:23:00.266153Z",
+     "iopub.status.idle": "2026-09-11T00:23:00.338623Z",
+     "shell.execute_reply": "2026-09-11T00:23:00.338186Z"
     },
     "papermill": {
-     "duration": 0.069384,
-     "end_time": "2026-09-09T00:42:28.536837+00:00",
+     "duration": 0.075131,
+     "end_time": "2026-09-11T00:23:00.338993+00:00",
      "exception": false,
-     "start_time": "2026-09-09T00:42:28.467453+00:00",
+     "start_time": "2026-09-11T00:23:00.263862+00:00",
      "status": "completed"
     }
    },
@@ -881,9 +1013,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Backtest final value: $143,939.01\n",
-      "Backtest total return: 43.94%\n",
-      "Backtest signals: 80\n"
+      "Backtest final value: $145,736.79\n",
+      "Backtest total return: 45.74%\n",
+      "Backtest signals: 84\n"
      ]
     }
    ],
@@ -898,6 +1030,7 @@
     "    top_k=TOP_K,\n",
     "    rebalance_every=REBALANCE_EVERY_N_DAYS,\n",
     "    symbols=ALL_SYMBOLS,\n",
+    "    cash_buffer=CASH_BUFFER,\n",
     ")\n",
     "engine_backtest = Engine(\n",
     "    feed=feed_backtest,\n",
@@ -917,13 +1050,75 @@
   },
   {
    "cell_type": "markdown",
-   "id": "577c4c80",
+   "id": "c0c9f6fb",
    "metadata": {
     "papermill": {
-     "duration": 0.002979,
-     "end_time": "2026-09-09T00:42:28.543287+00:00",
+     "duration": 0.00177,
+     "end_time": "2026-09-11T00:23:00.342764+00:00",
      "exception": false,
-     "start_time": "2026-09-09T00:42:28.540308+00:00",
+     "start_time": "2026-09-11T00:23:00.340994+00:00",
+     "status": "completed"
+    }
+   },
+   "source": [
+    "The replay is read below as the deterministic record of what the deployment would have done, so\n",
+    "an order it emitted and the broker refused has to stop it being read that way. The same four\n",
+    "buckets the live leg reports apply here: a signal the strategy logged is intended, and only a\n",
+    "filled order is accepted. Sizing every leg at the full account value produced eight rejections\n",
+    "over this window before `CASH_BUFFER` existed, and nothing in the notebook looked."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "6c6fe745",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-11T00:23:00.346841Z",
+     "iopub.status.busy": "2026-09-11T00:23:00.346762Z",
+     "iopub.status.idle": "2026-09-11T00:23:00.349546Z",
+     "shell.execute_reply": "2026-09-11T00:23:00.349089Z"
+    },
+    "papermill": {
+     "duration": 0.005267,
+     "end_time": "2026-09-11T00:23:00.349799+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T00:23:00.344532+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Offline order dispositions: {'FILLED': 84}\n"
+     ]
+    }
+   ],
+   "source": [
+    "order_status_counts: dict[str, int] = {}\n",
+    "for order in engine_backtest.broker.orders:\n",
+    "    name = order.status.name if hasattr(order.status, \"name\") else str(order.status)\n",
+    "    order_status_counts[name] = order_status_counts.get(name, 0) + 1\n",
+    "print(f\"Offline order dispositions: {dict(sorted(order_status_counts.items()))}\")\n",
+    "unfilled = {k: v for k, v in order_status_counts.items() if k != \"FILLED\"}\n",
+    "assert not unfilled, (\n",
+    "    f\"The offline replay did not place the basket it logged: {unfilled}. \"\n",
+    "    \"A rejected order means the reference tape and the strategy's own signal log disagree, \"\n",
+    "    \"so the reconciliation below would compare an intended basket against one never held.\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "545db439",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001761,
+     "end_time": "2026-09-11T00:23:00.353424+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T00:23:00.351663+00:00",
      "status": "completed"
     }
    },
@@ -941,34 +1136,34 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
-   "id": "b88bfa12",
+   "execution_count": 15,
+   "id": "cb7a92ae",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T00:42:28.549461Z",
-     "iopub.status.busy": "2026-09-09T00:42:28.549245Z",
-     "iopub.status.idle": "2026-09-09T00:42:28.682531Z",
-     "shell.execute_reply": "2026-09-09T00:42:28.681945Z"
+     "iopub.execute_input": "2026-09-11T00:23:00.357527Z",
+     "iopub.status.busy": "2026-09-11T00:23:00.357460Z",
+     "iopub.status.idle": "2026-09-11T00:23:00.479943Z",
+     "shell.execute_reply": "2026-09-11T00:23:00.479522Z"
     },
     "papermill": {
-     "duration": 0.13652,
-     "end_time": "2026-09-09T00:42:28.682853+00:00",
+     "duration": 0.125116,
+     "end_time": "2026-09-11T00:23:00.480387+00:00",
      "exception": false,
-     "start_time": "2026-09-09T00:42:28.546333+00:00",
+     "start_time": "2026-09-11T00:23:00.355271+00:00",
      "status": "completed"
     }
    },
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAkgAAAFVCAYAAAAUvhB3AAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjksIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvJkbTWQAAAAlwSFlzAAAPYQAAD2EBqD+naQAAq4JJREFUeJzs3XV4E0sXwOFf6i64lALFpRR3d3d3u9jF3d3dubi7u7u7u0NpKVb3Jvn+SBsIFeqFj/M+Dw9tdnb37GazPZmZnVEEBQWqEUIIIYQQWnpJHYAQQgghxO9GEiQhhBBCiJ9IgiSEEEII8RNJkIQQQgghfiIJUhQ2btuLjZ0Tl6/dStD93H3wmDLVmpI+e3GmzFpCUFAwXXoNwz5XKYpXbMC6zbuwsXPizPkrAAwfN4PchasQEBCYoHHFxflL17Gxc2Ldpl2Jts+37z9Qo2F70mUrRq+BY39Z3rF4Deo17xKnfYZdI0n93gQEBJK7cBWGj5sRq/XPnL+CjZ0TG7ftjefIEkf1Bu1wLF4jTtuwsXOK1nUTU3sPniBjntLcuHUv3rcd32zsnOjSa1i8bnPKrCXY2Dnx6vW7eN1uTLx9/wEbOydmzFuWZDGIP89fnSB17zcKGzunCP+dv3Q90eIYNWE2z168ZsKo/tStWZld+46wbfchateoyJhhfdDX19cp37NLW9Yvn42JiXGixfgnmDF3GZev3WbYgB60bdFQZ9mq9duwsXNK8BiS6r0xMTFm/fLZ9OzSNlH3KzQ69hhMrcadIlxWqXxJNq6YS768uQA4cfoiNnZOvH3/ITFD/KtE9X4IEV0GSR1AUurasSW1qlVAqVTRrusAypQsQteOLQHInTMr75xdEiWON++cyZsrOx3bNAVg/+GTAPTp3oEc2RzCfatPlzY16dKmTpTY/iRv3jmTMkUyenVrF26Z26eviRJDUr43hQo4Jsl+RdTXl4W5GaVLFP5e9vOXxAjpr5ZYn3fx/+2vrkHK75iL2tUrUqtaeQDs0qeldvWK1K5ekeTJbLXlrt+8R7X67ciQsyQdewwmODgYAKVSyeyFK8lbrDpZncozdMx0goKCw+3Hx9ePQSOnkKNgJXIUrMTgUVPx8fUDNM087967cPPOA2zsnOjebxRTZy8BoFiFBkyZtSTc9sJqvkJCQgBNtfjM+cvp3m8UDo7lKF6xAfcfPdWWf/LsJfWad8EuRwnK1WjO9Zvhq/rDmoqu37xHycqNady6R5TrhlVZT539H/Wad8E+VykatOyKi6tbhOf6ybOXdOk1jLzFqmOfqxSd/h2Ct48vnl7epM1ajP7DJmrLbt99CBs7J548e6mzjaCgYKbMWkLeYtXJnLcsXXoP5/MXzY2wVuNOXLh8g89fvoWrAezebxTT5vynPVc/frMMDAxk1ITZ5CxUmbzFqnP2wtUYnbeo3psO3QeRKU8Z7fsUEBBI+uzFGT1xTrS2r1KpyOpUnqZtewLg+vETNnZOlK3eDNBcf3Y5SjB0zHTtsYU1j4S9nyfPXKRK3TZkyFmSTv8O0V67arWaRcvXk7twFfIUqcqm7ft09q1Wq1m+ZgsFS9fBPlcpWnTsw5u3zgAsX7MFGzsnbt15AECfweOxsXPi0LEzAMxfsgbbDPlxd/eM9DyFhISwYu1WKtZqiV2OEhQsXYfDx89olzsWr8GgkVMYNnYGOQpWwrF4DZ335s07Z+q36EqGnCVp0uZfvn7zCLePmJ4/AE8vb3oNHIuDYzmKVfj+Ofrm7sGYSXMoVqEB6bIVo1r9djx/+UYb68UrN7h45QY2dk7hPrM/NsNOmbWEf/uPBsCpRM0ImwUvXrlJ2erNSJ6xoLZGO3fhKoCm9qlhq244OJYje4GK2uv6+KkL2Ng5se/QCe12eg8aR/YCFVEqlfj7BzBywixyFKxEniJVmTl/OSqVKsL3xtXtM60798M+Vykq12nNoyfPAfDz92f2wpWUqtKEdNmKUapKE67dvKtdz93dkz6Dx5OzUGWy5CvP4FFTUat1h9lTqVQ0bduTrE7lI/wCunv/UUpUaohdjhLUadqZew+faJfVatyJNv/0Z8a8ZTgWr0H2AhXZtutguG1E9X64fvxEu64Dsc9dmkq1W+Hs8lG77PDxM5Ss3Bj7XKVo1r4XH90+62z38dMX2Ng5MX/JGuD7fSqsWftW6D38wJFTUV4v1Ru0o2j5+tpz4+Lqho2dEyvXbYvw/RBJ569OkKJr2erNNGlQkxJFC7Jr31GOnDgHwMKl6xg/dT61qlVg2IAebNq2l2VrNodbv+/g8azbvIsenVvTvVMr1mzcQf+hEwCYN20UKZLbkj1rZjasmEOf7u1pWLcaALMmj6BRverRinHyzMUks7WmV9e2PHn2iskzFwPg4elF/RZdcfv0mQmj+mNvl46Wnfrg5+8f4XZadupD0wY1Gdq/W7TWXbRsHeVKF2NQny5cvHKTfj8kOj9y/vARXz9/BvfpQuP6Ndi59wj/rdyItZUldWpWYv/hk9pE4uiJc+TKkYWc2bPobGPq7CVMn7uUZg1rMXxgD46ePEfbrgNRqVSMHPwvuXJkwdbGmg0r5pA7Z1btel07tqRksUIAbFgxh5GD/9Uuu3L9Dt88POjdvT3u7h4MHzczVuctIvVrV8PD04troYnPhcs38PXzp37tKtHavp6eHmVKFuH6rXuo1Wqu3biLibExDx49w8vbh0dPX+Dj66dTO/GzPoPH06xRbUoULcjOvUe01+6+gycYMW4mhQo4MnJILz646Ca2azfuZNDIKZQrXZSJowZw/8ETGrbqjp+/P2VLFQXQ/nG8dvMOJsbGXLl2G4CrN+6QJ1d2bG2tI41LX1+fM+evUKViGcaP7IdaraZrn5HaLw6gScS8vL3p06MD3765a98bpVJJq079uH3vIWOG9aFIoXw4f/gYbh+xOX/7D5/EysqCXl3b8vT598+RUqnkxu0HtG/VmMF9u3L/4RMGjpgMaD7DtjbW5MqRhQ0r5kT5mW1Urzr1ammSnblTRzFv2iid5T6+frTq1Be1Ws3UcYPJaJ+e3DmzMX/GWABu3L6PQyZ7xo/sR64cWZkyawmXr92iXOli2FhbcezkeUCTiBw9eY66NSujr6/PyAmzWLpqE+1aNqJb51ZMmbWEA0dORRjjleu3yZ41M2OG9eH5qzd0+ncIKpUKPYUeZy9cpUn9Gowe2ptPn7/QtfcI1Go1KpWKNl36s3XnATq1bUqf7u3Jmd0BhUKhs+0ps5Zw6txl1i6dhb1dOp1lp85eokP3wWTP6sC0CUP5+s2Des268Onz99qg/YdPcuvuQ/p0b49CoWDwqKkolUqd7UT1fmzctpfcObPSrkVDbt55wIL/1gKaa7llx77YpUvD5LGDeP/ehb6h9+gwObNnIWWKZN+v+xs/X/d3USgUlCpWKMrrpWXTejx78ZrHT18AcOzkefT09KhTo1KE74dIOn91E1t0zZk6iioVS5Mvb06OnTqv/SawbPVmypQswrAB3QG4eOUGB4+c0ukH8s3dgx17D9OoXnX69OgAwJ37j9m2+xDTxg+lYrmSmJqakszWmtrVKwKQLUtmACqUKY5DZnuuR6NzZ71alZk0eiCguQk8f/EagH2HTvDR7TOLZ4+nYP68FCrgSNlqzbh+8x7lShcLt52eXdpq41y3eVek62bKaAdA25YN6d9TUyNz+vxljp+6oK2l+FHlCqWoVL4kT5+/wtTUhPVbdmtrTFo1q8e2XQe5ePUmpYoV4sSZi3Tr1EpnfZVKxfI1WyhcwJFRQ3oB8N7Zlfn/reHew6eUKFqQZLa2eHp6a89jmPyOubBLp2n2+nlZofx5WTRrPAAnTl/gwuUbsTpvEalasTQW5mYcPXGWksUKcuTEWTLYpaOAUx7Wb9kdre2XLVWU3fuP8eLVW67evEPlCqU4fPws12/e5e37D9obcmQiu3bXb9mNjbUVyxdMwcTEGFsbKy5euaFdb9nqzaROlYLZU0aiUCgICg5m4IjJnDh9kTo1KpE6VQqu37pH88Z1ePz0JQ3qVOXytVuo1Wqu37pHw7pRJ/YKhYINK+bg5e3D7XsPyZs7O/sPn+TZ81cUzJ83yvfm9t2HPHz8jPEj+tG5naY26NCxMxHWIsX0/NWvXSXCz1HKFMk5uGMlLq5u3H3wmAx26bh+8y5qtVrzGTYxJpmtbbjr62fZs2YmW5ZMAFQoV4KMGdLrLH/x8g0enl7MnDScxvVr4O3jy9zFq6lcoRQAQ/t3Izg4mDv3HlO0kBNnL1zl+s17lChakDo1KnH05DlUKhV37j3C7dMX6tXSPDCwZuNOmjasRY9/WgOw/9BJDhw5Rd2alcPFWL1yOUYP7Q3A/YdPWLNxJ2/ffSBzpgzs3bKMr9/cuX33EVmzZOLy1Vt8/eaOs4sbFy7fYNiA7gzqE/GDDwePnWbGvGVMHTeYUsXDX7NLV2/GwMCAhbPGYWlhTsrkyWjarifbdh/U3lNTpUzOppVzUSgUPHj0lDUbd/L5yzfSpE6p3U5E70dYf69uHVsypF83bQ3m85ea93fF2q2YmZqwcNY4jIwM8fPzZ8joaQQFBWNkZAhortmypYpy4fIN1Go1V2/epUbVcuw7dBIfXz+u37qr88UgsuulQZ1qDB09jd37j5E7ZzaOnjpPyWIFSZUyeZTXjkh8kiBFg6Gh5jSlCG12CwwMIigomA+ubnxwdSNTnjLaslkdMuqsG9Ys4RTaQROgQL7c7DlwjDfvnKP8lh2jGA2+v5UpktvywfUTAG/faW4MDVt11yn/+cu3CLfj5Pg9zqjWDUuQfvyGmCNbFk6dvYyHp1e47T5++oLOPYfx9PkrCuTLjaGBAV7e3gCUKVEE+wzp2HvgOMZGRpraldpVdNb/5u6Bt4+vTnwFnHJr4nzrTP4fXo+JsPcWNO9vWBNpTM9bRExNTahRpTxHT55j7PC+HDlxjvq1q6BQKKK9/bIlNbU112/d49qNu1SvUo5nL15z+fptPri4/bKmJqJrF+Cdswt26dNG2pn8zTtnSpcoon1/C+QLPdfvNElF2ZJFuXrzDjdu3cfY2IiaVSvQo/8onr98w6fPX6Os1QJNE97E6QtZvHwD1taW2iZtL2+fcLGHxR/23oQ1zThkto9yHxDz8xfZ58jL24dufUdy5PhZsjpkxM8/AD//AJRKJQYG8XcbzeKQERNjY/YfPkmeXNk4fvoC6dOm0i7fc+AYQ0ZPw9fXjzy5smtjA2hYtxrrt+zmzr1HHDlxjpQpklGyWEHevHVGqVSyefs+Nv/QlGphYRZhDD9/pkHz+UufLg0Dhk9i8479pE+XGiNDTeLg5eXDm7fvAXDMkzPSYxs7eR4Q+Wfo7TtnsjrYY2lhDuh+vsMY6Otr40uRPBkAgUFBke7zZ4ahMRsYGGBrY0Vg4PfPu6+fP9kL6Ca439w9dJKvsiWLsnPvEZ4+f8WDR88Y2Psfdu8/xs3b97l+6z61qlUAor5eLC3MqVe7KnsPHmdg7384e/4KE0YNiPYxiMQjCVIsGRkZki5NKtKnS6P9tgWaDpk/Cksk7tx/pH3t9j3Nz5ns7RI8zrBvqHOmjiSrQybt6z82QcVm3R+bQsI8e/4KSwvz0BvXK51lA0dMQV9fj9cPzmFpYa7T90JPT4+WTeqxduMOUqZIHmHzWjJbGywtzLlz74fzeFfzc8aMvz6PeqFPAgYEBEbrCbO4nLcfNahbje17DnH63GWcP7hSP7R5Jbrbd8hsj126NNx/+JSHj58zfGAPnr14zb37T3D7/OWXiUhkUqVMztUbd/D3D8DU1CRcX5FM9nbcuf8ItVqNQqHQXrMZ7TVxly1dlO17DnH52i2c8uaicAFHgoND2L770C9rtUDT3DhrwQqWL5hC4/o12LR9n7Zvzq9jTwHA3fuPtTUEP8cfJr7O36Jl6zl15hI3zu7FIbM93fuN0kk29PT1CQyM3tAOenqang1hyeqPLC3MaduyIctWb2bvweNYWVqw5j9NH5eAgEC69hlBq6b1mD5hKB9c3XAqUVO7bpmSRUiR3JaTZy9x8oympk9fX5/06dKgp6dHjSrldGpmkyez+WWsz15oPscOmezZvucQ67fs5uietRQrnJ8ps5Zo+0CFNZc9ePSUmlXLR7itcqWLkt8xN/P/W0OTBjXDfcYz2ttx4vRFvH18sbQwj9Hn+2cxeT8AMmZIx8PHz9iwYo7OU8MpktvqlAur3d2x5zAKhYJK5UuSPm1qzl++zntnF+319KvrpVXTemzevo+tOw8QEBgkzWu/KemDFAed2zfn+q17bN15gLfvP3D05Llwbe7JbG1oXK8GB4+eZt7i1cxdtIpDx07TtEHNaNcepUuj+QYZ1sQQE3VqVCJVyuQsXLqOO/ce8fDxMy5cvqHTCT0u6+49eIJV67cxfup8Tp69RJsWDVAoFN9jvnIDlUqFv78/X758Y9+hEwwYPon3P3XQbNGkDq5un1m9YTv1alUNF4uenh7/tG/OzTsPmDBtAcvXbGHt5p2UKFqAfHly/PJYwpLRaXP+49zFa/Fy7PDr96ZSuZJYWVkyetJc7NKl0TYfRXf7CoWCMqWKcujYafwDAijolJfCBRy5c/8Rz56/jnWCVK9WFYKDQ+g3bCLrt+xm/NT5Osu7dGjBp89f6T9sIus27WLuolU4ZLLXNvWUKVkEgB17D1OogCOZMtqRzNaGbbsP6tTK7Nx7mIKl63Dl+m2d7fv7BwBw+dot1m7cyaz5K6Ide+ECjqRLk4q1m3ayduNORk6Yxb0HTyIsG1/nz98/gIDAQI6dOs+sBSs4EPqkaZhM9um59/AJG7bu4cGjZ1FuK+xL07wlq7V9hsL4+fuzct02WjSpy4BenZkxcRgpUiRDrVYTHBJCcHAIT5+/ZtvuQ/QdMl5nXQMDA+rWrMzufUe5dfehtq+TiYkxbVs04Nip8xw8epq37z+w7+BxrKwsI4zvwuUbLFy2jnmLV7Nx217q1KiEra219j07cfoiS1ZsZPWG7dp1nBxzUdApD3MWrmL2wpWs27SLoWOm6ySuU8YOZkDvzqRMnoz+wyaFS2q7tG+OUqnk3/6j2bhtL2OnzMPG2oom9WsSUzF5PwA6tm2Kr5+mE/rLV2+5fO0WLq5u4WoHM9qnxy59WrbvOUTunFkxNzOjUAHHcF8MfnW9lCxWkEwZ7Zg4Y6E0r/3GJEGKg97d2jF2WB8uXLnB4JFTuHz1lk4TQZg500bRpnkDFi5bx+IVG2jXoiGzp46KYIsRK1rYiby5c7By3bZwHRJ/xdbWmn1bl5PRPj3T5y5l3uLVfPn6LcKn7WKzbo6smVmzcScr12+jXctGjByseWLIIbM95UoX48Dhk7h9+sL4kf0xNDJkzKQ5GBkZUb1KOZ19ZcyQnrKlivLp89dwzWthhvbvzsDe/7Blx34mzVhE1QplWLdslvYbeVQ6t2tK6RKFWbpqE3MWrYyXY4dfvzfGxkbUqlaBB4+eUrdWZW2sMXlfypYqytt3H8iWJRM2NlYUKZiPT5+/EhAY+Muamsi0b9WInl3bcvzUBeYuWkWnts10lrdr1Yhp44dw+vwVRoyfSZ7c2dm1cQlmpqaAJuHMaJ+et+8+ULhAXhQKBUUKOvL23QedpCMgMIj3H1zYe/CEzvYrlS9J04a12LrzAOu37KZ3BEMzRMbExJiNK+eSLm1qRk2czQeXj9oHGyISH+eve+dWFC3kxKQZi7h554G271OYscP6YG+XjmFjprP34PEot9WgdlVqV6/Inv3HGDt5rk6fPTNTU0oVL8Se/ceYtWAFXfuMoGy1ZnTuORRLC3MmjxnIw8fPmDF3GXVqVCJlimS6265TjUdPX5DM1kann8+UsYPp3qk1Bw6fZOjoaTx5/gp3j4ifMmzRpA6Hj51l1oIV1KxagXnTNTV7zRvXoXL5Uixevp7Dx8/o9LXU19dn06p51KhajgX/rWXKrMUYGRpqH7wATfOluZkZ40b049LVm+GGL6lUvhSrFk/j6fNXDB45BVsba/ZuXUbqVCmiPJ8Ricn7AVC8SAE2rZqLu4cnw8bOYOvOAxHeyxUKBeVKFw297jXDahQpmI+37z7ofDH41fWiqTWvy6fPX2lQJ/JrVyQtRVBQYMR100JE4e37DziVqMnA3v9ok6K4atq2J1++fuPUwU3xsj3xe2jVqS8F8+dlQK/OSR3Kb+/E6Yu06Nib+1eOkCZ1Snz9/OjccxgXL9/g3eOLSR2eiEfzl6xh6uwl3L18iJQppAbpdyR9kESSu//oKXv2H+PYqfPs3SJTAfw/GT91PvcePmXutOjXmP7NnD+4EhwcwuSZiylRrCAvX7/l7Pkr1JY+Kv83XFzdOHDkFLMXrqRHlzaSHP3GJEESSW7Bf2s5dvI8A/v8E+1H6MWfoViR/HTv3Er+CERT88Z1uP/oKXsPHmfrrgPYpUvDv13aaofSEH++46cuMG7KPCqWK0mf7h2SOhwRBWliE0IIIYT4iXTSFkIIIYT4yV+fIDVo25dmnQbSqutQOvcZw+nz1yIdU+VHPQZNxPXj51+Wi62goGAGj5kd4ejAMS136+4jJsxcqv39xp2HzF+WuB2hJ8xcypZdR+K8nZ+P5eCxcwwZOyfO242N6O7752ulQdu+PHv5Nlb7XLF+J3OWrI/VujHZVoO2fWO93Z/fo4SycftBjp76fToux+We8ON78fLNe8ZNDz8H4+/C9eNnqjT8Plr2ivU7OXjsXBJGJETCkD5IwIThvcieJSPvnF0ZMm4OIUolVcqXSNKYjIwMmT6uf7yV+1Hh/HkonD9PbEMT4rfQqkmtpA4hQWTJlIExg7v/uqAQIkFJgvQDe7u09O7SioUrNlOlfAnUajVrt+zj8IkLqNVqalQuTYeW9Zkwcyn3Hz2n/6gZ5M6RhVEDu/Lg8QtmL16Hr58/aVOnYPSgbiSztabHoInUqFyGfYdPU7lccSzMzbh97zFKlYp7D5+RJ2cWmtavzor1O3n24i0dWtWnST3NQIlVGnZh3eJJpE2TkgZt+9K5TUMOHjvHqzfO9OjYjLo1KuiUS5UyOdPmr+TG7UcYGurTvkV9MqRPw/gZS/HzD6Bt9+EM7t2Rr+4ebN19hMUzRgJw9NRF1m87gJ5CQSb79Iwd0l1nbKEaTbvTtX0T9hw8Rf8ebUmXJiXT56/m3YePGBkZMrhXB/LmysqK9Tv56PYFd08vPrh+xi5dakYN7Iq1lYXOeX773oWFKzbz+Ys7vn7+dOvQlEplizF+xn/kzpGFxnU14yCt3LAbtVpF5zaNAHjw+EW4YwHw9vVl8pzl3H3wFCtLS2ZNGIiVpTkTZi4lR9ZMnL5wnbw5s/Jv5+bsP3qWLbsOgxpyZc9M3+5tsDA3Y8X6nXj7+NGvexsAhoydQ9mShahVtSw37zxi9uJ1ePn48uWrOxkzpKNb+yZR7jtMRNcKwPnLt5i/dCMvXr+je4dm1KupeS8PHD3Lxh0HUSpVFCmYlwE92oYb5+mdsysDR8/C2cUt9Bx3wdrKksvX77Juyz58/fxBoWDs4O44ZLKL9D3+0dWb91mwfBP/zRrFiInz+ej2hbbdh1OiiBPdOzbj4tXb/Ld6O0HBQWRzyMjIAV0wNDSM1vWWN9f30cGj+pxUKluMc5du8vzlOxrVrUyn1g0B2L73GJt3HsbXzx9fP38cMqZn+rj+bN55GEsLMzq3acSK9TsJCAzCxfUTj5+/xiGjHdPG9MXAwIAvX90jvF4jE9Vn7f6j58xfthE//wCS2Vgz4N92ZLJPF+n7HNX1HplnL98yZNwcdq+bS8deo+nesSlFCmgGGJ04cylOjjmpXbVshPemH/18/ffo1CzCdb5+82Dk5IV8+eqOmZkJw/v9Q46smShRrTXHdi7F0sJcJ6Yfbd97jG17jmFmasLW3UdYtXACBj+MRC3En0wSpJ/kyZmVd86uhCiVnDx7lbfvXdi4dApqNfQeNpWSRZwYNbArt+49ZvaEQaRNkxJvH18mz17OnEmDSZ0qObsPnmTtlr30664ZSO3g0bMsmj4CIyNDDh47x817j1k8fQS2NlY06aCZg2fGuAHcf/ycQaNn0bhulXAjcgN8dPvCoukjuHDlFtPnr9betMO8ePWWMxeuc2jrYoKCQwgMDMLWxop/2jbi1r3H2pv22UvfR32++/AZi1duZdmcMaROlZxv7p7h/iB7eHrj7OLG6oUTUCgU9B0+jeYNa1C8cD7evPvA6KmLWbd4EgAfXD8xfVx/LMzNGDV5Ieu37adn5xY627OxtqJn5xZkzJCOew+fMXTcXCqWKUqz+tWYOGs5jepoJtA8fuYysycO1K6XN1fWcMfy9r0Lrm5fGDmgC6lSJKNLv/GcOn+V+jU1U1Ds2HeclfM1k1/euf+EtZv3snzuWGysLZm9eB0Ll29maN+onxCavmAV/7RtTKWyxZi5cA3JbG0oX7oIB4+di3LfQLhr5Ts1C6YN076X9WpW4O7DZxw5dZHVCydiaGDA+Bn/ce7yTcqXKqITT0BAoM45Xrd1P73+aUm6NCmZOqYf1lYWrNm8l5UbdjFpZO9fvsdv37swc+Ea5kwajIW5GfOmDKVEtdasWzJZ+54uW7eDRTNGYGlhxn+rt7H70CkKOuaM1vUW5lefk6cv3jBr4iDevP1A+39H0qpxLXx8/ViwfBM7Vs8ima017XuOol+PtqSJYPDAm3ceMWfSYEyMjWjScSA37z6mWCFHJs5aFun1GpmIPmte3r4MHT+X6WP7kSdnVk6fv8bQ8XPZuHRqFO9z5Nd7RJ/xn9WoXJpT565RpEBegoNDuHLzHn27t+HY6csR3ptyZMuss/6P1//RU5ciXOfWvceYm5myeMYIvn7zwPKHBP9XmtSrypPnrymYLxe1qpaN9npC/AkkQfqJWq1CoVCgQMH5yzd5+PQlHXtpRpL18w/A1e1LuJvQg8cvcPvylUFjZgGgVKrInPH7LN1NG1TXzggNkN0ho/Ymmj1rRooVyoehoQH5cmfDzz8AXz//cHO6AZQpUQiFQkHeXNn4EkGfo4z26cmZzYHRUxfTqnFN8kRj3rALl29Ro3JpUqfSPIadLJLpT1o3qY1CocDPP4Abtx/yzd2TxSu3AJo/fNpjy5pJO9lkmRIF2XPwVLhtWVtZ8NHtM0tWbeXNOxfcPb3w8/MnR7bMWFiY8ejpS/T19Ulua62dyiMq2R0yasvlyuGg0x+rXo0K2nguXL1NlQolsLWxAqBp/Wp07T/+lwlS6pQp+ObuSXBwCF7evjpzWEW176hE9F5euHyLt+9c6NJ3LKAZhTp3DofwxxvJObZLl4arN+9x5cY9Hj97RVDoCM1RvcfePr4MHjubutXLY5cudYSxXr1xD7dPX+k5WJNUBAWHULJo/hhfb7/6nJQqVgADfX2yZM6AoaEh7p7e2FpbYmJsjLunNyYmJgQEBBJZWpEvT3ZsrDXTZ2TPYs+Xb+6/vF4jE9H78+DxczKkS609zgplijLnv/W8/+BKJvv0kW4rsuvdPILP+M8qlytO260jGKBUcu3WfZzy5MDC3Cza96Yfr//I1ilZND8Hjp5jwfLNNK1fFWMjo1/GJcTfQBKkn9x/9IJMGdKhr6+HWq2mRcMaNK0f9VDwarUau3SpWbso4m+l+vqR94U30P/+FoTN+/OrTuIGBhFXYZsYGzF/6lDuPXzGopVbyJzRjkE920e5LZVahYHi11XiPx6DGnVobULU3zT19fUjnBh276HTHD5xng6tGtCuRT0q1e+MKvSYmzWoxr7DZ7C0NKdm1TK/jOtnBvr6OudPP4rqfoVCof0Wr1AoCIlkGpeaVUqzbst+dh88Sa7sDjRvWCPCcj/vO1rx/vBeqlFTuXxx+nRtHe31fzzHE2b+h7GREXVrlKd0sQIsXLEZiPo9PnLyIt07NGXv4dPUrVEhXHNoWFz5HXMydXTfcMticr396nMSRqFQaM6LWo2JiTHlSxdm2rxVBAYGUbtaOZzy/nruPQN9A1B/jz8612uE24nks6aNFQVEmrJpRHW9/4qtjRU5s2Xi1t3HnDp/jeqVNHPhRffe9OP1H9U6a5dM4syF6/QcPJl/2jamWsWSAISExGxqIyH+n/z1T7H96M07F+Yv20j70Lb80sULsm3PUW2tgMvHT9qyaVKlwNVN88RKnpxZcfv0lVPnNZOg+vr54+7hlaixg+bpEpePn8iXJzttm9Xl0rU72lg/un2J8I93ySL5OXLyAp+/ugPw/sPHKPdhZmpCgXy5WL5uJyqVCqVShavbF+3yj25fCA4OISgomD2HTlGyaH5A8ydErVYBcOHqLSqUKUqxQo68fP1eZ/tlihfi8fPXXL5+lwqli4bbf1TH8iulixXg+OnLeHh6o1ar2b73KGWKFwQ0M5s/fvqSwKAgXr1x5uHTF9r1Dhw9x7B+ndm8fDqjB3XDzNQkRvv98VqJSqliBTh0/ALvnF0BcHX7glKpClfuo9sXQkLCn+PzV27RuG4VcufIwuPnr7Xlo3qPq1YoQZtmdahfqyLzl238Iebk2ieyihZ05PqtB9x/9BwAdw8vTe1DDK+32HxOQpRKzly4zrI5o9m4bCrtW9SLVtNUmF9drzGRN1c2nF3dePjkJQBnLl7H1NSEDOnTAJG/z1Fd72EUCkWk13T1SqU5df4q9x89p3hhJyDqe1NkIlvn8bNXBAYGUblccSqWLca1W/cBSJHMhrsPnhKiVHL4xA+T6ioUqNTfr8voXt9C/GmkBgkYNXkB+nr6mJqa0KNjM8qX1vT5qF6pFJ+/fqPHoIkYGxmRMkUyJo3ohYmJMfVrVmTUlEUUzJeLCcN7MmPcAOYt3cDK9bswNjbk304tKJQ/d6Ieh6+fPwuWb+KbuxeBQUH06doKAMfc2QgKDqZllyH07dZGZ51C+XPTtnldeg+dgqGhIZkypGN4/38wMY68mn3M4O7MXLiGFv8MwdjIkFpVy9KsQXUA3D296DdiOp++fKNEkXw0qKXpj1O0kCMr1u+iUZ0qNK5blUUrNnPy3FWKFsxL6h9mstbX16NUsfx8/uIeYSIS1bH8Sn7HnLRrUY9/B08CNeTMnpn+oZ2yK5YpxsFj52naYSBFCzlS7od+P455sjF47GxSJLPF2Fhzjjq0ahDt/f58rUSmgGNOev3TgiHj5mCgb4C1lQVjhnQnZXJbnXImJsb0HR7+HHdq1ZCRkxeQKkVyihfOpy0f2XsMYB06o3vzBtVp33MUV2/ep1ghRxrVqUKX/uOpVLYYfbu1ZtzQf5k+fzVq1JiZmjCkT0fUKnW0rrdihRxD92UR48+Jgb4+DhntaNpxEBbmplhamJMjW2a6tm8c7fMf2fV6/Mxlbt59xNA+0Rul2srSnCmj+jJnyToCAoOwsbZk6ui+2trVyN7nqK73MAXy5WLy7OW0ahz+ybzSxQswc+EaKpYpiqGh5pYd1b0pMpGt4+r2hZkL1+Ln74+piQmjB2n6jv3TthGT56zAfnsaWjetzZmLmr6LqVMmwz59WrbvPUaTelWpVLYYA0bP5NK1u8ycMIBkNhE30wvxp5GRtEW8+flJsNjwDwiga7/xjBv6r07/lKTiHxBAm27DWbdkMmamJvj5B9Ct/3jq16xIw9DO5CLh3L7/hA3bDjBzvOZhBmcXN1p3G8baRROj7PcTHUFBwfQaOoWls0fHR6hCiP8zUoMkfhsHjp5l1cY9tGpS87dIjgBMjI0pVSw/PQdPIig4hJAQJaWK5ad2tXJJHdpfIWOGtBgZGtKh5yiCQ0LQ19dnQI+2cU6OABat3EzX0OEahBDiZ1KDJIT4K6nV6hj1ZxJC/F2kk7YQ4q8kyZEQIiqSIAkhhBBC/EQSJCGEEEKIn/y1CZJarSYkJCRW4+kIIYQQ4v/bX5sgKZVKytRqjzKS0ZOFEEII8ff6axMkIYQQQojISIIkhBBCCPETSZCEEEIIIX4iCZIQQgghxE8kQRJCCCGE+IkkSEIIIYQQP5EESQghhBCx5uHh9X85pqBBUgcghBBCiD/Tzr2H6fTvUObPGEPbFg3jtC2VSsXRk+e4//ApXt4+eHp64+PrS/XK5WjWqHY8RRx9kiAJIYQQIsbUajWd/h0KwPwla2KdIKnVao6ePMekGYu4//BpuOW79x/D08ubLh1axCnemJIESQghhBAxduL0Re3PqVKmiPV2Fi5bx6gJswHIktmeFk3qkjyZDVaWFnz6/I0R42cydMx0qlcph71dujjHHV2SIAkhhBAiHJVKhZ5e5F2VV2/cof35g+vHWO1DqVSyZPkGAGZPGUHbFg0xMNBNTe49fMLm7fs4ffYy7Vo1itV+YkM6aQshhBBCx+BRU8lTpCof3T5HWubm7fvanz+4uMVqbtNTZy/j8vETTo656NimabjkCKB86WIAnL14NcbbjwtJkIQQQgihY9nqzbi6fWbKrCURLnf9+Am3T19InzY1WTLbExISgmsUyVRkwmqhWjerH2mZsqWKAnDu4jVUKlWM9xFbkiAJIYQQQisgIFD784Ejp3R+D3Pn/iMAnPLlxj6Dpl/Qe2eXGO1n47a9HDp6GksLc5rUrxlpubRpUpEjmwNfvrrz6MmLGO0jLiRBEkIIIYTW67fvtT9//eZO2y4DuH33oU6ZO/ceA5DfMRcZ0oclSK7R3sfRk+foP2wiAAtnjcfGxirK8mG1SInZzCadtIUQQgih9fL1OwDsM6TD08ubY6fOc+zUeYoVzk+3Ti2pXb2itgapQL48KBQKAN5FswZpy479/DtgDEqlkqH9u1OvVuVfrlO7ekWCg4MpkC9PLI8q5iRBEkIIIYTWq9AEqVnD2vzbpQ3L12xhxdqtXL1xh6s37pA2dUo8PL0ByJ8vF9/cPYDo1SAtWr6eEeNmAjBhZH96dWsXrZjKlS5GudDO2olFmtiEEEIIofXi1VtAMyaRjbUVg/p04f6VIyxfMIVC+fPi6vYZ/4AACjrlIWWK5GQIHZvo2YtXUT7JNmXWEkaMm4m+vj6L50yIdnKUVKQGSQghhPhL+fj6YWZqojPeUVgTW1aHjNrXjIwMadKgJk0a1OTV63eo1Wpt5+wsme0BuHztNiUqNWJIv640qFNNZ5surm5Mm/MfxsZGrPlvBjWqlE+Eo4sbqUESQggh/kLPX74he/4KlKrSmMvXbmlff/U6rAYpY4TrOWS2J4tDRgwNDQFInSoFW9cuIHfObDx78ZpO/w6lZOVG3Lh1T7vOxSs3AU1foj8hOQJJkIQQQoi/0u79R/HzD+Dx05fUaNiB3oPGceb8FVzdPmNrY42trXW0t1WtUlkuHNvGmv9mkDO7A0+evaJL7xHaJreLV24AUKp4oQQ5loQgCZIQQgjxFzp+6gIAbZo3wNzMlHWbd1G/RVcA2sdiSg89PT3q167KxeM7yJs7B6/evGP/4ZPA9xqkUsULx1P0CU8SJCGEEOIv8/WbOzdu38fK0oLZU0Zw5fRualQtD0DDutUYNaRXrLetr69Pn+7tAZi3ZA0f3T7z/OUbUqZIRvasmeMh+sQhnbSFEEKIv8zJM5dQq9WUL1McQ0NDMqRPy+ZV83jn7EKG9Gm1YxvFVoM6VRk5YRa37z5kx97DAJQsVijO201MUoMkhBBC/GVOnNY0r1WpWFrndXu7dPGSxBgYGFC8SAEAFi9bD/xZ/Y8ggROkzbsOU6dFTzZuP6jz+owFq+kxaKL29z2HTtGq61C69h/Pp89fAfDw9KbXkCm06jKUDdsPxKqsEEIIIXQplUpOnLkEQOXypRJsP0ULOwHg8vET8Gf1P4IETpAKOuakaCFHnddevH7Pgx8mm/vm7sn6rftZOW8cjetWYdHKrQCs2ribcqUKs3bxRA6fuMA7Z9cYlRVCCCH+nzx9/oqnz1/FeTu37jzkm7sH+fLmJG2aVPEQWcSKFnTS/mxrY02uHFkSbF8JIUETpBzZMpM2dQrt72q1mgXLNtKxVQPta1dv3id7lkyYmBiT3zEnl6/fAeDStTvkd8yJgYEBjrmycfn63RiVFUIIIf5fBAcHU6xCA4pVaIBarY7Tto6dOg9AlQqlf1EybvLlzYmxsREAJYsV1Bk48k+QqNGeu3yT9GlTk/2H0Tm/fvPA3i4NACmS2aBUqQgIDOKbuyd26VIDYG+Xli9fPWJUVgghhPidLVq+nuwFKvL6zftfln3w6Jn257C5z2Lr1FlN89rP/Y/im7GxEfkdcwNQqsSf1bwGifgUW1BQMOu27Gf2xIH4+QV8X6BAJxtWq9QoFGg6iYW+rlKrUOgpYlY2Ajv2HWfn/uOadeOYgQshhBCx9er1O8ZNmUdQUDDnL18nc6YMkZZVKpVcvXFH+/sHVzeSJ7ON1X7VajVPnr1ET0+PAvnyxGobMdG9cysUCmhUt3qC7yu+JVqCdPfhU7y8fRgwaiZBwSF8cHVjzpL15M7hwIPHmj5Jn7+6Y2hoiLGREclsrXF2cSOrgz3vnT+S1cEeK0vzaJeNSOO6VWhctwoAISEhlKnVPlGOXQghhPjRsLHTCQoKBsD5w8dIy/23ciOjJs7GytJS+5rrx0/ky5MzVvt1+/QFXz9/7DOk0zZ/JaT6tatSv3bVBN9PQki0JrYiBfKyffUsVswbx7TRfcmRNRP9urehaEFHnr98S0BAILfvPaFk0fwAlCpWgNv3nxASEsKDxy8oUcQpRmWFEEKI39Hh42c4evK89ndnl4gfLHL79IUJ0xYQHBzC12/u2tddXN1ive+wiWjDJpgVkUuwGqTPX90ZMHIGX9090VMouHzjLgunDQ9XztbGivYt69Opzxgszc2YMEIzemeHlvUZNXkhew6eona1sto+RjEpK4QQQvxOAgICGTpmOgAd2zRh1frtkdYgTZqxCF8//3Cvf4hTghT1RLTiuwRLkFImt2XdkskRLkubJiWLZ4zU/l6nWjnqVCunU8bayoL5U4eGWzcmZYUQQojfyfz/1vD23QeKFc7PgF7/sGr9dj64hE+QHjx6xvotuzE1MWHU0F4MHzsDUxMT/AMCcA0dVyg2XoXWIDlIDdIvyVQjQgghRCJ45+zC7AUrUSgUTJ84lDSpU2BgYICzy0fUarV2BGu1Ws3ICbNQq9X06taOHp1bU6p4IT5//kbjNj2kiS2R/FmDEgghhBB/ILVazcDhkwkIDKRjmyY45c2Fvr4+6dKmIjAwiLMXrmprd46fusCZ81dInSoFvUMnfXXKm4vs2TQTvbq4xr4GSRKk6JMESQghhEhgm7bv49ip86RJnZJRg3tpX7dLlxaA+i26UrtJJ4KCghk1cTYAIwf3xMLcTFs2TaqUKBSKWNcgqVQqXr95j76+PhkzpI/D0fwdJEESQgghEtDiFRvoNXAsALMmj8DGxkq7zC59Gu3PLh8/MXTMNJ4+f0Xe3Dlo2aSuznaMjAxJlTI53j6+eHn7xDgO14+f8Q8IwN4uHYaGhrE7mL+IJEhCCCFEAnnz1pnhY2egUCiYPHYQtapV0Fluly6Nzu+r1m8HYNiA7ujr64fbXrq0mqe0Y9NR++FjzWjcuXJmjfG6fyNJkIQQQogEcjJ0Wo+WTerSo3PrcMsNDMI/K5U2dUqqVSoT4fbCEqonz2I+ae39R08BcMydI8br/o0kQRJCCCHi2ZIVG6lStw3bdh0EoGK5EhGWa96oNilTJGPW5BFYWWlGy27dvEGEidOP29l78FiMY7r/MDRByiMJUnTIY/5CCCFEPDpy4izDxk7X/q5QKChXuliEZR0y2/P8zmlA0xy3fc8h2rdqHOm269aszKCRUzly/Cy+fn6Ym5lFWvZn9x8+ASRBii6pQRJCCCHiyavX7+jSewSg6VQNkD9fbpLZ2vxy3Qmj+vPk5gnSRzEbRPJktlQoUxw//wAOHzsb7bi8fXx5+fodVlaW2Nuli/Z6f7MoEyT/gACevnjDqfPXuHP/Cd/cPRMrLiGEEOKP4uvnR+t/+uPl5U2rZvWYNn4IAHVrVIrX/TSuXwOAeUtWo1KporVOWAdtx9w5tANSiqiFa2JTq9WcPHuVrXuOAJAuTSpSpUiGh5c3rh8/4+7pRZVyJWhcr4rO+AxCCCHE30qtVtN38AQePXmOk2MuZk4cjqmpCWVKFiGTvV287qth3WrMnL+c+w+fsn33IZo1qv3LdS5euQlI81pMKIKCAtU/vrB41VbMTEyoV7MCtj+M1RAmJCSEk+eucvLsVSaP7oNBBI8h/glCQkIoU6s95w+uibQznBBCCBEdG7buoeeAMdjaWHPm8OYEH4jxwJFTtO7cD7v0ablxdi8mJsaRlg0ICMSpZE3cPn3h6J61FCucP0Fj+38RLjPo0bFZ1CsYGFCtYimqVSyVYEEJIYQQf5LN2/cDMGfqyEQZpbpWtQoUL5KfK9fvsHzNFnp1axdp2a07D+D26QslixWS5CgGIq06efD4BWu37OX12w/o6+uROaMd7VvUI2foXDBCCCGE0HSAvnbzDibGxlSrVDZR9qlQKBg/sj9V67Vl5oLltG5WH1tb63DllEol85asAaDfvx0TJbb/FxF20r517zHDJ86jZNH8TB7Vh/FD/6WQU24GjZnN3QdPEztGIYQQ4rd14fJ1goNDKFW8EKamJom236KFnKhXqwqent7MXLAcgM079rN01SZtmf2HT/LqzTvy5MpO5QrS8hMTEdYgrVy/i6mj+5I7RxbtazmyZSZntswsWb2VxTNGJlqAQgghxO/s1BnNaNkVy5dM9H2PHtKLg0dPs3zNFqpWLEP3vpq/z00b1MLGxoo5i1YBmtojeXotZiKsQfLw8tZJjsI45s6Gh4d3ggclhBBC/CnOXboOQKVyiZ8gZXHISIfWjQkKCqZR6x7a19+7uHL63GXu3n9MRvv01K9dJdFj+9NFWIOkp9DD188f1OpwyyKaPE8IIYT4GwUGBvHi1VvMzUzJnjVp+uiOHtqbC5ev8/jpS+1rzh8+smTFBgB6d2svT2vHQoRn7OWb91Rt1CWi/AipoRNCCPEn2rhtL84fXBnUpwt6evEzkcTrt+9RKpVkccgYb9uMKUsLczaumEvLTn20k9gePHqK85eukzJFMlo2qZskcf3pIkyQLh1Zn9hxCCGEEAnmnbMLfQaPJyQkhPfOrrx49YbunVpTL45NT89evAYge5akfcLbIbM9V07tZsXarQwcMZk9+zWT2TauXzNRO47/P4kwQVKr1TqduQICg7h68x7p06Yma+YMiRacEEIIER8WLFlDSEgIoBnUEUCpVMU5QXrx6i0A2bJmitN24otd+jQAmm4yQL68OZMynD9ahPWB67bu58xFTacztVpNn2FTmb90I72HTOHgsXOJGqAQQggRF26fvrBuy2709fXp37MTKZLbAnD/4VOCg4PjtO2wGqRsWTLFNcx4kSG97kS0eXJlS6JI/nwRJkinz1+jVNECABw7fQkfHz+2r57FhqVTWL/tQKIGKIQQQsSESqXCxdWNwMAgABYvX09gYBBNG9Zi9NDevLh7hoJOeQgIDOTBo2cx3r6/fwDLVm+mSZt/2b77EADZkqiD9s/CapBA81BVjqwOSRjNny3CBCkgMAhDQ03r29bdR2nbvA56enoks7VGXz9pOqEJIYQQv/Lw8XOy5CtP7iJVqdvsHzw8vFi5bhsKhUJnJOkihZwAuHrjToz30XvQOAaPmsrx0xdQKpUAZMlsHy/xx5W1lSVWVpYAZMuSEWNjoySO6M8VYbaTKkUytu4+wvJ1O/H28aVS2WIAeHr5YGIc+YR4QgghRFI6cuIs7h6egCb56TNkPD6+ftStWVnnMfxihTUJ0vVb92K0fR9fP/YeOo6RkSGZMtppXzczNY2H6OOHXTpNLVKeXNmTOJI/W4QJ0pA+Hbl07Q7Xbt1n/LB/teMnrN+2n3o1yidmfEIIIUS0PXikmQ4rrE/Q3oPHAejfq5NOubAapGs3Y5Ygnb1wlaCgYEqXKMyezUvJYJeOnl3bxjHq+JXBLi0gCVJcRfgUW/q0qZg3ZWi419s1r4uFuVmCByWEEELExsPHzwEYP7IfLTr0AaBKhdI45c2lU84uXRqMjAxx/fgp3JPbUTl28jwAVSuWIZO9HfcuH/rtpvAoXaIwJ05fpGLZEkkdyh8twgTpxat3Or8r9BSkTpkcSwvzGG18867DbNp+kOYNa9CqSS32HjrN3sOncPfwokqFknTv0BSFQsGeQ6fYvvcYFuZmTBj2L6lSJsfD05tRkxfyzd2TGlVK07pJbYAYlRVCCPH38PcP4MWrt1iYm1GtUlkK5c/LzTsPGNC7c7iyCoUCK0sLvnx1xz8gIFpNZGq1mmMnNU9yV6tUVrud382//7ShfavGMf6bLXRFmCANHjtH53e1WsU3dy+yZbFnzODuZPihl3xUCjrm1Em20qVNybI5Y1CqVDRu15/6NStgYmzM+q372bh0Kuev3GLRyq2MG9qDVRt3U65UYerXrEC7f0dStkQhLMzNol3WPrSKUQghxN/h8dMXqFQq8uTKjp6eHhtWzOH9B1eKhjan/czK0pIvX93x8vKJVoJ07+ETXN0+kz1rZjJn+n3HBNTT05PkKB5EmCDtWjcn3GsqlYo9h04zc+GaCJvfIpIjW2bSpk6h/b1IgbyEKJW8fP0ec3MzUiZPxomzV8ieJRMmJsbkd8zJjAWrAbh07Q51a1TAwMAAx1zZuHz9LlaWFtEuKwmSEEL8XcIe2Q8b+ydtmlSkTZMq0vJWVhYAeHn7kCZ1yl9uX9u8VqlMXEMVf4Boz16np6dHw9qV2H3gZJx2OHjMbK7evMf8KcMwNDTg6zcP7O00NVIpktmgVKkICAzim7sndulSA2Bvl5YvXz0IDg6JdtmI7Nh3nJ37NR321BFNNCeEEOKPde/hEwDy5o5e52Qry9AEycs7WuXDEqSw5jXx/y1G0/v6BwRox3yIrdkTB/HO2ZWh4+YyeVRvUOgmK2qVGoUitF039HWVWoVCTxGzshFoXLcKjetqhpUPCQmhTK32cToWIYQQvwcPTy+2hQ7aWLJYoWito02QvH1+WfbL12/cuH0fKytLihfJH+s4xZ8jwgTp/OWbOr+r1Gq+uXty8Ng5KpUrHued2tulpUjBvNy6+5iUyW158PgFAJ+/umNoaIixkRHJbK1xdnEjq4M9750/ktXBHitL82iXFUII8f/nm7sHjVv3IESppHABR5Ils8HWxpp7D57g5eVNrWoVyJk9S7S29WMT268cP30RtVpNxbIlMDQ0jNMxiD9DhAnSll1HdH5X6ClIlSIZTetXo2qFkrHakbePL5t2HqJjywYEBQVx/dYDypYohEMmO5at3UFAQCC37z2hZNH8AJQqVoDb95+QyT4dDx6/oE2zOpibmUa7rBBCiP8/Q0dP49bdhwDce/Ak/PIB3aO9LStLzYjTXl6/TpC0T69Vlua1v0WECdKiGSPivOHPX90ZMHIGX9090VMouHTtDkUK5KVz3zF4evpQo0ppCjrlQqFQ0L5lfTr1GYOluRkTRvQCoEPL+oyavJA9B09Ru1pZbR+jmJQVQgjx/2PLjv1s230Ia2tLVi+ezsdPX/Dw9MLd3RN3D0/y5c2JY+4c0d5eWBObp3fUfZCCg4M5efYyCoWCKhVKxekYxJ9DERQUqNNbedeBk2TNnIF8eSLv5Ob26Sv7j56hfcv6GOjrJ3iQCSGsD9L5g2u0I4ULIYRIWh9c3LC1tQr32P3egyfo0H0QKpWK5Qum0KRBzTjva+GydYwcP4tBfbowYtC/OsuCgoIZOmYaFcuVxNrKkjpNO1O4gCMn9m+I837FnyFcZlC8sCPrtx5g0cot5M+bg/RpU5EqZXI8vbxx+fiZJ89eExgURNtmdf7Y5EgIIcTv58mzl5St3ozKFUqzaeVc7eshISGMGDcDlUrF9AlD4yU5gog7aQ8aMZlrt+7R/99OrFq/nVXrt2un7JDH+/8u4RKkdGlSMaRPR765e/Lw6UvevXfl6cu3JLOxwt4uLeVLFSFzxvRJEasQQoj/Q8PHzeDE6Yvkz5eboKBgDh09zfOXb7TzqR05cQ5nl4/kz5ebf9o3j7f9Wof1QQpNkD59/srK9dtRqVSs2bRDW+7h42ekSG5L88bSv/VvEmnbUjJba8oULwhxf2hNCCGEiJC/fwCr1+/APyCAZy9ea1+fOX85tatXxMXVjfVb9gDQuV2zeJ3aQ/sUW+g4SLv3H0WlUgFw+twVABrVq07RQk60aFJXW+Mk/g7S+UYIIUSSOXvxKv4BAdrfM2fMwJt3zmzdeYCtOw9oX09ma0PDutXidd8/N7Ht2HM4XJlRQ3qRyd4uXvcr/gySIAkhhEgyR09oHp/PlSMLj5++ZHC/rjh/cOXM+aukT5uKdGlTky5tasqWKhqt+dJiwsrqexPbm7fOXL91DzNTE/z8NQmblaUFGTNIl5K/1S8TpGcv3+Lq9plyJQsDEBgUhLGRUYIHJoQQ4v+bSqXSJkgbV8zFwNCADOnTolAoGNSnS4Lv//tUIz7s2KupPWrRpC57Dx7ny1d38uTKFq9NeuLPohfVwjWb9zL3v/UsXL4ZANePnxk5aUGiBCaEEOL/28Kl63D5+IncObLikNkee7t0iZqQ/NjEtj10mpImDWpSIF8eAPLmit6cbuL/U5QJ0uETF5g/ZSimpiYApE2Tkk9fviVKYEII8ac5f+k6pas25fK1W0kdym/vzv3HTJi+AD09PWZOjvvgxLFhYmIcOmm6O0+fvyKDXTqKFnKicuhgkOXLlkiSuMTvIcoESaFQoFDoEZbQf3P3JCAgKDHiEkKIP0pISAgDR0zmwaOn/NNreLTm9/pbvHr9jkkzFuHt4wuAn78///QcSnBwCP17daJksYJJEpdCodBONwLQpH4N9PT0+Kd9c26d30+tahWSJC7xe4gyQapRuTQTZy3Dx8eP7XuP0W3ABOpUK5dYsQkhxB9jy84DPH3+CgDnD66MGDcziSP6Pbh9+kLd5l2YMW8ZS1ZoRqEeOX4Wz1++oXABR4b07Zqk8f346H7j+jUA0NPTwyGzTHr+t4syQWrXvC4liuQjd44s3H3wlI6t6tO6ae3Eik0IIf4IDx49Y3hoQjRz0nAsLcxZv2U3x06eT+LIkpa/fwCtOvXF+YMrANt3H+LQsTOsWr8dC3Mzli+YgqGhYZLGGDYWUu6c2cidM1uSxiJ+L798iq1qhZJUrVAyMWIRQog/yvOXb2jZsQ+v3rxHqVTStkVDOrVtipGRIb0HjaPP4HFcPrkLGxurpA410SmVSnr0H8WN2/fJmd0BP/8Anr98Q+d/hwAwbcJQMmfKkMRRfq9BahpP05eI/x9RJkj/DpoU4RMFC6cPT7CAhBDiT3Hg8Emev3yDsbERrZrWY/aUESgUCto0b8CBw6c4duo8g0dPZdn8yUkdaqIKDAyiS+/h7D14nBTJbdmyZgEbtu5h5rzl+PkH0LZFQ1o2qZvUYQJQr1YVPL28afGbxCN+H1E2sTVrUJ2m9atp/9lYW1KnuvRBEkIIgEdPXgCwdN4k5s8Yg4GB5junQqFg3vTR2FhbsW3XQdZu3JmUYcbJoyfPKVmpESfPXIxWeS9vHxq36cHeg8dJlTI5uzb9RyZ7O9o0b4BdujR069SKudNG/TbjC3Vu14xzR7aSOlWKpA5F/GairEEqW7KQzu/FC+ej34jpVKtYKkGDEkKIP8Gjp5oEKVeOrOGWpU2TinnTx9C+20D6DZtI6tQpqF75z/uCuWTFRh49fcGCpeuoVD7qe/+nz19p3KYH9x48IVNGO3Zv/E/bjJYxQ3oeXDuaGCELES+irEH62Zv3Lrx4/T6hYhFCiD9GcHAwz168wsjIkCyRPPFUr1ZlpowdhEqlYtSE2dqJUH+mVqu5fvMeHh5eCRlyjAUFBbP/8EkALl65gWfopK4RefPWmWr123HvwRPy5s7B0d1rf4s+RkLEVpQ1SFUbdQE01aBKpZKg4GDat6ifCGEJIcTv7eXrdwQHh5A3dw5t01pEunRowZqNO3jy7BWLlq8nS+aM1KhSTtvEpFQqGTF+Fv+t3Ejt6hXZsGJOYh3CL50+fxkPT03SFhwcwqmzl2hQJ/yEsR/dPlOtQTvcPn2hVPHCbFo1F2sry3DlhPiTRJkgrV38vWOhQgE21laYGMs8bEII8Ti0eS13zvDNaz/S09Pj3y5t6TVwLKMmzAagXctGZM+WmfOXrnPp6i28QmtmDhw5xTd3D5LZ2iRo7NG1Y7dmfrJ8eXNy78ET9h8+GWGCtPfgcdw+faF8meJsWT0fExPjxA5ViHgXZRNb2tQptP/SpEqBibER5y/fTKzYhBDit/XwyXMAckfQ/+hnTRvUIm/uHKRPmxpLC3PWbtrJiHEzOXL8LN7ePhR0ykOmjHaAJtmIK3d3T6bO/o+Grbrx6vW7WG3D7dMX9hw8hpGRIYtnT8DIyJBd+44yY94y1Gq1Ttmbdx4A0KppPUmOxP+NCGuQ2vYYQUQPGKhVagKDgilTolD4hUIIkQg8vbzZve8otWtUJEXyZIm+f5VKxYq1W1m8bD2gqV35FWNjIy4c2wbArTsPmDhjIdmyZKZMySKUKlYIW1trDh49TatOfdm++zAdWjeJU4xtuvTnwuUbAMxeuJKFs8bFeBtrNu4gODiEFk3qkjd3dpYvmErnnkOYNGMRXl4+jB/ZT9tMeCs0QSpcwDFOcQvxO1EEBQWqf37x1r3HERdWKMjmYI+FuVmCB5bQQkJCKFOrPecPromy/4AQ4vdx684D2nYdiPMHVyqULc7uTUsTdf9v3jnTc8AYbfLRtWNLpo4bHC+PrAcGBpEtfwW8fXx5de8strbWsdqOs8tH8hathpWVJT4+vpiZmvD09knMzcxQqVR8/vKNVCmTa2P28vahUu1WeHh6kTVLJrJmzoitjTWr1m/Dx9ePM4e3kN8xFwAnz1ykdef++AcE0L5VI2ZNHoG3ty+Z8pbB1saaV/fP/jaP7wsRVxFmBgXz5UrsOIQQIkrPX76hUeseuHt4AnD63BWu3bxL0UJOCb5vH18/lq7axOwFK/D188c+QzoWzhxH2VJF420fxsZGlCxeiCPHz3Lx6k1qV68Yq+0cOnoagDo1KuLm9oUTZy7SuecwvLx8uPfgMd4+vowd1oe+/3YE4Matezx/+QaAz1++cfnqLe22OrVtqk2OACqVL8WuTUto1q4XazbuxNvHl6YNawFQKH9eSY7E/5Uoq07evPvAyg27cXZxQ6X+/njq2kWTEjwwIYQIExISQsuOfXD38KRpw1rkyZmNMZPnMm32f+zcuCTB99+h2yCOn74AQMc2TRg3oh+WFubxvp/SJQpz5PhZLly+Ea0EycPDC2trS53E5NCxMwDUrFqBwMBATpy5yOHQ18KcOHNRmyA9fvYSgH/aN6dF4zq8ePWW9x9cKVOySITJZ4miBdm/fQUNW3Zn594jHD+tGUCyYP68sTlkIX5bUSZIY6ctoUKZonz89JV/2jbiyfNXGEpzlBAike07dILnL9+QJ1d2Fs4cR3BIMAuWruXk2Utcv3mPIoXyxXib3j6+tOrUF3cPT8qULML4Ef10mtv9/P3ZsGUP9WpV4dS5y5iZmnBg+8oETQTKlCwCoG3Ci4yLqxsTpi9ky479FCmYj0Wzx5MtSyY+f/nKhcs3MDUxoULZ4hgbGTFhpBv6BvoUyJebzBkzkLNQZe4/eoparUahUPA4dDTwQvnzUjD036845c3F4V2radiyG84uHwEoV7pYHI9eiN9LlNmOGjXtmtflm7sHFuamtG1Wlz7DptKikUzqJ4RIHGq1mnlL1gDQv2dHjIwMMTIypFfXdppapDn/sWPD4hhv9/ip85y7eA2A+w+f4u8fwOwpI7W1MUtXbmLc1Pls330IpVJJ/nz5E7yWJG+u7FhbW/Lw8TPc3T0j7Ie0av02Ro6fhZ9/AADXbt6lTNWmjBraCxdXN0JCQmhYtxpmpqYA9OrWTmd9h0z2vHrzjnfOLmTMkJ4noTVIuX4xXMHPsmfNzPWze3ny7CWGhobkzZ09NocsxG8rysf8zUxN8fbxpXhhJ/YdOcOL1+/5+OlrYsUmhBCcvXCVu/cfk9E+PfVqVdG+3qldM5Ins+XEmYtcvBL58CNnL15lwPBJ4UapDutr075VI6wsLVi9YQfzFq/WLr8Uuvz6rXuApoYloenr61OyWCHUajUXr4Y/pucv3zBo5FT8AwJp3aw+ty8coFunVgQEBjJi3EwWLVuPnp4eg/t2iXQfYU/d3X+oqUV68uwlenp6ZM+SOcbxmpqaUMApjyRH4v9SlAlS22Z18PD0plghRwICAunWfzz1a0W/4+DmXYep06InG7cfBOD4mct07jOGJh0GsOfQKW25PYdO0arrULr2H8+nz5oEzMPTm15DptCqy1A2bD8Qq7JCiD/fvCWapKVnl7Y6TWAW5mYM7P0PAENGT0OpVIZbV61WM2jEFFau20bbrgMIDg7WLrt8/Q4AHds2Zd2yWRgYGDB2yjx27j2MSqXi2q27OtsqmD9PfB9ahEqXKAzA+UvXwy0bN2UeSqWSXl3bsXDWODJnysDUcYM5sH2ldhyl5o1rk9UhU6Tbd8yTA4B7D57w/oMrPr5+ZLK3w9TUJP4PRog/WJQJUn7HHGRInwY9PT3GDunBid3LadGwRrQ3XtAxJ0ULacbFUCpVvHN2ZfGMkayYN5YFyzfh5e3LN3dP1m/dz8p542hctwqLVm4FYNXG3ZQrVZi1iydy+MQF3jm7xqisEOLPd/fBY06fu0LyZLa0alYv3PLO7ZqSM7sDDx49Zc3GneHXv/+YZy9eA3Du4jUGjpiCWq3Gw9OLh4+fYWVpQZ6c2Shfpjjzpo8GoHu/UazdtBNPT915xxKrE3JYgvRjP6QXr97QrF1PDhw5hY21Ff17dgq3zoVj21m3bBazJo2Icvv58mhqkO49fMKTp6HNazmyxOchCPF/IcoEqVHb/oydtpjL1++iVEY8yWJUcmTLTNrUKQDQ19ejU+uGGBkZYm1lSbrUqfDw9OLqzftkz5IJExNj8jvm1H6ru3TtDvkdc2JgYIBjrmxcvn43RmWFEH++BUvWAtClQ3Ntn5ofGRoaMnXcEAAmTl/IN3cPrly/TYuOfXBxdWPrLk3tdcO61bCytGDtpp0sXLaOazfuolarKVrICX19fUAzCvSQft0ICgqm39CJAKRJnRKAFMltsbdLl+DHC7r9kN68dWbE+JkUr9iIoyfPkyK5Lf/Nm4iNjVW49SzMzahbs/Iva4LCmtjOnLvC2CnzAMidM1v8H4gQf7goO2nvWjeHS9fvcuDoWWYsWEOZEgWpXqkUubI7xGmnX7664+3jS/q0qTl36Sb2dmkASJHMBqVKRUBgEN/cPbFLlxoAe7u0fPnqQXBwSLTLCiH+PJ+/fGXanKW8fvOefHlzsvvAMcxMTfinffNI1ylfpjh1alRi/+GTTJ65mJt3HnD77kMyZkjPrn1HABg2oAetm9WnSduejJ44hyyZ7QEoWVx3VoCh/bvxztmFzdv3AdC/Zyf2HDhO+TLFEm2Mn7B+SIePnaFYxQYEBgZhaGhAz65tGdSnS5wngU2dKgUD+/zDzHnLefTkOTmzO9C5XbN4il6I/x9RJkgmJsZULFOUimWK4h8QwNrN++jSbxznD66N9Q7VajXzl22iQ8v66OvrgQKdeX3UKjUKhWbUbkJfV6lVKPQUMSsbgR37jrNz/3FtHEKI34darabngDEcPXkegJNnLwHQpkWzX07eOnH0AI6fusDKddu0n+1lqzejUqkoVjg/2bJkIluWTEyfMJQBwyfx4tVbcufMRodWjXW2o1AomDdtNJ8/f+XytVvUqlaRLh1axP/B/kKZkkU4fOwMgYFBVK9SjkmjBpDFIWO8bX/koJ7kzZWdm7cfMLDPP3FOuoT4f/TLQY0ePnnJyXNXOXfpBpns0zNmcPc47XDTjkMYGhpQt0Z5AFImt+XBY804HJ+/umNoaIixkRHJbK1xdnEjq4M9750/ktXBHitL82iXjUjjulVoXFfzFEzYVCNCiN/D3oPHOXryPKlSJmfGhGEMGzsdH18/evzT+pfrZsyQnj49OjBtzn/a11QqTbeA7p1baV/r1LYpfn7+3Lr7gJmThkf4GL2RkSHb1y/Cz98fc7OkmVapfatGfHP3oGTRglQsVzJB9lG/dlXq166aINsW4v9BlAlSgzZ9sLWxonql0iybO4ZkNrGbGyjM+Su3OHf5JvOnDtVWVxct6MiytTsICAjk9r0nlCyaH4BSxQpw+/4TMtmn48HjF7RpVgdzM9NolxVC/DmUSiUTpi0AYOq4wdSrXYVqlcvi7eNDyhTJo7WNPj3as3XXAT5//krblo1YsmIDdunShBuR+udxgSKiUCiSLDkCzRArIwf1TLL9CyEimaw2zJt3H8hknz5WG/781Z0BI2fw1d0TPYUCe7u0PH72ilQpk2NkZAhqNTUql6ZFo5rsP3qWLbsOY2luxoQRvUiZ3BZPLx9GTV7I128e1K5WVjs4ZUzKRkUmqxV/u259R6JSqVg6b1KSz6F14MgpWnfuR+6c2bh4fHus4/n6zR1fP38szc3pNWgsrZrVo0aV8vEbrBDirxBlgvT/TBIk8Td7+eothcrWBeDyyZ3kyhGzUZTjQ2BgEPcfPuH6rfusWr+N5y/fsHjOBFo2qZvosQghxM8kMxDiLxQ28Spoam8SO0EaPm4GK9ZuJSjo+8CNWTLb07he9MdZE0KIhBTlOEhL12wP99r8pRsTLBghROI4EToDO8D+wycTdd8BAYEsX7OF4OAQihTMR7dOrVi5aConD2zUNL8LIcRvIMoE6VLoQIxhXN2+cPLc1YSMRwiRwPz8/blw+QaGhgYkT2bLvQdPePPOOdH2f//hU21ydHzfeqaOG0yjejWwsQ4/+KEQQiSVCJvYGrbth0KhSYhK1WijfT11yhQ0qS+PhQrxJ9t38AQBgYGUK10Mu/Rp2Lh1L+cvXSeTvV2i7P/G7fsAFCrgmCj7E0KI2IgwQdq1bg4AfYdPY+7kIYkakBAi4QQHBzM1dKygTm2b4uHpxcate7l24y5tmjdIsP0qlUqCg0MwMTHmZmiCVLhA4sxtJoQQsRFlJ21JjoT4/7Jh6x7evHWmgFMe6tSopJ3I9drNhJ2/sPfgcWzdeZBmjWpx+dotQGqQhBC/tygTpKfPX7N512G+fPOAHwYDWDh9eAKHJYSIb/7+AcyYuwyAUYN7olAoyJYlEzbWVjx9/gp3d88IR5aOK6VSyf5DJwkJCWHj1r0ApEyRjIwZYjfGmhBCJIYoE6ThE+dTrmRhypYsjEHojNdCiD/TyvXbcPn4iVLFC1OhbAkA9PT0KFrIiWOnznPt1l2qVSob7/t98uwVXt4+ZHXISLXKZVm/eTdNGtRM8sEphRAiKlEmSNZWFvTu2iqqIkKIP4C3jy9zFq4CYNSQnjrJSdHCmgSpRYc+tGvZkNlTRmqX+/n7o1SqsLQwj/W+r4c235UpWYRJowcyafTAOByJEEIkjigf8y9dvCA37jxMrFiEEAlkyYoNfP3mTtWKZShepIDOsiYNalKscH4MDQ1YvWEHu/Yd0S6r16wLJSo2JCAgMNb7vhqaIBUp5BTrbQghRGKLsgbpzMUbrNq4BzNTk9BX1ICCYzuXJnxkQoh44e3jy8Kl6wAYMfjfcMszZkjP0T1r2XvwBO26DmDI6GlUKFsCf/9Art+6B8Cd+4/CJVbRFVaDVEwSJCHEHyTKBGnamH6JFYcQIoHcvvsQL28fypQsglPeXJGWq1uzEjWrVeDQ0dOMnDCLCmVKaJddvX4nVgmSi6sbL169JXkyWxwy28cqfiGESApRJkhpU6dIrDiEEAnk4ePnAOR3zB1lOYVCwcyJw7hw6Tqbtu3j/sOn2mVXbtyhTwTr+Pr50W/oRJw/fGT3pv8wNjbSWb5zr6a5rkaVctIpWwjxR4kyQQobUftnO9fOSah4hPht3Lh1jwNHTtGneweate+FY54czJo8IqnDirGHj58BkCdXtl+WTZc2NWOG9WHA8Ek6CdK1G3dRq9U6SY7rx0+06NiHO/ceAXDu4jWqVCyts72tuw4C0LRhrTgfhxBCJKZfNLH11fn98IkL5HfMmZDxCME7ZxfqN+/KoL5daNG4TpLE8PLVWxq16YGnpzfHTp7n0dMXXLt5989MkJ5oapDy5s4RrfIdWjdm++6DXLl+h+TJbLGxtuTl63e8ePWWbFkyAfDg0TOatevJB1c3zExN8PMP4MiJszoJ0qMnz3nw6Cnp06amdInC8X5cQgiRkKJ8ii1blow6//7t3IL12w4kVmziL7X3wHFevXlH974jmTh9IVXqtuH1m/eJtn9PL29adOyDp6c3AI+evki0fcc3pVLJ4ycvMDAwIHvWzNFaR09Pj3nTx5A8mS1NG9aiVHFNchP2dNuxk+ep3qAdH1zdqFy+FId2rgbg6IlzqNXfR5TdvvsQAI3q1UBPL8pbjRBC/HaivGv5+vpp/3l6eXPh6i3eObsmVmziL+UfEKD9eeb85Vy/dY9GrXvw5eu3GG3Hy9uH6g3aseC/teGWBQYG8eZt+BnslUolXXoN49mL1xQt5ETRn568CgoKjlEMCS0gIJBWnfqyZsOOCJe/evOegMBAsmfNjJGRYbS3myObA89un2TK2EF0atcUgCUrNjJ74Uqad+iNj68fnds1Y8ua+eTPl5usDhlxdvnI4hUb8PTyRqVSaRMkaV4TQvyJomxiq9KoKwoFhH0pTJHchn87N0+MuMRf7KPbZ53fszpk5MWrtzRv35t925ZjZmoare2cOnuJK9fvcPf+E1o1q0cyWxtA89h7naaduXPvEY3qVadIwXxksEtHofx5WbpqE0dPniddmlSsXz6bJ89e0rBVd5RKJQBe3t6kSJ4sXo83Lq7dvMvBo6c5ePQ0tjbW1KtdRWd5WP+jvNHof/Qz/dDR853y5qJa5bIcPXGO8VPno1AomDJ2MN06tdT2SapdvSJzF69mxLiZ3Lx9n45tmuLs8pHcObORN3f2OB6lEEIkvigTpEtH1idWHEJouXz8BEClciWpU6MS9WtXpXrDdty4fZ+OPYawYflsDAyivHQBuHRVMymqf0AAazfupF/PTgQGBtG6cz9tx+Kde49on7QKY2JszMaVc0mdKgWpU6Xg3eMLVKvfngePnuLl5fNbJUhun75of+7WdyQZ7NJSMH9e7Ws3bt8HwDFP3PoOjhzck1t3HpAzexYG9elC2VJFdZYP6deNLA4Z6T1oHCdOX8TExBiAZlJ7JIT4Q/2yY4DLx0/sPniSPYdO4frx86+KCxFnYTVIk8cOon3rxtjYWLF9/WLSpk7JkeNnGTxqarS2c+X6be3Py1ZvxsfXj+79RnL2wlXsM6Tj7JEtjBvel37/dqRWtQqkS5MKAwMDFs0eRwGnPNp1zc3MsLK0AMDLxzcejzTuPn7SnKtUKZPjHxBAi459cHb5qF1+7uI1gDh3knbMnYPnd06zf9uKcMkRgKmpCW2aN6BAvtx4efuwZccBFAoFjerXiNN+hRAiqURdg3TtDpPnLKdIgbyAgpXrdzG8/z+UKCIj4oqEE5YgpUmdUvtahvRp2b5+MTUbdWDV+u2UK12cerUqR7oNL28fHjx6hoW5GY55c3L56i3KVmvGqzfvSJ7Mll0bl5DVIVO4gRODg4MxNAzfV8fKKjRB8vKOj0OMN2E1SAN7/8OZC1c5dPQ0LTr05vCuNQQHBXP/4VOsrCzJlzdxnj6tWK4kt+4+RKVSUbpEYezSpUmU/QohRHyLMkFavm4nS2ePIX3aVAB8cP3EyEkLJEESCSYkJIRPn79ibmaqrbUJkzd3dmZPGUnnnkMZNHIyZUsWwdbWGm8fX85dvIa3tw9+/v74+vnz9t0HVCoVRQrlY+q4IZSu2oRXb95hbmbK9nULyeqQKcL9R5QcAd9rkLx94vV448rNTZMgpU2TimXzJ1OjYXvuP3zK1NlLKFY4P2q1mpLFCmr7EyW08mWKM3P+ckA6Zwsh/mxRJkjBISHa5AggfdpUBIeEJHhQ4s90684D+g6dwMhBPalaqUystvH5yzdUKhVpUqeMcOTlRvWqs33PIY6eOMeSlRsZPrAHQ8dMY+PWvRFur2SxQuTI5sCk0QOZ/99a5k0bpdNHJ7qikyCt37IbUxMTGidis5LbZ02ClCZVSizMzVgyZyKlqzbh0NEz2ifuImoSSyhFCzlha2NNUFAQdWtGXsMnhBC/uygTpPRpU7Fl1xEa160MCgU79x0nfZpUUa0i/mKLlq/n3oMnNG3XkxP71lO4YL4Yb+N781rE15lCoWD4wB4cPXGOtZt2MrD3P1y5pulr1LpZfWxtrDEzM0VfXw99fX06t2sGQJcOLfinffNYT3cRliB5R5IgKZVK+g2diLm5aeImSKFNbKlDpwXKkysb6dKk4tWbd2zd5Q5A+dLFEi0eIyNDDu5YiVKlwsbaKtH2K4QQ8S3KBGlQz/aMn7GURSs3o1AoKOCYk1EDuyZWbOIPolaruRz61BhArSadmDCyP106tIjRdlxDE6S0P/Q/+plT3lwUL5KfK9fvsGnbXl6+foe1tSULZo6NMgGKy1xgv6pBCgwKIiQkBC8vn3BTciSksE7aqVNqEiSFQkHFciXZsHUPnp7eFHTKQ+6cMX/EPy4Se39CCJEQokyQUiS3Zf7UodqB+0xNTBIlKPHnefLsJS4fP5E5Ywbq1qzE/P/WMnjUVPLkyk6p4oWivR3X0Ef806SJPEEC+Kd9c65cv8OE6QsBzVNWCZmUfO+kHXGCFBSoac5Sq9X4BwREe6ymuPD3D8DT0xsbayudSWIrldckSAAd2zZN8DiEEOL/UZSP+W/ZdQQPT29MTUwwNTHh/YePrN2yL7FiE3+Qk2cvAVC5QinGjejHxNEDABg5YRYqlQqAm7fv02/oBKbMWsKnz18j3I6rW2iCFEUNEkDNqhUwNzPl6zdNM1JCP6VlafHrGqQwvr5+CRpLmE9fNOcwTWjzWphypYthbGxEMlsbGtatliixCCHE/5soE6RDJ85jY22p/T1D+jScuXA92hvfvOswdVr0ZON2zYzeH1w/0W/EdCo16KxTbs+hU7TqOpSu/cdr/3B6eHrTa8gUWnUZyobtB2JVViQOP39/Nm3TJM6VypcE4J92zXHIZM/tuw/ZsecwoEmWVm/YwbQ5/zF+6vwIt+X8QTOGT1RNbKAZd+fHjuBxHQjxV7Q1SN4RP+YfEBio/dnX1z9BYwmj7X+USvdcJbO14dCOVRzcsTJRarKEEOL/UZQJUkhwCMHB359aCw4Owc8/IIo1dBV0zEnRQo7a3y3MzWjTtDZq1fcJLb+5e7J+635WzhtH47pVWLRyKwCrNu6mXKnCrF08kcMnLvDO2TVGZUXiUKvV/Nt/NI+ePCd3jqxUKFMC0HTWHTeiLwDjp87n6zd3rt+6j56eHgqFgn2HThAQEBhue3fva0a4zpPr19NT/PiUVL6ETpC0nbQjHijyxznafP0SJ0EK69CeOlWKcMsKFXAkV46siRKHEEL8P4oyQSpdvACDx87m+u0H3LjzkOET51Hsh4TnV3Jky0zaH6r/ra0sKOiUW6fM1Zv3yZ4lEyYmxuR3zMnl63cAzSCV+R1zYmBggGOubFy+fjdGZUXimDZnKbv3HyNFcls2r5mv0xemdvWKlChWEGeXj3ToPpiQkBDKlipKmZJF8PL24eiJczrb8vL24cmzV1hZWkRr5vkqFctgYW6GlZUl2bNmiu9D02FlaamNMSI6NUh+idPEFlaDlCZV1LVtQgghYi7KTtpd2jdh4/aDLF2zHZVKTali+WnTtE68BvD1mwf2dprRdlMks0GpUhEQGMQ3d0/s0qUGwN4uLV++ehAcHBLtshHZse84O/cfBzQ1HyJudu8/ytTZSzAyMmT98tlkzJBeZ7lCoWDy6IFUqNVSO+VFmZJFSJUyOecuXmPb7oM6k6veufcItVpNAac86On9chYcLMzNOLhzFWp15AM8xpdfNbEFBSZ+H6T3oTWlqVOHr0ESQggRN1EmSAb6+rRrXpd2zetqX/uxKSFeKHSTFbVKjUIR+kh26OsqtQqFniJmZSPQuG4VGtfV/EEOCQmhTK328Xssf5Fbdx7Qve8oAOZOG02JogUjLFfAKQ9NG9Rk2+5DgCZBypHNgYEjJnP89AU8PLywsdGMl3MzdGLVwgWiX0v581QhCcXSwhyI/Cm2wCRoYguba67gD/PGCSGEiB9Rfk0fO20x7h5e2t/ff/jI5DnL4zWAlMlteRfaMffzV3cMDQ0xNjIima01zi5umv06fyRlctsYlRUJx8XVjZad+hIQGEif7u1p2aRulOVHDe2NqYkJyWxtKJAvN9ZWllSrVJagoGD2Hvxeo3ft1j2AWI10ndC0CVJkT7HpdNJOuBqkN++c6dpnBHMXreLW3YeYmphQ0On3O19CCPGni7IG6fW7D9jafB8NN0P6NLx55xKvARQt6MiytTsICAjk9r0nlCyaH4BSxQpw+/4TMtmn48HjF7RpVgdzM9NolxUJQ61W06H7YD66faZG1fKMHtr7l+tkSJ+W04c2oaenp20Ka9KgJvsOnWDp6s1cv3WPMxeu4vxB02QUkxqkxKKvr4+lhTnePr4olcpwc5vpPOafAH2QVCoVK9ZuZdyUeTo1VCWLFdTp9yWEECJ+RJkgqZRqPn9119bIfPnqHu0mts9f3RkwcgZf3T3RUyi4fOMu+XJn58KVWwQEBtG2+3DatahHpbLFaN+yPp36jMHS3IwJI3oB0KFlfUZNXsieg6eoXa2sto9RTMqK+Hf3wROu3rhD+rSpWTZ/crQnQc2ZPYvO71UrlsHa2pJHT57z6MlzADLap6d1s/oRPpX1O7CytMDbxxdvH99w02gEBvzYByl+m9hevX5Hz4FjuXT1JgBZHTLy4tVbgBgNwimEECL6okyQWjetRZe+Y6leuTQKFBw5eZG2zaNXO5MyuS3rlkwO93qXdo3DvVanWjnqVCun85q1lQXzpw6NU1kR/7bu1Iwz1aJJXW2zU2wYGxsxe/IIjp48T4miBahQpgSZMtrFV5gJwsrKgg+ubnh5+4RPkHRqkOInQVKr1fy3chPjp87HPyCAjPbpmT9jDNkcMpG/VC2CgoIpVbxwvOxLCCGErigTpGoVS5EmdUouXrmFSq1m5IB/wj2mL/4eISEh7Nij6WzdrFHtOG+vUb0aNKqXeBO7xpV2NO0IOmonxEja67fsZtjY6YBmst3RQ3tjYW4GwLTxQ7h15yHFi+SPl30JIYTQFWWCBOCUJztOeTSD9t25/4QZC1YzqFeHBA9M/H7OX7rO5y/fKOiUh2xZMiV1OIlOO1ikTwQJUmD89kH6+s2dMZPmArBu2SydQTEBOrRuQofWTeK8HyGEEBH7ZYL09Plrjp25zMmzV1Gr1VSvVCox4hK/ocPHzwKE+2P9t/g+FtIvapDioYltycqNuHt4Uq9Wlb/2fAshRFKKMEF6+96FY6cvc/zMZdRqNSWLOmFoaMDWlTOiNYCf+P+jVqs5elIz8nX1KuV+Ufr/U1gNUoRNbPE8UOTTZ68AaN2sfpy3JYQQIuYiTJBadhlCvRoVmTVhIBnSa0auvvNghCRHf7Enz17y9t0HMtqnJ0c2h6QOJ0lo+yBFVIMUz01sH1w0433ZhX7+hBBCJK4IE6SRA7py4uxl+o2YTiGn3JQo6kRIiDKxYxO/kYNHTwNQvXI5zcjlfyFtE5tX+OlGgn5oYvPzi/6EzpFxDk2Q0qeTBEkIIZJChAlSjcqlqVG5NJ5e3pw6f41te47yztmVUZMXUqtqWYoXzpfYcYokpFQqWbtpFwAN6lRN4miSzvdO2r7hlgX8UIPkE8cmtsDAID59/oqVlaV2n0IIIRJXlJ20ra0saVCrEg1qVeLTl2+cOHOFZWt3SIL0FwkJCeHg0TO8d3Yhb+4cFCucP6lDSjJWVpZAxE1sQfE4kraLq2baHLu0MuCpEEIklV8+xRYmVYpktGxck5aNayZkPOI34u7uSakqjXH5+AmAf9o1+2ub1+DHTtrhm9gCfpiL7c1bZwqVqUOZkkUY1Kcr6dOlRq1Wc+HyDXJmdyBliuRR7sdZ2/8obTxGL4QQIiainSCJv8/qjTtw+fgJczNT8ubOQeMGf86gjgkhbORwz4hqkAJ1p+B5+fodL1+/Y/OO/XRq2xSVSs1/KzdSt2Zl1i2bFeV+vvc/khokIYRIKpIgiQgFBQWzbPVmAPZtXU6h33AC2cQW1sTm7R2+D9KP4yCFKV+mOOcvXWfx8g3a1/YdOvHL/XyQGiQhhEhy8tz+X0CtVnP1xh0CAgJ/XTjUzn1H+Oj2mRJFC0hyFMraMqrH/MOf21WLp3H9zB6a1K+pM3ebh4dXlPtx/uAKQHrpgySEEElGEqS/wMGjp6lWvx2TZy6OtExQUDBbdx7AxdUNtVrNwqXrAOjxT5vECvO3930k7fB9kAKDdJvYjI2NSGZrg0Nme5YvnMKbh+cpW6ooAI+evohyPx9cQjtpSw2SEEIkGUmQ/gKnz10G4ODRUxEu9/Typk7TznTtM4JBI6dw7uI1Hj5+RuaMGahZtXwiRvp7i3Ky2p9qkLJksg9XJnfObADcf/iE96G1RBFxdtEss5MxkIQQIslIgvR/SK1Wc+3mXb58/QbA1Rt3AU3H4TfvnMOVHzl+Fldv3AE0tU0z5i0DoHvnVujr6ydO0H8AIyNDTIyN8fbxRa1W6yz7cSRtgCwOGcOtnztnVgCGjJ5GvuI1OHX2Urgyfv7+PH/5FlMTE+mkLYQQSUgSpP8zISEhDBg+iar12lKwdB0WLlvHoyfPtcvPnLuiU97t0xe27jqAkZEhObNrphC5cPkG1taWtGxaL1Fj/xNYWVmgVCrx89edkDbgpwSpaCGncOvmCa1BAk0SO2byXFQqlU6ZO/ceExISQn6n3BgaGsZj5EIIIWJCEqT/I17ePjRv35tV67djYmyMl7cPI8fPQqVSYWSk+WN7KrS5LcyKtVsJCgqmUb0adO3YUvt6h1aNsTA3S9T4/wSRTVgbNlDkf3Mn0r5VI7p0aBFu3Zw5smh/NjY24v7Dp+w9eFynzI1b9wAoWlAGYxVCiKQkCdL/CWeXj1Rv0J4TZy5ilz4tJw9sZPLYQdrlrZrWw8DAgINHT3PmvKYWSaVSsX7LbkDTnFazagUUCgUGBgYR/oEXPyRIPz3JFtZJu1qlssydNhpjY6Nw65qbmdGxTRNqV6/IwpnjAJg0YxEhISHaMtdDE6TCkiAJIUSSknGQ/jB+/v7s2HOYDVv2YG+XjiVzJ+Dl7UPVum1w+fiJAk552LxqHmlSpyRXjixs332I23cf0rRhLbJmycSIcTNp320Qpw5sxNvXl49un8mRzYF8eXICsOa/mRgZGZBOHjGPkGUkNUhhnbSNjKNuFps9ZSSgSU7n/7eG+w+fsmn7Ptq2aIhardYmSBE10QkhhEg8kiD9Id68dWblum2s37IbD0/NODrXbt7FxsaK4OAQXD5+onyZ4mxcOQdzM03TmJ6eHgd3rOTR4+cULpiP4kUKcP/hU7bs2E/LTn2oUaU8AJUrlNLup16tyol+bH+S7xPWahKkp89fceHyDe3gkcZG4WuOIqKnp8eowb1o2q4n0+cspWmDWnz68pWPbp+xz5CO1KlSJMwBCCGEiBZJkH5zQUHB9Og3ip37jmifnKpQtjh1a1Zm5PhZrFi7FQBTExMWzByrTY7CmJmaaptrFAoFc6eO4vmL19y884Anz14BULl8KUT0hI2F5Or2mTGT5rBo+QZtE5m+vj4GBtH/SFWpWJriRfJz5fodVm/YgYWF5r0rUbRg/AcuhBAiRiRB+s0dPHqKHXsPY2lhTosmdencrhnZs2YGIEvmjIwYP5P7D58ybEB3MkRjYEETE2M2rJhDhVot+ej2GTNTE/mDHANWlprpRvoMHq/TdwjA2ChmT50pFApGDelNrcYdmbXg+3QuFcoUj59ghRBCxJokSL+5sLm7Jo0eSNuWDXWWlS1VlHNHtvL5yzdSpYx6hvgfpU2Tig3LZ9OgZTfq1KyEiYlxvMb8/8w6dD62kJAQSpcoTOECjsxdvBoAY+OYn8dSxQtRqVxJTp69xNET5wDNHG5CCCGSljzF9hvz9w/g2Mnz6OvrU6t6hQjLKBSKGCVHYQoXzMfT2ydZNGt8XMP8q9StWYnK5UuxfMEU9m9boZPMRPTkWnSMGtJL+3PuHFlJkzplnOMUQggRN5Ig/ab2HTpBw1bd8PXzp1TxQiRPZhvv+zAzNUWhUMT7dv+f5c6ZjR0bFtOkQU0UCoXO035GMWxiC5M/X27q1tR0ji8ntUdCCPFbkCa239TICbN4994FgOaN6yRxNCIyPyZIJrFoYgszY+IwHDJloHvn1vERlhBCiDhK0ARp867DbNp+kOYNa9CqSS08PL0ZNXkh39w9qVGlNK2b1AZgz6FTbN97DAtzMyYM+5dUKZPHS9mk5uXtg4W5GXp6Mauo++Dixrv3LqRJnZJdG5eQK0fWBIpQxFV8jTaeOlUKxg7vGy/bEkIIEXcJ2sRW0DEnRQs5an9ftXE35UoVZu3iiRw+cYF3zq58c/dk/db9rJw3jsZ1q7Bo5dZ4KZvU9h48gYNjORyLVWfI6GlcunoLpVIZrXWvXL8FQMliBcmdM5s0g/3mwhLgr988kjYQIYQQ8SZBa5ByZMtM2tTfB7y7dO0OdWtUwMDAAMdc2bh8/S5WlhZkz5IJExNj8jvmZMaC1fFS1t7u14+8Azx98QaDH2ast7Q0J12aVAQGBfHm7YcIjwng7XsXAgICdZalSZ0SaysLrt64Q58hEzAwMOCruydrN+1i1YYdpLC1ZuPKuZibm4fbbpbMGTAwMMDZxY0Tpy9hYmJC1iwOPH3+mpQpkpHM1hovb19cP37SWc/Y2IhM9um1x8JPs8xntE+PibERrm5f8PLy1llma2tNqhTJ8PXzx/nDR51l+gYGZM2cAYAXr9+j/OmRdrv0aTA3M+XTl2+4u3vqLLOysiRt6hQEBAbx9t1P51ChIEfWTAC8efeBwJ8meU2bJhVWluZ8c/fk85dvOsvMzc2wS5eakJAQXr5+H+4cZnXIiL6+Hu8/fMTPT3cy2VQpk2NrY4Wnlw8f3T7rLDMxMSZjhnQAPH3+Otx2M2VMj7GRES4fP2kHhAyTPJkNKZLb8uWrO75+/jrrGxoa4pDJDoAXr96FS5Az2KXFzNSET5+/4u7hpbPM2tqSNKlSEBAQyNvQptYwCj09smfJCMDrtx+088CFSZc2FZYW5nz95sGXr+46yywszEmfNhXBwSG8ehP+HGbLkhE9PT3eObvi7x+gsyx1qhTYWFvi4emN26cvOstMTU2wt0uLSqXi+cu34bbrkCkDhoYGfHD9hI+P7jlMkdyW5Mls8PbxxcVV9/o2MjIic0bN9f3s5VvUP03umzFDOkxMjPn46Quenj9d3zZWpEqZHD//AN7/9KVJX1+frA72ALx640xwcLDOcrt0qTE3N+PLV/dwiW983CPcPbz49PmrzjIzM1MypE+DUqnixavw5/DHe4Svr5/OMrlHaPzO9whfXz+cXdx0lsk94rvf4R4R9tkNk6h9kL65e2KXTtNnw94uLV++ehAcHIK9XRoAUiSzQalSERAYFOeyEdmx7zg792smBw0bdLFzn7E6ZapVLMnYIT349Pkb7XuOCreNy0c3ADBx1jIePH6hs2zM4G5Uq1iKwWNmkjZ9Bt0VVUoeP37ExOmLcP2q+yYBHNq6GFsbK+Yt3cCdx6/JnCUb+49dYP+xC/Tu0pIWjWpy/fYDRk5aoLNe9qwZWbtoEgD/9B1LcLDuTWrj0qk4ZLJj9abd7D9yVmdZm2Z16NGxGU+fv+bfwZN1lqVMYcu+jZp99R85nc9fdD9Ei6YPp6BTbnbsO876rft1ltWpXo7h/f7BxfVTuHNoaGjAuQNrNOdr2mKevdD9oEwc0YtKZYtx9NRF5i/bpLOsdPECzBg3AG8fvwjfmxO7lmFubsasRWu5evO+zrIB/7ajcd0qXL5+h3HT/9NZljdXVpbPHQsQ4Xa3rZpJhvRpWLZ2B0dPXdJZ1ql1A1Iks8XXLxD7TJl11k+fNhU71swGoNfQKXj89OFcNmcMjrmzsXnXYbbsOqKzrGGdygzq2Z63713CxWRmZsLJ3SsAGDFxPq9/+gMzfWw/ypQoxIFj5/hv9TadZRXKFGXyyN64e3hGeKxn96/GyEiPqfNWcvveE51lw/p2om6NCpy7dIMpc1fqLCuQLyeLZ4wkJEQZ4Xb3bphHqpTJWbRyC6fPX9NZ1q1DU9o1r8ud+08YPHaOzrLM9unZtHwaAN0HTsDPT/eGvGbhBHJky8z6bQfYtf+EzrLmDavTp2trXr5+T5d+43SW2VhbcnjbEgAGj53Nh59uunMmDaZ44XzsOXSKlRt26yyL6z2ieqXSnDx3lVmL1uosK1bIkbmThxAQEBDhdn+8R1y4cltnmdwjNH7Xe0TnNo24//gF/UZM11km94jvfod7RNhnN4wiKChQ9+tEPFuxfiemJia0alKLSvU7c3DLIs1ghdsP4OXti5WlOV5ePvTo1By1Wk2l+p05vH0JNZv2iFPZHh2bRRlXSEgIZWq1Z8W8sfFeg/Tg8TMWLV3Pv13bYhg2srICKtduhY+vH3u3riD1T4/mh307fPzsFRVqtcTc1JT921egr6cn3w5D/a7fDtt3G8ilq7cwMjLi7OEt2mXy7fC73+Hb4Y+kBuk7uUdoSA2Sxt98j/i5BilRE6QmHQYwZVQfsjrYM2XOCrI62GNlac7pC9eZOrovn758o0234Rzd8V+cyzapVzXKuMISpPMH18Roeoi46DN4PGs37aRVs3oM6NkZh8z24cqcu3iNus3+oXyZ4uzZvDRR4hJx06H7IHbvPwaAh/PdJI5GCCFEfEjUcZBKFSvA7ftPCAkJ4cHjF5Qo4kTRgo48f/mWgIBAbt97Qsmi+eOl7O+oTfP6AGzcupdSVZqEy7AB7tx7BECBfLkTMzQRBz27tNX837VtEkcihBAiviRY1cnnr+4MGDmDr+6e6CkUXL5xl0kjejNq8kL2HDxF7Wpltf2G2resT6c+Y7A0N2PCCM2owh1a1o9z2d9N4YL5WLV4GouXb+DG7fts23WQXt3a6ZS5dfchAPnz5UmKEEUsFCrgyLvHF7G0CN/5XgghxJ8pwZvYfldJ0cQW5sLlG9Ru0okc2Ry4cmqXzmP8TiVr8vbdB+5dOYy9XbpEjUsIIYQQGjLVSBIoVbwQmTNm4OnzV9y49f1Jim/uHrx994HkyWzJkD56wxQIIYQQIv5JgpQEFAoFLZvWBWDjtj2AZtiBLTsPAFDQKY8MDimEEEIkIUmQkkiLJnVRKBTs3HuE+4+e0qBlN4aPnQFA7eoVkzg6IYQQ4u8mk9UmEbt0aahQtjinzl6mTNWmAKRLk4qp44dQp0alJI5OCCGE+LtJDVISatO8AaCZy6vHP625emYPdWtWluY1IYQQIolJDVISql+7KkqlipzZs5A3d/akDkcIIYQQoSRBSkIKhYLG9WskdRhCCCGE+Ik0sQkhhBBC/EQSJCGEEEKIn0iCJIQQQgjxE0mQhBBCCCF+IgmSEEIIIcRP/tqn2NRqzRy9ISEhSRyJEEIIIX4H+vr62rEI/9oESalUAlChXuckjkQIIYQQv4PzB9dgYKBJjRRBQYHqJI4nSahUKoKCgnSyxfjSutswNvw3JV63+f9MzlfsybmLPTl3cSfnMPbk3MVeQp47qUFCM72HiYlJgmxboVBoM1Dxa3K+Yk/OXezJuYs7OYexJ+cu9hLr3EknbSGEEEKIn0iClAAa1amS1CH8UeR8xZ6cu9iTcxd3cg5jT85d7CXWuftr+yAJIYQQQkRGapCEEEIIIX4iCZIQQgghxE8kQRJCCCGE+EmCPifnHxDAO+ePfHD9RDIbK+zt0pLM1johdymEEEIIEWfxniCp1WpOnr3K1j1HAEiXJhWpUiTDw8sb14+fcff0okq5EjSuVwULc7P43r0QQgghRJzF+1Nsi1dtxczEhHo1K2BrYxVueUhICCfPXeXk2atMHt0HA339+Ny9EEIIIUScJcpj/l7evji7fCRFcltSpUiW0LsTQgghhIiTBB+r+9jpSxw6fp5M9ul5+vw1Tnlz0K1D0wTZ155Dp9i+9xgW5mZMGPYvqVImj7SsWq1GqVQmyFxsQgghhPizJchTbIFBQdqfz1++xZxJg+nbrTULpg/n6OlLCbFLvrl7sn7rflbOG0fjulVYtHJrlOWVSiVlarVHqVQmSDxCCCGE+HMlSA3SpFnLKVnUieqVSpMnZ1bGz1hK7hwO3H/0nHy5syfELrl68z7Zs2TCxMSY/I45mbFgdYLsRwghhBD//xIkQRo/7F9Onb/GiInzaVyvKoUL5OH1W2ca1alMvjwJkyB9/eaBvV0aAFIks0GpUhEQGISJsVGC7O9X1AEBqN3dwdgYhaFh7LYRHAyBgZEXMDREYWz8vbyfP6h+qBH7ed8qFejFvNJQ7e8PagC1Zhu/oDAzi9V+wollvPFKqYSwBwl+h3jiQO3vrzmeH/10DSU1nWs+gth+vMYVpqbf35skEtlnNN4+A38JtZ8/AAozU80LP37ufiz34/k2MEBhYhJ1GSMjFEZG4ZbH9p4clQivBT09zbVAJJ8/AIUChbl59HeUAPehyM5JtM5VSAjqgIDEu+bNzFAk0uc+wfogVSxTlNLFCrBt71Fev/1A+xb1yJA+TULtDhSafkVh1Co1P3ct2rHvODv3H9csVyds33T116+onj9HHRSE2t1Dc1M3t4CYdHcKDkYvWeSd2tX+/qh9fcHYGPz8UCRLpnMxqwMCUH/9BlaW4OGpedEminGo1Gg+fPo/XOQ+PihSptRc+Aq9cOc0Iiq3T2BqGrNj/TkUb28UCj2wMNfElRTdxIJDNNeVn5/mRuwfANbhn8z8IwQGobC0CJdwqLy9QaUGvd+gH15AAJiaoWeh+WOhDgxE/fkLarVa80fO3ByFmSmK0Juwys0NzJJgqBA14O8HgMI2GQqj8H9AVK6uYGGRyIH9gdSApweKdOk0v376pHm/DQ3B2ET3c68GQr7fE9VKlSbpCAnW3LeUKkCNwtpamxSpPD1BoUB74/LyRmFrg8rTE4WRsea+HEGSFSvBIegls9U9PJUKtYsL6BugSJkChUH4P7lqpRL1588QnSRJpQJvb7COh/EEg4PB1w9sbVAYGqL+/AXMzcDAQHOuPdxRpEiB2stb83pk/PzRS50K1bv3YGsT97j8/TX3XgMDzd8dfT0ICtJcD8oQDMqXR5EiRdz3Ew0JkiB5evmw7/BpPn76gr1dWjq2asC2PUfQ19OnXYt6WFvF/40jZXJbHjx+AcDnr+4YGhpi/NM3h8Z1q9C4rmYW4JCQEMrUah/vcYTRS58evfTpAVAHBaF69w7Vy5egUqMw/fUHUh0QgJ59RvSd8kVZJvj4idBvXQoMypXT+bakVqtR3riB+utX1MmTg1qNXiQXulqtRu3piUKhh8LSUvOaUnPzMKhQIUYZu9LZGeWNG5obVSw7wKvUoGdrg9rXV5OgGBqhsEy8PzhqpRK1vz+G5coRfO4chCjBxkT7x/tPo1J7oVewIPopU+q8rnz1CtXjxzH7BhtP1CEh4B+AGrXm+sqQAYNChbRJvlqtRvX2LZiYoJc8ebhvsiG376B2+xhhLUKCxKtWg48van099B0d0XNwiHTfysePUb18iUKSJOCH+4uhEYrQe5DmNS/0S5VC38EBtVJJyPHjKPT00EuXHtXbNzrXpdrbB738+dF3cIh4HyoVqFQ6SYjy1StUjx6BuTlqLy/0nZzQy52LkMuXNbU5Xl7x8h6pQ0JQpLbCoGjRcMcdcuEC+PlFeh9Vff6M8vIV7X03wu0HBGhq1AICUVtYorCwiPPDRWofHwwqVkRhY6OJw8MD5d27qD09QaVCv3x59NKmJfjoUfQiOUdqlQqsrNAvXlzzpTaKY/hlPAGBqJUh6OfMiV6WLJov/qEPUam9vQk+e45ofUOPRwlSHzZ03BwsLc2pV7MiAYFBLFqxmX7d21KrWllmLVqbELukaEFHnr98S0BAILfvPaFk0fwJsp/YUBgZoZ81KwYVKmi+7USDOigYPYfMUW/XxASD0qUA0MuSJVxVskKhQD9fPtS+fuhnyojCykpzQUe0P29v9AsW1P1G7uOLftGiMa7O1LezQ79IEfDyjn1NnZER+vnzo/b2xqBsWRQpU2q+LcaQOjgY1efPkS6LKD61Wg2+vhiULo3C0hJ9e3tN7Us0EtvflUJPL8LaSL00aUK/eSc+dUAAek5OGFaogEGNGhgWL66TBCkUCvQzZUI/TZoIq/n1c+XUfAtOLF7e6DnmxbB6NfRz544yMdPLkUPzRzkx4/uNqb280Xd01DbRq9Vq8PRCv0hhbcKj0NdHv3Bh9IsUQS9bVghRovbyQuXlpanpNDZCL2PGSPeh0NMLV0OjZ2en2aenF/oFCqCfNw8KPT0MS5XCsGxZTU13fPD3RxH6hVgnJoUCgyJF0C9ZMtL7qMLEBHUUf/fVSiWg0NRgo/nyTVA8XFdmZtrkCEDPxgbDcuXQL1EC/ZIlNfc9Q0P0s2VH5e6h+ULzMz8/9OwzamqmI6gdiwm1MgTDqlXRz5cPhbk5CgMDbRKosLREP3cu8PON0z5iKkFqkD5/dadm5TIYGRmSMrktPUOfXMuSKQPjh/2bELvE1saK9i3r06nPGCzNzZgwoleC7CcuFEZGYGGhqUL+RSasMDWJVjauZ2uLXqVKkW/H2Bj9YsXQS5EcjIxQPX0aripXrVajMDZGL0MGcPdA9dFVU12cLSt6sazK1U+fHpRKVHfvQgy/VahDQlDY2qCwtMSwenUUlpYobGwIOXMWdVBQuEQwSv4BmsTwp/XUgUGgp9A0U4aEoEABxkZgZKT5plm8OHqhNw+9HDlQZMyE8uaNGB1HYlErlag9PNBLHvGwFmqVCqytI7xBK8zMwNQkWtdkfFKrVChsk6FvnyHW21CYmKCwyxCnWiS1SoXa2wf0FBF+K9d+oVAowNoK/UyZohebnh4GxYoRcuIE6h9u9H8jtbc3+tmzoZ8lC6qPHzXdAvwD0C9VEr2fajT1fmg60StRAtQq9ExMwEjz2YzplzWFkZHmy2OaNBF+PvRSpET10TVW/fDUSqWmdtvAEFBE2h1CYWIS9fVpaqq5/0S2Hx9fDEqXQv3lKyq3jyhSJEft9lFzv4oldXAwCtuI4/25llkvezYUKVKgfPoE9bdvmuY3czMUenqo1Wr0UqfSFIzJffnnePz80M/sEGV/J720aVFGow9sfEqQBKlVk/+1d+fxUVVnH8B/59w7SyY72fcEEiCBLAQIi+DWIiJq3YoWLWqt+/7qW1/3fanaqlW0Llh36y6tS+vSuoILKJuAIAJJSNgJ2SaZmXvP+8dJhiQzk0xm5s5kwvP9fPr5lGRyz73HmbnPPec5z5mLsy+9EbnZGahv2IHfn3GSEc14OG72YThu9mFhaStQvKAA+rp1/c439/fmDYSSK59seFoatLVrPT+K7e3gxSVgjIHl5UJs2gSWkAA+dmxQ7fLcXOjr1vW6+boDErMFzNcHvN0OXloKAO4gkakq1BmHwPnRx3LY1c8vSsEAtaoKrq+/dgdIwuWC0DWYDj8S4ByipUU+6e/YAX33bvmkmZHhPgbrSvTUFMWvJPWwczrBkpKgN7eAJ3gJRtvbwceN9/nnPDsbel1d6HIx/GG3y4A8SErpWLjqgzj39nY5EmU2Q1u5EqzPA4FoaQWYfNDgWVmDOjSz2cCrquRxg5h6iGaipRUsO8f9XcKLi6EtWQL1iCPcDyC+KOlp/f7eX8q4cb5/mZ0FsXVLYAsV2tuh1NRA/+EHCKHLRQMBYKoKqN6/z4TdDp6fB56SApGcDJ6fJwPMYEd9OzvBfDxQeZwfY2ApI8CnT5cj8o2N0H/+GaK1DSwpyZ2EjpgYmaw9yERtIQSESwMvHtX/ecTEhC33qJshAdKJc3+B444+HM3NrUhMiIei0GqObjwrC9qq1TL52dfc9yDevIMSH+99lYGmgxfkA4DMG1JVqFNqBv1G74txDj5uPLTvvztwgxAC6iGHQPtyie8nIOb9aax7SlH79DP/k6UVBTwjAywuXg5Vcw60t8N0xBHuL0XW3VZGBvoNu0wmCLs96H4JOZcLfOxYiD17IbZvd+d4dBNCgKf5/mJhGRkyKA5jgCQ0vddoQaCY1QqWlwfR2NjvDUrY7V5HIIQuwLOy5Puz0wFtwwbwHrlujHMIhQOdDqBH0OwvJT8f+rZtMv8mnAFoiAmXS+b3DGKUQN+/H8qoYvBxZe4HJJ6eDj5nzpDpC56UBJ0FsLJX04CUFCgZGeDx8TIpPxheAjQhBIQA1PHy4YZxLqcENQ2C9TfmNDCh62ABLDhhJhOU/Hwo+fkev+NJydBrtw7qYUUIAXSN2Pvz3uI+8s+MEvJv+kcX/R33PLgItXWNGJGc6BEc7W9uwTMvL8al19wN10FYpJHFxMB01CywlBSIHgU1exJCBPTmHbBtzqGUlkK0tPRqC7E29xcWUxSoR80K2RMvz8kGs1jkVIYQgC1WBj82m8/8JMG5z5sdT0oCHz8OorV1wLaFroPFy35UqidAtLZCNDeDT50a0PUxs9n7Mt1I0zQwmw1KVSVgi/F4XzFF7XfEkiUkhGUKqGfOF+Ns0FOvvijjxh14f/lqW9OBtjaP1zCFu1ebKWNGg+fmyif0blaLfFjRXAFPN6uTJwMWi0y0jVKivb3/kiM9XyuEDI4qKmTOT4/3FmNsyARHALpWywU2esS7pluZzQZlVP+jHwOyWrume3t8N7e0QKme4DntZLEEnavMBltawB9JiYPKCRROp0y8nzq114h9f3hxsTGDBz6EfATponNOw5p1P+HxZ15DfcMOxMXZkJE2AvuaWrB3337Exsbg5ON+iQfvuuagHVliNhtYSQn0JUu8Rs0MBrx5u/CRI6E3NkK0tckRFIfDY+oglF9gjDHw8nK5qk1V3V8qvCDfdz7UANfOi4qgb94CoWnuEQEhumo09fyfw3FgaD8pCTw/HywxEUp6emDXYjL5THKPJMG4nAZUFKjTpsH58ceyRgzn8nzj4/sNgJjZDJjDUAupaxRHuFzySz7IpM5uzGSCMn489JWrZEmLPkRnJ5S8XCA9HdrX34B1lboQQnj0jVJZAZfdDrG/SfZh8giw7CzoDY0Bfy6YqkI95BC4PvggoL8fCpjFAijqgLlqQtOA1lYoU6ZAyTSwrEsoBVJThzGP/Klg8MREaDt2yPweTQNcLrD0dK99yEwmQA2yjpOihrz+GY+NRVc6+YBEWztgscD0y18cmKLzQ7hH7w2ZYhtfWow/3nIlAKBpfwsatu9EclIiMtNTDupkxZ54cjJ0Xx9MVTGseB9jDOqkSXB++JG8WXV2AoPMrRgsnpkJPcYG0doC1vWkwLOzoa1b5/lhcjjAu2qi+MI4B6+qhLZkKVjXDVE0t4BlpMvcJpMqV1RoGniPoWB1woTgLsRsHpo5SAzuBElmtUKpqYH2VdeyYbu9Vx/4lJQol+mGKGjpSwgBJCRCPXQm9Pp6WdckhHh+PvSffnIHzd3LopnJBNHZCV5UBJaQAIwrg7ZuvczVstvBi4t7HYdxDrVmMlyffw6xZy94WRl4WhrE6JKgzo+ZzeCFhdBra33eEESLXPXJE4ZWrS1ht8vVY6oKfeNGn6OR3aUx1MMOGzC/aEhRFHRVwvWL0DQgMSm0xSYTE4GOTihTp0BfvQYAoFZW+n69l9pbg2I14P5is4F1jeT2d5/Xm5vB8/LkarUIF3odiOHhWFJiPMrGjEJWRioFRz0wRQFGjPC+dNLgIWhmtUKZNMldjNHoLzPGGHhFuUwm7pqmYDY5recxLdLpAPwY4eEpKb0K9DGTCaapU6FWT4BSXg6ltBTK+PEBJ056ZbEMGCB5/e9pMAYAPb6seWqqnFaDnGb050mXZ2YC7e0GnSGAzk7wtFQ5zZufD6VPYBIsxhiUiRPdU6/C6YSwd8gv65gYGRwBUEpKwPNyZTCiaXIZeN9jqSrU6dPB4uPBk5PBTCao/SX6+omXlMgFAg4H9OZmmWNit8v/39Iqpw/6KcURKcLpBM/PB8/J6Vpy7kNbO5QJE6IrOAIAkzq4Pm+3gxf6LjcQCB4XBz66RE7xai4gPa3/7y6LJeASKsLh6LW8P1SYyQReUQE4HND3N3v9LhROJ1h6OtQJE4Z8cASEIUAivvHCQqC9d20f0SOIMJKSlSnraVjMhpTd92gvPV0m4vX4UPD8Ao+bsmAA9yM3hTEGXjTyQL5IOGoU+TGCJBq3G38efXHuUT8IiQnyZqaofuX68MxMsJwc9427p5DcsB3+Bb7B4ElJ8ibe1ASloKs2S2sb+Oje2xsplZVg2TmysKqP0RxmsUCd9ctBDf8PhFksMM2ZI2u9lJYCAuAFhVBnzIB6zBwopaWyQF5baAJVIQRES6vPXEe/jqFpcuFGXBxYbCx4Xl6vPJler2VyZDzaMD8efPriASTs93sOSUlQqqpkkJGbO2BAzpOS/M4J89DR6R7JDzWlqAjqUUdBOWQ6YLFC75sr2tHhTrOIBhQgRRBPS+u1xYPQdZkbZPCUVzelshK8Kshpp8G012dZN8/Ldd98habJaTJV9bt4Gy/IB3Qhn4gSk0J9uh6Y2SxLfPfL2C1svPIS4PKcHIh9+6Dk5/k1b88sFqgTJ0KpqfG4AeoNDcFvzcN4wEnOg6GUlwOcgxcXy5u5y+kxSsQ4hzqxesCpLCPyHboDWaWkBKYjj4BSVgo+YoT7wYGHMm+npRV87JigksNFWzt4aZn73+qECTKPsbnZ88WKEtKAMlwGs/hC5vTFDa4Wm7/n0fUeUCZNGnARCS8okLXcAmB0IMsYg5KaCtPMGZ6LkRjzWa9tKDJsL7Zuddu2Y8/epl63jQnlwdXXGS6YqgKJibIGj9MJ4XJBnTkzbG8gpqohqzUSUPs2G5gtVq6QSUoCHzsWPC3N76lYZrUCthi5D1046mMoCgTrPwlRRGIa2UveEE9Ph+bSwIv6r8bel5KZCT01VdavsZjliGaczNcJat8zs8mQm0pfzGKBOnu2rFtUVChXaEbBUH43ZjIBSUkQTkdQAZpwuYC0NCglJdDr6uSKzn6OJ7qqTUNVZU0fxgEhZD20PiUilHHjAKsV2uo1YIlyBaQQInprPVms/q9ObW8HH++7plgo+PP9x+LjwWJjB/zv6vVvFf8fQoOlVlbC9VFXvquuA3HxYZmxCBVDA6R7HlyEdz/8DPk5WVC6CmExBjy78E4jm40qvKBAJtRmZcNUM3lI7aweDurMGe4VV4HgubnQVqwAD8MmskxVB9wLiIV5AEkIAZi8rIS02aBMnBjQaki1uhquDz+UdarsHeAlxXJfsUDP0eEIa4E3d32rmBgo/WxNMVTxnGy5f1gwe4TZ7e4bOS8ugfbttxAmWdFbKF0LGHrubdjZCT52DHhREUR7uxxFVFTw7CyvN2yla68sfdlyiMQE2V6wS90jxTqIKTYR4lG+IPDRJYPeqUCu3Ax+Hzd/MZsNSEmRo5h2O3hZ2cB/NIQYGiB9+c0KvPPyI0j0Vt2XAJCFIzF5Mnhh4UGZxB7sqALPzoa2apV/O2EHq3uX6wGEddsOTfP55K6UBJYIzaxW8LIyWfGdMSgFBRCbN/t8vXC5IJr2g41I9hroCnsH1DAXeItmPC0Nmq4HVQgQjLkLcfKcbECb4M4lgqLA9f6/er/e6QJSUg5si+Fj24yelNxcMIsFrq++AhwOsBAuew8rq38jSH1rxkUaz8mBvn59r3InA4pADhDPzYW+erVcoTlEgkt/GZqDNKa4EDFD5M00VDGTCUpR0UEZHIUCi48HLy0zbHl6L4rS7wCSEAJQ5NRE2LhchuR98KIiwBoDoXB5U7V4/xyLzk5Zybus1PcqOLOcNiJ+iouTyfUDEJ2dEC0t0Nvaem3kLJxOGex0fSaYokApKpK5Tt3VxPss8xYMPnds7w9PS4Pp6KNhmjPH515kQx0zmSB8VNMWmga9ab/8R1ubfyUzwoQpCpTJk+V2OP5yOMN+DTwtTT40mi1Rl6Nm6F2lYlwJrr39IUyZWN7r5/NOmG1ks+Qgo44Pfgm2XxQF/WYg6bp8ja5739LFCC5XcLlBPjDOoUyaCL22Tv47ZQTE7t29N/xttwMxMVAPmQ64XHB6mYYTHR1QcnLoAWAQGGNgyUlyWxsfIwN6cwt4ZoZMSldVaCtXQt+2DSw+HsJuh2nq1P7bSEiAaG4+EER1b2MRyPmaTF4XCkQL5qUOkr59uxwRs9vBMzMhGhuA2DivZSEiiScngxfkyy2GBvjvJzo6wHJzDCtC7Auz2WQ5mUxjVs4ZydAAqbauEcmJ8djw05YDP6QvShKtBhrGFuJAgBQumm7YUxlPSnLXtOFFRXDV1R/Y8LetDRgxAmpNjbzBmM1gXqpxC6dz0InipGv6ZPVqr3lIwm6HUlgApaLC/TN10iRoBQXQli2TJRsGyEth6ekQO3ceOL415uANYk2mXvcl0dEBlpQM2O0QQkAtHQtUVgBW65DsI2X8eDgbGmRSfX/n53T1v3GvgVhuLlgINqcON0MDpBuuPt/IwxMSVowxn7tuA5ABEg9vgCQY873pcQjx5GSwhHiZb9TWDt51g+75hcwzM6Fv2Sy37+BcDqtbLNG7uimCeFoaNCE8R+SEkAUuS0s9/kZJSwOfNcuvKV6enOzOcxIul7uQ5kFJVdFz61fhcECdNAmu5cvl+zsubkivhGQmE5TqamjffOvew1N0dvZa8CPa28FHjYxY/pRSUT70Nvn2g6FnfMypF+Hmex7Fux9+hl179hnZFCHh0d+HPBIjSCY1bPP6Snk54HJBqZ4AtbLS42mVl5WCV1YC3cXh/N3mhHhgNpvHtJXoyjVSamp8LpVmqurfMuq4OLmUHwA6OsK6ynDI6THFJoQAs8WCZWbKG7rFOqSDo25KVhZYaorMS+t0QOzd665dJoSQCdIlwW2XE4xoDI4Ag0eQXn7yXny/ah2WrViLl157D5xzTK4ej8vOm29ks4QYp78vSyEAk2p4krZoa5d1chISwvrkz1NTwY8+2ufvmckEpbBQ7onWPdJBAVLA+IgREM3Ncod0lwt81CjwkpKQ1JFhigI+ejS0dWvBEhNlVf2DFFOUAw8+rW3g3aMdFqt7RCYaqJMmwfXfTwB7mywk2doqq/+3tUEpK4uq+kNDhaEBUmJCHA6fMRnjSosxvnQUvvx6Bd585yMKkEj04v0HSMxqBbq3PwkxoesQLS3gBQVgug5982YolVWGtBUMnpkJva6uqxBodK1aGUpYTg702lrwUaPkDS7ENdKUMaPBs7PkJqNRMEpiqO5VsAzuzbJ5RjoQRVOPzGKRm0Hv2gVoGsS6dRAmE6Ca5GbDZNAMDZD+tPBZrFzzIywWCyaUj8Exs2bi2it/b2SThBirv2X8ug5mtvjcqyoYoqMDQtOgTJsGJT1dbnK6YaNHleOhgGVnQ6xaDWVKTaRPJarxzEzwuXNDu+FyH5Qf1kVRZHmEtDT3SAsvLh54YcYQw2w2KAUF0HfvBlyaLE1QWkoBcIAMDZBWr92I2FgbqsrHoLqiFOVlo2G1GL/dACGGUU0QnR3e59SFkDV/givx1+eQcsNRlpYK08SJ7lVkLCYGytSpg6qiGy4sMRGIiz2op21CgSlK2LaEOOhxBaK1BaZJk9w/MjIwNRqLiZHbHum6u2AoGTxDA6RnFt6B/c2t+G7lWnz65XL89W+vwWoxY+F91xvZLCGGYWYThL3de7K2EHLPoQH2axuU1jYopWOheEmwVAqH5rA5UxSYDj10yFQcJmRAqiKnMIdLQVOrVVYuYDy4LWsOcoaXH25vt6O13Y629na02+3gUZrNTgggt0YRmu79k9MVIIWK0DQgxiqH+qMMGy43GnJwMJvBMzKHZJ2jQHTXJgNXaHotCIYGSCcuuAIupwtTJpbjkJoJuOKC3yIxgaJZEsXMZkD4WMYvhMxfCNGXrGhrgzJt2rD50iZkqOJ5ecNvKspkohyzIBkaIN1785UoHplPX/Bk+DCbfW9sKYTMEQrR+50xHtD+WISQwVGGYb4ci48Hy4i+7T2GEkMDpJJRBfjwk6X4fOlyAAwzp1Vj1uHTjGySEGOZzb4LQTIun9pCVQaJAQjx0m5CyMGB5eaBR1Edp6HI0ADpuVf+gc+Xfofjjj4cjDG8+vYH2LFzD86Yd6yRzRJiGGa2+FzmLyAO1FMJBVWN2gq0hJDIUrIyI30KUc/QAOmD/y7FUw/eAqtVPgX/8rApOPeKWylAItFLVSDgY5UaY6ENkExUEoMQQiLF0MdToQuYzQfKm5tNZgjd2G0YCDESU1X4XMQvRNe2BcHnIIkQr4gjhBAyOIaOIE2ZWI7r73gYpxw/CwDwxjsfoWbieCObJMRYiuK7yBHjsj4SVyB0/UDAFAiXCywxKdCzJIQQEiRDA6SLzjkVz7/6Dh59+hUAwMyp1Thj3lwjmyTEWIoC5jNCEnKaTeFAaxtgNkNvbQOLjwPjXG5l4HCCxfqxP5nTCRYbG9JTJ4QQ4j9DAyRVVXH2/BNw9vwTjGyGkPBRVQD9TBNzOYokGGCaOQN6Swv0lasgHJ0QjPlf8sLlAuJpiT8hhESKIQHSohfe6vf355xxohHNEmI8RfFZ54iBuQMkxjlgs0GJjQVPT4deWwuWmAht+XK/mhEAeBTvBUUIIdHOkACppbUNALD2x00YkZyIzHRZoXTjpq3IykwzoklCwoJx7rsQJIP8HeddeyEx998ohYUAAM1mg7DbB85NYoxqIBFCSAQZEiBdccEZAIBL/nAX7rz+MiiKXCxn7+jADXc+bESThISPr+BGCBkcMQ4W7z3PiKekQP/55wF3aWegAIkQQiLJ0GX+u/bs7fVvq8WChu27jGySEONxX6M/XaNHJhUsLd37S5KTAadLLuPvj0qbTBJCSCQZmqRdXVGGa297EPNOnA1FUfDuvz9Ffk5WwMfb1rgT9z/yDFat3YCP33rK/fO33/sPXlv8AeJibbj92ouRnpYSitMnxLv+AhfGwGJiwJMSvf6ax8VBYwD2NQFmE5iXvdaEEIDNj5VuhBBCDGPoCNKVF/4WY0oK8djTr+LBvz6P2Fgbrr/qvICPFxdrw2/nHdur2OTeffvx/Cv/xKKHbsUpx8/CwkWvhOLUCfFN8fGxYTLfiOXlAb520bZagc5OKKNLILjifSSpsxPc1wgUIYSQsDB0BMnhdOKcM07COWecFJLjJSbEobqyrNfPvl6+GqNHFcJqtaCqfCzue/hvIWmLEJ+4AqG5PJfsd/1bSU31+aeMc/CSEvCxY4HYWOhrfvBczu9wgKXTYgZCCIkkQwOkX599FfJyMjFlYjlqqstRNmaUO2E7VPbsbUJ+rtyUL3VEEjRdR0enA1YLbdNADGI2AW0Oz6k2n7lJvamVlfLl+fnQ1q2XFbd7BluMg/kagSKEEBIWhgZI7/59ITZu2oplK9bimZcXo7a+ESUj83HXjZcP+LfPvLQYS5et7PUzr/lFDL2mKYQufK7Cfv0fH+KNf34oXzdQkiwhPjCzBaKlxTNAGuQWbExRoIweDX39eiDuQNVsYVLBaAUbIYRElKEBEuccxSML0OlwwuF0wuVyYc36n/z627Pm/wpnzf/VgK9LS0nGmnXymLv27IPJZILFxyafpxw/y70vnMvlwsy5Z/l3IYT0wMwmuddaX3zwo6O8qBDahh/dsZXQdRo9IoSQIcDQAOmqG+/Hjl17MLIgB1Xlpbjywt+iMD8npG3UVJfjiWdfR0dHJ75ftR7Ta6pCenxCPJjMQFeAJOx2CHsHmNUCqKZBH+rAKNKPYHGxQHs7eNHIUJ8xIYSQQTJ0FZvJpMJsMkFRFKiqAlUNLh574tnXseDC69DR6cCCC6/Dx599jeSkBJw1/wScc/nNeOudj3DROaeG6OwJ8cFiBpxO6Pv3g2VmQZlSI/dO44OcY+vCCwshuv5UCAGeSmUqCCEk0pjD0WloMo6u69iwaSuWr1iL71evx89b6vHmcw8Y2aRfuqfYPn/3maADN3Jw0RoboX/3PZTp08CTkyGamuD87HOw2FiYfnFkYMfcsAH6ho0QnME0Z47/m9oSQggxhLHL/B1OrFm3EctWrMV3K9di+849qBhXYmSThBiOZ2SAzzla7ssGyC1BuvdhC/SYI0dC+/FHsMQRFBwRQsgQYGiANPuUC1A8Mh9TJ5Xj0vPmo3T0SPAAElkJGUpY3/ew2SyTrIN4bzNVhTJ6tCwkSQghJOIMDZDefuEhJCZ4bqVAyHDCFEUmaAc58KOMGUPlJwghZIgwNEAym1W8+c7HqG/YASEOLIu+/PwzjGyWkPBTlaBGkLrR9BohhAwNhs533XjXQny2ZBm++Oo7xNpi0NC4C4zRFBsZhkym/jexJYQQElUMjVYat+/Cg3ddg6ryMZh95CG49dqLsa1xh5FNEhIRzGajAIkQQoYRQwMkq9UCTdNROW4MlnyzAiZVRW19o5FNEhIRLC5e5iIRQggZFgwNkH5x6BT89PNWHDGzBovf+y+Om38Jxo0tNrJJQiIjLtbvzWoJIYQMfYYmaZ9y/CyYzXL7hacfvg1b6xsxqijPyCYJiQhmswHm5kifBiGEkBAxdATpwqvvcP9/q9WCMcWFUGkaggxDzGKhGkaEEDKMGBogjS0pxJdff29kE4QMCSw+HnzUqEifBiGEkBAxdIptX1Mzrrn1QRTmZ0NRDsRizy6808hm/dJdkM/lckX4TAghhBAyFCiK4q5HZ+hmtd+tWuf159UVpUY16beOjg4c8avfR/o0CCGEEDJE9NzA3tAACQB0XQdjbMhVCNZ1HQ6Ho1e0GCpnXHAtXvjr3SE95nBG/RU46rvAUd8Fj/owcNR3gTOy73rGBIZNsX306Vd45uXFqKvfDjCgMD8bZ88/AYcfMtmoJgeFcw6rQUm1jDF3BEoGRv0VOOq7wFHfBY/6MHDUd4ELV98Z0sInX3yLp194C5edfzrGjR0FXRdYvXYjHn7yRXDGcej0iUY0SwghhBASEoYESC++/h7+eMuVyMvJdP9sxtQJyM3OwJ1/fmLYB0gnHzcr0qcQVai/Akd9Fzjqu+BRHwaO+i5w4eo7Q3KQ+psfPP28/8OLT9wT6iYJIYQQQkLGkBEkl0vDT5vrAOEZe2m6bkSThBBCCCEhY0iA1Olw4A83/9nr74bYYjZCCCGEEA+GL/MnhBBCCIk2tMawh+aWNtzz0CLU1W9HYkIcbrv2YnDOceNdj2Dvvv2YM2sGzvj1sV5fNyI5EU89/wYWv/8JkhPjAQC3XHMRRhbm9mqjo9OB2+59DFvrGjG5ejwuP/90MMbw7/8swZPPvY6pkypx9SVnRuLyAxKpPmtta8cDjz2PDZu2wuXS8IfLzh4SBUj9Fcn32okLroAtxgqFc+RkZeDumy6PRBcELFJ999WyVXjs6Vfcr9lS14AnH7gZY0qKwnr9oRDJ999zr/wD//zXp0hOSsANV52H/NysSHRBwMLRd/ubW3HvX57GZ0uX458vPYKkrtdG632iW7B953K58MBjz2PFmh+RmBCHW/5wIdLTUnq10bS/xeN4APDym+/jpdfexWknzcHpv57r1/nSCFIPS75ZgZgYKyaUj8XDT74EAHA6XcjPzcIJxxyBMy++AXffeDnqG3Z4vO7Sc+fjqeffQEZ6Ko6bfZjPNl5+4z3s3tuES37/G1x5/b2Yf/IxqJlYjs1bt+H9jz5Hu70zqt74keqzcaXF2LS5DhXjRuPzr77DS6+/h8fuvyEs1xwKkXyvnbTgSrz6t/ujduPoSPZdt/UbN+O5V/6Ju264zNiLNUik+jA1JRm33PsYnvjzTVi1diOeefltPHpf9HxugfD0XUdHJ9b+uAk33r0QLz5+jztAitb7RLdg++61xR9gS10Drr74TNRt246sjDSYTL3Hef786HMex8vPzcKPGzfj1cUfYGRBrt8BkqGb1Uab6TVVmFA+FgBQXlaCXbv3Yck3K1BVPhaqqqK8tARLv13p9XXdkhLi+m3jy67jMcZQVT4WS75dCQAoKshBQV62QVdmnEj1WawtBhXjRqO1rR1baxswelSBcRdpgEi+1+LjbVEbHAGR7btuC5/6Oy49d36Iryx8ItWHP2+pR9X4MbBaLZhUVYYtWxvQ0tpm3IUaIBx9Z7VaUF1ZBrPZ1Ovn0Xqf6BZs373/0Rc47cSjwRhDfm6WR3AEwOvxAGBMSRGyMlIHdb4UIPmwfMVaVIwbjb379iM3OwMAkJ+bhd17mry+rtuLr72L+edegz8tfBYuTfM47p69TSjoGlIuyM3C7j37PF4TrcLdZ407dmPuqRfj/Y+/wAVn/9qgqzJeuPvN5dJwyTV3YcGF1+HzpcsNuqrwiMTndEvtNlgs5kF/2Q5V4ezD7Kw0rFjzI5xOF9as+wkOp7NX4BBtjOq7g0Egfbd95258891qnHnx9bjzz0967buBjjcYFCB5sWlLHb79/gccd/Rhck+WrnIFutDBOPP6OgA4dvZhuOHq8/HIfddh/cbN+PfHX+LDT5ZiwYXXYcGF12H7zt1gYND17uMJcD48lvVFos+yMlLxn8WLcNpJc3D1jX8K8xWHRiT67fr/ORf33fo/uPKiBbjlj4+h3d4R5qsOjUh9Tj/5chmmTa4I45UaJ9x9WDZmFKZPrsTvLr0JX3z1HTIzUhEXGxP+Cw8BI/tuuAu079rtHYiLjcXfHr4de/ftx2dLluPlN95z951L0/o93mBRknYf+5qacfM9j+KO6y+FxWzGiORE1DfsQPHIfNTVb0fxyHyvrwOAzPQDT5RHzqzB1roGXHTOaZh1+DT3z1NTklG3rRGF+dmoq9+O1BHJ4b1AA0SyzxSF49ijDsVfHn8RHZ0OWC3mMF118CLVb2VjRgEAJpSPRVZmGnbu2ovC/Ogato/ke279xs34zUlzwnSlxolUH15w9jxccPY8uFwuvPfR50iJwu9Ao/tuOAum71KSE1E1fgw455hUVYaGxp04Y96x+M3Jx7iP7+t4gaARpB4cDieuu/0hnLvgZBQX5QEADpkyAd+vXg+XSw4JT5tc6fV1nQ4HFr/3X2iajrZ2O779/gevq1sOmVKF71ethxACK9asx/QpVeG8xJCLVJ998sW3+Hr5agghsGzFD4iLjYGlz3z9UBapflv1wwb8sH4TAOCnzXVoaWlDdmZa+C48BCL9Od2xcw9SRiSF41INE6k+FELIIsIA/vGvTzFjSjUUJbpuQ+Hou+EqmL4DgBlTq/GfL76BS9OwbMVaj9V/vo4XKFrF1sOiF97Ci6+9g8L8bLhccm7zT3f8L26/73Hs2duEY2cfit+cfIzX1z3+wE145c1/47Oly7CvqRlHHjoFl/z+N3K4r4dOhwO33ftXbKltwJRJFbj0XPmaBRdeh+aWNnR0diI9dQSeeuhWjwS9oShSfbZnbxPuX/gsausaISBwzWW/Q1VXUl80iFS/7dqzDw88+jzqG3bA4XTiqovPRE31+LBffzAi+TkFgHm/uxqP3nc9UlOib+SjW6T6sK3djpvuXoidu/ciJysd1//PeUiIjw379QcjHH335jsf4+13P8bm2m3Iz8nC8XMOx6knHh2194luwfTdEw/cjE6HE7fd91fU1jdi8oTx+N9Lz/Lou/3Nrbjxrkd6HW/Xnn246ob7sGfffnDGUJCfjUf+eN2A50sBEiGEEEJIH9E1tkkIIYQQEgYUIBFCCCGE9EEBEiGEEEJIHxQgEUIIIYT0QQESIYQQQkgfFCARQgghhPRBARIhhBBCSB+01QghZNg5ccEVMJtUqKqKGKsFp58yF4fPmOxRVK6np55/A1kZaZh71KFhPFNCyFBFARIhZFi6/bpLMXpUAWrrG3HNrQ/ApWkHzX5XhJDgUYBECBnW8nOzcNl5p+ORp15GdUUpHnr8BdQ37EBzSxvmnTAb806YjdcWf4BX3/4AthgrXnnrX3j6kdvR1NSMe//yN9Ru2w6z2YQ/XHo2xpcWR/pyCCFhQgESIWTYGze2GLX1jUiIj8Ppp8zFmJIi7Ny1B6ecfRXm/HIGfv2ro7B+42ZUV5S6p9ju+NMTOO2kOZg6qQJbarfhpnsexXOP3hnhKyGEhAsFSISQYU8IHYwxcM5htVqw6IW3sGlLHRgYduzcg/i43humtts7sOz7H7B33348uujvAICW1rZInDohJEIoQCKEDHur1/6EwrxsfPPdaixc9Hecf+YpOOX4WThrww3Qhff9ugUEFt53vUfwRAg5ONAyf0LIsLaltgF/eeJFnDX/BCz9diUmVY3DzGkTsa9pP1paDowKZaanonHHLgCALcaKCRWlePK5N6DrOjRNR+OO3ZG6BEJIBDCHo9P74xMhhESp7mX+ClcQE2PFb+cdi8NnTMaPGzfj/oXPQtN0lJeVYPXajfi/K87B6FEF+HlLPa666X4kJybg/tuvgqbpuP+RZ7CltgEWswlzjzoUp554dKQvjRASJhQgEUIIIYT0QVNshBBCCCF9UIBECCGEENIHBUiEEEIIIX1QgEQIIYQQ0gcFSIQQQgghffw/9tYzdQKm3acAAAAASUVORK5CYII=",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAkgAAAFVCAYAAAAUvhB3AAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjksIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvJkbTWQAAAAlwSFlzAAAPYQAAD2EBqD+naQAApYBJREFUeJzs3XVYFFsfwPHvLN2hYCF2i2J3d3df29e89rW7O67d3d3dndjdiiAg3bDsvH8s7HUlBCREz+d5eB525+w5Z2ZnZ397aqSwsFAZQRAEQRAEQUOR2hUQBEEQBEH41YgASRAEQRAE4TsiQBIEQRAEQfiOCJAEQRAEQRC+IwIkgQ+fPmNpV5Sps5ekdlVi1bP/KCztiv4wnVKpxNKuKH0Gj0uBWmnbtG0flnZFuXztdoqX/avZuusglnZFuX7L6afycShbj7rNOgPg7PKFHIUrs2zNlqSoYoIsW7OFHIUr4+zyJVGvr9usMw5l6yVxrQRBSE4iQIp04/Y9LO2KkjlPGYKCg1O7OrFat3lXvAIFQUhJeYtVZ8a85claRuaMtmxdu5C2LRomazkxaduiIVvXLiRLpgwpXrYgCKlDBEiRDh49Q6niRQhXKjlz/mpqVydWbu6eqV0FQdASERHBV0/vZC9HoVBQvkxxrK0sk72s71lbWVK+THEkSUrxsgVBSB0iQAJUKhWHjp6meeO6VCxXkkNHz2i2PXvxmlYd+2FfsCJFytVj666DgLorZ9HyDRSv2Ai7fOVo1bEfnl7qL4kHj5/RsFV37PKVo3yNFhw4ckqT34x5y7G0K8rbdx+B/7oiLly+AUCDlt3p+L8hzPl3FQ5l65G3WHV27TsKQJ/B45i1YAUAlnZFadCyu9Z+1GjYgfI1W2oef3Zxw9KuKGs27sTL24cJ0xZQplozMucpQ52mnXn15n2Mx+P7Ol2+dhtLu6Js2rYPUH8hzl+ylsJl6pK7aFVGTphNWFh4tHx27z9GvRZdsS9YkcKl62he/6P9BPD08qZTz6HYF6hA3WadeffBOdb37+KVm5Sr0ZzshSoxYvysGPfl9t2HlK/ZkpZ/9SUoOJj5S9ZSoVYrMucpQ4Varbh19wEA46bMx9KuKB5f1YFos/a9sLQryuOnLwH4Z8x0sheqhEqlQqlUMmnGv+QuWpXiFRtx5oJ2YB0WFs6MecspXKYuOQpXpueA0Zp8E1JOn8HjqN6gPeu37KZUlSbkKFyZRcs3xHgsPL560nPAaHIUroxD2XrMnL+C8PBwIiIiyFe8Bm27DtCkjWo1PXX2MgDHT1+gfM2W2BeoQJsu/fni5hHrMYzy4dNn0mUrjkqlYtaCFdG6GG/ffUidpp3Jmr883foOJzxcfZ7E9xz61rddwc9fvsHSrihLVm3SbJ+7aDU2OUrg4+sXr/xXb9iBpV1RnO4/BmDg8MlY2hXl2KkLACxavgGrrI54e/tG+9w6lK3HsLEzGDVxDvmK18ChbD0uXrmpyfv9R2eatutF1vzlI68NPlplv//gTNuuA7AvUIHiFRuxZuNOZFlGpVKRu2hVWnf6GwDXL+5Y2hWlct02muNml68cIyfMjvNYCYLw80SABNy995jPrm7Url6ROjUqc+LMRUJCQvH46knDVj149vINk0YPpEn9WuTIlhWAOf+uZvy0BVQsV5Ip44aQL29OrCwtcHP/SpM2PfHx9WfWlJHkypmNLr2Hcf7S9XjX5/Dxszg9eMLAPl2QJInh42YSERFBr27tKV+mBABb1ixg7PB+Wq9r2qg2T5+/4tNnVwBOnr2IJEk0qleDiIgI7tx7TJcOLRk+qBePnjznnzHTE3W8lqzcxOSZi2hQpxqjhvZl266DrNqwPVq667ecKFWsCFPHDSFdOisGj5rKh0+ff7ifAH0Hj+PEmYsM7d+DRvVr8ibyi+l7nz670qZzfyRJwfSJwwgPV8aYrn33gbRuVp+RQ3qjkBRcvHKTVk3rMX7kANw9vtJrwBhkWaZyhdIA3HZ6pD5mTo8wNDDgxu17ANy8c5/yZUugUChYvmYrC5auo2Hd6gzp353Xbz9olTlz/nJmL1xJm+YNGP1PX06evUSnXv+gUqkSVA6A04Mn7Np/jL7/+4v06ayYNHMRXz29tMpTqVR0/N8QTp29zJhh/WjZpC4z5y9n1oKV6Ojo0Lh+TS5duUlISCgAJ05fxMLCjKqVynLr7gPadxuEXeaMTJ84jE+fXBg0ckqsxzCKTXpr5k0fA0DzxnXYsmYBBfPn1mxftX47rZrVp1zp4uw7dJITZy4B8T+HYpM/by4K5sutCe6i9qdapXJYWpjHK/+o9yAqOL519776Pbj133tQqEBerKwsYqzD6g078PP3Z2Dfrnh5eTN60lxAHcR06D6Yew+fMGHUQEqVKILz5//GLgUFB9OsfW8eP33J1PFDqVyhFP+Mmc7m7ftRKBRUKl+K204PkWWZW3ceYGhgwOOnL/HzD+Dpi9cEBAZRsVzJeB8rQRASRze1K/ArOHD0FDmz25Mlc0aqVirLyAmzOXfpOm/ff8TTy5uje9ZRoWwJTXpZllm+ZguVypdi0ZwJWnnt2n8UH18/1i6dSY2qFWhYtzrHTl1g5frtVKtcLl71sbVJx7a1C5EkicdPX7Bh6148vnrh6FAAu8zqMRAN61aP9rpmjeowbsp8Tp29TPdOrTlx+hLly5Qgg216AI7uWYuLqxsPHj8jq11mbt99gCwnfCH1Veu3U6l8KUYN7QPA1Rt3OHriHH/37KSVbv6MsQQHh3Dv4VOKFy3Eg0fPuPfgCdmyZolzPxUKBSfPXqZH5zYM7NsVgJu373Po2Bm+t/fAcUJCQ1kydyLFHQvTuH5NNm3fFy3d3z07afICOLhjFZ5e3tx78JTcubJz/aYTnl7elC1dDF1dXW7ffYC9XWYCAoNoVK8G12850bZlI548e0W7Vo0B2LxjPwXy5WLBzHFIkkRQUDDDx80E1MHK6g07KFnMgXEj+gPwydmVRSs28PDJiwSVE2XfluUYGRni7ePH5JmLePv+E+nTWWu2P3z8nBu37zO4Xzd6dFa3OFy8cpNV67czZlg/mjeuw+oNO7h87Ta1qlfkxJmL1K9dDX19PdZs3ImxkSFL5k1CX1+PoKBgRoyfpdXq8v0xBDA2MqJapbIA5MmVI9p5uWDmOGpVr0iRwvk5de6yptUyvudQXJo1rsOsBSvx9fMnNDSMu/cfs2TepHjnnzd3DjLYpue200PatmzEsxdvaNaoNtdvOSHLMredHtK8cd1Yyy/hWJil8yYDcOb8Fa5cvwPAvQdPePLsJZPHDNa8D8dOXdC0Ip0+d5V3Hz6xYOZYOrVrzl9tmnL05HlWrNtGp/bNqVyhNPsPn+L12w/cvHufmtUqcPz0RW7ffcCHT5+RJIkKZUrEWCdBEJLOHx8gybLMwaNncP7sSsbcpTXPHzx6GjNTEwAcCuXTeo2nlzd+/gHRngf48FHdQlLUoQAAFuZm5M6ZjQ8fY+8i+p6ujo5mrEPUF2BoWNgPX2eXOSNlSjpy8swl2rVqxMWrN5kydggAfv4B9B40lhOnL5I7ZzaCgkMICg7RtNjEV1hYOJ9d3fjs6kb2QpU0z+fOmS1a2pXrtjF93jIUkoIc2ezU9fAL+OF+eniou51y5rD/YX0+OrvEK23U+xG1D0NHT2P7nsNkyZwBfT09Td1y5rCmhGNhbjs9JKtdJnJky0rxooVYvWEH9x48QaVSaX69f/zkQvWq5WMcl+Ll7YN/QKBWucWKFgTgwwdnHB0KxLucKHp66o9remsr9bEK1T4n3keeY9plFsLpwRO8vH0oU9KRzBltOXn2EnlyZef5y7dMHD1IXaePnwkMCiZvMe0Ax8vbJ8ZjGF8x1Tkh51Bcmjeqw7Q5Szl/6ToBgUHo6OhQv1bVeOcvSRKVy5fm5t373HF6hIGBPvVrV6PvkHG8evMedw/POFtqovYtav+igskfnZNR14KihdXHU6FQ4OhQkGs37wJQuXxU6+JDbt15QN1aVXj5+h3Xb9/js4tbnK1agiAknT8+QHK6/xjnz64snDmOQgXyArBm006On77IkH7dAHj89CXlyxTXvMbayhITYyPNeJFvZbNXt47cf/iMmtUq4Ovnz+u3H6hVvSIA+vrqL2P3r57kzGGPv39AtDziotDRASAkJBRDQ4No25s1qs2kGYs4d/E6YWHhNKpXA4ClqzZz7sI17lw8SM4c9vQZPI7tuw/FWEZUwOAeGaj4BwT+t01fj8wZbcmSOSPjR/43nsXUxFgrjw+fPjNi/CzGjxzAoL5duXrjLo1a94jXPtpGtng9ePRM81xsLV22NpFpHz+jSoUy8WoR233gGJt37OfkgY2UKenIjHnLNWO7QN31snbTLnLnzEbxooUoVrQQn13duHj1JpYW5hSOPE9sbdPx8NEzZFlGkiStsq2tLDEzNeH+w6ea5+49UP+fLTJYjG858ZXdXp3v/YdPadqwdmSZTzA3M8XayhJJkmjaqDbHT12kQL7cmJuZUq2SulUzW9bMPHn2ki1rFqATeY4BpE9n9cNyFTrqbsDQ0NB41TO+59CP5MqZjSKF83P2wjUCAgOpWrGMJnCIb/6VK5Zm94FjXL/lRNHCBShZzIHwcCW79x9LdEuN5px89EzTovbtuZEt6n169JTijoVRqVTcf/RU83zOHPbYZc7IoycvePLsFaP/6cvL1+94+Og5bh5fRfeaIKSQP34M0sGjZzAw0Kdty0aUKlGEUiWK0KRBLfz8/MmcKQNmpib0HjSGjVv3snDpOtZu2oVCoaBrx1ZcunqLwSOnsGPPYfoNHY+Pjx+tmtbHwsKMiTP+Zeuug/w9dIJ6/FDXdgDkyZUdgKmzl0R+Ma9MUH2jvgRnLVjBpau3om1v0qAWIaGhzJy/grKlHMmU0RaA4OAQQkJDOXXuMvMWr+HI8bOa16RPZ4Wuri73HjwhIDCIPLlzALB45UbmLlqt6TaK0qNLW247PWTn3iN8+PSZk2cvRWtFCQ4OAdRf1tt2H2L8tAXx3sesWTJRrGghjhw/y4q1W5m9cCUnz16KMW1UADh11hK27T5EzwGjf5h/VN3OnL/K8jVbWb9lt9b2yhVK4+Xtw/nLNyhRzIFiRQshSRK79x/TGhfUpH4tnF2+MG7qfNZv2c2/y9Zr8lAoFPyvS1vu3n/MlFmLWb1hBxu376Vc6WIUiWx5jG858eVQKB9lSjqyYete1mzcyaQZ/+L04Ak9u7bTvD/NG9Xh3YdPrN+yh7q1qmBgoA9At06tCQxSD15/8/YD12854eLqhq7uj39DZbBJj6GBAUdOnGPfoRO4uX/94Wvicw6BOtD55OyqaR37XvNGdTh74SoXLt+kcYOaCc6/UvlSAOw5eJwSxRzIns0OaytLdu0/muiWmpLFHMic0ZaN2/aycetexk6Zx8PHzzXba1YrT/Zsdsxfso5N2/cxeORUPL560btbe0DdslWpQmmOnTpPcEgIxYsWpmQxB+4/esrLV+9EgCQIKeSPDpBkWebgsdOUKemo1RpTvkxxFAoFF6/e5OCOVWTJlIHRk+awdddBjIwMARg3vD9D+/fg9LkrjJgwi4CAIEJCQ8mYwYZDO1djbmbK8LEzePXmHeuWzdKMP6pXqwpNG9bmwaNnXL/lxIYVcxJU5x6dW1OxXElWrtvGgqVro23PlNGW8mVK8PjpC5o0qKV5vk+PDpQuUZRpc5Zy9/5jzdgIABNjY9q0aMC1m048f/GaooXz07NrO95/cOb4qQtsWD5b68tlQO/OTBw1kCs37jB87Ayu33TC77uWsPx5czGgdxfOX7rOslWb6dO9Q7z3UZIk1i2dhWORQkybs5Sbt+/TuX2LGNMWKpCH5Qun4v7VkwnTFlAwX27y5ckZZ/5tWzaiZtUKLFu9meOnL0Qb91KqeBEMDQz48PEzJYs5YG5mSv68Ofnw8bPWl9OIIb1p16oxm3fsZ83GXfT+bh9HDunDPwP+x449h5k2Zym1q1Vi06p5msAnvuXEl46ODlvWzKdm1QpMnb2E3fuPMXxQL4YP6qVJU6KYA/ZZM/P46QtNKxNA2VLF2LZuId4+voyaOIede49Ee09jY2RkyKzJI/D182f4uJnce/jkh6+JzzkE0L5VY3x8/Tj8TUD/raaNauPyxR0//wCt8U/xzT+7vR3Z7LNEvgeFkSSJUsUdEv0eABgaGrB17UIyZ8rAuKnz+ezyheaN62i2mxgbs3/rCgrlz82YSXO5dPUWs6eMpGO7Zpo0lSuU5sPHz+TJlR1LS3NKFS+Cu4cnIaGhYvyRIKQQKSwsNOGjdAVBEARBEH5jf3QLkiAIgiAIQkxEgCQIgiAIgvAdESAJgiAIgiB8RwRIgiAIgiAI3/njA6RmnQbRpvs/dOg1kh4DJ3D+8q14raXTd9hUXL94JFu9wsLCGT5hfrR7OCUmndODp0yZ+99yAnfuP2HRqm1JVNP4mTJ3JTv2nfjpfL7fl6OnLjFiYvyXEEhK8S37+3OlWadBvHzzIY5XxG7N5r0sWL45Ua9NSF7NOg1KdL7fv0fJZevuo5w89+vcWPpnrgnfvhdv3n9i0uzlSVm1JOX6xYNazXtqHq/ZvJejp2JehkMQ0rI/fqFIgCmj+5M3VzY+OrsyYtIClBER1Koav9uCJBd9fT1mTxqSZOm+VdKxECUdCyW2aoLwS+jQqkFqVyFZ5MqelQnD+6R2NQThjycCpG/Y22ViQM8OLFmznVpVyyHLMht3HOL4mSvIsky9mhXp2r4pU+au5NHTVwwZN4eC+XIx7p9ePH72mvnLNhEYFEymDOkZP6w31lYW9B02lXo1K3Ho+HlqVimLqYkx9x4+I0Kl4uGTlxTKn4vWTeuyZvNeXr7+QNcOTWnVRL0+Ta3mPdm0bBqZMtrQrNMgenRsztFTl3j73pm+3drQuF41rXS2NumYtWgtd+49RU9Phy7tmpI1S0Ymz1lJUHAInfqMZviAbnh6+7Bz/wmWzRkLwMlzV9m86wgKSSK7fRYmjuijtUhhvdZ96NWlFQeOnmNI305kzmjD7EXr+fj5C/r6egzv35XCBXKzZvNevrh9xdvXj8+uHthlzsC4f3phYW6qdZw/fHJhyZrteHz1JjAomN5dW1Ojchkmz1lBwXy5aNlYvX7T2i37kWUVPTqq10B6/Ox1tH0B8A8MZPqC1Tx4/AJzMzPmTfkHczMTpsxdSb7c2Tl/5TaF8+emX4+2HD55kR37joMMBfLmYFCfjpiaGLNm8178A4IY3KcjACMmLqBy+RI0qF2Zu/efMn/ZJvwCAvnq6U22rJnp3aVVnGVHielcAbh83YlFK7fy+t1H+nRtQ5P66vfyyMmLbN1zlIgIFaWKF2Zo307RFoz86OzKP+Pn4eziFnmMe2Jhbsb12w/YtOMQgUHBIElMHN6HnNntYn2Pv3Xz7iMWr97GinnjGDN1EV/cvtKpz2jKlSpKn25tuHrzHivW7yYsPIw8ObMxdmhP9PT04nW+FS7w381r4/qc1KhchkvX7vLqzUdaNK5J97+aA7D74Cm27z1OYFAwgUHB5MyWhdmThrB973HMTI3p0bEFazbvJSQ0DBdXd569ekfObHbMmjAIXV1dvnp6x3i+xiauz9qjp69YtGorQcEhWFtaMLRfZ7LbZ471fY7rfI/NyzcfGDFpAfs3LaRb//H06daaUsUKAzB17kqKOuSnYe3KMV6bvvX9+d+3e5sYX+Pp5cPY6Uv46umNsbEhowf/j3y5s1Ouzl+c2rsSM1MTrTp9a/fBU+w6cApjI0N27j/BuiVT0P1mJXZBSMtEgPSdQvlz89HZFWVEBGcv3uTDJxe2rpyBLMOAUTMpX6oo4/7phdPDZ8yfMoxMGW3wDwhk+vzVLJg2nAy26dh/9CwbdxxkcB/1AoRHT15k6ewx6OvrcfTUJe4+fMay2WOwsjSnVdehAMyZNJRHz14xbPw8WjauFeOqv1/cvrJ09hiu3HBi9qL1mot2lNdvP3Dhym2O7VxGWLiS0NAwrCzN+V+nFjg9fKa5aF+8dkfzmgdPXrJs7U5WLZhABtt0eHn7RvtC9vH1x9nFjfVLpiBJEoNGz6Jt83qULVmE9x8/M37mMjYtmwbAZ1d3Zk8agqmJMeOmL2HzrsP83aOdVn6WFub83aMd2bJm5uGTl4yctJDqlUrTpmkdps5bTYtG6hWRT1+4zvyp/2heV7hA7mj78uGTC65uXxk7tCe26a3pOXgy5y7fpGl99aKBew6dZu2iSerbfjx6zsbtB1m9cCKWFmbMX7aJJau3M3JQ9zjPidmL1/G/Ti2pUbkMc5dswNrKkqoVS3H01KU4ywainSv/kVk8a5TmvWxSvxoPnrzkxLmrrF8yFT1dXSbPWcGl63epWqGUVn1CQkK1jvGmnYfp/7/2ZM5ow8wJg7EwN2XD9oOs3bKPaWMH/PA9/vDJhblLNrBg2nBMTYz5d8ZIytX5i03Lp2ve01Wb9rB0zhjMTI1ZsX4X+4+do7hD/nidb1F+9Dl58fo986YO4/2Hz3TpN5YOLRsQEBjE4tXb2LN+HtZWFnT5exyD+3YiY+TtaL519/5TFkwbjqGBPq26/cPdB88oU8KBqfNWxXq+xiamz5qffyAjJy9k9sTBFMqfm/OXbzFy8kK2rpwZx/sc+/ke02f8e/VqVuTcpVuUKlaY8HAlN+4+ZFCfjpw6fz3Ga1O+PDm0Xv/t+X/y3LUYX+P08BkmxkYsmzMGTy8fzL4J8H+kVZPaPH/1juJFCtCgduV4v04Q0gIRIH1HllVIkoSExOXrd3ny4g3d+o8HICg4BFe3r9EuQo+fvcbtqyfDJswDICJCRY5sWTTbWzerq7kHG0DenNk0F9G8ubNRpkQR9PR0KVIwD0HBIQQGBcd436hK5UogSRKFC+ThawxjjrLZZyF/npyMn7mMDi3rUyh/7L+So1y57kS9mhXJYJsOAOtYbq3wV6uG6jvWB4dw594TvLx9WbZ2B6B9r7a8ubNrbvJbqVxxDhw9Fy0vC3NTvrh5sHzdTt5/dMHb14+goGDy5cmBqakxT1+8QUdHh3RWFmSOvFVKXPLmzKZJVyBfTq3xWE3qVdPU58rNe9SqVg4rS3MAWjetQ68hk38YIGWwSY+Xty/h4Ur8/ANJZ20Zr7LjEtN7eeW6Ex8+utBz0EQAQkLDKJgv+qrgsR1ju8wZuXn3ITfuPOTZy7eEhYdr8o3tPfYPCGT4xPk0rlsVu8wZYqzrzTsPcXP35O/h6qAiLFxJ+dKOCT7ffvQ5qVCmGLo6OuTKkRU9PT28ff2xsjDD0MAAb19/DA0NCQkJJbawokihvFhamKmPUS57vnp5//B8jU1M78/jZ6/ImjmDZj+rVSrNghWb+fTZlez2WWLNK7bz3SQe956rWaUsnXaOYWhEBLecHlG0UD5MTYzjfW369vyP7TXlSzty5OQlFq/eTuumtTHQ1/9hvQThTyACpO88evqa7Fkzo6OjQJZl2jWvR+umdeJ8jSzL2GXOwMalMf8q1dGJfSy8rs5/b0HUfa9+NEhcVzfmJmxDA30WzRzJwycvWbp2Bzmy2THs7y5x5qWSVehKP24S/3YfZOTI1oS4f2nq6OjEeEPdg8fOc/zMZbp2aEbndk2o0bQHqsh9btOsDoeOX8DMzIT6tStFe+2P6OroaB0/nTia+yVJ0vyKlyQJZUREjOnq16rIph2H2X/0LAXy5qRt83rxKjte9f3mvZSRqVm1LAN7/RXv1397jKfMXYGBvj6N61WlYpliLFmzHYj7PT5x9ip9urbm4PHzNK5XLVp3aFS9HB3yM3P8oGjbEnK+/ehzEkWSJPVxkWUMDQ2oWrEks/5dR2hoGA3rVKFo4Xxxvh4iP1fyf/WPz/kaYz6xfNY0dUWCWEM2tbjO9x+xsjQnf57sOD14xrnLt6hbowJAvK9N357/cb1m4/JpXLhym7+HT+d/nVpSp3p5AJTKmD8TgvAn+ONnsX3r/UcXFq3aSpfIvvyKZYuz68BJTauAyxd3TdqMtulxdVPPWCmUPzdu7p6cu6y+eWxgUDDePn4pWndQzy5x+eJOkUJ56dSmMddu3dfU9Yvb1xi/vMuXcuTE2St4eHoD8OnzlzjLMDYypFiRAqzetBeVSkVEhApXt/9uTvrF7Svh4UrCwsI5cOwc5Us7AuqvEFlWAXDlphPVKpWmTAkH3rz7pJV/pbIlePbqHddvP6BaxdLRyo9rX36kYplinD5/HR9ff2RZZvfBk1QqWxyAdNaWPHvxhtCwMN6+d+bJi9ea1x05eYlRg3uwffVsxg/rjXHk/fji69tzJS4VyhTj2OkrfHR2BcDV7SsREapo6b64fUWpjH6ML99womXjWhTMl4tnr95p0sf1HteuVo6ObRrRtEF1Fq3a+k2d02lmZJUu7sBtp8c8evoKAG8fP3XrQwLPt8R8TpQREVy4cptVC8azddVMurRrEq+uqSg/Ol8TonCBPDi7uvHk+RsALly9jZGRIVmzZARif5/jOt+jSJIU6zldt0ZFzl2+yaOnryhbsigQ97UpNrG95tnLt4SGhlGzSlmqVy7DLadHAKS3tuTB4xcoIyI4fubyt5VFJf93Xsb3/BaEtEa0IAHjpi9GR6GDkZEhfbu1oWpF9ZiPujUq4OHpRd9hUzHQ18cmvTXTxvTH0NCApvWrM27GUooXKcCU0X8zZ9JQ/l25hbWb92FgoEe/7u0o4VgwRfcjMCiYxau34eXtR2hYGAN7qW+e6lAwD2Hh4bTvOYJBvTtqvaaEY0E6tW3MgJEz0NPTI3vWzIwe8j8MDWJvZp8wvA9zl2yg3f9GYKCvR4PalWnTrC4A3r5+DB4zG/evXpQrVYRmDdTjcUqXcGDN5n20aFSLlo1rs3TNds5euknp4oXJYJNOk7eOjoIKZRzx+OodYyAS1778iKNDfjq3a0K/4dNAhvx5czAkclB29UplOHrqMq27/kPpEg5U+Wbcj0OhPAyfOJ/01lYYGKiPUdcOzWIrJprvz5XYFHPIT///tWPEpAXo6uhiYW7KhBF9sElnpZXO0NCAQaOjH+PuHZozdvpibNOno2zJIpr0sb3HABbm6i6pts3q0uXvcdy8+4gyJRxo0agWPYdMpkblMgzq/ReTRvZj9qL1yMgYGxkyYmA3ZJUcr/OtTAmHyLJME/w50dXRIWc2O1p3G4apiRFmpibky5ODXl1axvv4x3a+nr5wnbsPnjJyYNxdrFHMzUyYMW4QC5ZvIiQ0DEsLM2aOH6RpXY3tfY7rfI9SrEgBps9fTYeW0WfmVSxbjLlLNlC9Umn09NSX7LiuTbGJ7TWubl+Zu2QjQcHBGBkaMn6YeuzY/zq1YPqCNdjvzshfrRty4ap67GIGG2vss2Ri98FTtGpSmxqVyzB0/Fyu3XrA3ClDsbaMuZteENIacbNaIcl8PxMsMYJDQug1eDKTRvbTGp+SWoJDQujYezSblk/H2MiQoOAQeg+ZTNP61WkeOZhcSD73Hj1ny64jzJ2snszg7OLGX71HsXHp1DjH/cRHWFg4/UfOYOX88UlRVUEQfjOiBUn4ZRw5eZF1Ww/QoVX9XyI4AjA0MKBCGUf+Hj6NsHAlSmUEFco40rBOldSu2h8hW9ZM6Ovp0fXvcYQrlejo6DC0b6efDo4Alq7dTq/I5RoEQRC+J1qQBEH4I8mynKDxTIIg/FnEIG1BEP5IIjgSBCEuIkASBEEQBEH4jgiQBEEQBEEQvvPHBkiyLKNUKhO1no4gCIIgCL+3ZJ3Ftn3fcbbtPkrb5vXo0KoBazbv5eDxC1hF3g5g4oi+5Mxux+UbTqzcsBtdHR3GDu1J7pz2hISGMXn2cj58cqVU8cIM7NUBSZISlDYuERERVGrQhctHN2hWsBYEQRAEQYBkbkEq7pCf0pGLxEXp2bklm5ZPZ9Py6eTMbkd4uJJ5SzayaOZI/vm7C7MXrwdg/5EzZMpow5aVM3j/8TO3nR4nKK0gCIIgCEJiJWuAlC9PDjJl0L7rtuV393p68vw1lhZmWFtaUCBvTl68fo9/QCBXb93H0SE/kiTh6JCfa7cfJCitIAiCIAhCYqX4GKStu4/S/n8jmLd0I8qICL56+WBvlwlQ32bCLnMGPL188PTyIVvk89nsMvHV0ztBaQVBEARBEBIrRQffNKxThbo1KmJsbMiIiQs4efYqhoYGWgOlZZV68TYJCZVK/bxKllEopGg3dIwrbUz2HDrN3sOn1a8Vg7MFQRAEQYhFigZIGW3/626rXqk0Hz65UKFscT5+Vt+9PCJCxecv7qS3tiR9Ois+fXYlu31mPjl/Ib21FenTWcU7bUxaNq5Fy8a1AFAqlVRq0CV5d1gQBEEQhDQpxbrYQsPCOHjsPBERKgKDgrl97wn58uSgUL6c+PkH4uXty5PnrymYNycmJsZUKOPIvYfPkWWZ+4+fU76MY4LSCoIgCIIgJFay3YvNw9OboWPn4Onti0KSsLfLRKlihbl0/Q7ePn5Ur1yGv3u0Q5Ikrt26z7J1O9HT1WXcP73Imd2O0LAwJs9ewfuPLpQpWYT+/0t42rhEtSCJaf6CIAiCkHje3r5YWpr/drfv+WNvVisCJEEQBEH4Oas37GD4uJnMnzGGrn+1Su3qJCkRGQiCIAiCkGBPn79i2NgZABw5fu6nAyRZljl++iIvX73FzMwUM1MTzMxMKFe6OJYW5klR5QQRAZIgCIIgCAk2c/4Kzf+6ujo/ldenz64MGTmV0+evRNuWJVMGTh3cTJbMGX6qjIQSAZIgCIIgCAl2/9FTzf/uX70Snc/Fqzfp0G0QAYFBZMpgQ8d2zQkNDcXPP4B7D59y/+FT2nTpz/mjW9HT00uKqseLCJAEQRAEQUgQP/8APn5y0Tz28PBMdF7TZi8lIDCIdq0aM2PiMK3utIDAIKo3aM/jpy+4eecBFcuV/Kl6J0SKr6QtCIIgCMKv7cbte/y7bD0RERExbn/24jUA5cuUQE9PF/evnolagPnFq7fcuvsAm/TWLJo9PtpYI1MTYxrXrwnA9VtOCc7/Z4gWJEEQBEEQtNRv0Q2VSoWZmQndOraOtv3p81cAFCqQhw8fnfns6oavrz+WlgkbTL1150EA2rZoFGv3WbnSxYCUD5BEC5IgCIIgCFpUKhUAm3cciHH702eRAVL+PNjYpAPA/WvCutl8/fzZvGM/AB3aNIk1XakSRVEoFNy68wClUpmgMn6GCJAEQRAEQdDw8fHT/H/vwROWrdnClet3+OjsoglQHke2IBUskIcMkQGSm/vXBJWzeMVGvH18qVe7Kvnz5oo1nbmZKQ6F8hEQGMSjJy8SujuJJrrYBEEQBEHQePfhk9bj0RPnaP7X1dUlo216XL64A1AgX25s0qsDJI8EtCC9fP2OZas3o1AoGD+i/w/TlytdnAePnnHtlhPFihaKdzk/QwRIgiAIgiBoRAVIzRvXoWqlsjx6/Jx3H5z56OzCx08uOLt8QVdXl1bN6mNmakKGyBvRu7nHL0By9/CkZce+BAWH8L/ObSiQL/cPX1OvVhVCQ0NxdCiY+B1LIBEgCYIgCIKg8fa9OkDKnzcXndo119omyzJe3j6Ym5lqBlXbpLcG4teCFBQcTLuuA/j4yYUqFcswbcKweNWpSsUyVKlYJiG78dNEgCQIgiAIgkZUC1KObFmjbZMkiXTWVlrP2UYN0v7BWkgRERH07D+au/cfUyBfLjaunIu+fsot/JhQYpC2IAiCIPyhAgKDos0Me/feGYAc2ezilYetjbqL7UcB0oTpCzly4hwZbNOzc+OSVLm/WkKIAEkQBEEQ/kCv374nr2M1ilVsxLrNuwgNDQPgfVQLUvboLUgxiWpBuv/oKZev3Y4xjZe3D0tXbcbI0JCdGxZjb5c5CfYgeYkASRAEQRD+QLv3HycoOIRPzi4MGTUNx/L1GTlhNi5f3DE3M8XayjJe+WS3t6Ngvty4e3jSqHUP2nTpz/OXb7TSPHr6AlmWKV+mOI5FUm6g9c8QAZIgCIIg/IEOHz8LwOQxgylXuhiubh6sWLsVgEH9uiFJUrzy0dfX4+KJHcyeMpJ01lacPHOJ8jVbsmr9dk2ax09fAlC4YN4k3ovkIwIkQRAEQfjDvH33kafPX5Exgw1/9+rE8X0bOLpnHX+1acqezcsY8nf3BOWnp6dHz67tcLpymCF/d0eWZabMWoyvnz/wX4BUqIAIkARBEARB+EUdOXEOgAZ1qqFQqEOBCmVLsGTeJGpWq5DofC3MzRg/cgD1a1fFPyCQjVv3AvD4qXoFbNGCJAiCIAjCLyuqe61RvRrJkv+APl0AWLF2K2Fh4bx49RZ9fT3y5MqeLOUlBxEgCYIgCMIfxPWLO7edHmJpYU6FsiWSpYwyJR3JZp8Fly/uXLxyk7CwcPLnzaVZXDItEAGSIAiCIPxBjp48D0DdWlWSNWDJlzsnAPuPnATSVvcaiABJEARBEP4oR0+qxx8lV/dalFw5s0WWpw7IChfMl6zlJTURIAmCIAjCH+TJs1cAVCxXMlnLyZNLHSD5+qpnshVOQzPYQARIgiAIgpAmjJ0yj+HjZv5UHoFBQbh7eGJlaYGFuVkS1SxmUS1IUUQX23e27ztOo3Z/s3X3Ua3n5yxeT99hUzWPDxw7R4deI+k1ZLLmfi4+vv70HzGDDj1HsmX3kUSlFQRBEIS0ztvblyUrN7Fq/XYCg4ISnc/HTy4AZLPPklRVi1WenNk1/2fOaBvvlbl/FckeIBV3yE/pEg5az71+94nHz19rHnt5+7J552HW/juJlo1rsXTtTgDWbd1PlQol2bhsKsfPXOGjs2uC0gqCIAjCryoiIoIXr97GK+1tp4ea/12/uCe6zA+fPgOQLWvyB0iZMtpiYmwEpL3xR5ACAVK+PDnIlCG95rEsyyxetZVuHZppnrt59xF5c2XH0NAAR4f8XL99H4Brt+7j6JAfXV1dHArk4frtBwlKKwiCIAi/qj6Dx1GmWjOuXL/zw7S3nP77Tvvs6pboMt9/cAYgewq0IEmSpOlmS2vda5AKY5AuXb9LlkwZyPtN36Snlw/2dhkBSG9tSYRKRUhoGF7evthlzgCAvV0mvnr6JCitIAiCIPyKTp29zK596qEn9x48iTVdYFAQB4+c5vLV25rnXF1/pgUp5brYAArmzwOQZm5Q+y3dlCwsLCycTTsOM3/qPwQFhfy3QVK3LEWRVTKSpI4+iXxeJauQFFLC0n5nz6HT7D18Wv26b/IQBEEQhJQSEBjEkNHTNI+jur1i0mvAGM1tQaK4pJEuNoCxw/+mXKliNKxbPUXKS0opGiA9ePICP/8Aho6bS1i4ks+ubixYvpmC+XLy+Jl6TJKHpzd6enoY6OtjbWWBs4sbuXPa88n5C7lz2mNuZhLvtN9r2bgWLRvXAkCpVFKpQZcU23dBEARBAJg2ZynOn12xtUmHu4cnHz7GHCBdvHIzWnAE4JIkXWx2ic4jIewyZ6RzhxYpUlZSS9EutlLFCrN7/TzW/DuJWeMHkS93dgb36Ujp4g68evOBkJBQ7j18TvnSjgBUKFOMe4+eo1QqefzsNeVKFU1QWkEQBEH4lTjdf8zKddswMNBnxUL1TO6Pzi7R0imVSkZOmAXAgN5dKFe6GC2b1AMS34IkyzIfP31GkiTssmRK5B78OZK1BcnD05uhY+fg6e2LQpK4fucBS2aNjpbOytKcLu2b0n3gBMxMjJkypj8AXds3Zdz0JRw4eo6GdSprxhglJK0gCIIg/ArCw8MZMHwyKpWK4YN6UblCaXR0dPj4yYWPzi7o6eqSKaMtAOu37OHZizcUzJ+H8SP7o6ury4tXb9lz8HiiW5C8vH0ICAwiS6YMGBjoJ+Wu/ZaksLDQP3IwTlQX2+WjG9DVTdGeRkEQBOEPtGDJWibNXETBfLm5cHwH+vp6FClXT7M2Uc7s9ty9fAhvH1+KV2yEj68fh3aupnKF0gD4+QdgX6ACGWzT88LpbILLv3vvETUa/UX5MiU4tnddku7b70ispC0IgiAIyezZi9fMmL8chULBojkT0NdX3yTW3i6zJs3b9x9xcXVnxtxl+Pj60bh+TU1wBGBuZoqZqQnuHp6Eh4cnuA6aAdopNIMtrRMBkiAIgiAko9dv39O+2yDCwsLp36sTJYsX0Wz7PljZte8IazfvxsBAnynjhkTLK3OmDMiyzBf3rwmuR9Rg8JSawZbWxRkgBYeE8OL1e85dvsX9R8/x8vZNqXoJgiAIQpoXGBREg5bdeffhE+XLlGDU0L5a27Nkyqj1ePbCVahUKnp3ax9jIBM1Rumzy5cE10W0ICVMtME3sixz9uJNdh44Aajvn2Kb3hofP39cv3jg7etHrSrlaNmkFqYmxileYUEQBEFIKy5cvomb+1dKFS/C/m0rog2ONjM10XocHKJeI7BNi4Yx5pcnV3YuXL7Bzdv3KVuqWILq8j6yBSklVtH+HUQLkJav34WxoSGzJw7BytI82guUSiVnL91k8uwVTB8/EF0dnRSpqCAIgiCkFYtXbOTAkVOYm5sC0KpZ/RhnjnX5qyX3Hz2lTo3K9BygnuWdPZsdBfLljjHfhvWqs3rDDg4ePc3Avl0TVCfRxZYwYhabmMUmCIIgJKHNO/bT/5+JWs89uH4szsBElmXyOFbjq6c3ff/3F9MnDIsxnVKpJF/xmnh6efPwxnGtQd5xiYiIIEOu0ujoKHB9dROFQgxB/pFYj9DjZ68ZNmEeLbsMoU33fxg5eSHPX71LyboJgiAIQppy4fINBo9ULwBpbm4GQMF8uX/YaiNJkqbLrHH9mrGm09XV1dy24+CR0/Gu12dXN5RKJfZ2mUVwFE8xHiWnh88YPfVfypd2ZPq4gUwe2Y8SRQsybMJ8Hjx+kdJ1FARBEIRf3rMXr+nUcyhKpZKJowby76xxSJIU63ii782fMZaje9b9cGxRy6bqFbVXrt9OWFj8pvuL7rWEi7Fvae3mfcwcP4iC+XJpnsuXJwf58+Rg+fqdLJszNsUqKAiCIAi/Ojf3r7Tu3B8//wA6t2/BwL5dkSSJSuVLYW1lGa88bG3SYWuT7ofpKpYrScliDty594gdew/TqV3zH77m2Qv1PUzFDLb4i7EFycfPXys4iuJQMA8+Pv7JXilBEARBSEvmLlrNJ2cXqlcpx9xpo5AkCYD06ayTvEtLkiSGDeoJwPwla1EqlXGmDwkJZdGKjQDUqFohSevyO4vxXVNICgKDggkMDIr2pyNmrQmCIAiChizLHD91AYDZU0aip6eX7GXWrl6Jog4FeP/BmT0HjseZdvXGHTh/dqVMSUfq1aqS7HX7XcTYxfbm/Sdqt+iJHMP8tsigWBAEQRAE4NHTFzi7fCFPruzkzpk9RcqUJIl/BvyPjv8bwrzFa2jVrH6MDRg+Pn7MW7QGgMljB2tatoQfizFAunZic0rXQxAEQRDSpKjWo7o1U7Z1pkGdahTMl5unL15z6NgZmjWqEy3N/CVr8fH1o2Hd6pQp6Zii9UvrYuxik79rOgoJDePitTu8fvcpRSolCIIgCGnF6XNXAKhXu2qKlqtQKBg6oAcAc/5djUql4tpNJ46ePA/Ap8+urFy/DR0dHSaMGpiidfsdxNiCtGnnYbJlzUTVCqWQZZmBo2by1dOb4OBQ+vVoS4PalVO6noIgCILwy4mIiODR0xfo6elSsphDipfftGFtZs5fwdPnr5i7aDXT5y4D4P2Ty0yfu4zQ0DC6dWxFnlzZU7xuaV2MLUjnL9+iQmn1Ogynzl8jICCI3evnsWXlDDbvOpKiFRQEQRCEpHDx6k3Wbtr1w1lfCfHuwydCQ8PInTMb+vrJPzj7ezo6OowZ1g9AExwBnL90nR17DmNibMSIwb1TvF6/gxgDpJDQMPT01I1LO/efpFPbRigUCqytLNDREStwCoIgCGmLl7cP7bsOZOjoaVSu25YMuUox599VP53vsxdvAGK9d1pKaNqwNkP+7q713N6DJ5BlmRZN6pHBNn0q1SxtizHasU1vzc79J1i9aS/+AYHUqFwGAF+/AAwNDFK0goIgCILws1au205gUDAAT5+/IjQ0jG27Dv10vlELMObPG33twJQ0bkR/Nq6YS6N6NQC4euMuAHlyZ0/FWqVtMQZIIwZ249qt+9xyesTkUf00N3PdvOswTepVTcn6CYIgCMJP8Q8IZOW6bQDs3rSUudNGA+ruMTf3r4nKMywsnNt3H/Lk2SsgdVuQQD3tv0nDWlQqXwoAbx9fALLb26VmtdK0GAdpZ8lky78zRkZ7vnPbxpiaGCd7pQRBEAThZ0RERADqMTobtu7Bx9ePOjUqUat6RQAuX7vNwaOnuX7LiaYNayco74tXbtJ38Dg+u7ppnisQw90nUkOWzBm1HufIljWVapL2xdiC9PrtR62/N+8/ERAYhJmpiVhkShAEQfhlqVQqps5ZQvZClWjU+n+EhISydJV6bb8h/Xto0pWLnIh07aZTgsv4Z8x0reAIfp1AxC6LdoCUPZtoQUqsGFuQhk9coPVYllV4efuRJ5c9E4b3Iet3b4AgCIIg/AqOnDjH3H9XA3Dt5l1GTZzNFzcPKpQtqbVQYvmyJSLTJCxAevn6Ha/evMcuSybGj+hPzwGjKV2i6C9zG66sWTJp/rdJby16fX5CjAHSvk0Loj2nUqk4cOw8c5dsiLH7TRAEQRBSm9P9x4C6ay0iIoL1W/YAMOTvblrpCuXPg4GBPs9evEaW5Xj3jhw9cQ5Qr2LdunkD7LJkitZqk5qsLC0wNjIkKDjkl2nVSqviPWdfoVDQvGENvLz9krM+giAIgpBoUYOmp40fqnmuqEMBqlcpr5VOR0cHK0sLIiIi8A8IjHf+R74JkADKlymOvV3mn612kpEkSTMOKbt9llSuTdqWoEWNgkNCNAPf4mv7vuM0avc3W3cfBeDgsfN06z+OZh0HsmzdTs1tTQ4cO0eHXiPpNWQy7h6eAPj4+tN/xAw69BzJlt3/LVCZkLSCIAjCn+PJs5cAtGhSlyKF8wMw5O8eMbYQWZibAeDr5x+vvF1c3bh7/zFWlhaUL1M8iWqc9KJatLKLFqSfEmMX2+Xrd7Ueq2QZL29fjp66RI0qZRNUQHGH/Lx++1HzOHMmG1YtmECESkXLzkNoWr8ahgYGbN55mK0rZ3L5hhNL1+5k0si+rNu6nyoVStK0fjU69xtL5XIlMDUxjndae7tMcdRMEARB+J14efvg8sUdW5t02KRPx5olM7n/8CmN69eIMb2lhTkAvr7+WmN3YnP89EUA6taqoln+5leUK0c2zl+6Qd7cOVK7KmlajO/wjn0ntB5LCgnb9Na0blqH2tXKx/SSWOXLk4NMGf5bxbNUscIoIyJ48+4TJibG2KSz5szFG+TNlR1DQwMcHfIzZ/F6AK7duk/jetXQ1dXFoUAert9+gLmZabzTigBJEAThzxHVvVa4YF4A8ubOEWeQkNAWpCMnzgL/da/9qv4Z8D/y581F04a1UrsqaVqMAdLSOWOStdDhE+Zz8+5DFs0YhZ6eLp5ePtjbqZsE01tbEqFSERIahpe3L3aZMwBgb5eJr54+hIcr451WEARB+HM8fqruXiuUP2+80kcFSD6+Px5b6+Prx+VrdzAyNKR6lXKJr2QKyJjBhh6d26R2NdK8aAHSviNnyZ0jK0UKxX6Cubl7cvjkBbq0b4puIqY2zp86jI/OroyctJDp4waAhGYsEoCskpEk9WAzIp9XySokhZSwtN/Zc+g0ew+fVr/umzwEQRCEtO/6LfWU/UIF8sQrvYVF/FuQTp+7glKppE6NShgbGSW+kkKaES1AKlvSgc07j7B07Q4cC+cjSyZbbG3S4evnj8sXD56/fEdoWBid2jRKVHAUxd4uE6WKF8bpwTNs0lnx+Jn6fjYent7o6elhoK+PtZUFzi5u5M5pzyfnL+TOaY+5mUm8036vZeNatGysbnJUKpVUatAl0fUXBEEQfh3vPzhz5MQ5jI0MqV2jUrxe8+0YpB/RzF6rWz3xlRTSlGgBUuaMtowY2A0vb1+evHjDx0+uvHjzAWtLc+ztMlG1QilyZEvc1EH/gEC27T1Gt/bNCAsL47bTYyqXK0HO7Has2riHkJBQ7j18TvnSjgBUKFOMe4+ek90+M4+fvaZjm0aYGBvFO60gCILw+7n/8CnPXr5BIUkEBAYREBDIuUvXUalUdGrfAmsry3jlE98utpCQUM6cv4KOjg51a1b+2eoLaUSsw/CtrSyoVLY4JGzSmhYPT2+Gjp2Dp7cvCkni2q37lCpWmB6DJuDrG0C9WhUpXrQAkiTRpX1Tug+cgJmJMVPG9Aega/umjJu+hANHz9GwTmXNGKOEpBUEQRB+H0dPnqdD90ExbtPT06Vfz47xziumQdqfPrvyydmVgvlyU7tpJyqVL0WNqhUIDAqmUvlS8Q6+hLRPCgsL/SMH40R1sV0+uuGXnq4pCIIgqG8+e/DoaQYOn4x/QCDNG9fBwtwMUxMTTE2NMTU1oYRjYcqWKhbvPA8ePUPnXkNp16oxyxdMQZZlKtRsyfNXbxk/oj8TZ/wLqAOv8HAlMyYOp0+PDsm1i8IvRkQGgiAIwi9v4PDJbNl5AIDunVozb/rPz7a2/G6Q9q27D3j6Qj3GdeW6bZp04eFKGtevSecOzX+6TCHt+GGA9PLNB1zdPKhSviQAoWFhGOjrJ3vFBEEQhD/PzTv3sbfLTKaMtprnzl+6zpadBzA3N+PfWeNo0iBp1vfRjEHyUY9B2rR9n2abq5sHAKsWTae4YyFy58yeJGUKaUecAdKG7Qe55fQIj6/eVClfEtcvHsxfvok5k4bG9TJBEARBSLAXr95St1kXstpl4tqZvXj7+LJx617WbtoFwKTRA2nWqE6SlaeZxebnj39AIAcOn4qWpk7NyppASvizxBkgHT9zha0rZ9BtwAQAMmW0wf2rV4pUTBAEQfgzhIeHExgYzInTF5FlmY+fXKhStw3vPjijUqkAaNqwNp3bt0jScr8dpL3/0EkCg4KpXb0SN27fw88/gNw5s4ng6A8WZ4AkSRKSpCDqHn9e3r6EhISlRL0EQRCEP0SfQeM4duo8GTP816325t1HTE2MadOiId06to734o8JYWZmAoCfnz+bd+wHoFP75oQrwzl/6QbFihRK8jKFtCPOAKlezYpMnbeKgIAgdh88xe6Dp2hct2oKVU0QBEH43Xl89WT/kVNERETw9v1HjAwN2bVpCR+dXWhUrwbmZqbJVrauri5mpib4+Qdw2+khtjbpqFOjEm/efuD8pRtUKFsi2coWfn1xBkid2zbm1PlrKJVKHjx+QbcOTalbo2JK1U0QBEH4ze0/rA6OolSuUIpK5UulWPkWFub4BwQC0LZFI/T09Oj7v78oUjg/lSuUTrF6CL+eH85iq12tPLWrlU+JugiCIAh/mF37jgLQvnVjduw5QvtWTVK0fAtzM5w/uwLwV9umAOjp6VGt8q99Q1oh+cUZIPUbNk19E9jvLJk9OtkqJAiCIPwZDh8/y517j7C1Scei2RP4d9Z49PT0UrQOUYOwy5ZyJG/uHClatvBrizNAatOsrtbjU+evUalc8WStkCAIgvD7c/fwZNCIKQBMGTsk1e5okME2HQB/tW2WKuULv644z8jK5bUHqJUtWYTBY2ZTp3qFZK2UIAiC8PuSZZkBwyfh6eVN4/o1ad28QarVZdTQvpQtVYx2LcUNzgVtioQkfv/JhdfvPiVXXQRBENI0lUrFtZtOKJXK1K7KL+XmnfvUb9GN5y/fALB110FOnL6IrU065s8YE+NQjpSSN3cOenVrj46OTqrVQfg1xdmCVLtFT0B94kZERBAWHk6Xdk1ToFqCIAhpz+yFq5g5fzltWjRkxcKpqfrF/6uQZZkR42dx/+FTZsxbzuSxgxk1YTYA/84eT/p01qlcQ0GIWZwB0sZl0zX/S5J6WXZDA3EfNkEQhO99+PSZhUvXAbBz7xEqlS/FX22apm6lfgGXrt7i/sOnABw5cY53Hz7hHxBIx7bNqFeraupWThDiEGcXW6YM6TV/GW3TY2igz+Xrd1OqboIgCGlCYFAQfQaNIyQ0lNIligIwbMwMnj5/lco1S11hYeFMnb0EgEwZbIiIiODh4+fkzpmN6ROHpXLtBCFuMbYgdeo7hphahmWVTGhYOJXKidVFBUEQfHz9GD52BrecHvL+gzPZs9mxc8Ni5i5ezdJVm+nSexjnjm7D1MQ4taua4mRZZtjYGdx2ekiObFnZtHoejVr1wKFQPtYvn42ZqUlqV1EQ4hRjgDSo918xJpYkiTw57ZO1QoIgCGnF4eNn2bX/GKAe7Ltv2wqsrCyYMHIgN2/f5869RwwdPe2PG48UERHB0NHT2LhtL+ZmpuzYsIh8eXLy8t459PVTdp0jQUisGAOk4kUKpHQ9BEEQ0pyHj54BMG5Efwb07qxZ5FBfX491y2dTqU5rdu49Qr48ORnyd/fUrGqiKZVKtu85TL1aVeI1oDo0NIyeA0Zz8OjpyOBoMfny5AQQwZGQpsQ5SPv9x8+s3bIfZxc3VLJK8/zGpdOSvWKCIAi/uodPXgBQtWKZaCtA29tlZvWiGbTvPojJMxdhbGRI7+4dUqOaP2XD1r38M2Y6LZvUY83SmXGm9Q8I5K8eg7l45Sa2NunYs2UZRQrlT6GaCkLSinOQ9sRZy8md0x5dXV36dW9HjcplqCsWiRQEQSAiIoJHT56jo6NDwfx5YkxTu0YlNq2aB8D0ecvx8fWLMV1wcAgr1m7l0dMXyVbfxNq59wgAR0+eJyAwKNZ0Hz59pmGr7ly8cpNs9lk4uX+jCI6ENC3OAElGpnPbxhTMlwNTEyM6tWnMjTsPU6pugiAIv6w37z4SFBxC3tzZMTIyjDVd/dpVaVSvBn5+/rTvNoiO/xvC+4/OAHxx8+DgkdPUb9mNkRNm0/F/Q1CpVLHmldLevvvIbSf1NT84JITjpy7EmO6zixtV6rblwaNnFMyfhxP7NpAje9YUrKkgJL04u9iMjYzwDwikbMmiHDpxAX19fb64e6ZU3QRBEH5ZDx8/B8AhHq0kIwb35vDxs1y7qV4m5eqNu5iZmfDh42etdO8/OHPl+h0qVyid9BVOhKgB6FntMvPJ2YVN2/fRrFHtaPdNO3LiLD6+flSvUo7Nq+djYvznzdoTfj9xtiB1atMIH19/ypRwICQklN5DJtO0QfWUqpsgCEKMvnp6pWpLi8dXT7buOgBAUYcfT2opXDAvi+ZM4J8B/6NJg1p4efvw4eNnMmawoUmDWsycNJyRQ/oAsGXH/p+un4+vHzPnr6BBy+6J7rYLCQll/ZbdACybPxkrSwsuX7tN+26D8A8I1Ep74/Y9ADq2bSaCI+G3IYWFhcqxbQwOCcHIMPam47RMqVRSqUEXLh/dkGp3kRYEIWF8/fwZO3kem3fsp2PbZiyeOzFFy4+IiGD9lj1Mmb0YX19/zM3NuHRiB9nt7eKdh0ql4uHj51hampMtaxbN9H+Pr54ULFUbhULBm4cXf2rtpBYd+nD24jUAalatwJ4tyxKcx6Zt+xgwfBIVypbk6J61PHr6grad+/PZ1Y1CBfKyc+Ni7DJnRJZlCpashaubB09vnyJzpgyJrrcg/ErijAxadBpC6RKFqVO9AqWLO6Cjk6B72wKwfd9xtu0+Stvm9ejQqgGnL1xn5/4T+PoF0KFVA5rWV7dIHTh2jt0HT2FqYsyUUf2wtUmHj68/46Yvwcvbl3q1KvJXq4YJTisIwu/Bx9ePpu16aW5bsXnHfrp1bEWxooWSvWxZljl/6TqTZy3WlN+iSV2mjhtKpoy2CcpLoVDgWKRgtOdt0qejUvlSnLt4nSvXb1O3ZpVE1dXF1Y2zF69hYWEGwJkLV7kfuRzB8xev+fTZlZZN6mnGCIWFhdOyY19cv7iTLWsWstlnwcrKgg1b9gAwoE9nABwK5uPska207TqA+w+fUrPRX+xYvwgrKwtc3Tywz5pZBEfCbyXOAGnfpgVcu/2AIycvMmfxBiqVK07dGhUokDdnvAso7pCf128/AhARoeKjsyvL5owlOCSE5p0HU71SGZRKJZt3HmbryplcvuHE0rU7mTSyL+u27qdKhZI0rV+Nzv3GUrlcCUxNjOOd1t4u088dHUEQfgmyLNOl9zDuP3xKoQJ5qVS+FCvWbmXc1Pkc3rUm2RdhHDVxDivWbgUgT67szJ02mioVyyR5OdWrlOfcxeucvXAt0QHSgaOnAWhUtwbprC35d/kGqtZrq5XmybNXbFgxB4B7D59w6eotAF69ea+Vrl7tqtSqVlHzOGMGG47uWUvP/qM5evI89Vt0pUEd9Y/csqWKJaq+gvCrirNJyNDQgOqVSjNt7AC2rpqBkaEBPQdPSlAB+fLkIFOG9ADo6Cjo/ldz9PX1sDA3I3MGW3x8/bh59xF5c2XH0NAAR4f8XL99H4Brt+7j6JAfXV1dHArk4frtBwlKKwjC7+HshWtcuHyDLJkycHDHSsaP7E/mjLZcuX6HE2cuJirP4OAQWnToQ9nqzeg3dDyBQdpT2ENCQlm8ciOuX9zZuvMAkiQxd9porp7ekyzBEUCNKuUBOBfZPRabd+8/MWzsDEpUakTvQWNx9/hv8syBw6cAaNaoNr26tSd9OitMTYwp4ViY1s3qA3Dn3iNN+geRrUvtWzfm8K41LJk3idH/9OXgjlVsW7sQhUL7a8LE2JjNq+fTv1dngoJD2H1APZC7fOniP7n3gvBr+eHgmyfP33D20k0uXbtDdvssTBjeJ0kK/urpjX9AIFkyZeDStbvY22UEIL21JREqFSGhYXh5+2KXWd1ka2+Xia+ePoSHK+OdVhCEtE+WZabNXQrA8EG9NKs5jxn+N/2GjGfCtIXUqlYxwWMJL169qRmn8/zlWz45u7Jzw2LNlP0NW/cwbsp8du07in9AIIUL5qNH5zZJuGfR5c+bi8wZbXnz7qPm3m7fW7xiI5NnLSI8XAmolxs4fvoCk0cPJnt2O27dfYC1lSWVK5RGT0+PF05nkSQJhUKBLMtcvHoL58+ufPX0In06ax48VgdIlcqXplL5UlSi1A/rqVAomDJuCCWLOXDp2i1s0qejdYsGSXswBCGVxdmC1KzjQOYt3UBG23SsWjiBuZOHUrNK2Z8uVJZlFq3aRtf2TdXjmiT1c5rtKhlJUt/7jcjnVbIKSSElLO139hw6Tbv/Dafd/4bzV+9RP70fgiAkv2OnLnDvwROyZ7OjfevGmufbtmhI4YL5ePn6HctWb4n19Zu27aN4xUZcv+Wk9fzFK+pupV7d2pPNPguXrt6i4/+GEBoapt4e2e30KHK17HKlHJNyt2IkSRI1qqoX4z0bQyvS/YdPGT9tAbIMvbt34OzhLbRsUg9fX38GjphM8/bqH7Ajh/TWrOyto6OjaQWSJAnHyFl39x+qA6Oo5QqKFk74oo5NGtZi3vQxjBzSG2MjowS/XhB+ZXEGSAumDWfd4im0bloHa0uLJCt0255j6Onp0rheVQBs0lnx8fMXADw8vdHT08NAXx9rKwucXdwA+OT8BZt0VglK+72WjWuxffVstq+ezZYVM5JsfwRBSB4qlYrpc9UzsEYM7q11Ow8dHR3mTR+NJElMn7uMN28/RHu9Uqlk1oIVvH3/kTad+2sGKwNcvHwDUHctHdq5GrvMGTlz4Spd+w4nJCSUqzfuauVVJoXG2NSoqu5m+z5A+uLmweBRU5FlmRGDezFz0nBKFHNgzdKZ7N2yjGz2WYiIiKBS+VJxtnQ5FlEPar/38AmhoWE8e/EGQwMD8ubOkXw7JQhpUJwBUnb7LEle4OUbTly6fpfhA7pqBlaWLu7AqzcfCAkJ5d7D55Qv7QhAhTLFuPfoOUqlksfPXlOuVNEEpRUEIW07dOwMT569JE+u7JrxM98qU9KRnl3bERIaSv9hk1CpVCiVSi5fu41KpeLMhat8dnVDX18PP/8AWnTow4tXb3Fz/8rTF6+xtrLEoWA+smXNwqGdq8mYwYZjJ8/TqHUP/Pz8tcoqWzplAqSqFcuiUCi4fPUWYWHheHn7MH7qAopVaMi9B0/IlcOe/r06a72mRtUKXD+7l40r5rI1hnFD3ypWVD2D7t7Dpzx78RqlUknhgnnFcieC8J1k/UR4eHozdOwcPL19UUgS127d59nLt9japON/gyaBLFOvZkXatahPl/ZN6T5wAmYmxkwZ0x+Aru2bMm76Eg4cPUfDOpU1Y4wSklYQhLTl7r1HvHrznsIF8zFj3nIARg3tg46OTozpx43oz/HTF7h28y7rt+zh46fP/Lt8AzMmDufCFXUr0YyJw7lx6x67DxyjWbteNG1UG4DKFUprgomcOew5tHM1DVp209xeo26tKpw8c4ls9lmwy5wxuXcdAEtLc0o4Fua200P+Hjqe46cv4h8QiEKh4K82TRn9T18MDQ2ivc7YyIgmDWv9MH9HB3WAdOX6HcIiuxOLJKJ7TRB+d3EuFLlyw256dWml9dyilVsZ0Cvt3ZH6e2KhSEH49axct40R42dpPVcwfx6unNoVZ6vIhcs3aNqul2ZxxYDAIDJmsMHN/SsmxkY8u3sGQwN9OvYcyonT6llvkiSxY8Mi6tSorJXXk2evaNiqO94+vuzcuBh9PT1s0qejcMG8Sby3sZs5fwUz5y/XPG7RpC6jhvYhd87sSZJ/j34j2XPwOADp01lxZPda8ufNlSR5C8LvIs4utmuRU+ijuLp95eylm8lZH0EQ/lBPn79i/LQFSJKkdb+vUUP7xBkcAVStVJaObZsREBikueP8FzcPZFnmf13aYmZqgp6eHhuWz6Fm1QoYGxmyYfmcaMERQKECeTh9aBMLZ46jVrWKVKtcLkWDI4A2zRtgnzUz9WpX5cqp3axdOivJgiOAVYunM2XcEOrXqcaZQ1tEcCQIMYixBal5p8FIkjog+nb9tQw26WneqMZvsUq1aEEShF9Lg5bduXrjDgN6d2Hy2ME8fvqS9x+daVCnWrwWgvTx9aNc9ea4unnQvHEd9h06iZGhIQ9vHMMmfTpNOlmWCQkJ1UznFwRBiEmMkcG+TQsAGDR6Fgunj0jRCgmC8Oe5dPUWV2/cIWMGG0YNVU9VL1wwb4JabiwtzDm+bwPOLl8olD8Pbu6eNK5fQys4AnXXmgiOBEH4kTibTkRwJAhCcggPD+fu/cc8fPych4+fa1aOHtyv208FL9mz2WkWVzy6Z22S1FUQhD9TnAHSi1fv2L7vOF+9fOCbjrgls0cnc7UEQfidder1D8dPXdB6rqhDATq3b5E6FRIEQfhOnAHS6KmLqFK+JJXLl0Q3lim2giAICREWFs65i9fQ1dWlR+c2FCmcnyKF8pM/b04xHlAQhF9GnFcjC3PT32JKvyAIv44nz14SGhpGCcfCzJw0PLWrIwiCEKM4585WLFucO/efpFRdBEFIQTPnr2DwyCla9zZMCVGLMJYsXiRFyxUEQUiIOFuQLly9w7qtBzDWDJqUAYlTe1cmf80EQUg21246aRYi7NapNQ4F8yVred9Orb8TGSCVEgGSIAi/sDgDpFkTBqdUPQRBS1SrRnzWv0kJ+w+fRCEp4nUrh1+dSqVizOS5msfnLlxL9gBpwrSFLF65kYrlSvL85RsAShZzSNYyBUEQfkacXWyZMqSP8U8QkpO7hyd5HKsxYdpC/PwDuHj1Zop3A33rq6cXXfsMp3Pvf1KtDknpzPmr3HvwBCNDdcvwuUvXk73Mw8fPIssyl6/dxuOrF+nTWZEtGW6GLQiCkFTibEGKWlH7e3s3Lkiu+ggCN+/c56unN4tWbODMhas8ff6KxXMn0rFtsxSvi4+PH6fOXdE8Dg0Nw8BAP8XrkZTWbt4FwJjh/Zg8cxHXbzkRGBSEibFxspTn5e3Duw+fSGdtxfwZYzl64izVq5T/ZVoHBUEQYvKDLrZBWo+Pn7mCo4O467OQvNzcv2r+f/r8FQCTZvxLo3o1sLQwT5Iy3n90Zu/BE9ikt6Zh3epYW1lqbZdlmQHDJrF110EyZbDRPO8fEICBgXWS1CE1fPj0mVNnL2NqYkzn9i04fe4KF6/c5Mr1OzHelywpOEVO9ChZrDBNGtSkSYOayVKOIAhCUoqziy1Prmxaf/16tGPzriMpVTfhD+Xi6qb5X09Pl+JFC/HV05vZC5NmckBERASdeg5lyqzFDBg2iYq1WrH34HG+uHlo0sxdtJrNO/ajUqn4/E19AgKCkqQOqWXj1r3Iskzblo0wMzWhTk11UHT0xPkY0+8/fJKps5f8VBfn3fuPACjuWDjReQiCIKS0OAOkwMAgzZ+vnz9Xbjrx0dk1peom/KGiApKxw//m7JGtrF48Az09XVat38GLV28TlNcdp4e8/+is9dzm7ft5+Pg5ObPbU6ViGVy+uNO930hKVm7Mk2ev2L3/GNPmLEVPT5fqVcppvdYvIODndi4VhYWFs3nHfgC6dWwFQMO61QE4evI8X9w88Pb21aSXZZkR42cxd9FqHj97mehyne4/BqB4UREgCYKQdsTZxVarRS8kCaJ+PKZPZ0m/Hm1Tol7CH+yzyxcAqlUqS5FC6i7dfv/ryMJl6xk9cQ57tiyL1/iVL24e1GzcEQCPd3fQ09PDx8ePybMWAzBv+miqVCzDxm172b3/ONdu3qXvkHE8e/EagEVzJtK0QS2Wrt7Muk27cPnijr9/YHLscoo4fPwMHl+9KFe6GAXz5wHA3i4zxYoW4t6DJ+QvUROb9NacPbIVe7vMfHZ1w93DE4BHT14kaqabLMvcjQqQHAsl3c4IgiAkszhbkK6d2MzV45u5dkL9d2jrYhrXrZpCVRP+VC6u7gBkzpRB89zQAf8jYwYbzl68xokzF+OVz517jzT/HzhyGoBpc5fi5e1DgzrVqFa5HAqFgq5/tWLbuoVYWJjx4NEzwsLCGT6oF+1aNsLIyJB/BvyPsqWLARAQmHYDpDWb1IOzu3dqo/V843o1NP97fPWiQ/dBBAUHc+/Bf4vEPn76IlFl3nF6xFdPb/LnzUk6a6tE5SEIgpAa4gyQAFy+uLP/6FkOHDuH6xePHyUX/mCBQUFMm7M0wd1g35JlGRdXN3R1dbG1Sad53szUhAmjBgIweuJcQkPDfpjX/UdPNf8vWbWJx09fsnbTLgwM9Jk2QXvKvqWFOYP7dgOgdbP6jBraR2u7makpQJptQXr6/BXXbzqRPp0Vjb4JiAA6tGlK5QqlmTlpOA6F8vHoyQv+HjpB0zUG6hakxNh/5CQATRrUTnzlBUEQUkHcLUi37tNz8CQePnnJg8cv6Tl4EtdvP0ipuglpzMZt+5jz7yrKVGvGy9fvEpWHl7cPIaGhZMxgg853N0hu07wBJYs58O7DJzZs3fPDvO4/+C9AevDoGc3a90KlUjGgdxey29tFSz+gTxfOHdnK8oVTo3XhmZmZAOpZbGnR+s27AejYtlm0ZQpsbdJxaOdqenfvwNa1C0lnbcW+QydZtX67Js2jJy9iHKgdEhLKP2OmU7tJJ/z8tY+NSqXiYGTLXbNGIkASBCFtiTNAWr1pLyvnT2DC8D5MGN6bFfPHs2rjj7+YhD/T8VMXNP/XatKRLTsPJDiPqAHaWb7pXouiUCiYNEa9uvvcRasJCPxvRpl/QCDvPzpz/+FTLly+wf1Hz7j3UB0gbVgxB4VCgcdXL+wyZ2Tw391iLFuhUFDcsXC0wAzA1EQdIKXFWWzBwSHs2HsESZLo8lfLONPa22Vm48q56OrqEhgUDKgDKB9fP5wjx4ZFcf3iTsNW3VmzcSe37j7g5JlLWttvOz3ks6sbBfPlJn/eXEm7U4IgCMkszgApXKkkSyZbzeMsmWwJVyqTvVJC2uPr58/1W/fQ1dWlacPa+Pr68/fQCfEeLxQlaop/5m/Ou29VKFuCGlXK4/HVi5XrtgGwafs+7AtUwLF8A6rWb0fTdr2oWq8tnl7eZM9mR9OGtZk5aTiGBgbMmTYKYyOjBO9fVAvS960kacEtpwf4BwRSrnRxsmX98erVFcuVZOak4QAUyJeLMiUdAXUrXJQ7Tg+p1qA9d+49wtREvcDk9wHSvkPq7rWmovVIEIQ0KM4AKUsmW3bsO4FSqUQZEcHO/SfIkjHmLy7hz3b+0nWUSiU1q1Vgw4o5zJs+BoAR42cRHBwCwJNnr+g3dDyjJ83h9dv3Mebz2SWyBSlzxljLGjeiPwD/Lt+At7cvx09fRJZlcma3p3yZEtStVUWTNm+uHAD07NoO19c3qVeraqL2z8w0qost7Y1Bunz1NgBVKpaO92u6d2rNplXzWL14JuXKFAdg7aadAGzddZD6Lbvxxc2DurWqcPH4DgD2HDxOiw59WL9lt7p77ai6e61pQxEgCYKQ9sQ5zX/Y312YPGclS9duR5IkijnkZ9w/vVKqbkIaERwcwpKVmwCoU6MSAF3/asnu/Ue5cfs+85esZcywfkyfu5SjJ9ULEj58/Jwju9dGy+vDx8+A9gy27zkWKUjj+jU5dOwMi1Zs4PkL9c1PD+5cRdYsmQA4ceYiYybNpVunVprX/cytLaICpIA0GCBdunoLgMoV4h8gSZJE4/rqFa9zZLdj4dJ1nL90gxYd+nD24jUAhg3syaihfVAoFJrB3WcvXuPClZvky5OLL24eFCqQl7y5cyT9TgmCICSzOFuQ0qezYtHMkZzau5KTe1bw74yRpE8npuoK/1EqlXTrN4I79x6RJ1d2WjSpB6jH88ydNgYdHR3+Xb6eF6/ecvnabSRJwtTEmCvX7/Du/ado+d2+9xAAR4eCcZY7YnBvAHbsOcz7j86YmZpg902rU92aVbh7+TB1a1aJLYsE0cxi+8UCJJVKxaARk7UGVH/LPyAQpwdPMDYypISjQ6LKMDE2Zvgg9Q+jsxevYWxkyMYVcxkzrB8KhfoS0qJxXU36iIgIFq3YAEDzxnUSVaYgCEJqizNA2rHvBD6+/hgZGmJkaMinz1/YuONQggrYvu84jdr9zdbdRwH47OrO4DGzqdGsh1a6A8fO0aHXSHoNmaxZnM7H15/+I2bQoedItuw+kqi0QvKRZZkho6Zx/NQFMmWwYe/W5ZibmWq2Fy6Yl55d2xEWFk7rzn/j5x9AsSIFad+6CaDuqvlWaGgYTvcfo6enS7EicQdIBfPnJlMGG1zdPJBlmXx5cibrzU9NTdXjbH61FqTnL9+wYeteho+byeKVG6Ntv3HrHkqlkrKli6Gvr5focrp0aMH0icNYNHsCty8eoknDWlrb+/T4i10bl2hanU6cVo89a9qgVrS8BEEQ0oI4A6RjZy5jaWGmeZw1S0YuXLmdoAKKO+SndIn/frmamhjTsXVDZNV/U4a9vH3ZvPMwa/+dRMvGtVi6Vj3WYd3W/VSpUJKNy6Zy/MwVPjq7JiitkLymz13Gpu37MDc3Y8+W5djbZY6WZtTQPmTMYKPpOqtetTwd2zUDYNuug0RERGjSPnj8jNDQMBwdCmJkZBhn2ZIkUb5sCc3j5J4l9au2IEUtqgkwbsp8Nm7dq7Vd071WPv7dazHR1dWlb4+/6NS+OVkyR+/+NDDQp3aNSlSrXFbzXJHC+cmVM9tPlSsIgpBa4gyQlOFKwsP/m7UWHq4kKHLAbXzly5ODTBnSax5bmJtSvKh268DNu4/Imys7hoYGODrk5/rt+4B6HSZHh/zo6uriUCAP128/SFBaIfms3bSLOf+uwsBAn+3r/qVQgTwxpjM3M2XquKGaxzWqlMehYD6KOhTA5Ys75y5e12y7ceseAGVLFYtXHcqVLq75P3++ZA6QftF1kKJm/RXIlwtJkhg0cgr7Dp3QbL98Xf2DplL5UilSn2/fk2ZicLYgCGlYnIO0K5YtxvCJ82nfsj6SJLFz/wnKlEjcOIa4eHr5YG+nHj+S3tqSCJWKkNAwvLx9sYv8tWpvl4mvnj6EhyvjnVZIHoeOneGfMdNRKBSsXjyDCt+05MSkRZO6nD5/Bdcv7pQqXgRQL1j44NEzNu/YTzb7LFy9cUfT5VamlGO86vHtl3GB5G5BMokKkH6tdZBcvqhbkNq2aISZmQlDRk2j54AxWFlaUKxIIR48eoa5mSlFHQqkSH3y5cmJrU063D08xew1QRDStDgDpJ5dWrF191FWbtiNSiVToYwjHVs3SvpaSGit0iurZCQpctZR5PMqWYWkkBKW9jt7Dp1m72H11OOYVgUWfiwsLJx/xkxHlmXmTR+tGXMSF0mSWPnvNK3nWjapx5jJczl07AyHjp3RPG9makKFMnEHXFEK5MuFlaUF3j6+FMiXO2E7kkBRY5DiakEKDg4hXKnUGoeV3KJakDJltKV18wb4+PozeeYipsxazJD+PZBlmfJlS6CrG+dHPclIksTWNQv56uVFjuxZU6RMQRCE5BDnVVNXR4fObRvTuW1jzXNhYeFJXgmbdFY8fqa+g7qHpzd6enoY6OtjbWWBs4sbuXPa88n5C7lz2mNuZhLvtN9r2bgWLRurB40qlUoqNeiS5Pvyuzt++iLuHp6UKelIt46tE52PpaU5Hds2Y83GneTKYU/FcqWoULYEVSuVxcrKIl55RLVgubq5x7ksQFLQ09PDyNAQf/9AZFmOcUB4w1bdcXF14/GtkzGuxp0cXL9o39h3QO/OLF6xEacHT9i+Wz2hIiHT+5NCqRJFUrQ8QRCE5BDnGKSJs5bh7eOnefzp8xemL1id5JUoXdyBV28+EBISyr2Hzylf2hGACmWKce/Rc5RKJY+fvaZcqaIJSiskvU3b1IOAO7Vv/tN5zZ4yko/PrnL38mH+nT2e1s0baN2gNj5qVqtAx7bNfrou8WFqaoxKpSI4JOZxeK/evMfVzQM/v5QbpxTVxZY5cgFXXV1dakeuRXX05HkUCgV1a1ROsfoIgiD8LuJsQXr38TNWluaax1mzZOT9R5d4Z+7h6c3QsXPw9PZFIUlcv/OAIgXzcuWGEyGhYXTqM5rO7ZpQo3IZurRvSveBEzAzMWbKGPVKyV3bN2Xc9CUcOHqOhnUqa8YYJSStkHQ+u7hx7tJ1zM1Madrw56dvKxSKFO2O+llmpqZ4fPXC3z8wxtuVhISGAuAfGBjvVrCf9W0XW5T6taqyc696qYuWTeuRM0f01lRBEAQhbnEGSKoIGQ9Pb2wiF4f86umdoC42m3RWbFo+PdrzPTtHv2FmozpVaFRHe1E/C3NTFs0c+VNphaRz+PgZZFmmUf0amBgbp3Z1Uty345Ay2KbX2qZSqTSfjZRaKyk4OARvH1+sLC20lkWoXrU8hgYGhIWHM2xgzxSpiyAIwu8mzgDpr9YN6DloInVrVkRC4sTZq3RqmwyDtIU04dCxswDxGpj9O4paCykghplsoaFhmv8DAlNmplvU+KNM390f0czUhO3r/yUsPJw8ubKnSF0EQRB+N3EGSHWqVyBjBhuu3nBCJcuMHfq/aGsYCX8Gdw9Prt9ywtzMlKoVy/74Bb+hqLWQ/PyjjzEKCQnV/J9SLUhR44+yxDBAvVrlcilSB0EQhN/VD+f+Fi2Ul6KF8gJw/9Fz5ixez7D+XZO9YsKvZf/hk8iyTJ0alTEw0E/t6qSK/9ZCih4ARY0/Um9PmRakmMYfCYIgCEnjhwHSi1fvOHXhOmcv3kSWZerWqJAS9RJ+IRERESxfuxWADm2apHJtUk9UC1JMLUTaXWwp04L09PkrALJns0uR8gRBEP4kMQZIHz65cOr8dU5fuK5eaK50UfT0dNm5do7m7t3Cn+H6LScOHz/L+w/OFC6YjyoVy6R2lVKNmWn8WpCSu4vtybNXmJgYce6S+jYtVVJ4nSNBEIQ/QYwBUvueI2hSrzrzpvxD1izq23rcfzxGBEd/mI/OLjRu8z/N/fj+7tkxxgUS/xSmprG3IIWkwCBt1y/ujJ+6gN0HjmFpYY6Prx+WFuY4FhHjAgVBEJJajAHS2KG9OHPxOoPHzKZE0YKUK10UpTIipqTCb2zR8g2EhyupWK4kdWpWplWz+qldpVQVZwvSN4tHJnULUlhYOCvXbWPWghWa4MvHV72Aa9VKZVNs1W5BEIQ/SYxNQvVqVmTelGGsXTSJ/HlzsOvAST46uzJu+hJu3HmY0nUUftIXNw8Kl6nLouUb4v0a1y/ubN6xH11dXZYvnEr/Xp3/+C/iqBakmGaxaY1BSsIA6eKVm1Ss3YpxU+cTEBhE+9aNObZ3vea9qC5mqwmCICSLOAdpW5ib0axBDZo1qIH7Vy/OXLjBqo17KFtS3GspLTl78RrOn13ZsvMAA/p0iTVdQGAQBvp66OnpsWTVJkJDw+jYthlZs2RKucr+wjTrIMXQhaY1BikoOEnKu3D5Bs3a90aWZYo6FGDO1FGULqG+hc6ooX3Yd/AEDepWS5KyBEEQBG3xHlRkm96a9i3rs27x5OSsj5AMHj15AcDL1+/w9vaNtl2WZVau20b2QpX4+5+JfPX0Yv3m3SgUCgb365bS1f1lmUfOYvOPcR2kpG1B8vXzp9+Q8ciyzMghfTh3ZKsmOAL4Z8D/uHZ2L+msrX66LEEQBCG6H07zF9K+h4+fa/6/7fRQczPTKIuWb2DC9IUA7Nx7BGMjQ4KCQ2jdrL64j9c3TONYByn02xakJJjmv3HrXj67ulGtcllGDO71Rw+OFwRBSA1iWtpvLCAwCP+AQB4/faF57pbTA600TvcfM2X2EnR0dDAxVt+Adf2WPQAM6d8j5SqbBsS1DpL2Sto/P4vtxeu3APzVpqkIjgRBEFKBCJB+Q+8/OFOjYQfs8pUja/7y+PkHaJZouHVHO0AaP20BSqWSYQN7suLfaZrnG9evSf68uVK03r+6qDFIP1wHKQlakD58/AyAvV2Wn85LEARBSDgRIP1mHj55Tp1mnbl7/zF6ev/1oFavXA4dHR1u3XnAqzfvAfX08dtOD9HT02VQ367UqlYRczN1ECBaj6IzNTUGYh6D9O0stqS41ciHTy4AZLMXAZIgCEJqEAHSb+Tytds0bNkdN/evNKpXg6e3T2m2FSmcny4dWhASGkr7bgPx9fPn0ZPnhIaGUbRwAQwNDTA0NGDbun/ZuHIejg4FUnFPfk2mJuoA6Yez2H5ykLZSqcTF1Q1jI0Ns0lv/VF6CIAhC4ohB2r+Jw8fP0uPvkYSGhtH1r5bMnTYaHR0dTuzfwIKl6+jWqTU26ax59OQFt+4+oOeA0ZrbhpT6ZnZUxXIlU2sXfnlR47T8AwJRqVRaK8t/OwbJx9ePYWNnUDB/btq1bIyhoYH6eR8/TEyM0NPTi7McZ5cvREREYJ81mxh/JAiCkEpEgJRGybKMLMsoFAq8vH3439+jCA0NY/igXowa2kfzxVq2VDF2blised2mVfOoVr8dJ89c4vpNJwBKFXdIlX1Ii8zMTAkMCiYgMEjTHQnaLUgAqzfsAGDGvOX07fEXObJlpfegsdSoWp4taxbEWcaHT+rxR9myiu41QRCE1CK62NKYwKAglq/ZSpFy9SlZuQlfPb04cOQUIaGhNK5fk9H/9I2z1SFjBhu2rFmAvr6eZkXob1uQhLiZxXI/tm/HIEXJapcZdw9PJs74l869/yE4JIQjJ86hUqniLOO/AdqZk6jWgiAIQkKJFqQ0wtPLm5XrtrN6ww68ff5b7LHXgDGa+3K1bdkoXnmVKObAgpnj6DdkPHaZM2KXOWOy1Pl3ZBrL/di+7WKLsmvjYgICgliwbB0nz1wiIkJ9P8O37z+SO2f2WMv4GDlA214M0BYEQUg1IkBKA+b8u4r5i9cSHHlD1JpVK9C9c2v+GT2dsxevAWBpYU7NqhXinWeH1k2wMDcjc0ZbMc4lARLSgpQ3dw50dHTYtnYhSqWSvkPGs2vfUR48evaDAEl0sQmCIKQ20cX2i3vx6i3T5iwlNCyMlk3qcenkTvZsWUa9WlXZuXEJZUs5AtC5fXP09eMe/Pu9hnWrU9yxcDLU+vdlFksLUlTwGsXAQF/r5r66uroUjZwZePr8VVat305wsPZrorx9/wkQU/wFQRBSk2hB+sVduHwDgC4dWjB/xlitbYUL5uXE/o18cfMQ08FTSFQXm993ayF934KUL0/OaK8tWlgdIO3Yc5gdew7z9v0nZk4arpUmODiEB4+fYWCgT77c0fMQBEEQUoZoQfrFXbx6C4AqFcrEmiZjBhut1goh+ZhHdbF9txZS1Cy2YkULATD07+gLbToUyqf1ePWGHTx/+UbrudtODwkPV1KyWBHN8gCCIAhCyhMB0i9MqVRy5fodJEmiUoVSqV0dAfU0f4i+mnZUC9L86WO4eX4/TRrWivZaC3MzCubPA0D1KuWIiIhg1MTZyLKsSXMtcumFCmVLJEv9BUEQhPhJ9i627fuOs233Udo2r0eHVg3w8fVn3PQleHn7Uq9WRf5q1RCAA8fOsfvgKUxNjJkyqh+2NumSJG1adfnabeYtXoOfnz9FCufH2soytaskEMcstsgWJAtzM3LmsI/19dvWLsTTy5u8eXJSqkoTzl+6wbFTF2hQpxoAV2/cAUSAJAiCkNqSvQWpuEN+Spf4byHCdVv3U6VCSTYum8rxM1f46OyKl7cvm3ceZu2/k2jZuBZL1+5MkrSpyfWLO03a9mTYmOl4enkn+PUz5i3XjD+qX7taUldPSKSoQdqr1m+nbdcBjJk8l627DuLr5w+AgUHc3WLZs9lRopgDZqYmTBw1EIAxk+cSEhJKaGgYt++q741XqkSR5N0RQRAEIU7J3oKUL08OMmVIr3l87dZ9Gterhq6uLg4F8nD99gPMzUzJmys7hoYGODrkZ87i9UmS1t4uU3LvXoxCQ8Po1HMot50ecvHKTXYdOMbIwX3o0bn1D28zARAeHo7T/cfo6upyeNdqShUXX5a/irKli2FpYY67hycnTl+Mtt3IKP7jhlo3b8DaTbu47fSQZWu2UKxIQUJCQylXpjjGRkZJWW1BEAQhgVJ8FpuXty92mTMAYG+Xia+ePoSHK7G3Uy9WmN7akgiVipDQsJ9OGx8vXr9H95sBzmZmJmTOaEtoWBjvP3yOlj5fnhyA+m7r3y8OmDGDDRbmpvwzZjqPnr4kX97c5Mphz7mL1xg/fSHrt+xm3bJZ6OnpR8s3V46s6Orq4uzixp17j0CSKFwwH9ZWVvj5B2JtZYGffyCuX9y1XmdgoE/2yOngL16/h2/Gs4B6qrihgT6ubl/xi2zliGJlZYFtemsCg4Jx/vxFa5uOri65c2QF4PW7T0QolVrb7bJkxMTYCPevXnh7+2ptMzc3I1OG9ISEhmlWhdaQJPLlzg7A+4+fo83+ypTRFnMzE7y8ffH46qW1zcTEGLvMGVAqlbx59ynaMcydMxs6Ogo+ff5CUFCw1jZbm3RYWZrj6xfAFzcPrW2GhgZky6petfrFq3fR8s2eLQsG+vq4fHFHX0+f4/s34ubxlc+fv3Dxyg127TuKQqFAX1+fj86ueHxVtxjq6emRM7ud+hi+/ahZKDJKVrtMzJo8gtpNO7NoxSbKlHTE0NCQ0iUc+eL+lYy26QkJCeVD5MKRmkOoUJA3VzYA3n34TFiY9jHMnMkWM1MTPL18+Oqp3XppampClky2hIcrNcsJfCtPrmwoFAo+OrtGW4Ygg216LC3M8PH1x839q9Y2IyND7O0yoVKpePXmQ7R8c2bPip6eLp9d3aOtIZU+nRXprC3xDwjExVX7/NbX1ydHNvX5/fLNB+TvViHPljUzhoYGfHH/iq/vd+e3pTm2NukICg7h03ctyjo6OuTOqe4KffvemfDwcK3tdpkzYGJizFdPbzy9fLS2JcU1wtvHD3cPT61txsZGZM2SkYgIFa/fRj+G314jAr+bJGCT3lpcI/g1rhH+/trndzprS9KnsyIwMAhnFzetbfG5RhgbGeLu4Ym3j5/WNgsLM3GNIGmvEVGf3SgpHiBJkqT5gKpkFZJCAgmtgaqySkaSkiDtd/YcOs3ew6fVr4tM22PgRK00daqXZ+KIvrh7eNHl73HR8rh+cgsAU+et4vGz11rbJgzvTd0aFcmePTs5cqkH475z9iBHrjxIqHj65AkjJ87B0zf6+jfHdi7DytKcf1du4cqNe+TIlYfQCOjy9zgG9GxPuxb1uX3vMWOnLdZ6Xd7c2di4dBoA/xs0kfBw7YvU1pUzyZndjvXb9nP4hHaLR8c2jejbrQ0vXr2j3/DpWtts0ltxaKu6rCFjZ2u+9KMsnT2a4kULsufQaTbvPKy1rVHdKowe/D9cXN2jHUM9PV0uHdmgPl6zlvHytfYHZeqY/tSoXIaT566yaNU2rW0VyxZjzqSh+AcExfjenNm3ChMTY+Yt3cjNu4+0tg3t15mWjWtx/fZ9Js1eobWtcIHcrF44ESDGfHetm0vWLBlZtXEPJ89d09pWraL65r5GRsbYZ89Bn3+mabZlyWTLng3zAeg/cgY+3304Vy2YQHHHwlQoXxZ3T18+unqSI1ceTl28jam5BcP+7sKHTy7R6mRsbMjZ/WsAGDN1Ee+++4KZPXEwlcqV4MipS6xYv0u7vpVKM33sALx9fGPc14uH16Ovr2Dmv2u59/C51rZRg7rTuF41Ll27w4yFa7W2FSuSn2VzxqJURsSY78Et/2Jrk46la3dw/vItrW29u7amc9vG3H/0nOETte9Tl8M+C9tWzwKgzz9TCArS/uxsWDKFfHlysHnXEfYdPqO1rW3zugzs9Rdv3n2i5+BJWtssLcw4vms5AMMnzufzdxfdBdOGU7ZkEQ4cO8faLfu1tiXFNeLspZvMW7pRa1uZEg4snD6CkJCQGPP9/hrxLXGNUPsVrxHd/2pGj44tePTsNYPHzNbaFp9rhEPBPGzfd5wd+05obWveqKa4RpC014ioz24UKSwsVPvnRDJYs3kvRoaGdGjVgFZdhzJj3EBy57RnxoI15M5pj7mZCeev3Gbm+EG4f/WiY+/RnNyz4qfTtmpSO9Y6KZVKKjXowpp/JyZ5C5K3jx9f3L+i+GaFaoVCQY2G7fEPCOTwrrXR1i369tfhP2NmcOHydSaOHkS1SmXFr8NIv+KvQz//AGo1/guFQoGRkTHnjvz3AYvvr8Onz9/QqHUPAoOCyJQpA9vX/oulpfh1CKIF6VuiBUktrV0jRAuSWlq4RnzfgpTiAdLCFVvIksmWZg2q07nvWGZNHIyJsRE9Bk5g68qZXLx2lxt3HjJheO+fThvV5RaTqADp8tEN6OqmTEPa30MnsGXnAaaMG0L/Xp1jTVewZC1cvrjz5NYpssSxD0LqCw4OIVMe9RpVZqYmfHp+7QeviNnS1ZsZM2kuA/t0YdKYwUlZRUEQBCERkjVA8vD0ZujYOXh6+6KQJLLZZ2bamAGMm74ETy8fGtapTLsW9QE4fPIiO/Ydx8zEmClj+mOTzgpfv4CfThub1AiQLl29ReM2/yODbXpmTx4Z41o5Hl89yeNYnUwZbHh290wMuQi/GvuCFfHz88fAQB+3N7cTlYcsy9y8c5+ihQtgZGSYxDUUBEEQEipFWpB+RakRIKlUKpp36KOZvn/28BZKFHPQSnPh8g2atutFrWoV2b15aYrUS/g5JSs31nSJ+Dg/SOXaCIIgCElBrKSdghQKBfu2LqdPj78A2Hf4ZLQ0j56+AKBQgTwpWjch8Wxt0v84kSAIgpCmiAAphSkUCjq1awbAoWNntWbkATx59gqAwgXzRXut8GuytUmX2lUQBEEQkpgIkFJB/ry5yJs7B5+cXbj/8KnWtsdPXwKiBSkt+X5GoiAIgpD2iQApFUiSROP6NQE4ePS05vnw8HBevHqDvr4eeXJlT6XaCQmVwVZ0sQmCIPxuRICUSho3iAqQzmi62Q4ePUN4uJL8eXOl2MBx4ef91aYphgYGDOzTJbWrIgiCICQR8S2cShwK5iNHtqy8+/CJM+evsmXnAU1rkrg5bdqSMYMNzi+uiaBWEAThNyJakFKJJEk0iWxFatWpHwePnsbK0oLFcycyfFDPVK6dkFAiOBIEQfi9iAApFTVt+N+tUNq1asztiwfo2LYZCoV4WwRBEAQhNYmfvanIsUhBtq//l3TWVpQuUTS1qyMIgiAIQiQRIKWyerWqpnYVBEEQBEH4jujLEQRBEARB+I4IkARBEARBEL4jAiRBEARBEITviABJEARBEAThOyJAEgRBEARB+M4fO4st6vYeSqUylWsiCIIgCMKvQEdHB0mSgD84QIqIiACgWpMeqVwTQRAEQRB+BZePbtDcGUEKCwuVU7k+qUKlUhEWFqYVLSaVv3qPYsuKGUma5+9OHLPEE8cu8cSx+zni+CWeOHaJl5zHTrQgAQqFAkNDw2TJW5IkcW+uBBLHLPHEsUs8cex+jjh+iSeOXeKl1LETg7QFQRAEQRC+IwKkZNCiUa3UrkKaI45Z4oljl3ji2P0ccfwSTxy7xEupY/fHjkESBEEQBEGIjWhBEgRBEARB+I4IkARBEARBEL4jAiRBEARBEITvJPs8ueCQED46f+GzqzvWlubY22XC2soiuYsVBEEQBEFItGQJkGRZ5uzFm+w8cAKAzBltsU1vjY+fP65fPPD29aNWlXK0bFILUxPj5KiCIAiCIAhCoiXLLLZl63ZibGhIk/rVsLI0j7ZdqVRy9tJNzl68yfTxA9HV0UnqKgiCIAiCICRaik3z9/MPxNnlC+nTWWGb3jolihQEQRAEQUiUFFnn/NT5axw7fZns9ll48eodRQvno3fX1klezoFj59h98BSmJsZMGdUPW5t0saaVZZmIiIhkuRebIAiCIAhpW7LNYgsNC9P8f/m6EwumDWdQ779YPHs0J89fS/LyvLx92bzzMGv/nUTLxrVYunZnnOkjIiKo1KALERERSV4XQRAEQRDStmRrQZo2bzXlSxelbo2KFMqfm8lzVlIwX04ePX1FkYJ5k7y8m3cfkTdXdgwNDXB0yM+cxeuTvAxBEARBEP4MyRYgTR7Vj3OXbzFm6iJaNqlNyWKFePfBmRaNalKkUNIHSJ5ePtjbZQQgvbUlESoVIaFhGBroJ3lZ8SGHhyN//QoGBkh6eonLJCICOSQkMsMYhorp6iIZGv5XZkgIKJXaaXR0kIyMNPmRiAHxckgIqGRABpXqh+klI6NElRNNIuubbFQqUPw+S4fJ4eGgUiEZGKRe+aGhsSfQ04tWNzk4WH1egPrcT+W7oce2D5Kx8W91riQJlQokSf33HTkoGJDVxw3U17EY3ls5NBTCw9UPJEl9jGUAWX2N/P46GcM5FFvePyvGc0GSkExM1Nu/OXdjSxMvSXQd0qqvvj6SfvTvSjk8/MffX0olckhIyp3zxsZIKfS9kKxXl+qVSlOxTDF2HTzJuw+f6dKuCVmzZEyewiT1uKIoskqO9jncc+g0ew+fVm+PKeBIQrK/P6oXL5BDQ5Hd3cHCIsYLQ5wCAlFkyogsx/xSOSwc2dsbjI0gNAzJ1EQrYILIQM3TS31RUEhgZpawOoSEIFlYgJ4eIMVrF1Te3up/fuYiFBik3mkjIwgKAgP91P0yjFCBvz9Y/iZreAUHq99XpVJ9oUzpQFSl/jJTxHE85fBw5C9u6gfGRurA29AQKfIirPL0BD19SOkhhCoVckAAkr4BkoUFkn70LxCVhwcYGCT8M/+7koGgQHVwY2mpfk4lI/v7IZmYqM9FGVRuX9QBg5GROhDQ1YPgYPX1y9wM6bsvRznqB5skEdP1SeXnD7Lqv0DKzw8pfTpkLy91sCIpwCL6TOtECVeisLbS3m1ZRv70SR2o2dggxRT0RaiQ3d3A1PTHZSiVEBISv7Q/EhaGIp16nK6sVCL7+iIHhyCZmaoDTf8ApHTpkH19Yi9PBsJCUaRPj+rjJ7Cy/Pl6xSU0FN2qVZHSp0/eciIl2zeOr18Ah46f54v7V+ztMtGtQzN2HTiBjkKHzu2aYGGeBG/wN2zSWfH42WsAPDy90dPTw+C7iLhl41q0bKy+C7BSqaRSgy5JWodvKaytUVStCkDE589E3H+ApJD+a82JB9nQEN3IPGLcrlSiPHMWdBQgy+hWrvzfL7Bv0oSfOqUuNzw8xl8JmrSyDEql5heDLMvICgW61aolqBVMDgwk/OJFJClh+/stlSyjyJkT1YsXSBlswc8fKaHBXRKQQ8PUxzcoGMxMU6UOyUEGdCtVQvXVE9WDB+qLYnKXGRQEyggwNUEOCECnVCl0MmeO+zW+vuovNxMTTWAUJeLDB1QPHqbYeyKHhiGHhiCZm6NTrDiKTBlj/VxEuLsTcf06CvMk+vJN4+TAQBSOjqhcXEFWIQcGIhkboVO8GIrMmZF0dJBVKpTnzoOsQrdcOcLPX0DS10OROxeKbNkS1soSKcLZGdW9e2Bqiuznh06pUijy5kH29UUCwm/cRGH48y2ocmgokp0dusWKRdumvHMH2c8P3SpVYmz5UHl5obxyBUUc57EcGKgOKBUKpPQ2oJB+qhVFVqnA0grdShX/e06pRPXlC6rXr0Elo1OpMpKlBeEnTyEZGcY4mUkOCkKRuxCKnDmQ/QN++joiR0Sozw1DQ/WPNpVK/RcaBibGka2FKSfZAqSRkxZQp0YFypQswvXbD1i6ZjvTxw3kzftPzFu6kcmj+iVpeaWLO7Bq4x5CQkK59/A55Us7Jmn+P0MnSxYUtrZE3L+P7O4erw+6HBb2wyhZ0tVFt1JFlPfuIaVPHy040qQpXRrJ0BDlkyfI/v4x/4pRqcDPH1kh/Rcg+fmhU7pMgrsIJRMT9GrVIuLuXWRv70QFSZKBAToFC4J/ADrFi6F68QKVs3OM+5hYckAgUU3zMX3JymFh6l+mQUGRX9K/x5edrFSCtTWSsTEKWwWqFLzqKIo5onr7FsncHEWmTD9ML1nE3sKksLdH9eYNslIZ4zkdX3J4OCgUP/zCkZXh6NWoEa/Pr46tLRQqTMTTpyjMf4+gOrHkkBAwNUORNy9YWxNx9Ro6pUuhkyWLVjpJoUCnTGmQQTI1Ra9uHfUwgp9ohVNkykTE/QcQGIhOuXLq9wWQIluxFOnTI3t5xvnDMdb9kmX1tUFXFzk0DJ1s2WJMp1OsGERExHp+STEE/1rlhISAtTUKCwtkH18kS0tUHz/8XKtvSAiK74+/ri46dnbo2Nlp19+xKBEPHqhb3GSQZRWSjLrXBlDkzhXZw/Bz5KBgMDJEt3x5FN9998n+/oRfvBSvIR5JKdkCJA9Pb+rXrIS+vh426az4O3LmWq7sWZM8OAKwsjSnS/umdB84ATMTY6aM6Z/kZfwMSU8PnRIlCD9xIn49AiGhSD/4dQ2RwUjFinGmiTrZFBkyoHL3gJiifH9/dCpXUn/h+PhARASKjBnRyZS4LlHN/p4+rQ5AIi9ymn5vI6NYLxhyaCiKjBmRFAp0y5VV171AASKcnbXy+hlyaBhYWaFbtgyq9++JePI0MlAyRVIo1E3Oygj0qldD5e6O7OaGHBamDlzTeLeJHBik+aUrGRrCd92yyVKmLIOxCTpZs6KTNWuS5ClJEjolSqC8cBEpkd0kcliYOvjV1VX/AjbVDn7koCD1RdnICMnSMkGtGDq5cyH7+yG7uCL9oXcMkENCQE8P3fLl1AGQrS2Khg1i/dH1bStKosdufkPS0UGnRAkUFuYx/4DMZo/s8hkSESDh548if35Unz6C9F/QFVMd4gpmJAODWMfuyCoVskpGr2RJzfGIcHGBN+E/9bmVlUokG5t4pdXJnBmdzJmRIyLUXaShoeru74gIFKam/wWXMXQ1x7s+KhXo6qi7z2K4vkpmZugUKkTE9aSfAR+XZAuQOrRqQNf+47DLnAFnFzd6/NU8uYrSaFSnCo3qVEn2chJLUihQ2Noie3n9+BeLBIpYPnCJpUiXjghZjhagyYGBKPLmRWFtjRwRgeraNdDVjbG5OCEkPT10ihYl4q4TUtSv6JAQFAUKoHr2LNbxUHJoKNJ3X6Ix5hUPsiwj+/ii+L5vPDQU3cqV1BfQXOomfJWrKxH374OJCXJQMHrVqyEZGqJjb4+cNSsRt2+rB1qm8sDgnyHLsrq53Pq/xVoVmTKjcv4UbfxakgoNRZFEgdG3FBYWKOztkV1d4mxdlEND1RMWvnvv5OAQdMqXQ5E+PREPH6L69AnFN+MtZKUSJAVScDCKnLkSXD+dokVRBgSoxywlsrs5rZIDAiGdNbqlSmkd96QIfBIirh95CisrVIkYWCxHREA6a3Ty5UWRzR6Vq2ucrUA/ZKD+7MmBgVpBuOzvrx468c0xU5iYxHgdTwhJoUBKYPevJtAzNIy57MQEmZHkgAB0SpaM88enIlNGIn6XFqRmDWrQqG5V/PwCsDA3Q0dHzOgAkLJnV3+YfnQyGRgk/ReWiQmSIoYTUJJQ5MsHqIMolSyjcHRMVLPz93SyZEH19q16loOeHhgaoZM7t7pVJigoxq4RSaGIsWtFJ0sWVK/fIIeFxv8iG7kelxwaqpnNIgcEosiXT+sLS9LVRWFnh+rFS/D1UwdP33xRSpK661FO4Q9okgsIROFQWOtCpLDPSsTbN7Geb98eu0QLC4PI7o2kpuNQGKW7O3Ic3RiyUgnhSjBE+8taR4HC2hpJktAtWpQIXV0i3rz5b+yQvj4KW1tUb9+hsEn4wFB1K2g5lDdvIvv6IRmnzSBJDghEVqni1V0oyzKynz86uXOhKFjwl25xlXR11RNBEkgODEKncGF1HoaG6OTI8XP1MDNF9vBADghQz9KSJHXQkC8fCivtgd8YxjweKEEMDH+qWzpGxsaxDuGIixwejmRm9sMud8nQECmZriGxSZaoZdnaHcxcuJaPn1yxtrKIFhz5+vmzYftB+o+YgfIPW6hRYW2NpKurbomIhSzLYJT0TfKSQoFka/vf0gFRZRkba379SAoFutWrRxsf8DN0S5SAoGB111kG9QmuyJNH3X0Rkzi633RLFFfPaomv0DB0HIuqB/kR2ZQbOfDze+oum+IoypXVzO7QYmCQ4n3gSU6SUHw3xkAyN0cyiD0YV3l5qbtGf6pcBYo4xhP9VNa6uuiULQMBATFul4OD0cmWDb1qVdXdpJH7IqtUYG6uda7pFCqETv78qHz9kMPDUaRLh07OnOqZaokYJBxVP91y5UBPN84AW5ZldZffr0iWkQwNfzj7V1Yqwc8PnRLF0SlU6JcOjjR0EhEo6OigiGcXVXxI1umQff1Q5MoFISHq88DcXPPDVSttHF1y8SErlYnuko6Lwtw8+jIzP6qLLENwMLplysTrXFHkypWiy2ckSwtS3+5tefzsNSs37MbZxQ1TU2My2Fjj7eOPl7cvJiZGtGhUk4XTR/xxLUtRAYjy5i3k4GCkmNZpCgtL0g/ft3SKFUN59ux/A1vDwqIP1kvimTeSsTGKPHmIePgAqVQpQD0uKkI3eiuQevxR7L8kJFNTFDlyqAdsx+eXnyShyJRJ/evMyws5NAzdihViDcCi/Vr7lr5+mg6Q5JAQFFntYvyFp8iShYiXLwH1r1nNQP2ICHXXVUjozw3EjGWdlaSisLBALlAA1ctXSKYmqPz9kZDUs2rClShy5UIyMkKvalXCL1wEIgMnhyLR8tLJmxf09Ii4eQuFgwP8v737DoyiTP8A/n3fmdnd9EpCQkhCSAghJIRQAoiIcAgqdkVFRTnPLpbT33mKvZ9YT8De29nlrGc7FRSP3kQEkZKQ0EIC6buz8/7+mBSS7Cab3Z3Z3fB8/pLdybwzr1uefd/nfd6YGHAPP8DdYZyDFxXBuWQJhCSDWS1tI5pOJ9DQoJfwYdCXhAdRYCHsdrDkZLDkJGjr1rvOYURzfqEA5MmT242+Bj2Loo9we/jFK5qaIKX1821KrQMWGwOWlASelQW1vBxwOKCMHev+deDLe8luB+vqc85bUVF6jpKHMx/C6dRHtMeO8XjxDc/K8uUKe8ywKbahedn4x53XAwCqD9agfPdexMXGoG9SQlC9+QOBWa2Q8odA/ekntwESXI1g+KNtRYF81FFQv/0WIjpaH1kxYdiS5w6CqK5qnTpjjEHKzIS2fVv7N4fdDnSTGM4HD4a2Y4dH7QpZ0ofAhw+H+t/vwFP6uh4d8oTFqtdDClV2B3hOjsuneGaG/sGfOwiO777T83U413PG0jP0HCUvmxWNjeAp3S848BXPyYFWsRuivg4sMlIfKW1qAktNaQ2mWXg4lGMnQv3hB0gDBoBnull5NGAAEBHROv0mJSf7fH1Snz5AcTFYZCScGzfqiyGsNiBKD/p5aiq00lJomzd7PVplBNHQCLlkEBAeDue6dW5XZImGBkhjx4ZWcAR96kbU1Xk8MiGamvz+Rc1iYyGPHqWnQTCuj6J3Vb7CFgahOrz7LnWohgRILDwcLTF+d1pGcuVjJ/aoFIbZsYMp2aaxMVGIjTmyl7p2xGJj3f4CEQLtEkX93nZUFPjw4XCuWQPGmCm1WpgkQR43rt1jfECmXnMDzdMdDQ0QTq3b5HSmKOA5g6Bt2dK66kg0Hl5hFxCMgYm2ZeJMUSBPONqnpbHMagW00JwSFpoGuFnJA+gjc/KIYgCAPG4cnIsXQ0RHQzidkDLSIXaVed+2wwGe5VuOhicYY5BLRkP94gtIo0sg9u+Hc906yBMmtD8uLAzK1Kndnk8y4IdDy1JwNn58u5pjLXhmJrRNv/mlLdHQoOddyZLX5TGEqn+ZtryP5GOOgfOnpXreSIeRAsa43xeWmIHZwvTRDA9GSIXQq337u/YWk2Wg5XPYZgPPye7yeB4bA23XLq9WsgnO/FoupQWz2TwqjCoaGwFZgTJ5grELQ/zgyJrfCiJMkoCYGP2N2fE5zgADXsCHk9LTwfv31yP+AL1IWVgY0CcRWl09oFjAcwdDmTzJo6kYnj0QgvO2nAiHA/KEoyEfPw3K9OlQpk0DYmPAk9qmKpnN5tsKGlmC+WWb/aS+3uNVZDw+Hry4GOJQTVvCfBdJ2sLp1POUXLyWhRB6xWmTijkymw3ytGngCfHgAzIhjRoZlKvHWpL+Oz2uKEBSHz2Xx/dGIB83BTj8fdIFoaqdjhO1tZCHtU1D8uhoyJMnATEx0Gpq2o5ryWU0eYWaX4TZXG8B4kpdnZ4HYyCpeHintIeOeGamXqrEC4xzrxLTu2Wz6VXmu9g+SAgBcA75mOAPjgAKkAKKp2foFZo7UhRT9pqRCgshjRxpeDtdkUtKoJxwPJSjx0PKHujxFymTJEhD8/VVH4AevERHt+bXtIxY8eyuf4n1BJMkiBCdHhaaAO/BiIjUvz+knGx9tYuk962rL23R1ATRZAcfnKdvD9NRQwN4Rrovl95jLR+8zGKBlJlpatv+wDMyerYQwQVRVweemQlms4Hn5UFUVUEcPAStpgaipra5SOphx6uqPr0tK3o144ZGaA0NkIYO7bSilCkK5DFjIOUN0bencDr1Mg59fZ+GDIiwMM8DJIFugxdf8YSEbleCsagosKgo71bVWiyGTFUxzqFMmgTWpw9EXZ3+OusYmDc2gvfvHzKBtClTbKW7dqPyQHW7er3DCwab0XRQ48lJ0Dr+Ymv+JWYGJkmQPKhmbOg1+JDoyPv3h3P9Bv0fFmunN70/kygB6NNzoRkfARalx7khPC9P/7KG6yKjoq4OiI6GUlICMAZ169ZO5xBOJ3i6uQFSqOOJidCY5/kwUNXOBSw1re3/XfOqRRYRoU+tWK1Qv/ii/fGNjeBDh3ocUDLG9B80CfFwLlsGoaqdVkeGCmaxQIC5fWu3lI/QK9DHGbrYoCd47iBoK1cBPakLp2mG5rexyEjIxcX6tiW7dkFbs7bdXnfC4QDzQz6fWQwPkB58/AV8+tUPSO+XAknWR0UYA15ZcJ/RTQc9ZrUCEeH6NARjzfVDDkHKzw/0pYUExhhYTDREXT1YQnz3f+ArWfZojt1sQgiI/fvBEhJcBoVCVcHje94/jLHWD1OelgbnRr3aONC8Dc3AbPD8w+rcREVC1NdDOFTwmOjmopThhuQ79GZMlvXpd4fdfZ5iXT0EACmtHyDL0P7YBiiynnDcZAfiE9oS0yWp8zYYEZH6lhEtFe414dXiBR4XB+5BPlcwY4rS6X2tVVfrq3kdDr0ciaxAOOyQCjuvegwUnpICLTy8Z1vt2O1drhL2FybL+mvOoULb9GvrjzPGpS63Dwo2hgdIPy5bg0/emo+YI3w/Ind4aiq0bdsgmn+hSCUlkPp6t73HkYinpsK5fLm+z5PRZFnfgyjYOBzgfVP0MgbNW6W0U98ANmSIT00wWdZL/a9cBVgsLl+nPCMDWmkpWEudrbo6cB/bPVLxjAxoa9e6XFIvmpqAmGgoY8a0fjHygQPh/OUXPXFXkqE0J9y7PX9Skr6fV8t0JGdBtXLOVLLcbvRI2O16v9bXQ2gC0rhxQPVB8OQkt9uJBALjHNLIEVC//97joEM0r+o0C88a0LYQR4gua9wFI8MDpNzsTISFQDJWoPB+/eDcsAEsLQ3KiBFBM3wbKnifPnA6VPBYE36VSBJM307aE6oK1jcZPH8InIuXdA6SGPO+tMFheHq6PhIVHu7yQ45nZoJnZsK5eg3E/n2AJsA92E+QdOZq+h1oTqR2OPS9uQ6vCG6zQR4xAmLQIAjR/cILlpwEsWVLW/HHw4rFHnE65MOIxkbIo0ZBXb5cX5kXHx+000I8NhY8IwOioqLbxQiitg5SdrapKw0Z52CJCRBVVfr+ngbnb/mb4QFSYX4Obr7nCZSMKGj3+IxTQ3tY1m+ioiBPmuSXL7AjUmQkWHycKb9+GeemVnH1mKoCUVF68DL+KL0YYXR029TXYUUJfcEYc7t/XuvzAFhaP2g7d+qlLOjHkVeY1QpERrRNvzscemHZ2Fh9bzM3/cqiojxKk2PR0W0BkUnTLsGKyTLQvAWTUFWw2Diwvn31wElWgj6hWMrPh6O8vMuNvIWq6uUD8vJMvjqAJSVDVFRAaAIswDmvPWV4gLSztAJxMVHY/Pv2tgeDMI8jUBhjYBQceY0xBl5cbN7IGw++4WEBBt78hckTEiDGjoVz6c96fpbdDpZoTFV2d3hsLJyNDeADu57mIV3j6elwrl2nf1En9YFSUuK3KvdMUcCSk6GVl+tTTD7uJRbymkfjRH095OHF+udybBx4WPAH+ExRIBUVwbl8hfstROrqIU+eFJBRQh4XC6fQ9z0MpfwjwIQA6dYbLzO6CXKEMzVnq5v58467cZuCoV2dIikpCVp4mD510tgIlmbusDazWPTpOMql8wlPS9NHd7KyDBmJk0ePgnPPHvDYWL+MMIY0Wd8nj0VEgDcv+OADs/y/oatBpNRUaAnxEHX1+p5/lQdaN1cWNbXgQ/ICV+G8ZZP0sLCgH43ryPBw8oSzr8QdDy7Ep1/9gH2VVUY3R4ixutk7UBww/zXOGOtUyJGnpemVySXJqxVsvpLGjg25D8Ngw2w2SEOGGDpNKSUnU3AEAJIMUVsLPqRtBbGUlBSQ94635JEj9V0Eqg+CxcXq+Wqqqm9l48d6cD3FOAcUxbD9RY1keHj81nMPYfW6X7FizUa8+e5n4JxjVPFQXHPpTKObJsT/uhmiFoFI4pblTkPnPC0N6tq1kDsk85rlSN9vkYQYRQazWkO32CWaE/WPPRbagQPAwYP66jGnE3xYUcDfjyw5GQix/CPAhBGkmOhITBw/CheeezIuOHs6MtNT8cEnXxvdLCHG6GaKjXHJu+q2vlA651+xqChIOTngR3puCSEeYOER4Hl5AQ8kfMUURd9YOTYWcOhbx3B3eUkmkvLzwRMTA30ZPWb4T8tHFryCtRt+g9VqxfCCXJww5WjcfP1fjG6WEGMoir6ayN1IEuf6tgUmJUMKIQA3CeryiBGmXAMhoU7KG+z2fRSKeHg4nJzp9cGDoL5VqE63Gx4grd+4BRER4SgqyEVxYR4KhgyCzdp7XojkyMIsFn3/t64CJM3EaTaHIyR3UCckmPS6chRhYfpomKKETKJ5MDK8515ecC8OHqrFqrUb8f2PK/H0S+/CZrVgwby5RjdNiN8xi6XrKTTOAM3DjS/9QVWBQK1OIYQEJSZJEJJE2/z4yJTQsr6+AbX1Dairr0d9QwN4MBbbI8QTFivgJkASQgCS7PZ5IwiHqucbEELIYZjVSqPLPjI8QDpt1nVQHSpKRhTgqNHDcd3lFyAmmn7xkhBlteg5Rq4IoSdxmxggMYmH1FJkQog5WGwsQEWIfWJ4gPTQHdcjOys95FcHEAJAT+R0FwBpml71WHUY1rwQAqKmFlAdelXaqKiQ2vyREGIOnplJU2w+MjxAyhmYga++W4rFS1cCYDh6bDGmTBxrdLOEGELf0sRNsC8EmNUKoTo82g+rp0RtHSBLkEaNAhjg/PZbSGPGGNASISTU0ciy7wwPkF59+99YvHQVTpo2EYwxvPPRl9iztxLnz5hudNOE+B2TJAjmJkTSBFiYBaLOv22KxkbAoYIPGgSePbB1xEgMyKLtPAghxCCGB0hf/ncpnn/8Tthsejn7Px1Tgkuuu4sCJBKaZBnuR5A0fcsPP04ni/oGIDYGcnFxp6XI8lgaPSKEEKMYHiAJTcBiaSsSZVEsEGbWiSHEnyQJcLedSHPRRuanCTbhdAKSBLmkhPKMCCHEZIYHSCUjCjD33idx5slTAADvf/I1Ro8YanSzhBhDlt0HQJqm5yD5q626OvAxYyg4IoSQADA8QLry4rPx2jufYOGLbwMAjh5TjPNnnOj1+XZV7MXD81/Guo2b8c2Hz7c+/tFn3+LdRV8iMiIc99x8FZL60PJGYgBJcjvDBiEAq8398z0kGAOnIpCEEBIQhgdIsixj9sxTMXvmqX45X2REOC6YMR033v5I62MHqg7itbc/xhvPPIjFP6/Cghfexl1/v9Iv7RFyOCZJ7nOMhAAsit9ykBhjek4TIYQQ0xkWIL3w+oddPn/x+ad5dd6Y6EgUDxvS7rH/rVyPQQMzYbNZUVQwGPOefMmrcxPiEe5mykvTwGTF/fM9pSg0vUYIIQFiWIBUU6uvdd7421bEx8Wgb1IiAGDL1h1I6dvHr21VHqhGepq+3DkxPhZOTUNjk73Tprjv/fsrvP/xVwCat4UgxBtugxYGSLyL53uoF+0uTgghocawAOm6y88HAFz9t/tx39xrIEn6/msNjY249b4nPTrHy28uwtIVa9s95jK/iLUPeIQmXM5ynHnylNZkcVVVcfSJF3l4N4QcRnK9l6BgADgHJA5ht0M0NICFhTUXl2w+xun0aFRIqCpYdLS/rpgQQkgPGZ6DtK/yQLt/26xWlO/e59HfXjTzFFw085Ruj+uTEIcNv/7e3F4VFEWBlX59E6N0EeAwzvUgqbYOUmEhtL17IfbsBRQZwuEAVCdYfFz3bTgcFCARQkgAGR4gFRcOwc13P44Zp02FJEn49D/fI71fil/bGF1cgGdfeQ+NjU1YvW4Txo0u8uv5CWlHkvXtRFwNUzKmB1Ccg6emQhowAKKxEdrmzUBkFLQd2yGE6H5vQlUFYmKMuX5CCCHdMjxAuv6KC/DaOx/jqRffgepUUTR0MK657Hyvz/fsK+9hyc+r0Nhkx6wrbsGF556CyRNKcNHMU3HxtXcgKiIc98yd48c7IKQDiwLYm1yMJDUHR4qi10tqXoHGbDZIhYX6ITU10HZXdLs6TQgBThtNEkJIwDC7vcnQbOXaunpERgTfB31LDtLiT1+GLBseJ5JeRF21GqJyP5iitHtcq6mBMnkynBt/hXA4oLjYCsS5eze0ZcvBoqO6bEPU1EA+7rjWIIsQQoi5DI8Mzpp9A/r364uSEQUYXVyAIbkDWxO2CQlFzGrRtwHpECAxMIBzMIsClui6UCmPjoaTAaiv14/tsL9aC6EoFBwRQkgAGR4gffqvBdiydQdWrNmIl99ahJ1lFcjJSsf9t11rdNOEGMNiATTN9XOcA4mJ4LGxrp8PCwM0AURFQNTVAS7ykYSqgsW4+XtCCCGmMDxA4pwjOysDTXYH7A4HVFXFhk2/G90sIcaxWrsMkKTUVLd/yhgDH5AJKScH2v79cK5ZAxbVYbqtoQF8UK4fL5gQQkhPGR4g3XDbw9izrxJZGf1QVJCH66+4AJnp/YxulhDjWK2A09n5cQaPikTKzQnbPC0N2tatEA5Hu3wmAYC7maIjhBBiDsOTgRRFhkVRIEkSZFmihGgS8pgkQagqhMPRqSJ7t8v3OxwrjxgB1De0f0KxgNEKNkIICSjDo5UHb78OmqZh89YdWLlmIx5/+nX8sb0MH7z6mNFNE2IIFhsLafhwiOpqiEM10BobwITQ8496eq6oKPABmdDKysDCwyHsdho9IoSQIGB4gGS3O7Dh1y1YsWYjVq3diN17K1GYn2N0s4QYhskypKys1n9rBw5AXbIETPGuejvPy4OzrAwQAqKxETwjw1+XSgghxEuGB0hTz7wc2VnpGDOyAHMunYm8QVngXvzSJiRYMZtNr6DNPZ9ea/f3igJp2DA4V64CkyTw+Hg/XyEhhJCeMjxA+uj1JxATHWl0M4QEjs2m10Bi3gf+Ur9+0H7fCsiSR5vZEkIIMZbhAZLFIuODT75BWfkeCNG2NPpaH7YbISSYMM4BqwXwsQCqPGokRFOTn66KEEKILwwPkG67fwFUVUX57n047tix2LJ1J/qlJhvdLCHm6qp4pIdYeDitXiOEkCBheDJQxe59ePz+m1BUkIupk47CXTdfhV0Ve4xulhBTsfBwQBi6rSEhhBATGR4g2WxWOJ0ahuXn4qdla6DIMnaWVRjdLCGmYlFRHhWJJIQQEhoMD5AmTyjB73/swLFHj8aiz/6Lk2ZejfzB2UY3S4i5YmIAKoJKCCG9huGf6GeePAUWi76NwotP3o0dZRUYOKC/0c0SYioeHg5hswX6MgghhPiJ4SNIV9x4b+t/22xW5GZnQqapCNLb2GxABJWzIISQ3sLwAGlwTiZ+/N9qo5shJKCYzQZpcG6gL4MQQoifGD7FVlV9CDfd9Tgy01MhHVYn5pUF9xnddJdaNhlVVTWg10EIIYSQ4CBJUuum48xubzJ0bfKqdb+6fLy4MM/IZrvV2NiIY0/5S0CvgRBCCCHBY/GnL0NuXnBjeIAEAJqmgTHWGpUFA03TYLfb20WL/nL+5Tfj9acf8Os5ezvqM+9R33mP+s431H/eo77znpF9d3hMYOgU29ff/4yX31qE0rLdAAMy01Mxe+apmHjUKCOb9QjnHDaDVh0xxlojUOIZ6jPvUd95j/rON9R/3qO+855ZfWdYC98tWY4XX/8Q11x2HvIHD4SmCazfuAVPPvcGOOOYMG6EUU0TQgghhPjEsADpjfc+wz/uvB79+/VtfWz8mOFIS03GfY8+26sDpDNOmhLoSwg51Gfeo77zHvWdb6j/vEd95z2z+s6wHKSu5gjPu/TveOPZB41olhBCCCHEZ4aNIKmqE79vK3W5gafTx13PCSGEEEKMZFiA1GS34293POryuSBazEYIIYQQ0okpy/wJIYQQQkIJrTE8zKGaOjz4xAsoLduNmOhI3H3zVeCc47b75+NA1UEcP2U8zj9rusvj4uNi8Pxr72PR598hLiYKAHDnTVciKzOtXRuNTXbc/dBT2FFagVHFQ3HtZeeBMYb/fPsTnnv1PYwZOQw3Xn1hIG7fK4Hqs9q6ejz21GvYvHUHVNWJv10zO+DFR3sqkK+302Zdh/AwGyTO0S8lGQ/cfm0gusBrgeq7n1esw1Mvvt16zPbScjz32B3IzRlg6v37KpCvvVff/jc+/uJ7xMVG49YbLkV6WkogusBrZvTdwUO1eOifL+KHpSvx8ZvzEdt8bKh+T7Twte9UVcVjT72GNRt+Q0x0JO782xVI6pPQro3qgzWdzgcAb33wOd5891Occ/rxOO+sEz26XhpBOsxPy9YgLMyG4QWD8eRzbwIAHA4V6WkpOPWEY3HhVbfigduuRVn5nk7HzblkJp5/7X0kJyXipKnHuG3jrfc/w/4D1bj6L+fi+rkPYeYZJ2D0iAJs27ELn3+9GPUNTSH1wg9Un+XnZWPrtlIU5g/C4p9X4c33PsNTD99qyj37SyBfb6fPuh7vvPRwyG4cHci+a7Fpyza8+vbHuP/Wa4y9WQMEqv8SE+Jw50NP4dlHb8e6jVvw8lsfYeE8et921NjYhI2/bcVtDyzAG8882Bogher3RAtf++7dRV9ie2k5brzqQpTu2o2U5D5QlPbjPI8ufLXT+dLTUvDblm14Z9GXyMpI8zhAMnyz2lAybnQRhhcMBgAUDMnBvv1V+GnZGhQVDIYsyyjIy8HS5WtdHtciNrrrHd1/bD4fYwxFBYPx0/K1AIABGf2Q0T/VoDszTqD6LCI8DIX5g1BbV48dO8sxaGCGcTdpkEC+3qKiwkM2OAIC23ctFjz/L8y5ZKaf78wcgeq/P7aXoWhoLmw2K0YWDcH2HeWoqa0z7kYNYEbf2WxWFA8bAotFafd4qH5PtPC17z7/egnOOW0aGGNIT0vpFBwBcHk+AMjNGYCU5MQeXS8FSG6sXLMRhfmDcKDqINJSkwEA6Wkp2F9Z7fK4Fm+8+ylmXnITHlnwClSns9N5Kw9UI6N5SDkjLQX7K6s6HROqzO6zij37ceLZV+Hzb5bg8tlnGXRX5jC771TViatvuh+zrrgFi5euNOiuzBGI9+r2nbtgtVp6/IEbjMzsv9SUPliz4Tc4HCo2/Po77A5Hu8Ah1BjVd0cCb/pu9979WLZqPS68ai7ue/Q5l33X3fl6ggIkF7ZuL8Xy1b/gpGnH6HuyNJcq0IQGxpnL4wBg+tRjcOuNl2H+vFuwacs2/OebH/HVd0sx64pbMOuKW7B7734wMGhay/kEOO8dS/oC0WcpyYn4dtELOOf043HjbY+YfMf+E4i+m/vXSzDvrr/i+itn4c5/PIX6hkaT79o/AvVe/e7HFRg7qtDEOzWG2f03JHcgxo0ahj/PuR1Lfl6FvsmJiIwIM//G/cDIvuvtvO27+oZGREZE4KUn78GBqoP44aeVeOv9z1r7TnU6uzxfT1GSdgdV1Ydwx4MLce/cObBaLIiPi0FZ+R5kZ6WjtGw3srPSXR4HAH2T2n5NTjp6NHaUluPKi8/BlIljWx9PTIhD6a4KZKanorRsNxLj48y9QQMEss8kiWP6cRPwz2feQGOTHTarxaS79o9A9d2Q3IEAgOEFg5HStw/27juAzPTQGroP5Otu05ZtOPf04026U2MEqv8unz0Dl8+eAVVV8dnXi5EQgp+BRvddb+ZL3yXExaBoaC445xhZNATlFXtx/ozpOPeME1rP7+583qARpMPY7Q7ccs8TuGTWGcge0B8AcFTJcKxevwmqqg8Jjx01zOVxTXY7Fn32XzidGurqG7B89S8uV7YcVVKE1es2QQiBNRs2YVxJkZm36HeB6rPvlizH/1auhxACK9b8gsiIMFg7zNcHu0D13bpfNuOXTVsBAL9vK0VNTR1S+/Yx78b9INDv1T17K5EQH2vGrRoiUP0nhNALCAP49xffY3xJMSQptL6GzOi73sqXvgOA8WOK8e2SZVCdTqxYs7HT6j935/MWrWI7zAuvf4g33v0EmempUFV9bvORe/8P98x7BpUHqjF96gSce8YJLo975rHb8fYH/8EPS1egqvoQJk0owdV/OVcf7jtMk92Oux96Gtt3lqNkZCHmXKIfM+uKW3Copg6NTU1ISozH80/c1SlBLxgFqs8qD1Tj4QWvYGdpBQQEbrrmzyhqTuoLFYHqu32VVXhs4WsoK98Du8OBG666EKOLh5p+/74I5HsVAGb8+UYsnDcXiQmhN/oBBK7/6uobcPsDC7B3/wH0S0nC3L9eiuioCNPv3xdm9N0Hn3yDjz79Btt27kJ6vxScfPxEnH3atJD9nmjhS989+9gdaLI7cPe8p7GzrAKjhg/F/825qFPfHTxUi9vun9/ufPsqq3DDrfNQWXUQnDFkpKdi/j9u6fZ6KUAihBBCCOkgtMY2CSGEEEJMQAESIYQQQkgHFCARQgghhHRAARIhhBBCSAcUIBFCCCGEdEABEiGEEEJIBxQgEUIIIYR0QFuNEEJ6ndNmXQeLIkOWZYTZrDjvzBMxcfyoTkXlDvf8a+8jJbkPTjxugolXSggJVhQgEUJ6pXtumYNBAzOws6wCN931GFSn84jZ74oQ4jsKkAghvVp6WgquufQ8zH/+LRQX5uGJZ15HWfkeHKqpw4xTp2LGqVPx7qIv8c5HXyI8zIa3P/wCL86/B9XVh/DQP1/Czl27YbEo+Nuc2Rialx3o2yGEmIQCJEJIr5c/OBs7yyoQHRWJ8848Ebk5A7B3XyXOnH0Djv/TeJx1ynHYtGUbigvzWqfY7n3kWZxz+vEYM7IQ23fuwu0PLsSrC+8L8J0QQsxCARIhpNcTQgNjDJxz2GxWvPD6h9i6vRQMDHv2ViIqsv2GqfUNjVix+hccqDqIhS/8CwBQU1sXiEsnhAQIBUiEkF5v/cbfkdk/FctWrceCF/6Fyy48E2eePAUXbb4VmnC9X7eAwIJ5czsFT4SQIwMt8yeE9Grbd5bjn8++gYtmnoqly9diZFE+jh47AlXVB1FT0zYq1DcpERV79gEAwsNsGF6Yh+defR+apsHp1FCxZ3+gboEQEgDMbm9y/fOJEEJCVMsyf4lLCAuz4YIZ0zFx/Cj8tmUbHl7wCpxODQVDcrB+4xb8/bqLMWhgBv7YXoYbbn8YcTHRePieG+B0anh4/svYvrMcVouCE4+bgLNPmxboWyOEmIQCJEIIIYSQDmiKjRBCCCGkAwqQCCGEEEI6oACJEEIIIaQDCpAIIYQQQjqgAIkQQgghpIP/B9ra81ajPraeAAAAAElFTkSuQmCC",
       "text/plain": [
        "<Figure size 583.3x340 with 2 Axes>"
       ]
      },
      "metadata": {
       "image/png": {
-       "alt": "Two stacked panels over the live window. The upper panel is account value against a dashed line at the 100,000 starting balance, ending at 143,939. The lower panel is drawdown from the running peak, reaching -13.3% at its worst."
+       "alt": "Two panels sharing a date axis over the live window. The upper panel traces account value against a dashed line at the starting balance, ending above it. The lower panel shades the drawdown from the running peak, which returns to zero at each new high and reaches its deepest point early in the window."
       }
      },
      "output_type": "display_data"
@@ -988,27 +1183,28 @@
     "axes[1].set_xlabel(\"Date\")\n",
     "add_message_title(\n",
     "    axes[0],\n",
-    "    \"The offline replay of the live window, and what it gave back on the way\",\n",
+    "    \"Account value and drawdown over the live window\",\n",
     "    subtitle=\"Deterministic replay through the backtest engine, not a live result\",\n",
     ")\n",
     "show_with_alt(\n",
     "    fig,\n",
-    "    \"Two stacked panels over the live window. The upper panel is account value against a dashed \"\n",
-    "    f\"line at the {INITIAL_CASH:,.0f} starting balance, ending at \"\n",
-    "    f\"{backtest_results['final_value']:,.0f}. The lower panel is drawdown from the running peak, \"\n",
-    "    f\"reaching {drawdown.min():.1%} at its worst.\",\n",
+    "    \"Two panels sharing a date axis over the live window. The upper panel traces account value \"\n",
+    "    \"against a dashed line at the starting balance, \"\n",
+    "    + (\"ending above it\" if backtest_results[\"final_value\"] >= INITIAL_CASH else \"ending below it\")\n",
+    "    + \". The lower panel shades the drawdown from the running peak, which returns to zero at each \"\n",
+    "    \"new high and reaches its deepest point early in the window.\",\n",
     ")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "ac0b4fd5",
+   "id": "3237c0dc",
    "metadata": {
     "papermill": {
-     "duration": 0.001781,
-     "end_time": "2026-09-09T00:42:28.686642+00:00",
+     "duration": 0.00191,
+     "end_time": "2026-09-11T00:23:00.484429+00:00",
      "exception": false,
-     "start_time": "2026-09-09T00:42:28.684861+00:00",
+     "start_time": "2026-09-11T00:23:00.482519+00:00",
      "status": "completed"
     }
    },
@@ -1028,20 +1224,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
-   "id": "3b3556d3",
+   "execution_count": 16,
+   "id": "35bf40a3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T00:42:28.690978Z",
-     "iopub.status.busy": "2026-09-09T00:42:28.690830Z",
-     "iopub.status.idle": "2026-09-09T00:42:28.695213Z",
-     "shell.execute_reply": "2026-09-09T00:42:28.694789Z"
+     "iopub.execute_input": "2026-09-11T00:23:00.488798Z",
+     "iopub.status.busy": "2026-09-11T00:23:00.488722Z",
+     "iopub.status.idle": "2026-09-11T00:23:00.492749Z",
+     "shell.execute_reply": "2026-09-11T00:23:00.492376Z"
     },
     "papermill": {
-     "duration": 0.007202,
-     "end_time": "2026-09-09T00:42:28.695627+00:00",
+     "duration": 0.006701,
+     "end_time": "2026-09-11T00:23:00.493034+00:00",
      "exception": false,
-     "start_time": "2026-09-09T00:42:28.688425+00:00",
+     "start_time": "2026-09-11T00:23:00.486333+00:00",
      "status": "completed"
     }
    },
@@ -1099,20 +1295,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
-   "id": "7f6d785b",
+   "execution_count": 17,
+   "id": "042ca7d5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T00:42:28.703626Z",
-     "iopub.status.busy": "2026-09-09T00:42:28.703548Z",
-     "iopub.status.idle": "2026-09-09T00:42:28.706557Z",
-     "shell.execute_reply": "2026-09-09T00:42:28.706065Z"
+     "iopub.execute_input": "2026-09-11T00:23:00.497390Z",
+     "iopub.status.busy": "2026-09-11T00:23:00.497323Z",
+     "iopub.status.idle": "2026-09-11T00:23:00.499856Z",
+     "shell.execute_reply": "2026-09-11T00:23:00.499528Z"
     },
     "papermill": {
-     "duration": 0.00758,
-     "end_time": "2026-09-09T00:42:28.707002+00:00",
+     "duration": 0.005117,
+     "end_time": "2026-09-11T00:23:00.500078+00:00",
      "exception": false,
-     "start_time": "2026-09-09T00:42:28.699422+00:00",
+     "start_time": "2026-09-11T00:23:00.494961+00:00",
      "status": "completed"
     }
    },
@@ -1144,7 +1340,7 @@
        "└────────────┴────────┴──────────┴────────────┘"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1155,14 +1351,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2231a5fc",
+   "id": "83134b67",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.003594,
-     "end_time": "2026-09-09T00:42:28.714379+00:00",
+     "duration": 0.001993,
+     "end_time": "2026-09-11T00:23:00.504098+00:00",
      "exception": false,
-     "start_time": "2026-09-09T00:42:28.710785+00:00",
+     "start_time": "2026-09-11T00:23:00.502105+00:00",
      "status": "completed"
     }
    },
@@ -1179,20 +1375,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
-   "id": "a7667db2",
+   "execution_count": 18,
+   "id": "d9cb3b0d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T00:42:28.719367Z",
-     "iopub.status.busy": "2026-09-09T00:42:28.719268Z",
-     "iopub.status.idle": "2026-09-09T00:42:28.723002Z",
-     "shell.execute_reply": "2026-09-09T00:42:28.722586Z"
+     "iopub.execute_input": "2026-09-11T00:23:00.508639Z",
+     "iopub.status.busy": "2026-09-11T00:23:00.508577Z",
+     "iopub.status.idle": "2026-09-11T00:23:00.511995Z",
+     "shell.execute_reply": "2026-09-11T00:23:00.511623Z"
     },
     "papermill": {
-     "duration": 0.006532,
-     "end_time": "2026-09-09T00:42:28.723287+00:00",
+     "duration": 0.006191,
+     "end_time": "2026-09-11T00:23:00.512289+00:00",
      "exception": false,
-     "start_time": "2026-09-09T00:42:28.716755+00:00",
+     "start_time": "2026-09-11T00:23:00.506098+00:00",
      "status": "completed"
     }
    },
@@ -1249,13 +1445,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "322360cd",
+   "id": "b8d8ff41",
    "metadata": {
     "papermill": {
-     "duration": 0.00177,
-     "end_time": "2026-09-09T00:42:28.726974+00:00",
+     "duration": 0.001932,
+     "end_time": "2026-09-11T00:23:00.516287+00:00",
      "exception": false,
-     "start_time": "2026-09-09T00:42:28.725204+00:00",
+     "start_time": "2026-09-11T00:23:00.514355+00:00",
      "status": "completed"
     }
    },
@@ -1274,20 +1470,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
-   "id": "d9ec4a1a",
+   "execution_count": 19,
+   "id": "c7e942bb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T00:42:28.731462Z",
-     "iopub.status.busy": "2026-09-09T00:42:28.731359Z",
-     "iopub.status.idle": "2026-09-09T00:42:28.734765Z",
-     "shell.execute_reply": "2026-09-09T00:42:28.734047Z"
+     "iopub.execute_input": "2026-09-11T00:23:00.520904Z",
+     "iopub.status.busy": "2026-09-11T00:23:00.520828Z",
+     "iopub.status.idle": "2026-09-11T00:23:00.523810Z",
+     "shell.execute_reply": "2026-09-11T00:23:00.523398Z"
     },
     "papermill": {
-     "duration": 0.006396,
-     "end_time": "2026-09-09T00:42:28.735224+00:00",
+     "duration": 0.005843,
+     "end_time": "2026-09-11T00:23:00.524126+00:00",
      "exception": false,
-     "start_time": "2026-09-09T00:42:28.728828+00:00",
+     "start_time": "2026-09-11T00:23:00.518283+00:00",
      "status": "completed"
     }
    },
@@ -1322,20 +1518,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
-   "id": "88864d8a",
+   "execution_count": 20,
+   "id": "66d2db1e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T00:42:28.740352Z",
-     "iopub.status.busy": "2026-09-09T00:42:28.740190Z",
-     "iopub.status.idle": "2026-09-09T00:42:28.745162Z",
-     "shell.execute_reply": "2026-09-09T00:42:28.744525Z"
+     "iopub.execute_input": "2026-09-11T00:23:00.528897Z",
+     "iopub.status.busy": "2026-09-11T00:23:00.528827Z",
+     "iopub.status.idle": "2026-09-11T00:23:00.532065Z",
+     "shell.execute_reply": "2026-09-11T00:23:00.531607Z"
     },
     "papermill": {
-     "duration": 0.008244,
-     "end_time": "2026-09-09T00:42:28.745658+00:00",
+     "duration": 0.00603,
+     "end_time": "2026-09-11T00:23:00.532316+00:00",
      "exception": false,
-     "start_time": "2026-09-09T00:42:28.737414+00:00",
+     "start_time": "2026-09-11T00:23:00.526286+00:00",
      "status": "completed"
     }
    },
@@ -1367,7 +1563,7 @@
        "└────────┴──────────────────┴─────────┴──────┴──────────┴───────┘"
       ]
      },
-     "execution_count": 18,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1391,13 +1587,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1e1ce60d",
+   "id": "31ca1980",
    "metadata": {
     "papermill": {
-     "duration": 0.003148,
-     "end_time": "2026-09-09T00:42:28.753047+00:00",
+     "duration": 0.002009,
+     "end_time": "2026-09-11T00:23:00.536413+00:00",
      "exception": false,
-     "start_time": "2026-09-09T00:42:28.749899+00:00",
+     "start_time": "2026-09-11T00:23:00.534404+00:00",
      "status": "completed"
     }
    },
@@ -1419,14 +1615,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8551d2d4",
+   "id": "9dd2ca82",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.00194,
-     "end_time": "2026-09-09T00:42:28.756931+00:00",
+     "duration": 0.001974,
+     "end_time": "2026-09-11T00:23:00.540601+00:00",
      "exception": false,
-     "start_time": "2026-09-09T00:42:28.754991+00:00",
+     "start_time": "2026-09-11T00:23:00.538627+00:00",
      "status": "completed"
     }
    },
@@ -1441,20 +1637,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
-   "id": "39f23420",
+   "execution_count": 21,
+   "id": "c827cf20",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T00:42:28.762032Z",
-     "iopub.status.busy": "2026-09-09T00:42:28.761858Z",
-     "iopub.status.idle": "2026-09-09T00:42:28.764846Z",
-     "shell.execute_reply": "2026-09-09T00:42:28.764366Z"
+     "iopub.execute_input": "2026-09-11T00:23:00.545447Z",
+     "iopub.status.busy": "2026-09-11T00:23:00.545343Z",
+     "iopub.status.idle": "2026-09-11T00:23:00.547739Z",
+     "shell.execute_reply": "2026-09-11T00:23:00.547265Z"
     },
     "papermill": {
-     "duration": 0.006177,
-     "end_time": "2026-09-09T00:42:28.765179+00:00",
+     "duration": 0.005373,
+     "end_time": "2026-09-11T00:23:00.548019+00:00",
      "exception": false,
-     "start_time": "2026-09-09T00:42:28.759002+00:00",
+     "start_time": "2026-09-11T00:23:00.542646+00:00",
      "status": "completed"
     }
    },
@@ -1471,20 +1667,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
-   "id": "5744fa54",
+   "execution_count": 22,
+   "id": "a2fa2134",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T00:42:28.769742Z",
-     "iopub.status.busy": "2026-09-09T00:42:28.769626Z",
-     "iopub.status.idle": "2026-09-09T00:42:28.773641Z",
-     "shell.execute_reply": "2026-09-09T00:42:28.773130Z"
+     "iopub.execute_input": "2026-09-11T00:23:00.553074Z",
+     "iopub.status.busy": "2026-09-11T00:23:00.552992Z",
+     "iopub.status.idle": "2026-09-11T00:23:00.556111Z",
+     "shell.execute_reply": "2026-09-11T00:23:00.555734Z"
     },
     "papermill": {
-     "duration": 0.006802,
-     "end_time": "2026-09-09T00:42:28.773952+00:00",
+     "duration": 0.006246,
+     "end_time": "2026-09-11T00:23:00.556506+00:00",
      "exception": false,
-     "start_time": "2026-09-09T00:42:28.767150+00:00",
+     "start_time": "2026-09-11T00:23:00.550260+00:00",
      "status": "completed"
     }
    },
@@ -1493,7 +1689,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Offline reference tape: 80 signals over the live window\n",
+      "Offline reference tape: 84 signals over the live window\n",
       "Reconciliation date: 2025-12-04 (scheduled rebalance)\n",
       "Offline target basket: ['EWY', 'ITB', 'SMH', 'SOXX', 'XME']\n",
       "Staged paper basket:   ['EWY', 'ITB', 'SMH', 'SOXX', 'XME']\n",
@@ -1528,13 +1724,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f3b328b5",
+   "id": "2aaeb66e",
    "metadata": {
     "papermill": {
-     "duration": 0.001928,
-     "end_time": "2026-09-09T00:42:28.777890+00:00",
+     "duration": 0.002047,
+     "end_time": "2026-09-11T00:23:00.560734+00:00",
      "exception": false,
-     "start_time": "2026-09-09T00:42:28.775962+00:00",
+     "start_time": "2026-09-11T00:23:00.558687+00:00",
      "status": "completed"
     }
    },
@@ -1550,20 +1746,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
-   "id": "313c66ef",
+   "execution_count": 23,
+   "id": "bb1229d0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T00:42:28.782579Z",
-     "iopub.status.busy": "2026-09-09T00:42:28.782451Z",
-     "iopub.status.idle": "2026-09-09T00:42:28.787018Z",
-     "shell.execute_reply": "2026-09-09T00:42:28.786573Z"
+     "iopub.execute_input": "2026-09-11T00:23:00.565621Z",
+     "iopub.status.busy": "2026-09-11T00:23:00.565534Z",
+     "iopub.status.idle": "2026-09-11T00:23:00.569130Z",
+     "shell.execute_reply": "2026-09-11T00:23:00.568764Z"
     },
     "papermill": {
-     "duration": 0.007516,
-     "end_time": "2026-09-09T00:42:28.787390+00:00",
+     "duration": 0.006702,
+     "end_time": "2026-09-11T00:23:00.569569+00:00",
      "exception": false,
-     "start_time": "2026-09-09T00:42:28.779874+00:00",
+     "start_time": "2026-09-11T00:23:00.562867+00:00",
      "status": "completed"
     }
    },
@@ -1572,7 +1768,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Run metadata: 25_live_trading/output/etfs_deployment/runs/run_20260909T004228Z.json\n"
+      "Run metadata: 25_live_trading/output/etfs_deployment/runs/run_20260911T002300Z.json\n"
      ]
     }
    ],
@@ -1620,13 +1816,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "07239592",
+   "id": "27a499e9",
    "metadata": {
     "papermill": {
-     "duration": 0.00197,
-     "end_time": "2026-09-09T00:42:28.791488+00:00",
+     "duration": 0.002076,
+     "end_time": "2026-09-11T00:23:00.573850+00:00",
      "exception": false,
-     "start_time": "2026-09-09T00:42:28.789518+00:00",
+     "start_time": "2026-09-11T00:23:00.571774+00:00",
      "status": "completed"
     }
    },
@@ -1653,14 +1849,18 @@
     "  extended panel and a single train pass, not the case study's\n",
     "  walk-forward CV.\n",
     "- **The financial-only feature subset is a deliberate operational\n",
-    "  simplification.** Dropping HMM regimes and GARCH conditional\n",
-    "  volatility makes the refit complete in seconds instead of minutes; the\n",
-    "  resulting feature set is slightly weaker but cheap enough to refit on\n",
-    "  every data update.\n",
-    "- **Retrain cadence is monthly, not per-prediction.** The live trading\n",
-    "  loop re-runs the prediction and offline-reference steps daily against\n",
-    "  the persisted artefact and revisits the refit only when the artefact\n",
-    "  has aged past the configured window; Chapter 26 picks up the\n",
+    "  simplification, and it is not free.** Dropping HMM regimes and GARCH\n",
+    "  conditional volatility makes the refit complete in seconds instead of\n",
+    "  minutes. It also means the alpha this notebook borrows was selected\n",
+    "  against a feature set the deployment does not use, which the run\n",
+    "  prints rather than leaves implicit. What that costs in forecast\n",
+    "  quality is not measured here; measuring it means sweeping on the\n",
+    "  deployment's own feature set.\n",
+    "- **This notebook refits once per run, and does not decide how often to\n",
+    "  run.** Prediction and the offline reference could be re-run daily\n",
+    "  against a persisted artefact while the refit happens far less often.\n",
+    "  Nothing here implements that split - the artefact carries\n",
+    "  `trained_at` so a scheduler can, and Chapter 26 picks up the\n",
     "  cadence-decoupling discussion."
    ]
   }
@@ -1688,25 +1888,24 @@
    "version": "3.14.3"
   },
   "ml4t_provenance": {
-   "executed_at": "2026-09-09T00:42:36.681754+00:00",
+   "executed_at": "2026-09-11T00:23:09.237395+00:00",
    "executor": "local-uv",
-   "library_digest": "2cff20da78bb29085d93a03be6bc9c0f417506e35c450a43c39845449ea3dae2",
-   "outputs_digest": "47a3fd2a8586885fd95b1bb46e221e6a901e1d55f767a4a6484e636d5c748e5b",
+   "library_digest": "0af5dc39c6c29f1e215740139cdb8886b6f5894060fe3cbd08b809a63ae853aa",
+   "outputs_digest": "413659a989e6fe10cc92081c1c756cbad565b4562294df4b474f456467c73346",
    "parameters": {},
    "production": true,
-   "source_py_blob": "84e69ba8373b326d8b9e5451b9c6e11f25c0d2df",
-   "notes": "prose synced from the .py at 2026-09-09T01:21:38.485596+00:00 without re-executing; every code cell is identical to blob 1d15671bbdb7"
+   "source_py_blob": "bd4617a18183a38cc45bef078c14c6897a5d4aa0"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 35.138464,
-   "end_time": "2026-09-09T00:42:31.248084+00:00",
+   "duration": 33.435171,
+   "end_time": "2026-09-11T00:23:01.892381+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "~/ml4t/public-teach-g/25_live_trading/.02_etfs_deployment_loop.build.2789671.ipynb",
-   "output_path": "~/ml4t/public-teach-g/25_live_trading/.02_etfs_deployment_loop.papermill.2789671.ipynb",
+   "input_path": "~/ml4t/public-teach-g/25_live_trading/.02_etfs_deployment_loop.build.581467.ipynb",
+   "output_path": "~/ml4t/public-teach-g/25_live_trading/.02_etfs_deployment_loop.papermill.581467.ipynb",
    "parameters": {},
-   "start_time": "2026-09-09T00:41:56.109620+00:00",
+   "start_time": "2026-09-11T00:22:28.457210+00:00",
    "version": "2.7.0"
   }
  },

--- a/25_live_trading/02_etfs_deployment_loop.ipynb
+++ b/25_live_trading/02_etfs_deployment_loop.ipynb
@@ -2,13 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "13c31e0d",
+   "id": "44af5d0e",
    "metadata": {
     "papermill": {
-     "duration": 0.007077,
-     "end_time": "2026-09-11T00:22:29.114909+00:00",
+     "duration": 0.011017,
+     "end_time": "2026-09-11T00:32:32.565336+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:22:29.107832+00:00",
+     "start_time": "2026-09-11T00:32:32.554319+00:00",
      "status": "completed"
     }
    },
@@ -78,19 +78,19 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "6204f8db",
+   "id": "2b2393a9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:22:29.120471Z",
-     "iopub.status.busy": "2026-09-11T00:22:29.120295Z",
-     "iopub.status.idle": "2026-09-11T00:22:31.367423Z",
-     "shell.execute_reply": "2026-09-11T00:22:31.367138Z"
+     "iopub.execute_input": "2026-09-11T00:32:32.575668Z",
+     "iopub.status.busy": "2026-09-11T00:32:32.575521Z",
+     "iopub.status.idle": "2026-09-11T00:32:34.804752Z",
+     "shell.execute_reply": "2026-09-11T00:32:34.804275Z"
     },
     "papermill": {
-     "duration": 2.250906,
-     "end_time": "2026-09-11T00:22:31.368484+00:00",
+     "duration": 2.234045,
+     "end_time": "2026-09-11T00:32:34.805442+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:22:29.117578+00:00",
+     "start_time": "2026-09-11T00:32:32.571397+00:00",
      "status": "completed"
     }
    },
@@ -110,7 +110,15 @@
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
     "import polars as pl\n",
-    "from ml4t.backtest import BacktestConfig, DataFeed, Engine, ExecutionMode, OrderSide, Strategy\n",
+    "from ml4t.backtest import (\n",
+    "    BacktestConfig,\n",
+    "    DataFeed,\n",
+    "    Engine,\n",
+    "    ExecutionMode,\n",
+    "    OrderSide,\n",
+    "    OrderStatus,\n",
+    "    Strategy,\n",
+    ")\n",
     "from sklearn.impute import SimpleImputer\n",
     "from sklearn.linear_model import Ridge\n",
     "from sklearn.preprocessing import StandardScaler\n",
@@ -141,19 +149,19 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "e02e8c20",
+   "id": "26f70bdf",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:22:31.373085Z",
-     "iopub.status.busy": "2026-09-11T00:22:31.372999Z",
-     "iopub.status.idle": "2026-09-11T00:22:31.374976Z",
-     "shell.execute_reply": "2026-09-11T00:22:31.374573Z"
+     "iopub.execute_input": "2026-09-11T00:32:34.811856Z",
+     "iopub.status.busy": "2026-09-11T00:32:34.811775Z",
+     "iopub.status.idle": "2026-09-11T00:32:34.813610Z",
+     "shell.execute_reply": "2026-09-11T00:32:34.813337Z"
     },
     "papermill": {
-     "duration": 0.005102,
-     "end_time": "2026-09-11T00:22:31.375714+00:00",
+     "duration": 0.005431,
+     "end_time": "2026-09-11T00:32:34.814012+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:22:31.370612+00:00",
+     "start_time": "2026-09-11T00:32:34.808581+00:00",
      "status": "completed"
     },
     "tags": [
@@ -178,13 +186,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "177ad62e",
+   "id": "65f99947",
    "metadata": {
     "papermill": {
-     "duration": 0.001455,
-     "end_time": "2026-09-11T00:22:31.379983+00:00",
+     "duration": 0.001423,
+     "end_time": "2026-09-11T00:32:34.817085+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:22:31.378528+00:00",
+     "start_time": "2026-09-11T00:32:34.815662+00:00",
      "status": "completed"
     }
    },
@@ -206,19 +214,19 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "7a27fcc0",
+   "id": "92749bfe",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:22:31.383482Z",
-     "iopub.status.busy": "2026-09-11T00:22:31.383418Z",
-     "iopub.status.idle": "2026-09-11T00:22:31.385724Z",
-     "shell.execute_reply": "2026-09-11T00:22:31.385390Z"
+     "iopub.execute_input": "2026-09-11T00:32:34.820446Z",
+     "iopub.status.busy": "2026-09-11T00:32:34.820374Z",
+     "iopub.status.idle": "2026-09-11T00:32:34.822565Z",
+     "shell.execute_reply": "2026-09-11T00:32:34.822333Z"
     },
     "papermill": {
-     "duration": 0.004538,
-     "end_time": "2026-09-11T00:22:31.386003+00:00",
+     "duration": 0.004331,
+     "end_time": "2026-09-11T00:32:34.822906+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:22:31.381465+00:00",
+     "start_time": "2026-09-11T00:32:34.818575+00:00",
      "status": "completed"
     }
    },
@@ -253,13 +261,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "40fe2e5b",
+   "id": "5f01084c",
    "metadata": {
     "papermill": {
-     "duration": 0.001601,
-     "end_time": "2026-09-11T00:22:31.389150+00:00",
+     "duration": 0.001464,
+     "end_time": "2026-09-11T00:32:34.825930+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:22:31.387549+00:00",
+     "start_time": "2026-09-11T00:32:34.824466+00:00",
      "status": "completed"
     }
    },
@@ -279,19 +287,19 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "c0cd102b",
+   "id": "8168718f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:22:31.393525Z",
-     "iopub.status.busy": "2026-09-11T00:22:31.393454Z",
-     "iopub.status.idle": "2026-09-11T00:22:31.479939Z",
-     "shell.execute_reply": "2026-09-11T00:22:31.479468Z"
+     "iopub.execute_input": "2026-09-11T00:32:34.829817Z",
+     "iopub.status.busy": "2026-09-11T00:32:34.829681Z",
+     "iopub.status.idle": "2026-09-11T00:32:34.895774Z",
+     "shell.execute_reply": "2026-09-11T00:32:34.894945Z"
     },
     "papermill": {
-     "duration": 0.089413,
-     "end_time": "2026-09-11T00:22:31.480511+00:00",
+     "duration": 0.068797,
+     "end_time": "2026-09-11T00:32:34.896277+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:22:31.391098+00:00",
+     "start_time": "2026-09-11T00:32:34.827480+00:00",
      "status": "completed"
     }
    },
@@ -323,19 +331,19 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "d860922d",
+   "id": "5cd638eb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:22:31.489177Z",
-     "iopub.status.busy": "2026-09-11T00:22:31.488980Z",
-     "iopub.status.idle": "2026-09-11T00:22:57.889608Z",
-     "shell.execute_reply": "2026-09-11T00:22:57.889142Z"
+     "iopub.execute_input": "2026-09-11T00:32:34.903414Z",
+     "iopub.status.busy": "2026-09-11T00:32:34.903305Z",
+     "iopub.status.idle": "2026-09-11T00:33:01.146975Z",
+     "shell.execute_reply": "2026-09-11T00:33:01.146457Z"
     },
     "papermill": {
-     "duration": 26.405984,
-     "end_time": "2026-09-11T00:22:57.889893+00:00",
+     "duration": 26.247566,
+     "end_time": "2026-09-11T00:33:01.147303+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:22:31.483909+00:00",
+     "start_time": "2026-09-11T00:32:34.899737+00:00",
      "status": "completed"
     }
    },
@@ -344,14 +352,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2026-09-10 20:22:31 | mlquant.features.adx | INFO | [ADX] Starting calculation with parameters: period=14 (shape: (4,))\n"
+      "2026-09-10 20:32:35 | mlquant.features.adx | INFO | [ADX] Starting calculation with parameters: period=14 (shape: (4,))\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2026-09-10 20:22:31 | mlquant.features.adx | INFO | [ADX] Completed calculation (shape: (4,)) (0.05ms)\n"
+      "2026-09-10 20:32:35 | mlquant.features.adx | INFO | [ADX] Completed calculation (shape: (4,)) (0.04ms)\n"
      ]
     },
     {
@@ -370,13 +378,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "610c2869",
+   "id": "535378cb",
    "metadata": {
     "papermill": {
-     "duration": 0.001626,
-     "end_time": "2026-09-11T00:22:57.893343+00:00",
+     "duration": 0.001622,
+     "end_time": "2026-09-11T00:33:01.150777+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:22:57.891717+00:00",
+     "start_time": "2026-09-11T00:33:01.149155+00:00",
      "status": "completed"
     }
    },
@@ -412,19 +420,19 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "eb225a87",
+   "id": "b49fc1ff",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:22:57.897119Z",
-     "iopub.status.busy": "2026-09-11T00:22:57.897047Z",
-     "iopub.status.idle": "2026-09-11T00:22:57.901453Z",
-     "shell.execute_reply": "2026-09-11T00:22:57.901123Z"
+     "iopub.execute_input": "2026-09-11T00:33:01.154876Z",
+     "iopub.status.busy": "2026-09-11T00:33:01.154770Z",
+     "iopub.status.idle": "2026-09-11T00:33:01.159711Z",
+     "shell.execute_reply": "2026-09-11T00:33:01.159208Z"
     },
     "papermill": {
-     "duration": 0.006772,
-     "end_time": "2026-09-11T00:22:57.901704+00:00",
+     "duration": 0.007564,
+     "end_time": "2026-09-11T00:33:01.159964+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:22:57.894932+00:00",
+     "start_time": "2026-09-11T00:33:01.152400+00:00",
      "status": "completed"
     }
    },
@@ -442,7 +450,10 @@
    ],
    "source": [
     "registry_path = get_case_study_dir(\"etfs\") / \"run_log\" / \"registry.db\"\n",
-    "registry_uri = f\"{registry_path.resolve().as_uri()}?mode=ro&immutable=1\"\n",
+    "# Read-only, but not `immutable=1`: the registry is a WAL database that sweeps write to\n",
+    "# concurrently, and an immutable connection ignores the -wal file and reads the pre-WAL main\n",
+    "# file, which shows up here as a stale leader or as a table that appears not to exist.\n",
+    "registry_uri = f\"{registry_path.resolve().as_uri()}?mode=ro\"\n",
     "with sqlite3.connect(registry_uri, uri=True) as conn:\n",
     "    winner = conn.execute(\n",
     "        \"\"\"SELECT tr.config_name, tr.spec_json, pm.ic_mean\n",
@@ -495,13 +506,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a2a927d1",
+   "id": "a67fe3ed",
    "metadata": {
     "papermill": {
-     "duration": 0.001531,
-     "end_time": "2026-09-11T00:22:57.904854+00:00",
+     "duration": 0.001537,
+     "end_time": "2026-09-11T00:33:01.163187+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:22:57.903323+00:00",
+     "start_time": "2026-09-11T00:33:01.161650+00:00",
      "status": "completed"
     }
    },
@@ -518,19 +529,19 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "cb026485",
+   "id": "88bf98b3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:22:57.908546Z",
-     "iopub.status.busy": "2026-09-11T00:22:57.908473Z",
-     "iopub.status.idle": "2026-09-11T00:22:57.968442Z",
-     "shell.execute_reply": "2026-09-11T00:22:57.967872Z"
+     "iopub.execute_input": "2026-09-11T00:33:01.166863Z",
+     "iopub.status.busy": "2026-09-11T00:33:01.166791Z",
+     "iopub.status.idle": "2026-09-11T00:33:01.225375Z",
+     "shell.execute_reply": "2026-09-11T00:33:01.224856Z"
     },
     "papermill": {
-     "duration": 0.062571,
-     "end_time": "2026-09-11T00:22:57.969125+00:00",
+     "duration": 0.06105,
+     "end_time": "2026-09-11T00:33:01.225838+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:22:57.906554+00:00",
+     "start_time": "2026-09-11T00:33:01.164788+00:00",
      "status": "completed"
     }
    },
@@ -553,13 +564,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b1d41fdf",
+   "id": "4b3258ee",
    "metadata": {
     "papermill": {
-     "duration": 0.001693,
-     "end_time": "2026-09-11T00:22:57.972712+00:00",
+     "duration": 0.001627,
+     "end_time": "2026-09-11T00:33:01.230114+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:22:57.971019+00:00",
+     "start_time": "2026-09-11T00:33:01.228487+00:00",
      "status": "completed"
     }
    },
@@ -576,19 +587,19 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "4092420b",
+   "id": "aaaf1c5d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:22:57.976472Z",
-     "iopub.status.busy": "2026-09-11T00:22:57.976390Z",
-     "iopub.status.idle": "2026-09-11T00:22:57.982398Z",
-     "shell.execute_reply": "2026-09-11T00:22:57.982027Z"
+     "iopub.execute_input": "2026-09-11T00:33:01.233943Z",
+     "iopub.status.busy": "2026-09-11T00:33:01.233869Z",
+     "iopub.status.idle": "2026-09-11T00:33:01.241049Z",
+     "shell.execute_reply": "2026-09-11T00:33:01.240578Z"
     },
     "papermill": {
-     "duration": 0.008547,
-     "end_time": "2026-09-11T00:22:57.982881+00:00",
+     "duration": 0.009697,
+     "end_time": "2026-09-11T00:33:01.241462+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:22:57.974334+00:00",
+     "start_time": "2026-09-11T00:33:01.231765+00:00",
      "status": "completed"
     }
    },
@@ -623,19 +634,19 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "123366f6",
+   "id": "69963335",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:22:57.987429Z",
-     "iopub.status.busy": "2026-09-11T00:22:57.987349Z",
-     "iopub.status.idle": "2026-09-11T00:23:00.192513Z",
-     "shell.execute_reply": "2026-09-11T00:23:00.191960Z"
+     "iopub.execute_input": "2026-09-11T00:33:01.246226Z",
+     "iopub.status.busy": "2026-09-11T00:33:01.246143Z",
+     "iopub.status.idle": "2026-09-11T00:33:03.340098Z",
+     "shell.execute_reply": "2026-09-11T00:33:03.339637Z"
     },
     "papermill": {
-     "duration": 2.207629,
-     "end_time": "2026-09-11T00:23:00.192995+00:00",
+     "duration": 2.096725,
+     "end_time": "2026-09-11T00:33:03.340493+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:22:57.985366+00:00",
+     "start_time": "2026-09-11T00:33:01.243768+00:00",
      "status": "completed"
     }
    },
@@ -666,13 +677,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1c2b1f3b",
+   "id": "1499cada",
    "metadata": {
     "papermill": {
-     "duration": 0.003068,
-     "end_time": "2026-09-11T00:23:00.199390+00:00",
+     "duration": 0.001691,
+     "end_time": "2026-09-11T00:33:03.344104+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:23:00.196322+00:00",
+     "start_time": "2026-09-11T00:33:03.342413+00:00",
      "status": "completed"
     }
    },
@@ -689,19 +700,19 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "86ec02b0",
+   "id": "65dc7adb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:23:00.206376Z",
-     "iopub.status.busy": "2026-09-11T00:23:00.206249Z",
-     "iopub.status.idle": "2026-09-11T00:23:00.212371Z",
-     "shell.execute_reply": "2026-09-11T00:23:00.211839Z"
+     "iopub.execute_input": "2026-09-11T00:33:03.348005Z",
+     "iopub.status.busy": "2026-09-11T00:33:03.347920Z",
+     "iopub.status.idle": "2026-09-11T00:33:03.352195Z",
+     "shell.execute_reply": "2026-09-11T00:33:03.351796Z"
     },
     "papermill": {
-     "duration": 0.010187,
-     "end_time": "2026-09-11T00:23:00.212787+00:00",
+     "duration": 0.006794,
+     "end_time": "2026-09-11T00:33:03.352586+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:23:00.202600+00:00",
+     "start_time": "2026-09-11T00:33:03.345792+00:00",
      "status": "completed"
     }
    },
@@ -759,13 +770,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2e963aff",
+   "id": "926ffc89",
    "metadata": {
     "papermill": {
-     "duration": 0.001692,
-     "end_time": "2026-09-11T00:23:00.217861+00:00",
+     "duration": 0.003141,
+     "end_time": "2026-09-11T00:33:03.359097+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:23:00.216169+00:00",
+     "start_time": "2026-09-11T00:33:03.355956+00:00",
      "status": "completed"
     }
    },
@@ -783,19 +794,19 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "521b76be",
+   "id": "67e8c4ba",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:23:00.221909Z",
-     "iopub.status.busy": "2026-09-11T00:23:00.221793Z",
-     "iopub.status.idle": "2026-09-11T00:23:00.245746Z",
-     "shell.execute_reply": "2026-09-11T00:23:00.245290Z"
+     "iopub.execute_input": "2026-09-11T00:33:03.365265Z",
+     "iopub.status.busy": "2026-09-11T00:33:03.365127Z",
+     "iopub.status.idle": "2026-09-11T00:33:03.388523Z",
+     "shell.execute_reply": "2026-09-11T00:33:03.388026Z"
     },
     "papermill": {
-     "duration": 0.026472,
-     "end_time": "2026-09-11T00:23:00.246047+00:00",
+     "duration": 0.026732,
+     "end_time": "2026-09-11T00:33:03.389060+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:23:00.219575+00:00",
+     "start_time": "2026-09-11T00:33:03.362328+00:00",
      "status": "completed"
     }
    },
@@ -832,14 +843,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3b290ce3",
+   "id": "8fd00834",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.001726,
-     "end_time": "2026-09-11T00:23:00.249741+00:00",
+     "duration": 0.003233,
+     "end_time": "2026-09-11T00:33:03.395930+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:23:00.248015+00:00",
+     "start_time": "2026-09-11T00:33:03.392697+00:00",
      "status": "completed"
     }
    },
@@ -856,26 +867,28 @@
     "leverage stays constant as profit and loss accrue, and against slightly less than all of it.\n",
     "`CASH_BUFFER` is what the order is sized on the current bar's close but fills at the next bar's:\n",
     "an overnight move against the position, plus commission, makes a basket sized at the full account\n",
-    "value unaffordable, and the broker answers that by rejecting the last leg rather than by filling\n",
-    "it smaller."
+    "value unaffordable, and the broker answers that by refusing the last leg rather than by filling\n",
+    "it smaller. Two per cent is a margin measured on this window, not a guarantee - a basket that\n",
+    "gaps up about two per cent overnight is unaffordable again - and the disposition check below is\n",
+    "what turns that into a stop rather than a quietly short basket."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "f1204976",
+   "id": "17e1df33",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:23:00.254041Z",
-     "iopub.status.busy": "2026-09-11T00:23:00.253944Z",
-     "iopub.status.idle": "2026-09-11T00:23:00.258321Z",
-     "shell.execute_reply": "2026-09-11T00:23:00.257905Z"
+     "iopub.execute_input": "2026-09-11T00:33:03.403326Z",
+     "iopub.status.busy": "2026-09-11T00:33:03.403232Z",
+     "iopub.status.idle": "2026-09-11T00:33:03.407606Z",
+     "shell.execute_reply": "2026-09-11T00:33:03.407182Z"
     },
     "papermill": {
-     "duration": 0.007101,
-     "end_time": "2026-09-11T00:23:00.258589+00:00",
+     "duration": 0.00884,
+     "end_time": "2026-09-11T00:33:03.408084+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:23:00.251488+00:00",
+     "start_time": "2026-09-11T00:33:03.399244+00:00",
      "status": "completed"
     }
    },
@@ -965,13 +978,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8099c520",
+   "id": "d705a5dc",
    "metadata": {
     "papermill": {
-     "duration": 0.001696,
-     "end_time": "2026-09-11T00:23:00.262063+00:00",
+     "duration": 0.002078,
+     "end_time": "2026-09-11T00:33:03.413666+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:23:00.260367+00:00",
+     "start_time": "2026-09-11T00:33:03.411588+00:00",
      "status": "completed"
     }
    },
@@ -992,19 +1005,19 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "af1b9466",
+   "id": "74a8e32b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:23:00.266242Z",
-     "iopub.status.busy": "2026-09-11T00:23:00.266153Z",
-     "iopub.status.idle": "2026-09-11T00:23:00.338623Z",
-     "shell.execute_reply": "2026-09-11T00:23:00.338186Z"
+     "iopub.execute_input": "2026-09-11T00:33:03.417650Z",
+     "iopub.status.busy": "2026-09-11T00:33:03.417573Z",
+     "iopub.status.idle": "2026-09-11T00:33:03.473918Z",
+     "shell.execute_reply": "2026-09-11T00:33:03.473434Z"
     },
     "papermill": {
-     "duration": 0.075131,
-     "end_time": "2026-09-11T00:23:00.338993+00:00",
+     "duration": 0.058872,
+     "end_time": "2026-09-11T00:33:03.474276+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:23:00.263862+00:00",
+     "start_time": "2026-09-11T00:33:03.415404+00:00",
      "status": "completed"
     }
    },
@@ -1050,13 +1063,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c0c9f6fb",
+   "id": "3416c0bb",
    "metadata": {
     "papermill": {
-     "duration": 0.00177,
-     "end_time": "2026-09-11T00:23:00.342764+00:00",
+     "duration": 0.001744,
+     "end_time": "2026-09-11T00:33:03.477986+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:23:00.340994+00:00",
+     "start_time": "2026-09-11T00:33:03.476242+00:00",
      "status": "completed"
     }
    },
@@ -1064,26 +1077,31 @@
     "The replay is read below as the deterministic record of what the deployment would have done, so\n",
     "an order it emitted and the broker refused has to stop it being read that way. The same four\n",
     "buckets the live leg reports apply here: a signal the strategy logged is intended, and only a\n",
-    "filled order is accepted. Sizing every leg at the full account value produced eight rejections\n",
-    "over this window before `CASH_BUFFER` existed, and nothing in the notebook looked."
+    "filled order is accepted. Sizing every leg at the full account value produced eight refusals\n",
+    "over this window before `CASH_BUFFER` existed, and nothing in the notebook looked.\n",
+    "\n",
+    "An order still pending on the last bar is a different thing and is counted separately. Under\n",
+    "`NEXT_BAR` the engine fills an order at the start of the following bar, and the final bar has\n",
+    "no following bar, so a rebalance that lands on the last day of the window leaves its whole\n",
+    "basket unfilled. That is the replay running out of tape, not the broker refusing anything."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 14,
-   "id": "6c6fe745",
+   "id": "d874e27b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:23:00.346841Z",
-     "iopub.status.busy": "2026-09-11T00:23:00.346762Z",
-     "iopub.status.idle": "2026-09-11T00:23:00.349546Z",
-     "shell.execute_reply": "2026-09-11T00:23:00.349089Z"
+     "iopub.execute_input": "2026-09-11T00:33:03.482019Z",
+     "iopub.status.busy": "2026-09-11T00:33:03.481935Z",
+     "iopub.status.idle": "2026-09-11T00:33:03.484874Z",
+     "shell.execute_reply": "2026-09-11T00:33:03.484426Z"
     },
     "papermill": {
-     "duration": 0.005267,
-     "end_time": "2026-09-11T00:23:00.349799+00:00",
+     "duration": 0.005463,
+     "end_time": "2026-09-11T00:33:03.485180+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:23:00.344532+00:00",
+     "start_time": "2026-09-11T00:33:03.479717+00:00",
      "status": "completed"
     }
    },
@@ -1092,33 +1110,46 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Offline order dispositions: {'FILLED': 84}\n"
+      "Offline orders: 84\n",
+      "  filled:              84\n",
+      "  unfilled at the end: 0\n",
+      "  refused:             0\n"
      ]
     }
    ],
    "source": [
-    "order_status_counts: dict[str, int] = {}\n",
+    "last_bar_ts = engine_backtest.equity_curve[-1][0]\n",
+    "refused, pending_at_end = [], []\n",
     "for order in engine_backtest.broker.orders:\n",
-    "    name = order.status.name if hasattr(order.status, \"name\") else str(order.status)\n",
-    "    order_status_counts[name] = order_status_counts.get(name, 0) + 1\n",
-    "print(f\"Offline order dispositions: {dict(sorted(order_status_counts.items()))}\")\n",
-    "unfilled = {k: v for k, v in order_status_counts.items() if k != \"FILLED\"}\n",
-    "assert not unfilled, (\n",
-    "    f\"The offline replay did not place the basket it logged: {unfilled}. \"\n",
-    "    \"A rejected order means the reference tape and the strategy's own signal log disagree, \"\n",
+    "    if order.status is OrderStatus.FILLED:\n",
+    "        continue\n",
+    "    if order.status is OrderStatus.PENDING and order.created_at == last_bar_ts:\n",
+    "        pending_at_end.append(order)\n",
+    "    else:\n",
+    "        refused.append(order)\n",
+    "\n",
+    "print(f\"Offline orders: {len(engine_backtest.broker.orders)}\")\n",
+    "print(f\"  filled:              {len(engine_backtest.broker.fills)}\")\n",
+    "print(f\"  unfilled at the end: {len(pending_at_end)}\")\n",
+    "print(f\"  refused:             {len(refused)}\")\n",
+    "for order in refused[:5]:\n",
+    "    print(f\"    {order.asset} {order.side.value} {order.quantity:g}: {order.rejection_reason}\")\n",
+    "assert not refused, (\n",
+    "    f\"The offline replay did not place the basket it logged: {len(refused)} order(s) refused. \"\n",
+    "    \"A refused order means the reference tape and the strategy's own signal log disagree, \"\n",
     "    \"so the reconciliation below would compare an intended basket against one never held.\"\n",
     ")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "545db439",
+   "id": "b12c6c2b",
    "metadata": {
     "papermill": {
-     "duration": 0.001761,
-     "end_time": "2026-09-11T00:23:00.353424+00:00",
+     "duration": 0.001704,
+     "end_time": "2026-09-11T00:33:03.488646+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:23:00.351663+00:00",
+     "start_time": "2026-09-11T00:33:03.486942+00:00",
      "status": "completed"
     }
    },
@@ -1137,19 +1168,19 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "id": "cb7a92ae",
+   "id": "9c3779de",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:23:00.357527Z",
-     "iopub.status.busy": "2026-09-11T00:23:00.357460Z",
-     "iopub.status.idle": "2026-09-11T00:23:00.479943Z",
-     "shell.execute_reply": "2026-09-11T00:23:00.479522Z"
+     "iopub.execute_input": "2026-09-11T00:33:03.492721Z",
+     "iopub.status.busy": "2026-09-11T00:33:03.492644Z",
+     "iopub.status.idle": "2026-09-11T00:33:03.614289Z",
+     "shell.execute_reply": "2026-09-11T00:33:03.613775Z"
     },
     "papermill": {
-     "duration": 0.125116,
-     "end_time": "2026-09-11T00:23:00.480387+00:00",
+     "duration": 0.124284,
+     "end_time": "2026-09-11T00:33:03.614711+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:23:00.355271+00:00",
+     "start_time": "2026-09-11T00:33:03.490427+00:00",
      "status": "completed"
     }
    },
@@ -1163,7 +1194,7 @@
      },
      "metadata": {
       "image/png": {
-       "alt": "Two panels sharing a date axis over the live window. The upper panel traces account value against a dashed line at the starting balance, ending above it. The lower panel shades the drawdown from the running peak, which returns to zero at each new high and reaches its deepest point early in the window."
+       "alt": "Two panels sharing a date axis over the live window. The upper panel traces account value against a dashed line at the starting balance, ending above it. The lower panel shades the drawdown from the running peak, which returns to zero at each new high; its deepest point falls in April 2025."
       }
      },
      "output_type": "display_data"
@@ -1192,19 +1223,20 @@
     "    \"against a dashed line at the starting balance, \"\n",
     "    + (\"ending above it\" if backtest_results[\"final_value\"] >= INITIAL_CASH else \"ending below it\")\n",
     "    + \". The lower panel shades the drawdown from the running peak, which returns to zero at each \"\n",
-    "    \"new high and reaches its deepest point early in the window.\",\n",
+    "    \"new high; its deepest point falls in \"\n",
+    "    f\"{equity_dates[int(np.argmin(drawdown))]:%B %Y}.\",\n",
     ")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "3237c0dc",
+   "id": "850921ef",
    "metadata": {
     "papermill": {
-     "duration": 0.00191,
-     "end_time": "2026-09-11T00:23:00.484429+00:00",
+     "duration": 0.001931,
+     "end_time": "2026-09-11T00:33:03.618804+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:23:00.482519+00:00",
+     "start_time": "2026-09-11T00:33:03.616873+00:00",
      "status": "completed"
     }
    },
@@ -1225,19 +1257,19 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "id": "35bf40a3",
+   "id": "487617db",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:23:00.488798Z",
-     "iopub.status.busy": "2026-09-11T00:23:00.488722Z",
-     "iopub.status.idle": "2026-09-11T00:23:00.492749Z",
-     "shell.execute_reply": "2026-09-11T00:23:00.492376Z"
+     "iopub.execute_input": "2026-09-11T00:33:03.623776Z",
+     "iopub.status.busy": "2026-09-11T00:33:03.623613Z",
+     "iopub.status.idle": "2026-09-11T00:33:03.629097Z",
+     "shell.execute_reply": "2026-09-11T00:33:03.628687Z"
     },
     "papermill": {
-     "duration": 0.006701,
-     "end_time": "2026-09-11T00:23:00.493034+00:00",
+     "duration": 0.008799,
+     "end_time": "2026-09-11T00:33:03.629597+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:23:00.486333+00:00",
+     "start_time": "2026-09-11T00:33:03.620798+00:00",
      "status": "completed"
     }
    },
@@ -1296,19 +1328,19 @@
   {
    "cell_type": "code",
    "execution_count": 17,
-   "id": "042ca7d5",
+   "id": "d3f9253b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:23:00.497390Z",
-     "iopub.status.busy": "2026-09-11T00:23:00.497323Z",
-     "iopub.status.idle": "2026-09-11T00:23:00.499856Z",
-     "shell.execute_reply": "2026-09-11T00:23:00.499528Z"
+     "iopub.execute_input": "2026-09-11T00:33:03.638580Z",
+     "iopub.status.busy": "2026-09-11T00:33:03.638375Z",
+     "iopub.status.idle": "2026-09-11T00:33:03.642315Z",
+     "shell.execute_reply": "2026-09-11T00:33:03.641496Z"
     },
     "papermill": {
-     "duration": 0.005117,
-     "end_time": "2026-09-11T00:23:00.500078+00:00",
+     "duration": 0.009161,
+     "end_time": "2026-09-11T00:33:03.642952+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:23:00.494961+00:00",
+     "start_time": "2026-09-11T00:33:03.633791+00:00",
      "status": "completed"
     }
    },
@@ -1351,14 +1383,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "83134b67",
+   "id": "382d0957",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.001993,
-     "end_time": "2026-09-11T00:23:00.504098+00:00",
+     "duration": 0.005182,
+     "end_time": "2026-09-11T00:33:03.653092+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:23:00.502105+00:00",
+     "start_time": "2026-09-11T00:33:03.647910+00:00",
      "status": "completed"
     }
    },
@@ -1376,19 +1408,19 @@
   {
    "cell_type": "code",
    "execution_count": 18,
-   "id": "d9cb3b0d",
+   "id": "c110fc9a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:23:00.508639Z",
-     "iopub.status.busy": "2026-09-11T00:23:00.508577Z",
-     "iopub.status.idle": "2026-09-11T00:23:00.511995Z",
-     "shell.execute_reply": "2026-09-11T00:23:00.511623Z"
+     "iopub.execute_input": "2026-09-11T00:33:03.659926Z",
+     "iopub.status.busy": "2026-09-11T00:33:03.659776Z",
+     "iopub.status.idle": "2026-09-11T00:33:03.664477Z",
+     "shell.execute_reply": "2026-09-11T00:33:03.664075Z"
     },
     "papermill": {
-     "duration": 0.006191,
-     "end_time": "2026-09-11T00:23:00.512289+00:00",
+     "duration": 0.008307,
+     "end_time": "2026-09-11T00:33:03.664839+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:23:00.506098+00:00",
+     "start_time": "2026-09-11T00:33:03.656532+00:00",
      "status": "completed"
     }
    },
@@ -1445,13 +1477,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b8d8ff41",
+   "id": "fe40c6cb",
    "metadata": {
     "papermill": {
-     "duration": 0.001932,
-     "end_time": "2026-09-11T00:23:00.516287+00:00",
+     "duration": 0.002091,
+     "end_time": "2026-09-11T00:33:03.669639+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:23:00.514355+00:00",
+     "start_time": "2026-09-11T00:33:03.667548+00:00",
      "status": "completed"
     }
    },
@@ -1471,19 +1503,19 @@
   {
    "cell_type": "code",
    "execution_count": 19,
-   "id": "c7e942bb",
+   "id": "6521159b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:23:00.520904Z",
-     "iopub.status.busy": "2026-09-11T00:23:00.520828Z",
-     "iopub.status.idle": "2026-09-11T00:23:00.523810Z",
-     "shell.execute_reply": "2026-09-11T00:23:00.523398Z"
+     "iopub.execute_input": "2026-09-11T00:33:03.674341Z",
+     "iopub.status.busy": "2026-09-11T00:33:03.674277Z",
+     "iopub.status.idle": "2026-09-11T00:33:03.676737Z",
+     "shell.execute_reply": "2026-09-11T00:33:03.676447Z"
     },
     "papermill": {
-     "duration": 0.005843,
-     "end_time": "2026-09-11T00:23:00.524126+00:00",
+     "duration": 0.005355,
+     "end_time": "2026-09-11T00:33:03.677071+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:23:00.518283+00:00",
+     "start_time": "2026-09-11T00:33:03.671716+00:00",
      "status": "completed"
     }
    },
@@ -1519,19 +1551,19 @@
   {
    "cell_type": "code",
    "execution_count": 20,
-   "id": "66d2db1e",
+   "id": "c2ee3a24",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:23:00.528897Z",
-     "iopub.status.busy": "2026-09-11T00:23:00.528827Z",
-     "iopub.status.idle": "2026-09-11T00:23:00.532065Z",
-     "shell.execute_reply": "2026-09-11T00:23:00.531607Z"
+     "iopub.execute_input": "2026-09-11T00:33:03.681573Z",
+     "iopub.status.busy": "2026-09-11T00:33:03.681510Z",
+     "iopub.status.idle": "2026-09-11T00:33:03.683979Z",
+     "shell.execute_reply": "2026-09-11T00:33:03.683696Z"
     },
     "papermill": {
-     "duration": 0.00603,
-     "end_time": "2026-09-11T00:23:00.532316+00:00",
+     "duration": 0.005137,
+     "end_time": "2026-09-11T00:33:03.684247+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:23:00.526286+00:00",
+     "start_time": "2026-09-11T00:33:03.679110+00:00",
      "status": "completed"
     }
    },
@@ -1587,13 +1619,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "31ca1980",
+   "id": "027aa5f0",
    "metadata": {
     "papermill": {
-     "duration": 0.002009,
-     "end_time": "2026-09-11T00:23:00.536413+00:00",
+     "duration": 0.001988,
+     "end_time": "2026-09-11T00:33:03.688322+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:23:00.534404+00:00",
+     "start_time": "2026-09-11T00:33:03.686334+00:00",
      "status": "completed"
     }
    },
@@ -1615,14 +1647,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9dd2ca82",
+   "id": "0de9867e",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.001974,
-     "end_time": "2026-09-11T00:23:00.540601+00:00",
+     "duration": 0.001972,
+     "end_time": "2026-09-11T00:33:03.692347+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:23:00.538627+00:00",
+     "start_time": "2026-09-11T00:33:03.690375+00:00",
      "status": "completed"
     }
    },
@@ -1638,19 +1670,19 @@
   {
    "cell_type": "code",
    "execution_count": 21,
-   "id": "c827cf20",
+   "id": "a7c19bf8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:23:00.545447Z",
-     "iopub.status.busy": "2026-09-11T00:23:00.545343Z",
-     "iopub.status.idle": "2026-09-11T00:23:00.547739Z",
-     "shell.execute_reply": "2026-09-11T00:23:00.547265Z"
+     "iopub.execute_input": "2026-09-11T00:33:03.696941Z",
+     "iopub.status.busy": "2026-09-11T00:33:03.696881Z",
+     "iopub.status.idle": "2026-09-11T00:33:03.698978Z",
+     "shell.execute_reply": "2026-09-11T00:33:03.698570Z"
     },
     "papermill": {
-     "duration": 0.005373,
-     "end_time": "2026-09-11T00:23:00.548019+00:00",
+     "duration": 0.004921,
+     "end_time": "2026-09-11T00:33:03.699301+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:23:00.542646+00:00",
+     "start_time": "2026-09-11T00:33:03.694380+00:00",
      "status": "completed"
     }
    },
@@ -1668,19 +1700,19 @@
   {
    "cell_type": "code",
    "execution_count": 22,
-   "id": "a2fa2134",
+   "id": "e3e34491",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:23:00.553074Z",
-     "iopub.status.busy": "2026-09-11T00:23:00.552992Z",
-     "iopub.status.idle": "2026-09-11T00:23:00.556111Z",
-     "shell.execute_reply": "2026-09-11T00:23:00.555734Z"
+     "iopub.execute_input": "2026-09-11T00:33:03.703920Z",
+     "iopub.status.busy": "2026-09-11T00:33:03.703860Z",
+     "iopub.status.idle": "2026-09-11T00:33:03.706787Z",
+     "shell.execute_reply": "2026-09-11T00:33:03.706356Z"
     },
     "papermill": {
-     "duration": 0.006246,
-     "end_time": "2026-09-11T00:23:00.556506+00:00",
+     "duration": 0.005709,
+     "end_time": "2026-09-11T00:33:03.707080+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:23:00.550260+00:00",
+     "start_time": "2026-09-11T00:33:03.701371+00:00",
      "status": "completed"
     }
    },
@@ -1724,13 +1756,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2aaeb66e",
+   "id": "fb618e0d",
    "metadata": {
     "papermill": {
-     "duration": 0.002047,
-     "end_time": "2026-09-11T00:23:00.560734+00:00",
+     "duration": 0.002098,
+     "end_time": "2026-09-11T00:33:03.711294+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:23:00.558687+00:00",
+     "start_time": "2026-09-11T00:33:03.709196+00:00",
      "status": "completed"
     }
    },
@@ -1747,19 +1779,19 @@
   {
    "cell_type": "code",
    "execution_count": 23,
-   "id": "bb1229d0",
+   "id": "a35a5312",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:23:00.565621Z",
-     "iopub.status.busy": "2026-09-11T00:23:00.565534Z",
-     "iopub.status.idle": "2026-09-11T00:23:00.569130Z",
-     "shell.execute_reply": "2026-09-11T00:23:00.568764Z"
+     "iopub.execute_input": "2026-09-11T00:33:03.715938Z",
+     "iopub.status.busy": "2026-09-11T00:33:03.715876Z",
+     "iopub.status.idle": "2026-09-11T00:33:03.719191Z",
+     "shell.execute_reply": "2026-09-11T00:33:03.718807Z"
     },
     "papermill": {
-     "duration": 0.006702,
-     "end_time": "2026-09-11T00:23:00.569569+00:00",
+     "duration": 0.006119,
+     "end_time": "2026-09-11T00:33:03.719509+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:23:00.562867+00:00",
+     "start_time": "2026-09-11T00:33:03.713390+00:00",
      "status": "completed"
     }
    },
@@ -1768,7 +1800,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Run metadata: 25_live_trading/output/etfs_deployment/runs/run_20260911T002300Z.json\n"
+      "Run metadata: 25_live_trading/output/etfs_deployment/runs/run_20260911T003303Z.json\n"
      ]
     }
    ],
@@ -1816,13 +1848,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "27a499e9",
+   "id": "fad51d56",
    "metadata": {
     "papermill": {
-     "duration": 0.002076,
-     "end_time": "2026-09-11T00:23:00.573850+00:00",
+     "duration": 0.002057,
+     "end_time": "2026-09-11T00:33:03.723700+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:23:00.571774+00:00",
+     "start_time": "2026-09-11T00:33:03.721643+00:00",
      "status": "completed"
     }
    },
@@ -1888,24 +1920,24 @@
    "version": "3.14.3"
   },
   "ml4t_provenance": {
-   "executed_at": "2026-09-11T00:23:09.237395+00:00",
+   "executed_at": "2026-09-11T00:33:12.243179+00:00",
    "executor": "local-uv",
    "library_digest": "0af5dc39c6c29f1e215740139cdb8886b6f5894060fe3cbd08b809a63ae853aa",
-   "outputs_digest": "413659a989e6fe10cc92081c1c756cbad565b4562294df4b474f456467c73346",
+   "outputs_digest": "e83da8c9bc00ca15914225ffeca88da26c5392af5b0cb577d1b6660fa9ef39fb",
    "parameters": {},
    "production": true,
-   "source_py_blob": "bd4617a18183a38cc45bef078c14c6897a5d4aa0"
+   "source_py_blob": "2351304a3d247afcafc49a898ccadced3682c8f4"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 33.435171,
-   "end_time": "2026-09-11T00:23:01.892381+00:00",
+   "duration": 33.029825,
+   "end_time": "2026-09-11T00:33:04.941896+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "~/ml4t/public-teach-g/25_live_trading/.02_etfs_deployment_loop.build.581467.ipynb",
-   "output_path": "~/ml4t/public-teach-g/25_live_trading/.02_etfs_deployment_loop.papermill.581467.ipynb",
+   "input_path": "~/ml4t/public-teach-g/25_live_trading/.02_etfs_deployment_loop.build.608378.ipynb",
+   "output_path": "~/ml4t/public-teach-g/25_live_trading/.02_etfs_deployment_loop.papermill.608378.ipynb",
    "parameters": {},
-   "start_time": "2026-09-11T00:22:28.457210+00:00",
+   "start_time": "2026-09-11T00:32:31.912071+00:00",
    "version": "2.7.0"
   }
  },

--- a/25_live_trading/02_etfs_deployment_loop.ipynb
+++ b/25_live_trading/02_etfs_deployment_loop.ipynb
@@ -70,8 +70,8 @@
     "- FRED macro data under `ML4T_DATA_PATH/macro` (for the yield-curve\n",
     "  regime feature).\n",
     "- The ETFs case study's forward-return label parquet and its registry,\n",
-    "  both reached through `get_case_study_dir(\"etfs\")` so a run with\n",
-    "  `ML4T_OUTPUT_DIR` set reads the tree that run wrote.\n",
+    "  by default `case_studies/etfs/labels/fwd_ret_21d.parquet` and\n",
+    "  `case_studies/etfs/run_log/registry.db`.\n",
     "- Alpaca paper credentials in `ALPACA_API_KEY` / `ALPACA_SECRET_KEY`\n",
     "  (free at <https://app.alpaca.markets/paper>)."
    ]
@@ -1924,7 +1924,8 @@
    "outputs_digest": "26edb2f789f5bf544143568716a1ea8222ffadd9db62c767881c06840220693c",
    "parameters": {},
    "production": true,
-   "source_py_blob": "779e71293b6e91127721fc5d37543ae4d006c818"
+   "source_py_blob": "d65420d47c280c0145d4e71ca21f8df184117ef3",
+   "notes": "prose synced from the .py at 2026-09-11T00:40:46.688821+00:00 without re-executing; every code cell is identical to blob 779e71293b6e"
   },
   "papermill": {
    "default_parameters": {},

--- a/25_live_trading/02_etfs_deployment_loop.ipynb
+++ b/25_live_trading/02_etfs_deployment_loop.ipynb
@@ -2,13 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "2ce98e28",
+   "id": "f0421a9f",
    "metadata": {
     "papermill": {
-     "duration": 0.002809,
-     "end_time": "2026-09-11T00:38:48.784039+00:00",
+     "duration": 0.01007,
+     "end_time": "2026-09-11T00:48:19.126317+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:38:48.781230+00:00",
+     "start_time": "2026-09-11T00:48:19.116247+00:00",
      "status": "completed"
     }
    },
@@ -79,19 +79,19 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "79af7f19",
+   "id": "ba2dd9af",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:38:48.788081Z",
-     "iopub.status.busy": "2026-09-11T00:38:48.787964Z",
-     "iopub.status.idle": "2026-09-11T00:38:51.251469Z",
-     "shell.execute_reply": "2026-09-11T00:38:51.250979Z"
+     "iopub.execute_input": "2026-09-11T00:48:19.136812Z",
+     "iopub.status.busy": "2026-09-11T00:48:19.136667Z",
+     "iopub.status.idle": "2026-09-11T00:48:21.477275Z",
+     "shell.execute_reply": "2026-09-11T00:48:21.476864Z"
     },
     "papermill": {
-     "duration": 2.466203,
-     "end_time": "2026-09-11T00:38:51.252017+00:00",
+     "duration": 2.345052,
+     "end_time": "2026-09-11T00:48:21.477638+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:38:48.785814+00:00",
+     "start_time": "2026-09-11T00:48:19.132586+00:00",
      "status": "completed"
     }
    },
@@ -147,19 +147,19 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "3b41de32",
+   "id": "e28198ad",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:38:51.256348Z",
-     "iopub.status.busy": "2026-09-11T00:38:51.256237Z",
-     "iopub.status.idle": "2026-09-11T00:38:51.258460Z",
-     "shell.execute_reply": "2026-09-11T00:38:51.258132Z"
+     "iopub.execute_input": "2026-09-11T00:48:21.481529Z",
+     "iopub.status.busy": "2026-09-11T00:48:21.481439Z",
+     "iopub.status.idle": "2026-09-11T00:48:21.483269Z",
+     "shell.execute_reply": "2026-09-11T00:48:21.483001Z"
     },
     "papermill": {
-     "duration": 0.004792,
-     "end_time": "2026-09-11T00:38:51.258764+00:00",
+     "duration": 0.004049,
+     "end_time": "2026-09-11T00:48:21.483469+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:38:51.253972+00:00",
+     "start_time": "2026-09-11T00:48:21.479420+00:00",
      "status": "completed"
     },
     "tags": [
@@ -184,13 +184,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bdb6f598",
+   "id": "08146667",
    "metadata": {
     "papermill": {
-     "duration": 0.001451,
-     "end_time": "2026-09-11T00:38:51.261765+00:00",
+     "duration": 0.001432,
+     "end_time": "2026-09-11T00:48:21.486448+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:38:51.260314+00:00",
+     "start_time": "2026-09-11T00:48:21.485016+00:00",
      "status": "completed"
     }
    },
@@ -212,19 +212,19 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "d62d79c7",
+   "id": "6b0346f3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:38:51.265120Z",
-     "iopub.status.busy": "2026-09-11T00:38:51.265045Z",
-     "iopub.status.idle": "2026-09-11T00:38:51.267910Z",
-     "shell.execute_reply": "2026-09-11T00:38:51.267491Z"
+     "iopub.execute_input": "2026-09-11T00:48:21.489881Z",
+     "iopub.status.busy": "2026-09-11T00:48:21.489806Z",
+     "iopub.status.idle": "2026-09-11T00:48:21.492138Z",
+     "shell.execute_reply": "2026-09-11T00:48:21.491895Z"
     },
     "papermill": {
-     "duration": 0.004954,
-     "end_time": "2026-09-11T00:38:51.268194+00:00",
+     "duration": 0.004508,
+     "end_time": "2026-09-11T00:48:21.492461+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:38:51.263240+00:00",
+     "start_time": "2026-09-11T00:48:21.487953+00:00",
      "status": "completed"
     }
    },
@@ -259,13 +259,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "572b29d4",
+   "id": "41d4584d",
    "metadata": {
     "papermill": {
-     "duration": 0.001479,
-     "end_time": "2026-09-11T00:38:51.271322+00:00",
+     "duration": 0.001508,
+     "end_time": "2026-09-11T00:48:21.495584+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:38:51.269843+00:00",
+     "start_time": "2026-09-11T00:48:21.494076+00:00",
      "status": "completed"
     }
    },
@@ -285,19 +285,19 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "936c1e94",
+   "id": "b128b063",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:38:51.274875Z",
-     "iopub.status.busy": "2026-09-11T00:38:51.274800Z",
-     "iopub.status.idle": "2026-09-11T00:38:51.345488Z",
-     "shell.execute_reply": "2026-09-11T00:38:51.344949Z"
+     "iopub.execute_input": "2026-09-11T00:48:21.499293Z",
+     "iopub.status.busy": "2026-09-11T00:48:21.499210Z",
+     "iopub.status.idle": "2026-09-11T00:48:21.560793Z",
+     "shell.execute_reply": "2026-09-11T00:48:21.560442Z"
     },
     "papermill": {
-     "duration": 0.072931,
-     "end_time": "2026-09-11T00:38:51.345776+00:00",
+     "duration": 0.064263,
+     "end_time": "2026-09-11T00:48:21.561413+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:38:51.272845+00:00",
+     "start_time": "2026-09-11T00:48:21.497150+00:00",
      "status": "completed"
     }
    },
@@ -329,19 +329,19 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "970a4cc0",
+   "id": "10cf02c4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:38:51.349799Z",
-     "iopub.status.busy": "2026-09-11T00:38:51.349678Z",
-     "iopub.status.idle": "2026-09-11T00:39:19.280226Z",
-     "shell.execute_reply": "2026-09-11T00:39:19.279705Z"
+     "iopub.execute_input": "2026-09-11T00:48:21.565440Z",
+     "iopub.status.busy": "2026-09-11T00:48:21.565349Z",
+     "iopub.status.idle": "2026-09-11T00:48:48.448639Z",
+     "shell.execute_reply": "2026-09-11T00:48:48.448219Z"
     },
     "papermill": {
-     "duration": 27.933263,
-     "end_time": "2026-09-11T00:39:19.280810+00:00",
+     "duration": 26.88581,
+     "end_time": "2026-09-11T00:48:48.449086+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:38:51.347547+00:00",
+     "start_time": "2026-09-11T00:48:21.563276+00:00",
      "status": "completed"
     }
    },
@@ -350,14 +350,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2026-09-10 20:38:51 | mlquant.features.adx | INFO | [ADX] Starting calculation with parameters: period=14 (shape: (4,))\n"
+      "2026-09-10 20:48:21 | mlquant.features.adx | INFO | [ADX] Starting calculation with parameters: period=14 (shape: (4,))\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2026-09-10 20:38:51 | mlquant.features.adx | INFO | [ADX] Completed calculation (shape: (4,)) (0.05ms)\n"
+      "2026-09-10 20:48:21 | mlquant.features.adx | INFO | [ADX] Completed calculation (shape: (4,)) (0.05ms)\n"
      ]
     },
     {
@@ -376,13 +376,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c6beaa78",
+   "id": "469fb649",
    "metadata": {
     "papermill": {
-     "duration": 0.003131,
-     "end_time": "2026-09-11T00:39:19.287462+00:00",
+     "duration": 0.00302,
+     "end_time": "2026-09-11T00:48:48.455581+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:39:19.284331+00:00",
+     "start_time": "2026-09-11T00:48:48.452561+00:00",
      "status": "completed"
     }
    },
@@ -418,19 +418,19 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "8a2bda1e",
+   "id": "584f91d4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:39:19.294457Z",
-     "iopub.status.busy": "2026-09-11T00:39:19.294354Z",
-     "iopub.status.idle": "2026-09-11T00:39:19.299264Z",
-     "shell.execute_reply": "2026-09-11T00:39:19.298799Z"
+     "iopub.execute_input": "2026-09-11T00:48:48.461466Z",
+     "iopub.status.busy": "2026-09-11T00:48:48.461360Z",
+     "iopub.status.idle": "2026-09-11T00:48:48.466007Z",
+     "shell.execute_reply": "2026-09-11T00:48:48.465712Z"
     },
     "papermill": {
-     "duration": 0.009058,
-     "end_time": "2026-09-11T00:39:19.299825+00:00",
+     "duration": 0.007714,
+     "end_time": "2026-09-11T00:48:48.466488+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:39:19.290767+00:00",
+     "start_time": "2026-09-11T00:48:48.458774+00:00",
      "status": "completed"
     }
    },
@@ -442,7 +442,8 @@
       "Registry leader on validation IC: ridge_a1000000.0  (IC 0.0434)\n",
       "  alpha:        1e+06\n",
       "  tuned on:     ['financial', 'model_based']\n",
-      "  deployed on:  ['financial']\n"
+      "  deployed on:  ['financial']\n",
+      "  dropped here: ['model_based']\n"
      ]
     }
    ],
@@ -501,47 +502,50 @@
     "print(f\"Registry leader on validation IC: {SOURCE_CONFIG}  (IC {source_ic:.4f})\")\n",
     "print(f\"  alpha:        {RIDGE_ALPHA:g}\")\n",
     "print(f\"  tuned on:     {SOURCE_FEATURE_SETS}\")\n",
-    "print(f\"  deployed on:  {DEPLOYED_FEATURE_SETS}\")"
+    "print(f\"  deployed on:  {DEPLOYED_FEATURE_SETS}\")\n",
+    "dropped_feature_sets = sorted(set(SOURCE_FEATURE_SETS) - set(DEPLOYED_FEATURE_SETS))\n",
+    "print(f\"  dropped here: {dropped_feature_sets or 'none'}\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "bebe441f",
+   "id": "2c56688b",
    "metadata": {
     "papermill": {
-     "duration": 0.005868,
-     "end_time": "2026-09-11T00:39:19.310478+00:00",
+     "duration": 0.003002,
+     "end_time": "2026-09-11T00:48:48.473120+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:39:19.304610+00:00",
+     "start_time": "2026-09-11T00:48:48.470118+00:00",
      "status": "completed"
     }
    },
    "source": [
-    "The two feature lists differ, and the difference is the cost of the transfer. The registry's\n",
-    "leader was tuned with the model-based families alongside the financial ones; this notebook fits\n",
-    "the financial families alone, because an HMM and a GARCH refit per symbol on every data update is\n",
-    "what the deployment declines to pay for. An alpha selected against one feature set is not\n",
-    "selected against another, so the number below is a starting point carried over from research,\n",
-    "not a tuned value for the model actually fitted here. Nothing in this notebook re-derives it, and\n",
-    "a deployment that wanted it re-derived would sweep on its own feature set."
+    "Whatever the run prints as dropped is the cost of the transfer. This notebook fits the financial\n",
+    "families alone, because an HMM and a GARCH refit per symbol on every data update is what the\n",
+    "deployment declines to pay for, and the configuration it borrows from was tuned on whichever\n",
+    "families the registry records against it. An alpha selected against one feature set is not\n",
+    "selected against another, so with anything in that dropped list the number below is a starting\n",
+    "point carried over from research rather than a tuned value for the model actually fitted here.\n",
+    "Nothing in this notebook re-derives it, and a deployment that wanted it re-derived would sweep on\n",
+    "its own feature set."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "ff439c67",
+   "id": "c539d568",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:39:19.318704Z",
-     "iopub.status.busy": "2026-09-11T00:39:19.318501Z",
-     "iopub.status.idle": "2026-09-11T00:39:19.412516Z",
-     "shell.execute_reply": "2026-09-11T00:39:19.411755Z"
+     "iopub.execute_input": "2026-09-11T00:48:48.479905Z",
+     "iopub.status.busy": "2026-09-11T00:48:48.479815Z",
+     "iopub.status.idle": "2026-09-11T00:48:48.544760Z",
+     "shell.execute_reply": "2026-09-11T00:48:48.544195Z"
     },
     "papermill": {
-     "duration": 0.09939,
-     "end_time": "2026-09-11T00:39:19.412829+00:00",
+     "duration": 0.069095,
+     "end_time": "2026-09-11T00:48:48.545277+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:39:19.313439+00:00",
+     "start_time": "2026-09-11T00:48:48.476182+00:00",
      "status": "completed"
     }
    },
@@ -562,13 +566,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "97d1db54",
+   "id": "2fc6f1cf",
    "metadata": {
     "papermill": {
-     "duration": 0.001755,
-     "end_time": "2026-09-11T00:39:19.416510+00:00",
+     "duration": 0.001767,
+     "end_time": "2026-09-11T00:48:48.548998+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:39:19.414755+00:00",
+     "start_time": "2026-09-11T00:48:48.547231+00:00",
      "status": "completed"
     }
    },
@@ -585,19 +589,19 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "8dfc5295",
+   "id": "fb37e0b1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:39:19.421122Z",
-     "iopub.status.busy": "2026-09-11T00:39:19.420983Z",
-     "iopub.status.idle": "2026-09-11T00:39:19.430015Z",
-     "shell.execute_reply": "2026-09-11T00:39:19.429402Z"
+     "iopub.execute_input": "2026-09-11T00:48:48.553497Z",
+     "iopub.status.busy": "2026-09-11T00:48:48.553391Z",
+     "iopub.status.idle": "2026-09-11T00:48:48.560443Z",
+     "shell.execute_reply": "2026-09-11T00:48:48.560040Z"
     },
     "papermill": {
-     "duration": 0.011971,
-     "end_time": "2026-09-11T00:39:19.430351+00:00",
+     "duration": 0.00997,
+     "end_time": "2026-09-11T00:48:48.560734+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:39:19.418380+00:00",
+     "start_time": "2026-09-11T00:48:48.550764+00:00",
      "status": "completed"
     }
    },
@@ -632,19 +636,19 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "c0ac2f84",
+   "id": "ec33cddc",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:39:19.435086Z",
-     "iopub.status.busy": "2026-09-11T00:39:19.434916Z",
-     "iopub.status.idle": "2026-09-11T00:39:22.087060Z",
-     "shell.execute_reply": "2026-09-11T00:39:22.086514Z"
+     "iopub.execute_input": "2026-09-11T00:48:48.565581Z",
+     "iopub.status.busy": "2026-09-11T00:48:48.565497Z",
+     "iopub.status.idle": "2026-09-11T00:48:51.410975Z",
+     "shell.execute_reply": "2026-09-11T00:48:51.410587Z"
     },
     "papermill": {
-     "duration": 2.655192,
-     "end_time": "2026-09-11T00:39:22.087459+00:00",
+     "duration": 2.848757,
+     "end_time": "2026-09-11T00:48:51.411694+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:39:19.432267+00:00",
+     "start_time": "2026-09-11T00:48:48.562937+00:00",
      "status": "completed"
     }
    },
@@ -675,13 +679,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c609fb48",
+   "id": "be5b6e6d",
    "metadata": {
     "papermill": {
-     "duration": 0.001749,
-     "end_time": "2026-09-11T00:39:22.091211+00:00",
+     "duration": 0.003282,
+     "end_time": "2026-09-11T00:48:51.418777+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:39:22.089462+00:00",
+     "start_time": "2026-09-11T00:48:51.415495+00:00",
      "status": "completed"
     }
    },
@@ -698,19 +702,19 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "382679cc",
+   "id": "a2fb6d20",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:39:22.095477Z",
-     "iopub.status.busy": "2026-09-11T00:39:22.095364Z",
-     "iopub.status.idle": "2026-09-11T00:39:22.100584Z",
-     "shell.execute_reply": "2026-09-11T00:39:22.100144Z"
+     "iopub.execute_input": "2026-09-11T00:48:51.426611Z",
+     "iopub.status.busy": "2026-09-11T00:48:51.426385Z",
+     "iopub.status.idle": "2026-09-11T00:48:51.431492Z",
+     "shell.execute_reply": "2026-09-11T00:48:51.431203Z"
     },
     "papermill": {
-     "duration": 0.008213,
-     "end_time": "2026-09-11T00:39:22.101201+00:00",
+     "duration": 0.009705,
+     "end_time": "2026-09-11T00:48:51.431907+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:39:22.092988+00:00",
+     "start_time": "2026-09-11T00:48:51.422202+00:00",
      "status": "completed"
     }
    },
@@ -768,13 +772,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cfc16664",
+   "id": "d14a60f1",
    "metadata": {
     "papermill": {
-     "duration": 0.00323,
-     "end_time": "2026-09-11T00:39:22.108190+00:00",
+     "duration": 0.001908,
+     "end_time": "2026-09-11T00:48:51.435922+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:39:22.104960+00:00",
+     "start_time": "2026-09-11T00:48:51.434014+00:00",
      "status": "completed"
     }
    },
@@ -792,19 +796,19 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "7af73b18",
+   "id": "49fb8286",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:39:22.114799Z",
-     "iopub.status.busy": "2026-09-11T00:39:22.114704Z",
-     "iopub.status.idle": "2026-09-11T00:39:22.138387Z",
-     "shell.execute_reply": "2026-09-11T00:39:22.137953Z"
+     "iopub.execute_input": "2026-09-11T00:48:51.440128Z",
+     "iopub.status.busy": "2026-09-11T00:48:51.440035Z",
+     "iopub.status.idle": "2026-09-11T00:48:51.469341Z",
+     "shell.execute_reply": "2026-09-11T00:48:51.468799Z"
     },
     "papermill": {
-     "duration": 0.027343,
-     "end_time": "2026-09-11T00:39:22.138841+00:00",
+     "duration": 0.031975,
+     "end_time": "2026-09-11T00:48:51.469645+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:39:22.111498+00:00",
+     "start_time": "2026-09-11T00:48:51.437670+00:00",
      "status": "completed"
     }
    },
@@ -841,14 +845,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b51de843",
+   "id": "a4715d58",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.001758,
-     "end_time": "2026-09-11T00:39:22.142586+00:00",
+     "duration": 0.001737,
+     "end_time": "2026-09-11T00:48:51.473446+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:39:22.140828+00:00",
+     "start_time": "2026-09-11T00:48:51.471709+00:00",
      "status": "completed"
     }
    },
@@ -863,10 +867,10 @@
     "\n",
     "Positions are sized against the broker's current account value rather than `INITIAL_CASH`, so\n",
     "leverage stays constant as profit and loss accrue, and against slightly less than all of it.\n",
-    "`CASH_BUFFER` is what the order is sized on the current bar's close but fills at the next bar's:\n",
-    "an overnight move against the position, plus commission, makes a basket sized at the full account\n",
-    "value unaffordable, and the broker answers that by refusing the last leg rather than by filling\n",
-    "it smaller. Two per cent is a margin measured on this window, not a guarantee - a basket that\n",
+    "`CASH_BUFFER` exists because the order is sized on the current bar's close and fills at the next\n",
+    "bar's: an overnight move against the position, plus commission, makes a basket sized at the full\n",
+    "account value unaffordable, and the broker answers that by refusing the last leg rather than by\n",
+    "filling it smaller. Two per cent is a margin measured on this window, not a guarantee - a basket that\n",
     "gaps up about two per cent overnight is unaffordable again - and the disposition check below is\n",
     "what turns that into a stop rather than a quietly short basket."
    ]
@@ -874,19 +878,19 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "f660e120",
+   "id": "04e7a997",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:39:22.146632Z",
-     "iopub.status.busy": "2026-09-11T00:39:22.146538Z",
-     "iopub.status.idle": "2026-09-11T00:39:22.150897Z",
-     "shell.execute_reply": "2026-09-11T00:39:22.150505Z"
+     "iopub.execute_input": "2026-09-11T00:48:51.477824Z",
+     "iopub.status.busy": "2026-09-11T00:48:51.477679Z",
+     "iopub.status.idle": "2026-09-11T00:48:51.483527Z",
+     "shell.execute_reply": "2026-09-11T00:48:51.483056Z"
     },
     "papermill": {
-     "duration": 0.006878,
-     "end_time": "2026-09-11T00:39:22.151212+00:00",
+     "duration": 0.008606,
+     "end_time": "2026-09-11T00:48:51.483842+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:39:22.144334+00:00",
+     "start_time": "2026-09-11T00:48:51.475236+00:00",
      "status": "completed"
     }
    },
@@ -976,13 +980,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "07db600e",
+   "id": "b6866914",
    "metadata": {
     "papermill": {
-     "duration": 0.00169,
-     "end_time": "2026-09-11T00:39:22.154726+00:00",
+     "duration": 0.001779,
+     "end_time": "2026-09-11T00:48:51.487614+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:39:22.153036+00:00",
+     "start_time": "2026-09-11T00:48:51.485835+00:00",
      "status": "completed"
     }
    },
@@ -1003,19 +1007,19 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "4aaa0a59",
+   "id": "ae2bcefa",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:39:22.158596Z",
-     "iopub.status.busy": "2026-09-11T00:39:22.158523Z",
-     "iopub.status.idle": "2026-09-11T00:39:22.228121Z",
-     "shell.execute_reply": "2026-09-11T00:39:22.227478Z"
+     "iopub.execute_input": "2026-09-11T00:48:51.492131Z",
+     "iopub.status.busy": "2026-09-11T00:48:51.491977Z",
+     "iopub.status.idle": "2026-09-11T00:48:51.561818Z",
+     "shell.execute_reply": "2026-09-11T00:48:51.561349Z"
     },
     "papermill": {
-     "duration": 0.072035,
-     "end_time": "2026-09-11T00:39:22.228492+00:00",
+     "duration": 0.072704,
+     "end_time": "2026-09-11T00:48:51.562118+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:39:22.156457+00:00",
+     "start_time": "2026-09-11T00:48:51.489414+00:00",
      "status": "completed"
     }
    },
@@ -1061,13 +1065,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dfb5e0b1",
+   "id": "1ef74013",
    "metadata": {
     "papermill": {
-     "duration": 0.001839,
-     "end_time": "2026-09-11T00:39:22.232699+00:00",
+     "duration": 0.001926,
+     "end_time": "2026-09-11T00:48:51.566327+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:39:22.230860+00:00",
+     "start_time": "2026-09-11T00:48:51.564401+00:00",
      "status": "completed"
     }
    },
@@ -1087,19 +1091,19 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "id": "c2b10b2f",
+   "id": "84cb0b5e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:39:22.237224Z",
-     "iopub.status.busy": "2026-09-11T00:39:22.237095Z",
-     "iopub.status.idle": "2026-09-11T00:39:22.242828Z",
-     "shell.execute_reply": "2026-09-11T00:39:22.239991Z"
+     "iopub.execute_input": "2026-09-11T00:48:51.571001Z",
+     "iopub.status.busy": "2026-09-11T00:48:51.570894Z",
+     "iopub.status.idle": "2026-09-11T00:48:51.574324Z",
+     "shell.execute_reply": "2026-09-11T00:48:51.573717Z"
     },
     "papermill": {
-     "duration": 0.008665,
-     "end_time": "2026-09-11T00:39:22.243159+00:00",
+     "duration": 0.00642,
+     "end_time": "2026-09-11T00:48:51.574637+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:39:22.234494+00:00",
+     "start_time": "2026-09-11T00:48:51.568217+00:00",
      "status": "completed"
     }
    },
@@ -1141,13 +1145,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0348a854",
+   "id": "b3139a57",
    "metadata": {
     "papermill": {
-     "duration": 0.001815,
-     "end_time": "2026-09-11T00:39:22.246941+00:00",
+     "duration": 0.001998,
+     "end_time": "2026-09-11T00:48:51.578666+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:39:22.245126+00:00",
+     "start_time": "2026-09-11T00:48:51.576668+00:00",
      "status": "completed"
     }
    },
@@ -1166,19 +1170,19 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "id": "142f60c1",
+   "id": "4e2b6ab5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:39:22.251031Z",
-     "iopub.status.busy": "2026-09-11T00:39:22.250952Z",
-     "iopub.status.idle": "2026-09-11T00:39:22.382619Z",
-     "shell.execute_reply": "2026-09-11T00:39:22.382180Z"
+     "iopub.execute_input": "2026-09-11T00:48:51.583199Z",
+     "iopub.status.busy": "2026-09-11T00:48:51.583080Z",
+     "iopub.status.idle": "2026-09-11T00:48:51.708162Z",
+     "shell.execute_reply": "2026-09-11T00:48:51.707607Z"
     },
     "papermill": {
-     "duration": 0.134152,
-     "end_time": "2026-09-11T00:39:22.382903+00:00",
+     "duration": 0.127846,
+     "end_time": "2026-09-11T00:48:51.708430+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:39:22.248751+00:00",
+     "start_time": "2026-09-11T00:48:51.580584+00:00",
      "status": "completed"
     }
    },
@@ -1228,13 +1232,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "86dfbbe4",
+   "id": "1e6a56a2",
    "metadata": {
     "papermill": {
-     "duration": 0.002011,
-     "end_time": "2026-09-11T00:39:22.387228+00:00",
+     "duration": 0.001992,
+     "end_time": "2026-09-11T00:48:51.712667+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:39:22.385217+00:00",
+     "start_time": "2026-09-11T00:48:51.710675+00:00",
      "status": "completed"
     }
    },
@@ -1255,19 +1259,19 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "id": "3f8b6e83",
+   "id": "7659a182",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:39:22.391769Z",
-     "iopub.status.busy": "2026-09-11T00:39:22.391682Z",
-     "iopub.status.idle": "2026-09-11T00:39:22.396070Z",
-     "shell.execute_reply": "2026-09-11T00:39:22.395568Z"
+     "iopub.execute_input": "2026-09-11T00:48:51.717339Z",
+     "iopub.status.busy": "2026-09-11T00:48:51.717255Z",
+     "iopub.status.idle": "2026-09-11T00:48:51.721444Z",
+     "shell.execute_reply": "2026-09-11T00:48:51.721184Z"
     },
     "papermill": {
-     "duration": 0.00724,
-     "end_time": "2026-09-11T00:39:22.396411+00:00",
+     "duration": 0.00719,
+     "end_time": "2026-09-11T00:48:51.721887+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:39:22.389171+00:00",
+     "start_time": "2026-09-11T00:48:51.714697+00:00",
      "status": "completed"
     }
    },
@@ -1326,19 +1330,19 @@
   {
    "cell_type": "code",
    "execution_count": 17,
-   "id": "84246f35",
+   "id": "a6852caf",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:39:22.400976Z",
-     "iopub.status.busy": "2026-09-11T00:39:22.400896Z",
-     "iopub.status.idle": "2026-09-11T00:39:22.403528Z",
-     "shell.execute_reply": "2026-09-11T00:39:22.403205Z"
+     "iopub.execute_input": "2026-09-11T00:48:51.726488Z",
+     "iopub.status.busy": "2026-09-11T00:48:51.726421Z",
+     "iopub.status.idle": "2026-09-11T00:48:51.728479Z",
+     "shell.execute_reply": "2026-09-11T00:48:51.728277Z"
     },
     "papermill": {
-     "duration": 0.005353,
-     "end_time": "2026-09-11T00:39:22.403874+00:00",
+     "duration": 0.004835,
+     "end_time": "2026-09-11T00:48:51.728870+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:39:22.398521+00:00",
+     "start_time": "2026-09-11T00:48:51.724035+00:00",
      "status": "completed"
     }
    },
@@ -1381,14 +1385,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2b50fdcc",
+   "id": "9d9338fc",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.001951,
-     "end_time": "2026-09-11T00:39:22.407878+00:00",
+     "duration": 0.001958,
+     "end_time": "2026-09-11T00:48:51.732888+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:39:22.405927+00:00",
+     "start_time": "2026-09-11T00:48:51.730930+00:00",
      "status": "completed"
     }
    },
@@ -1406,19 +1410,19 @@
   {
    "cell_type": "code",
    "execution_count": 18,
-   "id": "0e914e75",
+   "id": "a24bc746",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:39:22.412581Z",
-     "iopub.status.busy": "2026-09-11T00:39:22.412462Z",
-     "iopub.status.idle": "2026-09-11T00:39:22.416335Z",
-     "shell.execute_reply": "2026-09-11T00:39:22.415927Z"
+     "iopub.execute_input": "2026-09-11T00:48:51.737550Z",
+     "iopub.status.busy": "2026-09-11T00:48:51.737484Z",
+     "iopub.status.idle": "2026-09-11T00:48:51.740822Z",
+     "shell.execute_reply": "2026-09-11T00:48:51.740533Z"
     },
     "papermill": {
-     "duration": 0.006748,
-     "end_time": "2026-09-11T00:39:22.416617+00:00",
+     "duration": 0.006159,
+     "end_time": "2026-09-11T00:48:51.741083+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:39:22.409869+00:00",
+     "start_time": "2026-09-11T00:48:51.734924+00:00",
      "status": "completed"
     }
    },
@@ -1475,13 +1479,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8e4b3a99",
+   "id": "a3136b28",
    "metadata": {
     "papermill": {
-     "duration": 0.001966,
-     "end_time": "2026-09-11T00:39:22.420759+00:00",
+     "duration": 0.002138,
+     "end_time": "2026-09-11T00:48:51.745342+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:39:22.418793+00:00",
+     "start_time": "2026-09-11T00:48:51.743204+00:00",
      "status": "completed"
     }
    },
@@ -1501,19 +1505,19 @@
   {
    "cell_type": "code",
    "execution_count": 19,
-   "id": "f5ac3fff",
+   "id": "3375e062",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:39:22.425481Z",
-     "iopub.status.busy": "2026-09-11T00:39:22.425402Z",
-     "iopub.status.idle": "2026-09-11T00:39:22.428342Z",
-     "shell.execute_reply": "2026-09-11T00:39:22.428007Z"
+     "iopub.execute_input": "2026-09-11T00:48:51.750316Z",
+     "iopub.status.busy": "2026-09-11T00:48:51.750228Z",
+     "iopub.status.idle": "2026-09-11T00:48:51.753241Z",
+     "shell.execute_reply": "2026-09-11T00:48:51.752758Z"
     },
     "papermill": {
-     "duration": 0.00579,
-     "end_time": "2026-09-11T00:39:22.428618+00:00",
+     "duration": 0.006218,
+     "end_time": "2026-09-11T00:48:51.753634+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:39:22.422828+00:00",
+     "start_time": "2026-09-11T00:48:51.747416+00:00",
      "status": "completed"
     }
    },
@@ -1549,19 +1553,19 @@
   {
    "cell_type": "code",
    "execution_count": 20,
-   "id": "37b3aa2c",
+   "id": "d389d0ec",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:39:22.433211Z",
-     "iopub.status.busy": "2026-09-11T00:39:22.433141Z",
-     "iopub.status.idle": "2026-09-11T00:39:22.436331Z",
-     "shell.execute_reply": "2026-09-11T00:39:22.435829Z"
+     "iopub.execute_input": "2026-09-11T00:48:51.758523Z",
+     "iopub.status.busy": "2026-09-11T00:48:51.758453Z",
+     "iopub.status.idle": "2026-09-11T00:48:51.761119Z",
+     "shell.execute_reply": "2026-09-11T00:48:51.760785Z"
     },
     "papermill": {
-     "duration": 0.005936,
-     "end_time": "2026-09-11T00:39:22.436628+00:00",
+     "duration": 0.005535,
+     "end_time": "2026-09-11T00:48:51.761406+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:39:22.430692+00:00",
+     "start_time": "2026-09-11T00:48:51.755871+00:00",
      "status": "completed"
     }
    },
@@ -1617,13 +1621,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2b02fc62",
+   "id": "d62d4aed",
    "metadata": {
     "papermill": {
-     "duration": 0.002046,
-     "end_time": "2026-09-11T00:39:22.440990+00:00",
+     "duration": 0.00211,
+     "end_time": "2026-09-11T00:48:51.765675+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:39:22.438944+00:00",
+     "start_time": "2026-09-11T00:48:51.763565+00:00",
      "status": "completed"
     }
    },
@@ -1645,14 +1649,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "139dd0d7",
+   "id": "46155789",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.002022,
-     "end_time": "2026-09-11T00:39:22.445107+00:00",
+     "duration": 0.002111,
+     "end_time": "2026-09-11T00:48:51.769927+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:39:22.443085+00:00",
+     "start_time": "2026-09-11T00:48:51.767816+00:00",
      "status": "completed"
     }
    },
@@ -1668,19 +1672,19 @@
   {
    "cell_type": "code",
    "execution_count": 21,
-   "id": "9b164e44",
+   "id": "9d6d3795",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:39:22.449968Z",
-     "iopub.status.busy": "2026-09-11T00:39:22.449872Z",
-     "iopub.status.idle": "2026-09-11T00:39:22.452241Z",
-     "shell.execute_reply": "2026-09-11T00:39:22.451849Z"
+     "iopub.execute_input": "2026-09-11T00:48:51.775010Z",
+     "iopub.status.busy": "2026-09-11T00:48:51.774847Z",
+     "iopub.status.idle": "2026-09-11T00:48:51.776919Z",
+     "shell.execute_reply": "2026-09-11T00:48:51.776579Z"
     },
     "papermill": {
-     "duration": 0.00534,
-     "end_time": "2026-09-11T00:39:22.452536+00:00",
+     "duration": 0.005121,
+     "end_time": "2026-09-11T00:48:51.777358+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:39:22.447196+00:00",
+     "start_time": "2026-09-11T00:48:51.772237+00:00",
      "status": "completed"
     }
    },
@@ -1698,19 +1702,19 @@
   {
    "cell_type": "code",
    "execution_count": 22,
-   "id": "8f6bd4e5",
+   "id": "f75fff4f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:39:22.457333Z",
-     "iopub.status.busy": "2026-09-11T00:39:22.457249Z",
-     "iopub.status.idle": "2026-09-11T00:39:22.460477Z",
-     "shell.execute_reply": "2026-09-11T00:39:22.459926Z"
+     "iopub.execute_input": "2026-09-11T00:48:51.785698Z",
+     "iopub.status.busy": "2026-09-11T00:48:51.785622Z",
+     "iopub.status.idle": "2026-09-11T00:48:51.788353Z",
+     "shell.execute_reply": "2026-09-11T00:48:51.788095Z"
     },
     "papermill": {
-     "duration": 0.006089,
-     "end_time": "2026-09-11T00:39:22.460776+00:00",
+     "duration": 0.007951,
+     "end_time": "2026-09-11T00:48:51.788852+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:39:22.454687+00:00",
+     "start_time": "2026-09-11T00:48:51.780901+00:00",
      "status": "completed"
     }
    },
@@ -1754,13 +1758,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bb333fde",
+   "id": "71090057",
    "metadata": {
     "papermill": {
-     "duration": 0.002079,
-     "end_time": "2026-09-11T00:39:22.465079+00:00",
+     "duration": 0.002736,
+     "end_time": "2026-09-11T00:48:51.794213+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:39:22.463000+00:00",
+     "start_time": "2026-09-11T00:48:51.791477+00:00",
      "status": "completed"
     }
    },
@@ -1777,19 +1781,19 @@
   {
    "cell_type": "code",
    "execution_count": 23,
-   "id": "9194a4b1",
+   "id": "6d809547",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:39:22.470331Z",
-     "iopub.status.busy": "2026-09-11T00:39:22.470236Z",
-     "iopub.status.idle": "2026-09-11T00:39:22.473891Z",
-     "shell.execute_reply": "2026-09-11T00:39:22.473516Z"
+     "iopub.execute_input": "2026-09-11T00:48:51.800228Z",
+     "iopub.status.busy": "2026-09-11T00:48:51.800119Z",
+     "iopub.status.idle": "2026-09-11T00:48:51.803302Z",
+     "shell.execute_reply": "2026-09-11T00:48:51.803052Z"
     },
     "papermill": {
-     "duration": 0.006946,
-     "end_time": "2026-09-11T00:39:22.474202+00:00",
+     "duration": 0.006632,
+     "end_time": "2026-09-11T00:48:51.803825+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:39:22.467256+00:00",
+     "start_time": "2026-09-11T00:48:51.797193+00:00",
      "status": "completed"
     }
    },
@@ -1798,7 +1802,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Run metadata: 25_live_trading/output/etfs_deployment/runs/run_20260911T003922Z.json\n"
+      "Run metadata: 25_live_trading/output/etfs_deployment/runs/run_20260911T004851Z.json\n"
      ]
     }
    ],
@@ -1846,13 +1850,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ea100b5d",
+   "id": "750d849c",
    "metadata": {
     "papermill": {
-     "duration": 0.00211,
-     "end_time": "2026-09-11T00:39:22.478507+00:00",
+     "duration": 0.002466,
+     "end_time": "2026-09-11T00:48:51.809313+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:39:22.476397+00:00",
+     "start_time": "2026-09-11T00:48:51.806847+00:00",
      "status": "completed"
     }
    },
@@ -1879,13 +1883,13 @@
     "  extended panel and a single train pass, not the case study's\n",
     "  walk-forward CV.\n",
     "- **The financial-only feature subset is a deliberate operational\n",
-    "  simplification, and it is not free.** Dropping HMM regimes and GARCH\n",
-    "  conditional volatility makes the refit complete in seconds instead of\n",
-    "  minutes. It also means the alpha this notebook borrows was selected\n",
+    "  simplification, and it is not free.** Dropping the model-based\n",
+    "  families makes the refit complete in seconds instead of minutes. It\n",
+    "  also means the alpha this notebook borrows may have been selected\n",
     "  against a feature set the deployment does not use, which the run\n",
-    "  prints rather than leaves implicit. What that costs in forecast\n",
-    "  quality is not measured here; measuring it means sweeping on the\n",
-    "  deployment's own feature set.\n",
+    "  prints as a dropped list rather than leaving implicit. What that\n",
+    "  costs in forecast quality is not measured here; measuring it means\n",
+    "  sweeping on the deployment's own feature set.\n",
     "- **This notebook refits once per run, and does not decide how often to\n",
     "  run.** Prediction and the offline reference could be re-run daily\n",
     "  against a persisted artefact while the refit happens far less often.\n",
@@ -1918,25 +1922,24 @@
    "version": "3.14.3"
   },
   "ml4t_provenance": {
-   "executed_at": "2026-09-11T00:39:31.400309+00:00",
+   "executed_at": "2026-09-11T00:49:00.521796+00:00",
    "executor": "local-uv",
    "library_digest": "0af5dc39c6c29f1e215740139cdb8886b6f5894060fe3cbd08b809a63ae853aa",
-   "outputs_digest": "26edb2f789f5bf544143568716a1ea8222ffadd9db62c767881c06840220693c",
+   "outputs_digest": "4307a73ca3a0b44ced42cefe07ddbfc70be330784a50691dd356a02dc943de6f",
    "parameters": {},
    "production": true,
-   "source_py_blob": "d65420d47c280c0145d4e71ca21f8df184117ef3",
-   "notes": "prose synced from the .py at 2026-09-11T00:40:46.688821+00:00 without re-executing; every code cell is identical to blob 779e71293b6e"
+   "source_py_blob": "964a2cb79c00cb06b3bd388fefa10e7cd36e76c0"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 35.764581,
-   "end_time": "2026-09-11T00:39:23.897457+00:00",
+   "duration": 34.663913,
+   "end_time": "2026-09-11T00:48:53.129578+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "~/ml4t/public-teach-g/25_live_trading/.02_etfs_deployment_loop.build.629375.ipynb",
-   "output_path": "~/ml4t/public-teach-g/25_live_trading/.02_etfs_deployment_loop.papermill.629375.ipynb",
+   "input_path": "~/ml4t/public-teach-g/25_live_trading/.02_etfs_deployment_loop.build.694628.ipynb",
+   "output_path": "~/ml4t/public-teach-g/25_live_trading/.02_etfs_deployment_loop.papermill.694628.ipynb",
    "parameters": {},
-   "start_time": "2026-09-11T00:38:48.132876+00:00",
+   "start_time": "2026-09-11T00:48:18.465665+00:00",
    "version": "2.7.0"
   }
  },

--- a/25_live_trading/02_etfs_deployment_loop.py
+++ b/25_live_trading/02_etfs_deployment_loop.py
@@ -72,8 +72,8 @@
 # - FRED macro data under `ML4T_DATA_PATH/macro` (for the yield-curve
 #   regime feature).
 # - The ETFs case study's forward-return label parquet and its registry,
-#   both reached through `get_case_study_dir("etfs")` so a run with
-#   `ML4T_OUTPUT_DIR` set reads the tree that run wrote.
+#   by default `case_studies/etfs/labels/fwd_ret_21d.parquet` and
+#   `case_studies/etfs/run_log/registry.db`.
 # - Alpaca paper credentials in `ALPACA_API_KEY` / `ALPACA_SECRET_KEY`
 #   (free at <https://app.alpaca.markets/paper>).
 

--- a/25_live_trading/02_etfs_deployment_loop.py
+++ b/25_live_trading/02_etfs_deployment_loop.py
@@ -83,6 +83,7 @@ import json
 import logging
 import os
 import pickle
+import sqlite3
 import warnings
 from datetime import UTC, datetime
 from pathlib import Path
@@ -96,7 +97,7 @@ from sklearn.linear_model import Ridge
 from sklearn.preprocessing import StandardScaler
 
 from data import load_etfs, load_macro
-from utils.paths import display_path, get_chapter_dir, get_output_dir
+from utils.paths import display_path, get_case_study_dir, get_chapter_dir, get_output_dir
 from utils.style import COLORS, add_message_title, show_with_alt
 
 CHAPTER_DIR = get_chapter_dir(25)
@@ -118,11 +119,12 @@ for _noisy in ("ml4t", "mlquant", "mlquant.features"):
     logging.getLogger(_noisy).setLevel(logging.WARNING)
 
 # %% tags=["parameters"]
-RIDGE_ALPHA = 1_000_000.0  # ridge_a1000000.0 from the ETF case study's CV sweep
+EXPECTED_RIDGE_CONFIG = "ridge_a1000000.0"  # None reports the registry's pick instead of asserting
 PRIMARY_LABEL = "fwd_ret_21d"
 LIVE_WINDOW_START = "2025-01-01"  # cross-sections from here become "live" predictions
 FORWARD_HORIZON_DAYS = 21  # fwd_ret_21d label horizon (trading days)
 TOP_K = 5
+CASH_BUFFER = 0.02  # share of the account left unallocated, so a next-bar fill is affordable
 REBALANCE_EVERY_N_DAYS = 21  # match the label horizon
 INITIAL_CASH = 100_000.0
 COMMISSION_RATE = 0.0005
@@ -205,11 +207,83 @@ print(f"Features: {features.shape}, {len(fc)} feature columns")
 #
 # The deployment fit is a **single Ridge regression on the full extended
 # panel** - no walk-forward CV, no per-fold scaling, no hyperparameter
-# search. The hyperparameters come from the case study (`α = 10⁶` is the
-# highest-validation-IC Ridge configuration in the ETFs registry); we adopt it here
-# rather than re-deriving them. This separates the *research artefact*
+# search. The regularisation strength comes from the case study rather
+# than from a sweep here, which separates the *research artefact*
 # (registry-stored, CV-evaluated, IC-reported) from the *deployment
 # artefact* (single fit, full history, governed path).
+#
+# ### Where the regularisation strength comes from
+#
+# A borrowed hyperparameter that sits in the parameters cell as a literal is a number nobody can
+# check: the registry's leader can move on the next sweep and nothing here would notice. The cell
+# below asks the registry which Ridge configuration leads on validation IC for this label, reads
+# the alpha out of that run's resolved specification, and checks the answer against
+# `EXPECTED_RIDGE_CONFIG`. Setting that pin to `None` reports the registry's pick instead of
+# asserting it, which is what to do when the case study is deliberately re-swept.
+#
+# The pin names a **configuration**, not a training hash. A refit re-keys the hash while selecting
+# the same configuration, so a hash pin would fire on runs where nothing had changed.
+
+# %%
+registry_path = get_case_study_dir("etfs") / "run_log" / "registry.db"
+registry_uri = f"{registry_path.resolve().as_uri()}?mode=ro&immutable=1"
+with sqlite3.connect(registry_uri, uri=True) as conn:
+    winner = conn.execute(
+        """SELECT tr.config_name, tr.spec_json, pm.ic_mean
+           FROM training_runs tr
+           JOIN prediction_sets ps ON ps.training_hash = tr.training_hash
+           JOIN prediction_metrics pm ON pm.prediction_hash = ps.prediction_hash
+           WHERE tr.family = 'linear'
+             AND tr.label = ?
+             AND tr.config_name LIKE 'ridge_%'
+             AND ps.split = 'validation'
+           ORDER BY pm.ic_mean DESC
+           LIMIT 1""",
+        (PRIMARY_LABEL,),
+    ).fetchone()
+if winner is None:
+    raise RuntimeError(
+        f"The ETFs registry holds no validated Ridge run for {PRIMARY_LABEL}; "
+        "the case study's linear stage has to run before this notebook can borrow from it."
+    )
+SOURCE_CONFIG, source_spec_json, source_ic = winner
+source_spec = json.loads(source_spec_json)
+
+# Every fold of a sweep configuration is fitted at one alpha; a set with more than one member
+# would mean the configuration name no longer identifies a single regularisation strength.
+fold_alphas = {
+    params["alpha"]
+    for params in source_spec["computation"]["model"]["effective_params_by_fold"].values()
+}
+if len(fold_alphas) != 1:
+    raise RuntimeError(f"{SOURCE_CONFIG} was fitted at more than one alpha: {sorted(fold_alphas)}")
+RIDGE_ALPHA = float(fold_alphas.pop())
+
+# The artefacts the source run read are what its feature set was; "label" is the target, not a
+# feature family.
+SOURCE_FEATURE_SETS = sorted(set(source_spec["computation"]["feature_artifacts"]) - {"label"})
+
+# `_etfs_features.compute_financial_features` builds exactly the financial families, so this names
+# what was fitted above rather than restating an intention.
+DEPLOYED_FEATURE_SETS = ["financial"]
+
+assert EXPECTED_RIDGE_CONFIG in (None, SOURCE_CONFIG), (
+    f"The registry now leads with {SOURCE_CONFIG}, not {EXPECTED_RIDGE_CONFIG}. "
+    "Re-pin deliberately rather than following the leader silently."
+)
+print(f"Registry leader on validation IC: {SOURCE_CONFIG}  (IC {source_ic:.4f})")
+print(f"  alpha:        {RIDGE_ALPHA:g}")
+print(f"  tuned on:     {SOURCE_FEATURE_SETS}")
+print(f"  deployed on:  {DEPLOYED_FEATURE_SETS}")
+
+# %% [markdown]
+# The two feature lists differ, and the difference is the cost of the transfer. The registry's
+# leader was tuned with the model-based families alongside the financial ones; this notebook fits
+# the financial families alone, because an HMM and a GARCH refit per symbol on every data update is
+# what the deployment declines to pay for. An alpha selected against one feature set is not
+# selected against another, so the number below is a starting point carried over from research,
+# not a tuned value for the model actually fitted here. Nothing in this notebook re-derives it, and
+# a deployment that wanted it re-derived would sweep on its own feature set.
 
 # %%
 labels = pl.read_parquet(
@@ -298,8 +372,9 @@ training_metadata = {
     "model_class": "sklearn.linear_model.Ridge",
     "ridge_alpha": RIDGE_ALPHA,
     "source_case_study": "etfs",
-    "source_config_name": f"ridge_a{RIDGE_ALPHA:g}",
-    "source_feature_sets": ["financial"],  # deployment dropped model_based
+    "source_config_name": SOURCE_CONFIG,
+    "source_config_feature_sets": SOURCE_FEATURE_SETS,  # what the alpha was tuned on
+    "deployed_feature_sets": DEPLOYED_FEATURE_SETS,  # what this fit used
     "intercept": float(model.intercept_),
     "coef_l2_norm": float(np.linalg.norm(model.coef_)),
 }
@@ -328,7 +403,13 @@ live_panel = live_panel.filter(~pl.all_horizontal([pl.col(c).is_null() for c in 
 X_live = live_panel.select(fc).to_numpy()
 preds = model.predict(scaler.transform(imputer.transform(X_live)))
 predictions = live_panel.select(["timestamp", "symbol"]).with_columns(pl.Series("score", preds))
-assert predictions["timestamp"].max() == live_panel["timestamp"].max()
+# The live window must reach the end of the feature panel: a prediction tape that stops short is
+# how a deployment silently scores a stale cross-section. Comparing against `predictions` itself
+# would compare the frame with a copy of its own column and could not fail.
+assert predictions["timestamp"].max() == features["timestamp"].max(), (
+    f"Predictions stop at {predictions['timestamp'].max()} but features run to "
+    f"{features['timestamp'].max()}; the newest cross-section carries no score."
+)
 print(
     f"Predictions over live window: {len(predictions):,} rows on {predictions['timestamp'].n_unique()} dates"
 )
@@ -341,6 +422,13 @@ print(
 # `on_data` interface is identical to every other strategy in this
 # chapter: receive the bar dictionary, look up the prediction frame for
 # the current timestamp, compute target weights, route orders.
+#
+# Positions are sized against the broker's current account value rather than `INITIAL_CASH`, so
+# leverage stays constant as profit and loss accrue, and against slightly less than all of it.
+# `CASH_BUFFER` is what the order is sized on the current bar's close but fills at the next bar's:
+# an overnight move against the position, plus commission, makes a basket sized at the full account
+# value unaffordable, and the broker answers that by rejecting the last leg rather than by filling
+# it smaller.
 
 
 # %%
@@ -354,11 +442,13 @@ class CrossSectionalRidgeStrategy(Strategy):
         top_k: int,
         rebalance_every: int,
         symbols: list[str],
+        cash_buffer: float,
     ):
         self.predictions = predictions
         self.top_k = top_k
         self.rebalance_every = rebalance_every
         self.symbols = symbols
+        self.cash_buffer = cash_buffer
         self._bars_seen = 0
         self.signal_log: list[dict] = []
         self.rebalance_log: list[dict] = []
@@ -384,10 +474,7 @@ class CrossSectionalRidgeStrategy(Strategy):
         self.rebalance_log.append({"timestamp": timestamp, "targets": targets})
         prices = {s: data[s]["close"] for s in self.symbols if s in data}
 
-        # Size positions against the broker's current account value rather
-        # than INITIAL_CASH so leverage stays constant as PnL accrues across
-        # rebalances.
-        account_value = broker.get_account_value()
+        account_value = broker.get_account_value() * (1.0 - self.cash_buffer)
 
         for symbol in self.symbols:
             position = broker.get_position(symbol)
@@ -451,6 +538,7 @@ strategy_backtest = CrossSectionalRidgeStrategy(
     top_k=TOP_K,
     rebalance_every=REBALANCE_EVERY_N_DAYS,
     symbols=ALL_SYMBOLS,
+    cash_buffer=CASH_BUFFER,
 )
 engine_backtest = Engine(
     feed=feed_backtest,
@@ -466,6 +554,26 @@ assert strategy_backtest.rebalance_log, "Offline replay produced no scheduled re
 print(f"Backtest final value: ${backtest_results['final_value']:,.2f}")
 print(f"Backtest total return: {backtest_results['total_return_pct']:.2f}%")
 print(f"Backtest signals: {len(strategy_backtest.signal_log)}")
+
+# %% [markdown]
+# The replay is read below as the deterministic record of what the deployment would have done, so
+# an order it emitted and the broker refused has to stop it being read that way. The same four
+# buckets the live leg reports apply here: a signal the strategy logged is intended, and only a
+# filled order is accepted. Sizing every leg at the full account value produced eight rejections
+# over this window before `CASH_BUFFER` existed, and nothing in the notebook looked.
+
+# %%
+order_status_counts: dict[str, int] = {}
+for order in engine_backtest.broker.orders:
+    name = order.status.name if hasattr(order.status, "name") else str(order.status)
+    order_status_counts[name] = order_status_counts.get(name, 0) + 1
+print(f"Offline order dispositions: {dict(sorted(order_status_counts.items()))}")
+unfilled = {k: v for k, v in order_status_counts.items() if k != "FILLED"}
+assert not unfilled, (
+    f"The offline replay did not place the basket it logged: {unfilled}. "
+    "A rejected order means the reference tape and the strategy's own signal log disagree, "
+    "so the reconciliation below would compare an intended basket against one never held."
+)
 
 # %% [markdown]
 # ### What the replay looks like over the window
@@ -492,15 +600,16 @@ axes[1].set_ylabel("Drawdown (%)")
 axes[1].set_xlabel("Date")
 add_message_title(
     axes[0],
-    "The offline replay of the live window, and what it gave back on the way",
+    "Account value and drawdown over the live window",
     subtitle="Deterministic replay through the backtest engine, not a live result",
 )
 show_with_alt(
     fig,
-    "Two stacked panels over the live window. The upper panel is account value against a dashed "
-    f"line at the {INITIAL_CASH:,.0f} starting balance, ending at "
-    f"{backtest_results['final_value']:,.0f}. The lower panel is drawdown from the running peak, "
-    f"reaching {drawdown.min():.1%} at its worst.",
+    "Two panels sharing a date axis over the live window. The upper panel traces account value "
+    "against a dashed line at the starting balance, "
+    + ("ending above it" if backtest_results["final_value"] >= INITIAL_CASH else "ending below it")
+    + ". The lower panel shades the drawdown from the running peak, which returns to zero at each "
+    "new high and reaches its deepest point early in the window.",
 )
 
 # %% [markdown]
@@ -796,12 +905,16 @@ print(f"Run metadata: {display_path(run_path)}")
 #   extended panel and a single train pass, not the case study's
 #   walk-forward CV.
 # - **The financial-only feature subset is a deliberate operational
-#   simplification.** Dropping HMM regimes and GARCH conditional
-#   volatility makes the refit complete in seconds instead of minutes; the
-#   resulting feature set is slightly weaker but cheap enough to refit on
-#   every data update.
-# - **Retrain cadence is monthly, not per-prediction.** The live trading
-#   loop re-runs the prediction and offline-reference steps daily against
-#   the persisted artefact and revisits the refit only when the artefact
-#   has aged past the configured window; Chapter 26 picks up the
+#   simplification, and it is not free.** Dropping HMM regimes and GARCH
+#   conditional volatility makes the refit complete in seconds instead of
+#   minutes. It also means the alpha this notebook borrows was selected
+#   against a feature set the deployment does not use, which the run
+#   prints rather than leaves implicit. What that costs in forecast
+#   quality is not measured here; measuring it means sweeping on the
+#   deployment's own feature set.
+# - **This notebook refits once per run, and does not decide how often to
+#   run.** Prediction and the offline reference could be re-run daily
+#   against a persisted artefact while the refit happens far less often.
+#   Nothing here implements that split - the artefact carries
+#   `trained_at` so a scheduler can, and Chapter 26 picks up the
 #   cadence-decoupling discussion.

--- a/25_live_trading/02_etfs_deployment_loop.py
+++ b/25_live_trading/02_etfs_deployment_loop.py
@@ -286,15 +286,18 @@ print(f"Registry leader on validation IC: {SOURCE_CONFIG}  (IC {source_ic:.4f})"
 print(f"  alpha:        {RIDGE_ALPHA:g}")
 print(f"  tuned on:     {SOURCE_FEATURE_SETS}")
 print(f"  deployed on:  {DEPLOYED_FEATURE_SETS}")
+dropped_feature_sets = sorted(set(SOURCE_FEATURE_SETS) - set(DEPLOYED_FEATURE_SETS))
+print(f"  dropped here: {dropped_feature_sets or 'none'}")
 
 # %% [markdown]
-# The two feature lists differ, and the difference is the cost of the transfer. The registry's
-# leader was tuned with the model-based families alongside the financial ones; this notebook fits
-# the financial families alone, because an HMM and a GARCH refit per symbol on every data update is
-# what the deployment declines to pay for. An alpha selected against one feature set is not
-# selected against another, so the number below is a starting point carried over from research,
-# not a tuned value for the model actually fitted here. Nothing in this notebook re-derives it, and
-# a deployment that wanted it re-derived would sweep on its own feature set.
+# Whatever the run prints as dropped is the cost of the transfer. This notebook fits the financial
+# families alone, because an HMM and a GARCH refit per symbol on every data update is what the
+# deployment declines to pay for, and the configuration it borrows from was tuned on whichever
+# families the registry records against it. An alpha selected against one feature set is not
+# selected against another, so with anything in that dropped list the number below is a starting
+# point carried over from research rather than a tuned value for the model actually fitted here.
+# Nothing in this notebook re-derives it, and a deployment that wanted it re-derived would sweep on
+# its own feature set.
 
 # %%
 labels = pl.read_parquet(labels_path)
@@ -434,10 +437,10 @@ print(
 #
 # Positions are sized against the broker's current account value rather than `INITIAL_CASH`, so
 # leverage stays constant as profit and loss accrue, and against slightly less than all of it.
-# `CASH_BUFFER` is what the order is sized on the current bar's close but fills at the next bar's:
-# an overnight move against the position, plus commission, makes a basket sized at the full account
-# value unaffordable, and the broker answers that by refusing the last leg rather than by filling
-# it smaller. Two per cent is a margin measured on this window, not a guarantee - a basket that
+# `CASH_BUFFER` exists because the order is sized on the current bar's close and fills at the next
+# bar's: an overnight move against the position, plus commission, makes a basket sized at the full
+# account value unaffordable, and the broker answers that by refusing the last leg rather than by
+# filling it smaller. Two per cent is a margin measured on this window, not a guarantee - a basket that
 # gaps up about two per cent overnight is unaffordable again - and the disposition check below is
 # what turns that into a stop rather than a quietly short basket.
 
@@ -932,13 +935,13 @@ print(f"Run metadata: {display_path(run_path)}")
 #   extended panel and a single train pass, not the case study's
 #   walk-forward CV.
 # - **The financial-only feature subset is a deliberate operational
-#   simplification, and it is not free.** Dropping HMM regimes and GARCH
-#   conditional volatility makes the refit complete in seconds instead of
-#   minutes. It also means the alpha this notebook borrows was selected
+#   simplification, and it is not free.** Dropping the model-based
+#   families makes the refit complete in seconds instead of minutes. It
+#   also means the alpha this notebook borrows may have been selected
 #   against a feature set the deployment does not use, which the run
-#   prints rather than leaves implicit. What that costs in forecast
-#   quality is not measured here; measuring it means sweeping on the
-#   deployment's own feature set.
+#   prints as a dropped list rather than leaving implicit. What that
+#   costs in forecast quality is not measured here; measuring it means
+#   sweeping on the deployment's own feature set.
 # - **This notebook refits once per run, and does not decide how often to
 #   run.** Prediction and the offline reference could be re-run daily
 #   against a persisted artefact while the refit happens far less often.

--- a/25_live_trading/02_etfs_deployment_loop.py
+++ b/25_live_trading/02_etfs_deployment_loop.py
@@ -91,7 +91,15 @@ from pathlib import Path
 import matplotlib.pyplot as plt
 import numpy as np
 import polars as pl
-from ml4t.backtest import BacktestConfig, DataFeed, Engine, ExecutionMode, OrderSide, Strategy
+from ml4t.backtest import (
+    BacktestConfig,
+    DataFeed,
+    Engine,
+    ExecutionMode,
+    OrderSide,
+    OrderStatus,
+    Strategy,
+)
 from sklearn.impute import SimpleImputer
 from sklearn.linear_model import Ridge
 from sklearn.preprocessing import StandardScaler
@@ -226,7 +234,10 @@ print(f"Features: {features.shape}, {len(fc)} feature columns")
 
 # %%
 registry_path = get_case_study_dir("etfs") / "run_log" / "registry.db"
-registry_uri = f"{registry_path.resolve().as_uri()}?mode=ro&immutable=1"
+# Read-only, but not `immutable=1`: the registry is a WAL database that sweeps write to
+# concurrently, and an immutable connection ignores the -wal file and reads the pre-WAL main
+# file, which shows up here as a stale leader or as a table that appears not to exist.
+registry_uri = f"{registry_path.resolve().as_uri()}?mode=ro"
 with sqlite3.connect(registry_uri, uri=True) as conn:
     winner = conn.execute(
         """SELECT tr.config_name, tr.spec_json, pm.ic_mean
@@ -427,8 +438,10 @@ print(
 # leverage stays constant as profit and loss accrue, and against slightly less than all of it.
 # `CASH_BUFFER` is what the order is sized on the current bar's close but fills at the next bar's:
 # an overnight move against the position, plus commission, makes a basket sized at the full account
-# value unaffordable, and the broker answers that by rejecting the last leg rather than by filling
-# it smaller.
+# value unaffordable, and the broker answers that by refusing the last leg rather than by filling
+# it smaller. Two per cent is a margin measured on this window, not a guarantee - a basket that
+# gaps up about two per cent overnight is unaffordable again - and the disposition check below is
+# what turns that into a stop rather than a quietly short basket.
 
 
 # %%
@@ -559,19 +572,34 @@ print(f"Backtest signals: {len(strategy_backtest.signal_log)}")
 # The replay is read below as the deterministic record of what the deployment would have done, so
 # an order it emitted and the broker refused has to stop it being read that way. The same four
 # buckets the live leg reports apply here: a signal the strategy logged is intended, and only a
-# filled order is accepted. Sizing every leg at the full account value produced eight rejections
+# filled order is accepted. Sizing every leg at the full account value produced eight refusals
 # over this window before `CASH_BUFFER` existed, and nothing in the notebook looked.
+#
+# An order still pending on the last bar is a different thing and is counted separately. Under
+# `NEXT_BAR` the engine fills an order at the start of the following bar, and the final bar has
+# no following bar, so a rebalance that lands on the last day of the window leaves its whole
+# basket unfilled. That is the replay running out of tape, not the broker refusing anything.
 
 # %%
-order_status_counts: dict[str, int] = {}
+last_bar_ts = engine_backtest.equity_curve[-1][0]
+refused, pending_at_end = [], []
 for order in engine_backtest.broker.orders:
-    name = order.status.name if hasattr(order.status, "name") else str(order.status)
-    order_status_counts[name] = order_status_counts.get(name, 0) + 1
-print(f"Offline order dispositions: {dict(sorted(order_status_counts.items()))}")
-unfilled = {k: v for k, v in order_status_counts.items() if k != "FILLED"}
-assert not unfilled, (
-    f"The offline replay did not place the basket it logged: {unfilled}. "
-    "A rejected order means the reference tape and the strategy's own signal log disagree, "
+    if order.status is OrderStatus.FILLED:
+        continue
+    if order.status is OrderStatus.PENDING and order.created_at == last_bar_ts:
+        pending_at_end.append(order)
+    else:
+        refused.append(order)
+
+print(f"Offline orders: {len(engine_backtest.broker.orders)}")
+print(f"  filled:              {len(engine_backtest.broker.fills)}")
+print(f"  unfilled at the end: {len(pending_at_end)}")
+print(f"  refused:             {len(refused)}")
+for order in refused[:5]:
+    print(f"    {order.asset} {order.side.value} {order.quantity:g}: {order.rejection_reason}")
+assert not refused, (
+    f"The offline replay did not place the basket it logged: {len(refused)} order(s) refused. "
+    "A refused order means the reference tape and the strategy's own signal log disagree, "
     "so the reconciliation below would compare an intended basket against one never held."
 )
 
@@ -609,7 +637,8 @@ show_with_alt(
     "against a dashed line at the starting balance, "
     + ("ending above it" if backtest_results["final_value"] >= INITIAL_CASH else "ending below it")
     + ". The lower panel shades the drawdown from the running peak, which returns to zero at each "
-    "new high and reaches its deepest point early in the window.",
+    "new high; its deepest point falls in "
+    f"{equity_dates[int(np.argmin(drawdown))]:%B %Y}.",
 )
 
 # %% [markdown]

--- a/25_live_trading/02_etfs_deployment_loop.py
+++ b/25_live_trading/02_etfs_deployment_loop.py
@@ -71,8 +71,9 @@
 # - ETF data downloaded under `ML4T_DATA_PATH/etfs/market`.
 # - FRED macro data under `ML4T_DATA_PATH/macro` (for the yield-curve
 #   regime feature).
-# - Forward-return label parquet at
-#   `case_studies/etfs/labels/fwd_ret_21d.parquet`.
+# - The ETFs case study's forward-return label parquet and its registry,
+#   both reached through `get_case_study_dir("etfs")` so a run with
+#   `ML4T_OUTPUT_DIR` set reads the tree that run wrote.
 # - Alpaca paper credentials in `ALPACA_API_KEY` / `ALPACA_SECRET_KEY`
 #   (free at <https://app.alpaca.markets/paper>).
 
@@ -91,6 +92,8 @@ from pathlib import Path
 import matplotlib.pyplot as plt
 import numpy as np
 import polars as pl
+from _etfs_features import build_yield_curve, compute_financial_features, feature_columns
+from async_utils import run_async
 from ml4t.backtest import (
     BacktestConfig,
     DataFeed,
@@ -105,13 +108,8 @@ from sklearn.linear_model import Ridge
 from sklearn.preprocessing import StandardScaler
 
 from data import load_etfs, load_macro
-from utils.paths import display_path, get_case_study_dir, get_chapter_dir, get_output_dir
+from utils.paths import display_path, get_case_study_dir, get_output_dir
 from utils.style import COLORS, add_message_title, show_with_alt
-
-CHAPTER_DIR = get_chapter_dir(25)
-
-from _etfs_features import build_yield_curve, compute_financial_features, feature_columns
-from async_utils import run_async
 
 # basicConfig is a no-op once a handler exists, and importing the feature libraries installs one,
 # so configuring the root logger here would leave two handlers attached and print every line
@@ -233,7 +231,9 @@ print(f"Features: {features.shape}, {len(fc)} feature columns")
 # the same configuration, so a hash pin would fire on runs where nothing had changed.
 
 # %%
-registry_path = get_case_study_dir("etfs") / "run_log" / "registry.db"
+etfs_dir = get_case_study_dir("etfs")
+labels_path = etfs_dir / "labels" / f"{PRIMARY_LABEL}.parquet"
+registry_path = etfs_dir / "run_log" / "registry.db"
 # Read-only, but not `immutable=1`: the registry is a WAL database that sweeps write to
 # concurrently, and an immutable connection ignores the -wal file and reads the pre-WAL main
 # file, which shows up here as a stale leader or as a table that appears not to exist.
@@ -297,9 +297,7 @@ print(f"  deployed on:  {DEPLOYED_FEATURE_SETS}")
 # a deployment that wanted it re-derived would sweep on its own feature set.
 
 # %%
-labels = pl.read_parquet(
-    CHAPTER_DIR.parent / "case_studies" / "etfs" / "labels" / f"{PRIMARY_LABEL}.parquet"
-)
+labels = pl.read_parquet(labels_path)
 panel = features.join(labels, on=["timestamp", "symbol"], how="inner")
 print(f"Joined panel: {len(panel):,} rows over {panel['symbol'].n_unique()} symbols")
 

--- a/25_live_trading/06_quantconnect_case_study.ipynb
+++ b/25_live_trading/06_quantconnect_case_study.ipynb
@@ -2,13 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "8f3288bd",
+   "id": "39b6ce63",
    "metadata": {
     "papermill": {
-     "duration": 0.002435,
-     "end_time": "2026-09-09T00:57:38.724622+00:00",
+     "duration": 0.004511,
+     "end_time": "2026-09-11T00:33:42.503904+00:00",
      "exception": false,
-     "start_time": "2026-09-09T00:57:38.722187+00:00",
+     "start_time": "2026-09-11T00:33:42.499393+00:00",
      "status": "completed"
     }
    },
@@ -47,13 +47,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0b463add",
+   "id": "c593fc02",
    "metadata": {
     "papermill": {
-     "duration": 0.002194,
-     "end_time": "2026-09-09T00:57:38.728974+00:00",
+     "duration": 0.001868,
+     "end_time": "2026-09-11T00:33:42.508598+00:00",
      "exception": false,
-     "start_time": "2026-09-09T00:57:38.726780+00:00",
+     "start_time": "2026-09-11T00:33:42.506730+00:00",
      "status": "completed"
     }
    },
@@ -68,19 +68,19 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "9a09dc3c",
+   "id": "54db3788",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T00:57:38.733738Z",
-     "iopub.status.busy": "2026-09-09T00:57:38.733615Z",
-     "iopub.status.idle": "2026-09-09T00:57:40.543196Z",
-     "shell.execute_reply": "2026-09-09T00:57:40.542717Z"
+     "iopub.execute_input": "2026-09-11T00:33:42.512595Z",
+     "iopub.status.busy": "2026-09-11T00:33:42.512447Z",
+     "iopub.status.idle": "2026-09-11T00:33:43.931353Z",
+     "shell.execute_reply": "2026-09-11T00:33:43.930827Z"
     },
     "papermill": {
-     "duration": 1.813028,
-     "end_time": "2026-09-09T00:57:40.543962+00:00",
+     "duration": 1.421686,
+     "end_time": "2026-09-11T00:33:43.931956+00:00",
      "exception": false,
-     "start_time": "2026-09-09T00:57:38.730934+00:00",
+     "start_time": "2026-09-11T00:33:42.510270+00:00",
      "status": "completed"
     }
    },
@@ -103,13 +103,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3c742160",
+   "id": "6914579b",
    "metadata": {
     "papermill": {
-     "duration": 0.001868,
-     "end_time": "2026-09-09T00:57:40.548128+00:00",
+     "duration": 0.002098,
+     "end_time": "2026-09-11T00:33:43.935378+00:00",
      "exception": false,
-     "start_time": "2026-09-09T00:57:40.546260+00:00",
+     "start_time": "2026-09-11T00:33:43.933280+00:00",
      "status": "completed"
     }
    },
@@ -136,20 +136,20 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "8d7f2738",
+   "id": "838df85d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T00:57:40.552727Z",
-     "iopub.status.busy": "2026-09-09T00:57:40.552630Z",
-     "iopub.status.idle": "2026-09-09T00:57:40.554496Z",
-     "shell.execute_reply": "2026-09-09T00:57:40.554225Z"
+     "iopub.execute_input": "2026-09-11T00:33:43.938551Z",
+     "iopub.status.busy": "2026-09-11T00:33:43.938457Z",
+     "iopub.status.idle": "2026-09-11T00:33:43.940478Z",
+     "shell.execute_reply": "2026-09-11T00:33:43.940120Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.004987,
-     "end_time": "2026-09-09T00:57:40.555047+00:00",
+     "duration": 0.004218,
+     "end_time": "2026-09-11T00:33:43.941066+00:00",
      "exception": false,
-     "start_time": "2026-09-09T00:57:40.550060+00:00",
+     "start_time": "2026-09-11T00:33:43.936848+00:00",
      "status": "completed"
     },
     "tags": [
@@ -167,19 +167,19 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "efbbfacc",
+   "id": "56e3cda0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T00:57:40.559532Z",
-     "iopub.status.busy": "2026-09-09T00:57:40.559461Z",
-     "iopub.status.idle": "2026-09-09T00:57:40.628377Z",
-     "shell.execute_reply": "2026-09-09T00:57:40.628059Z"
+     "iopub.execute_input": "2026-09-11T00:33:43.943727Z",
+     "iopub.status.busy": "2026-09-11T00:33:43.943658Z",
+     "iopub.status.idle": "2026-09-11T00:33:44.015058Z",
+     "shell.execute_reply": "2026-09-11T00:33:44.014402Z"
     },
     "papermill": {
-     "duration": 0.071723,
-     "end_time": "2026-09-09T00:57:40.628826+00:00",
+     "duration": 0.073237,
+     "end_time": "2026-09-11T00:33:44.015430+00:00",
      "exception": false,
-     "start_time": "2026-09-09T00:57:40.557103+00:00",
+     "start_time": "2026-09-11T00:33:43.942193+00:00",
      "status": "completed"
     }
    },
@@ -188,7 +188,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Registry SHA256: a9c522b237730fca75dce9027fac0b033c35adb3d854ef46c98a65744a3d603b\n",
+      "Registry SHA256: c8313b3860031c56608a30045b121dc753810540dda0511b301fe474f7705392\n",
       "Prediction parquet SHA256: 2efad22dbf40464939d143745116165c6447c3e4dfd154bd608dda8653b52925\n",
       "Training hash: ab5300c0cda4 | holdout prediction hash: 0afd2e256128\n",
       "Selection stage: risk_overlay | backtest hash: 18c7a8419306\n",
@@ -241,7 +241,11 @@
     "registry_path = case_study_dir / \"run_log\" / \"registry.db\"\n",
     "registry_hash_before = hashlib.sha256(registry_path.read_bytes()).hexdigest()\n",
     "\n",
-    "registry_uri = f\"{registry_path.resolve().as_uri()}?mode=ro&immutable=1\"\n",
+    "# Read-only, and deliberately not `immutable=1`. That flag promises SQLite the file cannot move\n",
+    "# while it is open, which lets it skip WAL recovery; it holds for a released case directory and\n",
+    "# not for a live one a sweep may be writing, and an immutable read of a database with an\n",
+    "# uncheckpointed WAL sees the pre-WAL main file.\n",
+    "registry_uri = f\"{registry_path.resolve().as_uri()}?mode=ro\"\n",
     "with sqlite3.connect(registry_uri, uri=True) as conn:\n",
     "    winner = conn.execute(\n",
     "        \"\"\"SELECT ps.training_hash, br.backtest_hash, br.stage, bm.sharpe\n",
@@ -328,13 +332,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fba8f7cf",
+   "id": "03b8440b",
    "metadata": {
     "papermill": {
-     "duration": 0.001107,
-     "end_time": "2026-09-09T00:57:40.631303+00:00",
+     "duration": 0.001126,
+     "end_time": "2026-09-11T00:33:44.017897+00:00",
      "exception": false,
-     "start_time": "2026-09-09T00:57:40.630196+00:00",
+     "start_time": "2026-09-11T00:33:44.016771+00:00",
      "status": "completed"
     }
    },
@@ -352,13 +356,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b48a2094",
+   "id": "2aa031c1",
    "metadata": {
     "papermill": {
-     "duration": 0.001105,
-     "end_time": "2026-09-09T00:57:40.633546+00:00",
+     "duration": 0.001038,
+     "end_time": "2026-09-11T00:33:44.020058+00:00",
      "exception": false,
-     "start_time": "2026-09-09T00:57:40.632441+00:00",
+     "start_time": "2026-09-11T00:33:44.019020+00:00",
      "status": "completed"
     }
    },
@@ -375,19 +379,19 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "df28d260",
+   "id": "74ad9d6d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T00:57:40.636575Z",
-     "iopub.status.busy": "2026-09-09T00:57:40.636467Z",
-     "iopub.status.idle": "2026-09-09T00:57:40.647369Z",
-     "shell.execute_reply": "2026-09-09T00:57:40.646912Z"
+     "iopub.execute_input": "2026-09-11T00:33:44.022859Z",
+     "iopub.status.busy": "2026-09-11T00:33:44.022770Z",
+     "iopub.status.idle": "2026-09-11T00:33:44.031373Z",
+     "shell.execute_reply": "2026-09-11T00:33:44.031014Z"
     },
     "papermill": {
-     "duration": 0.013236,
-     "end_time": "2026-09-09T00:57:40.647967+00:00",
+     "duration": 0.010444,
+     "end_time": "2026-09-11T00:33:44.031621+00:00",
      "exception": false,
-     "start_time": "2026-09-09T00:57:40.634731+00:00",
+     "start_time": "2026-09-11T00:33:44.021177+00:00",
      "status": "completed"
     }
    },
@@ -439,19 +443,19 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "a2975e03",
+   "id": "4d15a454",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T00:57:40.653651Z",
-     "iopub.status.busy": "2026-09-09T00:57:40.653542Z",
-     "iopub.status.idle": "2026-09-09T00:57:40.655809Z",
-     "shell.execute_reply": "2026-09-09T00:57:40.655504Z"
+     "iopub.execute_input": "2026-09-11T00:33:44.034559Z",
+     "iopub.status.busy": "2026-09-11T00:33:44.034480Z",
+     "iopub.status.idle": "2026-09-11T00:33:44.036491Z",
+     "shell.execute_reply": "2026-09-11T00:33:44.036201Z"
     },
     "papermill": {
-     "duration": 0.005822,
-     "end_time": "2026-09-09T00:57:40.656282+00:00",
+     "duration": 0.003965,
+     "end_time": "2026-09-11T00:33:44.036830+00:00",
      "exception": false,
-     "start_time": "2026-09-09T00:57:40.650460+00:00",
+     "start_time": "2026-09-11T00:33:44.032865+00:00",
      "status": "completed"
     }
    },
@@ -482,13 +486,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2272c65f",
+   "id": "7b06a341",
    "metadata": {
     "papermill": {
-     "duration": 0.001144,
-     "end_time": "2026-09-09T00:57:40.658763+00:00",
+     "duration": 0.001089,
+     "end_time": "2026-09-11T00:33:44.039114+00:00",
      "exception": false,
-     "start_time": "2026-09-09T00:57:40.657619+00:00",
+     "start_time": "2026-09-11T00:33:44.038025+00:00",
      "status": "completed"
     }
    },
@@ -500,19 +504,19 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "b3a6cd74",
+   "id": "e7f04bf4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T00:57:40.661618Z",
-     "iopub.status.busy": "2026-09-09T00:57:40.661544Z",
-     "iopub.status.idle": "2026-09-09T00:57:40.678860Z",
-     "shell.execute_reply": "2026-09-09T00:57:40.678529Z"
+     "iopub.execute_input": "2026-09-11T00:33:44.041861Z",
+     "iopub.status.busy": "2026-09-11T00:33:44.041792Z",
+     "iopub.status.idle": "2026-09-11T00:33:44.058145Z",
+     "shell.execute_reply": "2026-09-11T00:33:44.057809Z"
     },
     "papermill": {
-     "duration": 0.01922,
-     "end_time": "2026-09-09T00:57:40.679167+00:00",
+     "duration": 0.018197,
+     "end_time": "2026-09-11T00:33:44.058459+00:00",
      "exception": false,
-     "start_time": "2026-09-09T00:57:40.659947+00:00",
+     "start_time": "2026-09-11T00:33:44.040262+00:00",
      "status": "completed"
     }
    },
@@ -540,13 +544,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b1f9bb68",
+   "id": "d577220b",
    "metadata": {
     "papermill": {
-     "duration": 0.001351,
-     "end_time": "2026-09-09T00:57:40.681997+00:00",
+     "duration": 0.001177,
+     "end_time": "2026-09-11T00:33:44.060947+00:00",
      "exception": false,
-     "start_time": "2026-09-09T00:57:40.680646+00:00",
+     "start_time": "2026-09-11T00:33:44.059770+00:00",
      "status": "completed"
     }
    },
@@ -562,13 +566,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ff9487d3",
+   "id": "e9dcc9bc",
    "metadata": {
     "papermill": {
-     "duration": 0.001163,
-     "end_time": "2026-09-09T00:57:40.684474+00:00",
+     "duration": 0.001124,
+     "end_time": "2026-09-11T00:33:44.063301+00:00",
      "exception": false,
-     "start_time": "2026-09-09T00:57:40.683311+00:00",
+     "start_time": "2026-09-11T00:33:44.062177+00:00",
      "status": "completed"
     }
    },
@@ -585,13 +589,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0da72a27",
+   "id": "e021a41b",
    "metadata": {
     "papermill": {
-     "duration": 0.001144,
-     "end_time": "2026-09-09T00:57:40.686911+00:00",
+     "duration": 0.00109,
+     "end_time": "2026-09-11T00:33:44.065629+00:00",
      "exception": false,
-     "start_time": "2026-09-09T00:57:40.685767+00:00",
+     "start_time": "2026-09-11T00:33:44.064539+00:00",
      "status": "completed"
     }
    },
@@ -633,13 +637,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9b8f0692",
+   "id": "746a72e9",
    "metadata": {
     "papermill": {
-     "duration": 0.002663,
-     "end_time": "2026-09-09T00:57:40.690854+00:00",
+     "duration": 0.001122,
+     "end_time": "2026-09-11T00:33:44.067934+00:00",
      "exception": false,
-     "start_time": "2026-09-09T00:57:40.688191+00:00",
+     "start_time": "2026-09-11T00:33:44.066812+00:00",
      "status": "completed"
     }
    },
@@ -662,19 +666,19 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "4d9e703e",
+   "id": "f9d393d9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T00:57:40.694262Z",
-     "iopub.status.busy": "2026-09-09T00:57:40.694078Z",
-     "iopub.status.idle": "2026-09-09T00:57:40.696644Z",
-     "shell.execute_reply": "2026-09-09T00:57:40.696347Z"
+     "iopub.execute_input": "2026-09-11T00:33:44.070782Z",
+     "iopub.status.busy": "2026-09-11T00:33:44.070713Z",
+     "iopub.status.idle": "2026-09-11T00:33:44.073262Z",
+     "shell.execute_reply": "2026-09-11T00:33:44.072849Z"
     },
     "papermill": {
-     "duration": 0.004957,
-     "end_time": "2026-09-09T00:57:40.697048+00:00",
+     "duration": 0.004624,
+     "end_time": "2026-09-11T00:33:44.073721+00:00",
      "exception": false,
-     "start_time": "2026-09-09T00:57:40.692091+00:00",
+     "start_time": "2026-09-11T00:33:44.069097+00:00",
      "status": "completed"
     }
    },
@@ -775,13 +779,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a4ca2c84",
+   "id": "6130ac77",
    "metadata": {
     "papermill": {
-     "duration": 0.002374,
-     "end_time": "2026-09-09T00:57:40.702061+00:00",
+     "duration": 0.001163,
+     "end_time": "2026-09-11T00:33:44.076120+00:00",
      "exception": false,
-     "start_time": "2026-09-09T00:57:40.699687+00:00",
+     "start_time": "2026-09-11T00:33:44.074957+00:00",
      "status": "completed"
     }
    },
@@ -799,13 +803,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "58b24b5a",
+   "id": "12981968",
    "metadata": {
     "papermill": {
-     "duration": 0.002179,
-     "end_time": "2026-09-09T00:57:40.706833+00:00",
+     "duration": 0.001118,
+     "end_time": "2026-09-11T00:33:44.078451+00:00",
      "exception": false,
-     "start_time": "2026-09-09T00:57:40.704654+00:00",
+     "start_time": "2026-09-11T00:33:44.077333+00:00",
      "status": "completed"
     }
    },
@@ -841,13 +845,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "827f42ec",
+   "id": "af8ba5a2",
    "metadata": {
     "papermill": {
-     "duration": 0.002174,
-     "end_time": "2026-09-09T00:57:40.711296+00:00",
+     "duration": 0.001142,
+     "end_time": "2026-09-11T00:33:44.080798+00:00",
      "exception": false,
-     "start_time": "2026-09-09T00:57:40.709122+00:00",
+     "start_time": "2026-09-11T00:33:44.079656+00:00",
      "status": "completed"
     }
    },
@@ -860,19 +864,19 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "a57b52ec",
+   "id": "ebaab77d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T00:57:40.714575Z",
-     "iopub.status.busy": "2026-09-09T00:57:40.714459Z",
-     "iopub.status.idle": "2026-09-09T00:57:40.718484Z",
-     "shell.execute_reply": "2026-09-09T00:57:40.718161Z"
+     "iopub.execute_input": "2026-09-11T00:33:44.083688Z",
+     "iopub.status.busy": "2026-09-11T00:33:44.083617Z",
+     "iopub.status.idle": "2026-09-11T00:33:44.087572Z",
+     "shell.execute_reply": "2026-09-11T00:33:44.087316Z"
     },
     "papermill": {
-     "duration": 0.006306,
-     "end_time": "2026-09-09T00:57:40.718890+00:00",
+     "duration": 0.005967,
+     "end_time": "2026-09-11T00:33:44.087989+00:00",
      "exception": false,
-     "start_time": "2026-09-09T00:57:40.712584+00:00",
+     "start_time": "2026-09-11T00:33:44.082022+00:00",
      "status": "completed"
     }
    },
@@ -923,19 +927,19 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "d6bd1815",
+   "id": "c3c65e41",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T00:57:40.722147Z",
-     "iopub.status.busy": "2026-09-09T00:57:40.722053Z",
-     "iopub.status.idle": "2026-09-09T00:57:40.832138Z",
-     "shell.execute_reply": "2026-09-09T00:57:40.831673Z"
+     "iopub.execute_input": "2026-09-11T00:33:44.090993Z",
+     "iopub.status.busy": "2026-09-11T00:33:44.090928Z",
+     "iopub.status.idle": "2026-09-11T00:33:44.184289Z",
+     "shell.execute_reply": "2026-09-11T00:33:44.183950Z"
     },
     "papermill": {
-     "duration": 0.112264,
-     "end_time": "2026-09-09T00:57:40.832611+00:00",
+     "duration": 0.095634,
+     "end_time": "2026-09-11T00:33:44.184955+00:00",
      "exception": false,
-     "start_time": "2026-09-09T00:57:40.720347+00:00",
+     "start_time": "2026-09-11T00:33:44.089321+00:00",
      "status": "completed"
     }
    },
@@ -984,19 +988,19 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "2bcfa0eb",
+   "id": "16a7ff94",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T00:57:40.838844Z",
-     "iopub.status.busy": "2026-09-09T00:57:40.838743Z",
-     "iopub.status.idle": "2026-09-09T00:57:40.917886Z",
-     "shell.execute_reply": "2026-09-09T00:57:40.917333Z"
+     "iopub.execute_input": "2026-09-11T00:33:44.190762Z",
+     "iopub.status.busy": "2026-09-11T00:33:44.190683Z",
+     "iopub.status.idle": "2026-09-11T00:33:44.258739Z",
+     "shell.execute_reply": "2026-09-11T00:33:44.258495Z"
     },
     "papermill": {
-     "duration": 0.082942,
-     "end_time": "2026-09-09T00:57:40.918544+00:00",
+     "duration": 0.071648,
+     "end_time": "2026-09-11T00:33:44.259405+00:00",
      "exception": false,
-     "start_time": "2026-09-09T00:57:40.835602+00:00",
+     "start_time": "2026-09-11T00:33:44.187757+00:00",
      "status": "completed"
     }
    },
@@ -1055,13 +1059,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "73ce9a0a",
+   "id": "76eed987",
    "metadata": {
     "papermill": {
-     "duration": 0.001666,
-     "end_time": "2026-09-09T00:57:40.922039+00:00",
+     "duration": 0.001533,
+     "end_time": "2026-09-11T00:33:44.262651+00:00",
      "exception": false,
-     "start_time": "2026-09-09T00:57:40.920373+00:00",
+     "start_time": "2026-09-11T00:33:44.261118+00:00",
      "status": "completed"
     }
    },
@@ -1079,13 +1083,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e218bb88",
+   "id": "8cf82a5d",
    "metadata": {
     "papermill": {
-     "duration": 0.001456,
-     "end_time": "2026-09-09T00:57:40.925087+00:00",
+     "duration": 0.001434,
+     "end_time": "2026-09-11T00:33:44.265607+00:00",
      "exception": false,
-     "start_time": "2026-09-09T00:57:40.923631+00:00",
+     "start_time": "2026-09-11T00:33:44.264173+00:00",
      "status": "completed"
     }
    },
@@ -1114,13 +1118,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d5d68b99",
+   "id": "d789ef62",
    "metadata": {
     "papermill": {
-     "duration": 0.001485,
-     "end_time": "2026-09-09T00:57:40.928161+00:00",
+     "duration": 0.001434,
+     "end_time": "2026-09-11T00:33:44.268571+00:00",
      "exception": false,
-     "start_time": "2026-09-09T00:57:40.926676+00:00",
+     "start_time": "2026-09-11T00:33:44.267137+00:00",
      "status": "completed"
     }
    },
@@ -1157,19 +1161,19 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "6be65b81",
+   "id": "ed3d09fb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T00:57:40.932233Z",
-     "iopub.status.busy": "2026-09-09T00:57:40.932095Z",
-     "iopub.status.idle": "2026-09-09T00:57:40.950092Z",
-     "shell.execute_reply": "2026-09-09T00:57:40.949753Z"
+     "iopub.execute_input": "2026-09-11T00:33:44.272126Z",
+     "iopub.status.busy": "2026-09-11T00:33:44.272036Z",
+     "iopub.status.idle": "2026-09-11T00:33:44.288194Z",
+     "shell.execute_reply": "2026-09-11T00:33:44.287899Z"
     },
     "papermill": {
-     "duration": 0.020659,
-     "end_time": "2026-09-09T00:57:40.950419+00:00",
+     "duration": 0.018527,
+     "end_time": "2026-09-11T00:33:44.288612+00:00",
      "exception": false,
-     "start_time": "2026-09-09T00:57:40.929760+00:00",
+     "start_time": "2026-09-11T00:33:44.270085+00:00",
      "status": "completed"
     }
    },
@@ -1178,7 +1182,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Registry unchanged after export and analysis: a9c522b237730fca75dce9027fac0b033c35adb3d854ef46c98a65744a3d603b\n"
+      "Registry unchanged after export and analysis: c8313b3860031c56608a30045b121dc753810540dda0511b301fe474f7705392\n"
      ]
     }
    ],
@@ -1211,24 +1215,24 @@
    "version": "3.14.3"
   },
   "ml4t_provenance": {
-   "executed_at": "2026-09-09T00:57:48.194107+00:00",
+   "executed_at": "2026-09-11T00:33:52.288553+00:00",
    "executor": "local-uv",
-   "library_digest": "36a36edafbfe56badef4c2d31166d5565af7ef9aa02a71001cfc1bc02759449f",
-   "outputs_digest": "38a2e865b414886cf572b385ddc27fd1b7b65ae2eea751e13defa1a69dd55963",
+   "library_digest": "7e58b187ca6aebc857aa811db8a932631d991f67d95d37bc9a77bc4f43baa193",
+   "outputs_digest": "918052e0eea528e4516722f36bf742d96869cd9a47dec819120efd66e064e7ed",
    "parameters": {},
    "production": true,
-   "source_py_blob": "6deaf3d2493aad2d78b39aef7c70749f98c7c48a"
+   "source_py_blob": "93459fc8a80610f62ce734a1bcabc3c4374b31aa"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 3.896198,
-   "end_time": "2026-09-09T00:57:41.968987+00:00",
+   "duration": 3.151872,
+   "end_time": "2026-09-11T00:33:45.004857+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "~/ml4t/public-teach-g/25_live_trading/.06_quantconnect_case_study.build.2909261.ipynb",
-   "output_path": "~/ml4t/public-teach-g/25_live_trading/.06_quantconnect_case_study.papermill.2909261.ipynb",
+   "input_path": "~/ml4t/public-teach-g/25_live_trading/.06_quantconnect_case_study.build.610849.ipynb",
+   "output_path": "~/ml4t/public-teach-g/25_live_trading/.06_quantconnect_case_study.papermill.610849.ipynb",
    "parameters": {},
-   "start_time": "2026-09-09T00:57:38.072789+00:00",
+   "start_time": "2026-09-11T00:33:41.852985+00:00",
    "version": "2.7.0"
   }
  },

--- a/25_live_trading/06_quantconnect_case_study.ipynb
+++ b/25_live_trading/06_quantconnect_case_study.ipynb
@@ -178,8 +178,8 @@
    },
    "source": [
     "The registry is opened read-only, and deliberately not with `immutable=1`. That flag promises\n",
-    "SQLite the file cannot move while it is open, which lets it skip locking and WAL recovery. It\n",
-    "holds for a released case directory and not for a live one a sweep may be writing, and an\n",
+    "SQLite the database cannot change while it is open, which lets it skip locking and WAL recovery.\n",
+    "That holds for a released case directory and not for a live one a sweep may be writing, and an\n",
     "immutable read of a database with an uncheckpointed write-ahead log sees the pre-WAL main file:\n",
     "a stale configuration selected silently, or a table that appears not to exist."
    ]
@@ -1237,7 +1237,8 @@
    "outputs_digest": "918052e0eea528e4516722f36bf742d96869cd9a47dec819120efd66e064e7ed",
    "parameters": {},
    "production": true,
-   "source_py_blob": "01c130b28095c80d2fc57a5134c1e0c567fd37ec"
+   "source_py_blob": "d172ac58837f823f69ae0c670fe568697a1b0857",
+   "notes": "prose synced from the .py at 2026-09-11T00:48:09.896584+00:00 without re-executing; every code cell is identical to blob 01c130b28095"
   },
   "papermill": {
    "default_parameters": {},

--- a/25_live_trading/06_quantconnect_case_study.ipynb
+++ b/25_live_trading/06_quantconnect_case_study.ipynb
@@ -2,13 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "39b6ce63",
+   "id": "a3db3c3e",
    "metadata": {
     "papermill": {
-     "duration": 0.004511,
-     "end_time": "2026-09-11T00:33:42.503904+00:00",
+     "duration": 0.001429,
+     "end_time": "2026-09-11T00:34:25.146187+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:33:42.499393+00:00",
+     "start_time": "2026-09-11T00:34:25.144758+00:00",
      "status": "completed"
     }
    },
@@ -47,13 +47,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c593fc02",
+   "id": "89b2e25f",
    "metadata": {
     "papermill": {
-     "duration": 0.001868,
-     "end_time": "2026-09-11T00:33:42.508598+00:00",
+     "duration": 0.000968,
+     "end_time": "2026-09-11T00:34:25.148373+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:33:42.506730+00:00",
+     "start_time": "2026-09-11T00:34:25.147405+00:00",
      "status": "completed"
     }
    },
@@ -68,19 +68,19 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "54db3788",
+   "id": "ec12cf28",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:33:42.512595Z",
-     "iopub.status.busy": "2026-09-11T00:33:42.512447Z",
-     "iopub.status.idle": "2026-09-11T00:33:43.931353Z",
-     "shell.execute_reply": "2026-09-11T00:33:43.930827Z"
+     "iopub.execute_input": "2026-09-11T00:34:25.151568Z",
+     "iopub.status.busy": "2026-09-11T00:34:25.151452Z",
+     "iopub.status.idle": "2026-09-11T00:34:26.566836Z",
+     "shell.execute_reply": "2026-09-11T00:34:26.566307Z"
     },
     "papermill": {
-     "duration": 1.421686,
-     "end_time": "2026-09-11T00:33:43.931956+00:00",
+     "duration": 1.41776,
+     "end_time": "2026-09-11T00:34:26.567351+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:33:42.510270+00:00",
+     "start_time": "2026-09-11T00:34:25.149591+00:00",
      "status": "completed"
     }
    },
@@ -103,13 +103,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6914579b",
+   "id": "cfbcafbe",
    "metadata": {
     "papermill": {
-     "duration": 0.002098,
-     "end_time": "2026-09-11T00:33:43.935378+00:00",
+     "duration": 0.0016,
+     "end_time": "2026-09-11T00:34:26.570305+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:33:43.933280+00:00",
+     "start_time": "2026-09-11T00:34:26.568705+00:00",
      "status": "completed"
     }
    },
@@ -136,20 +136,20 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "838df85d",
+   "id": "cab2061b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:33:43.938551Z",
-     "iopub.status.busy": "2026-09-11T00:33:43.938457Z",
-     "iopub.status.idle": "2026-09-11T00:33:43.940478Z",
-     "shell.execute_reply": "2026-09-11T00:33:43.940120Z"
+     "iopub.execute_input": "2026-09-11T00:34:26.573002Z",
+     "iopub.status.busy": "2026-09-11T00:34:26.572904Z",
+     "iopub.status.idle": "2026-09-11T00:34:26.574940Z",
+     "shell.execute_reply": "2026-09-11T00:34:26.574552Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.004218,
-     "end_time": "2026-09-11T00:33:43.941066+00:00",
+     "duration": 0.003883,
+     "end_time": "2026-09-11T00:34:26.575247+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:33:43.936848+00:00",
+     "start_time": "2026-09-11T00:34:26.571364+00:00",
      "status": "completed"
     },
     "tags": [
@@ -165,21 +165,41 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "6367ebd4",
+   "metadata": {
+    "papermill": {
+     "duration": 0.000957,
+     "end_time": "2026-09-11T00:34:26.577345+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T00:34:26.576388+00:00",
+     "status": "completed"
+    }
+   },
+   "source": [
+    "The registry is opened read-only, and deliberately not with `immutable=1`. That flag promises\n",
+    "SQLite the file cannot move while it is open, which lets it skip locking and WAL recovery. It\n",
+    "holds for a released case directory and not for a live one a sweep may be writing, and an\n",
+    "immutable read of a database with an uncheckpointed write-ahead log sees the pre-WAL main file:\n",
+    "a stale configuration selected silently, or a table that appears not to exist."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "56e3cda0",
+   "id": "e47af1be",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:33:43.943727Z",
-     "iopub.status.busy": "2026-09-11T00:33:43.943658Z",
-     "iopub.status.idle": "2026-09-11T00:33:44.015058Z",
-     "shell.execute_reply": "2026-09-11T00:33:44.014402Z"
+     "iopub.execute_input": "2026-09-11T00:34:26.579996Z",
+     "iopub.status.busy": "2026-09-11T00:34:26.579935Z",
+     "iopub.status.idle": "2026-09-11T00:34:26.651256Z",
+     "shell.execute_reply": "2026-09-11T00:34:26.650361Z"
     },
     "papermill": {
-     "duration": 0.073237,
-     "end_time": "2026-09-11T00:33:44.015430+00:00",
+     "duration": 0.073525,
+     "end_time": "2026-09-11T00:34:26.652004+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:33:43.942193+00:00",
+     "start_time": "2026-09-11T00:34:26.578479+00:00",
      "status": "completed"
     }
    },
@@ -241,10 +261,6 @@
     "registry_path = case_study_dir / \"run_log\" / \"registry.db\"\n",
     "registry_hash_before = hashlib.sha256(registry_path.read_bytes()).hexdigest()\n",
     "\n",
-    "# Read-only, and deliberately not `immutable=1`. That flag promises SQLite the file cannot move\n",
-    "# while it is open, which lets it skip WAL recovery; it holds for a released case directory and\n",
-    "# not for a live one a sweep may be writing, and an immutable read of a database with an\n",
-    "# uncheckpointed WAL sees the pre-WAL main file.\n",
     "registry_uri = f\"{registry_path.resolve().as_uri()}?mode=ro\"\n",
     "with sqlite3.connect(registry_uri, uri=True) as conn:\n",
     "    winner = conn.execute(\n",
@@ -332,13 +348,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "03b8440b",
+   "id": "e67f9b9c",
    "metadata": {
     "papermill": {
-     "duration": 0.001126,
-     "end_time": "2026-09-11T00:33:44.017897+00:00",
+     "duration": 0.00266,
+     "end_time": "2026-09-11T00:34:26.657269+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:33:44.016771+00:00",
+     "start_time": "2026-09-11T00:34:26.654609+00:00",
      "status": "completed"
     }
    },
@@ -356,13 +372,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2aa031c1",
+   "id": "850c3f95",
    "metadata": {
     "papermill": {
-     "duration": 0.001038,
-     "end_time": "2026-09-11T00:33:44.020058+00:00",
+     "duration": 0.002843,
+     "end_time": "2026-09-11T00:34:26.663324+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:33:44.019020+00:00",
+     "start_time": "2026-09-11T00:34:26.660481+00:00",
      "status": "completed"
     }
    },
@@ -379,19 +395,19 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "74ad9d6d",
+   "id": "64b44d04",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:33:44.022859Z",
-     "iopub.status.busy": "2026-09-11T00:33:44.022770Z",
-     "iopub.status.idle": "2026-09-11T00:33:44.031373Z",
-     "shell.execute_reply": "2026-09-11T00:33:44.031014Z"
+     "iopub.execute_input": "2026-09-11T00:34:26.668077Z",
+     "iopub.status.busy": "2026-09-11T00:34:26.667970Z",
+     "iopub.status.idle": "2026-09-11T00:34:26.684440Z",
+     "shell.execute_reply": "2026-09-11T00:34:26.683659Z"
     },
     "papermill": {
-     "duration": 0.010444,
-     "end_time": "2026-09-11T00:33:44.031621+00:00",
+     "duration": 0.019948,
+     "end_time": "2026-09-11T00:34:26.685494+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:33:44.021177+00:00",
+     "start_time": "2026-09-11T00:34:26.665546+00:00",
      "status": "completed"
     }
    },
@@ -443,19 +459,19 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "4d15a454",
+   "id": "88ddee2d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:33:44.034559Z",
-     "iopub.status.busy": "2026-09-11T00:33:44.034480Z",
-     "iopub.status.idle": "2026-09-11T00:33:44.036491Z",
-     "shell.execute_reply": "2026-09-11T00:33:44.036201Z"
+     "iopub.execute_input": "2026-09-11T00:34:26.692294Z",
+     "iopub.status.busy": "2026-09-11T00:34:26.692162Z",
+     "iopub.status.idle": "2026-09-11T00:34:26.696451Z",
+     "shell.execute_reply": "2026-09-11T00:34:26.695643Z"
     },
     "papermill": {
-     "duration": 0.003965,
-     "end_time": "2026-09-11T00:33:44.036830+00:00",
+     "duration": 0.008733,
+     "end_time": "2026-09-11T00:34:26.697300+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:33:44.032865+00:00",
+     "start_time": "2026-09-11T00:34:26.688567+00:00",
      "status": "completed"
     }
    },
@@ -486,13 +502,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7b06a341",
+   "id": "9a1dfa47",
    "metadata": {
     "papermill": {
-     "duration": 0.001089,
-     "end_time": "2026-09-11T00:33:44.039114+00:00",
+     "duration": 0.00175,
+     "end_time": "2026-09-11T00:34:26.701425+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:33:44.038025+00:00",
+     "start_time": "2026-09-11T00:34:26.699675+00:00",
      "status": "completed"
     }
    },
@@ -504,19 +520,19 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "e7f04bf4",
+   "id": "70ebe8c3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:33:44.041861Z",
-     "iopub.status.busy": "2026-09-11T00:33:44.041792Z",
-     "iopub.status.idle": "2026-09-11T00:33:44.058145Z",
-     "shell.execute_reply": "2026-09-11T00:33:44.057809Z"
+     "iopub.execute_input": "2026-09-11T00:34:26.704796Z",
+     "iopub.status.busy": "2026-09-11T00:34:26.704733Z",
+     "iopub.status.idle": "2026-09-11T00:34:26.721447Z",
+     "shell.execute_reply": "2026-09-11T00:34:26.721114Z"
     },
     "papermill": {
-     "duration": 0.018197,
-     "end_time": "2026-09-11T00:33:44.058459+00:00",
+     "duration": 0.018972,
+     "end_time": "2026-09-11T00:34:26.721896+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:33:44.040262+00:00",
+     "start_time": "2026-09-11T00:34:26.702924+00:00",
      "status": "completed"
     }
    },
@@ -544,13 +560,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d577220b",
+   "id": "32b2eecc",
    "metadata": {
     "papermill": {
-     "duration": 0.001177,
-     "end_time": "2026-09-11T00:33:44.060947+00:00",
+     "duration": 0.001161,
+     "end_time": "2026-09-11T00:34:26.724367+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:33:44.059770+00:00",
+     "start_time": "2026-09-11T00:34:26.723206+00:00",
      "status": "completed"
     }
    },
@@ -566,13 +582,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e9dcc9bc",
+   "id": "04140a16",
    "metadata": {
     "papermill": {
-     "duration": 0.001124,
-     "end_time": "2026-09-11T00:33:44.063301+00:00",
+     "duration": 0.001134,
+     "end_time": "2026-09-11T00:34:26.726699+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:33:44.062177+00:00",
+     "start_time": "2026-09-11T00:34:26.725565+00:00",
      "status": "completed"
     }
    },
@@ -589,13 +605,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e021a41b",
+   "id": "2771a197",
    "metadata": {
     "papermill": {
-     "duration": 0.00109,
-     "end_time": "2026-09-11T00:33:44.065629+00:00",
+     "duration": 0.001143,
+     "end_time": "2026-09-11T00:34:26.729053+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:33:44.064539+00:00",
+     "start_time": "2026-09-11T00:34:26.727910+00:00",
      "status": "completed"
     }
    },
@@ -637,13 +653,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "746a72e9",
+   "id": "d43fe978",
    "metadata": {
     "papermill": {
-     "duration": 0.001122,
-     "end_time": "2026-09-11T00:33:44.067934+00:00",
+     "duration": 0.001086,
+     "end_time": "2026-09-11T00:34:26.731322+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:33:44.066812+00:00",
+     "start_time": "2026-09-11T00:34:26.730236+00:00",
      "status": "completed"
     }
    },
@@ -666,19 +682,19 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "f9d393d9",
+   "id": "c997560b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:33:44.070782Z",
-     "iopub.status.busy": "2026-09-11T00:33:44.070713Z",
-     "iopub.status.idle": "2026-09-11T00:33:44.073262Z",
-     "shell.execute_reply": "2026-09-11T00:33:44.072849Z"
+     "iopub.execute_input": "2026-09-11T00:34:26.734413Z",
+     "iopub.status.busy": "2026-09-11T00:34:26.734340Z",
+     "iopub.status.idle": "2026-09-11T00:34:26.736640Z",
+     "shell.execute_reply": "2026-09-11T00:34:26.736289Z"
     },
     "papermill": {
-     "duration": 0.004624,
-     "end_time": "2026-09-11T00:33:44.073721+00:00",
+     "duration": 0.004606,
+     "end_time": "2026-09-11T00:34:26.737211+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:33:44.069097+00:00",
+     "start_time": "2026-09-11T00:34:26.732605+00:00",
      "status": "completed"
     }
    },
@@ -779,13 +795,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6130ac77",
+   "id": "06d08ae0",
    "metadata": {
     "papermill": {
-     "duration": 0.001163,
-     "end_time": "2026-09-11T00:33:44.076120+00:00",
+     "duration": 0.001157,
+     "end_time": "2026-09-11T00:34:26.739611+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:33:44.074957+00:00",
+     "start_time": "2026-09-11T00:34:26.738454+00:00",
      "status": "completed"
     }
    },
@@ -803,13 +819,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "12981968",
+   "id": "2ce0f36e",
    "metadata": {
     "papermill": {
-     "duration": 0.001118,
-     "end_time": "2026-09-11T00:33:44.078451+00:00",
+     "duration": 0.001108,
+     "end_time": "2026-09-11T00:34:26.741912+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:33:44.077333+00:00",
+     "start_time": "2026-09-11T00:34:26.740804+00:00",
      "status": "completed"
     }
    },
@@ -845,13 +861,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "af8ba5a2",
+   "id": "e9d475fc",
    "metadata": {
     "papermill": {
-     "duration": 0.001142,
-     "end_time": "2026-09-11T00:33:44.080798+00:00",
+     "duration": 0.001213,
+     "end_time": "2026-09-11T00:34:26.744353+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:33:44.079656+00:00",
+     "start_time": "2026-09-11T00:34:26.743140+00:00",
      "status": "completed"
     }
    },
@@ -864,19 +880,19 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "ebaab77d",
+   "id": "e07ac357",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:33:44.083688Z",
-     "iopub.status.busy": "2026-09-11T00:33:44.083617Z",
-     "iopub.status.idle": "2026-09-11T00:33:44.087572Z",
-     "shell.execute_reply": "2026-09-11T00:33:44.087316Z"
+     "iopub.execute_input": "2026-09-11T00:34:26.747370Z",
+     "iopub.status.busy": "2026-09-11T00:34:26.747298Z",
+     "iopub.status.idle": "2026-09-11T00:34:26.751527Z",
+     "shell.execute_reply": "2026-09-11T00:34:26.751239Z"
     },
     "papermill": {
-     "duration": 0.005967,
-     "end_time": "2026-09-11T00:33:44.087989+00:00",
+     "duration": 0.006299,
+     "end_time": "2026-09-11T00:34:26.751887+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:33:44.082022+00:00",
+     "start_time": "2026-09-11T00:34:26.745588+00:00",
      "status": "completed"
     }
    },
@@ -927,19 +943,19 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "c3c65e41",
+   "id": "26ea86c1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:33:44.090993Z",
-     "iopub.status.busy": "2026-09-11T00:33:44.090928Z",
-     "iopub.status.idle": "2026-09-11T00:33:44.184289Z",
-     "shell.execute_reply": "2026-09-11T00:33:44.183950Z"
+     "iopub.execute_input": "2026-09-11T00:34:26.754969Z",
+     "iopub.status.busy": "2026-09-11T00:34:26.754903Z",
+     "iopub.status.idle": "2026-09-11T00:34:26.848001Z",
+     "shell.execute_reply": "2026-09-11T00:34:26.847568Z"
     },
     "papermill": {
-     "duration": 0.095634,
-     "end_time": "2026-09-11T00:33:44.184955+00:00",
+     "duration": 0.095181,
+     "end_time": "2026-09-11T00:34:26.848380+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:33:44.089321+00:00",
+     "start_time": "2026-09-11T00:34:26.753199+00:00",
      "status": "completed"
     }
    },
@@ -988,19 +1004,19 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "16a7ff94",
+   "id": "5960a84f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:33:44.190762Z",
-     "iopub.status.busy": "2026-09-11T00:33:44.190683Z",
-     "iopub.status.idle": "2026-09-11T00:33:44.258739Z",
-     "shell.execute_reply": "2026-09-11T00:33:44.258495Z"
+     "iopub.execute_input": "2026-09-11T00:34:26.851962Z",
+     "iopub.status.busy": "2026-09-11T00:34:26.851878Z",
+     "iopub.status.idle": "2026-09-11T00:34:26.918970Z",
+     "shell.execute_reply": "2026-09-11T00:34:26.918435Z"
     },
     "papermill": {
-     "duration": 0.071648,
-     "end_time": "2026-09-11T00:33:44.259405+00:00",
+     "duration": 0.069475,
+     "end_time": "2026-09-11T00:34:26.919439+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:33:44.187757+00:00",
+     "start_time": "2026-09-11T00:34:26.849964+00:00",
      "status": "completed"
     }
    },
@@ -1059,13 +1075,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "76eed987",
+   "id": "51d32895",
    "metadata": {
     "papermill": {
-     "duration": 0.001533,
-     "end_time": "2026-09-11T00:33:44.262651+00:00",
+     "duration": 0.001561,
+     "end_time": "2026-09-11T00:34:26.922723+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:33:44.261118+00:00",
+     "start_time": "2026-09-11T00:34:26.921162+00:00",
      "status": "completed"
     }
    },
@@ -1083,13 +1099,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8cf82a5d",
+   "id": "0f3debd4",
    "metadata": {
     "papermill": {
-     "duration": 0.001434,
-     "end_time": "2026-09-11T00:33:44.265607+00:00",
+     "duration": 0.001457,
+     "end_time": "2026-09-11T00:34:26.925749+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:33:44.264173+00:00",
+     "start_time": "2026-09-11T00:34:26.924292+00:00",
      "status": "completed"
     }
    },
@@ -1118,13 +1134,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d789ef62",
+   "id": "59f8daf6",
    "metadata": {
     "papermill": {
-     "duration": 0.001434,
-     "end_time": "2026-09-11T00:33:44.268571+00:00",
+     "duration": 0.001461,
+     "end_time": "2026-09-11T00:34:26.928746+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:33:44.267137+00:00",
+     "start_time": "2026-09-11T00:34:26.927285+00:00",
      "status": "completed"
     }
    },
@@ -1161,19 +1177,19 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "ed3d09fb",
+   "id": "e0b69d66",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:33:44.272126Z",
-     "iopub.status.busy": "2026-09-11T00:33:44.272036Z",
-     "iopub.status.idle": "2026-09-11T00:33:44.288194Z",
-     "shell.execute_reply": "2026-09-11T00:33:44.287899Z"
+     "iopub.execute_input": "2026-09-11T00:34:26.932371Z",
+     "iopub.status.busy": "2026-09-11T00:34:26.932290Z",
+     "iopub.status.idle": "2026-09-11T00:34:26.948528Z",
+     "shell.execute_reply": "2026-09-11T00:34:26.948152Z"
     },
     "papermill": {
-     "duration": 0.018527,
-     "end_time": "2026-09-11T00:33:44.288612+00:00",
+     "duration": 0.018758,
+     "end_time": "2026-09-11T00:34:26.949019+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:33:44.270085+00:00",
+     "start_time": "2026-09-11T00:34:26.930261+00:00",
      "status": "completed"
     }
    },
@@ -1215,24 +1231,24 @@
    "version": "3.14.3"
   },
   "ml4t_provenance": {
-   "executed_at": "2026-09-11T00:33:52.288553+00:00",
+   "executed_at": "2026-09-11T00:34:34.985693+00:00",
    "executor": "local-uv",
    "library_digest": "7e58b187ca6aebc857aa811db8a932631d991f67d95d37bc9a77bc4f43baa193",
    "outputs_digest": "918052e0eea528e4516722f36bf742d96869cd9a47dec819120efd66e064e7ed",
    "parameters": {},
    "production": true,
-   "source_py_blob": "93459fc8a80610f62ce734a1bcabc3c4374b31aa"
+   "source_py_blob": "01c130b28095c80d2fc57a5134c1e0c567fd37ec"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 3.151872,
-   "end_time": "2026-09-11T00:33:45.004857+00:00",
+   "duration": 3.269026,
+   "end_time": "2026-09-11T00:34:27.768560+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "~/ml4t/public-teach-g/25_live_trading/.06_quantconnect_case_study.build.610849.ipynb",
-   "output_path": "~/ml4t/public-teach-g/25_live_trading/.06_quantconnect_case_study.papermill.610849.ipynb",
+   "input_path": "~/ml4t/public-teach-g/25_live_trading/.06_quantconnect_case_study.build.612553.ipynb",
+   "output_path": "~/ml4t/public-teach-g/25_live_trading/.06_quantconnect_case_study.papermill.612553.ipynb",
    "parameters": {},
-   "start_time": "2026-09-11T00:33:41.852985+00:00",
+   "start_time": "2026-09-11T00:34:24.499534+00:00",
    "version": "2.7.0"
   }
  },

--- a/25_live_trading/06_quantconnect_case_study.py
+++ b/25_live_trading/06_quantconnect_case_study.py
@@ -98,7 +98,11 @@ case_study_dir = get_case_study_dir("etfs")
 registry_path = case_study_dir / "run_log" / "registry.db"
 registry_hash_before = hashlib.sha256(registry_path.read_bytes()).hexdigest()
 
-registry_uri = f"{registry_path.resolve().as_uri()}?mode=ro&immutable=1"
+# Read-only, and deliberately not `immutable=1`. That flag promises SQLite the file cannot move
+# while it is open, which lets it skip WAL recovery; it holds for a released case directory and
+# not for a live one a sweep may be writing, and an immutable read of a database with an
+# uncheckpointed WAL sees the pre-WAL main file.
+registry_uri = f"{registry_path.resolve().as_uri()}?mode=ro"
 with sqlite3.connect(registry_uri, uri=True) as conn:
     winner = conn.execute(
         """SELECT ps.training_hash, br.backtest_hash, br.stage, bm.sharpe

--- a/25_live_trading/06_quantconnect_case_study.py
+++ b/25_live_trading/06_quantconnect_case_study.py
@@ -93,15 +93,18 @@ EXPECTED_PREDICTIONS_SHA256 = "2efad22dbf40464939d143745116165c6447c3e4dfd154bd6
 EXPORT_PATH = get_output_dir(25, "quantconnect_export") / "ml4t_qc_predictions.json"
 
 
+# %% [markdown]
+# The registry is opened read-only, and deliberately not with `immutable=1`. That flag promises
+# SQLite the file cannot move while it is open, which lets it skip locking and WAL recovery. It
+# holds for a released case directory and not for a live one a sweep may be writing, and an
+# immutable read of a database with an uncheckpointed write-ahead log sees the pre-WAL main file:
+# a stale configuration selected silently, or a table that appears not to exist.
+
 # %%
 case_study_dir = get_case_study_dir("etfs")
 registry_path = case_study_dir / "run_log" / "registry.db"
 registry_hash_before = hashlib.sha256(registry_path.read_bytes()).hexdigest()
 
-# Read-only, and deliberately not `immutable=1`. That flag promises SQLite the file cannot move
-# while it is open, which lets it skip WAL recovery; it holds for a released case directory and
-# not for a live one a sweep may be writing, and an immutable read of a database with an
-# uncheckpointed WAL sees the pre-WAL main file.
 registry_uri = f"{registry_path.resolve().as_uri()}?mode=ro"
 with sqlite3.connect(registry_uri, uri=True) as conn:
     winner = conn.execute(

--- a/25_live_trading/06_quantconnect_case_study.py
+++ b/25_live_trading/06_quantconnect_case_study.py
@@ -95,8 +95,8 @@ EXPORT_PATH = get_output_dir(25, "quantconnect_export") / "ml4t_qc_predictions.j
 
 # %% [markdown]
 # The registry is opened read-only, and deliberately not with `immutable=1`. That flag promises
-# SQLite the file cannot move while it is open, which lets it skip locking and WAL recovery. It
-# holds for a released case directory and not for a live one a sweep may be writing, and an
+# SQLite the database cannot change while it is open, which lets it skip locking and WAL recovery.
+# That holds for a released case directory and not for a live one a sweep may be writing, and an
 # immutable read of a database with an uncheckpointed write-ahead log sees the pre-WAL main file:
 # a stale configuration selected silently, or a table that appears not to exist.
 

--- a/tests/overrides.yaml
+++ b/tests/overrides.yaml
@@ -1238,9 +1238,18 @@
   timeout: 180
 25_live_trading/02_etfs_deployment_loop:
   parameters:
+    # The notebook asserts that the registry still leads with the configuration it pins. A
+    # fixture registry is a sample of production, so the leader of an `ORDER BY ic_mean DESC`
+    # over it is whichever run the sampler drew. Null reads as "report the observed value";
+    # the assertion still binds on a production run. Same reasoning as 06 above.
+    EXPECTED_RIDGE_CONFIG: null
     REFRESH_DATA: false
   skip: true
-  skip_reason: Requires running IB Gateway (not available in CI)
+  skip_reason:
+    Reads the ETFs case study's fwd_ret_21d labels and its registry, and stages a
+    basket for Alpaca paper equities. It opens no broker session by default
+    (SUBMIT_PAPER_ORDERS is false), so the earlier reason naming IB Gateway was
+    never this notebook's.
   tier: weekly
   timeout: 360
 25_live_trading/03_ib_paper_trading_demo:

--- a/tests/overrides.yaml
+++ b/tests/overrides.yaml
@@ -1238,22 +1238,15 @@
   timeout: 180
 25_live_trading/02_etfs_deployment_loop:
   parameters:
-    # The notebook asserts that the registry still leads with the configuration it pins. A
-    # fixture registry is a sample of production, so the leader of an `ORDER BY ic_mean DESC`
-    # over it is whichever run the sampler drew. Null reads as "report the observed value";
-    # the assertion still binds on a production run. Same reasoning as 06 above.
-    EXPECTED_RIDGE_CONFIG: null
     REFRESH_DATA: false
-  skip: true
-  skip_reason:
-    Needs the ETFs case study's fwd_ret_21d label parquet and a registry carrying
-    its linear stage; the notebook refuses rather than guesses when the registry
-    holds no validated Ridge run for the label, and the sampled fixture registry
-    is not built to guarantee one. No broker is involved - SUBMIT_PAPER_ORDERS is
-    false by default and the execution plane is an offline dry run - so the
-    earlier reason naming IB Gateway described a different notebook. The
-    EXPECTED_RIDGE_CONFIG override below is inert while this skip stands and is
-    what the notebook needs if the skip is lifted.
+  # Was skipped for "Requires running IB Gateway", which described a different
+  # notebook: this one stages a basket for Alpaca paper equities, and with
+  # SUBMIT_PAPER_ORDERS false by default it opens no broker session at all. Its
+  # real inputs are the ETFs case study's fwd_ret_21d labels and its registry,
+  # both of which the intermediates tree carries - the fixture registry's
+  # validation-IC leader for that label is ridge_a1000000.0, the configuration
+  # the notebook pins, so EXPECTED_RIDGE_CONFIG needs no override here. Measured
+  # against the fixture: 21s, 2.3 GB peak.
   tier: weekly
   timeout: 360
 25_live_trading/03_ib_paper_trading_demo:

--- a/tests/overrides.yaml
+++ b/tests/overrides.yaml
@@ -1246,10 +1246,14 @@
     REFRESH_DATA: false
   skip: true
   skip_reason:
-    Reads the ETFs case study's fwd_ret_21d labels and its registry, and stages a
-    basket for Alpaca paper equities. It opens no broker session by default
-    (SUBMIT_PAPER_ORDERS is false), so the earlier reason naming IB Gateway was
-    never this notebook's.
+    Needs the ETFs case study's fwd_ret_21d label parquet and a registry carrying
+    its linear stage; the notebook refuses rather than guesses when the registry
+    holds no validated Ridge run for the label, and the sampled fixture registry
+    is not built to guarantee one. No broker is involved - SUBMIT_PAPER_ORDERS is
+    false by default and the execution plane is an offline dry run - so the
+    earlier reason naming IB Gateway described a different notebook. The
+    EXPECTED_RIDGE_CONFIG override below is inert while this skip stands and is
+    what the notebook needs if the skip is lifted.
   tier: weekly
   timeout: 360
 25_live_trading/03_ib_paper_trading_demo:


### PR DESCRIPTION
The two workable chapter 25 notebooks, plus one correction to a sibling and
one CI entry that recorded a blocker the notebook does not have.

**01 `unified_framework_demo`** is a parity test: one `Strategy` class through
`ml4t.backtest.Engine` and through `ml4t.live.LiveEngine` over the same bars,
compared field by field. Two things in it could hide a failure of exactly the
kind it exists to detect. The replay feed built each bar inside
`except (KeyError, ValueError): pass`, so a symbol missing on some dates would
have handed the live engine a shorter history, moved its moving averages, and
reported the difference as an engine disagreement. The simulated broker filled
at `limit_price or self._current_prices.get(asset, 100.0)`, so an asset the feed
had never priced would fill at a fabricated 100.0 and put a price into the
compared tape that no bar carried. Both now raise.

The rest of that notebook: the entire import block was duplicated verbatim with
a second `logging.basicConfig` under it; the figure title asserted the
comparison's verdict; prose said continuous integration lowers `MAX_SYMBOLS`,
which `tests/overrides.yaml` does not do; prose hardcoded "five signals of
nine"; the close was drawn in a navy indistinguishable from the fast average.

**02 `etfs_deployment_loop`** had a defect underneath the one on file. Eight of
its offline replay's eighty orders came back `REJECTED` and nothing looked. The
strategy sized every leg at the full account value on one bar and the orders
filled on the next, so an overnight move plus commission made the last leg
unaffordable. The notebook then read that tape as "every rebalance the
deployment would have made" and reconciled a five-name intended basket against a
portfolio holding four, with a fifth of the account in cash. The gap between
intended and accepted is the notebook's own subject.

`CASH_BUFFER` (2%) is what the leg is sized on one bar and filled on the next;
all eighty-four orders now fill. Dispositions are counted and the replay refuses
to be used as a reference if an order was refused. A refusal is `REJECTED` or
`CANCELLED`, or a `PENDING` order created before the last bar: under `NEXT_BAR`
the final bar has no following bar, so a rebalance landing on the last day of
the window leaves its whole basket pending, which is the replay running out of
tape rather than the broker refusing anything. Verified by truncating the window
to 232 bars so it ends on a rebalance: 7 pending, 0 refused.

The recorded HIGH finding was `RIDGE_ALPHA = 1_000_000.0`, a literal whose
comment named a registry configuration the notebook never opened. It now queries
the ETFs registry for the leading Ridge configuration on validation IC, reads
the alpha out of that run's resolved specification, and checks the selection
against `EXPECTED_RIDGE_CONFIG`. The pin names a configuration rather than a
training hash, so a refit does not fire it. The same query prints the feature
families that configuration was tuned on against the ones fitted here, and the
run prints `dropped here: ['model_based']` - which is the recorded MED finding,
established from the registry instead of asserted in prose.

Also in 02: the label parquet was read by a literal repo path while the registry
beside it went through `get_case_study_dir`, so a run with `ML4T_OUTPUT_DIR` set
read two different trees; a prediction-coverage assert compared a frame against
a copy of its own column and could not fail; two key takeaways described
behaviour the notebook does not have (a monthly retrain cadence with a
configured ageing window, and a feature set "slightly weaker" by no
measurement); the figure title interpreted and its alt text asserted numbers.

**06 `quantconnect_case_study`** carried the same `immutable=1` registry
connection that review caught in 02. That flag promises SQLite the database
cannot change while open, which lets it skip WAL recovery;
`case_studies/research/catalog.py` states the rule it obeys, and a live case
directory a sweep may be writing is not it. Re-run; both pins still bind.

### One decision worth your eye

**02's `skip: true` is gone.** Its reason was "Requires running IB Gateway",
which described a different notebook - 02 stages a basket for Alpaca paper
equities and with `SUBMIT_PAPER_ORDERS` false opens no broker session at all. I
first rewrote the reason and got it wrong in the other direction, claiming the
fixture registry might not carry the configuration; it does, by construction,
because `tests/sample_registry_for_tests.py` copies the training and prediction
tables in full. Running the notebook against the intermediates tree the way
`notebook_worker` wires it, with chapter outputs redirected out of the fixture:
end to end in 21s, 2.3 GB peak, 78 orders all filled, reconciliation clean, and
the `EXPECTED_RIDGE_CONFIG` assertion binding. It stays on the weekly tier with
its 360s timeout. Say the word if you would rather it stayed skipped.

### Left alone, deliberately

**11 `fx_deployment_loop` and 12 `ib_basket_rebalance_demo` stay blocked.** Both
need a live IB paper session to re-render, and the defects on record are exactly
what `nbcheck` still reports: 11 cell 25 and 12 cell 14 each carry a figure with
no alt text, and 11 cell 7 emits fourteen warnings into its output. Nothing
there is fixable without the session, and mocking the broker would produce a
render that claims a session that did not happen.

**`immutable=1` on a live registry survives in four notebooks outside this
chapter**: `11_ml_pipeline/07` (twice), `15_causal_estimation/10`,
`17_portfolio_construction/07` and `26_mlops_governance/03`. Same defect, other
chapters' notebooks, each needing its own re-run. `17/07` and `26/03`
additionally credit `immutable` with the read-only guarantee, which is
`mode=ro`'s.

Every notebook here re-executed, `nbcheck` and `check_notebook_prose` clean on
both, every rewritten alt text checked against the extracted PNG, and every
commit reviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VEtXvNk14uZckwswthVihc
