### PR TITLE
Chapter 26: a registry read that promised too much, and a CI gate that tested the wrong branch

### DIFF
--- a/26_mlops_governance/03_safe_model_rollout.ipynb
+++ b/26_mlops_governance/03_safe_model_rollout.ipynb
@@ -2,13 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "4a266754",
+   "id": "01319d50",
    "metadata": {
     "papermill": {
-     "duration": 0.003759,
-     "end_time": "2026-09-09T21:58:07.944213+00:00",
+     "duration": 0.002279,
+     "end_time": "2026-09-11T01:29:48.875239+00:00",
      "exception": false,
-     "start_time": "2026-09-09T21:58:07.940454+00:00",
+     "start_time": "2026-09-11T01:29:48.872960+00:00",
      "status": "completed"
     }
    },
@@ -49,19 +49,19 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "ea5a199a",
+   "id": "22eab206",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T21:58:07.951807Z",
-     "iopub.status.busy": "2026-09-09T21:58:07.951584Z",
-     "iopub.status.idle": "2026-09-09T21:58:07.957253Z",
-     "shell.execute_reply": "2026-09-09T21:58:07.956671Z"
+     "iopub.execute_input": "2026-09-11T01:29:48.879740Z",
+     "iopub.status.busy": "2026-09-11T01:29:48.879626Z",
+     "iopub.status.idle": "2026-09-11T01:29:48.883316Z",
+     "shell.execute_reply": "2026-09-11T01:29:48.882798Z"
     },
     "papermill": {
-     "duration": 0.009956,
-     "end_time": "2026-09-09T21:58:07.957602+00:00",
+     "duration": 0.006529,
+     "end_time": "2026-09-11T01:29:48.883609+00:00",
      "exception": false,
-     "start_time": "2026-09-09T21:58:07.947646+00:00",
+     "start_time": "2026-09-11T01:29:48.877080+00:00",
      "status": "completed"
     }
    },
@@ -83,13 +83,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "036ed32a",
+   "id": "821a48a5",
    "metadata": {
     "papermill": {
-     "duration": 0.001702,
-     "end_time": "2026-09-09T21:58:07.961277+00:00",
+     "duration": 0.001749,
+     "end_time": "2026-09-11T01:29:48.887240+00:00",
      "exception": false,
-     "start_time": "2026-09-09T21:58:07.959575+00:00",
+     "start_time": "2026-09-11T01:29:48.885491+00:00",
      "status": "completed"
     }
    },
@@ -138,19 +138,19 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "31acd6ac",
+   "id": "d8af3930",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T21:58:07.966358Z",
-     "iopub.status.busy": "2026-09-09T21:58:07.966196Z",
-     "iopub.status.idle": "2026-09-09T21:58:07.969283Z",
-     "shell.execute_reply": "2026-09-09T21:58:07.968726Z"
+     "iopub.execute_input": "2026-09-11T01:29:48.891676Z",
+     "iopub.status.busy": "2026-09-11T01:29:48.891567Z",
+     "iopub.status.idle": "2026-09-11T01:29:48.894487Z",
+     "shell.execute_reply": "2026-09-11T01:29:48.894065Z"
     },
     "papermill": {
-     "duration": 0.0063,
-     "end_time": "2026-09-09T21:58:07.969814+00:00",
+     "duration": 0.006186,
+     "end_time": "2026-09-11T01:29:48.895256+00:00",
      "exception": false,
-     "start_time": "2026-09-09T21:58:07.963514+00:00",
+     "start_time": "2026-09-11T01:29:48.889070+00:00",
      "status": "completed"
     },
     "tags": [
@@ -182,20 +182,20 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "3012cfc0",
+   "id": "8896bcc5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T21:58:07.977785Z",
-     "iopub.status.busy": "2026-09-09T21:58:07.977614Z",
-     "iopub.status.idle": "2026-09-09T21:58:11.275318Z",
-     "shell.execute_reply": "2026-09-09T21:58:11.274892Z"
+     "iopub.execute_input": "2026-09-11T01:29:48.905067Z",
+     "iopub.status.busy": "2026-09-11T01:29:48.904830Z",
+     "iopub.status.idle": "2026-09-11T01:29:52.728664Z",
+     "shell.execute_reply": "2026-09-11T01:29:52.727909Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 3.30277,
-     "end_time": "2026-09-09T21:58:11.276111+00:00",
+     "duration": 3.830141,
+     "end_time": "2026-09-11T01:29:52.729533+00:00",
      "exception": false,
-     "start_time": "2026-09-09T21:58:07.973341+00:00",
+     "start_time": "2026-09-11T01:29:48.899392+00:00",
      "status": "completed"
     }
    },
@@ -230,14 +230,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ddc8a986",
+   "id": "adbcbf3c",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.00322,
-     "end_time": "2026-09-09T21:58:11.282933+00:00",
+     "duration": 0.002021,
+     "end_time": "2026-09-11T01:29:52.735077+00:00",
      "exception": false,
-     "start_time": "2026-09-09T21:58:11.279713+00:00",
+     "start_time": "2026-09-11T01:29:52.733056+00:00",
      "status": "completed"
     }
    },
@@ -253,20 +253,20 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "8b8284e8",
+   "id": "9e35376e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T21:58:11.290540Z",
-     "iopub.status.busy": "2026-09-09T21:58:11.290287Z",
-     "iopub.status.idle": "2026-09-09T21:58:11.293484Z",
-     "shell.execute_reply": "2026-09-09T21:58:11.293072Z"
+     "iopub.execute_input": "2026-09-11T01:29:52.740928Z",
+     "iopub.status.busy": "2026-09-11T01:29:52.740701Z",
+     "iopub.status.idle": "2026-09-11T01:29:52.744469Z",
+     "shell.execute_reply": "2026-09-11T01:29:52.743903Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.007705,
-     "end_time": "2026-09-09T21:58:11.293939+00:00",
+     "duration": 0.007556,
+     "end_time": "2026-09-11T01:29:52.744872+00:00",
      "exception": false,
-     "start_time": "2026-09-09T21:58:11.286234+00:00",
+     "start_time": "2026-09-11T01:29:52.737316+00:00",
      "status": "completed"
     }
    },
@@ -283,48 +283,52 @@
   },
   {
    "cell_type": "markdown",
-   "id": "924dcbe9",
+   "id": "311b8e25",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.003246,
-     "end_time": "2026-09-09T21:58:11.300959+00:00",
+     "duration": 0.002005,
+     "end_time": "2026-09-11T01:29:52.749266+00:00",
      "exception": false,
-     "start_time": "2026-09-09T21:58:11.297713+00:00",
+     "start_time": "2026-09-11T01:29:52.747261+00:00",
      "status": "completed"
     }
    },
    "source": [
-    "The connection is opened read-only and immutable. Reviewing a candidate reads the case\n",
-    "study's result record and must not be able to write to it, and SQLite will enforce that if\n",
-    "it is asked to."
+    "The connection is opened read-only, by `mode=ro` on the URI and `PRAGMA query_only` on the\n",
+    "connection. Reviewing a candidate reads the case study's result record and must not be able\n",
+    "to write to it, and SQLite will enforce that if it is asked to. The URI deliberately leaves\n",
+    "out `immutable=1`, which promises something else: that the database cannot change while it\n",
+    "is open. The registry is what every sweep writes to, and an immutable connection skips\n",
+    "locking and ignores the write-ahead log, so it reads whatever the main file held before the\n",
+    "most recent writes - a superseded row, or a table that appears not to exist."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "9af1fbff",
+   "id": "4d7b455f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T21:58:11.308409Z",
-     "iopub.status.busy": "2026-09-09T21:58:11.308292Z",
-     "iopub.status.idle": "2026-09-09T21:58:11.310281Z",
-     "shell.execute_reply": "2026-09-09T21:58:11.309972Z"
+     "iopub.execute_input": "2026-09-11T01:29:52.754778Z",
+     "iopub.status.busy": "2026-09-11T01:29:52.754584Z",
+     "iopub.status.idle": "2026-09-11T01:29:52.758340Z",
+     "shell.execute_reply": "2026-09-11T01:29:52.757447Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.006345,
-     "end_time": "2026-09-09T21:58:11.310571+00:00",
+     "duration": 0.007508,
+     "end_time": "2026-09-11T01:29:52.758885+00:00",
      "exception": false,
-     "start_time": "2026-09-09T21:58:11.304226+00:00",
+     "start_time": "2026-09-11T01:29:52.751377+00:00",
      "status": "completed"
     }
    },
    "outputs": [],
    "source": [
     "def open_registry_readonly(path: Path) -> sqlite3.Connection:\n",
-    "    \"\"\"Open an immutable, query-only SQLite connection.\"\"\"\n",
-    "    uri = f\"file:{path.resolve()}?mode=ro&immutable=1\"\n",
+    "    \"\"\"Open a read-only, query-only SQLite connection.\"\"\"\n",
+    "    uri = f\"file:{path.resolve()}?mode=ro\"\n",
     "    connection = sqlite3.connect(uri, uri=True)\n",
     "    connection.execute(\"PRAGMA query_only=ON\")\n",
     "    return connection"
@@ -332,14 +336,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0c552f33",
+   "id": "5f12ef48",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.00174,
-     "end_time": "2026-09-09T21:58:11.314184+00:00",
+     "duration": 0.002091,
+     "end_time": "2026-09-11T01:29:52.763414+00:00",
      "exception": false,
-     "start_time": "2026-09-09T21:58:11.312444+00:00",
+     "start_time": "2026-09-11T01:29:52.761323+00:00",
      "status": "completed"
     }
    },
@@ -352,19 +356,19 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "f3585937",
+   "id": "62cbbc17",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T21:58:11.318358Z",
-     "iopub.status.busy": "2026-09-09T21:58:11.318265Z",
-     "iopub.status.idle": "2026-09-09T21:58:11.320395Z",
-     "shell.execute_reply": "2026-09-09T21:58:11.320157Z"
+     "iopub.execute_input": "2026-09-11T01:29:52.768578Z",
+     "iopub.status.busy": "2026-09-11T01:29:52.768426Z",
+     "iopub.status.idle": "2026-09-11T01:29:52.772058Z",
+     "shell.execute_reply": "2026-09-11T01:29:52.771374Z"
     },
     "papermill": {
-     "duration": 0.00494,
-     "end_time": "2026-09-09T21:58:11.320967+00:00",
+     "duration": 0.006985,
+     "end_time": "2026-09-11T01:29:52.772506+00:00",
      "exception": false,
-     "start_time": "2026-09-09T21:58:11.316027+00:00",
+     "start_time": "2026-09-11T01:29:52.765521+00:00",
      "status": "completed"
     }
    },
@@ -396,14 +400,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6ed00f42",
+   "id": "81cb776a",
    "metadata": {
     "lines_to_next_cell": 0,
     "papermill": {
-     "duration": 0.003292,
-     "end_time": "2026-09-09T21:58:11.327917+00:00",
+     "duration": 0.002075,
+     "end_time": "2026-09-11T01:29:52.777006+00:00",
      "exception": false,
-     "start_time": "2026-09-09T21:58:11.324625+00:00",
+     "start_time": "2026-09-11T01:29:52.774931+00:00",
      "status": "completed"
     }
    },
@@ -412,20 +416,20 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "baf59ea7",
+   "id": "c4384eec",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T21:58:11.335335Z",
-     "iopub.status.busy": "2026-09-09T21:58:11.335205Z",
-     "iopub.status.idle": "2026-09-09T21:58:11.342343Z",
-     "shell.execute_reply": "2026-09-09T21:58:11.341885Z"
+     "iopub.execute_input": "2026-09-11T01:29:52.782310Z",
+     "iopub.status.busy": "2026-09-11T01:29:52.782156Z",
+     "iopub.status.idle": "2026-09-11T01:29:52.797319Z",
+     "shell.execute_reply": "2026-09-11T01:29:52.796617Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.011673,
-     "end_time": "2026-09-09T21:58:11.342867+00:00",
+     "duration": 0.018578,
+     "end_time": "2026-09-11T01:29:52.797748+00:00",
      "exception": false,
-     "start_time": "2026-09-09T21:58:11.331194+00:00",
+     "start_time": "2026-09-11T01:29:52.779170+00:00",
      "status": "completed"
     }
    },
@@ -462,15 +466,15 @@
        "      <th>0</th>\n",
        "      <td>incumbent</td>\n",
        "      <td>ols</td>\n",
-       "      <td>e0567074e635</td>\n",
-       "      <td>97a84eee9bfe</td>\n",
+       "      <td>8a99078eec87</td>\n",
+       "      <td>ffa52037c87d</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
        "      <td>candidate</td>\n",
        "      <td>ridge_a100.0</td>\n",
-       "      <td>81f0182a1892</td>\n",
-       "      <td>16927ba7965a</td>\n",
+       "      <td>2426bde13930</td>\n",
+       "      <td>f2fa0a7e243b</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -478,8 +482,8 @@
       ],
       "text/plain": [
        "        role configuration training_hash prediction_hash\n",
-       "0  incumbent           ols  e0567074e635    97a84eee9bfe\n",
-       "1  candidate  ridge_a100.0  81f0182a1892    16927ba7965a"
+       "0  incumbent           ols  8a99078eec87    ffa52037c87d\n",
+       "1  candidate  ridge_a100.0  2426bde13930    f2fa0a7e243b"
       ]
      },
      "execution_count": 7,
@@ -512,14 +516,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "007174d9",
+   "id": "ca8d66af",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.003357,
-     "end_time": "2026-09-09T21:58:11.349989+00:00",
+     "duration": 0.002248,
+     "end_time": "2026-09-11T01:29:52.802344+00:00",
      "exception": false,
-     "start_time": "2026-09-09T21:58:11.346632+00:00",
+     "start_time": "2026-09-11T01:29:52.800096+00:00",
      "status": "completed"
     }
    },
@@ -533,20 +537,20 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "9ff8542a",
+   "id": "4bc65a5f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T21:58:11.355697Z",
-     "iopub.status.busy": "2026-09-09T21:58:11.355591Z",
-     "iopub.status.idle": "2026-09-09T21:58:11.357556Z",
-     "shell.execute_reply": "2026-09-09T21:58:11.357206Z"
+     "iopub.execute_input": "2026-09-11T01:29:52.807963Z",
+     "iopub.status.busy": "2026-09-11T01:29:52.807800Z",
+     "iopub.status.idle": "2026-09-11T01:29:52.810499Z",
+     "shell.execute_reply": "2026-09-11T01:29:52.809913Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.004843,
-     "end_time": "2026-09-09T21:58:11.357831+00:00",
+     "duration": 0.0064,
+     "end_time": "2026-09-11T01:29:52.811030+00:00",
      "exception": false,
-     "start_time": "2026-09-09T21:58:11.352988+00:00",
+     "start_time": "2026-09-11T01:29:52.804630+00:00",
      "status": "completed"
     }
    },
@@ -561,14 +565,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "726d028a",
+   "id": "dec0b54a",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.001954,
-     "end_time": "2026-09-09T21:58:11.362008+00:00",
+     "duration": 0.002167,
+     "end_time": "2026-09-11T01:29:52.815699+00:00",
      "exception": false,
-     "start_time": "2026-09-09T21:58:11.360054+00:00",
+     "start_time": "2026-09-11T01:29:52.813532+00:00",
      "status": "completed"
     }
    },
@@ -580,20 +584,20 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "47a0cfaf",
+   "id": "93f07c61",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T21:58:11.366428Z",
-     "iopub.status.busy": "2026-09-09T21:58:11.366279Z",
-     "iopub.status.idle": "2026-09-09T21:58:11.368997Z",
-     "shell.execute_reply": "2026-09-09T21:58:11.368591Z"
+     "iopub.execute_input": "2026-09-11T01:29:52.821491Z",
+     "iopub.status.busy": "2026-09-11T01:29:52.821324Z",
+     "iopub.status.idle": "2026-09-11T01:29:52.824951Z",
+     "shell.execute_reply": "2026-09-11T01:29:52.824324Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.005492,
-     "end_time": "2026-09-09T21:58:11.369328+00:00",
+     "duration": 0.0076,
+     "end_time": "2026-09-11T01:29:52.825550+00:00",
      "exception": false,
-     "start_time": "2026-09-09T21:58:11.363836+00:00",
+     "start_time": "2026-09-11T01:29:52.817950+00:00",
      "status": "completed"
     }
    },
@@ -617,14 +621,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d2952507",
+   "id": "e144ce59",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.002034,
-     "end_time": "2026-09-09T21:58:11.373422+00:00",
+     "duration": 0.002116,
+     "end_time": "2026-09-11T01:29:52.830246+00:00",
      "exception": false,
-     "start_time": "2026-09-09T21:58:11.371388+00:00",
+     "start_time": "2026-09-11T01:29:52.828130+00:00",
      "status": "completed"
     }
    },
@@ -635,20 +639,20 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "130deda2",
+   "id": "3b2b6988",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T21:58:11.378223Z",
-     "iopub.status.busy": "2026-09-09T21:58:11.378047Z",
-     "iopub.status.idle": "2026-09-09T21:58:11.381014Z",
-     "shell.execute_reply": "2026-09-09T21:58:11.380540Z"
+     "iopub.execute_input": "2026-09-11T01:29:52.835942Z",
+     "iopub.status.busy": "2026-09-11T01:29:52.835719Z",
+     "iopub.status.idle": "2026-09-11T01:29:52.839708Z",
+     "shell.execute_reply": "2026-09-11T01:29:52.839050Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.005977,
-     "end_time": "2026-09-09T21:58:11.381439+00:00",
+     "duration": 0.007959,
+     "end_time": "2026-09-11T01:29:52.840416+00:00",
      "exception": false,
-     "start_time": "2026-09-09T21:58:11.375462+00:00",
+     "start_time": "2026-09-11T01:29:52.832457+00:00",
      "status": "completed"
     }
    },
@@ -670,14 +674,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0c281023",
+   "id": "248c52c3",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.001783,
-     "end_time": "2026-09-09T21:58:11.386502+00:00",
+     "duration": 0.002394,
+     "end_time": "2026-09-11T01:29:52.845711+00:00",
      "exception": false,
-     "start_time": "2026-09-09T21:58:11.384719+00:00",
+     "start_time": "2026-09-11T01:29:52.843317+00:00",
      "status": "completed"
     }
    },
@@ -689,20 +693,20 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "689d4659",
+   "id": "3b04f5ca",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T21:58:11.391614Z",
-     "iopub.status.busy": "2026-09-09T21:58:11.391425Z",
-     "iopub.status.idle": "2026-09-09T21:58:11.394743Z",
-     "shell.execute_reply": "2026-09-09T21:58:11.394341Z"
+     "iopub.execute_input": "2026-09-11T01:29:52.851286Z",
+     "iopub.status.busy": "2026-09-11T01:29:52.851037Z",
+     "iopub.status.idle": "2026-09-11T01:29:52.854586Z",
+     "shell.execute_reply": "2026-09-11T01:29:52.853915Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.006394,
-     "end_time": "2026-09-09T21:58:11.394963+00:00",
+     "duration": 0.007018,
+     "end_time": "2026-09-11T01:29:52.854962+00:00",
      "exception": false,
-     "start_time": "2026-09-09T21:58:11.388569+00:00",
+     "start_time": "2026-09-11T01:29:52.847944+00:00",
      "status": "completed"
     }
    },
@@ -725,14 +729,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d1373b8d",
+   "id": "3ccecdad",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.001859,
-     "end_time": "2026-09-09T21:58:11.398877+00:00",
+     "duration": 0.002139,
+     "end_time": "2026-09-11T01:29:52.859620+00:00",
      "exception": false,
-     "start_time": "2026-09-09T21:58:11.397018+00:00",
+     "start_time": "2026-09-11T01:29:52.857481+00:00",
      "status": "completed"
     }
    },
@@ -759,20 +763,20 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "59334536",
+   "id": "3e5e1809",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T21:58:11.403089Z",
-     "iopub.status.busy": "2026-09-09T21:58:11.403002Z",
-     "iopub.status.idle": "2026-09-09T21:58:11.406877Z",
-     "shell.execute_reply": "2026-09-09T21:58:11.406483Z"
+     "iopub.execute_input": "2026-09-11T01:29:52.864928Z",
+     "iopub.status.busy": "2026-09-11T01:29:52.864804Z",
+     "iopub.status.idle": "2026-09-11T01:29:52.869449Z",
+     "shell.execute_reply": "2026-09-11T01:29:52.868886Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.006616,
-     "end_time": "2026-09-09T21:58:11.407330+00:00",
+     "duration": 0.007943,
+     "end_time": "2026-09-11T01:29:52.869755+00:00",
      "exception": false,
-     "start_time": "2026-09-09T21:58:11.400714+00:00",
+     "start_time": "2026-09-11T01:29:52.861812+00:00",
      "status": "completed"
     }
    },
@@ -826,14 +830,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ee1d251f",
+   "id": "21abb5f0",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.00181,
-     "end_time": "2026-09-09T21:58:11.411218+00:00",
+     "duration": 0.002229,
+     "end_time": "2026-09-11T01:29:52.874548+00:00",
      "exception": false,
-     "start_time": "2026-09-09T21:58:11.409408+00:00",
+     "start_time": "2026-09-11T01:29:52.872319+00:00",
      "status": "completed"
     }
    },
@@ -854,20 +858,20 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "1f9a0890",
+   "id": "1b893bfd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T21:58:11.415680Z",
-     "iopub.status.busy": "2026-09-09T21:58:11.415518Z",
-     "iopub.status.idle": "2026-09-09T21:58:13.954240Z",
-     "shell.execute_reply": "2026-09-09T21:58:13.953943Z"
+     "iopub.execute_input": "2026-09-11T01:29:52.880270Z",
+     "iopub.status.busy": "2026-09-11T01:29:52.880122Z",
+     "iopub.status.idle": "2026-09-11T01:29:55.803785Z",
+     "shell.execute_reply": "2026-09-11T01:29:55.803036Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 2.541899,
-     "end_time": "2026-09-09T21:58:13.954916+00:00",
+     "duration": 2.927589,
+     "end_time": "2026-09-11T01:29:55.804533+00:00",
      "exception": false,
-     "start_time": "2026-09-09T21:58:11.413017+00:00",
+     "start_time": "2026-09-11T01:29:52.876944+00:00",
      "status": "completed"
     }
    },
@@ -903,13 +907,13 @@
        "      <th>0</th>\n",
        "      <td>incumbent</td>\n",
        "      <td>linear/ols</td>\n",
-       "      <td>0.008745</td>\n",
+       "      <td>0.008504</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
        "      <td>candidate</td>\n",
        "      <td>linear/ridge_a100.0</td>\n",
-       "      <td>0.008719</td>\n",
+       "      <td>0.008487</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -917,8 +921,8 @@
       ],
       "text/plain": [
        "        role                model  mean_daily_spearman_ic\n",
-       "0  incumbent           linear/ols                0.008745\n",
-       "1  candidate  linear/ridge_a100.0                0.008719"
+       "0  incumbent           linear/ols                0.008504\n",
+       "1  candidate  linear/ridge_a100.0                0.008487"
       ]
      },
      "execution_count": 13,
@@ -952,14 +956,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b2d74059",
+   "id": "592464d8",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.003683,
-     "end_time": "2026-09-09T21:58:13.962572+00:00",
+     "duration": 0.002539,
+     "end_time": "2026-09-11T01:29:55.810185+00:00",
      "exception": false,
-     "start_time": "2026-09-09T21:58:13.958889+00:00",
+     "start_time": "2026-09-11T01:29:55.807646+00:00",
      "status": "completed"
     }
    },
@@ -988,20 +992,20 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "id": "cba98cc6",
+   "id": "d2bf3827",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T21:58:13.969244Z",
-     "iopub.status.busy": "2026-09-09T21:58:13.969064Z",
-     "iopub.status.idle": "2026-09-09T21:58:14.139425Z",
-     "shell.execute_reply": "2026-09-09T21:58:14.138855Z"
+     "iopub.execute_input": "2026-09-11T01:29:55.816708Z",
+     "iopub.status.busy": "2026-09-11T01:29:55.816503Z",
+     "iopub.status.idle": "2026-09-11T01:29:56.000692Z",
+     "shell.execute_reply": "2026-09-11T01:29:56.000111Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.173803,
-     "end_time": "2026-09-09T21:58:14.140043+00:00",
+     "duration": 0.188427,
+     "end_time": "2026-09-11T01:29:56.001301+00:00",
      "exception": false,
-     "start_time": "2026-09-09T21:58:13.966240+00:00",
+     "start_time": "2026-09-11T01:29:55.812874+00:00",
      "status": "completed"
     }
    },
@@ -1036,32 +1040,32 @@
        "    <tr>\n",
        "      <th>0</th>\n",
        "      <td>2015-01-02</td>\n",
-       "      <td>0.011407</td>\n",
-       "      <td>0.010045</td>\n",
+       "      <td>0.003411</td>\n",
+       "      <td>0.002932</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
        "      <td>2015-01-05</td>\n",
-       "      <td>0.005081</td>\n",
-       "      <td>0.005196</td>\n",
+       "      <td>0.000527</td>\n",
+       "      <td>0.000817</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
        "      <td>2015-01-06</td>\n",
-       "      <td>-0.007002</td>\n",
-       "      <td>-0.007088</td>\n",
+       "      <td>-0.015342</td>\n",
+       "      <td>-0.013669</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
        "      <td>2015-01-07</td>\n",
-       "      <td>-0.010503</td>\n",
-       "      <td>-0.010091</td>\n",
+       "      <td>-0.006978</td>\n",
+       "      <td>-0.006643</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
        "      <td>2015-01-08</td>\n",
-       "      <td>-0.001825</td>\n",
-       "      <td>-0.001477</td>\n",
+       "      <td>-0.001692</td>\n",
+       "      <td>-0.003387</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -1069,11 +1073,11 @@
       ],
       "text/plain": [
        "model  timestamp  linear/ols  linear/ridge_a100.0\n",
-       "0     2015-01-02    0.011407             0.010045\n",
-       "1     2015-01-05    0.005081             0.005196\n",
-       "2     2015-01-06   -0.007002            -0.007088\n",
-       "3     2015-01-07   -0.010503            -0.010091\n",
-       "4     2015-01-08   -0.001825            -0.001477"
+       "0     2015-01-02    0.003411             0.002932\n",
+       "1     2015-01-05    0.000527             0.000817\n",
+       "2     2015-01-06   -0.015342            -0.013669\n",
+       "3     2015-01-07   -0.006978            -0.006643\n",
+       "4     2015-01-08   -0.001692            -0.003387"
       ]
      },
      "execution_count": 14,
@@ -1098,14 +1102,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ad69470d",
+   "id": "7b1e8093",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.00367,
-     "end_time": "2026-09-09T21:58:14.147880+00:00",
+     "duration": 0.002465,
+     "end_time": "2026-09-11T01:29:56.006555+00:00",
      "exception": false,
-     "start_time": "2026-09-09T21:58:14.144210+00:00",
+     "start_time": "2026-09-11T01:29:56.004090+00:00",
      "status": "completed"
     }
    },
@@ -1118,20 +1122,20 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "id": "8dce49bd",
+   "id": "5b3507d3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T21:58:14.154288Z",
-     "iopub.status.busy": "2026-09-09T21:58:14.154183Z",
-     "iopub.status.idle": "2026-09-09T21:58:14.156175Z",
-     "shell.execute_reply": "2026-09-09T21:58:14.155924Z"
+     "iopub.execute_input": "2026-09-11T01:29:56.012529Z",
+     "iopub.status.busy": "2026-09-11T01:29:56.012395Z",
+     "iopub.status.idle": "2026-09-11T01:29:56.015177Z",
+     "shell.execute_reply": "2026-09-11T01:29:56.014547Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.005103,
-     "end_time": "2026-09-09T21:58:14.156608+00:00",
+     "duration": 0.006804,
+     "end_time": "2026-09-11T01:29:56.015888+00:00",
      "exception": false,
-     "start_time": "2026-09-09T21:58:14.151505+00:00",
+     "start_time": "2026-09-11T01:29:56.009084+00:00",
      "status": "completed"
     }
    },
@@ -1147,14 +1151,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1e3d5e7a",
+   "id": "a39270bc",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.002005,
-     "end_time": "2026-09-09T21:58:14.160621+00:00",
+     "duration": 0.004155,
+     "end_time": "2026-09-11T01:29:56.024711+00:00",
      "exception": false,
-     "start_time": "2026-09-09T21:58:14.158616+00:00",
+     "start_time": "2026-09-11T01:29:56.020556+00:00",
      "status": "completed"
     }
    },
@@ -1165,20 +1169,20 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "id": "b0bc493b",
+   "id": "6fccc3f3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T21:58:14.165252Z",
-     "iopub.status.busy": "2026-09-09T21:58:14.165157Z",
-     "iopub.status.idle": "2026-09-09T21:58:14.167259Z",
-     "shell.execute_reply": "2026-09-09T21:58:14.166851Z"
+     "iopub.execute_input": "2026-09-11T01:29:56.031699Z",
+     "iopub.status.busy": "2026-09-11T01:29:56.031535Z",
+     "iopub.status.idle": "2026-09-11T01:29:56.034328Z",
+     "shell.execute_reply": "2026-09-11T01:29:56.033745Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.004959,
-     "end_time": "2026-09-09T21:58:14.167542+00:00",
+     "duration": 0.006699,
+     "end_time": "2026-09-11T01:29:56.034700+00:00",
      "exception": false,
-     "start_time": "2026-09-09T21:58:14.162583+00:00",
+     "start_time": "2026-09-11T01:29:56.028001+00:00",
      "status": "completed"
     }
    },
@@ -1192,14 +1196,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "006418c4",
+   "id": "1ef0416d",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.001949,
-     "end_time": "2026-09-09T21:58:14.171473+00:00",
+     "duration": 0.002549,
+     "end_time": "2026-09-11T01:29:56.040066+00:00",
      "exception": false,
-     "start_time": "2026-09-09T21:58:14.169524+00:00",
+     "start_time": "2026-09-11T01:29:56.037517+00:00",
      "status": "completed"
     }
    },
@@ -1226,20 +1230,20 @@
   {
    "cell_type": "code",
    "execution_count": 17,
-   "id": "ab9b3feb",
+   "id": "e7eed628",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T21:58:14.176250Z",
-     "iopub.status.busy": "2026-09-09T21:58:14.176145Z",
-     "iopub.status.idle": "2026-09-09T21:58:14.620310Z",
-     "shell.execute_reply": "2026-09-09T21:58:14.619794Z"
+     "iopub.execute_input": "2026-09-11T01:29:56.046633Z",
+     "iopub.status.busy": "2026-09-11T01:29:56.046477Z",
+     "iopub.status.idle": "2026-09-11T01:29:56.559071Z",
+     "shell.execute_reply": "2026-09-11T01:29:56.558595Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.447286,
-     "end_time": "2026-09-09T21:58:14.620758+00:00",
+     "duration": 0.516838,
+     "end_time": "2026-09-11T01:29:56.559762+00:00",
      "exception": false,
-     "start_time": "2026-09-09T21:58:14.173472+00:00",
+     "start_time": "2026-09-11T01:29:56.042924+00:00",
      "status": "completed"
     }
    },
@@ -1274,14 +1278,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8a6214ad",
+   "id": "6a9d841d",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.002088,
-     "end_time": "2026-09-09T21:58:14.625174+00:00",
+     "duration": 0.002106,
+     "end_time": "2026-09-11T01:29:56.564366+00:00",
      "exception": false,
-     "start_time": "2026-09-09T21:58:14.623086+00:00",
+     "start_time": "2026-09-11T01:29:56.562260+00:00",
      "status": "completed"
     }
    },
@@ -1296,20 +1300,20 @@
   {
    "cell_type": "code",
    "execution_count": 18,
-   "id": "58140b96",
+   "id": "8846a0dc",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T21:58:14.630203Z",
-     "iopub.status.busy": "2026-09-09T21:58:14.630013Z",
-     "iopub.status.idle": "2026-09-09T21:58:14.635099Z",
-     "shell.execute_reply": "2026-09-09T21:58:14.634701Z"
+     "iopub.execute_input": "2026-09-11T01:29:56.569367Z",
+     "iopub.status.busy": "2026-09-11T01:29:56.569105Z",
+     "iopub.status.idle": "2026-09-11T01:29:56.575045Z",
+     "shell.execute_reply": "2026-09-11T01:29:56.574650Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.008142,
-     "end_time": "2026-09-09T21:58:14.635396+00:00",
+     "duration": 0.009034,
+     "end_time": "2026-09-11T01:29:56.575443+00:00",
      "exception": false,
-     "start_time": "2026-09-09T21:58:14.627254+00:00",
+     "start_time": "2026-09-11T01:29:56.566409+00:00",
      "status": "completed"
     }
    },
@@ -1345,16 +1349,16 @@
        "    <tr>\n",
        "      <th>0</th>\n",
        "      <td>linear/ols</td>\n",
-       "      <td>-0.734893</td>\n",
-       "      <td>-0.028108</td>\n",
-       "      <td>-0.094223</td>\n",
+       "      <td>-0.993985</td>\n",
+       "      <td>-0.035065</td>\n",
+       "      <td>-0.081068</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
        "      <td>linear/ridge_a100.0</td>\n",
-       "      <td>-0.549596</td>\n",
-       "      <td>-0.021798</td>\n",
-       "      <td>-0.089762</td>\n",
+       "      <td>-0.836962</td>\n",
+       "      <td>-0.029901</td>\n",
+       "      <td>-0.080155</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -1362,12 +1366,12 @@
       ],
       "text/plain": [
        "                 model  shadow_sharpe  shadow_total_return  \\\n",
-       "0           linear/ols      -0.734893            -0.028108   \n",
-       "1  linear/ridge_a100.0      -0.549596            -0.021798   \n",
+       "0           linear/ols      -0.993985            -0.035065   \n",
+       "1  linear/ridge_a100.0      -0.836962            -0.029901   \n",
        "\n",
        "   shadow_max_drawdown  \n",
-       "0            -0.094223  \n",
-       "1            -0.089762  "
+       "0            -0.081068  \n",
+       "1            -0.080155  "
       ]
      },
      "execution_count": 18,
@@ -1392,14 +1396,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "eab0d6ed",
+   "id": "7e64c1dd",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.002081,
-     "end_time": "2026-09-09T21:58:14.639736+00:00",
+     "duration": 0.002035,
+     "end_time": "2026-09-11T01:29:56.580011+00:00",
      "exception": false,
-     "start_time": "2026-09-09T21:58:14.637655+00:00",
+     "start_time": "2026-09-11T01:29:56.577976+00:00",
      "status": "completed"
     }
    },
@@ -1417,20 +1421,20 @@
   {
    "cell_type": "code",
    "execution_count": 19,
-   "id": "5da41074",
+   "id": "06a2d556",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T21:58:14.644669Z",
-     "iopub.status.busy": "2026-09-09T21:58:14.644566Z",
-     "iopub.status.idle": "2026-09-09T21:58:14.646983Z",
-     "shell.execute_reply": "2026-09-09T21:58:14.646718Z"
+     "iopub.execute_input": "2026-09-11T01:29:56.584886Z",
+     "iopub.status.busy": "2026-09-11T01:29:56.584772Z",
+     "iopub.status.idle": "2026-09-11T01:29:56.587278Z",
+     "shell.execute_reply": "2026-09-11T01:29:56.586998Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.0055,
-     "end_time": "2026-09-09T21:58:14.647347+00:00",
+     "duration": 0.005473,
+     "end_time": "2026-09-11T01:29:56.587528+00:00",
      "exception": false,
-     "start_time": "2026-09-09T21:58:14.641847+00:00",
+     "start_time": "2026-09-11T01:29:56.582055+00:00",
      "status": "completed"
     }
    },
@@ -1449,14 +1453,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0b67ccff",
+   "id": "f05fc040",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.004057,
-     "end_time": "2026-09-09T21:58:14.654495+00:00",
+     "duration": 0.001951,
+     "end_time": "2026-09-11T01:29:56.591489+00:00",
      "exception": false,
-     "start_time": "2026-09-09T21:58:14.650438+00:00",
+     "start_time": "2026-09-11T01:29:56.589538+00:00",
      "status": "completed"
     }
    },
@@ -1469,20 +1473,20 @@
   {
    "cell_type": "code",
    "execution_count": 20,
-   "id": "31ade02f",
+   "id": "cb6c81f4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T21:58:14.663821Z",
-     "iopub.status.busy": "2026-09-09T21:58:14.663596Z",
-     "iopub.status.idle": "2026-09-09T21:58:14.666862Z",
-     "shell.execute_reply": "2026-09-09T21:58:14.666513Z"
+     "iopub.execute_input": "2026-09-11T01:29:56.596477Z",
+     "iopub.status.busy": "2026-09-11T01:29:56.596353Z",
+     "iopub.status.idle": "2026-09-11T01:29:56.599565Z",
+     "shell.execute_reply": "2026-09-11T01:29:56.599276Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.00879,
-     "end_time": "2026-09-09T21:58:14.667399+00:00",
+     "duration": 0.006435,
+     "end_time": "2026-09-11T01:29:56.600036+00:00",
      "exception": false,
-     "start_time": "2026-09-09T21:58:14.658609+00:00",
+     "start_time": "2026-09-11T01:29:56.593601+00:00",
      "status": "completed"
     }
    },
@@ -1500,14 +1504,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a7faeb9d",
+   "id": "32588f96",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.002016,
-     "end_time": "2026-09-09T21:58:14.672129+00:00",
+     "duration": 0.001929,
+     "end_time": "2026-09-11T01:29:56.604731+00:00",
      "exception": false,
-     "start_time": "2026-09-09T21:58:14.670113+00:00",
+     "start_time": "2026-09-11T01:29:56.602802+00:00",
      "status": "completed"
     }
    },
@@ -1519,20 +1523,20 @@
   {
    "cell_type": "code",
    "execution_count": 21,
-   "id": "bae70e21",
+   "id": "0f32327c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T21:58:14.677058Z",
-     "iopub.status.busy": "2026-09-09T21:58:14.676954Z",
-     "iopub.status.idle": "2026-09-09T21:58:14.681822Z",
-     "shell.execute_reply": "2026-09-09T21:58:14.681390Z"
+     "iopub.execute_input": "2026-09-11T01:29:56.609409Z",
+     "iopub.status.busy": "2026-09-11T01:29:56.609292Z",
+     "iopub.status.idle": "2026-09-11T01:29:56.615330Z",
+     "shell.execute_reply": "2026-09-11T01:29:56.614974Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.00804,
-     "end_time": "2026-09-09T21:58:14.682288+00:00",
+     "duration": 0.008905,
+     "end_time": "2026-09-11T01:29:56.615600+00:00",
      "exception": false,
-     "start_time": "2026-09-09T21:58:14.674248+00:00",
+     "start_time": "2026-09-11T01:29:56.606695+00:00",
      "status": "completed"
     }
    },
@@ -1568,7 +1572,7 @@
        "    <tr>\n",
        "      <th>0</th>\n",
        "      <td>Sharpe improvement</td>\n",
-       "      <td>0.185298</td>\n",
+       "      <td>0.157023</td>\n",
        "      <td>0.20</td>\n",
        "      <td>False</td>\n",
        "    </tr>\n",
@@ -1582,21 +1586,21 @@
        "    <tr>\n",
        "      <th>2</th>\n",
        "      <td>Signal correlation</td>\n",
-       "      <td>0.998418</td>\n",
+       "      <td>0.998461</td>\n",
        "      <td>0.30</td>\n",
        "      <td>True</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
        "      <td>Position agreement</td>\n",
-       "      <td>0.945031</td>\n",
+       "      <td>0.944729</td>\n",
        "      <td>0.30</td>\n",
        "      <td>True</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
        "      <td>Drawdown ratio</td>\n",
-       "      <td>0.952663</td>\n",
+       "      <td>0.988740</td>\n",
        "      <td>1.25</td>\n",
        "      <td>True</td>\n",
        "    </tr>\n",
@@ -1606,11 +1610,11 @@
       ],
       "text/plain": [
        "              criterion   observed  required  passed\n",
-       "0    Sharpe improvement   0.185298      0.20   False\n",
+       "0    Sharpe improvement   0.157023      0.20   False\n",
        "1  Observation sessions  63.000000     63.00    True\n",
-       "2    Signal correlation   0.998418      0.30    True\n",
-       "3    Position agreement   0.945031      0.30    True\n",
-       "4        Drawdown ratio   0.952663      1.25    True"
+       "2    Signal correlation   0.998461      0.30    True\n",
+       "3    Position agreement   0.944729      0.30    True\n",
+       "4        Drawdown ratio   0.988740      1.25    True"
       ]
      },
      "execution_count": 21,
@@ -1659,14 +1663,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ad913bf7",
+   "id": "159246ab",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.002093,
-     "end_time": "2026-09-09T21:58:14.686596+00:00",
+     "duration": 0.002091,
+     "end_time": "2026-09-11T01:29:56.620047+00:00",
      "exception": false,
-     "start_time": "2026-09-09T21:58:14.684503+00:00",
+     "start_time": "2026-09-11T01:29:56.617956+00:00",
      "status": "completed"
     }
    },
@@ -1689,20 +1693,20 @@
   {
    "cell_type": "code",
    "execution_count": 22,
-   "id": "2817f4f6",
+   "id": "c1633381",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T21:58:14.691859Z",
-     "iopub.status.busy": "2026-09-09T21:58:14.691759Z",
-     "iopub.status.idle": "2026-09-09T21:58:14.695125Z",
-     "shell.execute_reply": "2026-09-09T21:58:14.694756Z"
+     "iopub.execute_input": "2026-09-11T01:29:56.625296Z",
+     "iopub.status.busy": "2026-09-11T01:29:56.625142Z",
+     "iopub.status.idle": "2026-09-11T01:29:56.629397Z",
+     "shell.execute_reply": "2026-09-11T01:29:56.629066Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.007,
-     "end_time": "2026-09-09T21:58:14.695694+00:00",
+     "duration": 0.007766,
+     "end_time": "2026-09-11T01:29:56.629904+00:00",
      "exception": false,
-     "start_time": "2026-09-09T21:58:14.688694+00:00",
+     "start_time": "2026-09-11T01:29:56.622138+00:00",
      "status": "completed"
     }
    },
@@ -1713,8 +1717,8 @@
        "\n",
        "**Decision: hold in shadow.**\n",
        "Over 63 shadow sessions, `linear/ols` records an annualized Sharpe of\n",
-       "-0.73 and `linear/ridge_a100.0` records\n",
-       "-0.55, a difference of +0.19 against a\n",
+       "-0.99 and `linear/ridge_a100.0` records\n",
+       "-0.84, a difference of +0.16 against a\n",
        "required 0.20.\n",
        "Unmet: Sharpe improvement. The candidate receives no capital.\n"
       ],
@@ -1750,14 +1754,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c21b1e4c",
+   "id": "ed46d604",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.003714,
-     "end_time": "2026-09-09T21:58:14.703535+00:00",
+     "duration": 0.002621,
+     "end_time": "2026-09-11T01:29:56.637081+00:00",
      "exception": false,
-     "start_time": "2026-09-09T21:58:14.699821+00:00",
+     "start_time": "2026-09-11T01:29:56.634460+00:00",
      "status": "completed"
     }
    },
@@ -1774,19 +1778,19 @@
   {
    "cell_type": "code",
    "execution_count": 23,
-   "id": "9039367c",
+   "id": "ffc3d4ed",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T21:58:14.708651Z",
-     "iopub.status.busy": "2026-09-09T21:58:14.708542Z",
-     "iopub.status.idle": "2026-09-09T21:58:14.711266Z",
-     "shell.execute_reply": "2026-09-09T21:58:14.710877Z"
+     "iopub.execute_input": "2026-09-11T01:29:56.643908Z",
+     "iopub.status.busy": "2026-09-11T01:29:56.643788Z",
+     "iopub.status.idle": "2026-09-11T01:29:56.646366Z",
+     "shell.execute_reply": "2026-09-11T01:29:56.646041Z"
     },
     "papermill": {
-     "duration": 0.005885,
-     "end_time": "2026-09-09T21:58:14.711539+00:00",
+     "duration": 0.006586,
+     "end_time": "2026-09-11T01:29:56.646596+00:00",
      "exception": false,
-     "start_time": "2026-09-09T21:58:14.705654+00:00",
+     "start_time": "2026-09-11T01:29:56.640010+00:00",
      "status": "completed"
     }
    },
@@ -1802,14 +1806,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "44606888",
+   "id": "89041ae3",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.003328,
-     "end_time": "2026-09-09T21:58:14.717438+00:00",
+     "duration": 0.002068,
+     "end_time": "2026-09-11T01:29:56.651121+00:00",
      "exception": false,
-     "start_time": "2026-09-09T21:58:14.714110+00:00",
+     "start_time": "2026-09-11T01:29:56.649053+00:00",
      "status": "completed"
     }
    },
@@ -1820,20 +1824,20 @@
   {
    "cell_type": "code",
    "execution_count": 24,
-   "id": "daca49e1",
+   "id": "a23a6491",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T21:58:14.726638Z",
-     "iopub.status.busy": "2026-09-09T21:58:14.726515Z",
-     "iopub.status.idle": "2026-09-09T21:58:14.729323Z",
-     "shell.execute_reply": "2026-09-09T21:58:14.728886Z"
+     "iopub.execute_input": "2026-09-11T01:29:56.656065Z",
+     "iopub.status.busy": "2026-09-11T01:29:56.655964Z",
+     "iopub.status.idle": "2026-09-11T01:29:56.658512Z",
+     "shell.execute_reply": "2026-09-11T01:29:56.658193Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.008082,
-     "end_time": "2026-09-09T21:58:14.729889+00:00",
+     "duration": 0.005585,
+     "end_time": "2026-09-11T01:29:56.658936+00:00",
      "exception": false,
-     "start_time": "2026-09-09T21:58:14.721807+00:00",
+     "start_time": "2026-09-11T01:29:56.653351+00:00",
      "status": "completed"
     }
    },
@@ -1872,14 +1876,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dd66dd0c",
+   "id": "c9f4a55a",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.002131,
-     "end_time": "2026-09-09T21:58:14.735091+00:00",
+     "duration": 0.002055,
+     "end_time": "2026-09-11T01:29:56.663208+00:00",
      "exception": false,
-     "start_time": "2026-09-09T21:58:14.732960+00:00",
+     "start_time": "2026-09-11T01:29:56.661153+00:00",
      "status": "completed"
     }
    },
@@ -1890,20 +1894,20 @@
   {
    "cell_type": "code",
    "execution_count": 25,
-   "id": "447eccb6",
+   "id": "a2ee8d69",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T21:58:14.741297Z",
-     "iopub.status.busy": "2026-09-09T21:58:14.741142Z",
-     "iopub.status.idle": "2026-09-09T21:58:14.744710Z",
-     "shell.execute_reply": "2026-09-09T21:58:14.744233Z"
+     "iopub.execute_input": "2026-09-11T01:29:56.668080Z",
+     "iopub.status.busy": "2026-09-11T01:29:56.667975Z",
+     "iopub.status.idle": "2026-09-11T01:29:56.670620Z",
+     "shell.execute_reply": "2026-09-11T01:29:56.670239Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.007804,
-     "end_time": "2026-09-09T21:58:14.745148+00:00",
+     "duration": 0.005749,
+     "end_time": "2026-09-11T01:29:56.671087+00:00",
      "exception": false,
-     "start_time": "2026-09-09T21:58:14.737344+00:00",
+     "start_time": "2026-09-11T01:29:56.665338+00:00",
      "status": "completed"
     }
    },
@@ -1948,14 +1952,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5d02ec75",
+   "id": "335b44e8",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.002159,
-     "end_time": "2026-09-09T21:58:14.751460+00:00",
+     "duration": 0.002987,
+     "end_time": "2026-09-11T01:29:56.676918+00:00",
      "exception": false,
-     "start_time": "2026-09-09T21:58:14.749301+00:00",
+     "start_time": "2026-09-11T01:29:56.673931+00:00",
      "status": "completed"
     }
    },
@@ -1967,27 +1971,27 @@
   {
    "cell_type": "code",
    "execution_count": 26,
-   "id": "07848a0e",
+   "id": "6e4fd89c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T21:58:14.756509Z",
-     "iopub.status.busy": "2026-09-09T21:58:14.756367Z",
-     "iopub.status.idle": "2026-09-09T21:58:14.906784Z",
-     "shell.execute_reply": "2026-09-09T21:58:14.906256Z"
+     "iopub.execute_input": "2026-09-11T01:29:56.683492Z",
+     "iopub.status.busy": "2026-09-11T01:29:56.683344Z",
+     "iopub.status.idle": "2026-09-11T01:29:56.865468Z",
+     "shell.execute_reply": "2026-09-11T01:29:56.864758Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.153738,
-     "end_time": "2026-09-09T21:58:14.907325+00:00",
+     "duration": 0.186599,
+     "end_time": "2026-09-11T01:29:56.866443+00:00",
      "exception": false,
-     "start_time": "2026-09-09T21:58:14.753587+00:00",
+     "start_time": "2026-09-11T01:29:56.679844+00:00",
      "status": "completed"
     }
    },
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAkgAAAH1CAYAAAANogGZAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjksIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvJkbTWQAAAAlwSFlzAAAPYQAAD2EBqD+naQABAABJREFUeJzs3XVYFF0UwOHfsizdXSIGYiF2d3d3d3eL3d3d3d3d3Y0gJiEp3bXfHwurSIgKrB/O+zw8ys7MnbPFnr1z77mimJhoKQKBQCAQCAQCOSVFByAQCAQCgUDwtxESJIFAIBAIBIIfCAmSQCAQCAQCwQ+EBEkgEAgEAoHgB0KC9D9kX74B9Vt0+61jo6KiKVy6Do7TF2ZyVCk1at2LEpUaZ0pbfYdMQM/KIVPayinWbNpFnqJV8fjirehQktGzcqDvkAmKDiNTZOf7JavFxcWhZ+XAgBGTATh++hK5i1Tm0ZMXqe4/a8Eq9Kwc+OzumZ1hCgR/DSFB+gXXb9+nYaueWBeuTOmqTZk5fyXR0TGKDitd0+Ysw758A/nvamqq7Ny4hMF9uyowqpxhy84DCk3a2rdqzO7Ny7A0N1VYDNmtdpPO8g/47JBZ75fIyCj0rBzYfeB4JkX252pVr8juTcsoVrTQH7d16eptIZkS5DhCgpRBR06co1m7vkilCcyaNJLO7Zpz8eot/L8GKjq0dPn4fU1xW6kS9lj8Qx+qWcXHN+Vjm50M9PWoWK4kIpFIoXFkp9Rez1ktM94vvv6Kfa2kRktTg8oVSqOiIvnjtnz8/DMhIoHg7yIkSBkQGRnFuCnzsS9ix4n9G+nasSXDB/Xk+tl9WFqY8tndEz0rB2YtWCU/5vvLDLsPHEfPyoHL125TvWEH8hWrztTZS3FydpX3SI2ZNBepVFaSasCIyehZORAXFwfA3MVr0bNy4MNHtxSxRURGsmTVZirVaYOFbTkq1WnDg8fPAdklrr0HT+Du8SVZ13pSbEHBIRjnKcXYyfPk7R04cho9Kwec375HKpWyY+8RSlVpQu4ilek71JGQ0LAUMVy/fZ+KtVphYVuOmo06cuX6Hfm2+IR4lq3egkPFhtgWr8GBI6cBWXf/pu37qdmoI1Z2FShZuQlnL16TH/c1IJCufUdhXagS9Vt04+Nnj2Tn9PP/St+hjuQpWhX78g2Yt2QdsbGxANRo1JHyNVsAEBsbi4VtOfIUrUpCQgIA5Wu2oGOv4cnaS3oOj5w4R+vOA8lTtCrR0TEEBYUwaNQU8hStSolKjdmx54j8OZq/dJ388WzUuheQ8vJno9a9KFy6TrrnsC/fgDGT5jJh2kLsStbCvnwDrt+6n+Jx/tGPr4uftRMYGMywsTMoWKo2+YpVZ+zkeUil0hTtJL1er928J78PXfuOYt6SdRQqVZtyNVpw4/YDNm3fT7EKDShath5Xb9xNFpuXjx+de4/AulAlajfpjJOzq3yb89v3NGvfFyu7ClRr0J6Hj18ke3y27jpIp17DsS5cmdpNOssvIepZOeDu8YW9B0+k2hvj/PY9fYdMoGi5+lgXqkSvQeMIDQsHQCqVMm/JOuxK1kLPykH+M2vBqnTfQ0nnTe29XKdpF3IVrEivQePkrz03jy80a98XC9tylK7alFUbdnDj9gMcKjQEYNDIKan2tMTFxbFi7TZKVm6ClV0F2nQZxNeAQAICg5g6eynlarTAwrYc9Zp3w/X9pww9XgDXb92nQq2W2BSpwrgp85Od88fnOTwigmFjZ5C7SGUq123L0+evk+1/8OgZGrTqgXXhyhQtW0/+Xpi7eC2DRk4BwKFCQ3mPdWRkFJNmLsauZC2KlKnLohUb5e9BgeD/QEiQMsD57Xv8/APo1rEVEsm3b1u/+s192LiZdG7XnHx5rFm+dhutOg2gWaPaFCmYn43b9vHshdMvx6YkUuL6rfu0ad6AKeOH4uvnT7+hE5FKpUwaO4gC+fNgZKjPrk1L6dezY7Jj9XR1qFmtIheu3JQnZ+cuXadggbwULJCPY6cuMHTMdEqVsGfW5FHcuvMwWRKYpP/QiSASMW/GOIoUKkB0zLfLjm7uX7j/+DlD+nVDSUmJsZPnER8fj1gs5trNe9SpWYUZk0YglUrpN2wSYeERAAwcMZlzl64zakhvmjSszfvvksOEhAS69BnJhcs3mThmEK2b1WfekrXMX7oegKoVy+D89gNBwSG8cnpLQoKUwKBg3r77SFBQCM5vP1C5QunUn6OxM7CyNGPtspmoqEjoM2QCp85dYfjAHrRqVp+hY6fz7IUT/Xp2pGK5UgDs2rSUSWMHZfg5+/4cqqoqAGzcto+Q0FCGDexBQEAgjtMXZbi976XVTkJCAl36jmT/4VP06tqWYQO6U7BA3gy/hk+cucTL184MHdADzy/etO4ykBNnLjGwd2dCQsNSjNG59/ApBfLnYeqEYbh++ESvQeNISEggKDiE5h364ePrx8zJI7G2sqBjr2FEREbKj50wdSHFihakW4eWPHr6kpXrtgOwff1iAKpULMOuTUupWqlssnN6eHoTHhHJ2GF9ad28AYePn2Pd5t0AHDp2lnlL1tKoXg3GjegPQP9enWjdvEG676G0DBs7g3atGlOhbEkOHz/HuUs3AJg5byVPnr1i1pRRNK5fk6ioaIoUsmX8yAEA9O3RgV2blmJsZJCsvYXLNzJl9lIqVyjNzMkjsSuQF309XeLj43n09BXdO7Vm7PB+vHztzOiJc5Idm9bj5e7pRbtuQxCJlJgzbQyxsXHpPsfTZi9j+57D9OrSll5d2/A2MRFLcvfBE8qUKMasySMxNNRnxIRZfHb3pFWz+jRrJPsSsGzeZJbPl30RmzRzMeu37KFbx1b0792JuYvXcurclXRjEAj+JsqKDuD/4JObrPfC0uLPutmXzp1EnZqVMTLU58Hj54we1pdeXdtiZmLM3QdPcXH9QAmHIr/UppqaKsf3beBrQCBPnzuRP58Nd+8/4WtAIBXKlsRAX5fIqGga16+Z6vEtm9Sj37CJvH33kbw2ubh07Q4DenUCYMPWveS1sWbBjPEgAtd3nzh8/CwLZo5P1oa2thYSiTIVypaka4eWybaZGBuyZ/MyRCIRr5xc2Lb7MH7+AZiZGrNr01JCQsN4+uI1RQsX4OTZy7x1/YCVpTnnL9+kd7d2DBvYA4D7D59x4swlAF68cubew2eMGNST3t3aAbJvyhu27mXimEFUrVSW5Wu38fjpS1zff6JY0YJ4fvHm7oMn5LK0AEgzQSpfpgRL501GJBLx8ZM7F6/eYsywvnTr1AqksOfAcU6dv8KkMYOxSnw9pPXYpuX7cyQpVbwoqxfPAODS1Vvcuvvol9r8WTsvXrtw6+4jJowawJhhfX+5XRNjQ3ZtWopIJOLqjbtcuHKT/dtWoq6uxtUbd7l07Q4JCQkoKcm+c9WvXY0p44cC8PK1M9t2H+azmyc37z7E28ePNUtmULJ4UUqVsKdqvXY8fPwCm9xWAPTr2YFxI/rLexld338EoFG96gBYWZqn+pjXrlGJWtUr4uL6AXV1NXbuOyrvnXrw+Dka6mosmDkeZWVlDh8/C0DBAvkA0nwPGRkapDgPwNJ5k6lTszLFihbkwpWb8l4dbW1NAPLlzU2Pzm3kz3H5MsUBcLAvlCJ2qVTK2k27qFKxDCsWTk22zdjIkNOHNvPFy4fnr96Qy8qCh4+fJ0ve0nq8Dh87S1R0NKsWTaNk8aI0bVibHXuPpHp/EhIS2H3gOHVrVpE/b+8/urFq/Q75PkvmTiIyMoqnL5wo6VCE5y/f8PT5a5o3rottPhsAalSrQO5clkRFRbNt92HatmzEwD6dATh55jKnzl2hacPaqcYgEPxthAQpA3JZmgPg5e37R+1IJLKH29BAX/a7sux3AwM9AGJiYn+5zZiYWEY5zmbvoZNYWpiiktjDFRISluYf9+81qFsdVVUVzl+6QfFihQkJCaVZI9kfsE+fPfDy8cOmaBX5/qmNVzi4czWz5q+ifM2W1K1VhdmTR5E3jzUAymKx/EMiKZ7omBikUimzFqxizcZd6Opqyx+TkNAw3BIvPyS18aOkhNXB/tvg0hIORXjy/DUBgUGUL1sCiUSZh09e8vbdBwoWyIeOthZ3HzzFO7c/ero6FC1UINW2HewLyeNNOs/C5RtYuHyDfB9//4B0H9Of+f4cSZJeGwBGBvq/9VpIr51Pn90BsC9S8Lfa/f55NDTUT3YuAwN94uPjkyVI398/O1tZEhIQGMRnN9lz27LTgGTt+/kHyBOkpF5aZWVl9PV0iI7O2GPxxuUdvQdPkH3RKFYYibIyIaGhANgXsSMiMoojJ85jZmrMx88e8sHtv/MeSrrvRomv26TJGjMmjcTAQI/OvUaQ29qKmZNGUKNqhXTj/hoQSEhoGPZF7FJsCwkNo//wSZy7eJ38eXMTERlFRGQU8fHx38WS+uPl5vEFSPt99D3/r4FEREalu+/6LXuYs3gNSiIl8iQ+VyEhKS+5A3h+8SY+Pp69B0+w9+AJ+e1aWho/jUUg+FsIl9gyoKBdfnR1tdm575h8XBAgH3eQ9AfVN3EAaWrjdH7Fj+2FhqXd3sFjZ9i57yinD23m+Z0ztGxaP9l2JSUx0dHRaR6vo61FnRqVuXz9Dpev3cY2nw2F7PIDkNvaEutcFpzYv5GTBzZx8sAmju/bkKKN3Lks2bhqLk9vn+L1m7cMHj3tp/fx1t1HLF65iRULp/Lm0UX5t0wAExMjAJ6/fCO/7ftvzDbWsj/O31+SfPr8NTraWhjo66GpoUHpksVwcnbl5WsXSjoUobhDYV68eoOTsysVy5eSf5CnJ3cuSwB6dmkjv/8nD2xiaP/uACiJxYBsKngSFYkyvn4B8pjDwsN/ep7sYG0l6zl75eSSYltS0ps0kDj0D1+/P3r77gMAeW2s5Y/p0nmTkj2mNaqW/2k7SUlXWq/n0RPnIhYr8fHVDS6e2Inhd8lNq2b1MTE2pO9QR5q264ND0YJ079wa+Pl76FdoaWowacxgXj+8gHUuCzr0kF0+THq9pRa77DWrziuntym2rd6wkyvX7vDo+nEeXDtGlYplMhyLiXHi++iV7H2U3iVDA31dlJWV5fv+uP9nd0/GTZnPsAE9eP/iGtMnjkh2/Lf7J0sULS3MUFJSolG9Gsme51mTR2U4foFA0YQepAzQ0tRg5sSRDB07nWbt+9GuVSOCg0NZv3Uva5fOpELZEujqanP6/FVyWZlz+vzVZN/kf5VtfhsAxk2ZT57cudi261Cy7RZmJrh7ePHJzYPIyChANs32ybPXbN11MNm+NrktuXP/MWs27aJMiWKUKVUsxflaNq1H/+GT+OLlQ7PGdeQfRL27taf34PFs3LaPOjUr4+b+hfJlSiQ79rO7J70GjqNF03poa2kSExOLWPzz5CMp7rsPnhAeHsGKxHETIOuxK+FQhFNnL7OuWGFCQsM4f/mGfLt9ETvKlS7Ott2HsbI0x/OLN0+ev2b00D7y2KtWLMvuA8f54uVDqZL2mH0xZsnKzYSFRyZLxtKTxyYXNatV4ODRM+jp6mCT24oXr5yZOmGY7LFNTNTmL11HjaoVqFqpLLb583Du4nWmzl7KJzdP3ri8k/cy/I7Y2FgatupJHptcbFgx5+cHpMHBvhAlHYqwdNUWlJWVMTLQx8nlHXOnjZFfHpm1YBWVypdmw9a9v32eJLfuPmLVhh3Ex8Wz+8BxmjSohb6+Lk0a1GLWwlWsWr+D7p1aI5EoExgUQpWKZeTjz9IiFouxzmXBjdsPOHDkNKVL2Cfr8YiMjMTfP4ATZy7x5Nkr3D2+YGluAsCho2cJCQlj8rghxMfHU9y+MOHhEWhraf70PZRRsbGxtO8+lOLFCmObz4aAgEBEIhEiROS2liWGew+exEBfj9o1KqOlKetNUVJSokeXNqxav4MR42dSrnRxbt59yOzJo4mMjCIqOpoLV24SHhHJqbOXMxxPkwa1mLdkLbPmr8Kziw8n0zlWWVmZRvVqcOrcFRat2IiGhjo79x2Tb096jJ69cGLPwRNs3nEg2fFJvX/L126lWcM61K1Vha4dWrD7wHFyWVlQtHABnr9wYtignhmOXyBQNKEHKYO6dmzJ3q3LiY2NZeL0RWzbfYh2LRtRrnRxlJWVWTBjPCKR7A9gv54dKV0yZSKSUZ3bNada5XJcv3Wfdx8/s3rJjGTbO7ZpSlBwCCfPXqZ96ybUrl6JNRt3cvbitRT1WkYN7o2DfSFmL1jF9j2HUz1fvdpVURaLcX3/ieaN6spvb9WsPisXTePtu4+MmzyfMxeupegRMTc1oUbVCmzcto/xU+aTP29ulsyd9NP7WKt6Rdq2bMT+w6fYue8oQ/t/m/klEonYsno+xYsVYfbC1dx/+IxuHVvJt4vFYnZtWkLt6pWYtWAVB4+eYezwfowd3k++T9VKZfHw9EJNVYVCBfJRuoQ9CQkJeHh6pTn+6EcikYjNq+bTokk9du0/xuRZS/D44k1AYBAAvbu1pXKF0qzfsoelqzcD4Dh6ILb5bBI/GMwZ0u/3CnomkUohLDycA0dOExQc8tvtiMVi9mxZToO61Vi5bjtzF69BRSIhLi6OBnWq0bxxXZ6/fMPdB0/Ytu7PiyJ2aNOEsxeus3jlJhrWrcHyBbJZTvr6upzYv5Hc1pYsWLae5Wu24v81IMOXFBfMHI+aqipjJs/lxu0HybbNmDQSiYqEqbOXoqKiQv061eTbqlYqS3xCPItXbGTOojW07TaYImXrcf7yjZ++hzJKWVmZjm2bcuHKTUaMn0VwSChb1y1AXV2N3LksGT9yAK7vP+E4bSHvPnxOduzksUMYNaQ3F6/cYtzU+YSFRRAVHc2A3p0oW8qB2QtX8/jZK/mYu4woUsiWtctm4ev/lamzl1LYLj92tnnT3H/R7AnUrVWF5Wu2cvzURfr2aC/fVrBAPob2787VG3dZs2GnfJxikhaN69K4fk2OnbzAtDnLiI2NZe60sQzo1ZlTZy8zfsp8nF0/EBgUnOH4BQJFE8XERKfd7yoQCBTupZMLdZt2xe3NrWSzKAUZ13PgWCIio9i3dQVSqZTP7p6UqdaMnl3aMn/GOEWHJxAI/kLCJTaB4C/27sMnOvUazviR/YXk6A94eHrz7sNnlq/ZioGBHucv3SAuLp76tasqOjSBQPCXEnqQBIK/mP/XAB49fUn92tV+vrMgTS+dXBg7eR7PXzghUZFQ2C4/Qwd0p0Gd6ooOTSAQ/KWEBEkgEAgEAoHgB8IgbYFAIBAIBIIfCAlSBgUEBTN+xjI6959Ar6FTefH6LfHxCew6eIqeQybTsusIRk1eRHAahdMy29eAIMZOXfLbBQUzIjwiklGTF9GlvyMXr939+QF/6NL1e/QZPp32vcfiOHM54YnTvuPi41m0ajud+o6nz/DpuHt+W2tqxYY9NO4wiKVrdyZrq0XX4bTrNYauAxzpOsCR569T1pgBeO38nh6DJ9Op73g27zoqr/3y0smVwePmULF+F/l6XqkJCApmuON8OvUdz6TZK4mMkk2HDggMZsrcVdRo2ovrd35eFfvJcydmLlr/0/1+VVr3IzIqislzVtGp73iGO84nIHF2UXqPdVZYsWEPj569/vmOqfDy9mPgmFmpbhs4ZlaGHvcfzVy0nifPv9XXOn3hBpt2pj77M7NERccwd+km6rbqy74j55JtO37mKp37T6Bz/wncvPdEfvvNe0/oOsCRTv3Gc/zM1SyJq0XX4b98jK/fVwaOmUXXgROTPY6ZJb3nXCDIbEKClEGzFm2gbImi7Fo3lzmThpLL0gwlJRG5c1mwYdk0Dm1bjFhJiaOnMl6n5E8YGuixYPrITFmJOy1v33/ms/sXdqydTZ3q6VcD/lOxsXG8ffeJ5XPHsWfDPGJi49hzWLYcxJkLN/D29WfX+rm0a1GP2Yu/FausWqEk5VKp7QSwYu54dqydw461c3AokrJydnx8ApNmr2Ds0B5sXTWT63ceyT+sTYwM6NmxebrF9QBWrN9NmRJF2b1hHro6WuzYfxIAVVUVmjesSS7LP1ue5k+ldT927DuJro42uzfMo3TxIqzcsAdI/7HOCkP7dqR08V9bXienURYrUa9mRQrb5Ut2u5uHF1t2H2XtokksnDaSOUs2EhYeQWhYOHOXbGL+tJGsXTSZzbuPZHkim1GPnjkhVhKzY81sSjoUVnQ4AsEfEWaxZYCnly+uH9xYOF1WBdbUxFC+rUr5ksTHJ+Dm4U1gcCiF7ZLXGYmMimLavLW8/+SOikTCsP6dKVfKns/uX1iwYitfA4PR0dZk0qi+WFuZc/jkRXYfPINEIqZ8aQeG9+/M81cuLFixlfiEeMxNjZk1cQhSqZS6rfpx9/wuQNZTsGLDbiIiozDQ02XUoG7YWFvg5e3HuOlLqVapDLfuPSE4JIzZk4ZQqEBePrl5Mn3BOsIjItHT1Wb6+EGYm8qq73r7+jN78Qb8vgbSbeBEVsybgOOs5TSoXYUTZ69Su1p52javx/Z9J7h49S5SqZTypYsxoGc7JBJlNu08TGRUNB5ffHBx/UT1ymUoV8qeXQdO8dHNkzGDu1OjyrfFRiUSZQb2+lZ3pYR9QT58li31ceXmA5rUr45IJKJ65TLMXbqJgKBgDPR0KW5fkEfPXhMalrLIoJ6edrrP65u3H1BXU6NQAdlzVqdaea7dekiZEkUxNTFM9jynJiEhgau3HjKsn6zwZMM6VZi1eAP9urVBU0Odkg6FUyytcO32Q3buP8XmFdPlt716844ZC9cTERlF1wGOjB3akyIF86X72Hr7+BMYHIKnlx9WFqZMHt0PXR2tFDGmdT+u3HzA1LH95XG36jaSKWOk6T7WSc5cvMnR05eJjIpGU0OdWROHYGyoj4/vV2YuWo+nty/ePv6YGBlQv1YlundsxvJ1u3n7/jOhYeFUr1SGQb1lz/W4aUupWrEUjepWZeai9VhbmfPi9VvevvtExbLFmTCiNwDrtx/k3KVbqKhIaFKvOrWrl2fI+LkEBAbTdYAjPTu1oHrl5FWm7z54zv6j5/D1C6BKhZIM7dsJkUjEJ7cvLFq9jcCgEDTU1RnWrxNFC+Vn7Zb9XL35gOevXLA0N6FFo1qs2bIfgBt3HrNg+kgM9fVYs2Uf9x+9RCQSUbdmRbq2a4JIJGLmovXksjTj+SsX3n9yp23zeujr6XDs9BX8/AOZPn4gDkVTLieirKxMSYfCnL54M8VrpXKFkmhraaKtpUlB2zzce/QCqVRKIbs88vdq5XIluX77EZ3bNk7tZcqT507sOniaXJamPHrqBCJYOH0kFmYmxMbGsXrzPu4+lK3v1rltY5rWr86wCfPw9vGn6wBHKpRxYEDPb/WXYmPjUn0MXju/Z8P2Q4SFR9BzyBS2rPxWv00qlbLvyFlOnLuGRFmZ0sWLMLRfJ8LCI1i6difObz8iUhLRvkV9GterluHn3MbaIs2/YQLBnxISpAxw9/TG0syY9dsPcu/RC6wsTBk3tAe6OrIP4LHTFnPnwXP6dWtD2VL2yY69/+glHl4+HNy6mJDQcMRiJeLi45k8ZxVTxvQnf15r7j16waqNe1kwfSRrtuxn9YKJ5M9rjf9XWSXe3YdO07heNTq0aoCXjx9amhrJLpeEhIYzfsYyFkwbQZGC+bl68wHjZyxj9/p5AHz45MHg3h3o2ak5KzbsZu/hs8yYMIgjpy5TtFB+Rg3qhpePP6bG35ZmMDMxwnFEb5at28WOtd8qOJ8+f53VCyaioiLh3OVb3Lr3hE0rpiFRVmbi7JXsPnSa7h2aAfDk+RuWzRmLVAqN2w9CSUmJlfMncPbyLTbtPJIsQfqeVCrl7sPnNKwjWwPO1y8Ak8TVz5XFYgwN9PD1C0j2of0jsZISk2avxM3Di7Il7RnSp2OK3jYfv6+YfHefTYwN07wUl5rgkDCkUil6utry45OWGUmLjrYW1lZmyW4rWig/fbq24smLN0weLSt2+bPH1tPLlwXTR6KlqcHkOavYeeAkg3t3yHDs3z+m+no6xMXHERIalqHHukC+3KyYNx51NTXmLdvM/qPnGNy7A1v3HiN3LnNWzp/A5Rv3OXb6CgN6tkMqldK4XjWKFMxHVHQ0zToNpWGdKuTJbZkiruevXJgzaShR0TE07jCYTm0aoaujzbY9xzmzfw2aGuoEh4ZhbKiP44jebNp1hDULUy9Mqq6uysp5jkTHxNCl/wRKFy9CudLFGDd9Cf27t6VGlbK8dn7HuOlL2btxAQN6tuPlG1d6d24p7/1499ENgN5dZIVKt+45xhdvP3asnU1sXBxDxs3FzMSIejUrAvDi9VvmTh6Gu6c3XQdOZMSALmxYOpUtu4+yY/9JFqeSIKXF57vnAsA08fWVIE3A2Oj7160BPonLEqXl1RtX+nVvw7B+nZk4ayXHz1xlQM927D50GlUVCXs3zicmJpZugyZRuVwJls8dT4V6nZO995PsOngqzcegT9dW3LjzmPnTki9FcvHaXc5eusW6xVPQ0dYkIFB2SXfFht1oqKuxa/1cgoJD6TN8GrkszbCxtszQc75kzY40/4YJBH9KuMSWAWFhEXxy/0KV8iXZvnoW6mqqbN93Ur598cwxnNizkmevnNlz6EyyY4sVLYCKRML85VsIDApGS1MDD09vPrt7MWPhOroOcGT1pn0EBssW1WzVpA6LV2/n5p3HGCeuJdWwdhVOnb/O/qPn5UnZ9169cSWXhSlFCsrWUKtRpSwRkZG4e3oBoK6uRtlS9ohEIooWsuVrQBAAtaqW49Gz12zedRQ1VZUMrU/WtkV9eaJx8+4TmjaogbqaGsrKyrRqUoebd7+NkyhWpAC6Otro6WpjbWVO5XLFUVJSoljhAvh9TTuROHH2GjGxsdSrWQkAkVLyhV2lUimi1A78zvTxA5k0qh8r5k7gwycPDhw7j8u7T/IxSWu37EdJ9GMrUlLc9IPugybRdYAjwybMQymVuH4WWMlihZg6dkD6O/Hzx7ZAfhu0tTQRiURUqVCS12/eyb9Zdx3g+NPxTCljBxBl6LHOZWXG7XvPmL98C6+c3+HxxQcAM2MjQkLDiY2NIzAoRP5YiEQijA312X3oNHOXbgLA40vql4TKlrRHTU1V9pqxNMM/IAgdbU3q1azItPlrePbSGaPExZ1/prh9QcRiJTTU1ShdvAivnd/j7uFNVFSMPDkvUjA/luamvHrzLkNt3rz7hNZN66CsrIy6mhpN61fn5t3HKeLPn9caNVVVqpQviUgkwr6QLX5fAwGYt3yz/Hny9vVP81w/vj6lUtnrU0n0w/tUSorFj39kZmKEXX4blJSUKFIon/xvwM27T7h66yHdB02i74jpxMTGphtTRh6D1Ny485hWTeqgq6OFSCTCMPE5vHX3Ke1a1EckEqGvp0Od6hW4de9php/z3/kbJhBklNCDlAEmxgZoqKtTtFB+RCIRFcsW58zFG8n2MTbUp1XTOuw6cIqOrRvKbzfQ02XLyhnce/SCKXNXU6d6BSqXL4mamirbVs9K8YYe2LMdXt5+bN9/gq17j7Np2TRqVClLmZJFOXnuGu16jWbV/IkYGqTdewIgQkRqn9bKymKkyMajOBS1Y9vqWZy/fJtugyYybdxAShYrlG676a2zJhKRZoKhrCz+9n+xmLSG9ly79ZCDJy6war6j/Fymxob4+H3FHlvi4uIICAzGxDj9y19JyaKujhbVK5fByeU9nds2TvaN+LXz+2TfvH38vmJqnH73/LbV3waISqVSxEpiAoNDMNDTxdcvALOfHP+70ntsxWIxamqqGOjrpvqNPzWyXocAjAz1CQgMRkWijI625k8fa6lUytDx8yhhX5CWjWtRuGA+biUmbnVqVODEuGv0GjoVfT0dRg/qDsjGsk2avZK+XVvToFZl/ANWkfCTsV2Q+JqRShGJREwbN5D3n9zZuOMw+4+dY/HMMRm6n9+3pa6mmuq2nyXb6RKJUk1ORCJR8td84n0BGD+sV4aaNjU2xMvHT/67j99XypUuRkJCQrKB7T5+X7GyyPhYN2WxMkmPvlQqZUifDlSpUCrDx6eQxmPwvQTpz798yNpKeq1n7Dn/nb9hAkFGCel2BhS2y4tIJLtkFB+fwO37TymQ34aPnz3Ztuc4sbFxxMTEcu/hc/LZ5Ep27IdPHgQGh1ChjAMtGtfi7qPn5LIyQ09Xi31HziGVSomJicXXP4DomBheOrlibmbMkN4d+OTmydeAIJ68eIOGuhrtWzbA3NSE187Jv+0WLWSLh5cPr53fA7KxC+rqauSyTH4p50cvXr9FhIgm9atTvKjdL886qVKhJCfPXSMqKpq4+HgOn7xE5fIlf6mN79179IK1W/ezZNYY+WUrgJpVynL20i2kUinXbj3CztYGfT2dNNt58OQVL51cAdllsOt3HmFfyDbFfgVt8xAdHYuTy3tiYmK5dO0eNatkfLV0kUhEjSplOJM4duTMxZvU+IXjv2dmYoS3j798MPXPHltvH3/56+7YmStULFv8l85Xs0o5zlz6Pu6yiESinz7WIaHhvHrjSodWDclrkwvntx/k285dvk2zhjXYuW4OK+aNx8baAoDHz16TJ7cltauXJz4hAR/f9C8H/Sg4JJR3H9zIZ5OLAT3acv/xK+Li4jAzNcLXL4D4+IRUj3P39EYqleLrH8D1O48oX7oYuazMUFNT4drth4AsSfb08qVoIVlCbWZihJfPtx6UH3+vUqEkR05eJi4+nsioKE6eu/ZHr/n0VK9chlv3nhIaFo6Xtx9v332mXCl7KpQuhrPrR7x8/AkJDef2g6cpxl9lVOXyJdix/5R8xugXb1/5NjMTQ7y8/VIc8zuPQaWyxTl6+op8QeKkQeWVK5Tg4PHzSKVSgoJDuXj1LpXKl8zwc/6nf8MEgvQIPUgZoKyszNwpw1m4citBwaHY5behS9smiMVKhISF02vYVEJDwyhUIC/jfvh2GBQSyoIVWwhN/MMwdkgPlMVi5k8dyaLV2zh5/hoqKhK6tG1CmRJFOHLqMotWbyMkNJzObRpjYmzI6Ys3WL5+F+HhkeTPa03NqmWJi4uXn0NHW5O5k4ezdO0OoqJj0NPVZt6U4en29gC4fvjM0rU7iYiMxNjQQD7YOKPq1ayEt+9Xeg6ZgkgkomyponRq3eiX2kgSGBTC+BnLMDLQY8zUxUgTZInCinkTaFC7Ci7vPtG53wQ0NNTlg4sfPH7Jqk17+RoYTEJCAk9fvGHKmP5YWZiwatM++UDcujUq0qxhzRTnFIuVmDVxMAtXbiM6OoY6NSpQIvHb54QZy/H0kl066j9qJsWL2jFmSI8UbQzt24lp89dw9uIt8uS2ZGjfjgBs33eCy9fv4fHFh+XrdrN97wm2rJzBqzfv2Lb3OLMnDUFVRUXejn1hW2JiY+nYdxzD+3f56WMbGBzCiIkL8PUPoEKZYrRolPL+pXc/urRtzOwlG+nUdzzGRvpMGzcQIM3HOomOtibtWzag74hpmJsaU7RQfvy/BgFQrIgtY6cu5cLVO0iUlbGyMKVp/erUqFKW2/ef0XXgRArky02exJXfMyoiIoqNOw7j5etPeHgEIwd0QVlZGQszE/LZ5KJdr9H07NRCPmYtiZ9/IH1HTCckNIx+3dtimy83gOy9t2obG3ccRkNdjblThqOtpQlAozpVmTZ/DWcu3mT5vPFUKOPAnkNn6DrAkSlj+tO5TWNWb95H1/6O8gHKdWv82QzP0xdvsP/IObx9v/LgySvOXLzBinkTsLIwpVeXlvQfNRORSMTEUX3Q1FAHYNKovoyduoSEhAR6d2mFpbkJANMXrKNmlTIZ7hHq0rYJYWER9BgyBTU1VfLZWDFlTH9EIhGtmtSh78gZ1KpajuH9v/1t+J3HoGGdKnj7fqXXUNl57AsVYNSgrgzt24kla3bQud8EREoiundohkORAnh5+2XoOY+Mivqjv2ECQXqEStoCQTaSSqUMGT+XOZOGoaOt+VttbNp5mNCwCEYM6JLJ0f2ZwePmMLBnOwrb5SMuPp4lq3cQEhrGrIlDFB3aP+PqzQe4f/Gma7umig5FIPjfE3qQBIJstOfQGRrWrvLbydHfrG6Niixdu4uoqGhiYmOxzWst71ETZD1fv69cv/OIkQO7KToUgSBHEHqQBIJsJE0cdCwQZLak8WvC60sgyBxCD5JAkI2EDy9BVhFeWwJB5hJmsQkEAoFAIBD8QEiQBAKBQCAQCH4gJEg/IZVKiYuL++mipQKBQCAQCHIOIUH6ifj4eKo06k58fPzPdxYIBAKBQJAjCAmSQCAQCAQCwQ+EBEkgEAgEAoHgB0KCJBAIBAKBQPADIUESCAQCgUAg+IGQIAkEAoFAIBD8QEiQBAKBQCAQCH4gJEgCgUAgEAgEP8gxa7GFhIYzb/lm3D280dXRYsaEQZy5eJPDJy9StWJpRgzoAsC2PcepU6MCluYmCo5YIBAIBALB3yrH9CC9euNKm2Z12bluDna2NuzYf5IL1+5yYMtiPn72xMf3K6Fh4YSEhQvJkUAgEAgEgnTlmASpYtnilLAvCIB9YVtc33/GwswYiUSZfHms8PUP4Mipy7RqUlvBkQoEAoHgX7DvyDmioqIVHUamuXnvCa7vPys6jGyTYxKk7z1+5kTViqXw/OJLUHAob1w+oKOtSXBIGO8/uuM4czknzl1L8/hDJy7Soc9YOvQZS+f+E7IvcIFAIBDIeXn70anveADefXBj+fpdWX7OpWt34uP7Nc3tA8fM4s3bDz9tJzIqiqcv3qCmpsqZizc5c/FmZob5U5t2Hmb3wdN/3M7MRet58twJAJtcFhw+demP2/y/yDFjkJK8/+TOw6evGdynA+rqagwYPZN6NSpx485jmjWozuwlG1m9YCLjpi+lSvmS6OvppGijddM6tG5aB4C4uDiqNOqezfdCIBBkhqioaNTUVBUdhiAT5M9rzbB+nbP8PH7+AZiaGP5xOxev3aNapdIANKxT5Y/b+xvksjTDzz+Q8PAINDU1FB1OlstRCVJgUAhT561h1sQhqKqo0LR+dZrWr054eASbdx9DU0MdQ309JBJlcucyx9PLN9UESSAQ/H+dvXgNdw8vypQsxqCRU+jeuTV9e3RQdFiCP/TkuRO7D51h8czRbNp5GKkUXju/w/WDG44jelOpXAkiIqOYu3QTb99/xtzUiBkTBqOhrsqi1dt5++4TYeGRjB/Wk5IOhdm08zAqKhJu3n1K2+Z1qVO9Ap5evpibGQPg5uHF3GWbCQkNwzavNWOH9kRDXU0ej1QqZfn63dy8+xhNTQ2mjOlP/jy55NvfuHyga7smgKw3R11NjU5tGjFwzCxqVS3HmYu3CAsPZ9nscZibGePp5cu8ZZsJDA4hj7UlMyYMYtDY2Qzp05FCBfJy+sIN3rz9yOjB3Zi5aD02uSy4fucRkVHROI7ozfa9J3jt8p6JI/tQsWxxQPb4DB47B29ff3p0bE6julWJi49n2dpdPHz6Ch1tLWaMH4i5mTEd+oylWsXSXLv9CDMTQxbNHM3BY+e5evMBz1+5UKGMA6MGdcMuvw2f3L9QpGD+7HvyFSTHJEgxMbE4zlxOn66tkr1IAY6evkKLRjXR1tbE/Ys30TExuH5wo12L+gqKViAQZJWN2/Zx5fpdundqhbPrB8ZNmY+JsSHNG9dVdGj/O7Wa9yY2Li5L2pYoK3P52KbfPt7Z9QMLp4/ixt3H7DtyjkrlSrB973GKFSnATMfBnLl4k2NnLtO1XVNaNKyJnW0eHjx+yeZdRynpUBiAs5dusXXlTHkv471Hz6lQxgGAGQvX0bVdU6pWLMWKDXvYse8E/Xu0lZ8/JDSM0xducPbgWkJCw9DUUE8Wn7evP8ZG+qnGHhoWwabl01i0ejvnrtymR8fmzFy4jrYt6lOzSlkCg0IQiUTp3n8vH382LpvGwpXbWLx6B6sWOHLn/jP2Hj4rT5BEIhHL5owlOCSMjn3HU71yGS5eu4uKioR9mxbw7JULO/afZNywnrh5eFGudDF6d21F90GTeP3mHR1aNeTmvSf07txS/piZmRji6eUrJEj/JzsPnMLl3Se27z3O5p1HANiwdCrxCQkEBIWQy9IMgLo1KtC2x2iqViyFmYmRIkMWCASZLCw8glt3H6GqqsLsqaMpbl+Y4eNn0neoIwb6elStVFbRIQoySclihZFIlCmQLzcBQcEAPHjyiujoGE6eu0Z8fALlStkDoKOjzeZdR3By+YC3r7+8jYa1qyS7BPv81Vua1KtOeEQkH908qVhWlizVrVGBBSu2JEuQdLS1KOlQiFmL1tOrc0sM9HSTxRcTE4uycuofseVK2SMSibDLlxvXD26ER0Ti6eVLjcplADJ0ZaN0iSKyNvLboKSkhIa6Gna2NgTsDZbvU9guH8rKyhga6GFlYYqbhxcPHr/E9YMbj56+QioFayvZZ6Oqiop8olP+PLkICAxO9bzGRga8++D20/hyghyTIPXq3IJenVukum1o347y/3dt15Su7ZpmV1gCgSAbXbt5j5iYWGpXr4SmhgbdO7fG29efeUvW0qnXcE4f3kKxIgUVHeb/xp/08GQXZbEYpLL/S6VSZk4cTD6bb1cRvnj7MmryIgb0aEfjutXoP3qmfJuS0rd5SjExsQCoqEiIjY396XlFIhHzp47g8TMnHGeuoFfnFlRPTHCS2k5ISEh2jh+JxWKkUkAqBZEo1V6juLj4dONQVhZ/+/93j0Vq+6mpqiKVwrB+nalcvkT6caWxLSQ0HF1d7XRjyily5Cw2gUDwbzp/6QYA9WpXld82bkQ/enRuTWhYOG26DOKTm4eiwhP8KpGIBGlChncvU6Io+46cIyEhgfCISEJCw3F2/YS1lTlVK5bCzdMrzWOfv3aheFE7ADQ1NbDJZcndh88BuHjtLqVLFJWFhIiEBCnBIaF8dv9CqeKFqV+rEk9fvknWnpGhPkHBoRmKW1NTAyMDPW7efQzIkjoAfV0d3rz9QExMLNdvP8rw45DEy8cfqVTKh08efA0IIpelKWVKFOHQiQvExsYRGxuXZk9RElNjQ3z9A+S/e/v6Y/WP1BIUEqT/KW9ff5xdPyo6DIHgr5GQkMDFq7cAqFvr26whkUjEotmONK5fk+DgUN79Q3Vc/u9MjAxQFivz4MmrDO3fvWMzoqNj6Nh3PEPGzcXTy4dSDoWJiIii55DJvHjtirpq6rMa7z58QfkyxeS/TxnTj90HT9Op33j8/APo3qEZIEvCjp25QlRUDCs37qVz/wlcuHaHlo2T19izsbbg3Uf3DN/XKWP6s/PAKbr0d2TN5v3ExMTSplldtu09zuBxc+RjgH5FeEQkfUdMZ/LcVUwe3Q9lZWWaNqxBLkszOvcfT5/h0376OVKvZiVWbtzL3KWy3sSPnz3IZWX+y7H8H4liYqLT6kkT8G2a/83T29K8npzdbtx5zPQFa4mOieXwtiWZMiVVIPi/e/bCieoNO1DILh93Lx9JsT0qKhpn1w8Uty+kgOgEfzvHmcuZM3lYprXn7evPxh2HmTy6X6a1qWhh4RHMXryRuVMy73H6mwk9SP8jUqmUbXuOM276UiIio4iPj+f2/aeKDksg+CsYGxkyYdQAendrn+p2NTXVZMnRjdsP5ONOBP82H9+vGBsZZGqbZiZGJCRIc1Ql7et3HtG4XtWf75hDCD1IP/G39CBFRkUxa9EGrtx8gFgspkblMly6fo+KZYuzeOZohcUlEPyNvHz8UVYWY2yY+jTr3QeOM3jUVNo0b8C65bPTHUgryPk+uXkSF5+QokTMn4qLi/trrjxkhvj4BEQi/pn3S8555nIwLx9/xk1fiuv7z+jr6jBn8lDy57Xm6q2HPHz6SqgWLBB8JzIqiu6DJgGwbfUszE1TlvMoU7IYero6HDh6BhMTI2ZNHpXdYQr+IjbWllnSbk5KjgDE4n8jMUryb93b/6FnL53pNWQKru8/Y5svN8P6daS4fUEuX7uDp/sn/Hx9eZy4To5A8K86efYy46cu4JXTW+4/eklIaBghoWFMmbuKuFQKHRbIn4cD21ehrqbGqvU7WLl+uwKiFggEfzMhQfqLHTtzhcHj5hIYHEL1SqUxM9SmXbdB7Np/jNjYWAIDgwgLDeXOg2eKDlUgUKgDR06zbvNu3ri84/od2XRoiUSZV2/esXbrgVSPKVOqGNvWL0QsFjN55hL2Hz6VnSELBIK/nJAg/YXi4uJYuGob85dvIT4+nm7tmvDunSsbtu5FQ10NXR1talWriJKSEuHhYdy8+wSpVBhKJvg3RUfHcPXGXZSUlKhepRy37z9FJBKxcPooVFQk7Dl0hlv3Up/MUK9WVVYsnArAoFFTuXX312vNCASCnElIkP4ygUEhDJ0wjyMnL6GhrsbIAZ3YtmsfF6/cwtLclLNHt9GkQS309XUpW6oYCQkJfPrszvtPQvE7wb/pzv3HhIVHUK5McT5+/kJoWARFCuanXCl7Rg3sCsDMRevx8f2a6vGd2jZj6vihVCxXkmJFhSrbAoFARkiQ/iLvPrjRc+gUnr5wxtLchP7dWjFu8jyc336gdAl7rpzeg0PRb9OU69SUFcMLCwsRpvsL/lnnL98EoF7NKlxLrDZcvVJpAJrUr07dGhUJCQ1jchrjkQCGD+rJkd1r0dHWyp6gBYK/2LnLt5KtWfd/4+3rz5mLN/+4HSFB+ktcvfmAPsOn4+3jT5kSRdm8YgaXr98mIDCINs0bcurgZkx/WFw3qVpwWGiYMA5J8E+SSqWcu3QdkH1hSFqqoVpigiQSiRg7tAfWVma8dHJl/bZDqbYjEonkM45CQsMYNGoKPv/jD4icwsvbj059xwOyL5DL1+/K8nMuXbsz1d7G6QvW4v81MMXt46Yt5UkWT5S5//glXfo7MmryIvlt8fEJzF++hU59xzN13hpiY2XJ/2vn93QdOJEu/R1TrUAeFR2D48zldOo7nmXrdqUYnpGQkMD5K3cwyeS6UCCrozRz0XoAdu4/yYPHL1Pss+/IOTbtPJxuOwPHzMLL2y/N7caGBly4eoeEhIwvU5MaIUFSsISEBDbtPIzjrBVERUfTrkV9lsweg66OFkvnTmLFwqlsWDkn1Wn8RQsVwNzMhJiYaJ48f01wSMbW/REIcgqPL958+uyBlaU58QlS/AOCyJcnF1YWpvJ9NDXUmeU4BBWJhF0HT/30y8SsBavYvf84rbsMJCQ0LIvvgSCj8ue1Zli/zll+Hj//gFRXJ5g6dgBGadTVympWFqY0qpu8QOPNu48JDg1j94Z5aKircebiTaRSKXOXbWLa2AEsmjGKecs2p0gSjp66hLmZMbvWz+WTmycPf0iiHj93omgh2yyvddSlXRPKlrLPkrbFYiXsC9vy5MWbn++cjpxVpOF/JiIyihkL13H99iMkEmUG927Prdv3CQgIwsTYEHV1Nbp2aJnm8SKRiE2r5rHv6DkePXvDvUcvqFezUjbeA4FAsbQ1NVm5aBoqEol89lq1iqVT7GebLzcjBnZh/vItzFi4jh1rZmNinPoSPZPGDubew6e8eOVM594jOLhjNaqqKll6PwQ/9+S5E7sPnWHxzNFs2nkYqRReO7/D9YMbjiN6U6lcCSIio5i7dBNv33/G3NSIGRMGo6GuyqLV23n77hNh4ZGMH9aTkg6F2bTzMCoqEm7efUrb5nWpU70Cnl6+mJsZA7Jeino1KnH09GVmTRzCkPFz2bpyJnq62hw8foEDx85jamJIYGCIPMbt+05w/MxV/L4GoKejTee2jWnVtA7L1u7i4dNX6GhrMWP8QPk5fuT6/jMrNuwhMDgEAz1d5k0djoa6GpbmJhTIZ83Dp9+SmdsPnlHCXjZmrrh9Qa7cvE/50sXw8w8kr40VAMrKYt5/dMc2X+5kx7VrUR+RSERx+4Lcefg8WaLy5u0HStjLFu2Nj09g7db93Ln/DFVVFSaP7oe6uhpL1mzHx/crEomEeVOHY2yoz8Axs6hVtRxnLt4iLDycZbPHYW5mzIdPHsxctB6pVIqBvi76ejqAbFxgpXIlqFmlLE9fOrNwxVbU1dVQV1OleOL5L9+4z74jZwkJDadiWQeG9evMig17eOnkysjJC6lfqzLd2jdly+6jXLh6FxWJMhNH9cUuvw0ORe144/KB0sWL/PZrTuhBUpAv3r70HTGd67cfYaCvy8QRvVmyYj079h5hzKS5GW6nUvlS1KtZGYDb959lUbQCwd9JT0+HLu1b0LZlI/lq50njj37UrEEN6lQvT3BIGJPnriYuPj7V/XS0tTi4YzU2ua24cfsB/YdP/OOu+v8zk7yl0/x5/urbN/TOvUekud+CZevl++3cdxSTvKk/R7/C2fUDC6ePYuTAruw7cg6A7XuPU6xIAfZvXkjdGhU5duYyysrKtGhYky0rZzJ6UDc27zoqb+PspVusnDeeOtUrAHDv0XMqlHGQb3/5xpWtq2Ym65F899Gdg8cvsGXlDBbPHC3v3ff1D+DAsfPs2TifTcunY2VhSrsW9Tl1/joqKhL2bVrAwF7t2LH/ZJr3yUBflylj+7Nr3Vz09XS4eutBmvt+DQjCOnHR2Ny5zPH/GoT/d7cBWFuZ4x8QlOK43EnHWZmnuGz4xctPPpzj9MUbuLl7sWPdHFbMG08uSzN0dbQY0qcjO9bOoUyJIpw4e1V+bGhYBJuWT6N0iaKcu3IbgFmL19Orc0u2rZ5F2ZIpe4xiYmKZsXAd08YPZNPyaeT7rpp5PhsrVs53ZPf6uVy7/Qgvbz+G9u2IkaE+S2aOoVv7ptx//JJ3H93Zs2Ee86YOZ8P2gwCYGhvi6e2b5uOXEUIPkoL4+AXwye0LBW3z0LpxDQYMn0hAYBClS9gzf8a4X2qrYtniSKVS7j58Rlx8PMpicRZFLRD8nd5/8sDTyxcLM2Py57VOdR+RSMS4oT1xdv3Ei9dv2bD9EAN7tkt1X1MTI47sWku9Ft04evICJsZGzJs+FpFIlJV3Q/ALShYrjESiTIF8uQkICgbgwZNXREfHcPLcNeLjEyiX2DOio6PN5l1HcHL5kGzwccPaVZINX3j+6i1N6lWX/96iUc0Uz/nTF2+oUbkM2lqaABgZ6AGyS7lKIhEREZEEBn3rVXrw+CWuH9x49PQVUilYW5mleZ8M9HV58OQV2/Ycw+Xdp2TJzo9EIuSJe0JCAkpKIkQikEq/JfNSaUKK+EWISEiQjTtKkEpRUkq+3cfvK0aGsvt079ELWjapjbJYLL+/EokyoWHhLFu3i+evXJIlNOVK2SMSibDLlxvXD26Eh0fg9zWIyuVLAGBuZoTrh8/Jzufm6Y2RgT4FEnu5zE2NCQsPT9zfmEvX7/HoqRPRUTF4+31N0ft2//FL3ri8l1fPV1dXA8DYyCDNmasZJSRIClLCviBLZo3h1es3dB8whtjYOFo3a8DKRdPkT3BG7dhzmPeuLpiaW/DKyZXi9sJUZcG/4ciJc7z78JkEqawzvFrF0ukmMZqaGsyaOIQ+w6axc/9JStgXTNZj8L28eaw5uGM1jdv0YsPWvXRo3YTixQpnyf34m/l+yFhtqF2blmZovy7tW9ClfYs/CSkZZbEYEscZS6VSZk4cTD6bbx/aX7x9GTV5EQN6tKNx3Wr0Hz1Tvu37cTZJCxerqEhS3Z4kLj6eiMioFLdraqhTsEAexk1fBsCYId0TY4Jh/TrLk4T07Dtylpdv3tGlbWOsLEwJj4hMc18jA33cPb2pUMYB98Qkw8hQHzcPb6RSKSKRCDcP7xTjpowM9XH39MLG2gJ3D9lx39PV0SI0NBxVQxWkCdIU76erNx9w6MRF+nRthX1h21TH9InFYqRSiE+QEhkZRXx8QprLlMTHxxMRmfr9nDR7JQVt89CrcwsiIiKRptaTK5XSsXUj2jSrm+zm0LBw9HS1U203o4RLbAp05dotRk6YRWxsHJPGDmbjqrm/nBwBqKqqEhsbS1hoqHCZTfBPOXz8HHMWreFa4qWIapXL/PSYAvlyM6y/bLDvjIXr8PUPSHPf4sUKs3PjErasmf9PJkcKJxKRIM345c0yJYqy78g5EhISCI+IJCQ0HGdXWU9M1YqlcPP0SvPY569dKF7U7qfnKGKXjwdPXhIdE0NoWDjunt4AREVF4/nFl43LprJx2VR5j0iZEkU4dOICsbFxxMbGERAYnGbbj545Ub9mJQrks+HdR/d046hUrgRPXzgD8PSFMxXLFcfEyAAzUyPef/LA29cfqVRK3tyWPHnuxIoNexKPK87TF85IpVKevZId9z0LMxN8/GQ9LyUdCnH8zBXi42WPZ2BQCI+fv6FqxVI4FLXj3Ue3dGPU1tLAQF+XZy9lcTq//ZhiH2srM/z8A/H08iUhIQGXd9/2efLiDW2a1UNHWwsPLx/57aZGBvL3bZmSRTlx9hrh4REkJCTIb/f28cfS3CTd+H5GSJAUqGK5kujoaLN9/WJGD+3z2933dRPHIMkSJKEekuDf8SVxjIGvfyAG+rrYF8qfoeNaNKpJrarlCAoOZWo645EAalStQIsm9TIlXsGvMTEyQFmsnOp09dR079iM6OgYOvYdz5Bxc/H08qGUQ2EiIqLoOWQyL167oq6a+sLedx++oHyZYj89h31hW6pWKE2X/o7MWLgOs8TFkFVVVUiQSmnXawxdB05k4qwVvHrzjqYNa5DL0ozO/cfTZ/g0nF1TJglJmjeqydqt+xk5aQFamhry20dOWsicpZt49sqZrgMc+eLtS+XyJTDQ16FT3/FEx8TQoJZsgo7jiN7MXLSOMVOW4DiiN0pKSgQGh+L5xUd+Dh+/r3TuN4G8Nrko5ZA88bextuB9YnLWvGFN9HR16NRvPMMd5+Pl40f9WpU4feEGg8bOlvfcpUUkEjFhRG8WrtpGn+HTUu15U1dTY9ywngybMI9BY2YnmxDRqXUj+o6YzoIVW7Ay/zYOrFG9akyavZIN2w9RvnQxalYtS48hU+g+eDL3E0sHvP/kTu5cFukH+BOimJhoYY2KdMTFxVGlUXdunt6WJSszBwWHoKer88ftlKrShPcf3ciTz5Yz+9emOUtCIMhJ7ErWwsfXnwIFC9OySW3GD+uV4WPDwyPoNmgSnl6+dO/QjH7d26S7f2RkFM5v31PC4fdnxQj+Xo4zlzNn8rDfPv7Rs9fcvPuYEQO6Eh+fwIoNuxCLlRnat2MmRpn1IqOimDJ3NQunj1J0KH9k9JTFzHIcnGqJnIwSxiApWGYkRwB1a1Vl7aZdhIWG8PKNq5AgCXK8mJhYfP2+oqysjFgsTnV6f3o0NTWYPWkofYZPY/u+ExS3Lygf1PsjqVSKffn6fA0I4tPrm+jq/NnYBsHfxcf3K8Z/WBgxj7Ulew+fpevAiURHx5A/Ty7GDOmR6r7zlm/Gyfl9stsa1K5Mh1YN/yiGzKCupkYuS3O8vP3+t58jXt5+5M5l/kfJEQg9SD+V1T1ImeXazXs079APdQ0NJowe8r/71iIQ/KrP7p44VGiIqqoq9sUcOHtgLRLJr79HD5+8yKJV29HX1WH72tkYp1EMsFWnAVy+fodDO9dQu4ZQbywn+eTmSVx8Avm/m5H1L4uLi/urP+8yIjPugzAGKYeoULYkamqqREdF8fqNq6LDEQiy3JfEQZvKyhLs8tv8VnIE0LJxbWpUKUtgcAhT56U9HqlcmeIA3HskjPPLaWysLYXk6Dv/9+QIMuc+CAlSDqGqqsLJA5uwK1iY9588/unCdoJ/g5aWJlUrlUNTSyvNqtgZIRKJcBzRG0tzE56+cGbLd4UEv5eUIN1/+Oy3zyUQCP4/hAQpBylTshjWuSwIj4jE0+vPKogKBH87+8J2dGrfEkMjY0yM/myNLK3E+kgSiTLb9h5PddZU6RL2iMViHj99SWxs7B+dTyAQ/P2EBCmHKWibR1ZLwvWTokMRCLJcUs0TE+M/X3m8oG0ehvTpiFQqZdr8NSmWYNDU0KBY0YJEREbxyuntH59PIBD83YQEKQeJiormwKFjvHvrkm6tDYEgJ7j38CnPXzqRkJCAyR/OQErSumkdqlcqQ2BQCNPmryU+Pvml6nKli2NooI+Xj1+mnE8gEPy9hAQpB1FTU0Ukgvj4OB49y1hhNYHg/2ri9EUcOnKSmJiYTEuQRCIRjiN7Y2FmzOPnTmzdk3w80pTxQ3j3/CoN61bPlPMJBIK/l5Ag5TClS8jquLx87YJUKlRwEORcSbPYJBIJxplwiS2JtpYmsyYOQVlZzJbdx3j49NuXDQ11dWHBWoHgHyEkSDlMmVKyUvmBgYHCZQBBjhUbG4u3rz9KSkqoqqqgl8mFGwsVyPvdeKS1fA0Ikm+TSqV8dvckOCQ0U88pEAj+LkKClMOUdCgKQFRkJM7CQG1BDuXj9xWpVIqysgQTI4NUV13/U22a1aVapdIEBAYzdf4a+XikMZPm4lChIecuXs/0cwoEgr+HkCDlMA72hRCJRERFReLk8kHR4fz1duw5wrgp84lPZ7FSwd/n+8trmTX+6Eey+kh9MDc15vEzJ7btPQ5AITvZgrj3Hz3LkvMKBIK/g5Ag5TBamhrkzmVJQkICj56+UHQ4f72hY6ezfsseTpy5lK3n9fziw4Ejp4Xp4r9JXkVbIvnjNbTSo6OtyUzHwSgri9m86wivnd9RrnRxAO4JBSMFghxNSJByoNVLZpK/QEG8fQOEgdrpiIqKlv9/y86D2Xruh0+e03eoI5XrtuHZC6dsPXdOEBMTi66ujqwHKRMHaKemSMF8dG7bGKlUypWbDyhklw8dbS3euLwjKDgkS88tEAgUR0iQcqBK5UuSO5cFwSFhePt+VXQ4fy3PL97y/8+cNDJbz+3u6SX//77Dp7L13DlB25aNGDdqMEbGJpj+wTIjGVU+cfKDk8sHxGIxZUoWQyqV8ujJyyw/t0AgUAwhQcqh7GzzIJVKcXknFIxMi5vHFwAa1K1O8WKFs/Xcnl985P+/fe9Rtp47p/DzD0AkEmH8h8uMZIRdfhvESko4v/1IXHw85cuWAISFawWCnExIkHIgqVTK9Ru3ePfWGSfn94oO568VFByCmqoquSzNAUhISCAmJnvW2Prk5iH//yuntwQFCZdqfkVwSCg+ib2jWTVI+3tqaqrkzZOLqOhoPrl9oVzp4ojFYr7+sByJQCDIOYQEKQcSiUTERMcQFxcnDCRNR4sm9fB6d58ZE0dw5fodytVowdpNu7Ll3J8+yxIkiUSCVCrl7sMn2XLetISEhtGx13CGjJ7G9dv3//pZfRVrtWLfgcPEx8dnS4IEUNguLwBOzu+oULYEn51usXTe5Gw5t0AgyH5CgpRDlU0cM/HK6a0wUDsdIpEINTVVNDU1cH3/iY3b9hEXF5fl5/VOLOKpo6sHwO17j7P8nOk5duoCZ85fZee+ozRr15eiZetx8uxlhcaUlri4OLx9/ZFKpUgkEvT1dLPlvIXt8gGycUgSiQQtTY1sOa9AIFAMIUHKocqVKQ5AQEAAfokrnguSi439djmtbCkHSjgUweOLN6fPX8vS88bHx2NoqI+Kqira2jqA4hOkS1dvA9CqWX3si9jh5eOHSTYMfv4dvn5fiY+PT6yBpI9YnD1/xooUTEqQvl22joyMkvcGCgSCnCVHJUjHzlyhU7/x9Bs5A1+/r+w6cIoWXYaxdO1O+T7b9hzH08tXgVFmj6SK2pFRQkXttJSs0pQCJWri7umNSCSiX48OAKzfsidLzysWi+nVrSP58hdATV0dExNjqlYso7CevtjYWK7dvIdIJGLBzPHcPH+AB9eOUbaUg0Li+ZnsqoH0I5tclqirqfLhkweRUVE8e+GEdeFKVKrTGue3wlg/gSCnyTEJUkBgMDv3n2Tz8um0blqHVZv2cuHaXQ5sWczHz574+H4lNCyckLBwLM1NFB1ulitYIC8SiYToqChevXFVdDh/ndjYWDy/ePM1IIjew6YSEBhMiyb1MDE25M79x7x47Zyl5/dLHNwrEomwzp2HqROGKWwR1Pj4BGZPHc3wgT0wNJDNCCuQPw8ikYituw7SomO/vyoBSPqCI1HOuiraqRGLlShYIA/xCQm4uH6ieLHCdO/YivCISDr3HkFIaFi2xSIQCLJejkmQ7j9+SYF8NqipqVLcviAXr93DwswYiUSZfHms8PUP4Mipy7RqUlvRoWYLZWVlbPPZAHDngTAV+UdfvH1JSEhAWSIhJDScI6cuoaqqQo/ObYCs7UUKCAzis/uXxLXExIRHRPLRzTPLzvczamqqdGnfgqkThqXY9vzlG67euMf9v2iw//c9SNmZIEHycUgAs6eOoVzp4rz78JmBIyYL4/0EghwkxyRIXwOCsLYyA8DIQA8VFQkfP3sQFBzKG5cP6GhrEhwSxvuP7jjOXM6Jc9fSbOvQiYt06DOWDn3G0rn/hGy6B5lvyoSh2OTJR4AwhTwFdw9ZoUZlZWUAjpy8THRMDD27tEFVVYXw8Mgs+7DbsvMgR46e4Ku/H2VLFkUqlXLw6Fl27DmSJef7E6VLygb7P3r69xRE9PSSFfiUSCQYZ3EV7R8VsUs+DklFRcK2dQsxMTbk1LkrLFu9JVvjEQgEWSfHJEiISPaBJlZSok2zegwYPZPypR24cecxzRpUZ9fBU0wfP4hrtx4SmEbi0LppHfZuXMDejQvYtW5udt2DTFe/VlVyW1sRGBSKv1CvJZmkStYSiQoAgcEhnL9yB1MTI5weXmDbuoVZdskr6dwqKipUrVAaqVTKomXrGOk4m/CIiCw5Z1q8vH3p2ncUR06cS3V76RL2AH/Vun4TRg2ge9cOaOvoKqwH6fV3A7XNzUzYunYhYrGYmQtWce3mvWyNSSAQZI0ckyAZG+rj5in7Zun3NRCJRCJPdNo0q0NgcCiaGuoY6ushkSiTO5f5PzFYu6BtHgBOnb+h4Ej+Lm7usktaEokEI0PZuJv9R84hlUrl43Cy7tyyCt4G+noUt7dDSUkJHV0d4uLiePg4exORi1dvceLMJc5dvM6NO495+/5zsu0F8udBR1sL57cf/poxNpoaGsTHS1FWVs72BMnE2ABDA128ffwJCAyW316pfClmTh6JkaE+Kioq2RqTQCDIGjkmQSpb0h7X95+Jiorm6QtnKpYtLt929PQVWjSqiba2Ju5fvImOicH1gxtGhnoKize7+Hh/4eN7V9Zs2cfy9buIj09QdEh/haRLbBIVFRrXrYqVhSkfPnvw8MkrQFZV++DRM4ybMj8Lzi1LkMzNTLC2MkdHWwslsQSAW9m87EjS9P7cua0ZN30p3QZOZNy0pfJESUlJiZLFZZcBnz5/na2xpcc3sXRFdidIIpGIwgWSj0NKMqBXJ+5dOULFciWzNSaBQJA1ckyCpK+nQ/eOzek1bCpHT11iYK92AIRHRBIQFEIuSzNUVVSoW6MCbXuMJo+1JWYmRgqOOusFBgUTFRVFZEQ4+46cY+LsFclWsf9XTXMcRo8u7dHU1MLC3IR2LeoDsO+o7FJTSGgYYybNZf2WPdx7mLmD3L0Si0RaW1kgEokoWigfGpqaQPbWQ/p+en9YpOw1oaQk4sbdx3QbOJHxM5bh+v7zd5fZFD8OKT4+nsp123Dv/gOUlEQYGmRPkcjvFU6lHhLIkicDfb1sj0cgEGSNHJMgATSpV43d6+exbskUjBMvm2hqqDO0b0f5Pl3bNeX47hWMGtRNUWFmq6YNZbP23N0+E/DVl6s37jN43BwCgoJ/cmTOZmRogFiigrKyMuamRjSsUwVtLQ3uPnzOJzdP9HR1GD2sDwBTZi3NtAHbIaFhhIdHIFZWxtRUlqAXLWSLuroGYrGYx09fEhkZleyYqKhoAgKDMuX833vw+AUhoWGUKFaYx8+cEIlE7F4/j95dWqGlqcH124/oOnAiUpGYBTPHy19LiuTnH8Arp7dERERgoK8nH2SfnQrbpZ4gJdlz8ARDRk8jKFiYHCEQ/J/lqARJkFLPLm1Yu2wW2lqa+Hj74O72iUdPXtJn2DT5Yp//qqSeHDMTIzTU1WjWoCYA+4+eB6BPt/ZY57LgwePnnDiTOctueHmnrOFjX9gWJSUlDA0MiImJ5fEz2WW+yMgoVq7bTqHSdchrX43qDTuweuPONNv+VZeu3gKgoJ0toWERFCtsi421Jb06t+DIjqX07tISgDsPX9Cne3t52QhFSprin901kL5XqIBsXJ+Ty/tUE+f9h0+xc99RXr52ye7QBAJBJlJ4ghQUHCqMi8lCIpGIDq2bcOviQSqULUFERARunz/y2f0Lh05cVHR4CuHr95W6zbvy8NETRCIRpolLarRuWgexkhJnL98iOCQUVVUVpowbCsD0ucuTLU3yu+xs8zJmxGCsrHPLezkL2+VDSUmEiqoaTRrUQiJRZtuuQ5Sq0oTJs5YQGBSMjrYWz1448eLVtwKWvn5fuXjlFtHRMb8Vy4UrsgRJJJb1wtSsWk6+TVtLk16dW2JmakRQcKi8sKWieSqwBlISbS1NrK3MCQ2LwOOLT4rtxYoUBMjyYqMCgSBrZXv/tK/fV/YcPsuL128Jj4hES1ODsPAIJBJlbHJZ0KZ5PRyKFMjusHK83LksOXVwM8vXbuOTmycPn7/lpdNbRYelEJ/dPHnw6DkampoUKlgQiUT2NjA1MaRm1bJcvHaPo6ev0L1DM1o2rcfqjTt5+vw1W3cdom/iciR/IigkRFbDx0iWIGmoq5HPJheuCVKmjB9GbGwMIybMQiqVUrlCaaaMH0qp4kV58Pg5Wlqa8naOnbrA2Mnz0NLUoFb1SjSsW516taqip6eToTgWzBzPlRt3uHFPNraoeqXSKfYpkDc33j7+HDp2Fqc3b2nRpC61qlf648fgd8l7kCQSTIyzdrZheooUzIebhxevnd+Ry9Is2TYH+0KArMimQCD4/8rWBGnL7qO8evOOFo1r0b9HW9RUv02HjY9P4P0ndw6fuMiOfceZP20kymJxdoaX44nFYkYO7kVUdAy1W/ThjetHYmPj5AnCv8LNI2mKvwrmpskH6rdr0YCL1+5x+MRFOrVuhESizHTH4TRt14e37z5myvn9/GW9McaG33pAihayxfWDGy+dXGnZpDbjR/anTMli1KhaQV6PqULZ5LOjzEyNqViuFPcePuX46YscP30RsVhMxXIl6dG5NS2b1k83jkrlS6EkVubM5fvYF7ZNdXHa/HmtuXH3MQ+evODYiXNoa2v9FQmSbIq/4hbTLWyXj7OXbuHk8oH6tSon21asqKwH6aXQgyQQ/K9l6ydj+5YN0FBXS3WbWKxEgXy5mTCiNxGRUUJylIXUVFXIY23Bs5dOvH3/iSIF8ys6pGwln+IvkWBuZpxsW5GC+ShWpAAvXr/l8MlLtG9Zn6qVyvLg2jEK5M/zx+ce5Tib8xcuYWJqLu9BAtk4pKOnL/PyzTtaNqnNuBH9f9pW04a1adqwNl8DAjl/+SZnzl/lyvU73LzzkErlv/UGffzkTnBIKA72hVIUv7xy8wEANauUIzW2+awBECeWIXis4Jlsnl+SepBUMMnmKtrfK2yXF0h9oHa+PNZoaqjj4vqRiMhINNTVszs8gUCQCbI1QfoxOXr7/jPL1u0kLi6eqKhoendpRdWKpdJMogSZ586du3wNCOTqzfv/XoL0XRXt1Eo9DOjRlgGjZ7F51xHq1ayIvp5OsuRIKpX+dpVtF9cPREZGoqauiqbGtw/OooVkz8HvLCxsaKBPxzZN6dimKZGRUVy/fZ+CibV6ANZv3cu6zbuxNDelQd3qNKhTjUUrN1GhTAluPZTVNqpRuUyqbRfIlxuAoJBwJBJlnr96Q0xMLCoqkl+OMzP07t4ODy8//INCFTYGCcA2b24kEmXevv+cohdWLBZTtLAd9x89w+mNq3y5lt9x5/4TbPPlxliBvWUCwb9KoYO0dx88zcLpo9iwdCor5zuyYsNuRYbzT7FPHEh67eZ9BUeS/b4ViZSkuMQGUNy+ILWrlScsPIIN2w8l23bizCVqNe7021Wlk85tbmqS7HYrC1P0dLXx+OKTZgmGhATZZeiDxy8wYcZyBo+bw+GTFwkJDZfvo66uRv3a1bCxtpLflsvKnAL58+Dp5cOm7ftp1Xkgd+8/4fT5a4SGhVO0UH5MTVL/ADY3NUZTQx0vH3+KFipAdHQMr99k39i1S1dvExcXJ/+9fJkSGBoZy3qQFJggSSTKFMiXm9jYOFw/fE6xvW3LRowY1POP6iK5uH6gXbfB1GjUiYDAIF46uQg1zASCbJTtCdKcpRvlS3zoaGty5eYD3n1058rN++jqaGd3OP+sGlXLA+Dk/O8N1P5+DJKZqXGq+wzq3R5VVRWOn70qryotlUrZvOMAT56/ZvLMJb98XqlUKp/mb2lummybSCTCvpAtAK/fvJPfHhUdw5mLN3GctYJG7QfRud8ElqzZwbXbD3n8zIlFq7bTpMNgpsxdxf3HL1OdETqoTxceXDvGw+vHme44nHKli6OsrEweG1nvUM0qZdOMWSQSYZsvN1KplLx5ZPs/fJI9y6HcuvuI1l0GUrVeOy5fuy2/3cdPVp4iaYkYRZGvy+ac8jJbr65tmTphGHnzWP9W20FBIXTsOYzQsHDq1qzM2k27qVK3Lbv2H/uTkAUCwS/I9gRpYM/2HDpxgdWb9tGtfVOioqI5fOIiQcGhLJwxMrvD+WfVThxo+/Vr4F8zhTu7jBvRHzu7AkgSi0SmxszEiC5tGyOVSlm6dqf8strKRdPQ0tRg+57DyT60M8L/awAxsbFIJJJUe2yKFpZdZnv55h1uHl4sX7+Lph2HMHPReq7efEBQcCh5rC1p2aQ2syYOYcH0kdSoUpYEaQIXr91juON8WnUbwfrtB1Odfm6bz4ZhA3tw/th2vFzvERQWCUCNdBIkANu8sg95QwNZj01WVtT29vEjMHGNM4lEmcIFbXFyeUerzgOp1bgTjVr3xMPTEwN9XYVPLihZTDZbbc/hM4RHRGZau/Hx8fQaNI73H92oUK4k86aPo3IF2Ziypas2/3ZZB4FA8Guy/S+Mnq42w/p15pObJ6s376OgbR5GDe4mDMrOZoXs8qGiIiE6Oor7j57TuF51RYeUbZo3rsvqLYeIiIyS10BKTafWjTh57jrPXjpz5eYDalUth7WVBbMmj2L4+JkMGT2NO5cPo6ebsWn1SQOMlSUSeQ2k7xVN7EE6eOwCO/eflN9epkRRGtWtSpkSRTDQT760RpXyJQkKDuXC1TucunAD1/ef2bbnONv2HKe4fUEa16tKzSplUVdLPq7v6UsXgkPCKGyX76dL7tgmjkNSVlFh2IDu1KhaIUP391d9DQikeYe+iMXKHNu7jnKli3Pz/H527z/OrIWr5AU01dTVMTEqlSUx/IqqFUtRolhBnr5wZs2W/YwZ3D3Z9guXb/L42StGD+2NRJLxMVvT567g8vU7WFmYsWP9IlRUJFStVJaypRx48Pg5ew+eoHvn1pl8bwQCwY8UMgbptfM73n10p2OrhthYWzJp9kqu3X6oiFD+WUpKSuTPawPAhSu/1hPyfxcaFkF4RCSGBnrpDjZWU1NlcG9Z3aNVG/cQlfjNvVunVtSoWp4v3r5MnLEow+f9NjhcgnEq42cKF8iLioqEqOhodLS16NCqIQe2LGLFvPHUq1kxRXKURE9Xm7bN67FjzWy2rZ5Fm2Z1ZYUlXzoza9EGGrcfzJylG3n++q288vOVxLFn6V1eS1IgsQfJxy+Q6RNHUL1K+Qzf54wKCQ2jVeeBOL/9gLqaKuqJM7/EYjFdO7bk8c2TjB7WBzU1VbS0tBU6/iiJkpISjiP6oKaqypGTl3j8zCnZ9jmL1zB/6TqcXT+k0UJKB46cZsW6baipqrJr8zL54GyRSMTY4f0AWLJ6c6YULRUIBOnL9gRp7tJN7D96Hv+vQazffohnL52ZPXEogUEhOM5akd3h/NPKly2JRCLB9X3KQaY51dPnr5k2dxnh4WFpXl77Xq1q5XAoUgBv36/sOXQakH1YrVg4DW0tTXbvP87FxIrUP1OhbAmaNqqPgYFRsin+SdTUVFk6eywzHQdzYs8KhvbtmKII4c/Y5bdh5MCunNyzklkTh1ChjANR0dGcPHed/iNn0L73GHbsP8GN27JFcTOSINnktkQsFvP+k3uWVL2PiIykXfchPHvhRJFCBTi4YzVamhrJ9tHW0mTSmMFsWDkfYxPTVBNMRbCyMJUvjD1n6UYivltHT15R+1XG6yGZmhihr6fLqsXTKZ5YcDJJreoVKelQBDf3L+w/cjoTohcIBOnJ9gTp0bPXzJgwiPYt6zN9/ECu336EWKxEi0a1mDiid3aH80+bPXkkhYoUJTwqhpiYf+Mb6Z0HT9iy4wDhYWGYpzFA+3sikYgRA7siEonYsf8k3r7+AOSyNGf2lNG0aFKXEg6FM3RuI0MDNLW1UdfQSPUSG8jGtdSuVh5VFZVUt2eUioqEWlXLsWTWGI7uXM6Anm3JZWmGm4c3a7ccIDA4hEIF8qaoA5UaVRUVbKwtiI6O4da9x8xZtIb9h0/9UXzfmzRjMXfvPyFfHmuO7lmHfho9ZQD+AUEACq2i/aNWTWpTvKgdX7z9WLtlv/z236moXa1yOZ7eOkXr5g1SbBOJRIwdIetFWrxiU7LZfQKBIPNle4JUolghps5bw/6j55g6bw1VKnyrDqz5w7dGQdZSV1fDLr8NsbFx8plaOZ2b+xcg9SraabHLb0PT+tWJjo5h3rLN8stUXTq0YOvahRgZZrw3w88/ACBbLxGZGBnQtV1T9m9eyLolU2hSvxpmpkZ0bts4w20kDdR++OQFC5atZ/+RzEmQ7j18ypadB9FQV+PwrrWpVvP+nq8CHr+fUVJSwnFkH1RVVTh04iJPnssutSX1IP2sonZMTCxnL16T/57eUjH1alWlRZO6jB/Z/7drcQkEgozJ9gRp0qi+tG5aB0N9Pfp0bcWAnu2yOwTBd4oUzE90VBR3HjxVdCjZQj4OSEWSoR6kJIN6t8fIUJ/7j19y4uw1gGQfUCGhYTz7SU/BpJmLefrsOdKEBPT10u4lySoikQiHIgVwHNGHozuWZejyWhLbvLkT25BNpnj87BUJCX9+ue2Llw/aWppMGD0Qm9xWP91fEQlmRuSyNGNAj7YAzF6ykcioKIoUtkVJSYmXr13SfazGTp5Lhx7DWL5m60/PIxKJ2Lp2Ie1aNUYsTGwRCLJUtiZIW/cc4/yVOxSyy0vt6uWxy2+TYp8Xr98ye8lG4uLjszO0f9bDR0/48N6VU+euKDqUbOHu8es9SCAbA+OYeAl4xYbdePn4y7d5+/hRsVYr2ncfIp+inppDx87y1d8fA31dxGKF1mj9ZUlLjrh/8aFggbwEB4fi8guDj9PSsml9Hlw7xoBenTK0v69f4jp2f1mCBNCmWV0cihTgi7cf2/YcR0NdnQL5bQgLj+DDJ7dUj9my8wDbdh9GR1uLBnWrZ2/AAoEgXdn6V7pt83r4+PnTc/BkpsxdzfptBzl6+jLb9hxn9pKN9Bo6ldMXbtC1XRNh2n82qZ64Bpezy7uf7Jm97tx/QuHSdegxYAzXb93PlN4KSL4Om9kvJEgAFco40LR+dSIio5i9ZIM8JlMTI4oUssXbx49xU+enemxcXBy+fl8RiUQZGvfzt0nqQXL94Ea50iUAePDo+W+39/3zaW5mgrJyxiqOJF1i+xsTJCUlJYb0lSV69x/LakU1qleTti0bkXhVNpnb9x4zdvJ8RCIRG1bO+aW1/p69cKJTr+HMX7ouU2IXCAQpZWuCpKmhTtd2Tdm8YgZd2zfFNl9uwiMiMTbWp1mDGiyfO44JI3r/8swdwe+rk1gwMjAwCB/frwqO5puDR0/zxduXoycv0Kx9X0pVacqy1VsICAz67TZDQsMICg5BWVkZJSWlNJfXSM/Qvh0xMzHk8TMnjp6+DMgueyybPwVdXW0OHDmdam+cl48fCQkJiUtk/P/W1dLTlU2tDwgMpkihAgDcf/zst9qSSqW06TKIKbOWEhGZ8QKLUVHRhISGoaujhZrqnw1izyp2+WVrtL3/5E5sbByTxw1hw4o52OazSbafm8cXuvUbRVycbJ/6tav90nkSEhI4ff4qp89fzcToBQLB9xTSzy+RKJM/Ty5qVilL5zaNaVSnKkUL5U8xtVeQ9XJbW6Khrk5sbAw37j5SdDhySVOjB/TujJ1tXj5+dmfa3OV4efv9dpsxMTG0adEQLW0djAz0fmummKamBhNG9AFg1cZ98orV5mYmzJ8+DoCRE2alSOQ8v3gDSTWQ/p4ZWL8iqWCkYeKg9PsPn/1WO/sOn+Ly9TscPn42zbIBUqmUl06uXLv9kEvX73Hu8i0On7wE/H3jj76nrKxMPptcxMXF89HNM9V9IiIj6dRrOP5fA2nZtB4jBvX85fMUK1oQHW0tXr52ISgo5E/DFggEqfh/DYQQZDqRSEQB27yAbGHQv8XmNfPZsWEx0yYM496VI5w9spXxIwdQJLHadEJCAs079GPZ6i34+mWs58vI0ICxw/tjbmGZ5hpsGVG2ZFFaNq5FVHQ0sxd/u9TWrlVjGtStjq/fV8ZOmpfsGA9PWYKUVhXt/4OkmWzhEVF07dCSfj07ymf0ZdTXgEAmTpcV11w42xFtLc0U+yQt79J3xHQmzFjO5DmrmL5gHas27QX46y9RFkhMJN+++wTAs5dv2H3geLLHyi5/XuyL2LFy0bTfmo2mrKxMhbIlkEql3L7/OFPiFggEySl2MSPBX6FS+VI8e/GaJ89fKzoUORtrq2Qr0lcoW5IKZb+VhLh97zHXbt7j2s17zFq4mkb1atC9UyuqVS6HklLaeX/S4OpfGaCdmkG9O3Dv0QuevXLh4PELtGtRX3apbd5k7j14yoUrN/H44o2VhexycU7qQXr30Y0VC6f+VhuTZi4hIDCIJg1q0TCNQcmbdh7h4PELaKirUbViaSQSMcpiZSQSMSoSFRrVrfK7dyFbFMifmCAlls7o3n80nz57ULVSWXJZmqOhrs7GVXMJDglFU+P3e80rVyzD+cs3uXnnIY3q1ciU2AUCwTdCgiSgUb0arNm4k68BQUTHxPxxkcLsULlCac4d3ca23Yc5dvICx09f5Pjpi+S2tqR313YM6d8txTHPXjhx/fZ94uPjf3mA9o801NWYOKovg8bMZu3WA1Qo44C1lTmmJkZsW7+Q/HlssLQwle9fsnhRihYpTEhYJMa/UDfpb5LUg/T2feozsn7m+u377D14Am0tTebPGJfqPvuOnGPL7qOoSCQsmDaSUsUzVoTzb2KXONjaJbEHqViRgnz67MGGLXsZOqAbxkaGiESiDK/hl5YqFWVlGm79RZfGBYKcRGGX2E6ev06TjkOo1KALlRp0oWJ92b+C7FeutAOtWjbH1MwcZ9dPig6HJas207brYO4/epbmPiKRiPJlSrBu2SycH19i/oxxFLLLx2c3Tx48/ja7KjY2Vn4JbNmarSxevp6IiPA/7kECWdXrts3rEh0dw8xFG+TjaapVKpcsOQKoUrEMefPmQVNL63/bg2RpboKGuhrunl4EBAazY+8RlqzanKFjo6KiGTl+FgBTxg/Fwtw0xT6nzl9n+fpdiJWUmOk4+H+ZHAHkz5MLJSUR7z64kZCQIK+ovXL9dmo07Ij/14BMOY994QLo6mrzysnljyYvCASC1CmsB2nt5v1MGNkb+0K2KCsLU/oVSSwWU9zejtfO73j5+i0ORQooNJ5rN+9x4/YDvPyDqVerCt3aN013ZqOeng79enakb48OPHzyAnX1byvXHzh6hvlL19GtYyveJtbtkUh+rUhkegb0aMedB8959caVvUfO0LnNt+rUkZFRzFq4ijIli9G8cV38vibV8Pl/JkiyBY6tefH6LZ/cvzDKcTZKSkoM6tMF1Z/MKlNWFtO9c2suXb1Nzy5tUmy/dvshc5dtAsBxZB+qViyVJfchO6ipqWJtZc4nty94fPGRV9QGqFW9EoYGmfP8i8Vils6dhLmZSapjuQQCwZ9RWA9SntyWVClfEj1dbbQ0NeQ/AsUo5VCY+Ph4tuw6jH/iB7kiSKVSXr52ASA6Jo7TF27QvvcYpi9Yyye3L+keKxKJKFvKAfvCdvLbbt55iJv7F2bOX4lTYq2nXy0SmR41NVUmje6HSCRi4/bDfPz8bebSlRt3Wb1hJyMnzGbWglW4uXugqaGOuppaOi3+3fInXmZz8/CiuH1hoqNjMrQYq7KyMkP6dePY3vUpKkA/e+nMlLmrSUiQMmJAFxrW+bvHGGVEUhFcl3efKFOqGIYG+lStVJaFsyZk6hIhLZvWp0LiotMCgSBzKSxBalS3Klt2H+XdB7dkPwLFiI+L5a2zE8+fP2fMtMVZsmp7Rnh88SYwKBg1NTXEYjHNG9ZEIpFw7vJtOvYdx+Q5q3j/yT3D7a1dOpOLx3fSqV0z1NXU0NDURCwWY2qSOQkSgEORAnRo1YCY2FhmLlovrwLfqF4NmjeuS0BgEItWbMT7i+dfPUU9IwokFYx8/5lyZYoDcO9R2svUJCQk8OHjt/f1j8lBZFQUsxZvIDY2jp6dWtC2eb3MD1oBCiTWPXr77jN6ujo4PbzAsb3rUVH5vURGUe9HgeBfprAEadPOI5w6f4Ox05bKf8ZNX6qocP55lcqXonGDWsTHx3Pu3GW27D6ikDiSeiMkEhWsrcwYN6wnR3YspUvbxqirqXLp+j0695vAhBnL5YNg0yMSiShTqhirF8/g9cPzWOfOg4G+bqYXGuzTtTW5c1nw5u0Hdh34tpDrotkT5P+Pj4/HxPj/nSAlLTny9r0bZUs5AOlX1N6x5wjlarZgw9a9qW7fuP0wnl6+OBQpQK/OLTI/YAX5NpPtEwCqqirpzq5MS1R0DKMmL6JR+4Hce/Qi1X3mLVlHlXptM21sk0AgkFFYgrR303yO7Fia7OfwdiFBUhSRSMTapTOxzmVBZGQEcxev4enLn186yWxJCZKaujqlixcBwEBPl4G92nNkx1K6d2yGpoY6124/pPugSYyZuhgnl/cZajsgKFS21EcmXV77npqqCpNH90VJScTmXUd491HWy2VkaMC6ZbLBybp6ehj9T2sgJclrkwuxkhLvPrhRqnhRAO4/epZqPSQfX3+mzFlGbGwc+RN7nr732vkd+4+dQ0UiYcKI3r+VQPytkpZmefv+8y/XikoSHRPD+OlLufPgGcEhYYyevIgTZ1NWzn7l5MLL1y7cvivUQxIIMpPC/iINHD1bUacWpEFbS5P921aioiIh4OtXBoycSlBwaLbG8OK1LEFSVVOjVGKClERXR5t+3dpwdOcyendphbaWJrfuPaXX0KmMmLiAF6/fptu2l4+sCndmDdD+UZGC+encpjFxcfHMXLSOuLg4ANq3bsKkccMwNbP43w7QTqKmqkKB/LmJio4mKCQcm9xW+Pp95XMqVaMnTFtASEgobZo3pGa1ism2xcbGMWfJJhISpPTq0oLcuSyy6y5kC10dLcxNjQkKDsXX79d7dmJiYnGcuYL7j19iZmJI947NiE9IYO6yzazbeiDZWnaVK5QG4Obdh5kWv0AgUGCCVNDWhtv30x67IFCMQnb5WbVoOgAuLm8ZOWn+b38D/h0jBvXCOnduNDQ0KeVQKNV9tLU06dW5BUd3LGVAz7bo6Wpz79EL+o2cweBxc3jy4k2qx3lnUpHI9PTq3JK8Nla8ffeZ7ftOyG9XUVFFLBb/b2sgfa94UdmsrOevXOjSvgXDBnRHWZJ8QuzFK7c4cuI8ero6zJk2OkUb2/cd58NnDwrkz03HVg2zJe7s9uNltoyKi4tj8pxV3HnwDGMjfVYtmEi/bm2YPWkoKioStu87wbT5a4mJiQW+r4ckJEgCQWZSWIIUGBTCuOnL6Nx/At0GTZT/CBSvbctGdO3YEhWJhKcv3rDvyNlsO7eWliaaWjoUssuLro52uvtqamrQtV1TjuxYypA+HTHQ1+XxMycGjZnNgFEzefDkVbLkLmkdtz9ZZuRnVFQkTBndD7GSElv3HJePk/q/T/H/noO9bJbgs5fOjBrSm+kTR8grhgOER0Qw0lHWQzxj0giMf1ic991Hd7bvO4FYSQnHEX1QVs6Z9WrlS44kVtTOiLi4OKbMXc2Nu48xMtBj9YKJWJqbAFCzSllWzXdET1ebi9fuMmzCPKKiYyhklw9DA32c337I8LI7AoHg5xSWILVuVpcV88YzcmBXhvXrLP8R/B0WzXLkwI7VaGhosGbLfl47Z2ycz596/MwJgFIORX6y5zfqamp0bN2Qw9uXMmJAF4wM9Xn2yoVhE+bRd8R07jyQjZHx9s36HiQAO9s8dOvQjPj4eGYuWk9MTCx+/rLLLCb/8zFIAA5FZAnS89dvk13qSbJp237cPb5QsVwpurRPPvA6Pj6BOUs2EhcXT+e2jeXT4XOipPv29l3GEqS4+HhmLFzH1VsPMdDXZeV8xxT1v+wL27Jx2TSsLEx59sqF67cfoqSkJL/Mlh29SOs272bOojXZ2rMsECiCwhKkksUKpfoj+DuoqEioVqkMPTu1IDY2juET5hIWHpGl5zx07Cwr120jMiKCMiUyniAlUVNVoW3zehzatpgxg7tjZmLIqzfvGDV5ET2HTMHJRVYoMqsTJIDuHZphmy837z+6s3XPse96kP7/l9j0dLXJY21JSGgYH908uXX3EXMXryU4RDZebUDvzkweN4Rl8yenmNZ/4Ng53rz9gLWVOT06NVdA9NmnwHe1kH4mPj6B2Ys3cPHaPfR1dVg5bwI21qmPy7KyMKVD4mXJ569k4+6qVCwDZP2yIy6uHxg/dQELlq1PddyZQJCTKKxve9CY2akWTFu1wFEB0QjS0q19M5av3oyz0yuGjpvN5pWzMrXQ3ffOXLjGW9d35LLOjUNRu58fkAZVFRVaNqlNk/rVOXvpJjv2n8TZ9aN8u1km1kBKi0SizORRfek5dAo7958EZNWk9XTTv2z4f1HcviAf3Tx5/tKF3fsOc/n6HcqWKkat6pVQUZEwakjvFMe4e3qzfvshRCIRjiP7/C/W/PsTRgZ66Ovp4OP3leCQ0DQvGSckJDB36UbOXb6NjrYWK+aNJ6+NVar7JnEoKqt2/zyxqGr9OtXQ1tKkaqWymXsnfpA/b25UVVWIjo7h7sOn2OROP06B4P9MYT1I7VrUp23zevIfPV1tmtSvpqhwBGlQVhbTsmldAE6cOsf2vcf/uM20uuYfP30JgH0ROzTU/7zatESiTNMGNdi3eSGTR/fDNq81tauVR01N9Y/bzgjbfLnp2akF8QkJxCckYGSgl2OmsiclsM9eOcsLRi5fu433H1K/nCSVSpm3bDPR0TG0alJb4cvZZAeRSCQfh+SSxmW2hIQEFqzYyumLN9HW0mDFvPHyauXpyWNtibaWBh8/exISGo6VhRntWjXG3MwkU+/Dj8RiMQtmjAfg3gNhko0gZ1PYX+uqFUsl+5kypj8nzl5TVDiCdEwZN4QypRyIi4tj0oxFuHzXG/Or5i9dR5Eydfni5ZPs9ojISNw8vqCkpES1SuX+NORklMViGtapwo61c5jpODhT2/6ZLu2aUNBWtrq7UQ6YwZakuDxBcpEXjLxx+wGV6rRJ8dwCnDh7jScv3mBmYkj/Hm2zNVZFko9DSmUmm1QqZfGaHRw/exUtTQ2Wzx2f4TFZSkpK2Be2RSqV8uqNa7I2XzmlX+7id312l11SK1+2BAD3HgoJkiBn+2u+zn5y/yIvrif4uygpKXFg20r09XQJCwulQ68RRERG/VZbi1du4ou3L5E/HP/ayRWpVIqqmhplSxXNjLD/CspiMVPG9MfU2JAqFUooOpxMY2piiLmpMX7+gVhYmMt7xlo3b4CFuWmyfX39A1i5cQ8A44b1QlNDPdvjVZQC8oHan5LdLpVKWbZuF0dOXkJDQ41lc8ZSqEDeX2rbvrCsFy6p/pdUKmXkhFlUb9iBazfv/XHs33vp5ELxio0YOHIyBfLnwUBfDxfXD3wNUNy6jQJBVlPYGKS6rfoCsrEs8fHxxMTG0r1Dc0WFI/gJfX1dDu5cTd1mXfnw4SMDR01n25q5v9yOpoYGMTHBmJsnvxTwKPHymqamJkXs8mVKzH+LPLktObpzWZaN3VIUh6J2ePn44frhM80a1eblaxdmThqZbB+pVMrClVsJj4ikYZ0qlC9dTEHRKkZql9ikUimrNu3lwLHzqKupsmTWWIoUzP/LbSdd5nyemCCJRCJy57IkLi6Orn1Hce7oNgoXtM2EewHzl6xDKpWSy9ICkUhEuTLFuXL9Di6uH6lY7v8/M1MgSI3CEqTta+bI/y8SgZ6uTqavjyXIXKVL2DN1wjCmzl7KrbuPOHPx5i+tvB4SGkZgUDDGRgZoqKtz4fJNCtrlw9rKguu37wNglz/vby/o+TfLackRQAl7O85dvsWzly5sXbsQqVSa4n5eun6PW/eeoq+nw9C+nRQUqeJYmpugqaGOu6c3EZFRqKupsm7rAfYcOoOqqgqLZo7+7fFYhQrkRVlZjJPLe2Jj45BIlBk2sAef3DzYtvswbbsN4dKJnX9c9+vFa2dOnbuCjo42A3rLnsNl8yajp6uDqvA3W5CDKewS24mzVzE3NcLc1AgzEyPUVFVYsX63osIRZNDQ/t1YOHsixiamLFq1jc/uXzJ8rLuHFwDWVhbs3HeUtt0GM2LcTKRSKSYmphgYGqVYkkLw95L3YLySzaT6MTkKCg5lyZodAIwe3B1dHa3sDfAvoKSkhG2+3EilUt59cGPTziPs2H8SFRUJi2aM+qPSJmqqKhS0zUNMTKy8lIBIJGLRbEdqVauIh6cX7XsMJTziz8pzzFuyDoBBfTqjp6sDgKmJkZAcCXI8hSVIdx4+S/a7l48/l2/c/+32Ll67S+9hU2nTYxTHzlwBZNWLuw2aSIc+Y/nwyQOA0LBwVmzY89vn+deJRCL6dGtL66Z1iIyKZsyUxURFx2ToWDcP2SBP61wWNGlQC3NTYy5fv8P+w6cICo3A1MychnWrZmX4gkxkbWWOvp4O7p7efA0ISrF92bqdBAWHUr1SGWpWydrp53+zpMtsS9bsYMvuo6hIJCyYNlK+GPOfSBqHlJSkAigrK7N13UIKF7Tl2Qsneg+eQHx8/G+1/+zlG86cv4qurjb9e6XsAQwOCSU2Nvb3ghcI/nLZniC17DqCVt1G4PrejUoNulCxfhcqNejCoDGzadO87m+1GR+fgJuHF2sWTmLT8mms3LiHkNBwTpy9RoeWDRg3tCf7jsqWyzh88hKtmtTOzLv0TxrcpwM6WmpcunyFXoMmZOiY73uQ9HR1WDx3EgDjpy7gjcs7tLU0KJDPJqtCFmQykUiUbDbb927ff8r5K3fQ1tJg1KCuigjvr5G0JpvLu09IJMrMnTKMcqXsM6XtpHpIL36YuaajrcWBHaswNzXGzMTot6tez1uyFoAh/bqlqOM0aNQUbIpU4f6j57/VtkDwt8v2MUhHdiwFYLjjfJbNGZcpbYrFSvTq3BKQVYC2MDUhKDgEv68BVKtYCnNTI3z9AggLjyAkNFy+tpHg96mqqNCxVUPu33/ImfOX2bTjEL27tk73mDy5c9GmeUNKl5QN1G1YtzpNGtTi5NnLBAWH0KplE8Tiv2ZipSADitsX5Oqthzx76UytqrLyDOHhESxYsRWAoX07YZQDllf5E4VsZbPTxGIxsycNpWLZ4pnWtn1h2SDsl69dU4wBs7Iw4/q5/RgbGfz2GLgWjevi7x9A3x4dUmwzMzFGKpVy/9Ez+VInAkFOorBB2svmjCMwKAQfv6/yOjGZwf9rIKFh4Viam2JhZsyzVy54+37F0tyEI6cu0bB2ZeYt20xMbCyDe3fAQF83RRuHTlzk8MmLQNpFDQXQrWNLrly/y/HTF5g4fQGVypegUIG0Z6DVqVkZm9y5OHzyEmevzMLdwxtvXz/5dulvXgYQKM6P45AAVm/ej69/AGVKFKWRcMmUvDZWjB3ag9y5LDJ9OSUDPV1yWZrh7umNu6c31lbmybabGBumcWTGtGvVmHatGqe6rXyZxHpIQsFIQQ4liomJVkgGcOr8dXYdPE1sbCyHty/Fy9uPjTsPM2VM/58eu23Pce7+0K07c8IgjI0MmDpvDaUcCtOsYQ2CQ0KZPGc1kVHRjB3SnbOXb2NspI++rjZmJkZcu/2I4f3TXyA3Li6OKo26c/P0thy76vifiIuLo0Tlprh7eGJlacGr+2fT3X/IuLk8evZa/ruerjYSsQgPDw8O71xNHptcWR2yIBPFxydQr3U/IiKjOH9oHa4f3Bg0ZjZqqqrs3jAXiyyu7CyAWYs3cPrCDRxH9qFJvZSrEbi+/8Tla7epUbUCdrYZq7UUGxuLRJL+bNKg4BDyFK2KtrYWH19eRywW/1b8AsHfSmGf+DsPnGL7mtn0HTEdAHMzY/lA6p/p3rEZ3Ts2S3H77oOnE5eXqA6Aro42K+bJyuLv3H+Slo1rsevgKcqUqIu5iSHbMmHZjH+dsrIypw9tpHjFxnh4fsHH1x/TNNY6O37qIi9evQFg1XxH8ue1/idnNuUkYrESxYoU4O7D5zx8+pq1W/YDMKBnWyE5yibFihTg9IUbvHj9NtUEaff+Yyxbs5Up44dmOEHq3HsE6urqzJs+Ns0yAXq6OhQuaMvrN2954/KeooVz/vIxgn+LwgZ8KCmJktU9Co+IJDLq96ozA9y894Qbdx8zdmiPFNfbwyMiCQwOxcrCFCMDPVzefcTl3ad/fmxEZrG2skRfXw+AW/eepLpPWHgE3fqP5tWrV+jqaFGqeGEhOcohitvLLrMtWLEFjy8+FC1kS6smdRQc1b8jqY7Si9cuqW6vVF42Puj23UcZau/h4xecv3yTm3ceoqWlme6+FYVlRwQ5mMISpPKli7F+20Gio2O4de8pIyctpHL5kr/VVlRUNFPnriY4JIw+w6fTdYAjew+fkW8/evoyLRrVBKBpgxrsP3KOBSu30b5lg0y5LwIoV6YkpmbmaU75d/eQ1UuSSFRSjJMQ/L85FC0IQHBIGBKJMo4jeguD7bORtZU5errauHl4ExgUkmJ7uTLFUVJS4v6jZ8TFxf20vaSZa0P7d0NLUyPdfZPWZXN5+/43IhcI/m4Ku8Q2qFd7dh86g7aWBlv3HKNy+RJ0aZv6YMCfUVNT5crxzWlu79zmW7smRgbsWDsnzX0Fv6dRvZp8dPchLDwy1e1uSQmSigRrS7PsDE2QxQrZ5kFFRUJMTCw9OjYnT25LRYf0TxGJRBQrXIAbdx/zwukt1Somn1Gmo62Fg30hnj5/zYtXzpQsnvZahw8eP+fy9TsYGerTu3u7n567bq2qvH5wAUsL05/uKxD8ieu37zNvyTratmhIj85tsuWcCkuQjp6+Qrf2TenWvqmiQhBkIutcsl6hz4m1jn7k5v5dD1IuoQcpJ1FRkdCnays+ffb87S85gj9jX8RWliC9TpkgAVQsV5Knz19z+97jdBOkuYvXADBsQA80NdLvPQLQ1tJE+yeX4QSCzPDipTN37z+hYtnfu9L0OxTWD37h6l3ihGndOYa5iSEBAV+5dOVGqtuTikRKJCpYWwoJUk7TuU1jJo3uJ8z0VBCHIrJxYC9ev011e9I4pFv30h6HdO/hU67euIexkQE9u/7aN/SEhARCw8J/6RiB4Fe8efsOgILplJLJbApLkJo1qM6QcXO5dushN+8+lv8I/p9yWZrh6+3F27euREVFp9ie7BKbMAZJIMhUdvltUJFIcHb9mOo4wIplS1KtcjmqVkp7yZfw8Aisc1kwbGDGeo+SXLh8k7z21Zg6e+lvxS4QZITL2w8A2BXI2EzMzKCwr3tnL91CSSTi4PEL8ttEIhFVKpRSVEiCP6CqqoqWliahoWE8fPqCKhXKJNuupamBskSCiooqlhbC9G+BIDOpqEgobJeXZ69ccHJ5n6IgpZ6eDsf3bUi3jVrVK/H4xgkSEtIvjRcaFk5sXBwGerIiu5YWZgQFhwgFIwVZRiqV4uL6Qbb4c16bbDuvwhKk1QsnKurUgixiYmxEaGgY9x8+T5EgTXUczuNX77EwM0ZVRVgFXCDIbCUdCvPslQsr1u9m9cKJaGqo/3IbPysOGRUdQ88hUwgLj+DIjqWoq6lRyC4fOjraOLm844uXDxbmwoBtQeby+OJNWHgEeW2sUVdXy7bzCnNxBZkmt7UVAC+dUo6DcHOXjUHKJcxgEwiyRIdWDcifxxqXd59wnLmc2NjkU/ojI6M4ff4qO/cdTXb7rbuP6DtkAq7vP/30HAePncfjiw9BwaE8eS4r+qqkpETDutUB6DvUMUOlBASCX+HsIisjUdAu+8YfgZAgCTJR4YL5AXj34XOy2yMjo3j55i1SqZTcwgw2gSBLaGlqsGT2GMxMjXjw5BWzl2wgISFBvj08IoJOvYYzdfYy+e1SqZQ5i9Zw4OgZLl+7nW77gUEhbN93Qv77vUcv5P+fN20sNrmtuHX3ETPnr8zkeyb41xUtXIA1S2fSM5um9ydRWIJ0/U7K2RTnLt9SQCSCzFIqcfqwl5dPsttv3X3E8DFT8fRwJ5cwg00gyDLGhvosmz0WHW0tzl+5w5rEpV8AjAwNKFggLwGBQTgnFna8cecBd+4/xtzUmO6dWqfb9tY9xwiPiKRQ4iDZ+49fyrfp6emwY8Ni1FRVWb52G3fup15RXyD4HeZmJnRs05TaNSpl63kVliBt2Z28mzchIYEtu48pJhhBpqhUviSaWlpoaiVfQkQ+g00izGATCLJa7lwWLJoxClVVFXYfPM3+o+fk2+TLjtx7jFQqZd5iWdXsEYN7oaammmabbh5eHDl1GYlEmVkTB2NiZIC7pzceX759GSpWpCCL5jjiOHog5csUz5o7JxBko2wfpD1ozGxEIhEeX3wYPPZbRWsfv6/ktbHK7nAEmcjEyBB7e3uCQ8IIj4iUDxJ1c/cEkhIkYQySQJDV7AvbMtNxMOOnL2X5+t1YW5lToYwDlcqXYvOOA9y+9xjbfDbcffAUCzMTunZomW57a7bsJz4+nnYtGmJhZkK50vacPHed+49fYGXxbd29zu2aZ/E9E/xrpFIpg0ZNwTavDcMH9Uyx1mpWyvYepEmj+zFxZB8M9HTp2bmF/GfF3PHMnzoiu8MRZLKkHiJ3T2/5bZ8Tq2hraGhgYmSgkLgEgn9NlfIlGdSrA1KplNMXZAVcK5aTlVG5fe8RcxN7j0YO6Z1u79Gzl85cv/0IbS1NurVvBkD50g4A3H/0Ms3jnJxdmbVgFVJp+mUDBIL0eHzxZs+BE+zcdyxbkyNQQA+SuakR8B97dx0W1dYFcPg3dKiEiHQYiKBid3d71Wt3fNfu7u7u7q5rd/e1RRELuxVBQDrm+2NklBRzUNf7PD7CiX3WmXNmZrH3PnvD7AkDyWiZ/mcfXvxgFulNCQoK5Mjxs7hmdQbg3gNVp20HOxu0tOS5ACF+lvKlCjFr0VqueasekrDKmIHMzg7ce/CYN75+2NlY0axh7ST3VyqVzFq0DoDWTWqTLq1qWpECedzR1tLi4tUbREZGoasb96skPDyCv5t25PnL17x67cvkMQPR15fhPcSX09QTbKDBPki+fu9o0WkQdVuoao1evvaNM2ik+DUFvgvg6eNHbNv18VrGTjOSNbOThqIS4s9kmSE9VpbpeePrz6s3bwGoW6sKzRrW5syhzWxaNSfZxOXw8XN4376HrbUldWuUVy9Pm8YYN9fMhIaFJzq9ib6+HvNnjCFdurSsWr+VGvXb8vLVm+9/guK3F/tAQXaXzOw7fAqvmz4/rVZSYwnSpFnLGNGvE8bGqiHtLS3M2XXguKbCEd+JR05XAJ586JgdFhbOu4BAtLS1yZrZUZOhCfFHyumWFfg4T9vA3h2ZNXk4bq5ZyZ4tS5L7RUREqp+C69C6QYJaosL5cwFw7tK1BPsClCxWkCO7VpM1sxPnL3lStlpjLl/1+ubzEX+W2DnYHB3sGDFxPr2HTv5px9ZYghQREYmTg436d4VCQXh4pKbCEd9J4QJ5AHj71g8AAwN9enRtj3OmLPIEmxAakNPNBYDr3ne/aL/NOw7y4tUbcmTPQtkSCedwi02QPh0PKb4smZw4tHM1lcqV4PnL11Sp24p9h+QPYZFysXOwGX2oTMnsZP/T+iJpLEGyt7Xi/KXrKBSqSRKnz18VJ2ESv6bsLs7o6OgSERnJ6ze+ALx85Yuenp48wSaEBuSKrUFKZIT7pAQEvmf5um0AdPlf40S/kLJlccYkXRru3n+M71v/JMsySZeWtUtn0KtLW0xN0pHTzfXLTkD8sT6dgy0qUjW4aZZM9j/t+BpLkPp2bcXaLXu49+Aplep14MGj5/Tu1EJT4YjvREdHh3Tp0gIf/7J8/OGJNhkkUoifL3MmBwwN9PG5/5iQ0LAU7bN83TaC3odQpngBcrm7JLqNtrYWBfPmBODc5aSfZlNtq82Qfl04d2QrtjYyV5tImYiISLp1bMX/WjbkyXPV90hmp5+XIGlsstr05qZMH9uP0DDVG9bQ4OdNQCd+LCurDPj5+XHx8jWuXffm4oULODs7q5+AEUL8PDra2ri7ZuHi1RvcuOVDgTw5kt3+6fNXbN5xEG1tbTq0bpDstoXz5+LgsbOcu3iNahVKfjYWU9N06p+VSuVPf2xb/Fr09fXo0+0fANr1HAlAZmeHn3Z8jdUgRUfHcP6yF8dOXeToyQvsOXiSPQdPaioc8R1lzeyMnr4+gUHBXL1+k/DwcCzSm2k6LCH+WLEdtVPSD2n+so1ERUVTt0b5z04uXSjfhxqkS15ER8cku22sLdv3UrJyA3bvP5qi7YVQKpXce/AEhUJBJifbn3ZcjdUg9RsxjTv3HpI1kyM6OtqAqqN21QolNBWS+E7q1qrCnfvPsLOz4/R/FwDInEmeYBNCU2KbyRJ7JP9T173vcvjEOdIYG9G6yV+fLTe9uSlZMzty994jbt19gLvr58eqCQgM4prXLXbsOUT1ymVTFL/4M23fdZCw8HBy5shOcEgodjYZf2prk8YSpPsPn7Jx6RQMZPCw347jh6fVHj15rh77xN016ceJhRA/Vo7sWVAoFHjd9CE6OgZt7YSNB6pBIdcC0KJRTUw+9CX8nML5c3H33iP+u3gtRQlStUpl6TVwLPsOnSAiIhI9Pd0vOxnxx5g5fzmXrnoxc9IIADI7/7z+R6DBJjZXF2ciIuSx/t+Rg501MTExeHnfJijoPVpaWmT7MKq2EOLnS2NsRCYnO4JDQnnw+Fmi2xw7dYHr3nexymhBvVoVU1x2Sh73/1RGSwsKF8hNYGAQJ06fT/FxxJ/l0yfYwiKjAMjykxMkjdUg2VpZ0n3gBDxyxH1Colu7phqKSHwvpiZpefbkEe/fvwdAV09PXaskhNCMnNmzcu/BE67duJPgiyYyMko9KGT7lvXR10t5zX7O7FkxMjTA+7YPL16+wdoqw2f3qV6lHGfPX2Hn3sOUL1Psy05E/BGePn/J++AQMjk58PTDk9BZfmIHbdBgDZKBgR7FCuUmjbFRnH/i16dQKLCw+DjPnp6eHjZWlhqMSAgR2w8psY7aW3cf5unzV2R3caZC6cJfVK6urg7lSxUmJkZJ76FTCHof/Nl9Yvse7d5/hOjo6C86nvgzfDoHm8/9J8DPb2LTWA1Sm6Z1NHVo8RM42tvw8OEj9PUNcMmaRfoZCKFhHxOkuB21g94Hs2T1VgA6/6/xV00o3aNDM3wePMH79j0GjJrBtNF9E0xN8ilHe1ty53Lj6jVvPK/fJG/u5IceEH+eW3dVCVLWTE4cPnUZA339n/6HtkytLn4IVxdVZ009PT08crppOBohhI1VBszNTHj24jVv/d6pl69cv5PAoPeULJKPvLmyf1XZBgb6TBrZExurDFy66s34GUs+O6Ho1LGDuH5unyRHIlGxk9SmT29GdEwMzo62iT5c8CNJgiR+iDwe7gCEh4fLHGxCpAIKhYJc8eZle/HyDRu37UdbS4uObZIfFPJzzE1NmDKqD2nTGLPn4EmWrtma7PZ5c+eQ0fVFkrJmcqJQ/tzo6ekDP3eKkVgaTZBOnLnEpu0HAIiJiYnzV434tcWO1hsREU5aY0MNRyOEgI8DRl77kCDNX76JiMhIalUri6P9t8+F6eRgw4ThPdDV1WHxqn/ZffDEZ/eJjIwkMOj9Nx9b/F66d2rN/m0riPwwAOnPnGIklsYSpClzVnDk5Dk27zgIwGtfP4ZPmKepcMR35mBng5GxMVpaWrhkcdJ0OEII4vZDunnnPgeOnsHIyIA2TWt/t2PkyenKoJ6q6SHGTV3M0HGzuXTVO9Emtx17DpE1d1mmzlr83Y4vfi/3Hqg6aP/sJ9hAgwnS+cteDO3THv0PA0VaWVoQIH9F/DZ0dXUoU6okrm45cMv2+cHjhBA/nktmR/R0dbl19wHT5q0CoFn9GpibmnzX41QqW5Ru7Zqipa3FwWP/0bnfWOq37s3qjbvwexeg3s7RwZZ3AYHs2HP4s32WxJ/j4eOnnDxzgXcBgeoE6Wc/wQYaTJC0tbSIioomdq7CJ89eEvVhMCjxexg7pCtzJg0ivbmppkMRQgB6erpkd3EmKiqa6953sbQwp2Htyj/kWA3rVGbHmll0bdcER3sbnj5/xZwl66ndrDs3bqk64OZyd8XRwZb7Dx/jfcvnh8Qhfj1btu+jRv22TJuzFF+/d1iYm2JqkrKR3b8njSVITepVo9eQyfi/C2TmwrX802METepX01Q44gdwtLchT05XTYchhPhEbDMbQLuW9TAw0P9hxzI1SUujOlVYt2gC8yYPpmhBDyIiItm25wig6jheo0o5ALbtOvDD4hC/Fi/v2wCYmZoCmqk9Ag0mSNUqluR/zetSuWwxtLW0GDekG9UqlNRUOEII8UfI8+FR/qyZHalc7ueMYq1QKMid05VenVoAcPbCVXWTWt2aqhqsjVt3ExMT81PiEamb14exunR0VOPnaSpB0thAkYtXbaFS2WJ0bNNQUyEIIcQfp3D+XAzr2568Hm5fNSjkt7CxssTJwYaHj59zx+ch2bI6kzuXG64umbh15z5nz1+hWOF8PzUmkbqEhIZy78Fj0hgbEfBhVHZNdNAGDdYgKRRa9B8xnbbdhrFp+wH83wVqKhQhhPhjKBQKKpcrjqWFuUaOX7RgbgBOn7+qjqfR3zVJlzYNj54kPpGu+HPcvOVDTEwM7tlduPfgKfAHNrG1aVqbNQvHM6jnPwQGvafn4En0HjpFU+EIIYT4CYp9SJDOfEiQAFo3r8+ty4doXK+mZoISqcaNm6oxutxcs/Lg0TO0tbRw+g5jdH0NjY+knd7clAwW5pibmfDyta+mwxFCCPED5XJ3IY2xEd6376tbDtKmMcbIUAaUFRAVHYWdjRV2ttaEfZiJQVNzeWosQdq1/zg9Bk2kafv+3HvwhLbN6rB6/jhNhSOEEOIn0NHRoWDeHCiVSv67eC3Oulevfdmyfa+GIhOpQetm9fE6v5+8uXMCmpliJJbGOmn/d/EadWtUoHCBXOhoa2sqDCGEED9Z0YK5OXLyPGfOX6VK+eIAREVFUaRcXfzfBVAgnwcOdpppVhGpw72HsQNEaqaDNmigBikqSjUY5OhBXSheOM93T44mzVpGxz6jAXjz1p8WnQbR6H99uf9Q1dkr6H0wMxeu/a7HFEIIkXJFCngAcO7SNaKiowFVzVLNquVQKpVs2LJLk+EJDQl6H8z9B4+JiYnBJ3YEbQ3MwRbrpydIg8bMAqBo5WYUq/LxX+zv38LnwRO8PhmNdcfeYzSqU4V+XVuzfquq2nbLzkPUrVH+m44jhBDi65mbmZDdJRNB70O4/mHiXIBGHzppr9+8U6Ye+QOdOH2evCVq8E+XgR/nYPuTmtj6dW0NwIEtC75ruUqlklkL19C6SW02bN0HwJu3fpQqmg/rjBa8fuPH++AQAoOCsbW2/K7HFkII8WWKFcrNzTv3OXPuqnrE/YL5PMjs7MC9B485f8mTQvlzazZI8VPFjqDt7GzP7kP/kcbYiIwZ0mssnp9eg2RuppoUcf+R06QxNorzb/ueo19d7omzl7C1zohLJkf1MhurDFz1us2V67extbbk312HqFq+OOOnL2HkpPn4+QckU6IQQogfJXY8pDMXrqqXKRQKdS3S2o07NBCV0KTYEbTTm5ujVCrJ5GSHInbCVg3QWCftHfuOUbdGBfXv4RERbNl5iCb1Pj8f2/K12zl70VP9e0xMDP7vAlkycwQhIWHq5bWqlGHI2DmEhoXTt0tL9h4+zYWrN8idMxtWlhas3LCT7u2bJih/846DbNl5EECqeYUQ4gfIlsUJczMT7j98ysvXvlhZWgDQoG51xkyaw9ad+xk/oi+GhgYajlT8LLEJkoG+6ppncrTTZDg/P0Gq07wHCgX4vn1H3RY91MvfB4dSqWzRFJXRsnEtWjaupf79whUvJs5cRq8hk4mIjOLZi1dMm7eKHh2aMXN8fwBWbdhJnerlWL1pFwXyVMTaMj3L121PtPy/a1bg75qq5C0qKooS1Vp+5dkKIYRIjJaWFkXy52L3wZOcOXeVOh/6htrbWtO0wV842NsQGRWFjI70Z3gfHMKDR08wMUlLYHAIAM6OthqN6acnSP+unAZA4//1Y8roPurl5mbp0NfT+6oyC+TJwaZlqlG4X7x8w6gpC+jR4WOH7+CQUPwDgrCzyYiFuSm3fR4QGBiERXqzbzgTIYQQ36JooTzsPniS0+c/JkgAsyYP11xQQiO8b6k667u7uvDw8XPgD0yQYq2aPw5t7Z/TBWrr7sPUrlYWgJpVytD7Q03T6EFdfsrxhRBCJFQwbw60tbW55OlNWHgEBvpf90ey+PU9ffYCXV0dcri5cPfDsDyabmJTRESEa6STzVu/d2zYuo+nz18R80k/n/FDu2sinCTFNrGd3L0cHR2N5ZNCCPFb6tx3LJc8vZk6uo96fCSA+w8eM3/pWlxdMtG6WX0NRih+loiISHz9/Knboifp0qZh36Z5Gu2krbGpRgaPmUXg+2CePn9F8UJ5SG9uStZPnkATQgjx+4t9mu3YqQtxlj9/+ZqFy9axYOk6eVjmD6Gnp6ueny+To61GkyPQYIIUHBJK/25tyJE9K64umejVsTk3PhnkUQghxO+vXMlCKBQKDp84R1h4hHp50UJ5cXSw5fbd+1zxvKHBCMWPFhMTQ0hoKAAPHj0DwMlBs/2PQIMJkr6+PmHhEeT1yM7hE/8RHBLKsxevNRWOEEIIDchomZ78ud0JDgnlxJmL6uVaWlo0rFsDgHWbZEyk39nDR0+xy1aUBi06c/9DgpTJSbP9j0CDCVKd6uV49uIVJYvk47LnTarU70jJIvk0FY4QQggNqVpBNWHtnoMn4yxv9LcqQdq0bS/hn9Quid/Lde87xMTEYGxsxINHqg7amn6CDTT4FFvsDM4AC6YOJTAomHRpjTUVjhBCCA0pVSw/RkYGXLjixWtfPywtzAFwcrSjaKF8nDl3iX2HTlCrmsyj+TuKnWLEPbsLJ89dBzT/BBtooAYpODgk0X8KBcxZvP5nhyOEEELDDA0MKFuiEDExSvYfPh1nXaN6qlqkLdv3aiI08RPc+DAGUpZMjrx685Z0adNgZppOw1FpoAapQt12KBQQ/6EEhQJKFc3/s8MRQgiRClStUIJd+4+z59BJmtavrn6C6a/qFdHR0aFm1XJfXfaNm3eZt3g1k8cMxMBA/3uFLL6T2BqkdOlUSVFqeIINNJAgndm36mcfUgghRCrn4e6CrbUlDx8/x/v2fdxdMwOQNo2xui/S13j2/BX1mnXk+cvXuGbLTOd/mn+vkMV3EBAYxOMnzzEzNSEoWPUkm3MqaF4DDXbSFkIIIWJpaWmp+6buOXQy0W38/N99UZkBgUHq5KhS+ZK0b92Y98EhMq5SKhI7xUgONxcefniCLTV00AYNJkhFKzejWJW4/6rW76ipcIQQQmhYbIJ08OhZIiIi46zrNXAMLnnKce3GrRSVFRERSbP/9cT7tg95PNxZOncCg0ZOIUuu0lz/0KQjNK9Q/tzcOH+A6eOHcP9R6phiJJbGnmI7sGWB+melUsmuAycwNzXRVDhCCCE0zMbKkjy5XLly7Ranzl2hbImC6nWmJumIiopi3aad5HJ3TbYcpVJJ515DOXH6PI4OtmxYPgtjIyMMDfQJCw9nx+5Dny1D/BxaWlrY2mQEPg4S+cfXIKUxNlL/S5vGmIa1K7N2y25NhSOEECIVqFq+BJBwTKSGsWMibd1NZGRkgv0+dezkf2zcugczUxM2r5qLZYb0ANSqVgGAbbsOSDNbKhMcHMJrXz9M0qWOJ9hAgwmSz/3H6n+37j5gw9b9+L59p6lwhBBCpAJlShTEQF+f/y544ucfoF6eNbMTBfN54PvWn4NHTydTApQpWYTp44ewfvlMsmZ2Ui/PncsNezsbfO4/4uZtmdoqNajV8B+q12vDVS9Vs6ezo12qeIINNNjE1nf4NPXPCgWkNzdlcK9/NBWOEEKIVMDYyJDSxQuw7/Ap9h89Q6M6VdTrGtWrwflLnqzbtIOqFUsnW07Lpn8nWKZQKKhVrTyzF6xk++5DuLlm/d7hiy8QExPDfxeuEB0dw2tfP0D1iH9qobEapH9XTlP/27JiGgunDaNIAQ9NhSOEECKVUE89ciBuM1vtGpXQ19dj36HjiT7RFhMTw9Vr3sk2n9WsqhqNe8eeg98vYPFVnj5/SXh4BE4Otjx++gJIHZPUxtLoY/637z7g5H+XOXn2kvqfEEKIP1s+DzcyZkiPz4PH3Ln3SL3c1CQd1SqVwdrKkgcPnyTY79jJ/yhdtRH/6zwgybLz58mJjZUl/u8Ceevn/0PiFylz/8FjADI7O6g7aKeWJ9hAg01sIybO48TZS2RxdkBHWxtQVX+WkAlrhRDij6alpUXlcsVYsX4Hew6exCWzo3rdtPFDSJvGGC2thH/fL1u9GYCC+ZNujdDS0mLv1uXY21onWob4ee59SJAyOTvifVeV8Do7pZ4aJI0lSFev32Ln2tkYGRpoKgQhhBCpVNUKJVixfgcHjpyhc9uG6Oiovq5M0qVNdPsXL1+z58AxDA0MqF+nWrJlO9qnni/hP9n9h6oEyc7GimNnPTE1SZuqhvvRWPqc082FsPBwTR1eCCFEKuZgZ02O7FnxDwjk7AXPBOuve99m78Fj6t9Xb9hGdHQ0dWpVwtQkZY+J3733kDe+b79XyOILxdYgGRoaAqln/KNYGqtBat6gBl36jSO7S6Y4y+VJNiGEEKDqrO118y57Dp6K0/3i3v1HlKhYn4yWFlQoUxyFQsGKtf8C0LppvRSVPWHafMZNmcfwAd3o3qn1D4lfJK9/zw5Ur1wWhULVzcY5FXXQBg3WII2bvgQHW2ucHWzJmslB/U8IIYQAKF+qMHq6upw6d5mAwCD18syZHMnj4c6r174cPfEfh4+d4emzF+R0z0be3DlSVHaRgnkB2L7n0A+JXXxe7pzZadrgL3w/jHeVWiapjaWxGqTwiAjGDe2mqcMLIYRI5dKmMaZk0XwcOv4fB46epV6tiup1jf6uwRXPG6zbvIO2LRpSomgB6tSslOJBBosWykt6czOueN7g0ZNn0i9Jgz4+wZa6roHGapBKFsnHpavemjq8EEKIX0DVCqqpR/Yeijsm0t9/VUFXV4fd+4/ili0LOzcupmWThINDJkVHR4cKZVXjLZ09d/n7BSxS5NKV63ToMYRtuw6oJ6mVGqQPTp27wsoNOz95ik0JKOJMYiuEEOLPViBvDizMTbl55wH3Hz4lk5PqS9TczJQqFUqzY88htu7aT6um9ZKtPXrz1p+Xr3zJ6fZx9OxcOVxZv3knXjfv/PDzEHFd9rzBuk07SGNsxBtff0xN0qaaOdhiaSxBmjCsh6YOLYQQ4heho61NpXLFWLNpN3sOnaRz20bqdY3q1WDHnkMsX7OFlk3+TjJB8nsXQJuuQ3nr9441Cybg5GADQI7sLgB4eUuC9LPFPsGWLq1q2IbU9gQbaLCJzTqjRaL/hBBCiE9VLa9qZtt/+DRR0dHq5eVLF6Nwgdw42tsmmRxFRUczdOwc3vj6ExOj5MTZi+p1Od2yoa+vh5ZW6pgc9U8SO4q2rp4eAE6psA+YxmqQ6jTvQWL385YV0xIuFEII8cfK5GRHdhdnbt55wIXLXup5O3V1ddm3dUWy+85ftpFLnt4YGRoQEhrG6XNXad6gJgBmZiY8u31WPQil+HnuPYidQkaVCNjbZtRcMEnQYBNb9zi/7z10itw5XTUTjBBCiFStSvkS3LzzgD0HT6Z4YvOjJ8+zZtNu9PR0mTl+AF0HjMPr5l3eBQRhaqJq2pHk6OeLiori0ZPnGOjrExQcCoCdTepLkDTWxJY1s2Ocf53aNmLVxl2aCkcIIUQqVrFMEXR0tDlx5hJB74M/u/3Dx88YPWUhAP26tsbdNTOF8uUiJkaZYGTu4JAQXr32/SFxi4QeP3lOVFQUmZzsefriFQD2tlYajiohjSVIwcEh6n8BgUGcOneZx09faCocIYQQqZhJurQUK5SHiMhIDp84l+y2wSGh9B85g5DQMOpUL6ceKqB4oTwAnPrv42P9+w+fwC5bUQaPnPLjgv/F3L33kHFT5hEVFcXmbXvp2HMISqXyu5VvaGhAvx7tadKgFk+fv0KhUGBtleG7lf+9aKxusULddigUEPuaW6Q3pVPbhpoKRwghRCpXrUIJjp++yJ6DJ/mratkkt5swYymPnjwnR/YsdG/fTL28SAEPFAoF5y5dJzIyCl1dHTI5OaBUKvG6eftnnEKqFxAYROPW3bh77yFGhgbMX7KGF6/e8Fe1ilQsV+K7HMPaypIBvTrg9y6A1VsOYGWZHv0PnbVTE40lSGf2rdLUoYUQQvyCihTwwMwkHde97/L46Qsc7KwTbHP77gMOHjtL2jTGjBnUBV3dj19zZqbpcHfNgtfNu3jeuE3+3O5kcrLH0MCAOz4PCQ+PQF8/9X1R/ywxMTH803Ugd+89pGA+D9q3aYK5uSldeg9n+NjplCtdFG1t7e92vCfPVM1rtqmw/xFooIntxStf/N4FJFh+/tJ1Xrx887PDEUII8YvQ0dGhQpkigOrBnsSsWL8DgIZ1KmOZIX2C9cULxzazXQFAW1sbN9csREdHc+vuvR8R9i9j7JS57D90AuuMGVi5cAr6+no0rleT7Nky433bh3Wbd36X46zfvJON/+7mzr0HANjbpL7+R6CBBGna3JU8f5EwETJJl4Zp86RWSQghRNKqVSwJqBKkmJiYOOsePHrG0VMXMDIy4O+aFRPbnWKf9EOK7VfjLgNGsn33ISbPWISeni6rFk3FKqOqT5C2tjbDB3YHYOykOYSEhn7zscZPm88/XQfy8MMcbKnxCTbQQIL08s1bcmTPkmB5tqzOvPb1+9nhCCGE+IW4ZHYki7MDr9685ZJn3Pk8V25Q1R79XaMC6dIaJ7p/Zic7rDJa8OzFax49UT0YlMPtz06QHj56SscegwGYNn4I+fPmirO+YtkSFC+Sn+cvXzN/ydpvOlZERCSPnzzH2MiQwCDV04h2qXAMJNDQU2yfjoQaKzIyisioKA1EI4QQ4ldStYJqktk9Bz82sz19/oqDR8+ir69HwzpVktxXoVBQrKCqFun0OVUzWw63bAA8evLsR4WcqjnY29C1Q0vat2lCk/q1EqxXKBSMHNQDhUKhHgH7az168oyYmBicnRx4+vw1IE1saqWK5mP89CWEhUeol4WFhTNh5lJ11acQQgiRlEpli6GtpcWxUxcIDlE1+azeuIvomBhqVSnz2UlPixXKDagmTQfIlzsHty4dYs3iP3MmBy0tLfr1aM+44X2S3CZv7hxcPL6d2VNGfNOxYkfQzuxsz9Pnqk7aNtaW31Tmj/LTE6QWDWuio61N7Wbd6NRnDB37jOavZt1QKBT807zuzw5HCCHEL8bczITCBTwICw/n6MnzvH7zlt0HT6Cjo02Tv6t+dv+8HtkxNNDn+o07BAS+R19fD6uMGZKcz+13NW/xGrxv3VX//rnzz5zJUf3z1NlLOHnmwhePjxQ7Sa2NtRXvg0OwtDDHIJU+OfjTH/PX0dGhf/c2tGr8Fz4fXqjMzvZYWcpEtUIIIVKmaoUSnD53hT2HTnL3/mOioqKpVbVMok+uxaevp0eBvDk4ceYS/128RqWyRQFQKpVERUWhq6v7o8PXuO27DzFg+ETMzUzxPLuHtGkS77OVmHv3HzFy/ExA1TzZrnUj6v1VFQMD/RTtC6qBPyH1dtAGDY6kndEyPcUK5aFYoTySHAkhhPgixQvlIW0aY65cu8W23UfQ1tKiWf0aKd+/cF7gYz+k1Ru2kSlnKWYtWPlD4k1Nbt72UXfKHjWk5xclRwAZMqRn7PA+ODna4eV9my69h+NesBKjJ87mxcvXye7r7GhPofy5MTZWHTM1TjESS2MJ0vcWFRXFpFnLaNKuPx37jOb1m7e8eetPi06DaPS/vtx/+BSAoPfBzFz4bb3whRBCaJaenq56TKSIyEgqlCmC7Rf0ZSn6YcLb/y56EhUVRbq0afB/F4CX9+89onZIaChN2/YgOCSU/7VokGin7M9JlzYNHds25dKJHaxdOoMSRQvw1s+fyTMXUbdpx2T37dK+Bfu3rcDA0AiQGqSfYuvuI6BQsHr+OPp3a4OZqQk79h6jUZ0q9OvamvVb9wKwZech6tYor+FohRBCfKuq5T9OfdG8Qc0v2je9uSnZXTIR9D6E6zd9yJGKx0KKjIzk1p3vM4jltl0HuffgMfly52BsMp2yU0JbW5uqFUuzc+NiTh3YRPNGdejQtol6vfetu2zetpfIyMgE+8Z20JYE6SfYe+gUDWtXRqFQ4GBnja6uDm/e+pHF2YGsmRx4/caP98EhBAYFf9FfGUIIIVInt2yZaNagBl3+1xhnR9sv3r9AHncAPL1u4+RoRxpjI3zuPyI0NOx7h/pNBo6YTJmqjdmyfe83l7V6/TYAurZv+V37WuVwc2HmpGE0a1hbvWz63GW07dyfXIWrMHnmInzuP+Ts+cu89fPnybOXQOpOkDQ2F9v39vK1L+cvX2fw2Fm4ZHaiX7fW2Fhl4KrXbV6+fouttSX/7jpE1fLFGT99CRGRkXRu2whzMxNNhy6EEOIrKBQKOrZu8NX753JX1Rpd976DlpYWbq5ZOX/Jk5u3fcibO8f3CvOrREVFoaWlhUKhwNDAgNCwMNp06o+X9x0G9+38VXOihYSGEhj0HjNTEypXKPUDoo6rWqWyPHz0lPOXPBk9cTajJ84GoHaNijx7HQiArU3qrbD4JROk5Wu3c/aiZ5xl7wKCSGNszLJZo+gzbConzlyiVpUyDBk7h9CwcPp2acnew6e5cPUGuXNmw8rSgpUbdtK9fdME5W/ecZAtOw8CfPEjjEIIIX4NObJnBeC6911iYmLI4ebC+UueeHnf0XiCNH7afP47f4W500YxcnAPcri50LXPCKbNWcqNm3dZNHuc+kmwlDIyNOTk/g28fPXmp0zKW6taeWpVK8/lq17MX7KGrbsOEBkZRdbMzty6fwaL9GYYGhj88Di+1i+ZILVsXIuWjeN2LKvboge5c2RDS0uL/LndeP7iNWVLFGTm+P4ArNqwkzrVy7F60y4K5KmItWV6lq/bnmj5f9eswN81KwCqLL5EtZY/9HyEEEL8fCbp0uDsYMuDx894+Pi5esqR6xruqH3pynWmzV6KlpaCdwGBONjZUL9ONbJmdqJp2x4cOHKSctWbsHbpDFyyOH9R2QqFAmurz9faxMTEMHfpBiIjI+nevtk3jRGVN3cOFs4ax8jBPTl7/jIO9nbsPHgmVTevwW/UB6l44bwcOXWeqOhoLl71JpOTnXpdcEgo/gFB2NlkxMLclNs+D7jt8xCL9GYajFgIIYSmxTazXfO+Q7VKZTmyaw0jBnXXWDwhoaG07z6Y6Oho+vfsQC53V/W6PB7uHNm9lsIFcuNz/xGHj51JcbnXvW9z5tzlFLeKLFi+iTWbdrNx2wEuXLnxxeeRGKuMGahdoxK+fu8AsE+lc7DF+m0SpNZNanPxyg0ate1LxgzpKfLhEU6ArbsPU7taWQBqVinDhn/3MXHW8mTn6xFCCPH7y+muama7duMOGS0tyJs7B0aGhhqLZ8S4mdy995ACeXPRrUPLBOszWlqwY8Ni5kwdSfs2jVNc7tRZi6latxWrN2z77LY79h5l5Yad6t/XbNqV4uOkxK/wBBv8ok1siTFJl4Ypo3onuq5pverqny0tzFk5b+zPCksIIUQqlutDs9q1G5p/vP/46XMsWLoWQwMD5k0fhY5O4l/Renq6ccYvunzVi4XL1zN13KBEkzt//wB27z+Knp4u1SuVTTaGc5euM3HmMhQKBUP7tGPGgjWcv+zF7bsPyJb1y5rzkvIxQUq9g0TCb1SDJIQQQnwpO5uMmJmm49mL1/j5B7Bw2TqKVajHyrX/fpfylUolI8fPZPGKDZ/ddtT4WQAMH9iNLJmcUlx+t34jWb95J5Vrt+TJsxcJttm0bQ8REZFUq1QGs2Se3Pa5/5iBo2cQHRND57aNqFyuOH/XrAjA6k27UxRPSvwKj/iDJEhCCCH+YAqF4mM/pBt3MNDX58bNO/QePJYdew59c/kXL19n6uwl9B40loiIhAMmfup/LRvSpnl9Wjerl+LyFQoFa5ZMJ6d7Nq553aJM1Uac/u9SnG1im9WaNvgryXLevPWn15DJhISEUad6ORrVVXVB+btmeQz09Tly8py65udb/SpNbJIgCSGE+KN92szWrFFt+nZvR0REJC3b92HFmi3fVPaGfz/23wkMCkp22wZ1qzNl7KAvHsDRwc6GfVuXU7tGRXzf+lOr4T8sXbURgGs3bnHN6xa21hkpXaJwovuHhUfQe+hkXvv6UbSgBz06Nlc/tWaSLi01q5QmJkbJui17viiuxAQGBRMQ+J705iYYGabeR/xBEiQhhBB/uE+fZFMoFAzs3ZGJo/qrm6+mzFr8VWPihYdHsHmbavTrq2d2Y5He/LvG/SljIyOWzp3I0P5diY6OpueAMUyfs5Q1G1TD2TSqVzPJwSWnzFnBHZ9HZM3kwKiBXdCJt12julXQ1tZm14ET+L0L+KY4nz7/0Lxmnbprj0ASJCGEEH+4bFmc0NPT5bbPQ8LCIwD4p1UjFs8eh66uDqMmzGLu4tVfXO7+wyd4FxBI0UL5cHKwS3bbWfNXMGfRKvz9vz4BUSgU9OzchnXLZuDsaE/tmpUoX7oYlcqVoHG9xOeq27n/OLv2HyeNsRHjhnZPtFbHytKCCqWLEBERyabtB746Pvikec02dXfQBkmQhBBC/OF0dXVwc8lEVFQ0N+/cVy+vW6sKG1fMJodbNur9VfWLy12/RdW81vDv6ty87cOajdsTrYlSKpXMnL+cQSMmExUd9fUn8kHl8qU4f2wrjva2VChbnA0rZpPJ2SHBdnfvPWLy7OUADOndLtl5SpvUqwbAlh2HCPmGuep+lf5HIAmSEEIIQU73xB/3L1OyCCf2rccyQ3pA1WwWHBKSojLr1qxExbIlqFWtAg1adqFTz6E8evIswXaPnjzjja8fTo52ZLBI/41novK5fkzvg0MYOHomERGRNKlXjZJF8yW7fRZne4oW9CDofTDb9x796rgkQRJCCCF+IcmNh6SlpfqqjI6Opn33QdSs/z/e+vl/tsy6taqwceVsTNKlpXD+3ACcjzePKMCFS9cAKJg319eG/0WUSiVjpy7i6fNX5M6RjfYtU/bUXNP6NQBYvXEX6//dh8+DJ1/cN+vJM1WCZC8JkhBCCJH65XSLO3FtYgICg7h524dLV72oUqdVomMOJaXghwTp3MWrCdadv6RKmvL/pARpw9b9HD11ATPTdIwc2DnJASnjy50jGwXz5sDPP4AZC1bTrP0AqjfqzNBxc9i5/zgvXvl+toxnUoMkhBBC/DpM0qXBycGGoPfBPHqSeOJjbmbK3i3LKZjPgzs+D6j8Vwtu3bmXYLs7Pg9o2KorBw6fVC8rmF81/dW5xGqQLn+oQcrnkWDd9/bsxWtmL16HlpaCkQM6keEL5iRVKBRMHNGT8cO6U7dGBRztbfDzD+DgsbOMnbqIOs27U69VLybMWMqRk+cJCIw7rMH74BD8AwIxM02HsbHR9z617+63mWpECCGE+Ba53Fx4+Pg5127cwdnRNtFtzMxM2LZ+AS3b9eHAkZNUqdOKjStmUyDfx9qf9Zt3su/gcTI7O1CxXAkA3F2zksbYCO9bdwkMek+6tGkA1eS0Xt53MDQwwD171gTHe/r8FecuXaNahZIYGOh/8znu2n+c6Oho6tQoT/7c7l+8v76eHqWK5qdU0fwAvPb14+KVG1y4coOLV2/w9Pkrnj5/xbY9R1AoFLhkdiR/HncK5MmBvp6qX9SvUHsEkiAJIYQQgKqZbce+Y1zzvkOtqmWS3M7I0JA1S6bRqdcwNv67m1oN/8e5Y9uwt7UmJiaGDeqn12qo99HW1iZ/3lwcO/kfl65cp0zJIgBERETSt/s/BAeHJOhYHRYeQfeBE3j24jX/7jrMuCHdcLCz/urzi46OYc9BVa1WrSpJn9+XsLQwp2qFElStUAKlUsmjJy+4cMWLi1dvcNnzJrd9HnLb5yFrPpmqRBIkIYQQ4heSK4kn2RKjq6vL/OmjyWBhjqGhAfa2qsTl5NkLPHvxihxu2cjpli3OPiWLFSQ8IkI9SjWAqUk6+nZvl+gxlq3ZyrMXr9HW0uL+w6e06jKEwT3/oUyJgl91fheuePHa1w+XLI64ZHb8qjKSo1AocHKwwcnBhnq1KhIVHc3tuw/VCdP1G3eJiIxU9/dK7SRBEkIIIQB7WyvMTNLx9Pkr/PwDME9mYldQPd02ekivOMtmzF0GqMY+iq9n5zb07NwmRbH43H/Mms170NHRZtH04ezYe4ytuw8zcPRMGtapTKc2DVPcuTrW7gMnAKhesdQX7fe1dLS1cXfNjLtrZlo2qkVYeAQvX71RJ5OpnXTSFkIIIVDVgMTWbhw9dT7F+8TWCF27cYsjx88CpGhgSaVSyeiJs9m260Ccx+Wjo2MYP2MJ0dHRNK1fHdeszvTt2oqhfdqjr6/H+n/30anvWF77+qX43AIC33PizCV0dXWoWKZIivf7ngz09XBysEVb+9dIPX6NKIUQQoifoGLZogBMnbuSfYdPfdG+L1++wcjQgNo1KpLR0iLRbd4FBHL42GlevHzN46fPmTxzEUPHTIvT7PbvrkPcuHUPe1srWjaqpV5epXxxFs8Ygb2tFddu3KFlp8FcuuqdotgOHjtLRGQkJQrnxSRd2i86rz+VJEhCCCHEB+VKFqJnx+bExCgZOWkBO75g1OiK5Upw5+pRlsyZkOQ2I8fPpG7Tjuw7dPyTASI/Pt7/6vVb5i/bCED/bq3R19OLs38WZ3uWzRpJmeIF8H8XSNcB41i+bnuSYzfFUjevVfo5zWu/A0mQhBBCiE/Uq1WR/t1UfYXGTV/C5h0HU7xvGmMj9cjbAFFRUfQeOoWpc1cCH8c6OnfRUz1AZOwQAUqlkilzVhASGkb1SqXI6+GW6DGMjY0YM7grXds1QaHQYsHyTfQdPo3AoOBEt/e5/5hbdx+QwcKMgnlzpvhc/nSSIAkhhBDx1KpahiG926GlpWDKnBWs3bznq8o5dvoip89d4d+dhwgNC6NQ7IjaF64mGCDy+OmLnPzvMmYm6ejctlGy5SoUChrVqcKcSYOwSG/G6XNXaNlpMLfuPkiw7a4PtUdVyhX/Zfr/pAbySgkhhBCJqFK+OCP6d0JbS4tZi9aybO22Ly5j47b9AETHxHDr7kOcHO2wzJCeB4+ecMXzBoYGBuT4MA/c0g/ld2vfFJN0aVJUvoe7CyvmjiZfbjdevHpDux4j2bbniLrTd2RkFPuPnAagWsWSXxz/n0wSJCGEECIJ5UsVZsyQrujoaLNwxWYWLN+U4glab965z3Xvu+rfb9z0QaFQxJlSJLeHG7q6ugS9D8bn/mOMjQwpX6rwF8VobmrCjLH9adGwJhGRkUyYsZRRkxcQFhbO6XNXeBcQhIe7yzcNMvknkgRJCCGESEapovmZOLwnenq6LF+3nVkL16YoSYqtPcru4gzAjVuqedtim9kAalUtD4DXTR+USiU53bJ+VTOYtrYW7VvVZ9KIXqRNY8TeQ6do2304a7eomgarSefsLyYJkhBCCPEZRQp4MGVUbwz09Vn3714mz1mR7JNjvm/9OXT8P3R1dRjQvS0AXjfvolQqKVQgNw72Ngzo1YH2bZoAH0fv9nDPlmSZKVG8cB6WzxlNtixO3HvwhOvedzHQ16fsV46+/SeTBEkIIYRIgfy53Zk+ti9GRgb8u/PQh8EcE0+Stu4+QlRUNBVLFyFrZkesLNPj6/eO12/8KJA3F9fO7qVfj/bq7T1v3AYgl/u3T8NhY2XJgmlD1fPJ1ahcCmMjw28u908jCZIQQgiRQh45sjFz3ADSpjFi577jjJo8n6jo6DjbREREsnX3YQDq164MgLtrFgC8bvnEGRQSVB2pvW/fR1tbG7dsmb9LnPp6evTv1oZ/V06nW7um36XMP40kSEIIIcQXcHfNzKwJAzFJl4b9R84wdNwcIiOj1OsPHj+L/7tAcud0VU8K655dlSDduOmToLw79x4SHh6Ba1YnDAz0v2us1hkt5NH+rySvmhBCCPGFsmVxYs6kQZibmXD05HkGjp5BeEQESqVS3Tm7wV+V1Nvn+KQGKT5PL1X/o1wfHvcXqYMkSEIIIcRXyOxkz9xJg8hgYcap/67Qb/g0zl/24o7PI6wyWlCiSD71ti5ZHNHR0ea2z8M4tU0A17w/JEg5JEFKTSRBEkIIIb6So70N8yYPwSqjBecuXaf30MkA/F2jQpymLX09PVwyOxEREYnPg8fq5UqlkmuxNUjukiClJpIgCSGEEN/A1tqSeZMHY2eTkaioaAz09alRuXSC7dxdVR2wvT7ph/Tk2Uv8AwKxt7XC3NTkZ4UsUkASJCGEEOIbWVlaMHfyYIoWzE3HNg1Il9Y4wTaxT7Ld+KQfkucNqT1KrXQ0HYAQQgjxO8iQ3owpo3onuT7HhyfZPq1BUg8QmePbBogU35/UIAkhhBA/gY1VBsxM0vHsxWv83wUCcC12gEi3bx8gUnxfkiAJIYQQP4FCocA9u6ofkvfte/i9C+Dx05eYmqSViWRTIUmQhBBCiJ/k0xG1r3vfBVT9j+KPri00T/ogCSGEED9JDvWI2vcID48EZIDI1EoSJCGEEOInyZ7VGYVCwY3bPrwPDgGkg3ZqJU1sQgghxE9ibGyEs6MtISFh3LxzHz09XbJlcdJ0WCIRkiAJIYQQP1HsvGwAbtkyo6srjTmpkSRIQgghxE/knv1jguQhA0SmWr9FguT71p92PUdSp3kPRk6aT0xMDCGhYXTsM5q/W/bksqc3AFHR0UyYsVTD0QohhPiTfVqDJCNop16/RYK0cdt+ihbMzeblU4iJieHilRscO3WBAnlyMGfiIJat3Q7A/iOnqVS2qIajFUII8SdzcrDBJF0adHV1yJFdBohMrX6Lhk8jI0PMTNKipaVFZid7dHS0efPWnyzO9mS0TE9YeDhR0dF4eftQrUJJTYcrhBDiD6alpcWUUX0IDw9PdM42kTr8FglS3Rrl6dR3LK/e+PHk2Usa/V2Vt/4BXPW6jY21JWnTGHPw6FnKlSrEzAVr8PXzp22zukmOXLp5x0G27DwIgFKp/JmnIoQQ4g/g7ppZ0yGIz1BERIT/UhnA8rXbOXvRM86yQvlyolSCoYE+ew6dZPLIXpibmjB84jyePn9Fv66t2H3gJAXz5eDBo2dULV+CqfNWMmFYj88eLyoqihLVWnJy93J0dH6LfFIIIYQQn/HLfeO3bFyLlo1rxVnWpF1/VswZjY6ODjo62uw+cJI2TWszdnBXQNX3qHzpwlz3vkuWTA5ktEyvnihQCCGEECK+36KTdkREJDdu3SMmJoYHj57FWRcdHcO1G3fImys7Fuam3PF5yIuXb9DT1dVQtEIIIYRI7X65GqTEDO7djokzlxIWFk5mJ3s6tW2oXnf4xH+UK1kIgNLFC9Br8CT2HjpF/+5tNBWuEEIIIVK5X64P0s8mfZCEEEKIP89v0cQmhBBCCPE9SYIkhBBCCBGPJEhCCCGEEPFIgiSEEEIIEY/0Ov6M2JG0o6KiNByJEEIIIX4kbW1tFAoFIAnSZ0VHRwNQplZbDUcihBBCiB/p0yfW5TH/z4iJiSEiIiJOVvm1mrYfwOr5475TZEKkjNx34lvI/SM0RRP3ntQgfQEtLS0MDAy+S1kKhULGUhI/ndx34lvI/SM0RdP3nnTSFkIIIYSIRxKkn6hujQqaDkH8geS+E99C7h+hKZq+96QPkhBCCCFEPFKDJIQQQggRjyRIQgghhBDxSIIkhBBCCBGPPLuZAqMmL6BYoTyULVHwq/YPj4hg2txVeN++h66uLkP7tMPR3oaw8AhGTpzHoycvKJA3B93aNUGhULD/yBkWrdxM4fwe9O7cAoDdB04we/E6MqQ3A6Bz20YUzJfzu52jSF2KVm5GFmd79e9D+7QnSyaHBNtd9vRmzeY9TBnVO9FyYmJiWLB8E/9dukZ0dAz9urYmp1tWoqNjmDx7Oddu3CFLJgcG9/oHXV0dzl26zuxF67DMYK4u87KnN32HT8PGKgMADepUplqFkj/grMX3UKRSU6aN6Uvh/LkAuHHLh7bdhvPvimlYf7iGKfXytS8TZizl9Rs/7GwzMqJfRwwM9Hn6/BXDJ8wlNCycZvWrU7lccQDmLlnPtj1H6d+9jfrzctTkBVy5dos0xoYAzJ44iHRpjb/jGYvUZui42YSEhjN5ZK+v2j+1fG5JDdJP8ODRMwrkzcHKeWOpUr44C1ZsBmDrrkNYW2Vg9YJxPHz8jAuXvQBwyeyYaDJWu1o5Vs4by8p5YyU5+s0Z6Oupr/XKeWMTTY5S4rWvH5YZzFk+ezQdWtVn2ryVAJw8e4mAoPesWTgeI0MD9hw8CYCdTUaqVUz4IVKiSD51LJIcpW621pYcOXlO/fuRk+exzvhliVGsy5436fK/xqxeMA5tbW12HTgBwIwFq2nV+C8WTh3KguWbeB8cAkDxwnlxy5YpQTkDe7ZV3z+SHP3eIiOjePn6LW/93hESGvZVZaSWzy2pQfpCm7YfYO+hUwS9D6ZO9XI0qluVy57e7Nh3DKUSPL1uU61iSf7XvK56H9eszrhmdQYgp1tW9h85A8Dp81dpULsyCoWC3DldOXPBk4L5cuLsaIujvQ037zyIc2xTk7Q/70RFquPnH8DISfN58cqXrJkcGNa3g3p5/5HTVYl4nhz06tRcPRKslaWF+lHZnG4uvPH1B1T3Xp6crgDkzunKkZPnqFW1DLbWlrhkduDCFa84xzY1SfOzTlN8Iwc7a27deUBUVBTa2tpcuXYTZ0db9foFyzdx7tJ1AoPe065lPSqULsLuAyd49PQF3rfvUaxgbhrVrQpA1Qol1PvldMvKG18/oqNj+O/iNYb37YCxsREOdtZc9rxJyaL5yOXuQnpz0wQxmaaTz64/xeVrN8mWxQmlEs5fuk7p4gV48fINg8bMwsHOirv3HuPsaMuQPu3Q19OjWfuBFCnogffte8waPwCFQpFqPrekBukL5cnpysLpw1g+exTL1m4jPCICAM8bd+j8v0YsnTWS1Rt3ER0dk+j+l656k8s9KwBv/d7haGcNgKOdNb5v/ZM99r7Dp2nyT39GTJxHcEjodzwr8SuYPn81dWtWYP3iiTg72nHs9AUAQkJD6du1FWsWjMPr5l0ue95MdP9LV2+Q090FUN17DrH3nr01vm/fJXvs85e9aNZ+IH2HTeXNZ+5ToVnh4RF45MjGJc+b3PZ5SCYne8LDI9TrSxcvwJKZI5g2pi/zlm5UL9+1/zgj+3dSJ0fxqT67XAgICsI0XVqMjY0AVUL2uc+uWYvW0rBtX5au2aqeAFz8nk6cvUQ+DzfyeWTnxNlL6uXPX76mTdM6rF4wjsjIKA4ePQvA/UdPsLPJyOwJAxOdzkuTn1uSIH0h64wWbNt9hAkzlxIdHYP/u0AAMjnakSG9GeZmJpiYpOF9cHCCfX3f+rN192Ga/F0NAAUKYmJUHxYxSiVaWknP9Va8cB4G9vwfC6cNJTQsnHVb9vyAsxOpRVh4BM07DKR5h4FMmrUMgAtXvFi4fDMtOg7i4LGzvPULAMDOxgpzUxN0dHQokCcHt+4+SFBeSGgYi1f/S5umtQFQKFTt/KD6P7l7z801CwN7tGXRjOFYZkjP/GUbk9xWaJ4SJeVKFuLYqQscO3WB8qUKE6P8+AdbBgsz1mzezbxlG3nt66deXrpYAczNTBIt89yl6wS9D6Zowdyqz61PkpwYpRJFMvdP8wY1GNy7HdPH9mX3gRNcuZZ4Ai9+fUqlkjPnrpAnV3byemTnvwvXiPow4Xt6M1Psba1QKBQUypeT2z4PAdDV1aVGpVKJlqfpzy1JkFIgLCwcLS0FSqWSTn3HAtDlnybYWluijEn415C2tjbx/0gKCwtnwKgZ9OncUv0hZJHejCfPXgDw5OlLLMzNkozBJF1asjjbY2xsROWyxXj05MV3OjuRGn3aB6lPl1bq5fOnDmHlvLGsXzyRhnUqJ9hPR0cbAwO9OMuio2MYPn4ujepUIbOTquO3hbkZT569BODJs+TvPQN9Pdxds2Cgr0eNSiV59OT59zhF8QPlcnfh7v1H3Lh1j/y53dTLg4ND6NRnDBbmpvTr2gpDA331Oi2txL8OHj99wcwFaxg1sDMKhQKTdGkIeh+s7nf05OlLLNInff842tuQIb0ZVpYWFCuUh4fy2fXbuu3zEP+AILr0G0uXfuMICQvj2o07CbbT0dFGX1/1OaWlUCRac5QaPrckQUrC0ZPnuXPvEYFBwdy4dQ9HOxsCAt/z8rUvf1UrizImBr93ASkqKyYmhlGTF1ChdJE4nauLFcrNlWu3UCqVXPW6RdFCuZPc/99dh4mIiCQiIpKzFzzJltXpO5yl+JXk83Bj/b97AfB7F6Bu3vXzDyAsPILg4BCOnrpAPg+3OPvNXboeWxtLqn/yV1qxQnm4cu0WAFeuJX3vAezcf5zg4BCio2M4de4K2T70pxOpl5aWFu6umbG1sYwz2efjZy/R1dWlUtli+PkHqu+hpAQEvmfQ6FkM7NkWSwtzddlFCnhw5fot3geH8OTZC/Lmyp7o/v7vAtl/5AxKpZJ3AUF43rhNtixO3+08Repy4swlWjaqpf7jrmXDWpz80MwWFBxMYFAwkZFR7D18OsHnVHyp4XNLOmknwSWLE8PGz+Hla1+qli+Bs6MtSqWq6rpFh0Fkz5YJW+uMKSpr3+HTHD9ziZev37Jr/3EAxgzuyl/VyjJy4nyathtAofy51DdM8w4DCQwKJiw8nGs3brN4xgi0tBR06D0a/3eB5M6Zjfq1Kv2wcxepU48OzRgzdRFN/ulP2jRG6k7a6dIa02/4VF6+9qVerUo4OXzskHvl+i3Wbt5DdhdnmncYqCqnY3OKF87DuUvXaPJPf1yyOFKlXDEAeg6exOOnL/APCKR5h4GMH9Ydk7Rp6D5oEv7vAnB2tGVwr3Y//+TFF2vdpLa6CT9WFmcH7KwtadFxEHk93MiYIX2yZcxatJY3b/2YPHsF0dHRpEljxNxJg+nerilDx89h/rKNdGjdAGMjQ27euc+4aYt5+fotl6/d5OTZS/Tv3oZbd++zbsse3gUE0aB2JdxdM//I0xYadPLsZUYP6qz+vUyJAvQaMpl6tSqijFEyavJ8Hj99Sali+dXDUCQmtXxuyVxsQgghhPhhXrx8Q++hU1izcLymQ/ki0sQmhBBCCBGP1CAJIYQQQsQjNUhCCCGEEPFIgiSEEEIIEY8kSEIIIYQQ8UiCJIQQQggRjyRIQohU5b+L12jWfiBN/ulP227DOH7mIgC7D5yg3/Bp31T28TMX6dhn9PcIM1kV6vzDi5dvkt3mxcs3PyUWIcTXkYEihRCpRkREJIPGzGTOxEG4ZnXG960/D2VqEyGEBkiCJIRINaKiowkPjyQwSDXZs0V6szjzfAUFBzN22iI8vW6TLm1apozqTbq0xpy94MnK9TsIDgkFhYLhfTuQyckOgM07DrJh6z5M0qXBzDRdnOPt3H9cNX2LErK7ONO9QzMMDQyoUr8Dy+eMwsbKkhkLVnPu4nXWLpoAQLP2AxnWrwNZnO3V5fg8eMKEGUsJCwvH2dGWyKgo9bo1m3Zz+MQ5QsPCsLHKwMgBnQl6H0yX/uPw8w+geYeBtG5Sm1LF8rNi/Q72HjqFUqmkSvnitGr81496qYUQnyFNbEKIVMPI0IABPdowaPRM+o2YhqfX7TjrX7zypWWjWqxZMJ7o6GiOnDwHgI1VBsYP68HKeWMpW6IgS1b/C8DlazdZs3k386cMYfGMEeTO4aou6+r1W6xYt53ZEwayesE4DA0NmL1oHdraWhTKl5NLnqpZ569738XY2Ajft/74vwvkXWAQmT8kX6BK6gaMnE79vyqyav5YOrZpgPKT2arzemRn4bShrF04gejoGPYdPoWVpQUDe7TF1cWZlfPGUrp4AQ4cPcujJ89Zs2AcaxaM5/xlL27fffDDXmshRPKkBkkIkapUq1CSogVys2PfMfqPnE7FMkXo0aE5AC6ZHLGxsgQge7ZMvPV7B4CdjRXnLl3jv4vXuHnnPhGRkQCcOX+VymWLkd7cVLWd7cf5E0+du0KFMkXUtUr1/6pEu54j6d+9DYXz5+LCFS+KF8qDjrY2Od1cuOTpjY6ODgXyuMeZffzJ05eER0RQvlRhAKwsLdDT1VWvd7CzZt/h03jeuMPT5694+vxVoud98uwlbty+R+suQwEICQ3jxStfmRxYCA2RBEkIkeqYmaajRcOalC1RkAZt+tC6SZ0E2+hoa6trakZNno++nh41q5SmeKE8zF68DoCoqGgM9PVSdEyFQqFOfArmy8nCFZu55OlN7pyu5HJ34eipC+jp6VIoX844+0VFRaGtrR0naYoVGhZG227DqFm5NE3rVcPSwpz3wSGJHl+pVNKoThXq/yUTUQuRGkgTmxAi1bh55z6rN+0iMlLVh+fla19M0qXB2Ngw2f1O/neZv2tWwC1bZm5+0iyVO2c2jpw4T3BwCEqlkuved9XrihfKw8GjZ3kXEIRSqWTT9v2UKJwXgAzpzTBJl4YjJ8+TN1d2PNxduO59l5u371EgT444x7a3syY8PIILV7wAuO3zkLDwcAAeP3nBu4Ag6tWqSEZLC+7ee6TezyqjBa/f+BEdHaOKp3BeNm7br64Ve/7y9de8hEKI70RqkIQQqYaTgw2HT5yjTdehhEdEYmxkyIRhPdDR1k52vzZN6jB47CwsLdJTOH8u9fJSRfNz3fsuzTsOwtLCnJzuLup1uXO60qJRLTr1HQNKcHVxpmeHZur1hfPnYsO2/Qzp/Q+GBgYYGxkSExODuZlJnGMb6Osxon9Hps1dhb6+Hu6uWbCytAAgs7M9RQvmpkm7ATjaWWNrY0lMjKrWy8bKksxO9jRo05vWTWpTpXxx3rz1o2Of0ejr6ZHBwpwxg7pgYKD/za+rEOLLyWS1QgghhBDxSBObEEIIIUQ8kiAJIYQQQsQjCZIQQgghRDySIAkhhBBCxCMJkhBCCCFEPJIgCSGEEELEIwmSEEIIIUQ8kiAJIYQQQsQjCZIQQgghRDySIH1H1f5ug1v+CpoOI8VGT5yNqZ0Hj548+6L9OvQYQnrHvD8oqu/nny4DMLXzACAsLBy3/BUYOGKSev3Gf3eTo2AlHN2Lc+joaR49eUaVOi2xyVqILr2Hayjq1KXZ/3pSumqjn37ccVPmYWrnwbMkZr5PjZ4+f4lzjpLMXbz6u5QXFRWFqZ0HHXoMSdH2P+t9+S3HefTkGaZ2HoyeODvR9fcfPMbUzoNxU+Z9S4hCfBeSIH2Bzdv2UrZaY2xdClO4bG3GTp5LRESkpsP6ITy9blKr4T/YuxYlV5EqdO83Et+3fpoO66sZGOizatFUOv/THIDw8Ai69R2Jvr4eY4f1IY+HG5OmL+Ts+SsM6NWR5o0Szh7/JxoxsDtzpoz85nLK12ia5Bd9aGgYpnYerNm4/ZuPo0k2VpasWTKdhnWr//Bj3fF5gKmdByfPXPjhxxLiTyWT1abQ3MWrGTh8ElUqlqZNiwZcv3GbSTMWcuPmHdYsma7p8L6r98Eh1GncAZN0aRkxqDvBwaGsXPcvd3weYpHeXNPhfbV8eXKqf371xpfQsDCqVy5Lk/q1AHj4+CkZLMzp0r6FpkJMdTI5O3yXcl69eUvWLM6Jrnvt+/a7HEPTtLS0KFro59Ssvnrt+1OOI8SfTGqQUiAgMIhxk+dSvEh+1i6ZTpP6tRg/oi99u7dj9/6jnP7vknrbiMhIBo2cTOZcpclTrDrbdx1Ur/t3xz7yFKuOXbYiVPu7DVc8bwDw7l0gnXoNxTlHSfIUq87Ktf+q98lZuArDx05nwPBJOLoXZ/LMRZjaebBjzyH1Nl37jMAlT1mio6MJDQ1j8KgpZMtbDvcCFZk8cxExMTEABIeE0K3vSBzdi1O8Yn318ePzufeQt37+VK1UmtbN6tOlfQvOH9sW58NfqVSyav1WCpWpjZN7CWbOW65et2nrHqrUbYWDW3FyFKwU53yq/d2GNp36MX3OUjLnKs3mbXsZN2Ue9q5FWbpqI3mL1yBr7jKMmTRHHXd0dDRTZy8hR6HKZPEoTf9hExOtuXvr50/zf3rhkL0YlWu34MGjp3HWm9p58E+XATx68oxchasAMGPecnIWrkK1v9tw6uxF3vj6qf8yT+64HXoMoULNZqzbvBO3/BWYNnsJAHsPHqNo+b9xyF6MBi278PLVGwDWbNyOqZ0Hh4+dpkLNZti7FqVNp35ERn48j32HjlO6aiNsshaiRKX6XL7qBcCz569o2rYHDtmLUahMbfYdOp7g3P383zFszDQKlamNTdZCVPqrBXfvPVSv37n3MAVK1cLMPjemdh6Y2nlQuXaLFF2v2Gbj2OaRZas30aRNdxzcilO+RlOePn8JQEREJF16D8fJvQSu+crTa+AYgt4HY2rnwZOnz1m3aUeCmqKTZy7gUaQqAJ16Dk3Q5Lv/8HFKVKqPQ/Zi9B82Ub08ufs8/jVfsHQt/3QZgL1rUZ48e/HZ90j3fiNxci9B/pI16TN4XJyYchauon7dknp9YpuPxk2ZR7a85Th87DR5ilWnR/9RAJy7eJXyNZpil60IVeu2jnOdjp86R5FydXByL0G/oRMSnA+o7qUa9dsCUKN+W3UzMiT/voz/WfLfhSvJ3uPXbtyifI2mWGcpRNFyddn47+4UHed9cAh9Bo8jW95yZMtbjr5DxvM+OCTRcwFVzXzuYtXI4lGaaXOWJrmdED+bJEgpcPO2D0Hvg6lfuxoKhUK9vH5t1Qf7uYtX1ct83/rz8tUbRg7ugZGRIW279OfZ81cEh4TQrtsgbKwzMnZYH2ysLFEqlSiVSv7XZQC79h2he8dW1K1Vma59R3D1mre6zCUrN+LlfZsJI/rxT6tGmJqk48DhkwDExMSw//AJalYtj7a2NoNHTWHB0rW0aFyX9m2bMG7KPHbtOwLA8DHTWbF2C22a1adN83rc+eSD+VNZszhhlTEDC5aupUf/Udy4eTfOecced+2mHbRv05gMFuaMGD9T3QR39vxlCuTJxeghPUmf3oweA0bH+dI7cPgkW3bsY8Sg7pQqXhCAoPfBrF6/jR6dW1O0UD4mzVjIzr2quGcvWMnI8TOpVqkMA3p1ZO3G7Sxcvi5B3B17DGHfoeP06tKWGlXLc+/B40TPL4OFOdPHq5p7alWrwIwJQxjctxPZs2XGzNSE1Yun4eaa5bPHvXHzDpNnLKRv93bUrlGJ85c8ady6O3Y2Vowd3ocnT57T/cOXYqxufUfSoG51ihTMy5bt+9h36AQAx0+fo2HLrhgbGTFhVH/y5c6BvZ01kZGR1G/RmSueNxjUpxNFCuahRbvevHj5Ok650dHRXLziRcsmf9O3ezuu37hF70FjAdUXd+uOfbHKmIFxw/tgbmZKqeKFGNKva4quV3wDhk0iVw5XWjSqw8Ur15k1fwUA6zbtYNX6rbRt0YCObZsSGhaGnq4uKxZMAaBE0QKsXjyNksUKqstyc81C/54dAPinVSNWL55GBouPtZSLl2+gdbN6ZMuaiflL1uDpdRMg2fs8vtETZxMWHsG08UOws7H67Htk+ZottG5Wj07/NFNfn6/1xteP7v1H075NY9q2aMjDx0+p3agdWlpajB3eB4VCQcv2fVAqlTx59oIGLbqgUKjWRUZGJVpmyWIFaduiAQCD+nRi9eJp6nXJvS8h7mdJrhyuyd7jfQaN4+WrN4wf0ZfiRQsQGhqWouN07zuSlev+pWPbpnRo04TlazbTM977INalK9dp27k/ttZWjBrSC/93Ad/0egvxPUkTWwo8f6HqKGppmT7OcktLCwCeffgLGsDM1IQlc1R/+enr6dG2c38OHz9N/drVMDQ0xEBfj7Kli9K8saqPy4OHTzh49BR9uv1DiyZ1QQlrN25n1/4j5M7lBoCRkSGrF0/DJF1aAGpUKcf+wyeIiYnh6jVvXr32pVa1CoSFhbN8zRbq16lGx/81BWDnnsPs2neE6pXLsmbjdiqWLcHQ/qovxnsPHjN7wcoE52tsZMShnavpO2Q8y1ZvZtnqzfxVvSKTxwyI08T27+p5GBoa4P8ukJHjZ3L/4RMs0pszddxgQkPDuHLNm7we7nhev8kVzxs42tsCEBkZxZol03Gws4lz3FmTR+CePSvlSxdj++6D7DlwlFrVyrNw2TpKFC3AgF6qL9LT/11k974j6v5EAK/fvGX/4ZO0bdGAbh1bAXDuwtU4NW2xjAwNKVOqCABZMztRtlRRAMzNzAgICKJ65bIAnz1uSGgYC2eOVTfdjZ0yFyNDA2ZPGYGeni4hIaH0GzohTm3XtPFDqFC2OLlyuHLgyEl17cG8xWtIlzYN65bNIF3aNDRrWBtQ1SjcuHmHmROHUbNaecLCwlm7aQcHj56K008qg0V6dm9ewvMXr/D0uom9nQ0XLnmiVCq5eu0mkZFRDOnXhYL5PLh15x4Xr3hRrHA+gM9er/jatW5Evx7tiYqKYvGKDdy99wCAtGmNP8RiTovGdTEw0AegWqXSANjZWqtf21jpzc0oXCA3AB45sydYv2z+JLJlzUTaNGm4cPkad30eki1LpiTv85pVyyeI18HeliVzxqOrq/vd3iMpFRMTw8hB3aldoxIAoyfNJiQ0jFmTh5PR0gKL9OY0bt2Nh4+esn33QcLCw5k9eTh5c+egZtXyrFz3b4Iy7W2tyeXuCkDhAnkoUbRAnPVJvS8h4WdJcvd42jTGoFDgkTO76rMpnsSOo6Wlxebte6lbq7L6fXj1+k02bt3DhJH9E5SxZuN2FAoFy+ZNxDJDejxyuCaZ6Arxs0mClAL2tqov8vh/tcf+/ukX/ac1LdlcMgHg7x+AgYE+e7csY8S4GXgUqUq92lUZOagHDx+rmoEmzVjIpBkL1fv6+n78q8/Z0U79gQZQp2YlVq3fytVr3uw7dIIMFuYULZSXh4+eEh0dzbpNO1i3aYd6+zRpjPB9609IaFiK+5TY2Vixdsl0fO4/ZOrsJazduIOoqKg4f63q6qpuHwtzM0DV8RlgwdK1jJ0yFy2FFs6OdgAEBr5X72duZpIgOVK9dqr/ra0sMTFJi5/fOyIiInn24hXPXrzCyb2EetssmRzj7Pv4Q43H9+ozk9LjeuTMrv750eNnBIeE4pIn7pe8n/879c9JvWYPHz3BydGOdGnTxNn34Ydmwq59R9C17wj1ct+3/nG2Cwx6T/vug9l38DhZMjkSEhpGSGgY0dHR5MieFYVCweZtezEyNOT0f5fI5GSv3vdz1ys+XV1dAHR0dDAzTUd4uCoBrF2jEiGhYUyYtoCps5fQs3Mb/mn1bU/A6ep8eL3Sf3i9IiJ49vxlkvd5Ytxds6hjTm7fL32PpJRHjk/ukUeq+7RQmdpxtnnz1o/HT58D334PJ3WPQdzPks/d4/NnjGbC1PlU/Ks5+fPkYszQXuTxcE/2OLH366fnnCeXG9t2HeDh46eYm5vGifXxk+ekTZsmTq2hEKmFJEgpkN01C6Ym6diwZRctGtdFS0vVMhn7AVu0UL5E97tz9z4Azh++jNyzZ2Xjytl4ed+h6t+tAejb7R8AWjerp/4rE8DWOmOS8ZQoWgCL9GYcPn6Gw8dOU6NKObS1tbG1sUJLS4sqFUrRvk0T9fbpzU0xNzNBR0dH3UQBqn4ESXn95i2WGdKTJZMTc6aM5MTpC9zxeZD0i/TBoyfP6Dd0AkP7d6V7x1ac/u+Sur9ESr189YaAgCCcHO3Q09PFxsoSWxsr9V/1AGmM434ZxtbmeV5P2fl9TkqP+ylHextu3LzD6sXT0NbWVi+P/XJPjoOdLf9duELQ+2DVX+6xZTqoanH69+ygrvEByOQU90t0zsJVHDl2hovHt5PJ2YEOPYao789Mzg5UKl+ShcvWsXDZOjJaWjCob2fg+1yvWAqFgqYN/qJh3erMmLecfkMnkD1bFnXc4eHhie4X+35Kan18yd3n37KvuZkJ2trayb5H9HR1eP3GT73ufXBwimKOFXs9Vy2aiqlJOvVyN9esWGb4cA973aRUsULJ3r9a2rGvWUSS23zO5+5xi/TmTBozkH4929OwZVea/dMLr3P7ki3T6UOCffX6xy4CVz50F3BysCPwfdzE29IyPYGBQTx6/AwnRzu+4S0rxHcnCVIKpDE2Yki/LvQaOIZGrbpSs1oFPK/fZOGydfxdqwoF8uVSb/suIJAho6aSNYsTE6bOx8bKkvJlinHF8wb9hk6gfh1VP6aoyEi0tbVwdrKnbKkibNq6B1OTdDg52nHN6xbDBnRLMh4dHR1qVi3P1h37uXnnnvrDzcBAn+aNarNm43bs7WzI4eaC5zVvunVqjY6ODtUqlWHXviNMnrkIIyNDVq3flmj56zfvpHu/UbRs+je5crji5X2bp89e0OmfZp99rWL7KVy95s3aTTtYsnJjil/nMZPmUL1KOVav36b6sm34FwBtWzZk5PiZbNiyi8IF83Drzj3+rlUlzr72ttbk8XBn197DzM/lRmDQe/Yf/rb+Iyk57qdaN6/Ppm17mTp7CXVqVOK171sc7W3R0fn826x183ocOHKSxq270bh+LTyv36RuzcoULZQPt2xZWL5mM1paCjJYmHPH5yGjh/SMs39oaBhh4eEcOHKS4JBQdu09rF53/8Fj9h08Tvs2TUiTxogc2V3Q19NT7wdfd73iGzZmGr5+/pQoUoAHD58AoK2tjba2Ng72Npw4fZ6N/+4mf56ccWpJYpOGdZt2Ym5mSvkyxZM9TnL3+eek5D2ye//RJN8jWbM4s+/gcYaNmcbDx8+4edtHXYOSEo3r1WTOwlVMmbWYxvVqEhYWjq6uLiWKFqBGlXKMnzqP0RNm86zZK3Z+cg3jc3JQJSKLVqwnODiEmtUSNi2mRFL3+LuAQBq27EKFsiWwtrLkfXAw2tqf77JqbmbK37WqsHPfYWbMXYZSqWTPgaPUr10VMzMT9PR10dHR4YrnDd4Hh1CrWgXWbtxBv6HjqVW9IqsSaVIUQlOkk3YKtWlen+XzJ+H71p++g8dx4vQ5BvbuyPwZo+NsV750Md76+zN45BRsrDOyceUcjAwNyZLZCY+c2Zk2ewnDx06nVInCDO3XFYVCwZLZE6hdoxKrN2xjyOipPH3+Mk6zTGJq16iE920fzM1M49QsjBvelw5tmrJr72H6D53Arbv31R0fJ48ZQMVyJZgxdxnbdx3kn1YNEy27Ts3K9O/ZnrPnL9N74Bh27TtCz85tGNK3y2dfJ1eXzHRt35KjJ84yd+EqOnzyV/rnZLAwZ8ioKTx78ZIlc8arq+m7tm/B8AHdOPXfRfoOHsfZc5cJDIr7l6hCoWDpnAnkzuXOmElzOHfhKi0aJ+w38SVSctxPFS6Qh7VLp+P/LoABwyexYcuuZLf/VOXypVgwYwyv37yl14DRXPG8gUKh+it/46o5FMqfm3mL1zBm0hx8ff0SNIF1aNuEgvk8GDNpDpeueqk78QI42NuQNbMTK9duYfKMRbRs34dCZWozYtyMb7pe8dWuWZknT1/QZ/A4jhw/w7D+XdVPPk4c1R8DfX36DBnHidPn4+znaG9L/54duHvvIQOHT8Ln/qPPHiu5+/xb9p08ZiDlyxRjxtxl7Nh9kFKfdCgHGNi7I1kzO31IsKzp0u7LhoTI5OzAtvUL0NfTY8S4GSxasQE//3colUrcs2dl3vTRvPZ9y7Ax03DLloVsWTMlWk6xwvlo0bguZ/67xLBx09VPS36ppO7xdGnT8Ff1imz8dze9BozByNCQxbPGp6jMaROG0KxhbWYvXMncxatp0agOUz88FGFsZESDutU4c+4yt277ULFsCYYP6MY1r1uMnTSHGlXLx6lBFUKTFBER4VKpKTRq3JR5TJg2n8snd373/h8Clq7ayLgp8/A8uwcjQ0MCg95To35boqKiOX1wk6bDS9VGT5zN5JmL8Dy7J8lO60KI35M0sQnxm3v67CVvfP0YP2U+2V2zcP3GLa553aJX16/raySEEH8CSZCE+M11bd+SR0+esWLdFiLCI3FytGXUkJ7f1JwmhBC/O2liE0IIIYSIRzppCyGEEELEIwmSEEIIIUQ8kiClUGRkFItXbaF5h4E0az+Q3kOn8DzeyNrfot/waew+oBq3Z82m3ew/cjrR7abNW8XiVVs+W17HPqN58fLrHv39nBET53Hvwzg3P8LFqzeYuXDtDys/JRav2sK0eau+W3mXPb0ZNXnBdyvvR/r03O89fMKIifO+S7nNOwzksqf35zf8AV68fEPHPh+H5Ljs6U3zDgO/6zFGTV7A+n+TH0jxc1L6/v7e3vq9o++wqYlOAp2cO/ceUbt59x8TlBAaJp20U2jKnBVERkWxeIZqnq1rN+6oB9v73prUq/ZDyv1ehvXt8EPLz5/bnfy53T+/ofjhMjvZ//DrLTQvvbkpE0f0/PyGQvxBJEFKgZevfTl66gJbV01HT081p1Mudxf1+jWbdnP4xDlCw8KwscrAyAGdMTYyZPGqLYSFR/D8xWtu3n1AJkc7Jgzrjo6ODoFBwUycuZS79x9jZZkeX7936vKmzVtF2jRGtG1Wl/CICKbPW80lT28s0psSGRlNoXw5ALhxy4cFyzfzLjCIyMhI+nZtTZ6croyavIDr3nfpOWQSbtkyM6R3O7xu+jB17kqCQ0KxzmjB0D7tMTczUR/zsqc3qzftxtoqAxeveJExgwVd/teIxav+5cZtH6qWL0HHNqqBJZt3GEj39k3J6+FGxz6jKVeyECfOXOLuvcfUrVmeNk1Vk6gWqdSUA1sWkDaNMXfuPaLfiGlsXTmdt37vGDx2Nr5v/TEyMmBgj/+RLYuTOpbjZy6yYes+5k4arI7L3jYjF694gwImjeiJjZUlSqWS9f/uZce+Y+jq6JA/tztd2zWhY5/RNKhdmVJF8wNQoc4/rJw7BmurDNRu3p1Wjf9i1/7jvPV7R+/OLbnseZNT5y5jZGjIpBE91a/L46cv6D10Ck+fv8LOJiNDev+DSbq0+L71Z+LMZTx+9hI9PV36dmlFjuxZkrzet+4+ZOSkBYSEhtG8w0D6dm1NjuxZEr3X9hw8ydbdhwkNC8fYyJDRg7qQIb0Zuw+c4Mr1WyiVSq5738XUJC2TR/YmXVrjZO+z5F6LpO7bT3163Q6fOMeKdds/vCfeks/DjXFDuyV5b7187cv46Ut44+uPrbUl7wKDEj3nnfuPs/7fvaCE7C7OdO/QjJgYJXVb9GD7mpkYGRqgVCr5u2VPZozrj5lJWqbMXYn37fsoFNCpTSOKF87D7gMnuHnnAf7vAngfHML0sf1QKBS8fO1Ll/7j8PMPoHmHgbRuUpt0aY2JiIxi5oI1nLt8HZQwcURPbK0tCQ4OSbT8WNHRMUyYuYSLV7zR1dWmZaO/qFJeNfr3wyfP6DNsCrfuPKBwAQ8G9fxfsp8Ryb2/IyOjmLt0PecuXkehUFCxbFGaN6jB3fuP6Td8Kv+unI5CoaBFp0HkyJ6VPp1bEhAYRKO2/di1frZ6Cpd+w6dRokheqlcqxcmzl+g7fBq718/B3MyEafNWYmdjReVyxahYtx1n968GoNLf7WnX4m/2HTnNsxevGdijLcUKqV6DoyfPs2DFZowM9bHOmCHOtTz13xUWrdpMVFQ0djYZ6d25JRnSm9G8w0C6tWtKvtxubNy2nwUrNrF/8wJ0tLXpO2wqNaqUpkThvIneH0JoijSxpYDP/SdkcrLDyNAg0fV5PbKzcNpQ1i6cQHR0DPsOn1Kvu3TVm75dW7Nu4QTu3HvEJU/VPE8zF6xWzd6+aALjh3XHQF8/0bJXb9zFm7f+rFkwnpnj+mNu9nH+JgtzMwb3+h8r546hZaO/mPWhWWpI73ZYpDdj6qg+DOndjqD3wYyduohxQ7qxYckkShXLz4r12xMcy+vmXWpVKcOaBeN5HxzMtPmrGNqnHYumj2D1pt34JTFS8W2fh0wZ3YeZ4/uzbM02wsKSn1PrwNEzGBsZsnHpZKaM7I2TQ8KJa+PHVbVCSVbNH4uDrTXb9xwF4OCxs+w9dIr5U4ayYu6YFNe8vfH1Z8HUodT/qxKDRs+kZNF8rJ4/HiNDA/Ye+njtwsLCGda3PesWTcBAX4+VG3YCMHrKQurUKM/6xRMZ2b8jE2ctU++T2PXOkT0L/2telxJF8rJy3tgkkyMAl8yOzBzfn9Xzx+HsYMuGrR+bbC55etOmaW3WLhxPVFQ0R06eS/a4n5PcfZuYciULsXLeWKaO7oOxkQGd/9co2Xtr1KQF5PXIzpqF4xnU639oayX8uLl6/RYr1m1n9oSBrF4wDkNDA2YvWke6tMbkz+3O6XNXALh55z7mZqbY2WRk1qJ15HTLyrpFE5g7aTBT5iwnOjoGgJ37j9G0fnVmjOuvnjjaytKCgT3a4urizMp5YyldvACgmkS4UrlirJo3Fgc7a3bsVd1XyZUP4HP/EcdOXWDj0kksmz2awvk/TjX0+o0fowZ0ZtX8cew9dIrHT18k+1on9/5evWkXz1++YeW8MSyeOZyTZy9x4OhZsjjbExEZxfOXbwgIDMLIwABPr9sAXPa8Sf48burkCKBQ/lzq++Hi1Rvk83Dj0oemzotXvSmYN0eC6xIY9B59fT0WTB1Ki4Y1Wb5ONa/fk2cvmTBzKROH92DprFGUK1VYvc+TZy8ZO20RYwZ1Zc2C8Xi4Z2P0h2blwvlzfTzmlRtkz5qJW3ceEBUdzfWbd8mbK3uCGITQNKlBSqlkZlF0sLNm3+HTeN64w9Pnr3j6/JV6XS53F0xNVLNnu2R2wNdPNQv7mfOeLJg2FC0tLQwNDLBIYqLN0+eu0r5VffXM2VYfJmUFsMxgzpXrt1i/dT937z2Kc9xPed304ZXvW/oMmwKo/gJ2dkw4KrCVpQUumVUzeWfPlhkzk7QYGxthbGxEenNT3r59h7mpSYL9ihXKg462Npmd7dHV1cU/IAhrg8QTPoCiBXOza/8JZi1aR/2/Kn62qdLK0kJdw+SePTMPP8yIfuLMJerWqIBJujRAyiYrBShRJC8KhYKcblkxMUlLTresqrJdM/Pmrb96O5csTuppD0oUycu23UcICQ3j4pUb+PkHMHfJegCC3n+csDSp651S9nZWnDxzmUue3njd8sHO5uOkxS6ZHLGxsgQge7ZMvP2k1vFrjpvcfZsUpVLJ2GmLadnoL2ytLTl7wTPReyskNAxPr9tMHdMHAJN0aROdQuLUuStUKFMEM1NVYlD/r0q06zmS/t3bUKV8cfYcOkmF0kU4fOIclcsVBeDE2Utc977L1l2qucpiYpS8CwgEVM2z2V0Sn54jviTvqyTKj72/HB1scc2aiaHj59Lk76q4u35MeAvmzYmBgT4GBvo42Frh6/cOBzvrJF/r5N7fJ89epkPr+ujo6KjmX6xcmpNnL1GpbFFVwnH1BmnSGJM7pysXrnjx2tePi57eFMybM855Fs6fk+XrtqFUKrnqdZtWjf7i7AVP8nm4ERIahoOdNe+DQxK8PiWL5kOhUJAjexZ136rzl69TOH8uHOysAeLcn+cvX6dQvpzqZX/XrMDcpRsIDQujcP5cLFixmajoaJ69eE3dGuW5eOUGWloKnBxsE9RcCpEaSIKUApmd7bn38CkhoWEJapFCw8Jo220YNSuXpmm9alhamCf6YQOgo60DH/KsqOgodD6Z8T0pUdHR6CQxSeTCFZu5/+gpDetUoWbl0vyv+/BEt1MqldjZZGTFnDGfPd7HWOPGpqOjzecGzFIoFOjoaMdJJqOiohNs52hvw4p5Yzh26gKd+47lf83/plLZoimMS0cdR4xSyYdKgrhxoEj0uAnKijeJrI6ONsqwxM9SW1sbgw9JnxIlcyYN+uycUZ9e75RQKpV07T+ePDldqVO9HG6umTl19nISZWsnOdv7p8dN6rX4kvv2U9v3HkWhgJpVSqtjTuzeii1LOwX3+KcUCoW65qdIAQ8mz1lOcEgoJ89eZuG0YaqNlDCif0eyZEo4LU1K3lOJ+fS+Sq58AAN9PWaO78+1G3eYs2Q9zo529OncMmGZH94Lyb3Wyb2/E/jktSmcPxenz13B2MiQUkXzExkVxaWr3lzxvEmLBjXi7GZjZYmhgQHXvO+ir6dHgTzuzF26gSvXb1EwTw51mUm+Njo6KD+8OlFR0V90TWOLzunmwoNHz7h24w5ZMjmQJ1d2psxdgY6uNoXiJXRCpBbSxJYC1hktKFkkL1PmrFA/5XHr7gP+u3iNx09e8C4giHq1KpLR0oK79z4/0SZA7hyu7Nx/HAD/d4E8fvYi0e3y5MzGrgMniImJITQsjLufTOR58r/LVKtQkjw5Xblz72Gc/awsLXjxYQJLd9csvHr9liMnVZOEBoeE4v8u8Iteg69hYW6Kp9dtoqKj2XvopHr5zTv3CQ+PoHypwpQtWYjzl69/VfnFCuZm6+4j6i+bJ89eAqqaJE+v2yiVSg4d/089Y/2XevnKl6ioKCIiItm25whFC+bGyNCAPLmys2jlFmJiYoiOjuHFK9/PlmVlacHLV75JJjUAgUHBeN28S6O6VcnkZM+tO/e/Ku5PJfVaJHffKhSKRON8+vwVK9ZtZ0D3tuov1aTurTTGRjg72qmbLJ+/fB2nn12s4oXycPDoWd4FBKFUKtm0fb+6L4qurg4liuRj5fodONpbq2vIihXOw5LVW4mMjEKpVKboaVKrjBa8fuMXp6ksKZ8r/8XLNzx/+Zpc7i40b1CTM+evJltecq91cu/vEkXy8u/Ow0RFRxMaFsbOfcco/uG1KZg3B7fuPuTmnfvkdM9K3lzZOX3uCgotBZYZ0ieIoXD+XGzcuo+8ubJjbGxEGmMjjp++QMF8X5ac5M6RjbMXPPH9UNN63fuOel3BvDk5f9mLZy9Ur9eWXYfImys7hgYG6OrqkCenK1t2HCRvruw4Odjw/MUbPL1uUzBfwiY+IVIDqUFKob5dW7N41RZadR6Cto42lhbm9OjQjIwZzClaMDdN2g3A0c4aWxtLYmI+X23Qo2NzRk2eT5N/+mNnmxF7G6tEt2vdpA5jpiyk0f/6YWOVIU6nyKb1qjFv2QbWb91LqaL50f7kL9G/qpZlyLg55M2VnVEDOzNpRC9mLFjNklX/oq+vS6c2jciX2+3bX5hk/K95XcZOW4zDJiua1q/OsdMXAXjxypfJs1cQEhqKoYEBQ/u0+6ryq1YowcvXb2nTdSgGBvrkzO5Cr07NaVS3CgNHz+T8ZS9qVCpF1g/Nhl/KwECf7gMn8trXjyIFclG7WllA9RTf5NnLafS/fujr6VKtYkka1K6cbFk53bISERlJ43/60b19M3S0tdm04wBjBnVVX7d0aY1pWKcK//QYjnXGDOTIngXft+++KvZYSb0WmZ3tk7xv8+TKztipi2jyd9w+XXMWryc4JIyegycBYJkhPZNH9kry3hrSpx3jpi1m07b9ZHa2x9424T2eO6crLRrVolPfMaAEVxdnenZopl5ftXxx2vUYyfD+HdXLurVrwvR5q2jSrj8GBvoUypuTTm0bJvs62FhZktnJngZtetO6SW2sLBMmESktPzgklFmL1uLnH0h4RATd2iU/ZUtyr3Xy7+/qzFmynubtB6o7aVcsUwSIbbI0QkdbG0MDAzxyZGPAyBnUrl4u0RgK589F76GTmTamHwD5PNxYv3UvvTq1TDb2+LJldaZZgxq06zmS9OamFMr3sf+Vva0VA7q3ZcCoGURHR2NnnZHBvT++twvlz8WUOctp36o+CoUCt2yZuHztJtmyOH9RDEL8LDLViBAaEBMTQ6e+Y5k2pi8G+j9muAghhBBfT5rYhNCAFet3UL9WRUmOhBAilZIaJCE0QKlUfrZzrBBCCM2RGiQhNECSIyGESN0kQRJCCCGEiEcSJCGEEEKIeCRB+gylUklUVFSy49cIIYQQ4vciCdJnREdHU6JaS6KjPz8ysxBCCCF+D5IgCSGEEELEIwmSEEIIIUQ8kiAJIYQQfyBlWBjBVasRXLUayrCvm7PydyYJkhBCCCFEPJIgCSGEEELEIwmSEEIIIUQ8kiAJIYQQQsQjCZIQQgghRDySIAkhhBBCxKOj6QCEEEII8f0VrdyMLM72BL0PxipjBgb3+gdba8uPG2hpoV0gv/rnL+Fz/zG7D56gW7umXxVb8w4DmTCsB9ZWGRJdf/K/yyxYvgkdbW0G9/qHLJkc4qw/eOwsG7buIyDwPU3qVeOvqmUB2LbnCJu2HyCNsRGjBnTCMkP6r4oPJEESQgghfksG+nqsnDeWmJgYtuw8xPxlGxk1sLN6vUJPD4MRI76q7CyZHL46OfqcyMgopsxewdLZI3n+4g0TZy1j4bRh6vXR0TE8fvqCuZMGExoWRp0WPShbohBRUVGs2rCTNQvGc/K/y8xZsoER/Tt+dRySIAkhhBA/QLKDL2ppodDTS9m2CgUKff042yoMDFIch5aWFvk83Nh76BQAN275MGHmMsLDw6lesRTNGtQgODiEUVMW8uTpS7JmduC2z0PWLZrI7gMnuHnnAb07twCgbK02HNm+hMue3qzZvIcpo3qzeNUW9PR0OXn2CvX/qkg+DzdGTprPi1e+ZM3kwLC+HdDR0Wbeso0cP30BOxsr3gUGAfDytS+d+45l9YLxGOjrqeMzNUmLuakJJmnTctvnIUHvg0mbxhgAbW0t2jStA4Ceni42GS15FxDIjVv3cMnshIGBPrlzujJp1rIUv0aJkQRJCCGE+AFC6tRNcp12gfxxam9CGjWG8PBEt9XKmRPDCeM/btuyFcbr16U4jpiYGPYdOU22LE5ERkYxdtpipo3pi7mZCb2HTKZy+eJs2LoPGytLxg/tzp17j+g3YlqKywfYe+gUy2aNwsBAn6Hj5lC3ZgWKF8rD0jXbOHb6AkaGBly9fotV88YRERlJs/YDAFWC42hvg472xyY+X793ONhZq14nbS3sbDLy1u+dOkH6lO9bf4LeB2NrnZETZy7hYGcFgIW5KdExMYSFR6gTry8lCZIQQgjxGwoLj6B5h4G8fO1LyaL56dmxOY+fveDlK196D5kMSiXvHz7icav/cdHOhZEDuwBgndHii49VtXwJDAxUtVwXrnjx4NEzFq3YTERkFH9VLcvNN/epWqEEenq66OnpqpMdc1MTpozqHacshUKBUqlU/66MUaJQKBIcU6lUMnPhWlo1/gttbS1QkMh+X3wqapIgCSGEED+A0b9bkl4Zr1O00bq1SW8b71veaHnKmo5i+yBt2n6AR09eYGRogFIJDnbWLJs9CmVYmKqWK0rVryckNPFmvqjoqM8eSyve+cyfOgRjI0P179PmrSQkJGXzvVmkN+PxsxeAKq5nL19jYW6aYLu1m/egq6tDzSqlAciQ3gyvmz4AvHnrj66uLvp6X1d7BPKYvxBCCPFDKAwMkv4X74s72W0/6X8Uu+2XqF2tLJc8b+Dz4AkOtla8Cwjksqc3AK+VquTLzSUTJ89eBuDmnQfqfc1M03H33mOioqI4eOxsojU58eXzcGP9v3sB8HsXQHhEBG7ZsnDm/FWio2N4/eYtvn7vAPB/F0ivIZOJio5W7++eLROBQcH4+Qdw45YPbi6ZMDY24sDRM6zdvAdQPeV24uwl+nZtpY6pYN6c3L33iLCwcK5cu0XRgrm/6HWKTxIkIYQQ4jemo6ND+1b1mT5vFbq6Oowa2IWZC9fSvNtw5sYYEa2ENg1rcPHqDVp0GsSp/y6r982X2w09PV0atOnDG19/LDOYf/Z4PTo048atezT5pz8DR87Azy+AciULYpnBnCbt+jN78TqsM6oe7w8Lj+DRk+dERX6spdLR0aFP55Z0HTCeafNW0adLKwB8377j5WtfwsLCGTZuDgGB7/lf9xE07zCQdVv2YGaajpaN/6JNt2Fs3XWIjm0afNPrpoiICFd+frM/V1RUFCWqteTk7uXo6EiLpBBCiN+DuokNVXNgbM1U0PtgmnccxNaV0zUYneZJDZIQQgghRDySIAkhhBBCLW0a4z++9gjkKTYhhBDiz6RQoJUzp/pnEZckSEIIIcQfSKGvH2cAShGXNLEJIYQQQsQjCZIQQgghRDySIAkhhBB/IGVYGMENGxHcsFHyk+X+oaQPkhBCCPGnCgzUdASpltQgCSGEEELEIwmSEEIIIUQ8kiAJIYQQQsQjfZBSyMIpn6ZDEEII8Zt599RT0yGIJEgNkhBCCCFEPFKDJIQQQvyJFAq0smZV/yzikgRJCCGE+AMp9PUxnDFd02GkWtLEJoQQQggRjyRIQgghhBDxSIIkhBBC/IGUYWGEtGxFSMtWMtVIIqQPkhBCCPGHUr5+rekQUi2pQRJCCCGEiEcSJCGEEEKIeCRBEkIIIVKhvQePUbxifYqWq8uKNVsSrD9/yZOaDf6HmX1u3gUEqpf7+wdQr1knchWpQolK9bl6/SYAj548I71jXopXrE/xivUpUaMp4THKn3Y+v5okEyT/d4EMGDmDJu3607LTYE6evaRe17HPaG7euf9TAkzOtHmr2H3gRJxloyYv4MjJ8wDMWLAan/uPATh84hxN2w9g8aotXPb0ZtTkBT89XiGEECIl3gUE0qX3cNYunc6eLcuYMG0+9x88jrONjXVG+nT7B6UybpIzZ9EqLCzMuXp6NwN6dWTQiMnqdfZ21pw6sJFTBzZycudq9LVkgMikJNlJe8jY2VQpX5xqFbvh5x9Ap75jyGhpgUtmx58Z3zfp1q6p+ucde4/Ss2Nz8ubKzmVPbw1GJYQQQiTv8LHT5PXIgYOdDQCVK5Ri597DdOvYSr2NnY0VdjZWCfZNm8YY64wZ0NLSIq+HOzo62up1FuZmPz7430SiCdKDR88IDHpP1QolADA3M6Fp/eps2XGQAT3aArBj7zEmzVpOeEQEQ3u3I1tWZ/YfOc3CFZvR0dGhdZPaVCpblBu3fJgwcxnh4eFUr1iKZg1qsHjVFvT0dDl59grFCubmyvWbzBjXH4Alq//F3MyEGpVLM33eai5c8SJd2jSM7N8Ra6sMHDl5nvnLNmJumo6o6OhkE7aOfUbT5X+NuXr9Fte97zJ++hLq1arImk27CQkNo3mHgcyeOIh0aY2/9+sqhBBCfLVnz19hY22p/t3Wxoqnz1+maN/WzetTv3knOvcaRlR0NAN6dVCve/7iFVXqtiIgIIg2jevQyMHhu8f+u0g0QXr87AWZnR1QfDI3i0smR3bsPab+3dnRln7dWnP8zEWmL1jDvMmDWblhJ6MHdcHZ0Y7Q0DAiI6MYO20x08b0xdzMhN5DJlO5fHEA9h46xbJZo9DX12PPoZMEh4RibGTImfOeTBzeg137j6Onp8v6xRO56nWblRt28r8WdZk2bxWLpw/HIr0Zg8bMTNFJNqpblZP/XabL/xqT3SUTRoYGXL52kyG92yW6/eYdB9my8yBAgqpLIYQQ4kdTxGv6UiqVcb6Tk7P/0Ak8crpRvEh+ps9ZyskzFyhcIA92NlYsnDWOAnlzcfO2D/Wad8Jj6Qzy5831I07hl5dogqSlUABxE4MYpRItrY9dlnK6qSa4K5AnB6MnLwSgavkSzFywhtZNa1MgTw7uPXzCy1e+9B6iav8MCQ3j9Rs/9bYGBvoAFCuUmwuXvciRPQt6ujqkNzfl/KXr3L3/mItXvFAqwcHOihu37pEnpysZLdMDkDFD+u/4Unz0d80K/F2zAgBRUVGUqNbyhxxHCCGESIydjRUnTp1X//7s+UsyOaWstmfkhJmcP7oNAwN9ypcuhnvBStSqVgGXLM4UL5IfgNy53ChcIA/et30kQUpCogmSg501d3wexclYb/s8xMneJmEB2tro6+sC0KReNUoWzcfMhWs4c/4q1SqWwsHOmmWzR8XZ5+yFq3GSrdLFC7Jz71EC3wdTspjq4imVqj5ExQvnUW937PQFQkJltE8hhBC/t3Kli9F3yHgeP31OujRp2H/oBDs2LqJBi86MHtqbrJmdktzX2MiQy543KFIwDw8fPyXo/XsMDQ1YtX4rZUsWxdYmIz73H3Lh8jX69+yQZDl/ukSfYnO0tyGDhRk79x0DwPetP2s27ebvWhXU2zx/+QaAPYdOkjdXdmJiYvC66YO9rRWtm9Tm4hVvHGyteBcQqO4U/er120SDyJk9Cz4PnnD2vCeli6oSpAJ53Nm84wCRkVFERkbh5x9AtizO3LjlQ0DgeyIiIrn34EmCshRATExMsidtmcGc12/8pPlMCCFEqpQubRrmTBlJo1bdqFK3Jf17dcDW2orbPg8I+PBIf7P/9aR4xfoAVK3Til4DxwCwYOZYRoybQd7iNWjcujszJw7D3tYaR3tb2ncfRNFydanXrDMj+nbGecZUQtp3kKlGEpHkU2wj+ndi4sylbNi2H10dHbr8rzGZnezV6z29brNyww7SGhszrF8HoqKi2XvoJBNnLSMkJJQu/zRGT0+XUQO7MHn2cqKjY7C1sWTMoK4JjqWlpYW7a2Zu3X2ItVUGAGpWLcODx89o2r4/hgYG/NPib4oWzE3LRrVo03UoNlaWmJuZJCgrj0d2du47RvlShZM86ZzZsxL0PpjmHQYxYXh3bKwsk9xWCCGE0ISK5UpQsVyJOMuunt6t/nnVoqmJ7pfL3ZX921YkWF6yWEFKFiuo/l0ZFkbIikXfKdrfjyIiIlyqUZIR2wfp5o3rmg5FCCHEb+bdU0+NHVsZFkZInboAGP27BYWBgcZiSY1kJG0hhBBCiHgkQRJCCCGEiEcSJCGEEEKIeCRBEkIIIYSIJ8mn2IQQQgjxe1NYylPcSZEESQghhPgDKQwMMFq+TNNhpFrSxCaEEEIIEY8kSEIIIYQQ8UgTWwr5PryEjo68XEIIIX4PyvBwwvr2A8Bg4gQU+voajih1kW98IYQQ4k+kVBJz9676ZxGXNLEJIYQQQsQjCZIQQgghRDySIAkhhBBCxCMJkhBCCCFEPJIgCSGEEELEI0+xCT2blHEAAA/OSURBVCGEEH+qdOk0HUGqJQmSEEII8QdSGBhgvH6dpsNItaSJTQghhBAiHkmQhBBCCCHikQRJCCGE+AMpw8MJ7def0H79UYaHazqcVEf6IAkhhBB/IqWSmOvX1T+LuKQGSQghhBAiHkmQhBBCCCHikQRJCCGEECIeSZCEEEIIIeKRBEkIIYQQIh55ik0IIYT4U+nrazqCVEsSJCGEEOIPpDAwwHjrv5oOI9WSJjYhhBBCiHgkQRJCCCGEiEea2IQQQog/kDIigvAxYwDQHzQIhZ6ehiNKXSRBEkIIIf5EMTFEX7io/lnEJU1sQgghhBDxSIIkhBBCCBGPJEhCCCGEEPFIgiSEEEIIEY8kSEIIIYQQ8chTbJ+hVCoBiIqK0nAkQgghxPejjIoiSvUVR1RUFAr5nkNbWxuFQgGAIiIiXKnheFK1sLAwytRqq+kwhBBCCPGDndy9HB0dVd2R1CB9hp6eHg52VqyeP06dVYpfQ9P2A1g9f5ymwxBfSK7br0uu3a9JrttH2tra6p8lQfoMLS0ttLS00NXV1XQo4gspFAr1XwLi1yHX7dcl1+7XJNctcdJJWwghhBAiHkmQUqBujQqaDkF8Bbluvya5br8uuXa/JrluiZNO2kIIIYQQ8UgNkhBCCCFEPJIgCSGEEELEIwmSEEIIIUQ88lwfsG3PETZtP0AaYyNGDeiEZYb06nVPn79i+IS5hIaF06x+dSqXK45SqWTpmq0cOXEeywzmjBrYmTTGRho8gz/Tl163Fy/f0PB/fXG0swagXKnCtGhYU1Ph/7GSu2637j5g2rxVvH8fwpqF4wHk/ZZKfOl1k/db6pHctVv/7z4OHD1NcEgYnds2pESRfPKe++CPr0Hy8w9g1YadLJkxgr9rVmDOkg1x1s9YsJpWjf9i4dShLFi+iffBIdzxeciZ856snDeWPLlcWb1xl4ai/3N9zXUDcHPJxMp5Y1k5b6x8WGvA565benNT/q4Z94kaeb9p3tdcN5D3W2qQ3LULDgklPCKCRdNHMG5IN8ZOW4xSqZT33Ad/fIJ07tJ1XDI7YWCgT+6crpy9cFW9Ljo6hv8uXiN3jmwYGxvhYGfNZc+bnD5/FQ93F7S1tcidw5UzFzw1dwJ/qK+5bgAmJmk1FLGA5K8bQIb0ZuRwzRJnmbzfNO9rrhvI+y01SO7aGRsZ0qJhTbS1tXB2tCU6OprwiEh5z33wxydIb/3e4WBnBYCFuSnRMTGEhUcAEBAUhGm6tBh/qFp0sLPG962/ah97VbWxo71qmfi5vua6Afjcf0yrzkPo3G8sDx8/00zwf7Dkrluy+8j7TaO+5rqBvN9Sg5Reu9s+D7GzyYiBvp685z744xMkFKo+DrGUMUpip1xToCDmk3UxSiUKLQUoFMTEqJbHxCjR0pI52n66r7hulhnSM6RPexZMHUrBvDmYOGvZz45aJHPdkt5H3m8a9xXXTd5vqUQKrl1UdDQzFqyhXcv6H/aR9xxIgkSG9GY8fvYSgDdv/dHV1UVfTw8Ak3RpCHofrO6/8uTpSyzSm5HB3Iwnz14A8PjZSyzMzTQT/B/sa66btrYWHu4u6OnpUqtKWR49eaGx+P9UyV23JPeR95vGfc11k/db6pCSazd93mryeWSnUL6cqn3kPQdIgkTBvDm5e+8RYWHhXLl2i6IFc7Nm024OHD2DlpYWRQp4cOX6Ld4Hh/Dk2Qvy5spOsUK58fS6TXR0DFeu3aRowdyaPo0/ztdct4PHzvLW7x1KpZKTZy/hmtVJ06fxx0nuuiVF3m+a9zXXTd5vqcPnrt3mHQd56/eO1k1qq/eR95yKTDUC7Nx/nPX/7iWtsRGjBnVh1YadWFla0Pjvqrx4+Yah4+cQEhpGi4Y1qVimKADL1m7j0LH/sMqYnpEDOmNsZKjhs/jzfOl187xxh/nLNvLW7x3pzU0Z2rsd1lYZNH0af5zkrtvYaYu47n2X5y/e4GhvTa/OLfFwd5H3WyrwpdcNkPdbKpHUtStVLD8NWvfG2dFO3ezWrEENKpQuIu+5/7d353FVllkAx38XLgIqbigiq4IigpRopqlNlpnLVO6aA+Lkglvmhsq4Y4gsmkaYIBbkEraYNYqJuKJGmMAgCCTmggvKIqCyCMI7f1yl2MS0yWjO9y/ufe97nvM8vJ8P5/M8l89BCiQhhBBCiGr+74/YhBBCCCGqkgJJCCGEEKIKKZCEEEIIIaqQAkkIIYQQogopkIQQQgghqpACSQghhBCiCimQhBBCCCGqkAJJiL+A7w4cp9fAcU+tIWj4/igWrlgHaJpjLlj+PiUlpU8cd+GKdYTvj6r2/r6DxxkzcT7OU//FNDdP4hNTAdi8dSfrNm594nGfRMShE2z/Mvyp5vBnkXE9i+nzPZ92GkI8FvXTTkAI8eQij0Tz5qC+7D8cjev4kU81F8MWzfD1mPs/i389Mxu/gFDCNvlg1MqQ9CsZFX33/gwGvNL7aacghPgdSIEkRD2Xl3+bi+nXmD3VmXlL1zDZZQQqlYq4hGS2fRmOuWlrTsUngwr8POZiYmxE+P4o4hNTURSFxOQ0mjU1YM1KN5oYNOK9NUF0sLLkreEDAXCZtojZU53p+qwdeyOPsSv8IEXFd2nUUB/PxTNpZVi5keXtOwW8NmIK0RHbSDhzlrUBoQDk5ObTyrA5oRs8uXT5Gr7+IeTk5tPEoBFL5rliYdaGW7cL8PX/hLTz6RgbGZJ9M6/afIuLSygpKaWgsBgAC7M2la5n5eSy1CuApNRzWFma4rN8Dmq1utbcw/dHkXL2Arl5+dwpKGS910L6DZ2E06i/88Op0+Tl32bSuBEMeEXTZmhPxFG2fxVOWVk53bt2Zt50F7S0ftmM3/H1PtLOX2Kp2xTNOp9Ooay8nNNnzmJva83ooQPZvHUnZ89d4m2noYwa8hoArwyZWOOYGdezWLzKn949HImKjsV76WzUOmrWfBjKlYwbqNXauLqMpHcPRwI2h6Gjo2bK+FEAhEdGcSo+meULpnIiJp7AkC8pKS2hg5UlS+a5oqenyzCX2bz9j6HsiThKzs083N75J3EJKRyPiaOhvj5+HnNp0bwpBQWFrP1oC8k/nUelghkTx9Knp2Otz1JhUREz3VdzMzcfl2mLmOA0jL59uj/5Ay/EH0SO2ISo5w4dO0m3LnaYmxqjKAqpaRcqriWlpDG4/9/YGuiFhWkbvt17uOJabEIyE52H8dkmb+7dK+PQsZg6x7KxtsTf251tgatpZ2HK57v2PfTzz9rbsGWjF0HrltG4UUPmzRjPvbIylnoFMGfaOHZs9mWC0zACgsMA8A/aRhODxoQF++C9fDZ6urrVYra1MGGyywgmzVrOSr9Azp1Pr3Q943oW82aMJ2yTD2d/Tic2IaXO3HdHHMF59Ot8sNodlUpFUfFdrNuaE7x+Bb4r5rJ6/Wby8m+TcOYs+w6dICTAk7BgX+7cKSQqOvahaxB7OgVXl5FsD/Im/nQqX3yzDz+PeXgumUlgyBcoiqbbU21jAvx07iJNDBrz6YZVtDFuxUrfQJ7t3JHtQd6sWvwuXus2c+XaDQb268OhqJMVMQ9FxTCwX2+uZmSyactXbPBbzI7Nfpi2MWLX3kMVOWZl5xL0/jJGDx3AYk9//tarG9sCvWmor8d3B44D8GFwGA52HQgL9uEjvyWs3RBKWVm5Zo41PEvGRi1ZNGcStjbt2LLRS4ojUe/IDpIQ9VzkkWhGD3kNlUpFr+e7EHk4mk42VgAYG7WkY/u2ANh3subipV++o2RjZYmJsREAnTpakVPDbk1V5mbGHPs+jtiEZJJSz2Fm0vqRcgwIDuPlPt1xsOvAxfSrXLqcwUq/QAAUBfT0NIXQ9ycTCFq3DC0tLfT19GjZolmN8VzGaBoQf73nINPcPBk/9k2cR70OwDP2NjRraqCZo7UF2Tdz68z9uS72FWv2QLcudgC0szSllWFzzl1IJ+ZUIpfSr+E6ewUAxXdLsOtY+b6qbKwsK5q02rS3pEe3Z9DRUfOMXQcKi4opKCyicaOGtY5pamyEnq4uI9/sD0BhUTHxiamsfc8NADOT1nR3tOdkbCLD33gVXd0G/HzhMkatDDl/8Qrdutjx772HuZGZwzsLVgFQUnqvUof2F1/oikqlwsGuA02bGuBg1wEAe1trsnI06xcVHUtichq79hwEoLxcIS//VsUcf+uzJMSfnRRIQtRjmVk5JCankZ9/m5DPvqGwqJiS0lLemTy22mfV2mpq60yt1tau2HVQAffK7lX7jKIovOvujaODLcNf74edrTXHo+PqzPGHU6dJTDnHxx943I+jKYhCN3hWOpri/rhqbe06Y4Km+Js+YQzdHe1xX7m+okCqPC81KHXnXteYarU2+nq6KCi82rcns6Y4P1KONeZTEVPz84N1r21MAC0tLVQP2q3f9+vXKpWKB+3YB/XrzcGoGMxMWtO3T3fN7xaFLg62eC+b/fD81Ooqr7VRiu/np4CH+3TaW1nUMUftWuckRH0iR2xC1GMHjsbwUq9ufBbsw5aNXnz+8RoUBf6T9NNjxzRs0YzE5DTKysqJO53C1YxMAG7dLiApJY2xIwZj1dac1LPnf7lJBeVKebVY+bfu4PdhCMvmT0VHR/PH19zMmGZNG7Pj630oikJJSSmZ2TcB6NLZlt0RRwHIzbtF+tWMajFPxMSzJ+IoZWXlKIpCxo3sOneyHpp7LS5fvQ7AybgkCgqLsG5nQe8ejuyNPE76FU1eGTeyK46Zfg81jVlVQ309HB1s+Wp3JABXMzI5GZfE8107A9C/7wsc/yGeIyd+ZOD9L4w/39WBH+OSSExOAzRrW1hU/Jty693TkY+37aK09B6KonDtemad9xi3bklm1s3fdY2E+KPIDpIQ9Vjkkcr/taatrcWgfr2JPBxN/749HyvmkMEvM3/Z+4yZ6EbfPt15ztEegCYGjXhr+CBc56ygTetWdO7UnuycPAA627YnZPs3nEn9GQsz44pYn4Z9S27eLVb6bgQ0OyGhGzzxWT6XNRtC2R1xhAYNdBg3+g1efaknc6a78N6aQJxc3TEzbY25iXG1/Oxt2xMY8gU7du2jpKQUo5Yt8Fg4/aFzeljutdm5+wA+/p+gQsXqpbPQ022Ao4MtMyePZaHHOtTaapo2aczyhdOqfVH9cdU0Zk2WLZiKn38IeyKOolZrs2jOpIoisaVhc1oaNiPjRjY2949XzU2N8XCfga9/CAoKDfX1WDhrAtZtzR85t1lTnFi/cStOU9zR09OlR1cHZkx666H3mBgbYd3WnDET3ZjgNIzB/V985PGEeNpUJSV3ZS9UCCF+5YUBzuzfGYRB40Z/6TGFELWTIzYhhBBCiCpkB0kIIYQQogrZQRJCCCGEqEIKJCGEEEKIKqRAEkIIIYSo4r9vRlJxtQb2aQAAAABJRU5ErkJggg==",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAkgAAAH1CAYAAAANogGZAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjksIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvJkbTWQAAAAlwSFlzAAAPYQAAD2EBqD+naQABAABJREFUeJzs3XVY02sbwPHvYDRIdxpY2N3d3b52HruP3Xns1mN3H7u7uzsxEES6u7b3j8EUAUVFJvh8rstL2H5x77eN3XvifiSxsTFyBEEQBEEQBCU1VQcgCIIgCILwuxEJkiAIgiAIwhdEgiQIgiAIgvAFkSAJgiAIgiB8QSRIWVDhcvWp17zLD+0bHR1DwVK1GTtlbgZHlVLDVj0oXrFRhhyr18AxGNkVzZBjZRf/rt1KzkJV+PDRW9WhJGNkV5ReA8eoOowMkZnvl18tPj4eI7ui9B06AYCDR8/g6FKJO/cepbr99DnLMLIrynsPz8wMUxB+GyJB+g4Xr96kQcvuOBSsRKkqTZg2eykxMbGqDuurJv+ziMLl6it/19bWYsuaBQzo1VmFUWUP67f8p9Kk7X8tG7Ft3SJsrS1VFkNmq9W4o/IDPjNk1PslKioaI7uibPvvYAZF9vNqVqvAtrWLKFKowE8f68z5qyKZErIdkSCl075DJ2jathdyuYzp44fRsW0zTp+/gn9AkKpD+yofv4AUt5UsXhibP+hD9Vfx8U15bTOTibERFcqWQCKRqDSOzJTa6/lXy4j3i6+/al8rqdHX06VS+VJoamr89LF8/PwzICJB+L2IBCkdoqKiGTVxNoVd8nFo1xo6t2/BkP7duXh8J7Y2lrz38MTIrijT5yxT7vN5N8O2/w5iZFeUsxeuUq1BO3IXqcakGQt59sJV2SI1YvxM5HJFSaq+QydgZFeU+Ph4AGbOX4GRXVHevnNPEVtkVBQLlq2jYu3W2DiXpWLt1ty6+xBQdHHt2H0Ijw8fkzWtJ8UWHBKKec6SjJwwS3m8//YdxciuKC9evUEul7N5xz5KVm6Mo0sleg0aS2hYeIoYLl69SYWaLbFxLkuNhu05d/Ga8r4EWQKLlq+naIUGOBerzn/7jgKK5v61m3ZRo2F77PKVp0Slxhw/fUG5X0BgEJ17/Y1DgYrUa96Fd+8/JDunn38AvQaNJWehKhQuV59ZC1YSFxcHQPWG7SlXozkAcXFx2DiXJWehKshkMgDK1WhO+x5Dkh0v6Tncd+gErTr2I2ehKsTExBIcHEr/vyeSs1AVildsxObt+5TP0eyFK5XXs2GrHkDK7s+GrXpQsFTtr56jcLn6jBg/kzGT55KvRE0Kl6vPxSs3U1znL335uvjWcYKCQhg8cir5S9Yid5FqjJwwC7lcnuI4Sa/XC5dvKB9D515/M2vBSgqUrEXZ6s25dPUWazftokj5+hQqU5fzl64ni83Lx4+OPYfiUKAitRp35NkLV+V9L169oen/emGXrzxV6/+P23cfJbs+G7bupkOPITgUrEStxh2VXYhGdkXx+PCRHbsPpdoa8+LVG3oNHEOhsvVwKFCRHv1HERYeAYBcLmfWgpXkK1ETI7uiyn/T5yz76nso6bypvZdrN+mEff4K9Og/Svnac//wkab/64WNc1lKVWnCstWbuXT1FkXLNwCg/7CJqba0xMfHs2TFRkpUaoxdvvK07tSfgMAgAoOCmTRjIWWrN8fGuSx1m3XB9Y1buq4XwMUrNylfswVOLpUZNXF2snN++TxHREYyeORUHF0qUalOG+4/fJps+937j1G/ZTccClaiUJm6yvfCzPkr6D9sIgBFyzdQtlhHRUUzftp88pWoiUvpOsxbskb5HhSErEAkSOnw4tUb/PwD6dK+JRoan75tfe8398GjptGxbTNy53Rg8YqNtOzQl6YNa+GSPw9rNu7kwaNn3x2bmkSNi1du0rpZfSaOHoSvnz+9B41DLpczfmR/8ubJiZmpMVvXLqR39/bJ9jUyzEGNqhU4de6yMjk7ceYi+fPmIn/e3Bw4copBI6ZQsnhhpk/4myvXbidLApP0GTQOJBJmTR2FS4G8xMR+6nZ09/jIzbsPGdi7C2pqaoycMIuEhATU1dW5cPkGtWtUZur4ocjlcnoPHk94RCQA/YZO4MSZi/w9sCeNG9TizWfJoUwmo9Nfwzh19jLjRvSnVdN6zFqwgtkLVwFQpUJpXrx6S3BIKE+evUImkxMUHMKr1+8IDg7lxau3VCpfKvXnaORU7GytWLFoGpqaGvw1cAxHTpxjSL9utGxaj0Ejp/Dg0TN6d29PhbIlAdi6diHjR/ZP93P2+Tm0tDQBWLNxJ6FhYQzu143AwCDGTpmX7uN9Lq3jyGQyOvUaxq69R+jRuQ2D+3Ylf95c6X4NHzp2hsdPXzCobzc8P3rTqlM/Dh07Q7+eHQkNC08xRufG7fvkzZOTSWMG4/rWjR79RyGTyQgOCaVZu974+PoxbcIwHOxsaN9jMJFRUcp9x0yaS5FC+enSrgV37j9m6cpNAGxaNR+AyhVKs3XtQqpULJPsnB88vYmIjGLk4F60alafvQdPsHLdNgD2HDjOrAUraFi3OqOG9gGgT48OtGpW/6vvobQMHjmVti0bUb5MCfYePMGJM5cAmDZrKfcePGH6xL9pVK8G0dExuBRwZvSwvgD06taOrWsXYm5mkux4cxevYeKMhVQqX4ppE4aRL28ujI0MSUhI4M79J3Tt0IqRQ3rz+OkLho/7J9m+aV0vD08v2nYZiESixj+TRxAXF//V53jyjEVs2r6XHp3a0KNza14lJmJJrt+6R+niRZg+YRimpsYMHTOd9x6etGxaj6YNFV8CFs2awOLZii9i46fNZ9X67XRp35I+PTswc/4Kjpw499UYBOF3IlV1AFmBm7ui9cLW5uea2RfOHE/tGpUwMzXm1t2HDB/cix6d22BlYc71W/d56fqW4kVdvuuY2tpaHNy5moDAIO4/fEae3E5cv3mPgMAgypcpgYmxIVHRMTSqVyPV/Vs0rkvvweN49foduZzsOXPhGn17dABg9YYd5HJyYM7U0SAB19du7D14nDnTRic7hoGBPhoaUsqXKUHndi2S3Wdhbsr2dYuQSCQ8efaSjdv24ucfiJWlOVvXLiQ0LJz7j55SqGBeDh8/yyvXt9jZWnPy7GV6dmnL4H7dALh5+wGHjp0B4NGTF9y4/YCh/bvTs0tbQPFNefWGHYwb0Z8qFcuweMVG7t5/jOsbN4oUyo/nR2+u37qHva0NQJoJUrnSxVk4awISiYR3bh6cPn+FEYN70aVDS5DD9v8OcuTkOcaPGIBd4ushrWubls/PkaRksUIsnz8VgDPnr3Dl+p3vOua3jvPo6UuuXL/DmL/7MmJwr+8+roW5KVvXLkQikXD+0nVOnbvMro1L0dHR5vyl65y5cA2ZTIaamuI7V71aVZk4ehAAj5++YOO2vbx39+Ty9dt4+/jx74KplChWiJLFC1Olbltu332Ek6MdAL27t2PU0D7KVkbXN+8AaFi3GgB2ttapXvNa1StSs1oFXrq+RUdHmy079ytbp27dfYiujjZzpo1GKpWy9+BxAPLnzQ2Q5nvIzNQkxXkAFs6aQO0alShSKD+nzl1WtuoYGOgBkDuXI906tlY+x+VKFwOgaOECKWKXy+WsWLuVyhVKs2TupGT3mZuZcnTPOj56+fDwyXPs7Wy4ffdhsuQtreu198BxomNiWDZvMiWKFaJJg1ps3rEv1ccjk8nY9t9B6tSorHze3rxzZ9mqzcptFswcT1RUNPcfPaNEURcePn7O/YdPadaoDs65nQCoXrU8jva2REfHsHHbXtq0aEi/vzoCcPjYWY6cOEeTBrVSjUEQfjciQUoHe1trALy8fX/qOBoaisttamKs+F2q+N3ExAiA2Ni47z5mbGwcf4+dwY49h7G1sUQzsYUrNDQ8zT/un6tfpxpaWpqcPHOJYkUKEhoaRtOGij9gbu8/4OXjh1OhysrtUxuvsHvLcqbPXka5Gi2oU7MyMyb8Ta6cDgBI1dWVHxJJ8cTExiKXy5k+Zxn/rtmKoaGB8pqEhoXjntj9kHSMLyUlrEULfxpcWryoC/cePiUwKJhyZYqjoSHl9r3HvHr9lvx5c5PDQJ/rt+7j7eiPkWEOChXIm+qxixYuoIw36TxzF69m7uLVym38/QO/ek2/5fNzJEl6bQCYmRj/0Gvha8dxe+8BQGGX/D903M+fR1NT42TnMjExJiEhIVmC9Pnjy+esSEICg4J57654blt06Jvs+H7+gcoEKamVViqVYmyUg5iY9F2L5y9f03PAGMUXjSIF0ZBKCQ0LA6CwSz4io6LZd+gkVpbmvHv/QTm4/UfeQ0mP3SzxdZs0WWPq+GGYmBjRscdQHB3smDZ+KNWrlP9q3AGBQYSGhVPYJV+K+0LDwukzZDwnTl8kTy5HIqOiiYyKJiEh4bNYUr9e7h8+Amm/jz7nHxBEZFT0V7ddtX47/8z/FzWJGjkTn6vQ0JRd7gCeH71JSEhgx+5D7Nh9SHm7vr7uN2MRhN+F6GJLh/z58mBoaMCWnQeU44IA5biDpD+ovokDSFMbp/M9vjxeWHjax9t94Bhbdu7n6J51PLx2jBZN6iW7X01NnZiYmDT3z2GgT+3qlTh78RpnL1zFObcTBfLlAcDRwRYHexsO7VrD4f/Wcvi/tRzcuTrFMRztbVmzbCb3rx7h6fNXDBg++ZuP8cr1O8xfupYlcyfx/M5p5bdMAAsLMwAePn6uvO3zb8xODoo/zp93Sd5/+JQcBvqYGBuhp6tLqRJFePbClcdPX1KiqAvFihbk0ZPnPHvhSoVyJZUf5F/jaG8LQPdOrZWP//B/axnUpysAaurqgGIqeBJNDSm+foHKmMMjIr55nszgYKdoOXvy7GWK+5KS3qSBxGE/+fr90qvXbwHI5eSgvKYLZ41Pdk2rVyn3zeMkJV1pvZ6Hj5uJuroa755c4vShLZh+lty0bFoPC3NTeg0aS5O2f1G0UH66dmwFfPs99D309XQZP2IAT2+fwsHehnbdFN2HSa+31GJXvGZ1ePLsVYr7lq/ewrkL17hz8SC3LhygcoXS6Y7FwjzxffRE8T76WpehibEhUqlUue2X27/38GTUxNkM7tuNN48uMGXc0GT7f3p8ikTR1sYKNTU1Gtatnux5nj7h73THLwiqJlqQ0kFfT5dp44YxaOQUmv6vN21bNiQkJIxVG3awYuE0ypcpjqGhAUdPnsfezpqjJ88n+yb/vZzzOAEwauJscjras3HrnmT321hZ4PHBCzf3D0RFRQOKabb3Hjxlw9bdybZ1crTl2s27/Lt2K6WLF6F0ySIpzteiSV36DBnPRy8fmjaqrfwg6tnlf/QcMJo1G3dSu0Yl3D0+Uq508WT7vvfwpEe/UTRvUhcDfT1iY+NQV/928pEU9/Vb94iIiGRJ4rgJULTYFS/qwpHjZ1lZpCChYeGcPHtJeX9hl3yULVWMjdv2YmdrjedHb+49fMrwQX8pY69SoQzb/jvIRy8fSpYojNVHcxYsXUd4RFSyZOxrcjrZU6NqeXbvP4aRYQ6cHO149OQFk8YMVlzbxERt9sKVVK9SnioVy+CcJycnTl9k0oyFuLl78vzla2Urw4+Ii4ujQcvu5HSyZ/WSf769QxqKFi5AiaIuLFy2HqlUipmJMc9evmbm5BHK7pHpc5ZRsVwpVm/Y8cPnSXLl+h2Wrd5MQnwC2/47SOP6NTE2NqRx/ZpMn7uMZas207VDKzQ0pAQFh1K5Qmnl+LO0qKur42Bvw6Wrt/hv31FKFS+crMUjKioKf/9ADh07w70HT/D48BFbawsA9uw/TmhoOBNGDSQhIYFihQsSERGJgb7eN99D6RUXF8f/ug6iWJGCOOd2IjAwCIlEggQJjg6KxHDH7sOYGBtRq3ol9PUUrSlqamp069SaZas2M3T0NMqWKsbl67eZMWE4UVHRRMfEcOrcZSIiozhy/Gy642lcvyazFqxg+uxleHby4fBX9pVKpTSsW50jJ84xb8kadHV12LLzgPL+pGv04NEztu8+xLrN/yXbP6n1b/GKDTRtUJs6NSvTuV1ztv13EHs7GwoVzMvDR88Y3L97uuMXBFUTLUjp1Ll9C3ZsWExcXBzjpsxj47Y9tG3RkLKliiGVSpkzdTQSieIPYO/u7SlVImUikl4d2zajaqWyXLxyk9fv3rN8wdRk97dv3YTgkFAOHz/L/1o1pla1ivy7ZgvHT19IUa/l7wE9KVq4ADPmLGPT9r2pnq9urSpI1dVxfeNGs4Z1lLe3bFqPpfMm8+r1O0ZNmM2xUxdStIhYW1pQvUp51mzcyeiJs8mTy5EFM8d/8zHWrFaBNi0asmvvEbbs3M+gPp9mfkkkEtYvn02xIi7MmLucm7cf0KV9S+X96urqbF27gFrVKjJ9zjJ27z/GyCG9GTmkt3KbKhXL8MHTC20tTQrkzU2p4oWRyWR88PRKc/zRlyQSCeuWzaZ547ps3XWACdMX8OGjN4FBwQD07NKGSuVLsWr9dhYuXwfA2OH9cM7tlPjBYM3A3j9W0DOJXA7hERH8t+8owSGhP3wcdXV1tq9fTP06VVm6chMz5/+LpoYG8fHx1K9dlWaN6vDw8XOu37rHxpU/XxSxXevGHD91kflL19KgTnUWz1HMcjI2NuTQrjU4OtgyZ9EqFv+7Af+AwHR3Kc6ZNhptLS1GTJjJpau3kt03dfwwNDQ1mDRjIZqamtSrXVV5X5WKZUiQJTB/yRr+mfcvbboMwKVMXU6evfTN91B6SaVS2rdpwqlzlxk6ejohoWFsWDkHHR1tHO1tGT2sL65v3Bg7eS6v375Ptu+EkQP5e2BPTp+7wqhJswkPjyQ6Joa+PTtQpmRRZsxdzt0HT5Rj7tLDpYAzKxZNx9c/gEkzFlIwXx7yOedKc/t5M8ZQp2ZlFv+7gYNHTtOr2/+U9+XPm5tBfbpy/tJ1/l29RTlOMUnzRnVoVK8GBw6fYvI/i4iLi2Pm5JH07dGRI8fPMnribF64viUoOCTd8QuCqkliY2PSbncVBEHlHj97SZ0mnXF/fiXZLEoh/br3G0lkVDQ7NyxBLpfz3sOT0lWb0r1TG2ZPHaXq8ARB+A2JLjZB+I29futGhx5DGD2sj0iOfsIHT29ev33P4n83YGJixMkzl4iPT6BerSqqDk0QhN+UaEEShN+Yf0Agd+4/pl6tqt/eWEjT42cvGTlhFg8fPUNDU4OC+fIwqG9X6teupurQBEH4TYkESRAEQRAE4QtikLYgCIIgCMIXRIKUToHBIYyeuoiOfcbQY9AkHj19RUKCjK27j9B94ARadB7K3xPmEZJG4bSMFhAYzMhJC364oGB6RERG8feEeXTqM5bTF65/e4efdObiDf4aMoX/9RzJ2GmLiUic9h2fkMC8ZZvo0Gs0fw2Zgofnp7WmlqzeTqN2/Vm4YkuyYzXvPIS2PUbQue9YOvcdy8OnKWvMADx98YZuAybQoddo1m3dr6z98viZKwNG/UOFep2U63mlJjA4hCFjZ9Oh12jGz1hKVLRiOnRgUAgTZy6jepMeXLz27arY9x4+Y9q8Vd/c7nul9TiioqOZ8M8yOvQazZCxswlMnF30tWv9KyxZvZ07D55+e8NUeHn70W/E9FTv6zdierqu+5emzVvFvYef6msdPXWJtVtSn/2ZUaJjYpm5cC11WvZi574Tye47eOw8HfuMoWOfMVy+cU95++Ub9+jcdywdeo/m4LHzvySu5p2HfPc+vn4B9Bsxnc79xiW7jhnla8+5IGQ0kSCl0/R5qylTvBBbV87kn/GDsLe1Qk1NgqO9DasXTWbPxvmoq6mx/0j665T8DFMTI+ZMGZYhK3Gn5dWb97z3+MjmFTOoXe3r1YB/VlxcPK9eu7F45ii2r55FbFw82/cqloM4duoS3r7+bF01k7bN6zJj/qdilVXKl6BsKrWdAJbMHM3mFf+wecU/FHVJWTk7IUHG+BlLGDmoGxuWTePitTvKD2sLMxO6t2/21eJ6AEtWbaN08UJsWz0Lwxz6bN51GAAtLU2aNaiBve3PLU/zs9J6HJt3HsYwhwHbVs+iVDEXlq7eDnz9Wv8Kg3q1p1Sx71teJ7uRqqtRt0YFCubLnex29w9erN+2nxXzxjN38jD+WbCG8IhIwsIjmLlgLbMnD2PFvAms27bvlyey6XXnwTPU1dTZ/O8MShQtqOpwBOGniFls6eDp5YvrW3fmTlFUgbW0MFXeV7lcCRISZLh/8CYoJIyC+ZLXGYmKjmbyrBW8cfNAU0ODwX06UrZkYd57fGTOkg0EBIWQw0CP8X/3wsHOmr2HT7Nt9zE0NNQpV6ooQ/p05OGTl8xZsoEEWQLWluZMHzcQuVxOnZa9uX5yK6BoKViyehuRUdGYGBnyd/8uODnY4OXtx6gpC6lasTRXbtwjJDScGeMHUiBvLtzcPZkyZyURkVEYGRowZXR/rC0V1Xe9ff2ZMX81fgFBdOk3jiWzxjB2+mLq16rMoePnqVW1HG2a1WXTzkOcPn8duVxOuVJF6Nu9LRoaUtZu2UtUdAwfPvrw0tWNapVKU7ZkYbb+d4R37p6MGNCV6pU/LTaqoSGlX49PdVeKF87P2/eKpT7OXb5F43rVkEgkVKtUmpkL1xIYHIKJkSHFCufnzoOnhIWnLDJoZGTw1ef1+au36GhrUyCv4jmrXbUcF67cpnTxQlhamCZ7nlMjk8k4f+U2g3srCk82qF2Z6fNX07tLa/R0dShRtGCKpRUuXL3Nll1HWLdkivK2J89fM3XuKiKjouncdywjB3XHJX/ur15bbx9/gkJC8fTyw87GkgnDe2OYQz9FjGk9jnOXbzFpZB9l3C27DGPiCPlXr3WSY6cvs//oWaKiY9DT1WH6uIGYmxrj4xvAtHmr8PT2xdvHHwszE+rVrEjX9k1ZvHIbr968Jyw8gmoVS9O/p+K5HjV5IVUqlKRhnSpMm7cKBztrHj19xavXblQoU4wxQ3sCsGrTbk6cuYKmpgaN61ajVrVyDBw9k8CgEDr3HUv3Ds2pVil5lenrtx6ya/8JfP0CqVy+BIN6dUAikeDm/pF5yzcSFByKro4Og3t3oFCBPKxYv4vzl2/x8MlLbK0taN6wJv+u3wXApWt3mTNlGKbGRvy7fic37zxGIpFQp0YFOrdtjEQiYdq8VdjbWvHwyUveuHnQplldjI1ycODoOfz8g5gyuh9FC6VcTkQqlVKiaEGOnr6c4rVSqXwJDPT1MNDXI79zTm7ceYRcLqdAvpzK92qlsiW4ePUOHds0Su1lyr2Hz9i6+yj2tpbcuf8MJDB3yjBsrCyIi4tn+bqdXL+tWN+tY5tGNKlXjcFjZuHt40/nvmMpX7oofbt/qr8UFxef6jV4+uINqzftITwiku4DJ7J+6af6bXK5nJ37jnPoxAU0pFJKFXNhUO8OhEdEsnDFFl68eodETcL/mtejUd2q6X7OnRxs0vwbJgg/SyRI6eDh6Y2tlTmrNu3mxp1H2NlYMmpQNwxzKD6AR06ez7VbD+ndpTVlShZOtu/NO4/54OXD7g3zCQ2LQF1djfiEBCb8s4yJI/qQJ5cDN+48YtmaHcyZMox/1+9i+Zxx5MnlgH+AohLvtj1HaVS3Ku1a1sfLxw99Pd1k3SWhYRGMnrqIOZOH4pI/D+cv32L01EVsWzULgLduHxjQsx3dOzRjyept7Nh7nKlj+rPvyFkKFcjD3/274OXjj6X5p6UZrCzMGDu0J4tWbmXzik8VnI+evMjyOePQ1NTgxNkrXLlxj7VLJqMhlTJuxlK27TlK13ZNAbj38DmL/hmJXA6N/tcfNTU1ls4ew/GzV1i7ZV+yBOlzcrmc67cf0qC2Yg04X79ALBJXP5eqq2NqYoSvX2CyD+0vqaupMX7GUtw/eFGmRGEG/tU+RWubj18AFp89Zgtz0zS74lITEhqOXC7HyNBAuX/SMiNpyWGgj4OdVbLbChXIw1+dW3Lv0XMmDFcUu/zWtfX08mXOlGHo6+ky4Z9lbPnvMAN6tkt37J9fU2OjHMQnxBMaFp6ua503tyNLZo1GR1ubWYvWsWv/CQb0bMeGHQdwtLdm6ewxnL10kwNHz9G3e1vkcjmN6lbFJX9uomNiaNphEA1qVyano22KuB4+eck/4wcRHRNLo3YD6NC6IYY5DNi4/SDHdv2Lnq4OIWHhmJsaM3ZoT9Zu3ce/c1MvTKqjo8XSWWOJiY2lU58xlCrmQtlSRRg1ZQF9uraheuUyPH3xmlFTFrJjzRz6dm/L4+eu9OzYQtn68fqdOwA9OykKlW7YfoCP3n5sXjGDuPh4Bo6aiZWFGXVrVADg0dNXzJwwGA9Pbzr3G8fQvp1YvXAS67ftZ/Ouw8xPJUFKi89nzwWAZeLrSyaXYW72+evWBJ/EZYnS8uS5K727tmZw746Mm76Ug8fO07d7W7btOYqWpgY71swmNjaOLv3HU6lscRbPHE35uh2TvfeTbN19JM1r8Ffnlly6dpfZk5MvRXL6wnWOn7nCyvkTyWGgR2CQokt3yept6Opos3XVTIJDwvhryGTsba1wcrBN13O+4N/Naf4NE4SfJbrY0iE8PBI3j49ULleCTcuno6Otxaadh5X3z582gkPbl/LgyQu27zmWbN8ihfKiqaHB7MXrCQoOQV9Plw+e3rz38GLq3JV07juW5Wt3EhSiWFSzZePazF++icvX7mKeuJZUg1qVOXLyIrv2n1QmZZ978twVextLXPIr1lCrXrkMkVFReHh6AaCjo02ZkoWRSCQUKuBMQGAwADWrlOXOg6es27ofbS3NdK1P1qZ5PWWicfn6PZrUr46OtjZSqZSWjWtz+fqncRJFXPJimMMAI0MDHOysqVS2GGpqahQpmBe/gLQTiUPHLxAbF0fdGhUBkKglX9hVLpcjSW3Hz0wZ3Y/xf/dmycwxvHX7wH8HTvLytZtyTNKK9btQk3x5FDkpbvpC1/7j6dx3LIPHzEItlbi+FViJIgWYNLLv1zfi29c2bx4nDPT1kEgkVC5fgqfPXyu/WXfuO/ab45lSxg4gSde1trez4uqNB8xevJ4nL17z4aMPAFbmZoSGRRAXF09QcKjyWkgkEsxNjdm25ygzF64F4MPH1LuEypQojLa2luI1Y2uFf2AwOQz0qFujApNn/8uDxy8wS1zc+VuKFc6PuroaujralCrmwtMXb/D44E10dKwyOXfJnwdba0uePH+drmNevn6PVk1qI5VK0dHWpkm9aly+fjdF/HlyOaCtpUXlciWQSCQULuCMX0AQALMWr1M+T96+/mme68vXp1yueH2qSb54n8pJsfjxl6wszMiXxwk1NTVcCuRW/g24fP0e56/cpmv/8fQaOoXYuLivxpSea5CaS9fu0rJxbQxz6CORSDBNfA6vXL9P2+b1kEgkGBvloHa18ly5cT/dz/mP/A0ThPQSLUjpYGFugq6ODoUK5EEikVChTDGOnb6UbBtzU2NaNqnN1v+O0L5VA+XtJkaGrF86lRt3HjFx5nJqVytPpXIl0NbWYuPy6Sne0P26t8XL249Nuw6xYcdB1i6aTPXKZShdohCHT1ygbY/hLJs9DlOTtFtPACRISO3TWipVR45iPErRQvnYuHw6J89epUv/cUwe1Y8SRQp89bhfW2dNIiHNBEMqVf/0s7o6aQ3tuXDlNrsPnWLZ7LHKc1mam+LjF0BhnImPjycwKAQL8693fyUli4Y59KlWqTTPXr6hY5tGyb4RP33xJtk3bx+/ACzNv948v3H5pwGicrkcdTV1gkJCMTEyxNcvEKtv7P+jvnZt1dXV0dbWwsTYMNVv/KlRtDoEYmZqTGBQCJoaUnIY6H3zWsvlcgaNnkXxwvlp0agmBfPn5kpi4la7enkOjbpAj0GTMDbKwfD+XQHFWLbxM5bSq3Mr6teshH/gMmTfGNsFia8ZuRyJRMLkUf144+bBms172XXgBPOnjUjX4/z8WDraWqne961k+6skklSTE4lEkvw1n/hYAEYP7pGuQ1uam+Ll46f83ccvgLKliiCTyZINbPfxC8DOJv1j3aTqUpKuvlwuZ+Bf7ahcvmS6908hjWvwOZn8218+FMdKeq2n7zn/kb9hgpBeIt1Oh4L5ciGRKLqMEhJkXL15n7x5nHj33pON2w8SFxdPbGwcN24/JLeTfbJ937p9ICgklPKli9K8UU2u33mIvZ0VRob67Nx3ArlcTmxsHL7+gcTExvL4mSvWVuYM7NkON3dPAgKDuffoObo62vyvRX2sLS14+iL5t91CBZz54OXD0xdvAMXYBR0dbextk3flfOnR01dIkNC4XjWKFcr33bNOKpcvweETF4iOjiE+IYG9h89QqVyJ7zrG527cecSKDbtYMH2EstsKoEblMhw/cwW5XM6FK3fI5+yEsVGONI9z694THj9zBRTdYBev3aFwAecU2+V3zklMTBzPXr4hNjaOMxduUKNy+ldLl0gkVK9cmmOJY0eOnb5M9e/Y/3NWFmZ4+/grB1N/69p6+/grX3cHjp2jQpli33W+GpXLcuzM53GXQSKRfPNah4ZF8OS5K+1aNiCXkz0vXr1V3nfi7FWaNqjOlpX/sGTWaJwcbAC4++ApOR1tqVWtHAkyGT6+X+8O+lJIaBiv37qT28mevt3acPPuE+Lj47GyNMPXL5CEBFmq+3l4eiOXy/H1D+TitTuUK1UEezsrtLU1uXD1NqBIkj29fClUQJFQW1mY4eXzqQXly98rly/BvsNniU9IICo6msMnLvzUa/5rqlUqzZUb9wkLj8DL249Xr99TtmRhypcqwgvXd3j5+BMaFsHVW/dTjL9Kr0rlirN51xHljNGP3r7K+6wsTPHy9kuxz49cg4plirH/6DnlgsRJg8orlS/O7oMnkcvlBIeEcfr8dSqWK5Hu5/xn/4YJwteIFqR0kEqlzJw4hLlLNxAcEka+PE50atMYdXU1QsMj6DF4EmFh4RTIm4tRX3w7DA4NY86S9YQl/mEYObAbUnV1Zk8axrzlGzl88gKamhp0atOY0sVd2HfkLPOWbyQ0LIKOrRthYW7K0dOXWLxqKxERUeTJ5UCNKmWIj09QniOHgR4zJwxh4YrNRMfEYmRowKyJQ77a2gPg+vY9C1dsITIqCnNTE+Vg4/SqW6Mi3r4BdB84EYlEQpmShejQquF3HSNJUHAoo6cuwszEiBGT5iOXKRKFJbPGUL9WZV6+dqNj7zHo6uooBxffuvuYZWt3EBAUgkwm4/6j50wc0Qc7GwuWrd2pHIhbp3oFmjaokeKc6upqTB83gLlLNxITE0vt6uUpnvjtc8zUxXh6KbqO+vw9jWKF8jFiYLcUxxjUqwOTZ//L8dNXyOloy6Be7QHYtPMQZy/e4MNHHxav3MamHYdYv3QqT56/ZuOOg8wYPxAtTU3lcQoXdCY2Lo72vUYxpE+nb17boJBQho6bg69/IOVLF6F5w5SP72uPo1ObRsxYsIYOvUZjbmbM5FH9ANK81klyGOjxvxb16TV0MtaW5hQqkAf/gGAAirg4M3LSQk6dv4aGVIqdjSVN6lWjeuUyXL35gM79xpE3tyM5E1d+T6/IyGjWbN6Ll68/ERGRDOvbCalUio2VBbmd7GnbYzjdOzRXjllL4ucfRK+hUwgNC6d31zY453YEULz3lm1kzea96OpoM3PiEAz09QBoWLsKk2f/y7HTl1k8azTlSxdl+55jdO47lokj+tCxdSOWr9tJ5z5jlQOU61T/uRmeR09fYte+E3j7BnDr3hOOnb7EklljsLOxpEenFvT5exoSiYRxf/+Fnq4OAOP/7sXISQuQyWT07NQSW2sLAKbMWUmNyqXT3SLUqU1jwsMj6TZwItraWuR2smPiiD5IJBJaNq5Nr2FTqVmlLEP6fPrb8CPXoEHtynj7BtBjkOI8hQvk5e/+nRnUqwML/t1Mx95jkKhJ6NquKUVd8uLl7Zeu5zwqOvqn/oYJwteIStqCkInkcjkDR8/kn/GDyWGg90PHWLtlL2HhkQzt2ymDo/s5A0b9Q7/ubSmYLzfxCQksWL6Z0LBwpo8bqOrQ/hjnL9/C46M3nds2UXUogpDliRYkQchE2/cco0Gtyj+cHP3O6lSvwMIVW4mOjiE2Lg7nXA7KFjXh1/P1C+DitTsM69dF1aEIQrYgWpAEIRPJEwcdC0JGSxq/Jl5fgpAxRAuSIGQi8eEl/CritSUIGUvMYhMEQRAEQfiCSJAEQRAEQRC+IBKkb5DL5cTHx39z0VJBEARBELIPkSB9Q0JCApUbdiUhIeHbGwuCIAiCkC2IBEkQBEEQBOELIkESBEEQBEH4gkiQBEEQBEEQviASJEEQBEEQhC+IBEkQBEEQBOELIkESBEEQBEH4gkiQBEEQBEEQviASJEEQBEEQhC+IBEkQBEEQBOELIkESBEEQhF9g574TREfHqDqMDHP5xj1c37xXdRiZRiRIgiBkOzPnr2DekjWqDkP4SV7efnToNRqA12/dWbxq6y8/58IVW/DxDUjz/n4jpvP81dtvHicqOpr7j56jra3FsdOXOXb6ckaG+U1rt+xl2+6jP32cafNWce/hMwCc7G3Ye+TMTx8zqxAJkiAI2cpL17fMXrgSd4+Pqg5FyEB5cjkwuHfHX34eP/9ALC1Mf/o4py/coGrFUgA0qF2ZBrUr//QxVc3e1go//yAiIiJVHUqmkKo6AEEQhIy09+AJAPT1dVUciZCR7j18xrY9x5g/bThrt+xFLoenL17j+tadsUN7UrFscSKjopm5cC2v3rzH2tKMqWMGoKujxbzlm3j12o3wiChGD+5OiaIFWbtlL5qaGly+fp82zepQu1p5PL18sbYyB8D9gxczF60jNCwc51wOjBzUHV0dbWU8crmcxau2cfn6XfT0dJk4og95ctor73/+8i2d2zYGFK05OtradGjdkH4jplOzSlmOnb5CeEQEi2aMwtrKHE8vX2YtWkdQSCg5HWyZOqY//UfOYOBf7SmQNxdHT13i+at3DB/QhWnzVuFkb8PFa3eIio5h7NCebNpxiKcv3zBu2F9UKFMMUFyfASP/wdvXn27tm9GwThXiExJYtGIrt+8/IYeBPlNH98Paypx2f42kaoVSXLh6BysLU+ZNG87uAyc5f/kWD5+8pHzpovzdvwv58jjh5vERl/x5Mu/JVxGRIAmCkG3I5XL2HjwOQKum9QE4fPwsgYHBdOnQUpWhZUk1m/UkLj7+lxxbQyrl7IG1P7z/C9e3zJ3yN5eu32XnvhNULFucTTsOUsQlL9PGDuDY6cscOHaWzm2b0LxBDfI55+TW3ces27qfEkULAnD8zBU2LJ2GtrYWADfuPKR86aIATJ27ks5tm1ClQkmWrN7O5p2H6NOtjfL8oWHhHD11ieO7VxAaFo6erk6y+Lx9/TE3M0419rDwSNYunsy85Zs4ce4q3do3Y9rclbRpXo8alcsQFByKRCL56uP38vFnzaLJzF26kfnLN7Nszliu3XzAjr3HlQmSRCJh0T8jCQkNp32v0VSrVJrTF66jqanBzrVzePDkJZt3HWbU4O64f/CibKki9Ozckq79x/P0+WvatWzA5Rv36NmxhfKaWVmY4unlKxIkQRCErOTh4+e8eedOTkd7ihd1wcPTi+79RhIfn4CBgR4tmtRTdYhCBilRpCAaGlLy5nYkMDgEgFv3nhATE8vhExdISJBRtmRhAHLkMGDd1n08e/kWb19/5TEa1KqsTI4AHj55ReO61YiIjOKduycVyiiSpTrVyzNnyfpkCVIOA31KFC3A9Hmr6NGxBSZGhsnii42NQypN/SO2bMnCSCQS8uV2xPWtOxGRUXh6+VK9UmkAjI1yfPPxlyruojhGHifU1NTQ1dEmn7MTgTtClNsUzJcbqVSKqYkRdjaWuH/w4tbdx7i+defO/SfI5eBgZwWAlqYmxQvnByBPTnsCg0JSPa+5mQmv37p/M77sQCRIgiBkG0nday2b1kMikWBva82caaMZOno6vQePI4eBAbWqV1RxlFnHz7TwZBapujrIFT/L5XKmjRtAbqdPXV0fvX35e8I8+nZrS6M6VekzfJryPjW1T8NwY2PjANDU1CAuLu6b55VIJMyeNJS7D54xdtoSenRsTrXEBCfp2DKZLNk5vqSuro5cDsjlIJGk2moUH5/w1TikUvVPP392LVLbTltLC7kcBvfuSKVyxb8eVxr3hYZFYGho8NWYsgsxSFsQhGxBJpOx75AiQWrRpK7y9m4dWzNp9CDi4uLp9Ncwbty+r6oQhe8lkSCTy9K9eenihdi57wQymYyIyChCwyJ44eqGg501VSqUxN3TK819Hz59SbFC+QDQ09PFyd6W67cfAnD6wnVKFS+kCAkJMpmckNAw3nt8pGSxgtSrWZH7j58nO56ZqTHBIWHpiltPTxczEyMuX78LKJI6AGPDHDx/9ZbY2DguXr2T7uuQxMvHH7lczlu3DwQEBmNva0np4i7sOXSKuLh44uLi02wpSmJpboqvf6Dyd29ff+ysLb47lqxIJEiCIGQLUdHRtGhSj1rVKlIwv3Oy+4b0787A3l2Iio6mTZeBPH72UkVRCt/DwswEqbqUW/eepGv7ru2bEhMTS/teoxk4aiaeXj6ULFqQyMhoug+cwKOnruhoaaW67/XbjyhXuojy94kjerNt91E69B6Nn38gXds1BRRJ2IFj54iOjmXpmh107DOGUxeu0aJRrWTHc3Kw4fU7j3Q/1okj+rDlvyN06jOWf9ftIjY2jtZN67Bxx0EGjPpHOQboe0RERtFr6BQmzFzGhOG9kUqlNGlQHXtbKzr2Gc1fQybzwvXdV49Rt0ZFlq7ZwcyFitbEd+8/YG9n/d2xZEWS2NiYtFrSBCA+Pp7KDbty+ejGNPuTBUH4/cnlcgaNmMKWnfupWbUCe7etUHVIwm9k7LTF/DNhcIYdz9vXnzWb9zJheO8MO6aqhUdEMmP+GmZOzLjr9DsTn/iCIPwRJBIJi2ZPwNbGij492qs6HOE34uMbgLmZSYYe08rCDJlMTnR0TLKB4FnZxWt3aFS3iqrDyDSiBekbRAuSIPz+bty+z5kLV/lfy0bkyeWU7v1iY+OIjIrCyPDbs4aE7MvN3ZP4BFmyOkYZIT4+Plt9biQkyJBI+OrA8+wk+zxzgiD8sbbs3M+2XQcxMszBgF5O6donIjKSLr2GExQcwsFda9DXE4Ul/1RODra/5LjZKTkCUFf/MxKjJH/WoxUEIduJiYnl8PFzSCQSWjSu++0dEsXGxOHp5c3dB0/o0GMIMTGxvzBKQRCyGpEgCYKQpZ25cJXQ0DAqlC2JjbVluvczNjZk37aVONjbcPHKTXoOGE38L6oaLQhC1iMSJEEQsrSkpUVaNv3UenT15n1u3Hn0zX2trSw4sH0VFuamHD5+liGjpiGXi2GZgiCIBEkQhCwsMiqKE6cvIpVKadqwNgABgcGMmryQoePmcOj4+W8eI1dOB/ZtW4mhoQFbdx1gwvQFvzpsQRCyAJEgCYKQZb15505kVDTFChfA1ESxMOi5y7dIkCmqL89ctC5dSVKhgnn5b9My9HR1vqubThCyoxNnryRbsy6r8fb159jpyz99HJEgCYKQZVmamzF3+hh6d/9U1+jU+esANKxdGYlEku4kqWypYty7coR+PTv+sniF7+Pl7UeHXqMBeP3WncWrtv7ycy5csQUf34AUt0+ZswL/gKAUt4+avJB7D5/90phu3n1Mpz5j+XvCPOVtCQkyZi9eT4deo5k061/i4hTj556+eEPnfuPo1GdsqhXIo2NiGTttMR16jWbRyq0pupRlMhknz13DIoPrQoGijtK0easA2LLrMLfuPk6xzc59J1i7Ze9Xj9NvxHS8vP3SvN/c1IRT568hk6V/mZrUiARJEIQsy8LclL+6/o/WzRsAig/UJ89dMcyhz+ghPRg7tOd3JUmWFmbKn2/dfcjBI6d/WezC98mTy4HBvX998urnH4ilhWmK2yeN7IuZqfEvP39q7GwsaVgneYHGy9fvEhIWzrbVs9DV0ebY6cvI5XJmLlrL5JF9mTf1b2YtWpciSdh/5AzWVuZsXTUTN3dPbn+RRN19+IxCBZx/ea2jTm0bU6Zk4V9ybHV1NQoXdObeo+ff3vgrsleRBkEQ/mhnLt4AoHqlMkilUhrVrQrAPwvXMnPROgCa1K/+zeN4efvSvF1vYmLj0NPTpVb1ir8uaCFd7j18xrY9x5g/bThrt+xFLoenL17j+tadsUN7UrFscSKjopm5cC2v3rzH2tKMqWMGoKujxbzlm3j12o3wiChGD+5OiaIFWbtlL5qaGly+fp82zepQu1p5PL18sbYyBxStFHWrV2T/0bNMHzeQgaNnsmHpNIwMDdh98BT/HTiJpYUpQUGhyhg37TzEwWPn8QsIxCiHAR3bNKJlk9osWrGV2/efkMNAn6mj+ynP8SXXN+9Zsno7QSGhmBgZMmvSEHR1tLG1tiBvbgdu3/+UzFy99YDihfMDUKxwfs5dvkm5UkXw8w8il5MdAFKpOm/eeeCc2zHZfm2b10MikVCscH6u3X6YLFF5/uotxQsrFu1NSJCxYsMurt18gJaWJhOG90ZHR5sF/27CxzcADQ0NZk0agrmpMf1GTKdmlbIcO32F8IgIFs0YhbWVOW/dPjBt3irkcjkmxoYYGymKsk6bt4qKZYtTo3IZ7j9+wdwlG9DR0UZHW4tiiec/e+kmO/cdJzQsggplijK4d0eWrN7O42euDJswl3o1K9Hlf01Yv20/p85fR1NDyri/e5EvjxNFC+Xj+cu3lCrm8sOvOdGCJAhClrX/8EmWrNjIew9PQLHqOkDt6uWV2zSqW/W7W5KsrSwYPugv4uPj6fTXMG7cvv9rHkAWYJGrVJr/Hj759A29Y8+haW43Z9Eq5XZbdu7HIlepn47rhetb5k75m2H9OrNz3wkANu04SBGXvOxaN5c61Stw4NhZpFIpzRvUYP3SaQzv34V1W/crj3H8zBWWzhpN7WqK18uNOw8pX7qo8v7Hz13ZsGwadjafxqW9fufB7oOnWL90KvOnDVcuI+LrH8h/B06yfc1s1i6egp2NJW2b1+PIyYtoamqwc+0c+vVoy+Zdh9N8TCbGhkwc2YetK2dibJSD81dupbltQGAwDomLxjraW+MfEIz/Z7cBONhZ4x8YnGI/x6T97KxTdBt+9PJTtqQePX0Jdw8vNq/8hyWzRmNva4VhDn0G/tWezSv+oXRxl2Tvp7DwSNYunkyp4oU4ce4qANPnr6JHxxZsXD6dMiVSthjFxsYxde5KJo/ux9rFk8n9WTXz3E52LJ09lm2rZnLh6h28vP0Y1Ks9ZqbGLJg2gi7/a8LNu495/c6D7atnMWvSEFZv2g2Apbkpnt6+aV6/9BAtSIIgZFk79xzm5NnLFCtSELkcXN+6Y2ZqTFGXfMm2+5GWpCH9uxMUHMqSlRtp02UgR/eso3DBfF/dR8g8JYoURENDSt7cjgQGhwBw694TReHQExdISJBRNrFlJEcOA9Zt3cezl2+TDT5uUKtysnXSHj55ReO61ZS/N29YA4lEkuy89x89p3ql0hjo6wFgZmIEgJ6uDmoSCZGRUQQFf2pVunX3Ma5v3blz/wlyOTjYWaX5mEyMDbl17wkbtx/g5Wu3ZMnOlyQSlN1nMpkMNTUJEgnI5Z+61ORyWYr4JUiQyRTjjmRyOWpqye/38QvAzFTxmG7ceUSLxrWQqqsrH6+GhpSw8AgWrdzKwycvkyU0ZUsWRiKRkC+3I65v3YmIiMQvIJhK5YoDYG1lhuvb98nO5+7pjZmJMXkTW7msLc0Jj4hI3N6cMxdvcOf+M2KiY/H2C0jR+nbz7mOev3xD1/7jAdDR0QbA3Mwk1bFk30MkSIIgZFkfE78h2lhbcPqConutVtWyqS6J8L1JkkQiYcq4IQQFh7Bl535adujL2SPbsLdN+0MrO/J9eydd221duzBd23X6X3M6/a/5z4SUjFRdHRLHGcvlcqaNG0Bup08f2h+9ffl7wjz6dmtLozpV6TN8mvK+z8fZxMbGAaCpqZHq/UniExKIjIpOcbuerg758+Zk1JRFAIwY2DUxJhjcu6MySfianfuO8/j5azq1aYSdjSURkVFpbmtmYoyHpzflSxfFIzHJMDM1xv2DN3K5HIlEgvsH7xTjpsxMjfHw9MLJwQaPD4r9PmeYQ5+wsAi0TDWRy+QpEqzzl2+x59Bp/urcksIFnbl260GK2NTV1ZHLIUEmJyoqmoQEWZrLlCQkJBAZlfrjHD9jKfmdc9KjY3MiI6OQpzboWi6nfauGtG5aJ9nNYeERGBkapHrc9BJdbIIgZFnePoqZLJYW5p+616qVT3P77+1uk0gkLJo9gYZ1q+PrF8CaDTszLnjh2yQSZPL0z0QqXbwQO/edQCaTEREZRWhYBC9cFS0xVSqUxN3TK819Hz59SbFC324hdMmXm1v3HhMTG0tYeAQent4AREfH4PnRlzWLJrFm0SRli0jp4i7sOXSKuLh44uLiCQwKSfPYdx48o16NiuTN7cTrdx5fjaNi2eLcf/QCgPuPXlChbDEszEywsjTjjdsHvH39kcvl5HK05d7DZyxZvT1xv2Lcf/QCuVzOgyeK/T5nY2WBj5+i5aVE0QIcPHaOhATF9QwKDuXuw+dUqVCSooXy8fqd+1djNNDXxcTYkAePFXG+ePUuxTYOdlb4+Qfh6eWLTCbj5etP29x79JzWTeuSw0CfD14+ytstzUzw9Q8EoHSJQhw6foGIiEhkMpnydm8ff2ytLb4a37eIFqTfUHy84k0UEBSCf2AwgYGJ/wcF4+MXgLuHJx+9fLGxtmD7mrnZbkFEQUiP2Ng4/PwDyWGgz0cvXzw8vbG1tqBA3lxf3e97W5LU1dUZN6I/drbWNKpfI+MegPBNFmYmSNWl3Lr3BGk6Fkrt2r4psxevp32v0ejqaDNiYFdKFi3I/iNn6T5wAhXLlkBHSyvVfa/ffkSrJrW+eY7CBZ2pUr4UnfqMxdHeGitLxXgdLS1NZHI5bXuMQEtLE3sbS9q1bECTBtV55+5Jxz6j0dHWpleXVlQoUyzVYzdrWIN/1+1k7+HTyRbQHTZ+Lu4fvAgKCaVz37HMmjSESuWKc/PuIzr0Gk3ePI7Ur6mYSDB2aE+mzVuJLEHO2KE9UVNTIygkDM+PPspzTJ2zko69x1C2VBFKFi2YLAYnBxvevPPAJX8emjWowbv3nnToPRoDfV2G9u1EvZoVmbNkPRev3UnRlf0liUTCmKE9mb14PQb6uhTMlzvFNjra2owa3J3BY2ZhbmqMo4ON8r4OrRrSa+gU8uS0x+6z+mQN61Zl/IylNK5Xjb86t+SF6zu6DZyItrYWrZvWoXHdqrxx88DR3ibF+b6HJDY2RtTV/4r4+HgqN+zK5aMbMzQR8fUP5NylWwQEBhMQFJz4fwgBgcEEBYeSkBCPVKqRGEMcHz98ICY2hvi4uGTHOX1oK6VTGfgmCNmdh6cXhcvWI2+enHTq0Ibte47RtV1Tendtna79j5y8yD8L1yKXyxkzpEe6ZrcJ2dfYaYv5Z8LgH97/zoOnXL5+l6F9O5OQIGPJ6q2oq0sZ1Kv9t3f+jURFRzNx5nLmTvlb1aH8lOET5zN97IBkY8y+l2h6UBE//0AW/LuJ6OgoYmNiiY2NUfyLiSUuLhZdXV2aNmmAqbEROQz0+GfOYuRyObq6Ojg52PLuvSdRUVHce/hUJEjCH8krcfyRtaU5Z5LGH1Url+79f7QEgJD9+PgGYP6ThRFzOtiyY+9xOvcbR0xMLHly2jNiYLdUt521eB3PXrxJdlv9WpVo17LBT8WQEXS0tbG3tcbL2y/NcgS/Oy9vPxztrX8qOQKRIKmMrbUlFUsXYcOWlGMatLQ0yZ3TnuVzxikHyFWvWBIHe1vMzUyQSCR06zeGy9fv8JOFQgUhy9LW1qJx/ZqYm5ly/d5zcjnZJRucmx7fkySFhIaxct02/AOCmDt9zM8FL/xWoqKjaVyv2k8dw9TEiPnThqdr29GDe/zUuX61ft3bZOmhG9ZW5vTt1uanj5N1r0AWZ2RowJB+nXF3dyd3LkfyJP7LncsROxsr1NXVk21fqkSRZL/Xr1ONF288kH8xw0AQ/hRFXPKzZc0C5i7bCPeeU7tq2oOzvya9SZKmhgaLlm8gLj6e8SMHYJjj52bICL+Pz8f7CGTp5ChJRjyGrH8VsjBHe1v2blvxQ/smlcL39sm6CwoKws+KT0jg/CVFMb3v6V77UnqSJB0dbapWLsuJ0xc5e+EqLZrU++HzCYLw+xPT/LMoQwN9goODuHbjtqpDEQSVePjkOSfPXCYgKJjcOe2TVTv+EekpAVC/liKROnH64k+dSxCE359oQcqizEyN8PL8gL+vz7c3FoRsaMK0BVy6egunnLl/ut5Jkm+1JNWtpVgw9NS5K8THx2eLrghBEFInWpCyKFtrS6RSKXFxcQQFp114TBCyq6RZbFINKeamPzcD6XNfa0mysjSneFEXgkNCuXnnYYadUxCE30+2SpAOHDtHh96j6T1sKr5+AWz97wjNOw1m4Yotym02bj+Ip9fPLWD3O5BIJOjrKdbGefDo+Te2FoTsx8vbF4kEpFINLMyNv73Dd/haklQvsRVJdLMJQvaWbdqHA4NC2LLrMNtWzeLyjXssW7sDNw8v/ls/n78nzMPHNwBdXW1CwyMyrDle1UxMjAgOCeHRs5dUr/LjA1QFIasJC48gPCISPV1dJBJJhrYgJUmru61Fk3oYGxlSv061DD+nIAi/j2yTIN28+5i8uZ3Q1taiWOH8TJy5nKoVS6GhISV3Tjt8/QO59+g5LRt/u5R8VmFlacHbd+95+eqtqkMRhEyV1L2mnbhyt8VPFvlLy5dJkpWlOWVKFMI5t9MvOZ8gCL+PbJMgBQQG42BnBYCZiRGamhq8e/+B4JAwnr98S7MGNQgJDefNOw+Wr91BudJFaZJGYbA9h06z9/BpQLE69O/K0cGOazdu897DU9WhCEKm8vJJHH+UOEjawvzXJEigSJL8A4JZtWk3Zy5ep0yJQr/sXIIg/D6yzxgkSfJkRl1NjdZN69J3+DTKlSrKpWt3aVq/Glt3H2HK6P5cuHKboODQVA/VqkltdqyZw441c9i6cmZmPYLv5lIgDzq6umhqaqo6FEHIVBERURgaGgCKQqnmphk7BulLNauWBeDO/WcA+Pj603vwOLr0Tl/lZEEQsp5skyCZmxrj7ukNgF9AEBoaGspEp3XT2gSFhKGnq4OpsREaGlIc7a2z/GDtyuVL45QzNw4ODqoORRAyVYM61Xh1/xzGpuYY6Ov99JpL32JnY4mluSlePn54evmSw0CfQ0fPcPTkeYJDUv+iJQhC1pZtEqQyJQrj+uY90dEx3H/0ggpliinv23/0HM0b1sDAQA+Pj97ExMbi+tYdM1MjlcWbEawszADw9g1QcSSCkPn8A4IVA7TNfm3rEShmjZYqVhCAuw+eoqOjTbUq5YiPj+fshau//PyCIGS+bJMgGRvloGv7ZvQYPIn9R87Qr0dbACIiowgMDsXe1gotTU3qVC9Pm27Dyelgq0wwsipTUyPkCQm8efeekNAwVYcjCJkmLi4OX/9A4NcN0P5SqeIuANx58BSAhnUVBSRXrd/xW49VFAThx0hiY2PEO/sr4uPjqdywK5ePbvwtq+bmKlqdwIBAtq5bSKO6NVQdjiBkitpNOvHk+Susbe1p1bQuY4f+9cvP6RcQRJP2AzE2ysHRncuJjY2jVNWmeHz4yJY1C2hcv+Yvj0EQhMyTbVqQ/lSmxoruhafPXFUciSBkHi8fP6KiolFXl2ZaC5K5qTGO9jYEBYfy9v0HtLQ0GT+iPwBTZy0hPj4+U+IQBCFziAQpi7OxVizQ+dL1nYojEYTMIZPJ8PbxQ11dHXV19UxLkABKFUvsZruv6GZr3bwBhV3yERMbi7vHx0yLQxCEX08kSFmck4MdgKiFJPwxAgKDiI+PR09XJ3GQdiYmSMUVA7WTxiGpqamxde1Cbl84SK6cYjapIGQnv9+gGuG75HV2AsDL20e1gQhCJvmYWEVbI7H+V2YmSCWKFEQikXD/0QviExKQqqvjaG+baecXBCHziBakLM6lQF5A8a1aEP4EScuMqKmpA7++SOTnchjokS+PExGRUSm6td+5edBnyHh8/UTZDUHIDkSClMU52dsilUpRk6gRERmp6nAE4Zfz9vYDQCaTo6WlSQ4DvUw9f9I4pNuJ45CSzFm8mp17DjNn0apMjUcQhF9DJEhZnKWFCXny5qdo8eLo6eqqOhxB+OVaNK3HgZ2rMTIxxcLMBIlEkqnn/7IeUpIxf/dFU1ODjdv28vqtW6bGJAhCxhMJUhano62NsVEOQkLDiYqOVnU4QjYSHBzK9DnLOH76gqpDSSaHgT7mZmZoampmavdakqIueZFK1Xn81JXomFjl7Q52NvTq1o74+HgWLd+Q6XEJgpCxRIKUDVhZmCGXy3F7L2ayCRnj0LEzlK3RnHlL1jBuynxVh5OCX1IVbfPMG6CdRFtbi0IFnImNi+PJ8+T1x7p1aAXA7XuPMj0uQRAylkiQsoHIyHBePn/KlFlLVB2KkMVFRUXT6a9hdO71Nz6+/gC4uX8gNjZOxZF90mvQWCbPXEh8fLxKWpAgZT2kJDmd7NHX08X1jRuRUVGqCE0QhAwiEqRswNbaCrlcjruohST8JG1tLWJjYzE1MWbtslm4FMiLTCbDzf2DqkNTOnvhGg8ePkVNTS1Tp/h/Lq1xSGpqahQqqLhmorq9IGRtog5SNpDXOScA3j5+Ko5EyOokEgmL50xCQ0OKqYkxBgZ6qEnUsLayUHVoAMTExBIQGISmpiZqamoq6WIDcMmXC10dbZ6/ekt4RCT6ep8mSAwf1Iv4hHjl+1IQhKxJJEjZQL7cTkgkEoKCQ4iLi0NDQ0PVIQlZzIPHz4mPi6OwS36sLM2Vt9etWUWFUaXk7av4EqCjrQ1kbg2kz0mlUooVzse1Ww+5//gFlcuVUN5Xq3pFlcQkCELGEl1s2YC1lTmamprI5XI+eHqrOhwhC1qwdC21mnTi5NlLqg7lq5JaSdWliu92mbkO25eSxiFdvXFfZTEIgvDrqDxBCg4JIyFBpuowsjRLc1Plsgu/01gRIeu49+AJAKWKF052u59/AKMmzmbi9IWqCCuFpCrackBdTQ1jI0OVxVKjclnU1CScvnCdiMjkA7Knz1lGq479iIv7fQa3C4LwfTK9i83XL4Dte4/z6OkrIiKj0NfTJTwiEg0NKU72NrRuVpeiLnkzO6wszcjQAB0dHcLDwnj9zp3qVcqrOiQhC/H28ePDR29srCywsbZMdp9UXcqq9duxsjRn6vihKorwE6/EKtpqauqYmRqjrq6673iWFqZULFOcyzfucfLcNVo0qqm87+TZSzx++pJXr91wKeCsshgFQfhxmZogrd+2nyfPX9O8UU36dGuDtpam8r6EBBlv3DzYe+g0m3ceZPbkYUjV1TMzvCxLIpFQsEB+PHIYUbdmZVWHI2Qxd+4/BqBEsUIp7jM2NsTE2AhvHz/CwiMw0M/cZT2+VLF8SYb0687+YxcwN1PN+KPPNW9Uk8s37nHg6FmaN6yhrOpdpFB+Hj99yaOnL0SCJAhZVKZ+/fpfi/osmD6CyuVKJEuOANTV1cib25ExQ3sybexAkRx9p5yOdmhpaREYFKrqUIQs5m5igvRl91qSPLkcAXjzzj3TYkpLEZf81KlVFV09PZVN8f9cmRKFsbY0x/WtO0+ev1beXsQlPwCPn75QVWiCIPykTG1B0tXRTvb7qzfvWbRyC/HxCURHx9CzU0uqVCiZYjvh26wszADwTizuJwjpldSCVDIxQZLJZDx/9ZbL1+9x+/5TJGqK71Fv3rpRrHABlcWZxDepivZvkCCpq6vRrGF1Vqz/j/1Hz1K4oKK1qEghRYL06IlIkAQhq1LpNP9tu48yd8rf6OnqEBIaTo9BE6lSoaQqQ8qyLMxM8HjvxohxM6hb41imL+ApZF2mJsaYmhgjk8OsReu4cvMeAYEhyvujIsIAeP32vapCVFqyYiN3Hz5HJpOpbIr/lxrVqcqazXs5e/Emg3t3xDCHPoUK5gPg8bOXyOXyn3o/rlq/nWs377Fk7iQMcxhkVNiCIHxDpo9w/GfhGjy9FDNRchjoce7yLV6/8+Dc5Zvizf8TrK3MiY6OxuPDRwKDglUdjpCFbFw5l0P/rWX01MUcPH6egMAQcue0p2u7pujp6hAXr5hlquouNrlczqwFKzh09CQSiURlRSK/ZGJsSLWKpYmNi+PYaUWZBAN9PXI5ORASEsb7n6xwb2JsxMGjpxk9aU5GhCsIQjplegtSv+7/Y9POg0jVpXT5XxPOX7nN3kOnsTA3Ye7UYZkdTrZhZalY3Tw+Pg7XN26Ymvwe366FrOFR4rIYVSqUZFCvDthaKypn37z7iKDgENq3aUq9WqotGhkaFk5kVDQ6OjpIJJLfpgUJoHnDGpy5eIP9R8/xvxb1kUgkDO7blQRZAjkM9L/7eDKZDLXErs0KZUsilUrZsfsQDepUo3H9mt/YWxCEjJDpLUhGhgYM7t2RhnUqs3zdTmQyGX8P6EK39s0wUWFNk6zOytwUHV3FcgeXrt5ScTRCVvHo6Qs+evnw/OVbAGpXLa9MjgDsbCzR1NSkbasmNGlQS1VhEhEZyelzVwDQTKz59bu0IAEUL1IAR3sbPDy9ufvwGQBdOrSke6c2mBgbfdexoqNj6NBzKMvXbAHA1saS5fOnADB09DT8/AMyNHZBEFKnkiIiT1+85vU7D9q3bICTgy3jZyzlwtXbqggl2zA3M8bAQNFFeebCVRVHI2QV/YZOpGDpOty+pxioXSBfrmT329oo6iJ98PTJ9NiSzFm0CseClek5YDQAaokzXM1+o1ZSiURC84Y1ANh/5OwPHyc8IpI2XQZw/NQFlq/aTGhYOABtWjSkSYNa+AcEMXjUNORyeYbELQhC2jI9QZq5cC279p/EPyCYVZv28ODxC2aMG0RQcChjpy/J7HCyDalUioO9HWpqaty595jgYDHdX/i6iMhInr1wRVdXh6CQMHIY6GNjZZ5sG7vEBOnmnQcsW72ZN5kwUDshIYHgkE+vXxtrSzSkUiqVL8WQft0wNbPA2DAHmpq/15qD9WtVRktLk4vX7uIfEERCQgIr121L99ih4OBQmrfrzaWrt3B0sOXYvg3K7jmJRMKCmeOwMDfl2Mnz7Nhz+Fc+FEEQUEGCdOfBU6aO6c//WtRjyuh+XLx6B3V1NZo3rMm4oT0zO5xsxdrKHF09PWQyGReu3FB1OMJv7uHjF8hkMvLkUix2XCBvzhSzrexsrAC4cese46fO5/rtX7vuWHx8PH0Gj6dxm54EBSlm0rVqWp/3z65wZPc6unVqg4aGBubmv0/rUZIcBnrUqlqOhIQEjpy8hLq6OguXr2flum34BwR+dV9fvwAatu7B7XuPyJ83F8f3bsDJwS7ZNmamJiyeMxELc1PMTX+f7kVByK4yPUEqXqQAk2b9y679J5g0618ql/+0Craenm5mh5OtOOdyxMzMgr8H9aZh3eqqDkf4hTKiiyWpQKS5mSkA+Z1zptjGPrEFSZZ4ul/ZghQXF0eP/qPZfeAYnh998PJRzHbV1tZSthb5BQQpYv5NE4SGdRQD2a/feQh8Khj5tXpI3j5+1G/RlafPX1GsSEGO7lmfYsmXJPVrV+P+1SPUrlEpgyMXBOFLmZ4gjf+7F62a1MbU2Ii/Orekb/e2mR1CtlW6hAs6uroEh0WiofF7dT8IGScqKppyNVowYdoC5HI5cXFxnL90/buTpqQCkepSxaDnL8cfARgb5UBXR5uYuHjg19VCiomJpUufERw8ehpzMxOO7F5Lwfwpl+jw9ft9ikSmpoBzTtTUJLi+eU9CgkxZMPLx05dp7mNibEROR3vKly3BoV1rvjkDVU9XfJEUhMyQqQnShu0HOHnuGgXy5aJWtXLky+OUYptHT18xY8Ea4hMSMjO0bKFEkQKoqUm4/+g58fHxYiBnOty++4i9B49nqWt16twVXrq+5eGT50gkEjZs3UPz9n1o1q43j5+l/UH8paQWpLCISEDx4f4liUSCrY0lmhqKJOpXtCBFR8fQudcwjp08j5WlOUf3rE81OYLPWpB+g3XYUqOtrYWTgy1R0TF4eHp9akFKZcmRpNecpqYGm9fMZ+/Wf9NdEuDG7ft07DmUleu2ZVzwgiAkk6l1kNo0q8vew6fpPmACTg622FpbYGFuQkhIOJ7evrx1+0CenPZ0bttYrMX2Awz09SiQNxc3bt+nXI2WdO3YkgG9Oqs6rN9ar0Fjeffeg3fvPzB80F+qDidd9hw4BkCrZvUBMDUxwsrSnItXblKlblvat2nCuOH90+ymAcVsKQMDPawtzQkKCcfM1CjNtc3sbCx59doNdXV13ri5J6vRkxHmL13LybOXsbW25NCuNeROXPstNb/TMiNpyZfHibduH3j52o3CLoqK2l92sd2++4gpsxazdc1CjIxyoKuj813nCA+P5MiJc8TFxdGnR4cMi10QhE8ytQVJT1eHzm2bsG7JVDr/rwnOuR2JiIzC3NyYpvWrs3jmKMYM7Ym9rVVmhpWtlC5RCAnw+q0bZ86L6f5fI5PJePfeA4DY2DgVR5M+IaFhnDp3GU1NDZrUV9Qlatm0PncvH2L0sL7oaGuxbddBSlVpwj/z/iU8sXXoS/p6ulw/u4+VS2YmDtDOleZyGHY2lkgkEsxMjYmJieXDR+8MfUzmZibYWluybf3iryZHAH6JXWy/w0K1aUkay/XC9R1OjnYY6Ovx+u175XNx8cpNmrXrxZXrd9i4bc8PnaNYEcWaePcfPctSrZ+CkJWoZC02DQ0peXLakyenvSpOn62VLl4IXT191NTUuHbzLhGRkWLMQhp8/T4V3Bs7vF+mn9/zow9Pnr+kTo3K6V6r68iJc8TExNKwbnWMjHIob9fT1WX0sD507dCSGXOXs3XXAeYvXUvLpvXI55xybFGS1+8UCWL+r2yT9IXF3s6O0iWKEJ84Himj9OrWjh6d26CejlbjpC42i9+0iw1QDh144eqGmpoa3Tu1RkNDg7jYOI5dvUC3viOIiYmlT48ODOrb9YfOYWZqgr2dDR4fPvLRy1dZr0oQhIyjkkKRwq9TuIAzujo66OjqEhsbx9Xrd1Ud0m/LM7ElpFL5Usrbnj535aXr20w5f+M2PWnbZeB3rdX1Zffal6wszVk6bzKXT/7HnGmjlclRXFwcF6/eVG7n+saN2Ng4nr96B0DBVAZoJ0mqhVSoUEG2rl1IrpwO6Y43vdKTHMGnLrbfuQXJObcjEomEV2/ckMlkTBk3lPEjB3DmwlU6/TWMmJhYRg7pzczJI36qq7JEURcA7j18klGhC4LwGZEgZTMaGlKKF8mPnp5isKeoqp22Dx8V1aFtE2v9PH3uSv0WXWnVqT/ePn6/9Ny79x/jrZti8devTQH/XFh4BLfuPERfT5e631gXrVDBvPTo3Eb5++Yd+2nathctOvTh8bOX1GjYHseClXjyXLEGW2pT/JMkJUhJ1yujvHR9y+hJc3B945au7ePi4gkKDkVXVxs93e8bs5OZdHW0cbS3JjIyWnnNNm/fR69BY0lISGD6xL8ZO7xfulsN01K8SEEAHjx69tMxC4KQkkiQsqHSJQqhr69YduSsSJDSFBsbi4W5KfZ21gDkzeNEyeKF8PjwkbZdBxIdHfPLzn3zzgPlz6nNcEqNgb4ez+6c5r/Ny797UK9hDgMsLcw4d/E6leu0ISw8Ans7a0JCw7GyNMP4s+66L5mZGKGlpYmXtx8PHz/n2s1733XutKzdtIuV67axbdeBdG3vHxiMXC7/rQdoJ0nqZnv52o34+HjU1NXImycni2dPzLCJE8UTW5DuP3qaIccTBCE5lSVIh09epHH7gVSs34mK9TtRoZ7if+HnlS5eCE0tLbS1tXnzzj3DB9VmF62bN2DePxPQ0TUgIUGGhoYGm1bNp2C+PDx8/Jw9B4//snO/c/NQ/vw4nS1IoEh0KpQtgYenN0dPXUp3EteqWX3uXj7MiMG90NHWBsDJUTEGMLXp/Z+TSCTY2VgSExtL1fr/o9+wCemONy3hEZHs2nsEiURC146tvrptfEICF67eZtq8lcDvWyTyc/k+G6itrq5OaFg4/0waTpcOLTPsHMWKFGTquKGMHNI7w44pCMInKhmkDbBi3S7GDOtJ4QLOSKViSn9Gyu1kh6mJEVGRNmxZNVO5XISQ0pot+/APCKKoSz5qVStHDgN9xgzvR6e/hrFhy246tm32S87r5v5B+XN6utiS1tZLGpg9adZynr96x9otexncuyNVK5b6ZpeNvp4u40b0p1vHVhw+fpbQ8Gg8jp6jQN60xx8lsbOx5PVbd7S0NHH3+EhMTCxaWprf3C8te/YfIzQsnDo1KqdYUiOJf0AQB49f4ODxc/j5KwZnG+jr0SxxUdjfWVKX5UtXNyQSCf16dvzhY0VERPLkxRvU1CRoSKVIpVI0pOoYGxv+8CBvQRC+TWUJUk5HWyqXK/HtDYXvJpFIKF3chcCgEDw8fZXF6oTkAgKC8E+cFbVx50FqVCmDmpoa9WtXxdrSnLsPnvDg8XOKFS6QoedNSEjA/cNHNDU1MDLMgZePH37+AcolP1KzdvMu5ixaxZypo6lds4pycLW3bwBjpi2mbMnCDO3bCUd7m2+e38bakt7d2zN4zCwg9QraX0qa6m9hbobHh4+4uX/46uy4r5HL5azb8h8A3Tu3TnWbk+euMn3+auLjFQVjC+TNRcvGtahZtRzaP5GYZZa8uRQD2V++dkMul//weCP3D14MHjMLb9+AVO/fsGzaV8ePCYLw41TWxdawThXWb9vP67fuyf4JGaN08UIA3L7/hPj4eBJEZfIUytdqyYtnT0hISODNOw+u3lQsxCqVSuncXtEVsv2/gxl+3o/evsTFxeNob0uJYoXI55wLnzQ+AEGRUOw5cIzY2Djy58vNhSu3AWjaoDqTR/XDzMSIm3cf07HPGP5dt5PIqOhvxiCXy5VJVmoV7b+UNFA7qdLzzyw5cufeYx4/fYm9nQ21q6dcU+zE2StMnbuS+PgEGtSuzLolU1i/dCoN61TJEskRKNaVdLCzIjwiEk8v3x86huub9/T5exrevgHky+NElQolqVCmGGVKFFKWXth36BQjJ8xi3eb/MjJ8QRBQYQvS2i37ADhy8pLyNokE9m5aqKqQspXSxRUDOPceOMb6TdvYuGIuNapWUHFUv4+4uDj8/AORSCRoa2sRFxfPhu0HqVSuhGJcTIeW5M7pQJMGtTL83Enjj3I62rN93aJvTvV++tyVF6/eYm9nQ5mSRVm3TZG01ahUhjIlC1OpXHE2bD/Azn0n2PLfEU6cu8rAv9pTq2q5NFsuPL18CQuPwMHOCgN9vW/GnJQgaWj+/JIjm3co3vvdOrZKMb3/xNkrTJu3CplMzvABXWjZuPYPn0fV8uVxwv2DNy9fuymvX3o9evqK4RPnERYeSY3KZZg8qh8aGp/+XN+484ih4+bw6OlLTpw6S+UKpZPNWhQE4eepLEHasXY2WppZ49tgVmRhboqjvQ33H/gTGhrO7IWrqF6l/E9PLc4uvHz8kMvlaGhqUqtqOR48fsnzV2+5fe8JZUoWxtrKgjYtGv6SczvY2zBl7BDsbK3SVQdHWfuoaT38A4J48vw1Bvp6lCiq6PrT09VhQM92NKpThfnLN3PnwVMmzlzOgaPnGNa/M7mdUhZkff5KUevpawUiP5f0AZ8gU1Rt/pkWpJlTRlKyWCEa1K2e7PbslBwB5MuTk9MXbvDS9R01q5RN93637j5m1JRFRMfE0LheVUYN6oG6evLXSeECeVBTk+DtH4REIuHh4+cZvgSMIPzpVPZu6jd8hqpO/ccoU6IQRsYmmJoYc/POAw4dO6vqkH4bHzwVM/s0pBrYWJnTsU0jQDEW6UueH30ydDkHJwc7BvfrRsumimKPsbFxPH/5OtVt5XI5+w6fBBRLily8pij8WaV8CaTS5N9vnBxsWTJrNDPGD8LS3JR7j57Tpe84Fq3cmmLJkaTutfQM0AbF2meaGhpERsWip/dzldn19XTp2rEVFuafxlx9nhyNGNA1yydH8PmSI27p3ufCldsMnzSf6JgY2rVswJghPVMkR6Dowsud04GYmDicHOwIDQtX1tUSBCFjqCxByu/spBzzIfwapYu7oKamRuFCiu62yf8syjJrjv1qSVW0pRoaWJib0rBOZcxMjLj/6AUPn7xUbjdywiwKl6vH9Vu/5rUql8spWLo2FWq1SnXdtEdPX+Du8ZE8uRxxKeDM+Su3AKhWqUyqx5NIJNSoXIYda2fTtV1T1NTV2LX/BG17jODY6cvIZDLgUwtSgbzpG+CrpqaGjbU5Gppa3LpwgCVzJ333Y5XJZPj5pxxrdf32w2TJUYvGGd+tqQp58yjWlUsaqP0tR09dYtyMJcTFxdO7S2sG/tXuqy2+RV3yAmBpaQ7A/YeiYKQgZCSVJUhBwaGMmrKIjn3G0KX/OOU/IeMUL1IAdTU1gsOiKF7EhXfvPVi/RQzmhE8JkoaGBpbmpmhpatK+taJLbeOOT61I9rbWyGQy1mfgINhV67ezYetuIiIjkUgk5M2TC7lczpNnL1Ns6+Pjj621JQ3rVicoJJSHT16iq6tNmRKFvnoOHW1tendtzbZVsyhfuiiBQSFMm7eKPn9P44XrO169dkNNTaL8EE+PpJlsnh9/bNDx+UvXKVi6DtPnLEt2+/ptB5DJ5Az8q322SY5AUZLA1tqC0LBwvH38v7rtrv0nmD5/NTKZnGH9OtO1fdNvdocXSUyQNDW1ALj3UBSMFISMpLIxSK2a1qFV0zqqOv0fQV9Pl4L5c/P4mSv/a16P+4+eMnvhKv7XqjFGhmlXTv4TJE+QFIUHmzWozuadh7hx5xHPX72lQN5ctG/ThOlzl3Hw2Glm+o/46lT89Jq9cBWBQcE8c3WncEFnihTKz7Wbd3n05AXlShdPtm2dmpV5cusk0dExnDx/DZlMTsUyxdHU1EjXuextrZg/bThXbtxj0cqtPH7mSrcBikKPuZzslEUj0+PzJUecczkQnxD/Xddj3ZbdxMXFY2lhprzthes7njx3xczEiDbNst/fg/zOOfH08uXlazesrcxT3C+Xy1m/bT9rt+xDXU2NscP+okHtyuk6dlILUki4ouXxgaioLQgZSmUtSCWKFEj1n5Cx6tVUTKPefegslSqUpk+P9un+cM3OJo0dQrHixdE3yKFc+FRHW5u2zeoBsGnnIQBMTYxp2rA2cXHxbNv181P+Q0LDCAwKxsTYiCs37rN552EKF1R80KVVMFIikaCjo62c3l+9UunvOqdEIqFy+ZJsWz2bnp1aKJ9/l/y5v+s4SQnSvkMnyFm4CivWbkv3vh6eXpw4fRE9XR3atmykvH3PodMANGtYM8WYquwgqYTCC9d3Ke6TyWQsXrWNtVv2oaEhZcaEQelOjkAxEcPK0ozomHg6tm1Or27tMipsQRBQYQtS/xEzUm1CXjZn7A8d7/SF6+zaf4KQ0HA6tG5IswY18AsIYvjEecTGxjFj3CByOdkRFh7Bhu0HGdSr/c8+hCyhecMaREZGsXzdTgJCErCzs/+uVoPsSlNDg5jYeIwMcyRb+LRlk1ps3X2Ei1fv4Ob+EScHG7p3as1/+46yYdseBvXt+lMzhZIqaCcNUI6IjMLcXNGy8OWabLfvPkJfX5f8eXMTFh7JnQfP0NLSpFzpIj90bm0tTXp0bEGDWpU5ffE69Wul/8MY+Kwiu+J9e/dB+leR37R9LzKZjDYtGiprKYWEhnH6/HWkUnWaNaj+jSNkTZ8vOfK5+IQEZi1cy9HTl9HR1mL25KHK2mXfo6hLXrx9/GncsDZ1a1TMkJgFQVBQWQtS2+b1aNOsrvKfkaEBjetV/aFjJSTIcP/gxb9zx7N28WSWrtlOaFgEh45foF2L+owa1J2d+xXrau09fIaW2Wicw7dIJBI6tmnEhOG9UVdTY9naHSxZvY3g4BBVh6ZSvv6BAFiYJ1/Xy0Bfjyb1FR/Wh05cAKBsqWIUzO/Me3dP9h06+VPndXvvCUCOHJ+6OKNj4tDS0uT5y9fJBtGPnzaf8jVbcuX6HS7fuEtCQgLlShX56QTX2sqczm2bYG5q/F37JbUgxcbLkEgk3H/4VDno+2tiY+PYsmM/AN0/q9Vz+MRFYuPiqF6pDKYmRt8VS1aRL3GM16vX75UDtWNj45gwYxlHT1/GQF+XJbPG/FByBFAksfXx4ZNXGROwIAhKKkuQqlQomezfxBF9OHT8wg8dS11djR4dFV0HhjkMsLG0IDgkFL+AQPLkdMA5lwO+foGER0QSGhaBrbVFxj6YLKBB7crMnfo32lpaLF+9BediNbhz77Gqw1KJqKhomrTpgecHdyzNU46haVKvGgAnzlwhLi4eiUTCiMF/YWNlkWxq+o94n9iCpK2tpbzt5Rs3CuTLg7aWFh4fPgLg4+vPrbsPyZHDgLKliv1w91pGsrQwRV1dHR+/QPI55yI0LBzXN27f3O/oyXP4+PpTpmRRChfMByi+1Ow9cgaAVk2y/pT+tBjmMMDa0pygkFB8/QKJio5mxKT5XLh6GxNjQ/6dO55CBfL88PGLFFJcz5t3H7L43w1s2bk/o0IXhD/eb1NVzM3jI6/feXx7w2/wDwgiLDwCW2tLbKzMefDkJfcfv8TW2oJ9R87QoFYlZi1ax9S5KwkM+rNaUcqXLsqyOWPR0JASFx/P4pWbVB2SSnh6efPWzYOYmJgULUgATg42FHHJS1BIKFdu3AOgeeO63Lp4kCoVU59en15JXWwSyae33vOXb9i79V/eP7tC7lyKFodjp84jl8upV7MycfHx3Lr7BKlUnYpli6d63MwgVVfHxsqc2Lg4CuZ3BtLXzRYfn4CttSXdO31ad+3arft4+/jjnNuRwgWdf1nMv4P8zk4A3Hn4lMFjZnPr3hOsLM1YOX8CeRLXbPtRuRxt0dfT5e07Dyb9s4hN2/ZmQMSCIIAKxyDVadmLpLEMCQkJxMbF0bVds3Ttu3H7Qa7feZjstmlj+mNuZsKS1dvp1r4Z6upqNK1fnQn/LCcqOoaRA7ty/OxVbj94SrHC+bCyMGPzrsMM6ZNyle09h06z97Bi8GhGFgj8Hbjkz03jetVZuXYLHzy9VB2OSnh+9AEURSJTa0ECRSvSo6evOHzyItUrK5Ii/cQCiXK5nJeub8mf9/sGOQPkc85F9SrliI3/9LpyfeuOvr5esrFNR0+cB6BhvZpcv/WQ2Lg4KpQpqoxBVexsLPHw9MbeTrEo7r0HT2jfuslX92ndvAHNG9dJ9l5KGpzdqkntbF/dPW8eJ85fuc3MhetISEjA0d6GJTNH/XRrJCjqUxVxcebKjXCkUnUeP3tJXFwcGhpiIoYg/CyVJUib/v1H+bNEAkaGOdK9EGXX9k3p2r5pitu37T6KhoaUJvWrAYrm7SWzRgOwZddhWjSqydbdRyhdvA7WFqbJ6t18rlWT2spm//j4eCo37Podj+z35+RgC/DHtaAl+ZCsSGTKFiSAGlXKsGDFZm7ceYSPbwCWFooPM7lcTp8h49l78ASnD26meFGX7zp37+7t6dWtHTWa9kRNTUK+PDl5/uotrm/cKVQgD6Fh4cjlci5evYmWliY1q1Vg5sK1QNrFITNT0jgkExPF+CVPL5907ff5DDU394/cuvcEA3096lQrn/FB/maSKmonJCSQL48TC2eMxNgo48psFC6Yl2u3HmJpYY7nR2+ev3pDEZf8GXZ8QfhTqayL7dDx81hbmmFtaYaVhRnaWposWZX+acNfunzjHpeu32XkoG4pvpFGREYRFBKGnY0lZiZGvHz9jpev3TD7zkGq2UXS2lwhoWEqjkQ1Pq+BZGGWeoKko61N7WrlkcvlHD39+YLKEnI62hMfH0/PAaNTrX79LUEhoUTHxGBhbkrRQolT/J+9olDZeriUrsOps5eJi4unepXyaGhIuX77IWpqEiqXK/EDjzZjJa0ij0Sd1w/Ps2P94jS3jYiMZMK0Bbx6nXwG177EsUeN61VNNhYruypcIA/mZsaULl6IZXPGZmhyBFA0cRySjo6idfGBqKgtCBlCZQnStdsPkv3u5ePP2Us3f+hY0dExTJq5nJDQcP4aMoXOfceyY+8x5f37j56lecMaADSpX51d+04wZ+lG/tei/g/Hn5XlyaP4RhsZ+f0f7tmBsotNI+0uNvg0WPvwyYvJZmsNH9STsqWK8eadO2Mnz033eUNCwzh38Rr3HigK+tlYmlMwn6Kb7qWrGzraWoSFRxAUHEKl8qVo2rA29x4+Jyo6hiIu+TAyNPjeh5rhklqQvHz8MDNNPblMsvfACZau2pTsGkVERnH09CUkEgktGv0Zs0n19HTZv3kxi2eO+iVdpAXy5kIqVSc6cQbkk+diRpsgZIRM72Jr0XkoEokiIapYvxNyuaKLzdLcjNY/WElXW1uLcwfXpXl/x9afCtNZmJmwecU/aW77J7BPXEU+NjaW+Pj4bFmg72s+tSBpptmCBIoPntw57XnzzoM7959SpmRhQNFdtGrJDKrUbcvmHfuoWa0iTRt++8P+weNntOjQlxLFCgESrK3MlcUan718Q5FC+XF944aFuSlHditez3OXbgD4LVqPIHk1bVB0G4WFR6SozC6Xy1m7eReQfGr/ibNXiIyMpmLZ4n/UbNLUFpzNKNpamuR3zsWtu6EAPH3u+svOJQh/kkxvQdq3eSF7Ny2kTIlCXD2+hWsntnD1+Bb2bV6YLJERfh2pujr58+fHMWcuoqJjVB1OpuvTowOWVtaYmZl8tYtHIpEka0X6nJODHfNmKIqaDh45Rdkq9TXvE2sg6enpAWBrbYG1pTlGhgZ8+OhD3sSWvaSK2nK5nCs3FIvkVi7/eyRI1pZmqKur4+HpzblL13ByqczwsSm/cNy9/5hHT15gZ2tN3ZqKgpRyuTzZ4Gwh4xRxcUZLS5tiRVxoULeaqsMRhGxBZV1si/4ZRVBwaKol+IVfL0/unOjq6hEc8ueNQ3LOkxMTUzNslZWh01a3RkU0NTS4eO1OijFbbVo0pHWzBgSHhLL/yLcLSCZN8U+aYWRjZY5EIqFgvlwA6OsrutAWLFtHdHQMr968x9c/EAc7609jf1RMKpWSJ6c9sbFxSCTqhIVHpDrVf92W3QB07dASdXV1AO4+fIab+0fsba2+udiu8H2KuuRDXV2dsmVK0/+vTqoORxCyBZUlSEdOXqTv8OmMm74EAC9vP6bOXamqcP44SZWLAwKDVRqHKiRV0bZMYwbb5wxz6FO1Ykni4uI5cfZqivvn/TOWzavnM6BX528eKylBSkic7W5tqVhipGA+RaHAeNmnafC+/gHKGky/S+tRkqRxU0EhYZiaGPPuvQeBQcHK+4OCQth/6CRSqZRO/2uuvD2p9ahl41o/tVyLkFJSLamHT19mu9IkgqAqKvsrteW/I2xcPh29xEGL1lbmvHX7oKpw/jhBgYF4fnDnxJmL3944G3nv4cn8xWsICQn+6vijzzVO7GY7dOJCig8fwxwGNGmQvsHG794rXt/R0bEAyjE4SS1I7h+8GNSnK0P7d8fBzuZT99pvMv4oyadxU28pWUzREnT3/qdWpB17DxMdE0OTBjWxtDADwNvXn8vX76KjrfVdC7IK6WNslANHexv8A4JYsW47l67eUnVIgpDlqSxBUlOTJKt7FBEZRVR0tKrC+ePExMQQGhLC46cvVR1Kpnr56i0nzlwgLDQk3YX6ShYtiE1iAv/wSdrX69zFazRu05OINGYHuiUmSGHhUWhpaWJibAh8apF59vItU8YNYdKYwfj6BfDC9R2GOfQpVOD3qjSdFO/zl28pmbiG2OfdbJ3btWDx7InJWtX2HzmLTCanXs1KGOjrZW7Af4giLs5ERUUydvIcNm0XFbUF4WepLEEqV6oIqzbuJiYmlis37jNs/Fwq/WbflLMzG2vFbCQfvwAVR5K5PL0SZ7BJNdLVxQaKasVJg4oX/LuZ+Pj4FNvI5XJmLVjJ5Wu3GT91for7o6KiMTYyxMrSHDmKwc5J9boMc+hjZ2NJcEgYH739ALhy8wEAFcoU+6UzoH6Eo701urravHP3xCVxyZF7nyVI+nq6dOnQMnG2HsTExioX/m3Z5M+Y2q8KBfPlRltLsZDxUzHVXxB+msr+8vbv8T+0tbUw0Ndlw/YDlCtVhL7d2nx7RyFD2NtZAxAYGKTiSDJX0mwzRRXt9C/10LppHXI52eH61p2d+0+kuF8ikbBq8Qz09XTZsHUPR06cS3a/jo42964cZvOahQDYWCWf4v75dH+AqzcTxx/9hl8a1NTUKJA3F3K5HJ3EGXnPXiimloeFR6TY/tylWwSHhFGiSAFlkVIh4znnckRDUxN1dXVc37wn+g+coSoIGUllCdL+o+fo8r8mrF08hXVLptCtfbM/rh6PKuV2UiySGRISquJIMteHz2ogfa1I5JekUimjB/dAIpGwdss+vBJbej6X08meOdPHADBoxBS8vH1TbOPtq2ixs7EyT3Z7UrfV0xdviIyK5s79Z2hoSJW1l343Lonxenr5cu3MHu5fPYLnRx/yFqvBwOGTk20rpvZnjtxOdqirq6GlpU1CQgIvX79VdUiCkKWpLEE6df468QkJqjr9H885t2LV+B9ZKiMr+3yZEfPvXGqmcEFnmjesQUxMLHOXbUx1tlC7Vo1p0aQugUHB9B06QVmBOyQ0jNjYOD56KZKmtBKkZy/fcOveY2Lj4ihRpAB6ujrf/Rgzg0t+xcy7py/eUDC/MxoaGmzavpeo6OhkM9SevnjDs5dvsDAzoXKFkqoK94+gra2Fo50NmpqKsZ1PnoluNkH4GSpLkJrWr8bAUTO5cOU2l6/fVf4TMoeDvTUSNTViYmJSHVOTXXl4egFgamqMpub3r3jep1sbTE0MuX77IWcvplwaRyKRsGDmeOxsrblw+QarN+wAYPI/i7DKU4aLVxT72HxRRdo5twNSqTovX7tx8eodgN96TF7SzLtnLxWtFHFxcazf8h8A3Tu3Vm6397Ci9ah5w5pIE+shCb+Oc25HtLR/7TikkRNm0a3viGTL7whCdqSyBOn4mSuoSSTsPniKnftOsHPfCXbt/3axPSFj6OroYGVlhbmF5R81VqFqxbIYGOTA3tb6h/Y30NdjaF/F7KyFK7cQGpZyzI2RYQ5WLZ5B3ZqVad64LqCY4i+TyYiOUVxrG8vkLUhampo453IgNjaO0xduAFCpXPEfijEzmJkaY2luin9AEHfuPcI8Zyn8A4IoVbwwRQsVACAoOJQzF2+goSGlSYNqqg34D+Gc2wFtHR3s7Wyw+8HX+NfI5XLOXbzG/sOnkpV2EITsSGWDfpbPHaeqUwuJihR2wf2DN5HRMej/IVOv27Vpxq2Hr7C0SP/4oy/VqFyGCmWKce3WA/5dv5PRg3uk2KZiuZJULPepSympSGRYeBSQsosNFAUjn796R0JCAs65HbFKrCH0uyqYLxc+fgEEBocrb+vW6VPr0aETF4iLi6dezYqYGBmqIsQ/Tt5cjujq6lGhTAX69eyY4ceXSCQ0a1yHeYvXcPz0BUqXLJLh5xCE38XvNX9YyFQmxkbAn1VN2zexrMH3DND+kkQiYfiArmhraXHw2Pmv1kYCxfgjt/cf0NbSIjwyGsMc+soCqZ9L6rYCqFT29209SlIwcead61t3OrdrQanihWmR2GIWn5DA/iNnATE4OzPlya2YfPHq9fsMP3ZSV3yD2tUAOHbqfIafQxB+JyJB+oOpIScoKJAbdx6oOpRM4fb+A+cvXSc2NhaLdNZASou1pRm9urQEYPbi9cTFpT6OSyaTUaxCQwCiY2KQSCSpth7Bp6n+8PstL5Ia5UDtl69ZMncSZw5vRUdHMf7lyo17+PgFUCBvTuUAdOHXMzEyxMzUGB+/AE6cvoj7h48Zduw2XQbQZ8h47O2ssbY058Wrt7x9555hxxeE343KEqSL1+6kuO3E2SsqiOTP5evnh/dHTy5euqHqUDLFybOX2LBlF8FBgT/VgpSkdbO65MvjxDt3T7btPprqNmpqaowe1geAKpXKAp/WYPuSva0VuRztcM7tSL48Tj8d36+WL48TamoSXrx6R0JC8gG7ynXXmtRWFsQUMkfe3I4E+Pvxv26DOHjkdIYc89rNe5y7eJ3zl66jr6dH/TrVADh2+kKGHF8QfkcqS5DWb9uf7HeZTMb6bQdUE8wfKumD2tvXX8WRZA5lkUipRrrXYfsaqbo6o4f0QE1NwobtB/Dw9E51u97d23P64BaaNaoHfFqD7UtqampsXD6dtYsmZ4nFXHV1tMnlaE9UdAzv3D2Vt79778ndB88wzKFPrarlVBjhnynvZzPZnmTQTLZZC1YAMLhfN3R0tGlQpzoAx05eyJDjC8LvKNMHafcfMQOJRMKHjz4MGPmP8nYfvwByOdlldjh/tKSZXAEBf0Y1beUyI99ZRftr8jvnpHXTuuzaf4LZS9azdNaYVFtMSpcswtXbjwDFwsxp0dDIWsVSC+bLxet37jx7+YY8ORVVsvckTu1vUr86WpqaX9td+AWcczt+tuSI608f7+qNu1y6egtLCzO6dWgFQOUKpeneqTX1alX96eMLwu8q0/8ajx/eG+RyBo2ZRfeOzZW3W1uYffWDQ8h4OR0VCWlQSIiKI8kcyirampqYmxpl2HF7dWnFhSu3ufvgGcfPXElztfpPRSJTb0HKilzy5+bQiQs8e/GGJvWqER4RyfHTl1FTk9C8YU1Vh/dHcs7lgKaWFhKJhJeub4iLi0ND4/trfiWZvXAl8Kn1CEBLS5MFM8dnSLyC8LvK9ATJ2lIxdXnZ7LE/NdVa+Hl5cjsBEJ7K+lmqduP2fXoNGktMTCxSdXWkGlI0pFKkUnV2bVqGo70tAGMmz+Xp81fK+6RSKRoaGmhIpbRp0ZDaNSoBcPnabZ4nrnNmaWGWocva6Opo8/eALoyctIAlq7dRoUwxjAwNUmz30UexPElag7SzooKJA7WT1pA7fuYKUdExVKlQUvleFzKXrbUFeno6aGlpER0djesbNwomLir8vVJrPRKEP4XK2vP9A4MZOWUB4eGR7N20EG9ffy5fv0frpnVUFdIfx9HeBolEQnR0NAkJCaj/RpWO9xw4jrtH6jNw5LJPS3w8ePSU67fup7pd8WIuygTpwaNnhIaGoa6unuYYoJ9RuVwJqlUszYWrt1m6ZjsThvdOHrNcjpe3HxKJ5Levb/Q9cjrYoqOtxRs3DyKjotlz6BQgpvarkpqaGs45HXjt6kp0dDRPn7v+cIIUGhaGjZUFA/p0UbYeBQaHEBcbj6WFKSvWbuPk2Uvs3LAEbW2tjHwYgqByKkuQ5i7dwJRR/Zk4azkAFmYmHDl1USRImUhRj0cfkBMeEYlhjpStHqpSoWwJQsPC6dO9PblyOhAfH098fAJx8fHJZoEtmTuZ0NAw4hMSiIuLJyHx/7j4OArkzaPcrkbVCvgFBHH41GUsf1GCMrRfJ27df8yx05epX6sSpYq5KO8LDgkjMioaS3PTLDfO6GvU1dXInzcn9x+9YMt/h3H/4I2jvU2yxy5kPufcjpzT0sbYyFBZvf1H1K9djRpVKih/j4iIpFv/CURGRbNv80KOnjzHlet3uHj1JnVrVsmI0AXht6Gyv9SxsXE4Odgof5dIJMTExKkqnD+SmpoaJUuWwNc/EPi9pmK3aFKPFk3qfXM758Ruwm9xKeBM8WKFOX3pTobMYEuNhZkJfbu1Zf7yTcxZsoEtK/9RDlL+6J3YvWadfbrXkhTMl5v7j16w9b8jgKL1SEztVy3n3I6YmJrRolEtOv2v+bd3+AotrU8D7ddt3Z/49wLOX7lNg7rVuXL9DsdOXhAJkvBLJS0Onpl/W1Q2l9je1opbdx8jkSi+lSxauSVZwiRkDlMTIwACg7L/QG1fP8UfdsufLBL5Nc0b1sQlf248PL3ZtOOQ8navpAQpjRpIWZlLYiHI+PgEdHW1qV+rkoojEvLmdkQikfDqjdsP7X/t5j0GDp+sXCIH4I2bB/8d+LRe5qlz15RVtU+cuSgWrxV+qXduHji6VKbXoLGZdk6VJUgjB3Vj+95jvHn3gbqt+/Lu/UeG9++iqnD+WEY5DIiNjcX1B/+Q/gp37j1i8/Z9yf44ZwSfxGVGMmqKf2rU1dUYPbgH6urqbPnvMO/eK+oDeXorZrBZZ6MZbEk+rwDeoFZl9HR1VBiNAJDT0RZ1NTVc37rz9p0HUVHR37X/zPn/smXnfo6fuggovr3PW7aJBJmMdi0boKerw71Hz9HV06Vgvjz4+Ppz74FYvFb4dZ6/ekNoaBixsZnX06SyBMnUxIhF/4zi9L5VnN63iiWzRmNmaqyqcP5Yb9+9443rS3bvT70StCrsPXSSQSOncPpcxlZW/9SC9GtnT+bJ5UD7lvWJj09g9uJ1yGQyZQuSbTbsYjM3M8HK0gyJRELLxrVUHY4AaGlq4uRoy5vXrpSo3Ijb9x6le98r1+9w+dptLC3M6NpBsZzOqfPXePD4BVYWpvTq3JJqlUojl8s5c+EGDeomFo08deFXPBRBAODFK8VM2XzOub6xZcZRWYKUkCDj1r0nXLhyh/OXb3Ps9GWOnb6sqnD+WEkDnpM+wH8HDx4/A6Bo4QI/tL9cLicmNpbgkDC8fPx56/aBpy9e4+mlqKT9s+uwpUf3Ds2xsTLn4dNXHD5xUTkGKTu2IEkkEuZMGsrimaNwcrBVdThCIudcjmhqKmaWfU9F7aS6R0P6dUdHR5vwiEiWrtmuuK1vJ7S1tahTXTFw+9T5azRIWnZELF4r/EIvExOkApm4tqPKBmmPmrKQV2/ccM7liFSqmF4ukUjSLLIn/Bp2tlYA+AcEqjgSBZlMxuMnL1BTUyM0LIojJy8SFR1DZFQ0UVHRREVHExkVQ3TSbdHRREUl/zkqKpqENMZDSKXqmBob/fLHoa2txchB3RkydjbL1+1QFurLTjWQPuec21HVIQhfyJvbAR0dRXfnhUs36Nez4zf3SWo9srI0V7Yerd2yj4DAEMqXLkqV8iUBKFm0IKYmhrx87YaRkRH/TB5BzaoVvnZoQfgpzxMTpPx5/4AE6a3bB/5bPx9tLbEUgSo5Jn7jDwz+PQZpv3VzJzwiEmsrCybMXPZDx9DU1MBARw8dbW10dLTQ1dFW/lyhdDHU1TOn4bRsycLUqV6BU+evKeMyNTbMlHMLgnNuR/T1DVBXV+fsxWv4BwRiZvr11tOkNdeGJFbNfv3WnT0HT6GhIWVo307KGUTq6mrUqlqeXftPcPri9XQlX4LwoxISEnB97YZUKiWXk0OmnVdlCVL+vDmJjY0TCZKK5c6p+OYfHhau4kgUHj5+DoCOji4AtaqWw8bKHB0dbUWio6ONjraW8mddbS3FbYk/a2trZ1oClB6De3fg+u0HhIVHYm1pniUWoRWyB+dcjqipq2NsbIy/vz8Hj56hR+c2aW7v4+uP6xs3rCzN6dK+ZeLA7I0kyGR0/l8T7BNbm5PUrVFBkSCdv06vzq2QSCQEB4cyYvxMJo8dgq2N5a9+iMIfIjwikiYNahIdE4um5o8vm/O9VJYg2VpZMGTsbIoWypvs9sG9xTeRzJTTwRaJRELUb1JN++HjFwBEx8aja6DOmKE90U2s4JsVmRgbMqBnO2YuWkcuRzE+R8g8hjn0sbIwJSwsFPBnz4FjX02QLC3MeHD1KK5v3dDR0eb4mSs8fPoKa0tzOrdtnGL7/M45cbCzwv2DN09fvKFQgTz8M/9fdh84xvNXbzi+bwMG+nq/8BEKfwrDHAasXjoz08+rsq+z2tqaVCxbDH093WT/hMxlamKEVCpFLpcTGBSs6nDI6WRHsSIF0dDUxCV/7iydHCVpXK8a86cNZ0jfTqoORfjDOOdyRF9PHyPDHOQw0P/mFGkdHW2KuOQnLDxCOTB7aN+OqS4jIpFIkg3WBpg4ehBFCuXnybOXdO87kvj4+Ax+RIKQeVTWgtSjYwtVnVr4jIaGlCJFixIRGY2BgeqXGunWsTUJcjXWbd1PyaIFVR1OhpBIJFQoU0zVYQh/IOfcjly+cY+xIwfRq0vrNLdbumoTzRvXxc5G0Y22dstegoJDqVCmGJXKlUhzvzrVK7B2yz7OXLzBoN4d0NfTZdfGpdRu0onT568wcsIs5s0YK7qWhZ9y9cZddLS1cCmQN1ll919NvGoFrCzNkUgkv0ULEsDdB4pp/qWKZY8ESRBUpWihfABcv512HaTL124zYdoCGrbqjkwmw/XNe/YcOo2mhkaygdmpsbe1okDeXAQFh3L7nqJQpLWVBTs3LsVAX4/1W3ZTpd7/RBFJ4aeMmjibGo06ZHjx4G8RCZKgnPbuHxCs0jhevX7H0ZPnefDkBZqaGrgUyPPtnQRBSFPSdPwXru94/vItew4c552bh/J+uVzOzPmKmWv9/1J0Ac9bvgmZTE6nto2wS8dA67o1krrZritvK1QwLzs3LiVPLkeevXAlRw79jHxYwh8kISEB1zfv0NCQksvJPlPPrdIE6dK1u+w+eApQ1L8JCAxWZTh/LB8fH1xfvWDNxh0qjWPX3iN06DGEAH9/Chd0Vi70KgjCj1FXV6NONUUCM2bKXHoOGM3WXQeU91++dptrN+8qBmK3a8Hxs1d49PQVNlbmdGyTcmB2ampVLYeamoRL1+7w6OmngpQVy5Xkxrl9HN2zjjy5nACIi4ujS+/hv03dNeH39+69BzExseTJ5aisJ5dZVJYgzV++iXOXb7Ln0GkAfP0DmTx7harC+aMZ6OkSHxeH+wcvlcaRNMVfW1uHUkVdVBqLIGQXSS08EVGKAdq7DxxDLpcjl8uZtUBRNXvogB7ExcezfM1Oxe99O6e7BIupiRHVKpYmMiqa3sOmMnbaYjw8vQGQSqWUL/NpDNP6Lbs5ePQ0q9ar9suYkHW8ePUWUBSI/HfdTg4eO49cLs+Uc6ssQbp17wkTR/RRDriysjAj5DepxfOnsUlsRvdLXMxVFeRyuXKJES1tbUqK8UeCkCHy5nHCycGGsIgoHB1scff4yK27D5WtRzZWFnRu14LVm/YQFBJKpXLFqVSu+HedY+LIPgz8qz0G+rqcv3Kbdn+NYv7yTQQFhybbLn/iMhGXrt7KsMcnZG9Ja7A5Otix5b8jrNu276vj4jKSyhIkdTU14uMTSHqcHp7exMeJKaGq4KSsph2sshg+evniHxCEhoYGOQz0KZA3p8piEYTsRCKRULdGRSQSCY4OiirEe/YfY+X6xGn8A3rw/oMX+46cQVNTMTD7e2lpatK+VQN2b1hAu5YNUFOTsOfQaVp3+5s7D54qtytXqji6OtrcffCEsPCIjHmAQrb24qUiQTIwUIxjy52J45BUliB1aN2QvyfMIyg4lCWrt9Nr6BQ6tGmoqnD+aLlzKv5ohoWqrgXv4ZNP3WvFCudDKlVZBQpByHbqJtYrCg6LAmD/kVP8u2Aq/2fvrsOiyt4Ajn+HTmmkESxM7O7u/um6dsfa3d2ta3d3rN3dLXYHBqikSMf8/hidFQRERQfX9/M8PsLcOO+de+/MyznnnjN+RD+aNKzNlNmqjtnNG9XC4TsmVDZLZ0K39n+yfvEkypUsRGhYOL2HTuHC5RsA6OvrUbRQPmJiYjhz/vL3H5j4zzMw0MfC3AyFluo7IZPbz5tqRGMJUvVKpWjXvD5VyhVHW0uL8UO7U71iKU2F81tzdXZAoVAQFh5OXBKTvP5o6v5Hhobkl/5HQqQqezsb8uTMSnRMLFkyu+PnH8ilKzfo1LYJR05e4OadBzja29I0lf5IdbCzZczgrjRrVJOoqGj6Dp/G2YteAJQuURiAYyfPp0pZ4r9t9tSRPL5xnNBQVXKfyf03qEFavGoLFubp6NzmD/5q+wd5cnloKpTfno2VhXo0bf+AQI3EYGRogLGREQYGhtL/SIgfoHL54gA4OTrSruUfuDg78C4klDlLPnbMbpaqT44qFAo6tWpIyz9rExUdTf+R0zl9/iqlS6oSpOOnJEESKaNQKHj87CXwmzSxKRRaDBg5g7bdh7Np+4HPOvOJn8fIyBAX1wxkcHPHyFAz0700/7M+Lm4Zsbe3I7P7z6tCFeJ3Ua5kYXR1dfAPCmX4wO5kyeTGghWbCAoOoVTR/BQv/HUds1NCoVDQocX/aNusHtHRMQwYNYPAoPdUKFOc6pXLaqzGWvwa/AMCef3Gj5iYWB4/e4G2tjauzg4/rXyNJUhtmtZlzcIJDO7Vnnch7+k1ZDJ9hk3VVDi/NYVCgVsGFwyNjImIjNRIDFeuq5rY8ntml2kJhPgB0pkaU6xQHqKiozl66iJ3Hzxh267D6Onp0qPjj50kvE3TerRv0YCYmFiGjJvNyCG9GNz3L7nXRbKWrd5M1nzlGTVhFlFR0bg626Or+/P6p2r86rSyNMfG2hJLCzN83/hpOpzflpWlOQD+gcE/vexXPq/Ze/AESqVSmteE+IGqlFM1s+09dJIps5ejVCpp2bg29nY2P7zsVn/WoXG9qsTGxsYbdVuIpHx8gk3vw2TJP7ODNmgwQdq1/zg9B0+iaccBPHrynLbN6rF6/nhNhfPbi4gI59XLF2zZvvenlhsXF8e02UtYvGw1fm/f/GcmqBUiLSpayBMTYyOuXr/LrbuPcHJIz58Nqv208j/2g7p07RaHj51m8syFP23QP/HrufNhDKQ4pWo8oExuP3eqEY09S33u0nXq16xIkYK50dHW1lQY4gNlXBzBQYFMmbmQs+cvU7FsCSqULY5Hlow/bFCu+w+f0KP/aPXjvvb2dmRw+Xnty0L8bvT19ChXshA79h0DoFfn5j91Sp/M7i6Ymhjz6MlzuvYdySuf1zSoXRW3nzzHlkj7YmJi1HOwvQsJAyDjT06QfnoNUkyMajDIMYO7UqJIXkmO0ohCBTwxMTVFS6HgxOkLDB0zjaLl65OrSFUOHjmVqmVFRUUzacYCSlT6H2fOX8bG2gpnlwyULVnkp42QKsTvqlbVMmhpKShfqjBFC3r+1LK1tLTIm9sDhUKBRxbVZNTyNJtIzJNnL4iKiiazewaePHsB/AY1SIPH/s3E4T0pVqUZn34XKpWgUMDpvau+a/+T/17GE++XzJ08hLf+gfQZNoWoqGjGDu6GewYnQt6Hsmztdrq1//M7j+S/JYOzI84uGdDX08HKIh0R4WE8eerNi5c+2NpaqddbtHw9ERGR31y7FBcXR7X6rbh09QZaWlp06dCc8Kg4zlzwooD0PxLih8vhkYnNy6djY2WukfIL5MnBiTOXMU1nCsDx0+dp2bSBRmIRadedew8ByJQxAw+evcbUxBgba8ufGsNPT5D6d2sNwIEtC1J93w+fPOfm3YcYGxkCsGPvMRrXq4qdrTXrt+1lUM92bNl5iPo1K6R62b+6wgVykzNbZm7fe8ir16qZts0sbTE2tWD6vDV45sxCruxZmDV/Bc9fvGLomGk4OdpTsWxxKpQtQekShTEx/vIQAVpaWtSvXZWo6GhmTRqOlZUljdr0xcjQgLIlC/3owxRCAPbprTVWdj7PbAC8ex8BwInTF4mLi5Mn2kQ8L1+9BsDG2ooHz16T0c35p7cw/PQr0tLCDID9R05jYmwU79/2PUe/eb9KpZK/F66hdZO66tfe+geQyc2FzO4uvHkbwPvQMN6FhOJo/+1D6f9X2VhZsGjGcA5sWcjMcf1p07QuBfLkwNTUhHsPn7LxnwMMGfs3aOnh5OSEuVk6Xrz0YdnqzTRp0wO3nCXpNXBMispq3+oPjuxaQ57c2Vm/dS9KpZJaVctgamL8g49SCKFp7q5OWJilw/eNP5kzuuEfEMjNO/c1HZZIYzq1bcKLe2fJlzc38POb10CDnbR37DtG/ZoV1b9HRkWxZechmvzv24a6P3H2Mo726cni7qp+zcHOhms37+H7xh9He1u27jpEtQolmDBjCVHR0XRp21idsH1q846DbNl5EOC3e8LC2MiQQvlzUSh/LgBiYmN5+Nib67fu43XzHtdv3ccvIAhTMwusbCJ5/z6EiPAwHB3syJw5Y4rK0P7Q7yww6B27DpxAW0uLhnWq/LBjEkKkHQqFgry5PThy8oKq+eTRE46fOk/uHDKbgojPxNiIV69Vw//87A7aoIEEqV7znigU4OcfRP0WPdWvvw8Np3K5Yinax/K12zl7yUv9e1xcHIFB71gyayRhYRHq12tXLcvQcXMIj4ikX9eW7D18movXbpEnV1bsbK1ZuWFnogOkNahVkQa1VMlbTEwMJau3/Maj/fXpaGvjkdkNj8xuNKxTGaVSic/rtx8Spvtcv32fx09fEKdUsn7rAdq1aJhkx/tnz1/SuecwShQtwMDendi66xBRUdFUKltMo1X+QoifK79ndo6cvICZmRkN61YjV/asmg5JpCFxcXEolUq0tbV5/OQ58PPHQAINJEhbV04H4M92/Zk6pq/6dUuLdCl+3LTln7Vp+Wdt9e8Xr95k0qxl9B46hajoGF76vGb6vFX07NSMWRMGALBqw07q1SjP6k27KJi3Eva2Vixftz0Vj+z3oFAocLCzxcHOlirlSwDwLiSU1l2H8tLnDX7+gdjZJp7sPHz0lNPnLmFmZkpERCSbd6hq6b611lAI8WvK92G8s4DgUDYunaLhaERa8+iJNyUq/Y+qFUvz8o1qGjL3DE4/PQ6NNbGtmj8ebe3U6QJVMG9ONi1TTVPi4/uW0VMX0LNTM/Xy0LBwAoNDcHJIj7WlOfcePuHduxCsrSxSpfzfXTpTY7QVSl6+8Gblum30694u0fWeeqsmG3RzdWLPoVMEBYdQMG9OsmR0TXR9IcR/k6uzPVaWZjx/6csbvwBsf/LTSSJtu33nAZGRUcTExvE+NAxHe1uMDA1+ehwaS5CCgt+xYds+Xrx6Tdwn/XwmDOuR6mVt232YutXLAVCraln6fKhpGjO4a6qX9bvS1dXmXXAw5y5cTXKdJ89UVaUuTo6s27IH4KeO4iuESBsUCgX5cmfn4LGzHDl+ltDQUCzM01GvlvRFFKg77VtZWvDI+41G+h+BBhOkIWP/xtXFgRevXtOwTmXuPHiCpfnnHaa/lr2dDXMnD4n3WtP/1VD/bGttycp54767HBFfJvcMAHi/eJnkOk8/DPYVGhbBi1evyeTmQuEPncGFEL+X/J6qBOnk2SusWb+ZrJndqVuzsgwWK7h19wEA+gaqIXs00f8INDgXW2hYOAO6tyFntsx4ZHGnd+fm3Lr7UFPhiO+UwyMzAK+TmXD442ioF67eAlS1R/JhKMTv6eN4SD5v/HFytOfeg8fqwQHF7+3Whxqk6A8zb2iqBkljCZK+vj4RkVHk88zG4RPnCA0L56XPG02FI75TlkwZ0NLSIiTkPeHhEZ8tVyqVPPN+gUKh4Kn3K2ysLahQuogGIhVCpAVODumxtbbE57UflcqVBGDrzv0ajkpoWsj7UJ55v8TcLB2v3wQCmhkDCTSYINWrUZ6XPq8pVTQ/V7zuULVhZ0oVza+pcMR3crC3Re/DU4jPnn/ezBYXF8fE0QMoVqQQCi0tGtWpgq6uxlp4hRAaplAo1E+zZcigakL5Z+eB327sORHfx1rE7B6Z8H7hg76+Ho726TUSi8YSpKoVSpAxgzN6erosmDaMPRvm8lfbPzQVjvhOVhZm6BuonjJ49PjZZ8u1tbVp0rA2pmbmAJQtWfBnhieESIPyf2hmCwx+j6uLIw8fP+PG7XsajkpoUv48Obl0Yjud2zUnNi4Od1fHVHvi/Wv99FJDQ8MS/adQwJzF6392OCKVaGlp4erigo1teqySeGQ3JjaWlz6v0dPVJb2NDAwpxO8u/4capKvX71KnRiVAVYskfl/a2tpkcs+Ato4uABk11EEbNPAUW8X6HVAoIGEtqkIBpYsV+NnhiFSUJ3cOomOVGBp+PmntngPHOH3uMqHvQ8nmkUljfxEIIdIOezsb7NPb4PP6LWVKNkZPV5cGdapqOiyRBjx84g1Axgya6X8EGkiQzuxb9bOLFD+JXXorAHxf++GZI0u8Zbv2HWbtxh04Ojnj4mivifCEEGlQ/jzZ2bX/OO9Cwhnc9y9NhyM0SKlUUqJSQzK4OGJtawdAJnfNJUjyZ7xINbbWlgQFBrBq/dbPln18xF9XTw8XJ7ufHZoQIo0qlC8nAMfPXNJwJELTnr/04dad+9y594jHT1XfGb9VDdJHxao0I+EQOGampuzZOFczAYnv5mBni6/PK3b7vCIqKho9PV31smcfEiQ9XT1cnKQGSQihUqJIXgwN9Llw+QY+r98yd+EqLl+7ye7NS2SctN/Mx/GPsmRy45lPAFaWZliYp9NYPBpLkA5sWaD+WalUsuvAiVQZSVtojoOdDXp6+kRGRuD94qV6dO3w8Ahe+b5BV1cXLW1tnB2lBkkIoWJoYEDp4gXYd/g0x09fYt+h4zx49JQr126SP6+MtP87uXVHNYK2ra01z3wCNDaC9kcaa2IzMTZS/zM1MeaPulVYu2W3psIRqcA+vY16LKTHT56rX/d+8QpQDQ6qUChwdZYaJCHEv6qULwHA/iNnqFuzMiCDRv6OPtYgGX6YYiSzu2YnMtdYgvTwsbf6390HT9iwbT9+/kGaCkekAmsrC/VYSI+feqtf/zhJrUJLi3SmJpilM9VIfEKItKlAnhxYWZpx98ETChXIA8D2XQeJi4vTbGDip/pYgxQVEwtAlkyaTZA01sTWb8R09c8KBVhZmjOkd3tNhSNSgba2FtZWFvi9fcPtT+ZUsra0oErF0ly7+UD6HwkhPqOtrUWlMsVYt3UvD5+8wCOLO3fvP+bS1RsUyu+p6fDETxAeHsHDx88wNjLktZ9qihFN1yBpLEHaunL6l1cSvxwnR3vu3r3H/QdP1K8VyJebNi0aM2z8HHmCTQiRqCoVSrBu6172HzlNnRqVmDBtPlt37JcE6Teho6PNtrXzeeX7hjlLNqGvr6fx/qoafcz/3oMnnDx3hZNnL6v/iV9bRjcXjIyNcXJ0iPe69wsfAKlBEkIkKrO7C+4ZnPB9449H1swA7DlwVOZm+03o6upSukRh8nrmJDYujkxuzhofUFhjNUgjJ83jxNnLZHJzQUdbG1BNXlhSJqz9pWXJ5IZrBndKlyyqfm3PgWOcu3gNpVKJizzBJoRIhEKhoEq54sxduoE795+yYsFUShcvJI/6/2buP1LN5anp5jXQYIJ07cZddq6djZGhgaZCED+AXXrVHGs+r/0AiIuLo3WnfkRGRZE1Ww5c5Ak2IUQSKpcrxrxlGzly8gK9/mqO/oenYsV/36CRk4mKisY0nTkAmTNqPkHSWP1VruxZiIiM1FTx4gext7UmJiaaK143efHKl9dv/IiIjERPTw8tLS0c7dNrOkQhRBpla2NFPs9svA8N49S5qwC8C3lPbGyshiMTP5JSqWTDlt0sXrGBZ89Vw8JkSQMJksZqkJo3qknX/uPJlsU93uvyJNuvzT69Df5+fjy4d5cKpQqR3UPVl0BHRxc7W2sM9OUvQiFE0qqUK87la7fZd/gUJ0+dZd6SNWxZPY8SRWUy8/+qN2/98Q8IxNHBjmcvfNHSUpDJTXNTjHyksRqk8TOW4OJoj5uLI5ndXdT/xK/NxsYSA319AB4/8eapt8zBJoRIubIlCqKnp8vZi9fR09MjMjKKbTJo5H/axwEiM7q5EBYegbOjPQYG+hqOSoM1SJFRUYwf1l1TxYsfREdbGxsbK169esm9h08wNjYCQE9P5mATQnyZsbERpYvl5+Cxc1hYWgKwY88hJo7qj47Ot39l7dp3BK8bd+jVpQ2G0vc1Tbl1VzVApLW1FW+DXpAlY9qoLNFYDVKpovm5fO22pooXP5CLsxMAjx4/49knNUiaHtNCCPFr+Dj1yGWvO+T1zMFbvwBOn/v2YWCWrNxI07Y9mTxzIQ1bdOF9aFhqhSpSwccRtPX1VYlrWniCDTRYg3Tq/FVWbtj5yVNsSkARbxJb8WvK6OYMCgUvXvlSukRhDA0N0dPVw1VqkIQQKVAoX04szNJx6+4jqpUrylWvW2zbuZ/SJQp/0/78A1QjM+vo6HDyzEXqNu7AppVzMNfgTPHiXx+b2CKjYoC08QQbaDBBmji8p6aKFj+Yg50terq6REVF0ad7O3z93+H9whdnSZCEECmgo6NDxbJF2PjPAfQNVM30O/YcZsrYQd/UzBYepcQ9Y2a0tLV59cKbi1euU6NhW7atnYeNtVVqhy++UvdOrbh24zbXbj8G0sYTbKDBJjb79NaJ/hO/Pns7G/T09TEzS8fbt/689HmLnp4u6W0sNR2aEOIX8bGZ7cLVWxTImwt9PV31Qx9folQqmTxzIZeuXOfsRS/2HT6FlZUlBfLkwNHZFXu79Ny6c5/zl7x+5CGIFGpQpyq9u7bDPyAYK0szLC3MNB0SoMEapHrNe5LYAKlbVsgcbb86O1srnJxdKZw/F0ogJiaGDC4uaGlpdth4IcSvwyOzGy5O9ni/8GHs4K6UKVEwxZ8h46fOY9KMBSxavh6PbNkB6NK2Mfk8s9G0w0C0ta3p2aUNNaqU+5GHIL7Cg8feAGTJmEGzgXxCg01sPeL9vvfQKfLk8tBMMCJV2ae3QaFQcPP2XcrXWIeZmTnlSn1b3wEhxO9JoVBQtXwJFqzYxKVrt1P8GfI+NIwZc5eiq6tDpQpluXz9Hvk9s1OrahkUCgXNGtVgyeptXLx2h7ZxcfKHm4bt3HuYB4+eolSozkNaGu5HY1dG5oyu8f791bYxqzbu0lQ4IhWlt7FCoVDg6/sWAB1dXZmDTQjx1SqXKwbAoePniIqK5v7DJzx8/DTZbU6cvkBUVDR5cufgyo376Onp0r97a/Wcbs0a1cTJIT037zxkzabd9B0ynk49h/7oQxFJ2LpjH6MmzOKql+qp9rTSQRs0mCCFhoap/wW/C+HU+SvqGd/Fr01XVwcTYwNevlT1F9DT08NZBokUQnwlezsb8uTMSsj7UMZNm0ehMnWY+veSZLc5fOw0ACGhESiVSto3bxBviBF9PT36dGkJwPJ121m1fhubtu0hKPjdDzsOkbR7D54A8C5ENfRCWumgDRpsYqtYvwMKBSiVqt+trcz5q+0fmgpHpDJXZ0cunFf9rKunh6uTg2YDEkL8kqqUL8G1m/cICAxFoVCwe/9RIiOj0E9k2iKlUsnBo6cAiIqJw9PDjUb1qny2XuH8uShXshBHTl7A0cGeR4+fcujoaRrUqfrDj0f8KzY2lkdPnqGrq4NfYDCGBvppar5OjSVIZ/at0lTR4idwtLdV/6ynK4NECiG+TblShZg6dwXXbt2jUH5Pzl+6xpETZ6hascxn6z58/Azv56/Q09PDwMCAQT3boqOtneh+u3dsyrlL1wkKDABgz4GjkiD9ZN7PXxEZGUUGFyeUStVUI9raaadP2E+PxOe1HwFBwZ+9fuHyDXw+9FkRvz47W2vcMmbG2TUDNjZWmKUz0XRIQohfkKmJMSUK5yU6OoYsmTMCsG3ngUTXzejmwvwZY0lvZ08Oj0zJ9mextbakbo3ymJimQ6FQcOjoaaKion/IMYjE3X+kal6ztlINAZNWphj56KcnSNPnruSVz+eJkFk6E6bPk1ql/wr79DYYGBhgYmIqtUdCiO/ycUykkNAItLS02HvgGBERkZ+tp6WlRUhYJCam6SiYN+cX91sob050dHSwtrbiXch7Tp29mOqxi6Td/9D/SM9ANaNGWnrEHzSQIPm+9SdntkyfvZ41sxtv/AJ+djjiB/l00E+ZpFYI8T2KFvQknakJ9x55UzB/bkLeh3LoQ2fsj5QfOrRevHoTgIL5vpwg5c6RBV1dHXR0VTPH7zlwLHUDF8nK6O5KvVqV0dZW9fbJ/LvXIAHExMZ+9lp0dAzRMTEaiEb8CHbxEiSpQRJCfDtdXR0qlFaNg+Ti7ESRgnkwNNCPt87BI6fIV6Imp06fx0Bfn5wen/8hnpCBgT45s2XC2NiEgX26MLR/1x8Sv0hctUplWPT3BELDo9DSUuCewVnTIcXz0xOk0sXyM2HGEiIio9SvRUREMnHWUooXzvuzwxE/SHrbf+c3khokIcT3+tjMFvw+gr1bl1O+TPF4yw8ePcXjp97ExMaSN7cHuropewapQJ4c6OrpkS5dOszSmaZ63CJ5L31eEx4RiauTAwaJPJmoST/9KbYWf9RiyuwV1G3WHXdXJ5Qoefz0BSWL5qd98/o/Oxzxg+jr6WFtaY5fQBAujpIgCSG+T85smXC0t+X5y9fcvveYHB4Z4y0/fOwMACYmphTMmyPF+82fJweLVm7h0jXVQIVxMrr2TxH8LoT9h04QGqGqLMmUhkbQ/uinJ0g6OjoM6NGGVn/W4eET1dwrGd2csbOViWr/a5o1qsmDx95kcJExkIQQ30ehUFClfHGWrN7G7gPHefnyFd4vXtG2RSMeP/Hm8VNvDAwM0NPXp2C+XCneb46s7hgZGnDzzn3qNO5ASMh7Du9a8wOPRADcuHWP9t0GkTVzRrT0jNLk94TGxkFKb2sVrxlG/Pc0rFNZ0yEIIf5DKpdTJUgHjp5h4tTZ6Onq0vh/NdWDQxoYGmFpYUbGDE4p3qeOjg55cmXl9PlrXLt+m6Dgdzx7/hJXZ8cfdRgCuP/wMQBGxkZERJMmWxqkHlEIIcQvwdnRjpzZMhMaFoFnrmyER0Sw/9CJT5rXTCiYN6d63rWUKpAnBwqFAjc31bhJe+Vpth/u/sOnACg+TFKbFqejkgRJCCHEL6NKedUEtuYWqsEFN2zdzelzl9DS0sLI2OSr+h99lD+PahttbVUnYXncX+X4qfPsPXjsh+z7Yw1SeIRqcM60OF6eJEhCCCF+GRVKF0FHR5vXfkHo6upw/OR5Th/cTPbs2dHW1k7RAJEJZXJzxtzMlJCwCAwNDTh97jJBQWlj8tpTZy8xbspc3oeG/fSyT5+7TONW3Tl09PSXV/5KH2uQYmLjsLG2wMjQINXL+F6SIAkhhPhlmKUzpVjBPMTFKcmRLSsRkZHs3n+MWKUCFyf7b+rbqqWlRb7c2dDS0iJXDg9iY2OZu3j1D4g+5ZRKJXMWraJWo3ZMmrGA1p36EfOTxwp0clDV6vzVexh+/qk3kPP70DBevPTBxMQYbR2dNNn/CCRBEkII8YupUl41BpKhkTEAG7ftBvim2qOPCnxomsuY0R1dXR0ePXlGXFzcd0b6beLi4vir9zAGj5wCgJWlBQeOnKTvkPHqEcN/FO8Xr7hz7yEAzRrXpUrF0rx+40f3fqNSrezAoGAK5ffEPYMLCoUiTTavgSRIQgghfjHFCufBxNgI/6D3WJibEROr+uIumO/r+x99VOBDP6Q3fkHs37aChbPGaWw8JC0tLUxNTDAzM2Xzqjns2LAIUxNjVm/4h7v3H/2wcoPfhdCoRRcq12nBteu3USgU/D15ODbWluzef5RV67alSjnOjvYc2L6Sxg3rAml3tgVJkIQQQvxS9PX0KF+qMNra2nTt1BptXX20tBTky53tm/fp5JCe9DZWvPJ9i52dLdra2gC8fuPH+UvXUinylBs7rDcn9m2gXOli5MiWmVWLprF1zXyyZf3yFCrfIjo6mpYd+3Dn3iMyZ8xAlsxuANhYWzFn6igABgyfyKPHz1KtzOcvfYG0O9vCfyZBiomJYfLfy2jSYQCd+47hzVt/3voH0uKvwTRu14/HT18AEPI+lFkL12o4WiGEEN/jYzPb7oOniI6JJXvWjJiaGH/z/hQKBQXyZAfg0tVbAAQEBlGlbksaNO3MtRt3vj/oL1iwdC3bdx0kKioaHR2deGMxlSlZhJLFCqp/D3kfmqpl9x0ynqMnzuHs5MC6ZbMwMjRUL6tUviTtWjQiLDyCvYeOf3dZ9x8+wT8gEG9JkH6ObbuPgELB6vnjGdC9DRbmZuzYe4zG9arSv1tr1m/bC8CWnYeoX7OChqMVQgjxPXLnyIJdemvCwiOAf/sQfY+Pj/t/nHbEwtyM8mWKEfI+lAZNO6Vq7UlCUVHRDBk9lfbdB6Gllfw4TstXbyZfiRo8ePQ0Vco+d/Eqy9dsIZ2pCZtWzsbW5vOO7iOH9GTrmnl0ad/8u8tr0aE3GXOX4eHjp2hra2OfPm3OpPGfSZD2HjrFH3WroFConmTQ1dXhrX8AmdxcyOzuwpu3AbwPDeNdSCiO9raaDlcIIcR30NLSokq5fyes/Z4O2h99TLIue91GqVSiUCiYOKo/9WpVxs8/kLpNOuLj++a7y0nMvYePiY6OIVvWTOjoJD3JhVKp5OzFq7z1C+B/zf/irZ//d5c9Ydp8APr17IBHloyJrmNkaEi50sXUv2/+Z+83vRcxMTE8fPwMXV1dQAtHe5tkj1eT/jMJku8bPy5cuUGLvwYzdtoiYmJjcbCz4drNe1y9cQ9He1u27jpEtQolmDBjCaMmzycgMFjTYQshhPhGH5vZDPT1yenx/X1zbKwscHV2ICAwmMfPVN0ytLW1mT9jLGVLFcH7+SvqN+n0Q8ZIunHrHgC5smdNdj1Vx+kRlChagKfPXtC4VXfCwsO/udzAwGCeer/AxtqS1s3+l6Jt7t5/RMceQyhQqhYz5iwlMjIqxeU9835JdHQMjg7pPzzBljab1+AXTZCWr91Oh16j4v0LCg7BxNiYZX+PJiAwmBNnLlO7allOnLnMivU7qFOtHEHB77l47RZ5cmWlVpUyrNywM9H9b95xkMbt+tG4XT+adhz4k49OCCFESrg6OzC4VztGDeyMnp5uquyzUD5VTdSS1dvUj7Xr6emyatF08ufJye17D2neoXeqP25/8/aHBClH8gnSx3hWL5pO1szuXLp6g/ZdBxEbG/tN5VpYmHHx2D/s2LAoXr+j5FhamNOofnVCw8IZMX4mRcvXZ//hEyna9t7DJwBYW6lGQk+r/Y/gF02QWv5ZmwXThsX7Z5/emjw5s6KlpUWBPNl55fMGs3SmzJowgEUzhnPu0nXq1SjPs+evyOTuSmZ3F556v0x0/w1qVWTdokmsWzSJ1fPH/+SjE0IIkVI1KpemZNH8qba/Jg2qY2GWjqMnL7Bi/Q716ybGRmxcOZv8eXLSu1vbr57v7UvUNUgpSJAAzM3TsfFDf6Fd+44wdMy0by5bV1f3q56Os7VRPdl2aMcq8nnm4PFTbxq16EqjFl2+2E/r/gPVFCOGhkZA2n3EH37RBCkxJYrk48ipC8TExnLp2m3cP5nNOTQsnMDgEJwc0mNtac69h0+49/Ap1lYWGoxYCCFEWpPe1opxQ7uhra3NwhWbOXXuqnqZlaUFh3aupnTxwqlaplKpVCdIObJlSfF2rs6ObFj+N0aGBlz1ukVERORXlTtt9hLuf6jRSYz3Cx8ePnme5PIC+XJzaOdqZk8diY21JfsPn2TfF2qS7j9Slaf4MMaUSxodJBL+QwlS6yZ1uXT1Fo3b9iO9jRVFC3qql23bfZi61csBUKtqWTZs3cekv5fzR72qmgpXCCFEGpUnlwe9OjdHqVQyfOIcnnq/Ui/7tOZo5dqtDB415bub28IjIqhepSxVKpYmnanJV22b1zMHOzcuZtvaBRgY6Kd4uzPnrzBqwixqN2qX6BQmL33e0KrrUNp0G8brN0l3BNfS0qJpozpcOrGDof270r7lH+plXjfvfPbe+AcEARAR+WGS2jTcxKaIior8seOW/+JiYmIoWb0lJ3cvT7M97YUQQqS+CTOXsH3PUVyc7Fg8c2S8cZZev/EjX4kahIaFM2xAN3p1aaPBSP8VGhbG8xc+ST6N9lHtP9pz/NR5xo3oS+e2TeMti4mNpXOfMdy4/UC1btWyDOjxdcd3/+ETilVoQIG8OZk4egCeOf8dxNPfP5Aaf3bFyNCAQ9sWpXpzZWr5z9QgCSGEEKmpd+cW5M6RBe8XvgyfMJfY2H/nZktva82qRdPQ1dVh1IRZrFizRYORqgQFv6Pm/9pSs2Fbnnq/SHK9M+evcPzUedLbWtOqSYPPlq9cv4Mbtx/gYGeDnp4uu/YfV496nVL+AYE42Nty7uI1ylRtTM8Bo/EPCAQgOEQ1yKWzo12aTY5AEiQhhBAiUbq6Oowf2h1ba0vOXvRiwYpN8ZaXK12MBTPHolAo6DlwDDv2HPpsH3fuPaT/sIms3vBPkuUcPnaaS1euExUV/V3xpjM1wdnJgbd+ATRs3iXR4QhiY2MZP3UuAN07t8LQ0CDe8lt3H7F09Ta0tbQYNbAL9WtUIDYujsWrtn5VLEUL5eP8kW0M6tMZA319lq3eTO4iVVm0fD3PXqiaLNNyB22QBEkIIYRIkqWFGROG91A96r9hJwePnY23vF6tKkweM5C4uDjadhnAidMXANVYQQ2adqZo+fosWLqWXgPHJDk9SK9BY6lQqxlv/QK+K1YtLS3mzxhDofye3H/4hCZte8Ybo+h9aBiFy9bl5JmLidYehYVHMGLiXGLj4mjdtC45PDLSrFFNjAwNOHjsbLIdthNjaGhAvx4duHD8H+rWrERoWDh9h4xnxWpVbVtaHgMJJEESQgghkpUtizuDerYFYOy0Rdx7+DTe8rYtGtG/Z0eioqKZs3AloJpQ9/DxM5ibpcPF2YGoqGiOHDvz2b6Dgt/xzPsllhbmOKTCLA+GhgasWzYT9wwunD53ieYdeqs7YZsYG+GewYXsHplZNm/yZ7VHsxas4cWr1+TKnpnmf9QCwMI8HY3qVkGpVLJoxeZvisnZ0Z5l8yazc+NiGv+vFlbWqqlM0vIYSCAJkhBCCPFFlcsVp3H9akRGRjFg5HQCEzRfDejVkZkTh7F8/hQA3DI4s375LG5d3E/Pv1oDsPvA0c/2e+uOqiN0rhxZU60/jpWlBZtXzcHSwpz9h06wav029bKFs8Zx+uAmihXOF2+b42cusX3vUYyMDBjRvxM62trqZX82qIapiTEnzl7m1t1H3xxXyWIFmTd9NO/DVPPnSRObEEII8R/QuU0jCufPhe8bfwaNmRXv8XiFQkGLJvXj1cpULl8KYyMjqlQoDcCDR08/e+z9xq27QMoHiEwpdzcX1i+fhZOjPc8+GRTZ3DzdZ4lYyPtQJsxYAkCvzs1xsItfk2VibESzhjUAWLA8fj+sb/H8harDt3MaHgMJJEESQgghUkRHW5tRA7vgaG/LtRt3mTF/TYq2s7ez5eqpXRzZteaz5OTG7aTnYHvz1p+JM5fSuutQ7tx//NXxFsrvyc3z+xgxqEey663bspeg4BCKF85LtQolE12nQe2KWFqYcfHqTa543f7qWD56FxJKYPA7LC3MMDE2+ub9/AySIAkhhBAplM7UmEkjemFkaMCWnQfZsffzZrPEuGVwTrQJLbEpRoKCQ5i1cC3/a9WHf/Yc4c79J3TuM5aT566kzkF8Iig4hA3b9qFQKOjYqmGSzXyGBga0bFwbgLlLNyTZ4fxLPg4XkNb7H4EkSEIIIcRXcc/gxPB+nQCYPHs512/dT9F2SqWSm7fvq5vZlEol9na2ONqnJ3PGDISGhbNk9Vbqt+zJui17iI2NpXbVsjSsU4mIyEgGjJzOpu0HUvVYVm3cSVh4BBVKFyGTm3Oy69auWha79NbcuvuIus16MG/pBgKCgr+qPO8XPkDanmLkI0mQhBBCiK9Uqlh+2jarR0xMLANHz+TN26Sn4/ioZsO2lKj0P3XHbIVCwYblf3Pr4gF0dXUZO3Uhi1dtJSwsgoplirJu8SQG9GhDz07N6f1XCwCmzV3JzAWriYuLS66oFHnrH8jmHQfR1tKibbN6X1xfT0+XGWP7UapYfkLDwlm5YSf1mvdk+ryVyU5H8invl6oEyTmNd9AGSZCEEEKIb9LqzzqULl6AgMBgBoyaSWRUVLLr587pAcDeg8c+WxYTG8uZi15oa2mxYu5YRg38K14n5ga1KjJheE8M9PVZv3Ufg8f8/dWT0ya0Yt0OoqKiqVqxZIqbvFydHZg4vCdrFkygSvnixETHsPGfAzRo1Yux0xapa4iS8rGDtksaHwMJJEESQgghvomWlhZD+3TA3dWJO/cfM3Hm0mQnrq1WqSwAew4cA+Deg8e88nmNUqnk6bOXREZG4Z7BiSwZXRPdvmSRfMybOgQrSzOOnb5Il/7jvrqJ6yMf37ds33sEHR1tWjep+9Xbf2xm3LB0CnWrl0ehULBr/3H+aNuPIWP/5v6jZ4lu563ugyQ1SEIIIcR/lrGRIRNH9MTUxJi9h06xYdv+JNctUjAPFuZmXPW6xSuf1/QZPI7sBStx/tI1bn94Si1bFvdky/PI7MaiGSNxc3Hk1t1HtO8xkmfPX3113EvWbCMmJpbaVcthn976q7f/yNHeln7dWrFlxXT+bFANA309Dp84T4vOg+k9dDJen/TPiouL4/kLX7S0FDjap//mMn8WSZCEEEKI7+DkkJ4xg7uipaXg70VrWLF+B0dPXsDr1n1evHqtbgrT0dGhcoVSAOw9eFz9BFt2j8zcufchQcqafIIEYJ/emgXTh5HfMzsvfd7Qvucort24m+J4vV/4sPfQSfT19WjZuNbXHm6ibKws6NruT7atmkHbZvUwNTHmzAUvOvYaRac+Yzh/+QZv/QKJiIzEPr0Nuro6qVLuj5T2IxRCCCHSuEL5ctKlbWNmLVzL/GUbP1tevlRhxgzuSrVKZVi/eScLl60jKPgdbq7OpDM1UY9z9KUapI9MTYyZPrYf46YvZt/hU3QbOIGhfTpQsUzRL267eNUW4uKUNKhVEWsri6870C8wS2dKm6b1+KNeVbbvOcraLbu5duMuPW7cxc7215hi5CNJkIQQQohU8Ee9qqS3tebOvcf4BwYREBiMX0AQT71fcfjEefp0aUm50sVIZ2rCvQeqhChXjqxERkXx8Mlz9PR0yZjBKcXl6erqMKxvBxzsbFi6ZhvDxs/B5/VbmjWsmeR4Rjv3H+fQ8fMYGRnQ9H81UuW4E2NsZMifDapRv1YF9hw8yeqNu3jl+xZI+yNofyQJkhBCCJEKFAoF5UoWolzJQvFe7z9yOifOXOay123KlyrM/atHmDlvGeOnziNXjqw8fOxNbGws2bK4oaPzdV/LCoWCds3r42Bnw/gZS5i3dCOvfN/Sp0vLePOpKZVKVm/cxdylGwDo3r4J5mam33/QX6Cvp0fd6uWpWaUMh4+f4+xFLxrUqvjDy00N0gdJCCGE+IEK5s0JwKWrtwAwMNCPN4L27Xtf17yWmOqVSjFtTF+MjQzZvucofYdNJTQsHFB1jv574VrmLt2AtrY2I/p3plbVst9zSF9NR1ubyuWKM6J/51+mBkkSJCGEEOIHKpAnBwCXrt1Sv2Zulg4TYyNyZff46v5HSSmULycLpg8jvY0V5y5dp1Pv0fj4vmX0lIWs27oXA319Jo/sReVyxb6rnN+FJEhCCCHED+TqbI+1lQUvXr3G940fAE6O9jRuUBMHe9tUS5AAMmZwZtHMEWTJ5MqDx978r3Uf9h0+RTpTE2ZPGkjRgp7fXcbvQhIkIYQQ4gdSKBT/1iJ9aGYb0Ksjk8cOIiw8gmfPfTA2Mky1wRNtrCyYN2UoxQp5Ehsbi621JQumDSWHR6ZU2f/vQjppCyGEED9YgbzZ2Xf4FBev3qJG5dLq1+89eIJSqcQjsxtaWqlXZ2FkaMDEEb04ff4qubJlxtLCLNX2/buQBEkIIYT4wQp+qEG67HULpVKpfgw/pSNofwsdbW1KFyuQ6vv9XUgTmxBCCPGD2dpY4eJkh39AME+evVS//jUjaIufSxIkIYQQ4idI7Gm2O/efAD+mBkl8H0mQhBBCiJ8gYUftwKB3+Lx+i4VZOvU0HCLtkARJCCGE+AnyeWZHoVBw5fodYmJjufvgQ+1RVrckpwYRmiMJkhBCCPETmKUzIWumDISGhXPvwZNUGUFb/DiSIAkhhBA/ycdmtotXbqkHiMyeNaMmQxJJkARJCCGE+EkK5P23o3ZqjqAtUp+MgySEEEL8JJ45sqCrq8O1G3eJjYvDLr01FubpNB2WSITUIAkhhBA/iYGBPjmzZSI2Lg6Q2qO0TBIkIYQQ4if62A8JILskSGmWJEhCCCHET/RpgiQ1SGmXJEhCCCHET5Q9qzumJsbo6urgkTmDpsMRSZBO2kIIIcRPpKOjw/Sx/YiMjMTY2EjT4YgkSIIkhBBC/GQ5PGTso7ROmtiEEEIIIRKQBEkIIYQQIgFJkIQQQgghEpAESQghhBAiAUmQhBBCCCESkARJCCGEECIBSZCEEEIIIRKQBEkIIYQQIgFJkIQQQgghEpCRtL9AqVQCEBMTo+FIhBBCCPEjaWtro1AoAEmQvig2NhaAsrXbajgSIYQQQvxIJ3cvR0dHlRopoqIilRqOJ02Li4sjKioqXlb5rZp2HMjq+eNTKTIhUkauO/E95PoRmqKJa09qkL6ClpYWBgYGqbIvhUKhzkyF+FnkuhPfQ64foSmavvakk7YQQgghRAKSIP1E9WtW1HQI4jck1534HnL9CE3R9LUnfZCEEEIIIRKQGiQhhBBCiAQkQRJCCCGESEASJCGEEEKIBOTZzRQYPWUBxQvnpVzJQt+0fWRUFNPnruL2vUfo6uoyrG8HXJ0diIiMYtSkeTx77kPBfDnp3qEJCoWC/UfOsGjlZooU8KRPlxYA7D5wgtmL12FjZQFAl7aNKZQ/V6odo0hbilVpRiY3Z/Xvw/p2JJO7y2frXfG6zZrNe5g6uk+i+4mLi2PB8k2cu3yd2Ng4+ndrTa7smYmNjWPK7OVcv3WfTO4uDOndHl1dHc5fvsHsReuwtbFU7/OK1236jZiOg50NAI3qVaF6xVI/4KhFaihauSnTx/ajSIHcANy6+5C23UewdcV07D+cw5TyfePHxJlLefM2ACfH9Izs3xkDA31evHrNiIlzCY+IpFnDGlQpXwKAuUvW88+eowzo0Ub9eTl6ygKuXr+LibEhALMnDSadqXEqHrFIa4aNn01YeCRTRvX+pu3TyueW1CD9BE+evaRgvpysnDeOqhVKsGDFZgC27TqEvZ0NqxeM56n3Sy5euQlAloyuiSZjdauXZ+W8caycN06So/84A3099bleOW9coslRSrzxC8DWxpLls8fQqVVDps9bCcDJs5cJDnnPmoUTMDI0YM/BkwA4OaSneqXPP0RKFs2vjkWSo7TN0d6WIyfPq38/cvIC9um/LjH66IrXHbq2+5PVC8ajra3NrgMnAJi5YDWt/qzDwmnDWLB8E+9DwwAoUSQf2bO6f7afQb3aqq8fSY7+26KjY/B9449/QBBh4RHftI+08rklNUhfadP2A+w9dIqQ96HUq1GexvWrccXrNjv2HUOpBK+b96heqRTtmtdXb+OR2Q2PzG4A5Mqemf1HzgBw+sI1GtWtgkKhIE8uD85c9KJQ/ly4uTri6uzAnftP4pVtbmb68w5UpDkBgcGMmjwfn9d+ZHZ3YXi/TurXB4yaoUrE8+ak91/N1SPB2tlaqx+VzZU9C2/9AgHVtZc3lwcAeXJ5cOTkeWpXK4ujvS1ZMrpw8erNeGWbm5n8rMMU38nFyZ67958QExODtrY2V6/fwc3VUb18wfJNnL98g3ch7+nQ8n9ULFOU3QdO8OyFD7fvPaJ4oTw0rl8NgGoVS6q3y5U9M2/9AoiNjePcpeuM6NcJY2MjXJzsueJ1h1LF8pM7RxasLM0/i8k8nXx2/S6uXL9D1kwZUCrhwuUblClREB/ftwwe+zcuTnY8eOSNm6sjQ/t2QF9Pj2YdB1G0kCe37z3i7wkDUSgUaeZzS2qQvlLeXB4snDGc5bNHs2ztP0RGRQHgdes+Xdo1Zunfo1i9cRexsXGJbn/52m1y58gMgH9AEK5O9gC4Otnj5x+YbNn7Dp+mSfsBjJw0j9Cw8FQ8KvErmDF/NfVrVWT94km4uTpx7PRFAMLCw+nXrRVrFozn5p0HXPG6k+j2l6/dIleOLIDq2nP5eO052+PnH5Rs2Reu3KRZx0H0Gz6Nt1+4ToVmRUZG4ZkzK5e97nDv4VPcMzgTGRmlXl6mREGWzBrJ9LH9mLd0o/r1XfuPM2rAX+rkKCHVZ1cWgkNCME9nirGxEaBKyL702fX3orX80bYfS9dsU08ALv6bTpy9TH7P7OT3zMaJs5fVr7/yfUObpvVYvWA80dExHDx6FoDHz57j5JCe2RMHJTqdlyY/tyRB+kr26a35Z/cRJs5aSmxsHIFB7wBwd3XCxsoCSwszzMxMeB8a+tm2fv6BbNt9mCYNqgOgQEFcnOrDIk6pREsr6bneShTJy6Be7Vg4fRjhEZGs27LnBxydSCsiIqNo3mkQzTsNYvLfywC4ePUmC5dvpkXnwRw8dhb/gGAAnBzssDQ3Q0dHh4J5c3L3wZPP9hcWHsHi1Vtp07QuAAqFqp0fVP8nd+1l98jEoJ5tWTRzBLY2VsxftjHJdYXmKVFSvlRhjp26yLFTF6lQughxyn//YLOxtmDN5t3MW7aRN34B6tfLFC+IpYVZovs8f/kGIe9DKVYoj+pz65MkJ06pRJHM9dO8UU2G9OnAjHH92H3gBFevJ57Ai1+fUqnkzPmr5M2djXye2Th38ToxHyZ8t7Iwx9nRDoVCQeH8ubj38CkAurq61KxcOtH9afpzSxKkFIiIiERLS4FSqeSvfuMA6Nq+CY72tijjPv9rSFtbm4R/JEVERDJw9Ez6dmmp/hCytrLg+UsfAJ6/8MXa0iLJGMzSmZLJzRljYyOqlCvOs+c+qXR0Ii36tA9S366t1K/PnzaUlfPGsX7xJP6oV+Wz7XR0tDEw0Iv3WmxsHCMmzKVxvapkzKDq+G1tacHzl74APH+Z/LVnoK9HDo9MGOjrUbNyKZ49f5Uahyh+oNw5svDg8TNu3X1EgTzZ1a+HhobxV9+xWFua079bKwwN9NXLtLQS/zrwfuHDrAVrGD2oCwqFArN0JoS8D1X3O3r+whdrq6SvH1dnB2ysLLCztaZ44bw8lc+u/6x7D58SGBxC1/7j6Np/PGEREVy/df+z9XR0tNHXV31OaSkUidYcpYXPLUmQknD05AXuP3rGu5BQbt19hKuTA8Hv3uP7xo861cuhjIsjICg4RfuKi4tj9JQFVCxTNF7n6uKF83D1+l2USiXXbt6lWOE8SW6/dddhoqKiiYqK5uxFL7JmzpAKRyl+Jfk9s7N+614AAoKC1c27AYHBRERGERoaxtFTF8nvmT3ednOXrsfRwZYan/yVVrxwXq5evwvA1etJX3sAO/cfJzQ0jNjYOE6dv0rWD/3pRNqlpaVFDo+MODrYxpvs0/ulL7q6ulQuV5yAwHfqaygpwe/eM3jM3wzq1RZba0v1vosW9OTqjbu8Dw3j+Usf8uXOluj2gUHv2H/kDEqlkqDgELxu3SNrpgypdpwibTlx5jItG9dW/3HX8o/anPzQzBYSGsq7kFCio2PYe/j0Z59TCaWFzy3ppJ2ELJkyMHzCHHzf+FGtQkncXB1RKlVV1y06DSZbVncc7dOnaF/7Dp/m+JnL+L7xZ9f+4wCMHdKNOtXLMWrSfJp2GEjhArnVF0zzToN4FxJKRGQk12/dY/HMkWhpKejUZwyBQe/IkysrDWtX/mHHLtKmnp2aMXbaIpq0H4CpiZG6k3Y6U2P6j5iG7xs//le7Mhlc/u2Qe/XGXdZu3kO2LG407zRItZ/OzSlRJC/nL1+nSfsBZMnkStXyxQHoNWQy3i98CAx+R/NOg5gwvAdmpib0GDyZwKBg3FwdGdK7w88/ePHVWjepq27C/yiTmwtO9ra06DyYfJ7ZSW9jlew+/l60lrf+AUyZvYLY2FhMTIyYO3kIPTo0ZdiEOcxftpFOrRthbGTInfuPGT99Mb5v/Lly/Q4nz15mQI823H3wmHVb9hAUHEKjupXJ4ZHxRx620KCTZ68wZnAX9e9lSxak99Ap/K92JZRxSkZPmY/3C19KFy+gHoYiMWnlc0vmYhNCCCHED+Pj+5Y+w6ayZuEETYfyVaSJTQghhBAiAalBEkIIIYRIQGqQhBBCCCESkARJCCGEECIBSZCEEEIIIRKQBEkIIYQQIgFJkIQQacq5S9dp1nEQTdoPoG334Rw/cwmA3QdO0H/E9O/a9/Ezl+jcd0xqhJmsivXa4+P7Ntl1fHzf/pRYhBDfRgaKFEKkGVFR0QweO4s5kwbjkdkNP/9AnsrUJkIIDZAESQiRZsTExhIZGc27ENVkz9ZWFvHm+QoJDWXc9EV43bxHOlNTpo7uQzpTY85e9GLl+h2EhoWDQsGIfp1wz+AEwOYdB9mwbR9m6UywME8Xr7yd+4+rpm9RQrYsbvTo1AxDAwOqNuzE8jmjcbCzZeaC1Zy/dIO1iyYC0KzjIIb370QmN2f1fh4+ec7EmUuJiIjEzdWR6JgY9bI1m3Zz+MR5wiMicLCzYdTALoS8D6XrgPEEBAbTvNMgWjepS+niBVixfgd7D51CqVRStUIJWv1Z50e91UKIL5AmNiFEmmFkaMDAnm0YPGYW/UdOx+vmvXjLfV770bJxbdYsmEBsbCxHTp4HwMHOhgnDe7Jy3jjKlSzEktVbAbhy/Q5rNu9m/tShLJ45kjw5PdT7unbjLivWbWf2xEGsXjAeQ0MDZi9ah7a2FoXz5+Kyl2rW+Ru3H2BsbISffyCBQe8IehdCxg/JF6iSuoGjZtCwTiVWzR9H5zaNUH4yW3U+z2wsnD6MtQsnEhsbx77Dp7CztWZQz7Z4ZHFj5bxxlClRkANHz/Ls+SvWLBjPmgUTuHDlJvcePPlh77UQInlSgySESFOqVyxFsYJ52LHvGANGzaBS2aL07NQcgCzurjjY2QKQLas7/gFBADg52HH+8nXOXbrOnfuPiYqOBuDMhWtUKVccK0tz1XqO/86feOr8VSqWLaquVWpYpzIdeo1iQI82FCmQm4tXb1KicF50tLXJlT0Ll71uo6OjQ8G8OeLNPv78hS+RUVFUKF0EADtba/R0ddXLXZzs2Xf4NF637vPi1WtevHqd6HGfPHuZW/ce0brrMADCwiPwee0nkwMLoSGSIAkh0hwL83S0+KMW5UoWolGbvrRuUu+zdXS0tdU1NaOnzEdfT49aVctQonBeZi9eB0BMTCwG+nopKlOhUKgTn0L5c7FwxWYue90mTy4PcufIwtFTF9HT06Vw/lzxtouJiUFbWzte0vRReEQEbbsPp1aVMjT9X3VsrS15HxqWaPlKpZLG9arSsI5MRC1EWiBNbEKINOPO/ces3rSL6GhVHx7fN36YpTPB2Ngw2e1OnrtCg1oVyZ41I3c+aZbKkysrR05cIDQ0DKVSyY3bD9TLShTOy8GjZwkKDkGpVLJp+35KFskHgI2VBWbpTDhy8gL5cmfDM0cWbtx+wJ17jyiYN2e8sp2d7ImMjOLi1ZsA3Hv4lIjISAC8n/sQFBzC/2pXIr2tNQ8ePVNvZ5femjdvA4iNjVPFUyQfG//Zr64Ve+X75lveQiFEKpEaJCFEmpHBxYHDJ87TptswIqOiMTYyZOLwnuhoaye7XZsm9Rgy7m9sra0oUiC3+vXSxQpw4/YDmncejK21JblyZFEvy5PLgxaNa/NXv7GgBI8sbvTq1Ey9vEiB3Gz4Zz9D+7TH0MAAYyND4uLisLQwi1e2gb4eIwd0ZvrcVejr65HDIxN2ttYAZHRzplihPDTpMBBXJ3scHWyJi1PVejnY2ZIxgzON2vShdZO6VK1Qgrf+AXTuOwZ9PT1srC0ZO7grBgb63/2+CiG+nkxWK4QQQgiRgDSxCSGEEEIkIAmSEEIIIUQCkiAJIYQQQiQgCZIQQgghRAKSIAkhhBBCJCAJkhBCCCFEApIgCSGEEEIkIAmSEEIIIUQCkiAJIYQQQiQgCVIqqt6gDdkLVNR0GCk2ZtJszJ08efb85Vdt16nnUKxc8/2gqFJP+64DMXfyBCAiIpLsBSoyaORk9fKNW3eTs1BlXHOU4NDR0zx7/pKq9VrikLkwXfuM0FDUaUuzdr0oU63xTy93/NR5mDt58jKJme/TohevfHHLWYq5i1enyv5iYmIwd/KkU8+hKVr/Z92X31POs+cvMXfyZMyk2Ykuf/zEG3MnT8ZPnfc9IQqRKiRB+gqb/9lLuep/4pilCEXK1WXclLlERUVrOqwfwuvmHWr/0R5nj2LkLlqVHv1H4ecfoOmwvpmBgT6rFk2jS/vmAERGRtG93yj09fUYN7wveT2zM3nGQs5euMrA3p1p3vjz2eN/RyMH9WDO1FHfvZ8KNZsm+UUfHh6BuZMnazZu/+5yNMnBzpY1S2bwR/0aP7ys+w+fYO7kyckzF394WUL8rmSy2hSau3g1g0ZMpmqlMrRp0Ygbt+4xeeZCbt25z5olMzQdXqp6HxpGvT87YZbOlJGDexAaGs7KdVu5//Ap1laWmg7vm+XPm0v98+u3foRHRFCjSjmaNKwNwFPvF9hYW9K1YwtNhZjmuLu5pMp+Xr/1J3Mmt0SXvfHzT5UyNE1LS4tihX9OzerrN34/pRwhfmdSg5QCwe9CGD9lLiWKFmDtkhk0aVibCSP70a9HB3bvP8rpc5fV60ZFRzN41BQy5i5D3uI12L7roHrZ1h37yFu8Bk5Zi1K9QRuuet0CICjoHX/1HoZbzlLkLV6DlWu3qrfJVaQqI8bNYOCIybjmKMGUWYswd/Jkx55D6nW69R1JlrzliI2NJTw8giGjp5I1X3lyFKzElFmLiIuLAyA0LIzu/UbhmqMEJSo1VJef0MNHT/EPCKRa5TK0btaQrh1bcOHYP/E+/JVKJavWb6Nw2bpkyFGSWfOWq5dt2raHqvVb4ZK9BDkLVY53PNUbtKHNX/2ZMWcpGXOXYfM/exk/dR7OHsVYumoj+UrUJHOesoydPEcdd2xsLNNmLyFn4Spk8izDgOGTEq258w8IpHn73rhkK06Vui148uxFvOXmTp607zqQZ89fkrtIVQBmzltOriJVqd6gDafOXuKtX4D6L/Pkyu3UcygVazVj3eadZC9QkemzlwCw9+AxilVogEu24jRq2RXf128BWLNxO+ZOnhw+dpqKtZrh7FGMNn/1Jzr63+PYd+g4Zao1xiFzYUpWbsiVazcBePnqNU3b9sQlW3EKl63LvkPHPzv2gMAgho+dTuGydXHIXJjKdVrw4NFT9fKdew9TsHRtLJzzYO7kibmTJ1XqtkjR+frYbPyxeWTZ6k00adMDl+wlqFCzKS9e+QIQFRVN1z4jyJCjJB75K9B70FhC3odi7uTJ8xevWLdpx2c1RSfPXMSzaDUA/uo17LMm3/2Hj1OyckNcshVnwPBJ6teTu84TnvMFS9fSvutAnD2K8fylzxfvkR79R5EhR0kKlKpF3yHj48WUq0hV9fuW1Pvzsflo/NR5ZM1XnsPHTpO3eA16DhgNwPlL16hQsylOWYtSrX7reOfp+KnzFC1fjww5StJ/2MTPjgdU11LNhm0BqNmwrboZGZK/LxN+lpy7eDXZa/z6rbtUqNkU+0yFKVa+Phu37k5ROe9Dw+g7ZDxZ85Una77y9Bs6gfehYYkeC6hq5vMUr04mzzJMn7M0yfWE+NkkQUqBO/ceEvI+lIZ1q6NQKNSvN6yr+mA/f+ma+jU//0B8X79l1JCeGBkZ0rbrAF6+ek1oWBgdug/GwT4944b3xcHOFqVSiVKppF3Xgezad4QenVtRv3YVuvUbybXrt9X7XLJyIzdv32PiyP60b9UYc7N0HDh8EoC4uDj2Hz5BrWoV0NbWZsjoqSxYupYWf9anY9smjJ86j137jgAwYuwMVqzdQptmDWnT/H/c/+SD+VOZM2XALr0NC5aupeeA0dy68yDecX8sd+2mHXRs8yc21paMnDBL3QR39sIVCubNzZihvbCysqDnwDHxvvQOHD7Jlh37GDm4B6VLFAIg5H0oq9f/Q88urSlWOD+TZy5k515V3LMXrGTUhFlUr1yWgb07s3bjdhYuX/dZ3J17DmXfoeP07tqWmtUq8OiJd6LHZ2NtyYwJquae2tUrMnPiUIb0+4tsWTNiYW7G6sXTye6R6Yvl3rpznykzF9KvRwfq1qzMhcte/Nm6B04Odowb0Zfnz1/R48OX4kfd+42iUf0aFC2Ujy3b97Hv0AkAjp8+zx8tu2FsZMTE0QPInycnzk72REdH07BFF6563WJw378oWigvLTr0wcf3Tbz9xsbGcunqTVo2aUC/Hh24cesufQaPA1Rf3K0798MuvQ3jR/TF0sKc0iUKM7R/txSdr4QGDp9M7pwetGhcj0tXb/D3/BUArNu0g1Xrt9G2RSM6t21KeEQEerq6rFgwFYCSxQqyevF0ShUvpN5Xdo9MDOjVCYD2rRqzevF0bKz/raVcvHwDrZv9j6yZ3Zm/ZA1eN+8AJHudJzRm0mwiIqOYPmEoTg52X7xHlq/ZQutm/+Ov9s3U5+dbvfULoMeAMXRs8ydtW/zBU+8X1G3cAS0tLcaN6ItCoaBlx74olUqev/ShUYuuKBSqZdHRMYnus1TxQrRt0QiAwX3/YvXi6eplyd2XEP+zJHdOj2Sv8b6Dx+P7+i0TRvajRLGChIdHpKicHv1GsXLdVjq3bUqnNk1YvmYzvRLcBx9dvnqDtl0G4Ghvx+ihvQkMCv6u91uI1CRNbCnwykfVUdTW1ire67a21gC8/PAXNICFuRlL5qj+8tPX06NtlwEcPn6ahnWrY2hoiIG+HuXKFKP5n6o+Lk+ePufg0VP07d6eFk3qgxLWbtzOrv1HyJM7OwBGRoasXjwds3SmANSsWp79h08QFxfHteu3ef3Gj9rVKxIREcnyNVtoWK86nds1BWDnnsPs2neEGlXKsWbjdiqVK8mwAaovxkdPvJm9YOVnx2tsZMShnavpN3QCy1ZvZtnqzdSpUYkpYwfGa2LbunoehoYGBAa9Y9SEWTx++hxrK0umjR9CeHgEV6/fJp9nDrxu3OGq1y1cnR0BiI6OYc2SGbg4OcQr9+8pI8mRLTMVyhRn++6D7DlwlNrVK7Bw2TpKFivIwN6qL9LT5y6xe98RdX8igDdv/dl/+CRtWzSie+dWAJy/eC1eTdtHRoaGlC1dFIDMGTNQrnQxACwtLAgODqFGlXIAXyw3LDyChbPGqZvuxk2di5GhAbOnjkRPT5ewsHD6D5sYr7Zr+oShVCxXgtw5PThw5KS69mDe4jWkMzVh3bKZpDM1odkfdQFVjcKtO/eZNWk4tapXICIikrWbdnDw6Kl4/aRsrK3YvXkJr3xe43XzDs5ODly87IVSqeTa9TtER8cwtH9XCuX35O79R1y6epPiRfIDfPF8JdShdWP69+xITEwMi1ds4MGjJwCYmhp/iMWSFn/Wx8BAH4DqlcsA4ORor35vP7KytKBIwTwAeObK9tnyZfMnkzWzO6YmJly8cp0HD5+SNZN7ktd5rWoVPovXxdmRJXMmoKurm2r3SErFxcUxanAP6tasDMCYybMJC4/g7ykjSG9rjbWVJX+27s7TZy/YvvsgEZGRzJ4ygnx5clKrWgVWrtv62T6dHe3JncMDgCIF81KyWMF4y5O6L+Hzz5LkrnFTE2NQKPDMlU312ZRAYuVoaWmxefte6teuor4Pr924w8Zte5g4asBn+1izcTsKhYJl8yZha2OFZ06PJBNdIX42SZBSwNlR9UWe8K/2j79/+kX/aU1L1izuAAQGBmNgoM/eLcsYOX4mnkWr8b+61Rg1uCdPvVXNQJNnLmTyzIXqbf38/v2rz83VSf2BBlCvVmVWrd/Gteu32XfoBDbWlhQrnI+nz14QGxvLuk07WLdph3p9ExMj/PwDCQuPSHGfEicHO9YumcHDx0+ZNnsJazfuICYmJt5fq7q6qsvH2tICUHV8BliwdC3jps5FS6GFm6sTAO/evVdvZ2lh9llypHrvVP/b29liZmZKQEAQUVHRvPR5zUuf12TIUVK9biZ313jben+o8UitPjMpLdczVzb1z8+8XxIaFk6WvPG/5AMCg9Q/J/WePX32nAyuTqQzNYm37dMPzYTd+o2kW7+R6tf9/APjrfcu5D0dewxh38HjZHJ3JSw8grDwCGJjY8mZLTMKhYLN/+zFyNCQ0+cu457BWb3tl85XQrq6ugDo6OhgYZ6OyEhVAli3ZmXCwiOYOH0B02YvoVeXNrRv9X1PwOnqfHi/rD68X1FRvHzlm+R1npgcHpnUMSe37dfeIynlmfOTa+SZ6jotXLZuvHXe+gfg/eIV8P3XcFLXGMT/LPnSNT5/5hgmTptPpTrNKZA3N2OH9SavZ45ky/l4vX56zHlzZ+efXQd46v0CS0vzeLF6P3+FqalJvFpDIdIKSZBSIJtHJszN0rFhyy5a/FkfLS1Vy+THD9hihfMnut39B48BcPvwZZQjW2Y2rpzNzdv3qdagNQD9urcHoHWz/6n/ygRwtE+fZDwlixXE2sqCw8fPcPjYaWpWLY+2tjaODnZoaWlRtWJpOrZpol7fytIcSwszdHR01E0UoOpHkJQ3b/2xtbEik3sG5kwdxYnTF7n/8EnSb9IHz56/pP+wiQwb0I0enVtx+txldX+JlPJ9/Zbg4BAyuDqhp6eLg50tjg526r/qAUyM438ZfqzN87qRsuP7kpSW+ylXZwdu3bnP6sXT0dbWVr/+8cs9OS5Ojpy7eJWQ96Gqv9w/7tNFVYszoFcndY0PgHuG+F+icxau4sixM1w6vh13Nxc69Ryqvj7d3VyoXKEUC5etY+GydaS3tWZwvy5A6pyvjxQKBU0b1eGP+jWYOW85/YdNJFvWTOq4IyMjE93u4/2U1PKEkrvOv2dbSwsztLW1k71H9HR1ePM2QL3sfWhoimL+6OP5XLVoGuZm6dSvZ/fIjK3Nh2v45h1KFy+c7PWrpf3xPYtKcp0v+dI1bm1lyeSxg+jfqyN/tOxGs/a9uXl+X7L7zPAhwb52498uAlc/dBfI4OLEu/fxE29bWyvevQvhmfdLMrg68R23rBCpThKkFDAxNmJo/670HjSWxq26Uat6Rbxu3GHhsnU0qF2Vgvlzq9cNCn7H0NHTyJwpAxOnzcfBzpYKZYtz1esW/YdNpGE9VT+mmOhotLW1cMvgTLnSRdm0bQ/mZunI4OrE9Zt3GT6we5Lx6OjoUKtaBbbt2M+d+4/UH24GBvo0b1yXNRu34+zkQM7sWfC6fpvuf7VGR0eH6pXLsmvfEabMWoSRkSGr1v+T6P7Xb95Jj/6jadm0AblzenDz9j1evPThr/bNvvhefeyncO36bdZu2sGSlRtT/D6PnTyHGlXLs3r9P6ov2z/qANC25R+MmjCLDVt2UaRQXu7ef0SD2lXjbevsaE9ezxzs2nuY+bmz8y7kPfsPf1//kZSU+6nWzRuy6Z+9TJu9hHo1K/PGzx9XZ0d0dL58m7Vu/j8OHDnJn62782fD2njduEP9WlUoVjg/2bNmYvmazWhpKbCxtuT+w6eMGdor3vbh4RFEREZy4MhJQsPC2bX3sHrZ4yfe7Dt4nI5tmmBiYkTObFnQ19NTbwffdr4SGj52On4BgZQsWpAnT58DoK2tjba2Ni7ODpw4fYGNW3dTIG+ueLUkH5OGdZt2YmlhToWyJZItJ7nr/EtSco/s3n80yXskcyY39h08zvCx03nq/ZI79x6qa1BS4s//1WLOwlVM/Xsxf/6vFhERkejq6lKyWEFqVi3PhGnzGDNxNi+bvWbnJ+cwoQwuqkRk0Yr1hIaGUav6502LKZHUNR4U/I4/WnalYrmS2NvZ8j40FG3tL3dZtbQwp0Htquzcd5iZc5ehVCrZc+AoDetWw8LCDD19XXR0dLjqdYv3oWHUrl6RtRt30H/YBGrXqMSqRJoUhdAU6aSdQm2aN2T5/Mn4+QfSb8h4Tpw+z6A+nZk/c0y89SqUKY5/YCBDRk3FwT49G1fOwcjQkEwZM+CZKxvTZy9hxLgZlC5ZhGH9u6FQKFgyeyJ1a1Zm9YZ/GDpmGi9e+cZrlklM3ZqVuX3vIZYW5vFqFsaP6EenNk3ZtfcwA4ZN5O6Dx+qOj1PGDqRS+ZLMnLuM7bsO0r7VH4nuu16tKgzo1ZGzF67QZ9BYdu07Qq8ubRjar+sX3yePLBnp1rElR0+cZe7CVXT65K/0L7GxtmTo6Km89PFlyZwJ6mr6bh1bMGJgd06du0S/IeM5e/4K70Li/yWqUChYOmcieXLnYOzkOZy/eI0Wf37eb+JrpKTcTxUpmJe1S2cQGBTMwBGT2bBlV7Lrf6pKhdIsmDmWN2/96T1wDFe9bqFQqP7K37hqDoUL5GHe4jWMnTwHP7+Az5rAOrVtQqH8noydPIfL126qO/ECuDg7kDljBlau3cKUmYto2bEvhcvWZeT4md91vhKqW6sKz1/40HfIeI4cP8PwAd3UTz5OGj0AA319+g4dz4nTF+Jt5+rsyIBenXjw6CmDRkzm4eNnXywruev8e7adMnYQFcoWZ+bcZezYfZDSn3QoBxjUpzOZM2b4kGDZ07XD1w0J4e7mwj/rF6Cvp8fI8TNZtGIDAYFBKJVKcmTLzLwZY3jj58/wsdPJnjUTWTO7J7qf4kXy0+LP+pw5d5nh42eon5b8Wkld4+lMTahToxIbt+6m98CxGBkasvjvCSna5/SJQ2n2R11mL1zJ3MWradG4HtM+PBRhbGREo/rVOXP+CnfvPaRSuZKMGNid6zfvMm7yHGpWqxCvBlUITVJERUVKpabQqPFT5zFx+nyunNyZ6v0/BCxdtZHxU+fhdXYPRoaGvAt5T82GbYmJieX0wU2aDi9NGzNpNlNmLcLr7J4kO60LIf6bpIlNiP+4Fy99eesXwISp88nmkYkbt+5y/eZdenf7tr5GQgjxO5AESYj/uG4dW/Ls+UtWrNtCVGQ0GVwdGT2013c1pwkhxH+dNLEJIYQQQiQgnbSFEEIIIRKQBEkIIYQQIgFJkFIoOjqGxau20LzTIJp1HESfYVN5lWBk7e/Rf8R0dh9QjduzZtNu9h85neh60+etYvGqLV/cX+e+Y/Dx/bZHf79k5KR5PPowzs2PcOnaLWYtXPvD9p8Si1dtYfq8Vam2vytetxk9ZUGq7e9H+vTYHz19zshJ81Jlv807DeKK1+0vr/gD+Pi+pXPff4fkuOJ1m+adBqVqGaOnLGD91uQHUvySlN7fqc0/IIh+w6clOgl0cu4/ekbd5j1+TFBCaJh00k6hqXNWEB0Tw+KZqnm2rt+6rx5sL7U1+V/1H7Lf1DK8X6cfuv8CeXJQIE+OL68ofriMGZx/+PkWmmdlac6kkb2+vKIQvxFJkFLA940fR09dZNuqGejpqeZ0yp0ji3r5mk27OXziPOERETjY2TBqYBeMjQxZvGoLEZFRvPJ5w50HT3B3dWLi8B7o6OjwLiSUSbOW8uCxN3a2VvgFBKn3N33eKkxNjGjbrD6RUVHMmLeay163sbYyJzo6lsL5cwJw6+5DFizfTNC7EKKjo+nXrTV5c3kwesoCbtx+QK+hk8meNSND+3Tg5p2HTJu7ktCwcOzTWzOsb0csLczUZV7xus3qTbuxt7Ph0tWbpLexpmu7xixetZVb9x5SrUJJOrdRDSzZvNMgenRsSj7P7HTuO4bypQpz4sxlHjzypn6tCrRpqppEtWjlphzYsgBTE2PuP3pG/5HT2bZyBv4BQQwZNxs//0CMjAwY1LMdWTNlUMdy/MwlNmzbx9zJQ9RxOTum59LV26CAySN74WBni1KpZP3WvezYdwxdHR0K5MlBtw5N6Nx3DI3qVqF0sQIAVKzXnpVzx2JvZ0Pd5j1o9Wcddu0/jn9AEH26tOSK1x1Onb+CkaEhk0f2Ur8v3i986DNsKi9evcbJIT1D+7THLJ0pfv6BTJq1DO+Xvujp6dKvaytyZsuU5Pm+++ApoyYvICw8guadBtGvW2tyZsuU6LW25+BJtu0+THhEJMZGhowZ3BUbKwt2HzjB1Rt3USqV3Lj9AHMzU6aM6kM6U+Nkr7Pk3oukrttPfXreDp84z4p12z/cE/7k98zO+GHdk7y2fN/4MWHGEt76BeJob0vQu5BEj3nn/uOs37oXlJAtixs9OjUjLk5J/RY92b5mFkaGBiiVShq07MXM8QOwMDNl6tyV3L73GIUC/mrTmBJF8rL7wAnu3H9CYFAw70PDmDGuPwqFAt83fnQdMJ6AwGCadxpE6yZ1SWdqTFR0DLMWrOH8lRughEkje+Fob0toaFii+/8oNjaOibOWcOnqbXR1tWnZuA5VK6hG/376/CV9h0/l7v0nFCnoyeBe7ZL9jEju/o6OjmHu0vWcv3QDhUJBpXLFaN6oJg8ee9N/xDS2rpyBQqGgxV+DyZktM327tCT4XQiN2/Zn1/rZ6ilc+o+YTsmi+ahRuTQnz16m34jp7F4/B0sLM6bPW4mTgx1VyhenUv0OnN2/GoDKDTrSoUUD9h05zUufNwzq2ZbihVXvwdGTF1iwYjNGhvrYp7eJdy5PnbvKolWbiYmJxckhPX26tMTGyoLmnQbRvUNT8ufJzsZ/9rNgxSb2b16AjrY2/YZPo2bVMpQski/R60MITZEmthR4+Pg57hmcMDI0SHR5Ps9sLJw+jLULJxIbG8e+w6fUyy5fu02/bq1Zt3Ai9x8947KXap6nWQtWq2ZvXzSRCcN7YKCvn+i+V2/cxVv/QNYsmMCs8QOwtPh3/iZrSwuG9G7Hyrljadm4Dn9/aJYa2qcD1lYWTBvdl6F9OhDyPpRx0xYxfmh3NiyZTOniBVixfvtnZd2884DaVcuyZsEE3oeGMn3+Kob17cCiGSNZvWk3AUmMVHzv4VOmjunLrAkDWLbmHyIikp9T68DRMxgbGbJx6RSmjupDBpfPJ65NGFe1iqVYNX8cLo72bN9zFICDx86y99Ap5k8dxoq5Y1Nc8/bWL5AF04bRsE5lBo+ZRali+Vk9fwJGhgbsPfTvuYuIiGR4v46sWzQRA309Vm7YCcCYqQupV7MC6xdPYtSAzkz6e5l6m8TOd85smWjXvD4li+Zj5bxxSSZHAFkyujJrwgBWzx+Pm4sjG7b922Rz2es2bZrWZe3CCcTExHLk5Plky/2S5K7bxJQvVZiV88YxbUxfjI0M6NKucbLX1ujJC8jnmY01CycwuHc7tLU+/7i5duMuK9ZtZ/bEQaxeMB5DQwNmL1pHOlNjCuTJwenzVwG4c/8xlhbmODmk5+9F68iVPTPrFk1k7uQhTJ2znNjYOAB27j9G04Y1mDl+gHriaDtbawb1bItHFjdWzhtHmRIFAdUkwpXLF2fVvHG4ONmzY6/qukpu/wAPHz/j2KmLbFw6mWWzx1CkwL9TDb15G8DogV1YNX88ew+dwvuFT7LvdXL39+pNu3jl+5aV88ayeNYITp69zIGjZ8nk5kxUdAyvfN8S/C4EIwMDvG7eA+CK1x0K5M2uTo4AChfIrb4eLl27RX7P7Fz+0NR56dptCuXL+dl5eRfyHn19PRZMG0aLP2qxfJ1qXr/nL32ZOGspk0b0ZOnfoylfuoh6m+cvfRk3fRFjB3djzYIJeObIypgPzcpFCuT+t8yrt8iW2Z27958QExvLjTsPyJc722cxCKFpUoOUUsnMoujiZM++w6fxunWfF69e8+LVa/Wy3DmyYG6mmj07S0YX/AJUs7CfueDFgunD0NLSwtDAAOskJto8ff4aHVs1VM+cbfdhUlYAWxtLrt64y/pt+3nw6Fm8cj91885DXvv503f4VED1F7Cb6+ejAtvZWpMlo2om72xZM2JhZoqxsRHGxkZYWZrj7x+EpbnZZ9sVL5wXHW1tMro5o6urS2BwCPYGiSd8AMUK5WHX/hP8vWgdDetU+mJTpZ2ttbqGKUe2jDz9MCP6iTOXqV+zImbpTICUTVYKULJoPhQKBbmyZ8bMzJRc2TOr9u2Rkbf+ger1smTKoJ72oGTRfPyz+whh4RFcunqLgMBg5i5ZD0DI+38nLE3qfKeUs5MdJ89c4bLXbW7efYiTw7+TFmdxd8XBzhaAbFnd8f+k1vFbyk3uuk2KUqlk3PTFtGxcB0d7W85e9Er02goLj8Dr5j2mje0LgFk600SnkDh1/ioVyxbFwlyVGDSsU5kOvUYxoEcbqlYowZ5DJ6lYpiiHT5ynSvliAJw4e5kbtx+wbZdqrrK4OCVBwe8AVfNstiyJT8+RUJLXVRL7/3h9ubo44pHZnWET5tKkQTVyePyb8BbKlwsDA30MDPRxcbTDLyAIFyf7JN/r5O7vk2ev0Kl1Q3R0dFTzL1Ypw8mzl6lcrpgq4bh2CxMTY/Lk8uDi1Zu88QvgktdtCuXLFe84ixTIxfJ1/6BUKrl28x6tGtfh7EUv8ntmJyw8Ahcne96Hhn32/pQqlh+FQkHObJnUfasuXLlBkQK5cXGyB4h3fV64coPC+XOpX2tQqyJzl24gPCKCIgVys2DFZmJiY3np84b6NStw6eottLQUZHBx/KzmUoi0QBKkFMjo5syjpy8IC4/4rBYpPCKCtt2HU6tKGZr+rzq21paJftgA6GjrwIc8KyY2Bp1PZnxPSkxsLDpJTBK5cMVmHj97wR/1qlKrShna9RiR6HpKpRInh/SsmDP2i+X9G2v82HR0tPnSgFkKhQIdHe14yWRMTOxn67k6O7Bi3liOnbpIl37jaNe8AZXLFUthXDrqOOKUSj5UEsSPA0Wi5X62rwSTyOroaKOMSPwotbW1MfiQ9ClRMmfy4C/OGfXp+U4JpVJJtwETyJvLg3o1ypPdIyOnzl5JYt/aSc72/mm5Sb0XX3Pdfmr73qMoFFCrahl1zIldWx/3pZ2Ca/xTCoVCXfNTtKAnU+YsJzQsnJNnr7Bw+nDVSkoYOaAzmdw/n5YmJfdUYj69rpLbP4CBvh6zJgzg+q37zFmyHjdXJ/p2afn5Pj/cC8m918nd35/55L0pUiA3p89fxdjIkNLFChAdE8Pla7e56nWHFo1qxtvMwc4WQwMDrt9+gL6eHgXz5mDu0g1cvXGXQnlzqveZ5Hujo4Pyw7sTExP7Vef0465zZc/Ck2cvuX7rPpncXcibOxtT565AR1ebwgkSOiHSCmliSwH79NaUKpqPqXNWqJ/yuPvgCecuXcf7uQ9BwSH8r3Yl0tta8+DRlyfaBMiT04Od+48DEBj0Du+XPomulzdXVnYdOEFcXBzhERE8+GQiz5PnrlC9Yiny5vLg/qOn8bazs7XG58MEljk8MvH6jT9HTqomCQ0NCycw6N1XvQffwtrSHK+b94iJjWXvoZPq1+/cf0xkZBQVShehXKnCXLhy45v2X7xQHrbtPqL+snn+0hdQ1SR53byHUqnk0PFz6hnrv5bvaz9iYmKIiormnz1HKFYoD0aGBuTNnY1FK7cQFxdHbGwcPq/9vrgvO1trfF/7JZnUALwLCeXmnQc0rl8N9wzO3L3/+Jvi/lRS70Vy161CoUg0zhevXrNi3XYG9mir/lJN6toyMTbCzdVJ3WT5yvdNvH52H5UonJeDR88SFByCUqlk0/b96r4ouro6lCyan5Xrd+DqbK+uISteJC9LVm8jOjoGpVKZoqdJ7dJb8+ZtQLymsqR8af8+vm955fuG3Dmy0LxRLc5cuJbs/pJ7r5O7v0sWzcfWnYeJiY0lPCKCnfuOUeLDe1MoX07uPnjKnfuPyZUjM/lyZ+P0+asotBTY2lh9FkORArnZuG0f+XJnw9jYCBNjI46fvkih/F+XnOTJmZWzF73w+1DTeuP2ffWyQvlyceHKTV76qN6vLbsOkS93NgwNDNDV1SFvLg+27DhIvtzZyODiwCuft3jdvEeh/J838QmRFkgNUgr169aaxau20KrLULR1tLG1tqRnp2akt7GkWKE8NOkwEFcnexwdbImL+3K1Qc/OzRk9ZT5N2g/AyTE9zg52ia7Xukk9xk5dSON2/XGws4nXKbLp/6ozb9kG1m/bS+liBdD+5C/ROtXKMXT8HPLlzsboQV2YPLI3MxesZsmqrejr6/JXm8bkz5P9+9+YZLRrXp9x0xfjssmOpg1rcOz0JQB8XvsxZfYKwsLDMTQwYFjfDt+0/2oVS+L7xp823YZhYKBPrmxZ6P1XcxrXr8qgMbO4cOUmNSuXJvOHZsOvZWCgT49Bk3jjF0DRgrmpW70coHqKb8rs5TRu1x99PV2qVypFo7pVkt1XruyZiYqO5s/2/enRsRk62tps2nGAsYO7qc9bOlNj/qhXlfY9R2Cf3oac2TLh5x/0TbF/lNR7kdHNOcnrNm/ubIybtogmDeL36ZqzeD2hYRH0GjIZAFsbK6aM6p3ktTW0bwfGT1/Mpn/2k9HNGWfHz6/xPLk8aNG4Nn/1GwtK8MjiRq9OzdTLq1UoQYeeoxgxoLP6te4dmjBj3iqadBiAgYE+hfPl4q+2fyT7PjjY2ZIxgzON2vShdZO62Nl+nkSkdP+hYeH8vWgtAYHviIyKonuH5KdsSe69Tv7+rsGcJetp3nGQupN2pbJFgY9NlkboaGtjaGCAZ86sDBw1k7o1yicaQ5ECuekzbArTx/YHIL9ndtZv20vvv1omG3tCWTO70axRTTr0GoWVpTmF8//b/8rZ0Y6BPdoycPRMYmNjcbJPz5A+/97bhQvkZuqc5XRs1RCFQkH2rO5cuX6HrJncvioGIX4WmWpECA2Ii4vjr37jmD62Hwb6P2a4CCGEEN9OmtiE0IAV63fQsHYlSY6EECKNkhokITRAqVR+sXOsEEIIzZEaJCE0QJIjIYRI2yRBEkIIIYRIQBIkIYQQQogEJEH6AqVSSUxMTLLj1wghhBDiv0USpC+IjY2lZPWWxMZ+eWRmIYQQQvw3SIIkhBBCCJGAJEhCCCGEEAlIgiSEEEL8hpQREYRWq05oteooI75tzsr/MkmQhBBCCCESkARJCCGEECIBSZCEEEIIIRKQBEkIIYQQIgFJkIQQQgghEpAESQghhBAiAR1NByCEEEKI1FesSjMyuTkT8j4Uu/Q2DOndHkd7239X0NJCu2AB9c9f4+Fjb3YfPEH3Dk2/KbbmnQYxcXhP7O1sEl1+8twVFizfhI62NkN6tyeTu0u85QePnWXDtn0Ev3tPk/9Vp061cgD8s+cIm7YfwMTYiNED/8LWxuqb4gNJkIQQQoj/JAN9PVbOG0dcXBxbdh5i/rKNjB7URb1coaeHwciR37TvTO4u35wcfUl0dAxTZ69g6exRvPJ5y6S/l7Fw+nD18tjYOLxf+DB38hDCIyKo16In5UoWJiYmhlUbdrJmwQROnrvCnCUbGDmg8zfHIQmSEEII8QMkO/iilhYKPb2UratQoNDXj7euwsAgxXFoaWmR3zM7ew+dAuDW3YdMnLWMyMhIalQqTbNGNQkNDWP01IU8f+FL5owu3Hv4lHWLJrH7wAnu3H9Cny4tAChXuw1Hti/hitdt1mzew9TRfVi8agt6erqcPHuVhnUqkd8zO6Mmz8fntR+Z3V0Y3q8TOjrazFu2keOnL+LkYEfQuxAAfN/40aXfOFYvmICBvp46PnMzUyzNzTAzNeXew6eEvA/F1MQYAG1tLdo0rQeAnp4uDultCQp+x627j8iSMQMGBvrkyeXB5L+Xpfg9SowkSEIIIcQPEFavfpLLtAsWiFd7E9b4T4iMTHRdrVy5MJw44d91W7bCeP26FMcRFxfHviOnyZopA9HRMYybvpjpY/thaWFGn6FTqFKhBBu27cPBzpYJw3pw/9Ez+o+cnuL9A+w9dIplf4/GwECfYePnUL9WRUoUzsvSNf9w7PRFjAwNuHbjLqvmjScqOppmHQcCqgTH1dkBHe1/m/j8AoJwcbJXvU/aWjg5pMc/IEidIH3Kzz+QkPehONqn58SZy7g42QFgbWlObFwcEZFR6sTra0mCJIQQQvwHRURG0bzTIHzf+FGqWAF6dW6O90sffF/70WfoFFAqef/0Gd6t2nHJKQujBnUFwD699VeXVa1CSQwMVLVcF6/e5MmzlyxasZmo6BjqVCvHnbePqVaxJHp6uujp6aqTHUtzM6aO7hNvXwqFAqVSqf5dGadEoVB8VqZSqWTWwrW0+rMO2tpaoCCR7b76UNQkQRJCCCF+AKOtW5JemKBTtNG6tUmvm+Bb3mh5ypqOPvZB2rT9AM+e+2BkaIBSCS5O9iybPRplRISqlitG1a8nLDzxZr6Y2JgvlqWV4HjmTxuKsZGh+vfp81YSFpay+d6srSzwfukDqOJ66fsGa0vzz9Zbu3kPuro61KpaBgAbKwtu3nkIwFv/QHR1ddHX+7baI5DH/IUQQogfQmFgkPS/BF/cya77Sf+jj+t+jbrVy3HZ6xYPnzzHxdGOoOB3XPG6DcAbpSr5yp7FnZNnrwBw5/4T9bYW5ul48MibmJgYDh47m2hNTkL5PbOzfuteAAKCgomMiiJ71kycuXCN2Ng43rz1xy8gCIDAoHf0HjqFmNhY9fY5srrzLiSUgMBgbt19SPYs7hgbG3Hg6BnWbt4DqJ5yO3H2Mv26tVLHVChfLh48ekZERCRXr9+lWKE8X/U+JSQJkhBCCPEfpqOjQ8dWDZkxbxW6ujqMHtSVWQvX0rz7CObGGRGrhDZ/1OTStVu0+Gswp85dUW+bP0929PR0adSmL2/9ArG1sfxieT07NePW3Uc0aT+AQaNmEhAQTPlShbC1saRJhwHMXrwO+/Sqx/sjIqN49vwVMdH/1lLp6OjQt0tLug2cwPR5q+jbtRUAfv5B+L7xIyIikuHj5xD87j3teoykeadBrNuyBwvzdLT8sw5tug9n265DdG7T6LveN0VUVKTyy6v9vmJiYihZvSUndy9HR0daJIUQQvw3qJvYUDUHfqyZCnkfSvPOg9m2coYGo9M8qUESQgghhEhAEiQhhBBCqJmaGP/2tUcgT7EJIYQQvyeFAq1cudQ/i/gkQRJCCCF+Qwp9/XgDUIr4pIlNCCGEECIBSZCEEEIIIRKQBEkIIYT4DSkjIgj9ozGhfzROfrLc35T0QRJCCCF+V+/eaTqCNEtqkIQQQgghEpAESQghhBAiAUmQhBBCCCESkD5IKWSdIb+mQxBCiP+soBdemg5BiHikBkkIIYQQIgGpQRJCCCF+RwoFWpkzq38W8UmCJIQQQvyGFPr6GM6coekw0ixpYhNCCCGESEASJCGEEEKIBCRBEkIIIX5DyogIwlq2IqxlK5lqJBHSB0kIIYT4TSnfvNF0CGmW1CAJIYQQQiQgCZIQQgghRAKSIAkhhEjT9h48RolKDSlWvj4r1mz5bPmFy17UatQOC+c8BAX/Ozv9mo3bccleghKVGlKiUkPadxsEwKgJs9SvlajUEKesRZm7ePVPOx7xa0iyD1Jg0DsmzVqG90sfdHV0aNO0LiWLqqbb6Nx3DF3b/Um2LO4/LdDETJ+3iiwZXaleqZT6tdFTFlC8cF7KlSzEzAWrqV6xFJncXTh84jzL1v5DmeIFyJc7G7sPnmRonw4ajF4IIcSXBAW/o2ufERzZvZZ0JiYUq1CfksUK4u7mol7HwT49fbu358TpC59tX6tqeWZPHRnvtWEDujFsQDcAHj5+Svuug2jd9H8/9kDELyfJBGnouNlUrVCC6pW6ExAYzF/9xpLe1posGV1/ZnzfpXuHpuqfd+w9Sq/OzcmXOxtXvG5rMCohhBApdfjYafJ55sTFyQGAKhVLs3PvYbp3bqVex8nBDicHu0S3t7aySHb/vQaOZdLoARgY6Kde0OI/IdEE6cmzl7wLeU+1iiUBsLQwo2nDGmzZcZCBPdsCsGPvMSb/vZzIqCiG9elA1sxu7D9ymoUrNqOjo0PrJnWpXK4Yt+4+ZOKsZURGRlKjUmmaNarJ4lVb0NPT5eTZqxQvlIerN+4wc/wAAJas3oqlhRk1q5RhxrzVXLx6k3SmJowa0Bl7OxuOnLzA/GUbsTRPR0xsbLIJ28earms37nLj9gMmzFjC/2pXYs2m3YSFR9C80yBmTxpMOlPj1H5fhRBCpIKXr17jYG+r/t3RwY4Xr3xTvP2hY2c4fPwMJsZGDO7bhRJFC6iXXbt+m+joaArky52qMf9KFC4uX17pN5VoguT90oeMbi4oPpmbJYu7Kzv2HlP/7ubqSP/urTl+5hIzFqxh3pQhrNywkzGDu+Lm6kR4eATR0TGMm76Y6WP7YWlhRp+hU6hSoQQAew+dYtnfo9HX12PPoZOEhoVjbGTImQteTBrRk137j6Onp8v6xZO4dvMeKzfspF2L+kyft4rFM0ZgbWXB4LGzUnSQjetX4+S5K+pmQSNDA65cv5NkE9vmHQfZsvMgAEqlMkVlCCGESH0KrfhzhCmVynjfTcmpVrEMHpndyZXDgx17DtGkbQ/uXzmCvr4eAJv+2UPNahVSPeZfhcLAAKP58zQdRpqVaIKkpVAA8RODOKUSLa1/+3Tnyq6a4K5g3pyMmbIQgGoVSjJrwRpaN61Lwbw5efT0Ob6v/egzdAoAYeERvHkboF73Y5Vm8cJ5uHjlJjmzZUJPVwcrS3MuXL7Bg8feXLp6E6USXJzsuHX3EXlzeZDe1gqA9DZWqfhW/KtBrYo0qFURgJiYGEpWb/lDyhFCCJE8Jwc7Tpz6t2/Ry1e+uGdIWa2HhYUZ+S1yAdCgTlX6DhnPK5/XuGVwBuD8xWuMHtor9YMW/wmJJkguTvbcf/gsXqZ+7+FTMjg7fL4DbW309XUBaPK/6pQqlp9ZC9dw5sI1qlcqjYuTPctmj463zdmL1+IlW2VKFGLn3qO8ex9KqeKq6k+lUtWHqESRvOr1jp2+SFi4jPYphBC/i/JlitNv6AS8X7winYkJ+w+dYMfGRTRq0YUxw/qQOWOGRLeLjo5m8YqNtGhSD0MDA/YePI6+vh7OTvbqdZ56v8DezjbR7YVI9DF/V2cHbKwt2LnvGAB+/oGs2bSbBrUrqtd55fsWgD2HTpIvdzbi4uK4eechzo52tG5Sl0tXb+PiaEdQ8Dt1p+jXb/wTDSJXtkw8fPKcsxe8KFNMlSAVzJuDzTsOEB0dQ3R0DAGBwWTN5Matuw8JfveeqKhoHj15/tm+FEBcXFyyB21rY8mbtwHSfCaEEGlcOlMT5kwdReNW3alavyUDenfC0d6Oew+fEPzhkf5m7XpRolJDAKrVa0XvQWPR1tZGV1eHWg3bkb9kLabOWsS6pTPR0fm3XuBdyHuMjQw1clxpgTIigrCOnQjr2EmmGklEkk+xjRzwF5NmLWXDP/vR1dGha7s/yfihWhLA6+Y9Vm7YgamxMcP7dyImJpa9h04y6e9lhIWF07X9n+jp6TJ6UFemzF5ObGwcjg62jB3c7bOytLS0yOGRkbsPnmJvZwNArWpleeL9kqYdB2BoYED7Fg0oVigPLRvXpk23YTjY2WJpYfbZvvJ6ZmPnvmNUKF0kyYPOlS0zIe9Dad5pMBNH9MBB/oIQQog0q1L5klQqXzLea9dO71b/vGrRtES3a9uiEW1bNEpyv28eX0qdAH9hSm9vTYeQZimioiKlGiUZH/sg3bl1Q9OhCCHEf1bQCy9Nh/DbUUZEEFavPgBGW7egMDDQcERpi4ykLYQQQgiRgCRIQgghhBAJSIIkhBBCCJGAJEhCCCGEEAkk+RSbEEIIIf7bFLbyFHdSJEESQgghfkMKAwOMli/TdBhpljSxCSGEEEIkIAmSEEIIIUQC0sSWQn5PL8cbol4IIYT4lSkjI4no1x8Ag0kTUejraziitEW+8YUQQojfkVJJ3IMH6p9FfNLEJoQQQgiRgCRIQgghhBAJSIIkhBBCCJGAJEhCCCGEEAlIgiSEEEIIkYA8xSaEEEL8rtKl03QEaZYkSEIIIcRvSGFggPH6dZoOI82SJjYhhBBCiAQkQRJCCCGESEASJCGEEOI3pIyMJLz/AML7D0AZGanpcNIc6YMkhBBC/I6USuJu3FD/LOKTGiQhhBBCiAQkQRJCCCGESEASJCGEEEKIBCRBEkIIIYRIQBIkIYQQQogE5Ck2IYQQ4nelr6/pCNIsSZCEEEKI35DCwADjbVs1HUaaJU1sQgghhBAJSIIkhBBCCJGANLEJIYQQvyFlVBSRY8cCoD94MAo9PQ1HlLZIgiSEEEL8juLiiL14Sf2ziE+a2IQQQgghEpAESQghhBAiAUmQhBBCCCESkARJCCGEECIBSZCEEEIIIRKQp9i+QKlUAhATE6PhSIQQQojUo4yJIUb1FUdMTAwK+Z5DW1sbhUIBgCIqKlKp4XjStIiICMrWbqvpMIQQQgjxg53cvRwdHVXdkdQgfYGenh4uTnasnj9enVWKX0PTjgNZPX+8psMQX0nO269Lzt2vSc7bv7S1tdU/S4L0BVpaWmhpaaGrq6vpUMRXUigU6r8ExK9DztuvS87dr0nOW+Kkk7YQQgghRAKSIKVA/ZoVNR2C+AZy3n5Nct5+XXLufk1y3hInnbSFEEIIIRKQGiQhhBBCiAQkQRJCCCGESEASJCGEEEKIBOS5PuCfPUfYtP0AJsZGjB74F7Y2VuplL169ZsTEuYRHRNKsYQ2qlC+BUqlk6ZptHDlxAVsbS0YP6oKJsZEGj+D39LXnzcf3LX+064erkz0A5UsXocUftTQV/m8rufN298ETps9bxfv3YaxZOAFA7rc04mvPm9xvaUdy52791n0cOHqa0LAIurT9g5JF88s998FvX4MUEBjMqg07WTJzJA1qVWTOkg3xls9csJpWf9Zh4bRhLFi+ifehYdx/+JQzF7xYOW8ceXN7sHrjLg1F//v6lvMGkD2LOyvnjWPlvHHyYa0BXzpvVpbmNKgV/4kaud8071vOG8j9lhYkd+5Cw8KJjIpi0YyRjB/anXHTF6NUKuWe++C3T5DOX75BlowZMDDQJ08uD85evKZeFhsbx7lL18mTMyvGxka4ONlzxesOpy9cwzNHFrS1tciT04MzF700dwC/qW85bwBmZqYailhA8ucNwMbKgpwemeK9Jveb5n3LeQO539KC5M6dsZEhLf6ohba2Fm6ujsTGxhIZFS333Ae/fYLkHxCEi5MdANaW5sTGxRERGQVAcEgI5ulMMf5QtejiZI+ff6BqG2dVtbGrs+o18XN9y3kDePjYm1ZdhtKl/zieer/UTPC/seTOW7LbyP2mUd9y3kDut7Qgpefu3sOnODmkx0BfT+65D377BAmFqo/DR8o4JR+nXFOgIO6TZXFKJQotBSgUxMWpXo+LU6KlJXO0/XTfcN5sbawY2rcjC6YNo1C+nEz6e9nPjlokc96S3kbuN437hvMm91sakYJzFxMby8wFa+jQsuGHbeSeA0mQsLGywPulLwBv/QPR1dVFX08PALN0JoS8D1X3X3n+whdrKwtsLC14/tIHAO+XvlhbWmgm+N/Yt5w3bW0tPHNkQU9Pl9pVy/HsuY/G4v9dJXfektxG7jeN+5bzJvdb2pCSczdj3mrye2ajcP5cqm3kngMkQaJQvlw8ePSMiIhIrl6/S7FCeVizaTcHjp5BS0uLogU9uXrjLu9Dw3j+0od8ubNRvHAevG7eIzY2jqvX71CsUB5NH8Zv51vO28FjZ/EPCEKpVHLy7GU8MmfQ9GH8dpI7b0mR+03zvuW8yf2WNnzp3G3ecRD/gCBaN6mr3kbuORWZagTYuf8467fuxdTYiNGDu/YFOggAAApwSURBVLJqw07sbK35s0E1fHzfMmzCHMLCI2jxRy0qlS0GwLK1/3Do2Dns0lsxamAXjI0MNXwUv5+vPW9et+4zf9lG/AOCsLI0Z1ifDtjb2Wj6MH47yZ23cdMXceP2A175vMXV2Z7eXVrimSOL3G9pwNeeN0DutzQiqXNXungBGrXug5urk7rZrVmjmlQsU1TuOSRBEkIIIYT4zG/fxCaEEEIIkZAkSEIIIYQQCUiCJIQQQgiRgCRIQgghhBAJSIIkhBBCCJGAJEhCCCGEEAlIgiSEEEIIkYAkSEL8B+w9dIpiVZppbELQ3QdO0H/EdEA1OWa/4dOIior+7v32HzGd3QdOfPb6vsOnaNSmL007DqRTnzFcvXEXgMWrtjB93qrvLvd77D9ymjWbdms0hrTCx/ctnfuO0XQYQnwTHU0HIIT4fgePnaVW1TIcOHqW9i0aaDQWK0tzJo3s9cP27/vGj8mzl7Nu4URsbazwfuGjnncvLahcrrimQxBCpAJJkIT4xQUFh/DU+xU9Ojal99AptGteH4VCwRWv26zetBtnx/RcunobFDB5ZC8c7GzZfeAEV2/cRalUcuP2A8zNTJkyqg/pTI0ZPWUBmd1d+aNeFQCadxpEj45NyeeZnT0HT7Jt92HCIyIxNjJkzOCu2FjFn8gy5H0olep34Oz+1Xjdus/U2csB8A8MxsbKguVzxvDs+SsmzVqGf2Aw6UyNGdK7PS5O9rwLCWXSrKU8eOyNna0VfgFBnx1vREQUUVHRhIZFAODiZB9v+Vv/QIaOm83Nuw9xd3Vk4vCe6OjoJBn77gMnuHP/CYFBwbwPDWPGuP6Ur9OWJv+rzrlL1wkKDqFts/pULqeaZmjX/uOs2byb2Ng4CubLSe/OzdHS+rcyfv3WfTx4/IyhfTqo3ufrd4iNi+P6rfvk8MhIwzpVWLxqC/cfPqNVkzr8r3YlAMrVbpNomT6+bxk8dhbFC+flxNnLTBjaAx1dHab8vZwXPq/R0dGmffMGFC+cl9mL16Grq0OHFv8DYPfBE1y6epvh/Tpy+vxV5i/bRFR0FJndXRnSuz0GBvrUbd6DVn/WYdf+4/gHBNGnS0uueN3h1PkrGBkaMnlkLywtzAgNDWPq3JXcvvcYhQL+atOYEkXyJnkthYWH03XAeAICg2neaRCtm9SlTImC33/BC/GTSBObEL+4IycvkD9Pdpwd7VAqldx98ES97OadB1SrWIpV88fh4mjP9j1H1csue92mTdO6rF04gZiYWI6cPP/FsrJkdGXWhAGsnj8eNxdHNmzbl+z6njmysHLeOBZMH4aJsRG9/2pBTGwsQ8fNpmenZqxfPInWTeoye9E6AGYtWE06UxPWLZrIhOE9MNDX/2yfGVwcaNe8Pm27D2fU5Pk8fOwdb7mP71t6/9WCdQsncv+RN5e97nwx9p37j9G0YQ1mjh+AQqEgPCKSjBmcWTRjBJNG9GL8jMUEBYfgdes++46cZtnsMaxbNIn378M4cfZysu/B5et3aN+8AWsWTODq9bts/Gcfk0f2ZsyQrsxfthGlUjXbU1JlAtx7+JR0piasmDMWezsbRk2aj2fOrKxZMIGxg7sxbvpiXrx6TZXyJThy4oJ6n0dOnKdK+eK89HnDwpWbmTN5MOsXT8bR3pZte46oY3zrF8iCacNoWKcyg8fMolSx/KyePwEjQwP2HjoFwN+L1pEre2bWLZrI3MlDmDpnObGxcapjTORasrO1ZlDPtnhkcWPlvHGSHIlfjtQgCfGLO3jsLA1rV0KhUFCsUB4OHj1LtizuANjZWpM1UwYAcmTLyNNn//ZRyuLuioOdLQDZsrrjn0htTULOTnacPHOFy163uXn3IU4O6VMU4+xF6yhboiC5smfmqfdLnj33YdTk+QAolWBgoEqEzlzwYsH0YWhpaWFoYIC1pXmi+2veSDUB8dZdh+nU5//t3X1M1HUcwPH3cQeHCoKCQDz5ANLFcY4DUQydNGWlU1v2oAyrzefQQpsKawtFrXwsszltzbAns5Zp4ZyETnE6xQdsHqGFD4UigqCACXgH/Prj4JKD49S5ivZ5/XW/7ff9fD7f7912332/v9++K3k1eRLTXpwAwBB9BN5entY+hoVSdfOW09qHRuttY9YmNjoSgIH9g+jn04cLl0spOGXij9JrzF6wDIDGu2YiH2/fzl7EoP62Q1ojwvszPHYIrq4ahkQOpr6hkTv1DXj06ukwZ1CAH+5aLS9MSgKgvqGRM6bzrF+xCIDgQH/ijHpOnDYxeeJYtFo3Ll6+gl8/Hy79fpXY6Eh+3HuQispq5i95BwCzpandCe2jRsSgUqkwRA7Gy8sTQ+RgAPS6MG5UW8fv8LHTmIpL2LXnAAAtLQo1tXW2Pj7ob0mI/zqZIAnRjVXeqMZUXEJt7W2yt++mvqERs8XC/FnJHe7VqDU4Oplao1bbVh1UQFNzU4d7FEXhjYxVGA06Jk8YQ6QujCPHCp3WePzUWUznLrD1w6zWONYJ0bZNK9ttTdGaV6NWO40J1slf6vQpxBn1ZCzfYJsgte+XBhTntTvLqdGo6eGuRUFhbGI8aXOm3VeNndZji2n93DbujnICuLi4oGo7br3VvdcqlYq249jHjUngwOECggP9SRwZZ/1uUYg26FiVuaDr+jQau2s1SmNrfQpkZaQSPijUSR/VDvskRHciW2xCdGP78wsY/WQs2z9Zzeeb3+WbretQFPi56NeHjunT1xtTcQnNzS0Unj1HWXklAHW371B0roTk58czaEAI53+79HcjFbQoLR1i1db9ydqPsslcPBdXV+ufb0hwAN5eHuz4fh+KomA2W6isuglAdJSOnNx8AG7V1FFaVt4h5tGCM+zJzae5uQVFUSivqHK6ktVl7Q5cKbsOwInCIu7UNxA2MJSE4Ub25h2h9Kq1rvKKKts206PQWU57PXu4YzTo+C4nD4Cy8kpOFBYxLCYKgKTEERw5foZDR0/yTOsD48NiDJwsLMJUXAJYx7a+ofGBakuIN7L1y11YLE0oisK165VO2wT4+1J54+YjHSMh/imygiREN5Z3qP1ba2q1C+PGJJB38BhJifEPFfPZ8U+xOPN9psxYROLIOIYa9QD09uzF1MnjmL1wGY/59yPqiXCqqmsAiNKFk/3Vbn45f5HQ4ABbrM++/oFbNXUsX7MZsK6EbNu0ktVL32Tdpm3k5B7Czc2Vl1+ayNjR8SxMfYUV67aQMjuD4CB/QgIDOtSn14WzJftbduzah9lswc+3L1npqV32qavaHdmZs5/VGz9FhYr33k7DXeuG0aDj9VnJpGd9gEatwau3B0vTX+vwoPrD6ixnZzKXzGXtxmz25Oaj0ah5a+FM2yTR16cPvj7elFdUEdG6vRoSFEBWxjzWbMxGQaFnD3fS06YTNiDkvmtLm5PChs1fkDInA3d3LcNjDMybObXLNoEBfoQNCGHKjEVMT3mO8Umj7jufEP82ldl8V9ZChRDiHiOensZPOz/G06PX/zqnEMIx2WITQgghhLAjK0hCCCGEEHZkBUkIIYQQwo5MkIQQQggh7MgESQghhBDCzl/uKQS9xKn8hgAAAABJRU5ErkJggg==",
       "text/plain": [
        "<Figure size 583.3x500 with 2 Axes>"
       ]
@@ -2023,13 +2027,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ee0050b3",
+   "id": "cbb4f94f",
    "metadata": {
     "papermill": {
-     "duration": 0.004388,
-     "end_time": "2026-09-09T21:58:14.916535+00:00",
+     "duration": 0.003654,
+     "end_time": "2026-09-11T01:29:56.874035+00:00",
      "exception": false,
-     "start_time": "2026-09-09T21:58:14.912147+00:00",
+     "start_time": "2026-09-11T01:29:56.870381+00:00",
      "status": "completed"
     }
    },
@@ -2094,25 +2098,24 @@
    "version": "3.14.3"
   },
   "ml4t_provenance": {
-   "executed_at": "2026-09-09T21:58:23.862780+00:00",
+   "executed_at": "2026-09-11T01:30:09.204877+00:00",
    "executor": "local-uv",
-   "library_digest": "18fa4c71c8ae06ba0463f4fcc992b840267982310eaf7477de3f7aab98525b02",
-   "outputs_digest": "46195eaa823950d7adddc11733d8c7e847b317debe28d81f3e6e89dfd9befdcd",
+   "library_digest": "037c72d47b06deae928bf1e2c40e066cd6a7dc3fd10e055c49ea6ef2e5b19887",
+   "outputs_digest": "d913339fd4613473594087da5df49dbfed9afd51cdb26bffc4702c3e25d2bfd8",
    "parameters": {},
    "production": true,
-   "source_py_blob": "8703f0bc3f2440089e0bd6f0d60d70d1d78d0409",
-   "notes": "prose synced from the .py at 2026-09-09T22:35:05.137459+00:00 without re-executing; every code cell is identical to blob d81423be12a9"
+   "source_py_blob": "69eb2b3f0bf5fe9f76813349a33c77763b7bf0c3"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 8.952497,
-   "end_time": "2026-09-09T21:58:16.238371+00:00",
+   "duration": 10.942134,
+   "end_time": "2026-09-11T01:29:59.003058+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "~/ml4t/public-teach-g/26_mlops_governance/.03_safe_model_rollout.build.4193479.ipynb",
-   "output_path": "~/ml4t/public-teach-g/26_mlops_governance/.03_safe_model_rollout.papermill.4193479.ipynb",
+   "input_path": "~/ml4t/public-teach-g/26_mlops_governance/.03_safe_model_rollout.build.1107745.ipynb",
+   "output_path": "~/ml4t/public-teach-g/26_mlops_governance/.03_safe_model_rollout.papermill.1107745.ipynb",
    "parameters": {},
-   "start_time": "2026-09-09T21:58:07.285874+00:00",
+   "start_time": "2026-09-11T01:29:48.060924+00:00",
    "version": "2.7.0"
   }
  },

--- a/26_mlops_governance/03_safe_model_rollout.py
+++ b/26_mlops_governance/03_safe_model_rollout.py
@@ -158,15 +158,19 @@ class PredictionIdentity:
 
 
 # %% [markdown]
-# The connection is opened read-only and immutable. Reviewing a candidate reads the case
-# study's result record and must not be able to write to it, and SQLite will enforce that if
-# it is asked to.
+# The connection is opened read-only, by `mode=ro` on the URI and `PRAGMA query_only` on the
+# connection. Reviewing a candidate reads the case study's result record and must not be able
+# to write to it, and SQLite will enforce that if it is asked to. The URI deliberately leaves
+# out `immutable=1`, which promises something else: that the database cannot change while it
+# is open. The registry is what every sweep writes to, and an immutable connection skips
+# locking and ignores the write-ahead log, so it reads whatever the main file held before the
+# most recent writes - a superseded row, or a table that appears not to exist.
 
 
 # %%
 def open_registry_readonly(path: Path) -> sqlite3.Connection:
-    """Open an immutable, query-only SQLite connection."""
-    uri = f"file:{path.resolve()}?mode=ro&immutable=1"
+    """Open a read-only, query-only SQLite connection."""
+    uri = f"file:{path.resolve()}?mode=ro"
     connection = sqlite3.connect(uri, uri=True)
     connection.execute("PRAGMA query_only=ON")
     return connection

--- a/tests/overrides.yaml
+++ b/tests/overrides.yaml
@@ -1312,7 +1312,13 @@
   # configuration NAME rather than a prediction hash, so they survive a refit - but the
   # fixture is sampled from production by tests/sample_registry_for_tests.py and has not
   # been regenerated since PINNED_PREDICTION_CONFIGS changed, so the names it holds are
-  # ols, ridge_a100000.0 and ridge_a10000000.0.
+  # ols, ridge_a0.001, ridge_a100000.0 and ridge_a10000000.0.
+  #
+  # Only three of those four are usable, and the registry does not say which: ridge_a0.001
+  # has a training run and a prediction set but no run_log/predictions/<hash>/predictions
+  # parquet, because the sampler carried the rows and not the artifact. Both notebooks in
+  # this chapter check the file and raise when it is absent, so a substitute has to be
+  # picked against the tree rather than against the registry alone.
   #
   # ridge_a10000000.0 is the right substitute rather than an arbitrary one: this notebook
   # needs a stream that genuinely differs from the incumbent's, and the assertion in

--- a/tests/overrides.yaml
+++ b/tests/overrides.yaml
@@ -1343,17 +1343,21 @@
   # here is the other branch, a candidate that clears all five criteria.
   #
   # ridge_a10000000.0 is the one that does. Measured 2026-09-10 against the shipped
-  # fixture at TOP_K: 10, it promotes on +3.49 Sharpe improvement with every similarity
-  # and drawdown criterion met. The previous pin, ridge_a100000.0, does not: it fails on
-  # Sharpe improvement at +0.18 against the required 0.20, which is the same criterion
-  # and the same direction production fails on, so CI was covering the rejection path
-  # twice and the promotion path not at all. Of the fixture's remaining linear configs,
-  # ols is the incumbent and ridge_a0.001 has a registry row whose predictions parquet
-  # was never sampled, so it resolves to nothing.
+  # fixture at TOP_K: 10, it promotes on all five: Sharpe improvement +3.49 against 0.20,
+  # signal correlation 0.368 and position agreement 0.341 against 0.30 each, drawdown
+  # ratio 0.58 against 1.25, over the full 63 sessions. The two similarity criteria are
+  # what to watch - they clear by 0.068 and 0.041, so they are what a fixture rebuild
+  # would flip first. The previous pin, ridge_a100000.0, fails on Sharpe improvement at
+  # +0.18 against the required 0.20, which is the same criterion and the same direction
+  # production fails on, so CI was covering the rejection path twice and the promotion
+  # path not at all. Of the fixture's remaining linear configs, ols is the incumbent and
+  # ridge_a0.001 has a registry row whose predictions parquet was never sampled, so it
+  # resolves to nothing.
   #
   # Nothing asserts the verdict, in this notebook or in the harness, so a fixture rebuild
-  # that moves either model's predictions will silently change which branch CI covers.
-  # Re-measure both configs when the fixture is rebuilt.
+  # that moves this model's predictions will silently change which branch CI covers.
+  # Re-measure after a rebuild, and re-pick from whatever linear configs the rebuilt
+  # fixture carries if the margins above have gone.
   parameters:
     TOP_K: 10
     CANDIDATE_CONFIG: ridge_a10000000.0

--- a/tests/overrides.yaml
+++ b/tests/overrides.yaml
@@ -1337,16 +1337,26 @@
   # universe.
   #
   # CANDIDATE_CONFIG is overridden for the reason given under 02: the fixture holds a
-  # different slice of the linear grid. The shipped default, ridge_a100.0, demonstrates
-  # the case the gate exists for - an improvement that is positive and below the
-  # threshold, +0.185 against a required 0.20 on production. The fixture cannot supply
-  # it, and of what it does hold, ridge_a100000.0 is the one that clears the hurdle
-  # (+0.730) while ridge_a10000000.0 misses it by so much that the minimum-effect
-  # threshold does no work. CI therefore exercises the promotion path and production
-  # demonstrates the near miss. Raise this alongside the fixture.
+  # different slice of the linear grid, and ridge_a100.0 is not in it. Production's
+  # default candidate demonstrates the case the gate exists for - an improvement that
+  # is positive and falls short of the required threshold - so what is worth covering
+  # here is the other branch, a candidate that clears all five criteria.
+  #
+  # ridge_a10000000.0 is the one that does. Measured 2026-09-10 against the shipped
+  # fixture at TOP_K: 10, it promotes on +3.49 Sharpe improvement with every similarity
+  # and drawdown criterion met. The previous pin, ridge_a100000.0, does not: it fails on
+  # Sharpe improvement at +0.18 against the required 0.20, which is the same criterion
+  # and the same direction production fails on, so CI was covering the rejection path
+  # twice and the promotion path not at all. Of the fixture's remaining linear configs,
+  # ols is the incumbent and ridge_a0.001 has a registry row whose predictions parquet
+  # was never sampled, so it resolves to nothing.
+  #
+  # Nothing asserts the verdict, in this notebook or in the harness, so a fixture rebuild
+  # that moves either model's predictions will silently change which branch CI covers.
+  # Re-measure both configs when the fixture is rebuilt.
   parameters:
     TOP_K: 10
-    CANDIDATE_CONFIG: ridge_a100000.0
+    CANDIDATE_CONFIG: ridge_a10000000.0
   timeout: 300
 26_mlops_governance/04_circuit_breakers:
   timeout: 300

--- a/tests/sample_registry_for_tests.py
+++ b/tests/sample_registry_for_tests.py
@@ -78,8 +78,10 @@ TOP_N_PER_GROUP = 3
 # hashes it named on 2026-09-09 were in no registry on this machine, so this function raised
 # on every case study that reached it and the notebooks pinning them could not run outside
 # CI. The notebooks now pin configuration names and resolve the hash, and so does this.
-# Four entries for two notebooks: each names one configuration by default and a second
-# under `tests/overrides.yaml`, and both overrides happen to name `ridge_a10000000.0`.
+# Four entries for two notebooks: each names an incumbent and a challenger by default,
+# `ols` is the shared incumbent, and both notebooks override the challenger to the same
+# `ridge_a10000000.0` under `tests/overrides.yaml`. Those override values are checked
+# against this declaration by test_sample_registry_for_tests.py.
 # 26/02's override exists only while this declaration is ahead of the deployed fixture, and
 # can be deleted once a regenerated `us_equities_panel` carries all four. 26/03's cannot:
 # its default candidate fails the promotion gate on production and the fixture's only

--- a/tests/sample_registry_for_tests.py
+++ b/tests/sample_registry_for_tests.py
@@ -78,22 +78,24 @@ TOP_N_PER_GROUP = 3
 # hashes it named on 2026-09-09 were in no registry on this machine, so this function raised
 # on every case study that reached it and the notebooks pinning them could not run outside
 # CI. The notebooks now pin configuration names and resolve the hash, and so does this.
-# Five entries for two notebooks, because each names one configuration by default and a
-# second under `tests/overrides.yaml`. The overrides exist only while this declaration is
-# ahead of the deployed fixture: regenerating `us_equities_panel` here carries all five, and
-# both overrides can then be deleted.
+# Four entries for two notebooks: each names one configuration by default and a second
+# under `tests/overrides.yaml`, and both overrides happen to name `ridge_a10000000.0`.
+# 26/02's override exists only while this declaration is ahead of the deployed fixture, and
+# can be deleted once a regenerated `us_equities_panel` carries all four. 26/03's cannot:
+# its default candidate fails the promotion gate on production and the fixture's only
+# candidate that clears it is `ridge_a10000000.0`, so the override is what keeps CI on the
+# promotion branch rather than repeating production's rejection.
 PINNED_PREDICTION_CONFIGS = {
     "us_equities_panel": [
         # 26/02_online_drift_detection OLS_CONFIG, 26/03_safe_model_rollout INCUMBENT_CONFIG
         ("linear", "fwd_ret_1d", "ols", "validation"),
         # 26/02_online_drift_detection RIDGE_CONFIG, shipped default
         ("linear", "fwd_ret_1d", "ridge_a1000000.0", "validation"),
-        # 26/02_online_drift_detection RIDGE_CONFIG under tests/overrides.yaml
+        # 26/02_online_drift_detection RIDGE_CONFIG and 26/03_safe_model_rollout
+        # CANDIDATE_CONFIG, both under tests/overrides.yaml
         ("linear", "fwd_ret_1d", "ridge_a10000000.0", "validation"),
         # 26/03_safe_model_rollout CANDIDATE_CONFIG, shipped default
         ("linear", "fwd_ret_1d", "ridge_a100.0", "validation"),
-        # 26/03_safe_model_rollout CANDIDATE_CONFIG under tests/overrides.yaml
-        ("linear", "fwd_ret_1d", "ridge_a100000.0", "validation"),
     ],
 }
 

--- a/tests/test_sample_registry_for_tests.py
+++ b/tests/test_sample_registry_for_tests.py
@@ -6,13 +6,18 @@ its source, and a production registry.db is 43-180 MB and gitignored. A wrong
 from, which is the one failure in this path that cannot be undone by re-running it.
 """
 
+import ast
 import sqlite3
 from pathlib import Path
 
+import yaml
+
+from tests.pm_helpers import OVERRIDES_PATH, REPO_ROOT
 from tests.sample_registry_for_tests import (
     CASE_STUDY_IDS,
     CODE_CS_DIR,
     DEFAULT_INTERMEDIATES_DIR,
+    PINNED_PREDICTION_CONFIGS,
     _populate_sample_db,
     rejected_output_root,
 )
@@ -167,3 +172,59 @@ def test_a_registry_without_these_tables_still_samples(tmp_path: Path) -> None:
 
     assert stats["causal_runs"] == 0
     assert stats["status"] == "OK"
+
+
+def _case_study_of(notebook_py: Path) -> str | None:
+    """Return the CASE_STUDY_ID a notebook's parameters cell assigns, if it has one."""
+    tree = ast.parse(notebook_py.read_text(encoding="utf-8"))
+    for node in tree.body:
+        if not isinstance(node, ast.Assign) or len(node.targets) != 1:
+            continue
+        target = node.targets[0]
+        value = node.value
+        if isinstance(target, ast.Name) and target.id == "CASE_STUDY_ID":
+            if isinstance(value, ast.Constant) and isinstance(value.value, str):
+                return value.value
+    return None
+
+
+def test_every_config_an_override_names_is_declared_for_sampling() -> None:
+    """An override that names a configuration the sampler does not carry fails only in CI.
+
+    PINNED_PREDICTION_CONFIGS is what puts a configuration's predictions parquet in the
+    fixture, and `tests/overrides.yaml` is what a notebook is actually run with there.
+    Nothing couples them: _resolve_pinned_hashes checks the declaration against production,
+    where every configuration exists, so an override naming one the declaration omits
+    resolves a registry row with no artifact behind it and the notebook raises mid-run.
+    That has happened once already, to 26_mlops_governance/02_online_drift_detection.
+    """
+    overrides = yaml.safe_load(OVERRIDES_PATH.read_text(encoding="utf-8"))
+    checked: list[str] = []
+    for key, entry in overrides.items():
+        parameters = (entry or {}).get("parameters") or {}
+        named = {
+            value
+            for name, value in parameters.items()
+            if name.endswith("_CONFIG") and isinstance(value, str)
+        }
+        if not named:
+            continue
+        notebook_py = REPO_ROOT / f"{key}.py"
+        if not notebook_py.is_file():
+            continue
+        case_study_id = _case_study_of(notebook_py)
+        declared = PINNED_PREDICTION_CONFIGS.get(case_study_id or "")
+        if not declared:
+            continue
+        missing = named - {config for _family, _label, config, _split in declared}
+        assert not missing, (
+            f"{key} overrides a configuration the fixture is not built to carry: "
+            f"{sorted(missing)}. Add it to PINNED_PREDICTION_CONFIGS[{case_study_id!r}] "
+            "in tests/sample_registry_for_tests.py, or override to one already there."
+        )
+        checked.append(key)
+
+    assert checked, (
+        "no override names a *_CONFIG for a case study in PINNED_PREDICTION_CONFIGS, "
+        "so this check covered nothing"
+    )

--- a/tests/test_sample_registry_for_tests.py
+++ b/tests/test_sample_registry_for_tests.py
@@ -10,9 +10,7 @@ import ast
 import sqlite3
 from pathlib import Path
 
-import yaml
-
-from tests.pm_helpers import OVERRIDES_PATH, REPO_ROOT, get_overrides, invocations_for
+from tests.pm_helpers import REPO_ROOT, get_overrides, invocations_for
 from tests.sample_registry_for_tests import (
     CASE_STUDY_IDS,
     CODE_CS_DIR,
@@ -174,62 +172,82 @@ def test_a_registry_without_these_tables_still_samples(tmp_path: Path) -> None:
     assert stats["status"] == "OK"
 
 
-def _case_study_of(notebook_py: Path) -> str | None:
-    """Return the CASE_STUDY_ID a notebook's parameters cell assigns, if it has one."""
+def _pinned_parameters_of(notebook_py: Path) -> tuple[str | None, dict[str, str]]:
+    """A notebook's CASE_STUDY_ID and the ``*_CONFIG`` names its parameters cell assigns.
+
+    Both are read as module-level string constants, which is what the parameters cell of
+    a percent-format notebook compiles to and what papermill replaces at run time.
+    """
     tree = ast.parse(notebook_py.read_text(encoding="utf-8"))
+    case_study_id: str | None = None
+    configs: dict[str, str] = {}
     for node in tree.body:
         if not isinstance(node, ast.Assign) or len(node.targets) != 1:
             continue
         target = node.targets[0]
         value = node.value
-        if isinstance(target, ast.Name) and target.id == "CASE_STUDY_ID":
-            if isinstance(value, ast.Constant) and isinstance(value.value, str):
-                return value.value
-    return None
+        if not isinstance(target, ast.Name):
+            continue
+        if not isinstance(value, ast.Constant) or not isinstance(value.value, str):
+            continue
+        if target.id == "CASE_STUDY_ID":
+            case_study_id = value.value
+        elif target.id.endswith("_CONFIG"):
+            configs[target.id] = value.value
+    return case_study_id, configs
 
 
-def test_every_config_an_override_names_is_declared_for_sampling() -> None:
-    """An override that names a configuration the sampler does not carry fails only in CI.
+def test_every_config_a_pinned_notebook_runs_with_is_declared_for_sampling() -> None:
+    """A configuration the sampler does not carry fails only in CI, halfway through a run.
 
     PINNED_PREDICTION_CONFIGS is what puts a configuration's predictions parquet in the
-    fixture, and `tests/overrides.yaml` is what a notebook is actually run with there.
-    Nothing couples them: _resolve_pinned_hashes checks the declaration against production,
-    where every configuration exists, so an override naming one the declaration omits
-    resolves a registry row with no artifact behind it and the notebook raises mid-run.
-    That has happened once already, to 26_mlops_governance/02_online_drift_detection.
+    fixture. Nothing couples it to what the notebooks actually ask for: _resolve_pinned_hashes
+    checks the declaration against production, where every configuration exists, so a name
+    the declaration omits resolves a registry row with no artifact behind it and the notebook
+    raises mid-run. That has happened once already, to
+    26_mlops_governance/02_online_drift_detection.
 
-    Every invocation is enumerated through ``invocations_for`` rather than by reading
-    ``parameters``: an entry moved to the ``invocations`` shape would otherwise drop out
-    of this check silently, and a dropped entry looks exactly like a passing one.
+    Both sources of a name are checked: the ``*_CONFIG`` defaults in the notebook's own
+    parameters cell, and whatever `tests/overrides.yaml` replaces them with. A default is
+    checked even where an override currently replaces it, because the declaration is meant
+    to carry it - that is what lets an override be deleted once a regenerated fixture holds
+    every pinned configuration. Runs are enumerated through
+    ``invocations_for`` rather than by reading ``parameters``, so an entry moved to the
+    ``invocations`` shape is validated rather than silently dropped - and a dropped entry
+    looks exactly like a passing one.
     """
-    overrides = yaml.safe_load(OVERRIDES_PATH.read_text(encoding="utf-8"))
     checked: list[str] = []
-    for key in overrides:
+    for notebook_py in sorted(REPO_ROOT.rglob("*.py")):
+        if any(part.startswith(".") for part in notebook_py.parts):
+            continue
+        text = notebook_py.read_text(encoding="utf-8")
+        if "CASE_STUDY_ID" not in text:
+            continue
+        case_study_id, defaults = _pinned_parameters_of(notebook_py)
+        declared = PINNED_PREDICTION_CONFIGS.get(case_study_id or "")
+        if not declared:
+            continue
+
+        key = notebook_py.relative_to(REPO_ROOT).with_suffix("").as_posix()
+        names = {config for _family, _label, config, _split in declared}
         for run in invocations_for(get_overrides(key), key=key):
-            named = {
-                value
+            named = set(defaults.items()) | {
+                (name, value)
                 for name, value in run.parameters.items()
                 if name.endswith("_CONFIG") and isinstance(value, str)
             }
             if not named:
                 continue
-            notebook_py = REPO_ROOT / f"{key}.py"
-            if not notebook_py.is_file():
-                continue
-            case_study_id = _case_study_of(notebook_py)
-            declared = PINNED_PREDICTION_CONFIGS.get(case_study_id or "")
-            if not declared:
-                continue
             where = f"{key} [{run.id}]" if run.id else key
-            missing = named - {config for _family, _label, config, _split in declared}
+            missing = {f"{name}={value}" for name, value in named if value not in names}
             assert not missing, (
-                f"{where} overrides a configuration the fixture is not built to carry: "
+                f"{where} names a configuration the fixture is not built to carry: "
                 f"{sorted(missing)}. Add it to PINNED_PREDICTION_CONFIGS[{case_study_id!r}] "
-                "in tests/sample_registry_for_tests.py, or override to one already there."
+                "in tests/sample_registry_for_tests.py, or name one already there."
             )
             checked.append(where)
 
     assert checked, (
-        "no override names a *_CONFIG for a case study in PINNED_PREDICTION_CONFIGS, "
+        "no notebook names a *_CONFIG for a case study in PINNED_PREDICTION_CONFIGS, "
         "so this check covered nothing"
     )

--- a/tests/test_sample_registry_for_tests.py
+++ b/tests/test_sample_registry_for_tests.py
@@ -172,16 +172,40 @@ def test_a_registry_without_these_tables_still_samples(tmp_path: Path) -> None:
     assert stats["status"] == "OK"
 
 
+PARAMETERS_CELL = '# %% tags=["parameters"]'
+
+
+def _parameters_cell(notebook_py: Path) -> str | None:
+    """The source of a percent-format notebook's parameters cell, if it declares one.
+
+    Papermill replaces assignments in that cell and nowhere else, so a ``*_CONFIG``
+    defined further down the notebook is not a parameter and must not be read as one.
+    The cell runs from the tagged marker to the next ``# %%`` at the start of a line.
+    """
+    lines = notebook_py.read_text(encoding="utf-8").splitlines()
+    try:
+        opened = lines.index(PARAMETERS_CELL)
+    except ValueError:
+        return None
+    body = lines[opened + 1 :]
+    for offset, line in enumerate(body):
+        if line.startswith("# %%"):
+            return "\n".join(body[:offset])
+    return "\n".join(body)
+
+
 def _pinned_parameters_of(notebook_py: Path) -> tuple[str | None, dict[str, str]]:
     """A notebook's CASE_STUDY_ID and the ``*_CONFIG`` names its parameters cell assigns.
 
-    Both are read as module-level string constants, which is what the parameters cell of
-    a percent-format notebook compiles to and what papermill replaces at run time.
+    Both are read as string constants assigned in that cell, which is what papermill
+    replaces at run time.
     """
-    tree = ast.parse(notebook_py.read_text(encoding="utf-8"))
+    cell = _parameters_cell(notebook_py)
+    if cell is None:
+        return None, {}
     case_study_id: str | None = None
     configs: dict[str, str] = {}
-    for node in tree.body:
+    for node in ast.parse(cell).body:
         if not isinstance(node, ast.Assign) or len(node.targets) != 1:
             continue
         target = node.targets[0]

--- a/tests/test_sample_registry_for_tests.py
+++ b/tests/test_sample_registry_for_tests.py
@@ -12,7 +12,7 @@ from pathlib import Path
 
 import yaml
 
-from tests.pm_helpers import OVERRIDES_PATH, REPO_ROOT
+from tests.pm_helpers import OVERRIDES_PATH, REPO_ROOT, get_overrides, invocations_for
 from tests.sample_registry_for_tests import (
     CASE_STUDY_IDS,
     CODE_CS_DIR,
@@ -197,32 +197,37 @@ def test_every_config_an_override_names_is_declared_for_sampling() -> None:
     where every configuration exists, so an override naming one the declaration omits
     resolves a registry row with no artifact behind it and the notebook raises mid-run.
     That has happened once already, to 26_mlops_governance/02_online_drift_detection.
+
+    Every invocation is enumerated through ``invocations_for`` rather than by reading
+    ``parameters``: an entry moved to the ``invocations`` shape would otherwise drop out
+    of this check silently, and a dropped entry looks exactly like a passing one.
     """
     overrides = yaml.safe_load(OVERRIDES_PATH.read_text(encoding="utf-8"))
     checked: list[str] = []
-    for key, entry in overrides.items():
-        parameters = (entry or {}).get("parameters") or {}
-        named = {
-            value
-            for name, value in parameters.items()
-            if name.endswith("_CONFIG") and isinstance(value, str)
-        }
-        if not named:
-            continue
-        notebook_py = REPO_ROOT / f"{key}.py"
-        if not notebook_py.is_file():
-            continue
-        case_study_id = _case_study_of(notebook_py)
-        declared = PINNED_PREDICTION_CONFIGS.get(case_study_id or "")
-        if not declared:
-            continue
-        missing = named - {config for _family, _label, config, _split in declared}
-        assert not missing, (
-            f"{key} overrides a configuration the fixture is not built to carry: "
-            f"{sorted(missing)}. Add it to PINNED_PREDICTION_CONFIGS[{case_study_id!r}] "
-            "in tests/sample_registry_for_tests.py, or override to one already there."
-        )
-        checked.append(key)
+    for key in overrides:
+        for run in invocations_for(get_overrides(key), key=key):
+            named = {
+                value
+                for name, value in run.parameters.items()
+                if name.endswith("_CONFIG") and isinstance(value, str)
+            }
+            if not named:
+                continue
+            notebook_py = REPO_ROOT / f"{key}.py"
+            if not notebook_py.is_file():
+                continue
+            case_study_id = _case_study_of(notebook_py)
+            declared = PINNED_PREDICTION_CONFIGS.get(case_study_id or "")
+            if not declared:
+                continue
+            where = f"{key} [{run.id}]" if run.id else key
+            missing = named - {config for _family, _label, config, _split in declared}
+            assert not missing, (
+                f"{where} overrides a configuration the fixture is not built to carry: "
+                f"{sorted(missing)}. Add it to PINNED_PREDICTION_CONFIGS[{case_study_id!r}] "
+                "in tests/sample_registry_for_tests.py, or override to one already there."
+            )
+            checked.append(where)
 
     assert checked, (
         "no override names a *_CONFIG for a case study in PINNED_PREDICTION_CONFIGS, "


### PR DESCRIPTION
Chapter 26's notebook work was already done: six of its seven notebooks are `done` in `REGISTER.tsv`, and `01_drift_monitoring` is blocked for a recorded reason I confirmed rather than fixed. What this PR carries is the one editable defect left in the chapter, and what verifying it turned up.

## `03_safe_model_rollout` opened a live registry with `immutable=1`

`open_registry_readonly` read `us_equities_panel`'s registry with `?mode=ro&immutable=1`. That flag promises SQLite the database cannot change while it is open, which is why it may skip locking and ignore the `-wal` file. The registry is what every sweep writes to, so the promise is not the notebook's to make: with uncheckpointed WAL content the read returns whatever the main file held before the most recent writes, surfacing as a superseded row or a table that appears not to exist. `mode=ro` plus `PRAGMA query_only` is what enforces read-only, and the markdown above the function said `immutable` did that. It now names both mechanisms and says why `immutable` is left out. Same fix as `25_live_trading/02` and `06` in #936.

The WAL happened to be checkpointed when I ran, so both URIs resolve the same rows and the flag was latent rather than active. The notebook is re-executed against production anyway, because the change moves a code cell. Its numbers shift - a refit of the linear stage landed 2026-09-10T22:43 and both roles now resolve to it - and the verdict does not: the candidate still fails on Sharpe improvement alone, which is the case the notebook exists to show.

## CI was covering the rejection branch twice

`tests/overrides.yaml` pinned `CANDIDATE_CONFIG: ridge_a100000.0` with a comment saying it clears the promotion hurdle at +0.730, so CI exercised promotion while production demonstrated the near miss. Measured against the shipped fixture at `TOP_K: 10`, it does not clear: it fails on Sharpe improvement at +0.18 against the required 0.20 - the same criterion, in the same direction, as production. Running the pre-change notebook on the same fixture gives the identical +0.181384, so the claim was wrong when written rather than overtaken by a fixture rebuild.

`ridge_a10000000.0` clears all five criteria there, so it takes the pin. The comment now records every margin, because they are not equally safe: signal correlation clears by 0.068 and position agreement by 0.041, against a drawdown ratio clearing by 0.67, so the similarity pair is what a fixture rebuild flips first.

## Nothing coupled the overrides to the fixture declaration

`PINNED_PREDICTION_CONFIGS` is what puts a configuration's predictions parquet in the fixture, and `tests/overrides.yaml` plus the notebooks' own parameters cells decide which names are asked for. `_resolve_pinned_hashes` validates the declaration against production, where every configuration exists, so it cannot see a name the declaration omits - and the resulting failure is a registry row with no artifact behind it, raised mid-run in CI. That has happened once already, to `02_online_drift_detection`.

`tests/test_sample_registry_for_tests.py` now checks it. For every `.py` whose parameters cell assigns a `CASE_STUDY_ID` the declaration covers, it collects the cell's `*_CONFIG` string constants and each invocation's override values, and asserts every name is declared. Runs come from `invocations_for` so an entry in the `invocations` shape is validated rather than silently dropped, and the scan stops at the parameters cell boundary so a `*_CONFIG` defined further down a notebook is not mistaken for a papermill parameter.

Checked in both directions: a bad default fails, a bad override fails and names the run id, a `*_CONFIG` outside the parameters cell is ignored, a `*_CONFIG` in a notebook whose case study is not pinned is ignored, and restoring each passes. The trailing assertion fails if the check ever covers nothing.

## Also corrected

`26/02`'s entry listed three fixture configurations where the registry holds four, and omitted the part that matters: `ridge_a0.001` has a training run and a prediction set and no predictions parquet, because the sampler copies those tables in full and carries artifacts only for pinned configurations. Both notebooks check the file and raise when it is absent, so a substitute picked off the registry alone can be one that cannot run.

## Confirmed, not fixed

`01_drift_monitoring` needs a `split='holdout'` prediction set for `us_equities_panel`. The registry holds 214 prediction sets and every one is `split='validation'`; the recorded note said 166, so the registry has grown and still has no holdout set. The notebook raises with a clear message rather than proceeding. The block stands.

## Left for other bands

`immutable=1` against a live registry survives in `11_ml_pipeline/07` (two sites), `15_causal_estimation/10`, and `17_portfolio_construction/07`, each needing its own production re-run. `15_causal_estimation/10` is the sharpest: it runs `PRAGMA integrity_check` on that connection, so with uncheckpointed WAL content it integrity-checks a pre-WAL view and then reads from it. `17/07` also credits `immutable` with the read-only guarantee that is `mode=ro`'s.

`scripts/download_artifacts.py:197` was raised alongside those and is deliberately unchanged. It runs right after the installer makes the tree read-only, and a WAL-mode database in a read-only directory cannot be opened with plain `mode=ro` - SQLite needs to create the `-shm` file and raises "attempt to write a readonly database". Reproduced on a copy of the fixture registry: `mode=ro` raises, `mode=ro&immutable=1` returns `ok`. A just-installed bundle also has no concurrent writer and ships no `-wal`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VEtXvNk14uZckwswthVihc
