### PR TITLE
us_equities_panel: 06_linear is executed, and names the two candidate sets it replaces

### DIFF
--- a/case_studies/us_equities_panel/06_linear.ipynb
+++ b/case_studies/us_equities_panel/06_linear.ipynb
@@ -2,8 +2,16 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "fe5950ca",
-   "metadata": {},
+   "id": "25bcfda0",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002061,
+     "end_time": "2026-09-11T00:02:45.305919+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T00:02:45.303858+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "# US equities panel: what a penalized linear map of the cross-section is worth\n",
     "\n",
@@ -71,9 +79,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "2dfc0349",
-   "metadata": {},
+   "execution_count": 1,
+   "id": "b2239e2d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-11T00:02:45.310025Z",
+     "iopub.status.busy": "2026-09-11T00:02:45.309911Z",
+     "iopub.status.idle": "2026-09-11T00:02:49.098616Z",
+     "shell.execute_reply": "2026-09-11T00:02:49.098188Z"
+    },
+    "papermill": {
+     "duration": 3.791602,
+     "end_time": "2026-09-11T00:02:49.099300+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T00:02:45.307698+00:00",
+     "status": "completed"
+    }
+   },
    "outputs": [],
    "source": [
     "\"\"\"Fit the declared US equities panel linear population on the walk-forward folds.\"\"\"\n",
@@ -103,9 +125,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "bab524c2",
+   "execution_count": 2,
+   "id": "dd9333f7",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-11T00:02:49.103831Z",
+     "iopub.status.busy": "2026-09-11T00:02:49.103507Z",
+     "iopub.status.idle": "2026-09-11T00:02:49.106372Z",
+     "shell.execute_reply": "2026-09-11T00:02:49.105977Z"
+    },
+    "papermill": {
+     "duration": 0.00531,
+     "end_time": "2026-09-11T00:02:49.106609+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T00:02:49.101299+00:00",
+     "status": "completed"
+    },
     "tags": [
      "parameters"
     ]
@@ -120,14 +155,41 @@
     "DIAGNOSTIC_CONFIG_NAMES = [\"ols\"]\n",
     "POPULATION_NAME = \"\"\n",
     "SUPERSEDES_POPULATION: str = \"\"\n",
-    "SUPERSEDES_SETS: dict = {}"
+    "\n",
+    "# A candidate set is sealed once written, so a run whose members differ from the recorded\n",
+    "# generation has to name the set it replaces, keyed by the full set name because that is what\n",
+    "# the refusal prints. These two moved when 04_model_based_features was rebuilt at production\n",
+    "# scale on 2026-09-10: every stage-06 training run registered before that pinned the superseded\n",
+    "# `model_based` artifact, so the whole catalog refitted and both 2026-08-18 generations went\n",
+    "# stale. `fwd_ret_5d` and `fwd_ret_21d` have no recorded generation and need no entry.\n",
+    "# Resolved through `candidate_set_supersedes` rather than passed straight to `freeze`, because a\n",
+    "# reader's clean clone has no generation to supersede and `create` refuses a first version that\n",
+    "# claims to replace one.\n",
+    "SUPERSEDES_SETS: dict = {\n",
+    "    \"us-equities-fwd-ret-1d-linear-v1\": \"454f73021f33\",\n",
+    "    \"us-equities-fwd-ret-1d-linear-diagnostics-v1\": \"29155b2c69f1\",\n",
+    "}"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "57f1890c",
-   "metadata": {},
+   "execution_count": 3,
+   "id": "02842adf",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-11T00:02:49.109567Z",
+     "iopub.status.busy": "2026-09-11T00:02:49.109488Z",
+     "iopub.status.idle": "2026-09-11T00:06:09.959008Z",
+     "shell.execute_reply": "2026-09-11T00:06:09.958468Z"
+    },
+    "papermill": {
+     "duration": 200.852124,
+     "end_time": "2026-09-11T00:06:09.960034+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T00:02:49.107910+00:00",
+     "status": "completed"
+    }
+   },
    "outputs": [],
    "source": [
     "study = open_study(\"us_equities_panel\", execution_tier=EXECUTION_TIER, workspace=WORKSPACE or None)"
@@ -135,8 +197,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f432419d",
-   "metadata": {},
+   "id": "3a4a7268",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001312,
+     "end_time": "2026-09-11T00:06:09.963171+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T00:06:09.961859+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "## 1. Which labels, and which models\n",
     "\n",
@@ -152,18 +222,51 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "3cf1bae2",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 4,
+   "id": "60e3bb9f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-11T00:06:09.967110Z",
+     "iopub.status.busy": "2026-09-11T00:06:09.966961Z",
+     "iopub.status.idle": "2026-09-11T00:06:09.982977Z",
+     "shell.execute_reply": "2026-09-11T00:06:09.982249Z"
+    },
+    "papermill": {
+     "duration": 0.019012,
+     "end_time": "2026-09-11T00:06:09.983611+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T00:06:09.964599+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "('fwd_ret_1d', 'fwd_ret_21d', 'fwd_ret_5d')"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "declared_labels(study, \"linear\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "76a90b86",
-   "metadata": {},
+   "id": "5aa0c8e4",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00162,
+     "end_time": "2026-09-11T00:06:09.987055+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T00:06:09.985435+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "Each name in a menu resolves to a preset in `case_studies/config/{model_type}/`, which holds\n",
     "that configuration's hyperparameters. The frame below is the menu, with each name resolved to\n",
@@ -190,10 +293,62 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "bfe70234",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 5,
+   "id": "4348637f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-11T00:06:09.991264Z",
+     "iopub.status.busy": "2026-09-11T00:06:09.991013Z",
+     "iopub.status.idle": "2026-09-11T00:06:10.041649Z",
+     "shell.execute_reply": "2026-09-11T00:06:10.041037Z"
+    },
+    "papermill": {
+     "duration": 0.053546,
+     "end_time": "2026-09-11T00:06:10.041965+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T00:06:09.988419+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div><style>\n",
+       ".dataframe > thead > tr,\n",
+       ".dataframe > tbody > tr {\n",
+       "  text-align: right;\n",
+       "  white-space: pre-wrap;\n",
+       "}\n",
+       "</style>\n",
+       "<small>shape: (48, 5)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>family</th><th>label</th><th>config_name</th><th>model_class</th><th>params</th></tr><tr><td>str</td><td>str</td><td>str</td><td>str</td><td>str</td></tr></thead><tbody><tr><td>&quot;linear&quot;</td><td>&quot;fwd_ret_1d&quot;</td><td>&quot;ols&quot;</td><td>&quot;LinearRegression&quot;</td><td>&quot;defaults&quot;</td></tr><tr><td>&quot;linear&quot;</td><td>&quot;fwd_ret_1d&quot;</td><td>&quot;ridge_a0.001&quot;</td><td>&quot;Ridge&quot;</td><td>&quot;alpha=0.001&quot;</td></tr><tr><td>&quot;linear&quot;</td><td>&quot;fwd_ret_1d&quot;</td><td>&quot;ridge_a0.01&quot;</td><td>&quot;Ridge&quot;</td><td>&quot;alpha=0.01&quot;</td></tr><tr><td>&quot;linear&quot;</td><td>&quot;fwd_ret_1d&quot;</td><td>&quot;ridge_a0.1&quot;</td><td>&quot;Ridge&quot;</td><td>&quot;alpha=0.1&quot;</td></tr><tr><td>&quot;linear&quot;</td><td>&quot;fwd_ret_1d&quot;</td><td>&quot;ridge_a1.0&quot;</td><td>&quot;Ridge&quot;</td><td>&quot;alpha=1.0&quot;</td></tr><tr><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td></tr><tr><td>&quot;linear&quot;</td><td>&quot;fwd_ret_5d&quot;</td><td>&quot;ridge_a10000000.0&quot;</td><td>&quot;Ridge&quot;</td><td>&quot;alpha=10000000.0&quot;</td></tr><tr><td>&quot;linear&quot;</td><td>&quot;fwd_ret_5d&quot;</td><td>&quot;lasso_a0.01&quot;</td><td>&quot;Lasso&quot;</td><td>&quot;alpha=0.01, max_iter=1000&quot;</td></tr><tr><td>&quot;linear&quot;</td><td>&quot;fwd_ret_5d&quot;</td><td>&quot;lasso_a0.1&quot;</td><td>&quot;Lasso&quot;</td><td>&quot;alpha=0.1, max_iter=1000&quot;</td></tr><tr><td>&quot;linear&quot;</td><td>&quot;fwd_ret_5d&quot;</td><td>&quot;enet_a0.01&quot;</td><td>&quot;ElasticNet&quot;</td><td>&quot;alpha=0.01, l1_ratio=0.5, max_…</td></tr><tr><td>&quot;linear&quot;</td><td>&quot;fwd_ret_5d&quot;</td><td>&quot;enet_a0.1&quot;</td><td>&quot;ElasticNet&quot;</td><td>&quot;alpha=0.1, l1_ratio=0.5, max_i…</td></tr></tbody></table></div>"
+      ],
+      "text/plain": [
+       "shape: (48, 5)\n",
+       "┌────────┬────────────┬───────────────────┬──────────────────┬─────────────────────────────────┐\n",
+       "│ family ┆ label      ┆ config_name       ┆ model_class      ┆ params                          │\n",
+       "│ ---    ┆ ---        ┆ ---               ┆ ---              ┆ ---                             │\n",
+       "│ str    ┆ str        ┆ str               ┆ str              ┆ str                             │\n",
+       "╞════════╪════════════╪═══════════════════╪══════════════════╪═════════════════════════════════╡\n",
+       "│ linear ┆ fwd_ret_1d ┆ ols               ┆ LinearRegression ┆ defaults                        │\n",
+       "│ linear ┆ fwd_ret_1d ┆ ridge_a0.001      ┆ Ridge            ┆ alpha=0.001                     │\n",
+       "│ linear ┆ fwd_ret_1d ┆ ridge_a0.01       ┆ Ridge            ┆ alpha=0.01                      │\n",
+       "│ linear ┆ fwd_ret_1d ┆ ridge_a0.1        ┆ Ridge            ┆ alpha=0.1                       │\n",
+       "│ linear ┆ fwd_ret_1d ┆ ridge_a1.0        ┆ Ridge            ┆ alpha=1.0                       │\n",
+       "│ …      ┆ …          ┆ …                 ┆ …                ┆ …                               │\n",
+       "│ linear ┆ fwd_ret_5d ┆ ridge_a10000000.0 ┆ Ridge            ┆ alpha=10000000.0                │\n",
+       "│ linear ┆ fwd_ret_5d ┆ lasso_a0.01       ┆ Lasso            ┆ alpha=0.01, max_iter=1000       │\n",
+       "│ linear ┆ fwd_ret_5d ┆ lasso_a0.1        ┆ Lasso            ┆ alpha=0.1, max_iter=1000        │\n",
+       "│ linear ┆ fwd_ret_5d ┆ enet_a0.01        ┆ ElasticNet       ┆ alpha=0.01, l1_ratio=0.5, max_… │\n",
+       "│ linear ┆ fwd_ret_5d ┆ enet_a0.1         ┆ ElasticNet       ┆ alpha=0.1, l1_ratio=0.5, max_i… │\n",
+       "└────────┴────────────┴───────────────────┴──────────────────┴─────────────────────────────────┘"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "configs = load_model_configs(\n",
     "    study,\n",
@@ -206,8 +361,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "94f66187",
-   "metadata": {},
+   "id": "70ac155e",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001296,
+     "end_time": "2026-09-11T00:06:10.045065+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T00:06:10.043769+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "`LABELS` and `CONFIG_NAMES` both narrow what is fitted, and a narrowed run declares a different\n",
     "population from the canonical one. Publishing it under the canonical name would leave that name\n",
@@ -217,9 +380,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "e5afb014",
-   "metadata": {},
+   "execution_count": 6,
+   "id": "f548ea23",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-11T00:06:10.049586Z",
+     "iopub.status.busy": "2026-09-11T00:06:10.049278Z",
+     "iopub.status.idle": "2026-09-11T00:06:10.079262Z",
+     "shell.execute_reply": "2026-09-11T00:06:10.078871Z"
+    },
+    "papermill": {
+     "duration": 0.033528,
+     "end_time": "2026-09-11T00:06:10.080019+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T00:06:10.046491+00:00",
+     "status": "completed"
+    }
+   },
    "outputs": [],
    "source": [
     "if narrows_declared_catalog(study, \"linear\", configs) and not POPULATION_NAME:\n",
@@ -247,8 +424,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d5ce3b31",
-   "metadata": {},
+   "id": "d2643e53",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001919,
+     "end_time": "2026-09-11T00:06:10.083778+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T00:06:10.081859+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "## 2. Binding the declarations to the data\n",
     "\n",
@@ -282,10 +467,83 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "18e29809",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 7,
+   "id": "65c0cffe",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-11T00:06:10.089963Z",
+     "iopub.status.busy": "2026-09-11T00:06:10.089823Z",
+     "iopub.status.idle": "2026-09-11T00:07:25.062041Z",
+     "shell.execute_reply": "2026-09-11T00:07:25.058194Z"
+    },
+    "papermill": {
+     "duration": 75.122587,
+     "end_time": "2026-09-11T00:07:25.209157+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T00:06:10.086570+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div><style>\n",
+       ".dataframe > thead > tr,\n",
+       ".dataframe > tbody > tr {\n",
+       "  text-align: right;\n",
+       "  white-space: pre-wrap;\n",
+       "}\n",
+       "</style>\n",
+       "<small>shape: (48, 9)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>label</th><th>config_name</th><th>task</th><th>feature_count</th><th>eligible_rows</th><th>folds</th><th>checkpoints</th><th>validation_start</th><th>validation_end</th></tr><tr><td>str</td><td>str</td><td>str</td><td>i64</td><td>i64</td><td>i64</td><td>i64</td><td>str</td><td>str</td></tr></thead><tbody><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;enet_a0.01&quot;</td><td>&quot;regression&quot;</td><td>71</td><td>7170323</td><td>16</td><td>1</td><td>&quot;1999-12-22 00:00:00&quot;</td><td>&quot;2015-12-30 00:00:00&quot;</td></tr><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;enet_a0.1&quot;</td><td>&quot;regression&quot;</td><td>71</td><td>7170323</td><td>16</td><td>1</td><td>&quot;1999-12-22 00:00:00&quot;</td><td>&quot;2015-12-30 00:00:00&quot;</td></tr><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;lasso_a0.01&quot;</td><td>&quot;regression&quot;</td><td>71</td><td>7170323</td><td>16</td><td>1</td><td>&quot;1999-12-22 00:00:00&quot;</td><td>&quot;2015-12-30 00:00:00&quot;</td></tr><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;lasso_a0.1&quot;</td><td>&quot;regression&quot;</td><td>71</td><td>7170323</td><td>16</td><td>1</td><td>&quot;1999-12-22 00:00:00&quot;</td><td>&quot;2015-12-30 00:00:00&quot;</td></tr><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;ols&quot;</td><td>&quot;regression&quot;</td><td>71</td><td>7170323</td><td>16</td><td>1</td><td>&quot;1999-12-22 00:00:00&quot;</td><td>&quot;2015-12-30 00:00:00&quot;</td></tr><tr><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;ridge_a1000.0&quot;</td><td>&quot;regression&quot;</td><td>71</td><td>7160171</td><td>16</td><td>1</td><td>&quot;1999-12-22 00:00:00&quot;</td><td>&quot;2015-12-23 00:00:00&quot;</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;ridge_a10000.0&quot;</td><td>&quot;regression&quot;</td><td>71</td><td>7160171</td><td>16</td><td>1</td><td>&quot;1999-12-22 00:00:00&quot;</td><td>&quot;2015-12-23 00:00:00&quot;</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;ridge_a100000.0&quot;</td><td>&quot;regression&quot;</td><td>71</td><td>7160171</td><td>16</td><td>1</td><td>&quot;1999-12-22 00:00:00&quot;</td><td>&quot;2015-12-23 00:00:00&quot;</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;ridge_a1000000.0&quot;</td><td>&quot;regression&quot;</td><td>71</td><td>7160171</td><td>16</td><td>1</td><td>&quot;1999-12-22 00:00:00&quot;</td><td>&quot;2015-12-23 00:00:00&quot;</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;ridge_a10000000.0&quot;</td><td>&quot;regression&quot;</td><td>71</td><td>7160171</td><td>16</td><td>1</td><td>&quot;1999-12-22 00:00:00&quot;</td><td>&quot;2015-12-23 00:00:00&quot;</td></tr></tbody></table></div>"
+      ],
+      "text/plain": [
+       "shape: (48, 9)\n",
+       "┌────────────┬────────────┬────────────┬───────────┬───┬───────┬───────────┬───────────┬───────────┐\n",
+       "│ label      ┆ config_nam ┆ task       ┆ feature_c ┆ … ┆ folds ┆ checkpoin ┆ validatio ┆ validatio │\n",
+       "│ ---        ┆ e          ┆ ---        ┆ ount      ┆   ┆ ---   ┆ ts        ┆ n_start   ┆ n_end     │\n",
+       "│ str        ┆ ---        ┆ str        ┆ ---       ┆   ┆ i64   ┆ ---       ┆ ---       ┆ ---       │\n",
+       "│            ┆ str        ┆            ┆ i64       ┆   ┆       ┆ i64       ┆ str       ┆ str       │\n",
+       "╞════════════╪════════════╪════════════╪═══════════╪═══╪═══════╪═══════════╪═══════════╪═══════════╡\n",
+       "│ fwd_ret_1d ┆ enet_a0.01 ┆ regression ┆ 71        ┆ … ┆ 16    ┆ 1         ┆ 1999-12-2 ┆ 2015-12-3 │\n",
+       "│            ┆            ┆            ┆           ┆   ┆       ┆           ┆ 2         ┆ 0         │\n",
+       "│            ┆            ┆            ┆           ┆   ┆       ┆           ┆ 00:00:00  ┆ 00:00:00  │\n",
+       "│ fwd_ret_1d ┆ enet_a0.1  ┆ regression ┆ 71        ┆ … ┆ 16    ┆ 1         ┆ 1999-12-2 ┆ 2015-12-3 │\n",
+       "│            ┆            ┆            ┆           ┆   ┆       ┆           ┆ 2         ┆ 0         │\n",
+       "│            ┆            ┆            ┆           ┆   ┆       ┆           ┆ 00:00:00  ┆ 00:00:00  │\n",
+       "│ fwd_ret_1d ┆ lasso_a0.0 ┆ regression ┆ 71        ┆ … ┆ 16    ┆ 1         ┆ 1999-12-2 ┆ 2015-12-3 │\n",
+       "│            ┆ 1          ┆            ┆           ┆   ┆       ┆           ┆ 2         ┆ 0         │\n",
+       "│            ┆            ┆            ┆           ┆   ┆       ┆           ┆ 00:00:00  ┆ 00:00:00  │\n",
+       "│ fwd_ret_1d ┆ lasso_a0.1 ┆ regression ┆ 71        ┆ … ┆ 16    ┆ 1         ┆ 1999-12-2 ┆ 2015-12-3 │\n",
+       "│            ┆            ┆            ┆           ┆   ┆       ┆           ┆ 2         ┆ 0         │\n",
+       "│            ┆            ┆            ┆           ┆   ┆       ┆           ┆ 00:00:00  ┆ 00:00:00  │\n",
+       "│ fwd_ret_1d ┆ ols        ┆ regression ┆ 71        ┆ … ┆ 16    ┆ 1         ┆ 1999-12-2 ┆ 2015-12-3 │\n",
+       "│            ┆            ┆            ┆           ┆   ┆       ┆           ┆ 2         ┆ 0         │\n",
+       "│            ┆            ┆            ┆           ┆   ┆       ┆           ┆ 00:00:00  ┆ 00:00:00  │\n",
+       "│ …          ┆ …          ┆ …          ┆ …         ┆ … ┆ …     ┆ …         ┆ …         ┆ …         │\n",
+       "│ fwd_ret_5d ┆ ridge_a100 ┆ regression ┆ 71        ┆ … ┆ 16    ┆ 1         ┆ 1999-12-2 ┆ 2015-12-2 │\n",
+       "│            ┆ 0.0        ┆            ┆           ┆   ┆       ┆           ┆ 2         ┆ 3         │\n",
+       "│            ┆            ┆            ┆           ┆   ┆       ┆           ┆ 00:00:00  ┆ 00:00:00  │\n",
+       "│ fwd_ret_5d ┆ ridge_a100 ┆ regression ┆ 71        ┆ … ┆ 16    ┆ 1         ┆ 1999-12-2 ┆ 2015-12-2 │\n",
+       "│            ┆ 00.0       ┆            ┆           ┆   ┆       ┆           ┆ 2         ┆ 3         │\n",
+       "│            ┆            ┆            ┆           ┆   ┆       ┆           ┆ 00:00:00  ┆ 00:00:00  │\n",
+       "│ fwd_ret_5d ┆ ridge_a100 ┆ regression ┆ 71        ┆ … ┆ 16    ┆ 1         ┆ 1999-12-2 ┆ 2015-12-2 │\n",
+       "│            ┆ 000.0      ┆            ┆           ┆   ┆       ┆           ┆ 2         ┆ 3         │\n",
+       "│            ┆            ┆            ┆           ┆   ┆       ┆           ┆ 00:00:00  ┆ 00:00:00  │\n",
+       "│ fwd_ret_5d ┆ ridge_a100 ┆ regression ┆ 71        ┆ … ┆ 16    ┆ 1         ┆ 1999-12-2 ┆ 2015-12-2 │\n",
+       "│            ┆ 0000.0     ┆            ┆           ┆   ┆       ┆           ┆ 2         ┆ 3         │\n",
+       "│            ┆            ┆            ┆           ┆   ┆       ┆           ┆ 00:00:00  ┆ 00:00:00  │\n",
+       "│ fwd_ret_5d ┆ ridge_a100 ┆ regression ┆ 71        ┆ … ┆ 16    ┆ 1         ┆ 1999-12-2 ┆ 2015-12-2 │\n",
+       "│            ┆ 00000.0    ┆            ┆           ┆   ┆       ┆           ┆ 2         ┆ 3         │\n",
+       "│            ┆            ┆            ┆           ┆   ┆       ┆           ┆ 00:00:00  ┆ 00:00:00  │\n",
+       "└────────────┴────────────┴────────────┴───────────┴───┴───────┴───────────┴───────────┴───────────┘"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "requests = model_requests(\n",
     "    study,\n",
@@ -312,8 +570,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2a1e2d74",
-   "metadata": {},
+   "id": "a625a857",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003503,
+     "end_time": "2026-09-11T00:07:25.221950+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T00:07:25.218447+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "`checkpoints` is 1 on every row, and that is the structural difference between this notebook and\n",
     "[`07_gbm`](07_gbm.ipynb). A linear model has no intermediate states worth scoring: there is one\n",
@@ -324,8 +590,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f5e8870a",
-   "metadata": {},
+   "id": "90f117b7",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001373,
+     "end_time": "2026-09-11T00:07:25.225015+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T00:07:25.223642+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "## 3. Fitting the population\n",
     "\n",
@@ -375,10 +649,33 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "6001a468",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 8,
+   "id": "fd021a18",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-11T00:07:25.248234Z",
+     "iopub.status.busy": "2026-09-11T00:07:25.247807Z",
+     "iopub.status.idle": "2026-09-11T00:09:01.997577Z",
+     "shell.execute_reply": "2026-09-11T00:09:01.996789Z"
+    },
+    "papermill": {
+     "duration": 96.775156,
+     "end_time": "2026-09-11T00:09:02.001587+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T00:07:25.226431+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "48 configurations: 0 folds fitted, 768 reused\n",
+      "population us-equities-linear-checkpoints-v1: 48 prediction sets\n"
+     ]
+    }
+   ],
    "source": [
     "population_name = POPULATION_NAME or \"us-equities-linear-checkpoints-v1\"\n",
     "supersedes = supersedes_for_run(\n",
@@ -402,8 +699,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6067f7cf",
-   "metadata": {},
+   "id": "fcb1922a",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003514,
+     "end_time": "2026-09-11T00:09:02.007674+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T00:09:02.004160+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "`reused` is not zero on a second run. Every identity is re-derived from the inputs, the registry\n",
     "already holds the matching rows, and the runner returns the stored result rather than fitting\n",
@@ -438,8 +743,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cd223867",
-   "metadata": {},
+   "id": "658eb32e",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002048,
+     "end_time": "2026-09-11T00:09:02.012269+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T00:09:02.010221+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "## 4. What came out\n",
     "\n",
@@ -463,14 +776,87 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "1992a888",
+   "execution_count": 9,
+   "id": "08429f0b",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-11T00:09:02.020071Z",
+     "iopub.status.busy": "2026-09-11T00:09:02.019856Z",
+     "iopub.status.idle": "2026-09-11T00:09:02.043060Z",
+     "shell.execute_reply": "2026-09-11T00:09:02.042506Z"
+    },
+    "papermill": {
+     "duration": 0.029609,
+     "end_time": "2026-09-11T00:09:02.044843+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T00:09:02.015234+00:00",
+     "status": "completed"
+    },
     "tags": [
      "results"
     ]
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "48 candidate models across 3 labels\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div><style>\n",
+       ".dataframe > thead > tr,\n",
+       ".dataframe > tbody > tr {\n",
+       "  text-align: right;\n",
+       "  white-space: pre-wrap;\n",
+       "}\n",
+       "</style>\n",
+       "<small>shape: (48, 8)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>label</th><th>config_name</th><th>model_class</th><th>params</th><th>ic_mean</th><th>ic_std</th><th>ic_n_days</th><th>full_coverage</th></tr><tr><td>str</td><td>str</td><td>str</td><td>str</td><td>f64</td><td>f64</td><td>f64</td><td>bool</td></tr></thead><tbody><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;ridge_a1000000.0&quot;</td><td>&quot;Ridge&quot;</td><td>&quot;alpha=1000000.0&quot;</td><td>0.018286</td><td>0.009706</td><td>4031.0</td><td>true</td></tr><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;ridge_a100000.0&quot;</td><td>&quot;Ridge&quot;</td><td>&quot;alpha=100000.0&quot;</td><td>0.017667</td><td>0.010536</td><td>4031.0</td><td>true</td></tr><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;ridge_a10000.0&quot;</td><td>&quot;Ridge&quot;</td><td>&quot;alpha=10000.0&quot;</td><td>0.016109</td><td>0.010662</td><td>4031.0</td><td>true</td></tr><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;ridge_a0.001&quot;</td><td>&quot;Ridge&quot;</td><td>&quot;alpha=0.001&quot;</td><td>0.015987</td><td>0.010882</td><td>4031.0</td><td>true</td></tr><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;ols&quot;</td><td>&quot;LinearRegression&quot;</td><td>&quot;defaults&quot;</td><td>0.015987</td><td>0.010882</td><td>4031.0</td><td>true</td></tr><tr><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;ridge_a0.1&quot;</td><td>&quot;Ridge&quot;</td><td>&quot;alpha=0.1&quot;</td><td>0.013589</td><td>0.01583</td><td>4027.0</td><td>true</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;lasso_a0.01&quot;</td><td>&quot;Lasso&quot;</td><td>&quot;alpha=0.01, max_iter=1000&quot;</td><td>0.000786</td><td>0.007473</td><td>172.0</td><td>false</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;enet_a0.1&quot;</td><td>&quot;ElasticNet&quot;</td><td>&quot;alpha=0.1, l1_ratio=0.5, max_i…</td><td>0.000786</td><td>0.007473</td><td>172.0</td><td>false</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;enet_a0.01&quot;</td><td>&quot;ElasticNet&quot;</td><td>&quot;alpha=0.01, l1_ratio=0.5, max_…</td><td>0.000786</td><td>0.007473</td><td>172.0</td><td>false</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;lasso_a0.1&quot;</td><td>&quot;Lasso&quot;</td><td>&quot;alpha=0.1, max_iter=1000&quot;</td><td>0.000786</td><td>0.007473</td><td>172.0</td><td>false</td></tr></tbody></table></div>"
+      ],
+      "text/plain": [
+       "shape: (48, 8)\n",
+       "┌────────────┬────────────┬────────────┬────────────┬──────────┬──────────┬───────────┬────────────┐\n",
+       "│ label      ┆ config_nam ┆ model_clas ┆ params     ┆ ic_mean  ┆ ic_std   ┆ ic_n_days ┆ full_cover │\n",
+       "│ ---        ┆ e          ┆ s          ┆ ---        ┆ ---      ┆ ---      ┆ ---       ┆ age        │\n",
+       "│ str        ┆ ---        ┆ ---        ┆ str        ┆ f64      ┆ f64      ┆ f64       ┆ ---        │\n",
+       "│            ┆ str        ┆ str        ┆            ┆          ┆          ┆           ┆ bool       │\n",
+       "╞════════════╪════════════╪════════════╪════════════╪══════════╪══════════╪═══════════╪════════════╡\n",
+       "│ fwd_ret_1d ┆ ridge_a100 ┆ Ridge      ┆ alpha=1000 ┆ 0.018286 ┆ 0.009706 ┆ 4031.0    ┆ true       │\n",
+       "│            ┆ 0000.0     ┆            ┆ 000.0      ┆          ┆          ┆           ┆            │\n",
+       "│ fwd_ret_1d ┆ ridge_a100 ┆ Ridge      ┆ alpha=1000 ┆ 0.017667 ┆ 0.010536 ┆ 4031.0    ┆ true       │\n",
+       "│            ┆ 000.0      ┆            ┆ 00.0       ┆          ┆          ┆           ┆            │\n",
+       "│ fwd_ret_1d ┆ ridge_a100 ┆ Ridge      ┆ alpha=1000 ┆ 0.016109 ┆ 0.010662 ┆ 4031.0    ┆ true       │\n",
+       "│            ┆ 00.0       ┆            ┆ 0.0        ┆          ┆          ┆           ┆            │\n",
+       "│ fwd_ret_1d ┆ ridge_a0.0 ┆ Ridge      ┆ alpha=0.00 ┆ 0.015987 ┆ 0.010882 ┆ 4031.0    ┆ true       │\n",
+       "│            ┆ 01         ┆            ┆ 1          ┆          ┆          ┆           ┆            │\n",
+       "│ fwd_ret_1d ┆ ols        ┆ LinearRegr ┆ defaults   ┆ 0.015987 ┆ 0.010882 ┆ 4031.0    ┆ true       │\n",
+       "│            ┆            ┆ ession     ┆            ┆          ┆          ┆           ┆            │\n",
+       "│ …          ┆ …          ┆ …          ┆ …          ┆ …        ┆ …        ┆ …         ┆ …          │\n",
+       "│ fwd_ret_5d ┆ ridge_a0.1 ┆ Ridge      ┆ alpha=0.1  ┆ 0.013589 ┆ 0.01583  ┆ 4027.0    ┆ true       │\n",
+       "│ fwd_ret_5d ┆ lasso_a0.0 ┆ Lasso      ┆ alpha=0.01 ┆ 0.000786 ┆ 0.007473 ┆ 172.0     ┆ false      │\n",
+       "│            ┆ 1          ┆            ┆ , max_iter ┆          ┆          ┆           ┆            │\n",
+       "│            ┆            ┆            ┆ =1000      ┆          ┆          ┆           ┆            │\n",
+       "│ fwd_ret_5d ┆ enet_a0.1  ┆ ElasticNet ┆ alpha=0.1, ┆ 0.000786 ┆ 0.007473 ┆ 172.0     ┆ false      │\n",
+       "│            ┆            ┆            ┆ l1_ratio=0 ┆          ┆          ┆           ┆            │\n",
+       "│            ┆            ┆            ┆ .5, max_i… ┆          ┆          ┆           ┆            │\n",
+       "│ fwd_ret_5d ┆ enet_a0.01 ┆ ElasticNet ┆ alpha=0.01 ┆ 0.000786 ┆ 0.007473 ┆ 172.0     ┆ false      │\n",
+       "│            ┆            ┆            ┆ , l1_ratio ┆          ┆          ┆           ┆            │\n",
+       "│            ┆            ┆            ┆ =0.5,      ┆          ┆          ┆           ┆            │\n",
+       "│            ┆            ┆            ┆ max_…      ┆          ┆          ┆           ┆            │\n",
+       "│ fwd_ret_5d ┆ lasso_a0.1 ┆ Lasso      ┆ alpha=0.1, ┆ 0.000786 ┆ 0.007473 ┆ 172.0     ┆ false      │\n",
+       "│            ┆            ┆            ┆ max_iter=1 ┆          ┆          ┆           ┆            │\n",
+       "│            ┆            ┆            ┆ 000        ┆          ┆          ┆           ┆            │\n",
+       "└────────────┴────────────┴────────────┴────────────┴──────────┴──────────┴───────────┴────────────┘"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "catalog = (\n",
     "    execution.catalog_rows.select(\n",
@@ -519,8 +905,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "33d0b9df",
-   "metadata": {},
+   "id": "1b06fe9a",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001931,
+     "end_time": "2026-09-11T00:09:02.051207+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T00:09:02.049276+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "## Freeze the compatible result sets\n",
     "\n",
@@ -549,14 +943,60 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "cc2b5e77",
+   "execution_count": 10,
+   "id": "e2bb7f98",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-11T00:09:02.058295Z",
+     "iopub.status.busy": "2026-09-11T00:09:02.058047Z",
+     "iopub.status.idle": "2026-09-11T00:09:05.423692Z",
+     "shell.execute_reply": "2026-09-11T00:09:05.423164Z"
+    },
+    "papermill": {
+     "duration": 3.369405,
+     "end_time": "2026-09-11T00:09:05.424425+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T00:09:02.055020+00:00",
+     "status": "completed"
+    },
     "tags": [
      "results"
     ]
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div><style>\n",
+       ".dataframe > thead > tr,\n",
+       ".dataframe > tbody > tr {\n",
+       "  text-align: right;\n",
+       "  white-space: pre-wrap;\n",
+       "}\n",
+       "</style>\n",
+       "<small>shape: (6, 3)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>role</th><th>set_name</th><th>members</th></tr><tr><td>str</td><td>str</td><td>i64</td></tr></thead><tbody><tr><td>&quot;backtest population&quot;</td><td>&quot;us-equities-fwd-ret-1d-linear-…</td><td>16</td></tr><tr><td>&quot;bounded diagnostics&quot;</td><td>&quot;us-equities-fwd-ret-1d-linear-…</td><td>1</td></tr><tr><td>&quot;backtest population&quot;</td><td>&quot;us-equities-fwd-ret-21d-linear…</td><td>16</td></tr><tr><td>&quot;bounded diagnostics&quot;</td><td>&quot;us-equities-fwd-ret-21d-linear…</td><td>1</td></tr><tr><td>&quot;backtest population&quot;</td><td>&quot;us-equities-fwd-ret-5d-linear-…</td><td>16</td></tr><tr><td>&quot;bounded diagnostics&quot;</td><td>&quot;us-equities-fwd-ret-5d-linear-…</td><td>1</td></tr></tbody></table></div>"
+      ],
+      "text/plain": [
+       "shape: (6, 3)\n",
+       "┌─────────────────────┬─────────────────────────────────┬─────────┐\n",
+       "│ role                ┆ set_name                        ┆ members │\n",
+       "│ ---                 ┆ ---                             ┆ ---     │\n",
+       "│ str                 ┆ str                             ┆ i64     │\n",
+       "╞═════════════════════╪═════════════════════════════════╪═════════╡\n",
+       "│ backtest population ┆ us-equities-fwd-ret-1d-linear-… ┆ 16      │\n",
+       "│ bounded diagnostics ┆ us-equities-fwd-ret-1d-linear-… ┆ 1       │\n",
+       "│ backtest population ┆ us-equities-fwd-ret-21d-linear… ┆ 16      │\n",
+       "│ bounded diagnostics ┆ us-equities-fwd-ret-21d-linear… ┆ 1       │\n",
+       "│ backtest population ┆ us-equities-fwd-ret-5d-linear-… ┆ 16      │\n",
+       "│ bounded diagnostics ┆ us-equities-fwd-ret-5d-linear-… ┆ 1       │\n",
+       "└─────────────────────┴─────────────────────────────────┴─────────┘"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "set_rows = []\n",
     "if is_published_population:\n",
@@ -616,9 +1056,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8094346d",
+   "id": "288bfd55",
    "metadata": {
-    "lines_to_next_cell": 2
+    "lines_to_next_cell": 2,
+    "papermill": {
+     "duration": 0.002333,
+     "end_time": "2026-09-11T00:09:05.428920+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T00:09:05.426587+00:00",
+     "status": "completed"
+    }
    },
    "source": [
     "### How the penalty grid ranks\n",
@@ -633,10 +1080,419 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "9b6c823d",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 11,
+   "id": "5db5ec5f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-11T00:09:05.435764Z",
+     "iopub.status.busy": "2026-09-11T00:09:05.435639Z",
+     "iopub.status.idle": "2026-09-11T00:09:07.372938Z",
+     "shell.execute_reply": "2026-09-11T00:09:07.372449Z"
+    },
+    "papermill": {
+     "duration": 1.942877,
+     "end_time": "2026-09-11T00:09:07.375843+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T00:09:05.432966+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.plotly.v1+json": {
+       "config": {
+        "plotlyServerURL": "https://plot.ly"
+       },
+       "data": [
+        {
+         "marker": {
+          "color": [
+           "#D4A84B",
+           "#0a1628",
+           "#0a1628",
+           "#0a1628",
+           "#0a1628",
+           "#0a1628",
+           "#0a1628",
+           "#0a1628",
+           "#0a1628",
+           "#0a1628",
+           "#0a1628",
+           "#0a1628"
+          ]
+         },
+         "showlegend": false,
+         "type": "bar",
+         "x": [
+          "ridge_a1000000.0",
+          "ridge_a100000.0",
+          "ridge_a10000.0",
+          "ridge_a0.001",
+          "ols",
+          "ridge_a0.01",
+          "ridge_a0.1",
+          "ridge_a1.0",
+          "ridge_a10.0",
+          "ridge_a100.0",
+          "ridge_a1000.0",
+          "ridge_a10000000.0"
+         ],
+         "xaxis": "x",
+         "y": [
+          0.018286489066422905,
+          0.01766734144525931,
+          0.01610864699417105,
+          0.015987206165292027,
+          0.015987187711594547,
+          0.015987139197693387,
+          0.015986692642133184,
+          0.015983260353149523,
+          0.01595718298380513,
+          0.015807062613830004,
+          0.01569345261164781,
+          0.014966182402694128
+         ],
+         "yaxis": "y"
+        },
+        {
+         "marker": {
+          "color": [
+           "#0a1628",
+           "#D4A84B",
+           "#0a1628",
+           "#0a1628",
+           "#0a1628",
+           "#0a1628",
+           "#0a1628",
+           "#0a1628",
+           "#0a1628",
+           "#0a1628",
+           "#0a1628",
+           "#0a1628"
+          ]
+         },
+         "showlegend": false,
+         "type": "bar",
+         "x": [
+          "ridge_a1000000.0",
+          "ridge_a100000.0",
+          "ridge_a10000.0",
+          "ridge_a0.001",
+          "ols",
+          "ridge_a0.01",
+          "ridge_a0.1",
+          "ridge_a1.0",
+          "ridge_a10.0",
+          "ridge_a100.0",
+          "ridge_a1000.0",
+          "ridge_a10000000.0"
+         ],
+         "xaxis": "x2",
+         "y": [
+          0.009334421647723343,
+          0.010804693195027318,
+          0.010037473119414306,
+          0.010166057897074657,
+          0.010166061449758394,
+          0.01016603130355884,
+          0.010165830103092343,
+          0.01016418832998912,
+          0.010151974265503582,
+          0.010107724310019956,
+          0.01005199806909326,
+          0.0017462259710712856
+         ],
+         "yaxis": "y2"
+        },
+        {
+         "marker": {
+          "color": [
+           "#D4A84B",
+           "#0a1628",
+           "#0a1628",
+           "#0a1628",
+           "#0a1628",
+           "#0a1628",
+           "#0a1628",
+           "#0a1628",
+           "#0a1628",
+           "#0a1628",
+           "#0a1628",
+           "#0a1628"
+          ]
+         },
+         "showlegend": false,
+         "type": "bar",
+         "x": [
+          "ridge_a1000000.0",
+          "ridge_a100000.0",
+          "ridge_a10000.0",
+          "ridge_a0.001",
+          "ols",
+          "ridge_a0.01",
+          "ridge_a0.1",
+          "ridge_a1.0",
+          "ridge_a10.0",
+          "ridge_a100.0",
+          "ridge_a1000.0",
+          "ridge_a10000000.0"
+         ],
+         "xaxis": "x3",
+         "y": [
+          0.01892682115009793,
+          0.016905230429959117,
+          0.014200766663186041,
+          0.01358862107834921,
+          0.013588610911803956,
+          0.013588614422435292,
+          0.013588597579689176,
+          0.01358918431213243,
+          0.013594429083310865,
+          0.01359785868024413,
+          0.013640058111112331,
+          0.018289675721089155
+         ],
+         "yaxis": "y3"
+        }
+       ],
+       "layout": {
+        "annotations": [
+         {
+          "font": {
+           "size": 16
+          },
+          "showarrow": false,
+          "text": "fwd_ret_1d (primary)",
+          "x": 0.5,
+          "xanchor": "center",
+          "xref": "paper",
+          "y": 1.0,
+          "yanchor": "bottom",
+          "yref": "paper"
+         },
+         {
+          "font": {
+           "size": 16
+          },
+          "showarrow": false,
+          "text": "fwd_ret_21d (variant)",
+          "x": 0.5,
+          "xanchor": "center",
+          "xref": "paper",
+          "y": 0.6499999999999999,
+          "yanchor": "bottom",
+          "yref": "paper"
+         },
+         {
+          "font": {
+           "size": 16
+          },
+          "showarrow": false,
+          "text": "fwd_ret_5d (variant)",
+          "x": 0.5,
+          "xanchor": "center",
+          "xref": "paper",
+          "y": 0.3,
+          "yanchor": "bottom",
+          "yref": "paper"
+         }
+        ],
+        "height": 900,
+        "margin": {
+         "t": 90
+        },
+        "shapes": [
+         {
+          "line": {
+           "color": "#334155",
+           "dash": "dash",
+           "width": 1
+          },
+          "type": "line",
+          "x0": 0,
+          "x1": 1,
+          "xref": "x domain",
+          "y0": 0,
+          "y1": 0,
+          "yref": "y"
+         },
+         {
+          "line": {
+           "color": "#334155",
+           "dash": "dash",
+           "width": 1
+          },
+          "type": "line",
+          "x0": 0,
+          "x1": 1,
+          "xref": "x2 domain",
+          "y0": 0,
+          "y1": 0,
+          "yref": "y2"
+         },
+         {
+          "line": {
+           "color": "#334155",
+           "dash": "dash",
+           "width": 1
+          },
+          "type": "line",
+          "x0": 0,
+          "x1": 1,
+          "xref": "x3 domain",
+          "y0": 0,
+          "y1": 0,
+          "yref": "y3"
+         }
+        ],
+        "template": {
+         "layout": {
+          "colorway": [
+           "#0a1628",
+           "#D4A84B",
+           "#C87533",
+           "#10b981",
+           "#ef4444",
+           "#94a3b8"
+          ],
+          "font": {
+           "color": "#334155",
+           "family": "DM Sans, DejaVu Sans, sans-serif",
+           "size": 11
+          },
+          "hoverlabel": {
+           "bgcolor": "white",
+           "font": {
+            "family": "DM Sans, DejaVu Sans, sans-serif",
+            "size": 11
+           }
+          },
+          "legend": {
+           "bgcolor": "rgba(255,255,255,0.8)",
+           "bordercolor": "#e8e8e6",
+           "borderwidth": 1,
+           "font": {
+            "size": 10
+           }
+          },
+          "paper_bgcolor": "#FAFAF9",
+          "plot_bgcolor": "white",
+          "title": {
+           "font": {
+            "color": "#0a1628",
+            "size": 14
+           },
+           "x": 0.5,
+           "xanchor": "center"
+          },
+          "xaxis": {
+           "gridcolor": "#e8e8e6",
+           "gridwidth": 0.5,
+           "linecolor": "#e8e8e6",
+           "showgrid": true,
+           "tickfont": {
+            "size": 10
+           },
+           "title": {
+            "font": {
+             "size": 11
+            }
+           }
+          },
+          "yaxis": {
+           "gridcolor": "#e8e8e6",
+           "gridwidth": 0.5,
+           "linecolor": "#e8e8e6",
+           "showgrid": true,
+           "tickfont": {
+            "size": 10
+           },
+           "title": {
+            "font": {
+             "size": 11
+            }
+           }
+          }
+         }
+        },
+        "title": {
+         "text": "Validation IC across the penalty grid, at three prediction horizons"
+        },
+        "width": 1100,
+        "xaxis": {
+         "anchor": "y",
+         "domain": [
+          0.0,
+          1.0
+         ],
+         "matches": "x3",
+         "showticklabels": false
+        },
+        "xaxis2": {
+         "anchor": "y2",
+         "domain": [
+          0.0,
+          1.0
+         ],
+         "matches": "x3",
+         "showticklabels": false
+        },
+        "xaxis3": {
+         "anchor": "y3",
+         "domain": [
+          0.0,
+          1.0
+         ],
+         "tickangle": -45,
+         "title": {
+          "text": "Configuration, ordered by rank on fwd_ret_1d"
+         }
+        },
+        "yaxis": {
+         "anchor": "x",
+         "domain": [
+          0.7,
+          1.0
+         ],
+         "title": {
+          "text": "Mean IC (validation)"
+         }
+        },
+        "yaxis2": {
+         "anchor": "x2",
+         "domain": [
+          0.35,
+          0.6499999999999999
+         ],
+         "matches": "y",
+         "title": {
+          "text": "Mean IC (validation)"
+         }
+        },
+        "yaxis3": {
+         "anchor": "x3",
+         "domain": [
+          0.0,
+          0.3
+         ],
+         "matches": "y",
+         "title": {
+          "text": "Mean IC (validation)"
+         }
+        }
+       }
+      },
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABEwAAAOECAYAAAC7HaTtAAAQAElEQVR4AezdCbxM5RvA8Weufc1OJCRZyi6lSCokCaFsWSNkLUm2LNlCyK5Qloh/qZRS2iyhskbSamkh+861/ec5mnHu3NnvnTtnZn4+vTPnvNt53+85ZzKPc87Excefv0LCgGOAY4BjgGOAY4BjgGOAY4BjgGOAY4BjgGMgqo8BvvsHGP+IE/4ggAACCCCAAAIIIIAAAgggEHECDBiB0AoQMAmtL70jgAACCCCAAAIIIIAAAv4JUAsBBCwlQMDEUruDwSCAAAIIIIAAAgggED0CzAQBBBCIZAECJpG89xg7AggggAACCCCAQEoKsC0EEEAAgRgSIGASQzubqSKAAAIIIIAAAgkFWEMAAQQQQAABTwIETDzJkI8AAggggAACkSfAiBFAAAEEEEAAgWQSIGCSTJB0gwACCCCAQCgE6BMBBBBAAAEEEEAgPAIETMLjzlYRQACBWBVg3ggggAACCCCAAAIIRIQAAZOI2E0MEgEErCvAyBBAAAEEEEAAAQQQQCAaBQiYRONeZU4IJEWAtggggAACCCCAAAIIIIAAAkLAhIMg6gWYIAIIIIAAAggggAACCCCAAAKBChAwCVQs/PUZAQIIIIAAAggggAACCCCAAAIIhFjAAgGTEM+Q7hFAAAEEEEAAAQQQQAABBBBAwAICkTUEAiaRtb8YLQIIIIAAAggggAACCCCAgFUEGEdUCxAwierdy+QQQAABBBBAAAEEEEAAAf8FqIkAAtcECJhcs2AJAQQQQAABBBBAAAEEokuA2SCAAAJBCxAwCZqOhggggAACCCCAAAIIpLQA20MAAQQQSCkBAiYpJc12EEAAAQQQQAABBBILkIMAAggggIBFBQiYWHTHMCwEEEAAAQQQiEwBRo0AAggggAAC0SFAwCQ69iOzQAABBBBAIFQC9IsAAggggAACCMSkAAGTmNztTBoBBBCIZQHmjgACCCCAAAIIIICAbwECJr6NqIEAAghYW4DRIYAAAggggAACCCCAQLILEDBJdlI6RACBpArQHgEEEEAAAQQQQAABBBAItwABk3DvAbYfCwLMEQEEEEAAAQQQQAABBBBAIMIECJhE2A6zxnAZBQIIIIAAAggggAACCCCAAALRLUDARPcvCQEEEEAAAQQQQAABBBBAAAEEol8ggBkSMAkAi6oIIIAAAggggAACCCCAAAIIWEmAsYROgIBJ6GzpGQEEEEAAAQQQQAABBBBAIDABaiNgGQECJpbZFQwEAQQQQAABBBBAAAEEok+AGSGAQKQKEDCJ1D3HuBFAAAEEEEAAAQQQCIcA20QAAQRiRICASYzsaKaJAAIIIIAAAggg4F6AXAQQQAABBNwJEDBxp0IeAggggAACCCAQuQKMHAEEEEAAAQSSQYCASTIg0gUCCCCAAAIIhFKAvhFAAAEEEEAAgZQXIGCS8uZsEQEEolSg9VO95YXBLztn1/qpZ6Xvi6Od6+4WOvccKD37DnNXFFBe0TLV5f2PVgbUhsqhEchVuKKs/Gqt984jvPTmsvda6njbtuMnyXZDWTl0+KhH2XmLlsodNRp4LA9HQeOWXWTY6FfDsWlLbNP188+fz0xfA0+OPnxtQ8tDeZ6n1Bx0HiQEEEAAAe8CBEy8+1CKAAIxIPBEh2dEv7i4m+rPv+42voh9seobd8Ve80rcUlSKFCrotU6ghZNnzJUadZsnanZn5fKSM0e2RPnJmbF339+GxZp13yfo9qeff5eWHXpJhaoPy/XF7jC+lLZ/uq9s2fZjgnrRtuJpX0TbPH3NZ/PWHcZxcez4CV9VQ1aeKWMGubfanZImTeqQbcNTxzeWvFs++uRLT8XOfH/rORvE4EIgn5mejrtA+rAqcTTMwaq2jAsBBBAIVICASaBi1EcAgagTaN6kvnz+9Tfyz/5/HXNzvi9c8r4UvCG/1KhWxZnn78ILz3aRp9olDm742z6QegtenyBVq1QKpEmy1F3x+WqpVvsx+f2PvcZc584cJ12fai15cueQ0ROmJ8s26AQBXwJFixSS9xbOkOuyZvFVlXILCyTHZ2Zy9BFuomiYQ7gN2T4CCCCQXAIETJJLkn4QsLQAg/MmUPuBapI3dy6Zt+i9BNUuX74sC5cskyeaNpTTZ87KSy9PkloNWknBEnfJvQ81k3c/+CRBfdcV18uqT50+Y9x+c0v5+6T0nXWk35Axrk3ktTcWGle7FL61mlS65xEZPmayXLx40aj31pIPZMCwceL4l1W9BeGN+f8zylxvyTlw8JB07N5PSlaqKcXK1ZC2nfvIn3/9Y9TVl3GTZkmdR9vKzDkL5fbqj8hNpavLk137yv5/D2qxX0nn06vvMKlUvrR8tXyRETCpWaOq4TVycB95ffIoj/18snKVMb5St9eS4uXvN5Zdb6f4ffde0ductE6JCg/I088Mkp27fjP6dIxfr/KofG99yV6wnJHva97bd/7s7FP9bq1cW75avd5oq/Pp+fwwueuBRqJlBW6pIq9Of9Moc33xti+07oF/D0mTJ7qIXlVQtWYTefudDzXbmY4eOy69+480rsrR4+nR5p1Fx+as4GYhV+GKMnr8DKnbuL1xDGq/i9/9KEFNx9U+6qX7vXPPgWK+8sPh5m2/+7NvHBvds/cv5xVPesyqmx536qNjuHDhgqOq8a5lbTo9Zyy7e/ntjz1OtztqNJRF7yyTsnc9JOZ5qsObb70jaqbbVBN3t+TosaHnkNZp3r6HHD9+0t0mveb5sqhYrZ6cOHlKWjzZ0zhm9Fh116G3epcuXZZeL7xknKv6uTB01KvOc1770qvf+g8daxz/erw2aPaUZouvfX3p0iWZNH2u6HGix7JemfbB8pVGW08vui09B9SrmP1zQ8czeMSEZBmPcX7ZPy+8ff65fmaqrd7WqJ9Rei493rqrfPrFavF03Om8XPuIj79gfHZrH3quPdzkSflmw0ataqR1324y9p1eRahGWqfeY0/Kxs0/GOXeXnyd574+jxznox6r5s8x8xwc49Nzy5wcx4GOb+H/PjD+n6T7+d46zWTOvCWa7Ux6zugtad4+k8ZMfM34/1veorcbHm3t/89wdsACAgggEMMCcTE8d6YeyQKMHYFkFIiLi5OWTevL/LffkytXrjh7XrFytehfeFs1ayjx8fGSLl16GT9yoGxdt1ye7vCEPeAxNqBnVfQfMlaW2b+wvDF9jHy+bL4c+PewfPH1N87t6cKJk2fk2e5Pyrb1H8vLL/WVtes3ychxU7VImjd5RF4a+KyUL3urHPtzq5HatGxslJlfdA6Pt+omP9mDC+8umC6fvT9P/v7ngDzaopOYv8Bu+eFHI3/J3Kny3qIZ8vvufTJqnP9XhegtN9pvn54dJW3aNOYhGMuZMmY03t29HDt+XBrUrSVrPl0sb8+dJOnSppVWHZ91+v978LDUqt9KtI935k+Tbz7/n9xdpZL9y+m1L706/o1btsviN6fInh/XGG19zfv5gaPlhgL5ZMXSN+SP7asMzwwZ0htDnDh1tuze+6e8Pnm0/PXzOlk4Z6IUuD6PUeb64mtfaF9lS5eUqa8Mk1uK3SSdeg6Q3Xv+dHbzRIdn5eSpU/LapJGy5Zvl8nCdGvJo807y19/7nXXcLegXoS5PtpTt366Qdq2aGIGmr9dsMKqqWf3HO0jZ20rJsiWz5NP358p112WWx+xfMjX4Z1Syv6ib7rclHva7r31j78L5X6EbC8iXH71lrO/esVr0uJz56ghp9MiDcuHiBdGAg1Fofzl+4qS8/9Fn0sx+HNtXE/2nx2bTNt0kXfp0suqTt0XPE61/7NiJRHU1SNL2icby08aV0vnJFonKNdCiwcUeXdrK5rUfSpXbK9qDB+6DX4kamzJ8WWxcvUyyZskseoWXzv3H7z41tb626K3eInsw7eKFi/LysL7SpEEdI0j3zvufiPnPbPsX4KI3FZLVK94WvYrLn3398oQZ8sHHK2XIgF7y4/efyvM9O4kGP8z7xLwNx/KCxe9L5Yrl5Luv35cJowfK2/ag3NhXX3cUG+/BjMefzz+jc9NLi/Y97QHiH2XS2CH2OXwmHdo2MwJfno47U1Pn4osjxtsD0W/LaLuvfnbr7S71mz4lv/y2x1lHF+a+tVTGDe8n3371nhQskN9+zvY3PlO0zFPydp4H8jm80fQ55rqtKpUrGOeVHl+aNq7+wLj98o5KZY2qGgTTwGizxvVkx3crpH3rx4wAnP7/zKjw38trcxZJJ/tnhxo0f6y+fX7XPpM0WPSaPVg/bMAz8scPq2SV/TirXPFq//815w0BBBCIWQECJhbZ9QwDAQTCK/BE00dl776/ZNXab50DWfTOB6JXn+TLm1tyZM8mz/XoILeWLGYsN2n4kLRp0VgW/W+Z+PNH/3V17sJ35YVnO8tdd1SUPLlzGl9GTp85k6D5s93ai/4FWb+E3XfPXfJ8r6dkweIPEtTxtaJfoPVL8atjX5SSxYtK4UI3yKtjBos+j2X5p187m2fPdp0M7tfTKC9zawlp8dgj8u3GLc5yXwu/795rVLk9iL9YN21UTx6qfa9hWa50KXllZH/Z8P0W41/NtdM58/8nenvFq2MGGXNQfw1S3FHp6pUkWkeTfqHT+amXP/P+Z/8B0e3pbVbZ7fNvWK+WOPr8Z/9BKVK4oJQqcbMRqLnn7srSqH4d3UzAqWnjR2RAn272QMh9MvPV4caX6o1brv6LtR5jepXQlHFDpGL50saXn3ZPPCYVyt0q73ywwuu2Wjz+iNR9sIZho210Wf/lWBvpl9gytxU3jtNiRQsZz88ZObiP7PjxF/uXzh1axUg6b2/73de+MTrx8ZIuXVrRc2TRO9fOjyVLP7If97mkZo273bb+cvV6e9DuTyMoqfu0ZPGbjYCWBlpcGzRvUk/q1blf0tuDK7rvXcvfXPCuPGoP2jzRtKHofLt1aiUl7fvVtZ6v9eSw8LWNMrcWtwcEBhvzGdS3uzxw713283Bbgmbly9wqz3Rtb5wvOl9f+/r8+XiZMHWODLMHS+6vfpdxvDxY8x5pbf/MevOtq1elJdiAaUWvGOtpDzRluy6raFsNDr+xIGGbQMfj7+efaRiy+pvvjDR1/FC58/bykjlTRrvN3cZxZa7nbfns2XPy+puLpXf3jqKfp/o5MmrIc5L/+jwya+6iBE379X7afg7eJtfnyyN6vGhARQPmCSq5rHg7z/35PHJ0Z/4cc+S5e9crblo++YzcXqGMPN+rk1HltTcWGZ+levun7jM95h97tK7MnL3QKHe8aIBV96eeD106tJQ8uXLKpq3bjWL97FMbDZJkzJhB9P8H7gKRRmVeEEAAgRgTCFXAJMYYmS4CCES6gP6LpT408u13rt7ioLeHfPjJl9KscX3n1PSyZ70dQi8N10ujR70yTfb9ee02F2dFNwv6wFT9F8fqVas4S7NkzpTouSPrv9sszdv3kBIVHzAui67ftKPsP3BQzpw562zna0EDGRrkRUAepAAAEABJREFU0cCAo27xYkVEk97y4MgrWOB6x6LxnitnTtF/uTZW/Hix2WxGLb3031gI4GXfn3+LXvqvt0yoZe4ilUT72ffX30Yvv/6+2wgmpE6d2lh391K82E3GF0FHmT/zbmz/F3zdrt7eM3HaG7LJ/i+7jvYNH6ktc996V/Syf708/WN7cEn3maM8kPdSJYo5q+scbrwhv/MXXH77fY9ooCxX4YrGPtb5a/rks1VivgrF2YFp4bZSJUxrYv9iU9IeZNhn5Om+/ezLtQn61FuVdFt/mK5u8bXffe0bY2N+vDxhD0LqnPRc0uoL//ehNG1UV/SKLl13TXv2/inqlDtXDmeRPptEzxNnxn8L5Urf+t+S+zd9pk71qpUTFOr5nSDDj5XksvC2KQ0Mmcv1s+jQ4SPmLClXpmSCdV/7Wve3Bk0ebNgmwfHw4vDx8sfua1c6Jej0v5XSt97y39LVN71SyvUzKNDx+Pv5d3WLV19//W23PbCRV/QYuJoT+OvuvX8ZV9U9YArS6flY454qxnOXzD3ekD+vczW3PZigKwcPJdwPmmdO3s5zfz6PtC/XzzHNc5f0KrE2T129ne31KaOd59EvdqcH7r07QRNd3/nzbwmukMl//bX5aeW8eXKJY356K+XBQ4elxkPNjduXNNCpwRmtR0IAAQT8FIjaagRMonbXMjEEEAhUQK9g0FsA9AumXjmSO2cOeahWdaObt9/50Hh+xKC+3YxLtvXSaL2CIN7lGQ1GZS8vqVMn/NhNlTqVs7Z+CWryxNPy+KP1ZMXSN+Xwnk2y/J3ZRnmg20mTJo3RzvySKtW1bWm+uy+ugQQIbrm5iHYjf+y5+oXdWPHjRbehtwflzpVdFsyaKAd++06O7N0sOuYL8Rf96OFqlQzp019dML1qH6ZVY9E8b/1X5NnTXpYbCxaQb9Z/L/fXayn6nAetqP/6+sVHC6TKHRVFAzZP9ehnBK+0LNCU2rRfta3NZrN/edElEZvNJnqFkR5DrkmvtJEA/6inNrHZbMYVMa596npje6BI62jytt+1r+TYN7qdW0sWE716R2/x0Oez6DMhWj7eUIsCSjom1wbpM6RzzUq0bt7vWpja5fjXPG9Jt5tcFt624+5YEbl2a6C2zZA+4XxtNu/72ma7Gsxc9/k7ovvfnNZ/8a52GXAyfwYFOh7HxlJ7+fxz1DG/22xX52HOC2ZZgyTmdqlTJQ7EejsvzG3Ny6m9nOdaz9fnkdZx9zmm+a5Jn22jVw4unD3RuNrGXJ7oWLePS49fm+2an/v5Xe1FP49Wr1gszR97xB7MPSsjx02Te+s0DSiAfrUnXhGIJgHmgsBVgYR/c7+axysCCCAQkwKPPPSApE+fVvT5AW8teV8et/9ruOMvvOu/3yJ3279I6xfAfHlzGz4/7PjJePfn5caC+Y0vytu273JW1ysqNm+99tO7m7bskFz2IE39ug+I/iuz/iX4hx3X6mtDHd+Vywm/TGm+Od1U+EbjAa//mH7159Dho/LbH3uT9K+15m3ocoWyt4r+6+iwUZMkPv6CZiVIGnhKkPHfio7rl9/22P9yXt/evojo7Rs7fvrF+Jfg/6rIzTcVNq7+uPjfA28d+d7e/Z137furid7q9Pabk6V39ydl6YcrnN2Wva2k6O0IMyYOlzdmjBG9ysTdLSHawJ99ofVcU/FbbjK+iOhtOa5lvta3/5jwmNu2Y6cUKVTQaFa8WFFZaw8C6W0IRkYQL/7sG9du06W7+mVe/wXctaxl0wYyb+G78tbi90X/VV+Pa9c6jvVCN94ge//82/mv3pqvQUS9nUOXA0k3FblRtv+Y8NzRB8MG0oe/FvqF9/KVyz679reez47sFXzt66JFCoo+m+fzr76x1w7svx92/JygwdYfdhoPxdbbPRIUmFZ8jcefzz9Td8bizUULG89Y0is1jAyXF2/HnaNq4RsLiH6Obtt+7XNWyzZt3S432Y8RXQ5V8vfzyJ/tv/fhZzJ55jzR5/ro7WrmNsXsTub/r2jZ5m07pFTxm3XR76RXoHRs20xGDu4j61a+Yz8X/5HvN129jdDvTqhobQFGhwACQQkQMAmKjUYIIBCNAunt/4qrz10YN+l1+fGnX+1f6Bs4p1m61C2ycct2OXL0mPHF/pXJs0R/rcFZwceC3n/fqtmjMmLsFOOXXs6dOy8DX3pFjh477mx5a8lb5O/9B+SH/77offTJl8YDIJ0V7AtF7MEQ/VJp/uUTe3aC//TZG3oZfY8+Q2TXL3+I3ubxzAsvSSF70KZOzatXzCRoEOSKBpNGDnlOVn3zndSo20xmzH5LPv/6G8NFfwFIf3XHXdd6KXiB/Pnk86/WGsVqrbfJ6BcbI8P+0rZlY9E5dn9uqOGl7vrLK/qcE3ux2//8mbc+CHSTfT9qBydPnZbv7F8IHAGHKfYvJPozyRrI0rRqzbeSzx4c02dGaH3X5M++cG2j6/qMGr2a5elnB4k+bFGPBf11Iv2lDL0lS+t4Snpbix4XGsSZPW+x6HKbFo2M6u2eaGy8d+j+gmyzB/M0gLFz16+i/zKt9Y1CHy/+7BvXLgrecL0R9Nr+Y8Iv2lqv4cO17OfMcdFn0jRrXE+zPKYa1e40jtEezw8xjlkdu/6SULp0aT228VTQusWjsuDt9w0fsf/R2+k+/Xy1fenafydOnjKuGtu567drmaYlfy30Yaw7dv5iaul+0d967lsnzPW1r/WKCn1uh35O6Xmj548G0v733sfGw60T9pZwTa9i0NvV9PzT83nKa/Ok7RNNElZyWfM1Hn8+/1y6lGp33W7csti550DR80IDZyvtnxlLli43qno77owK9hcNGnVs29S4YkKDierw8oSZooHoDm2a2muE7j9/Po/82bpendW51wDRZ69on65tdB56RaT+kpTus6XLVsjct5ZKx3bNXKt6XH//o5Wiz0JSY620au13xi8jFSl8g65aNjEwBBBAICUECJikhDLbQACBiBHQX/DYs/cv+1/Ubxd95odj4PqA17q175X7H24ple9taP/X65+l19PtHcV+vQ9/sbdUqVxBGjZ7Su68/1HjmR16VYujcakSN8uUcUOli/0Lwh01Gsq4ya/L0P49HcXGu36pLHNbCSl8azXj2QSOnxU2Cv970UuvF815VTJnziwNmnWUmvWfMK5u+d+8aW5/zea/ZkG96YMU9VLuIoULGgGTx1t3kyef7mv8ApDjoYSuHWtgZMHr40X/kl7l/kbStG136dPzKcmUMYOzql4i/uGS2cYvyTRs/pTxs8fj7R76QEJnJZcFf+Z94N9D8lDjdoad/nyoBhUcxpcuX5au9iBGzkIVRNNHK74Q/RUbm83msqWrq/7si6s1E7++OXOc1LqvmvQbPFaKlrlXmrXtIavWbrDvs0zi7U+fnh1l7KTXpFCpqjJ77hLRX6RxfInKnu0641aujBkyyBMdnjGOkWdeGG5cWZTGy7NgzNvzZ9+Y6+uyPmOk19Pt5JHHO4g+i0V/OljzNekX1ob1akvaNGmMh5pqnqekAbgl86bIubPxcnfNJqLP32hU/0HjOTVZs2bx1Mxtvj6sVY+/F0eMl3J315XF7y6XXl0Tnq/Hj5+wf5GemuhZFo4O/bXo9lRrmTJzrjF3Tz8rrH36W0/r+kr+7OtnurYTvYVw9rwlUvqOOlKt9mNGsMR8nrnbTjt7cOQHe8BNP2M0kNm00cPybLeEdq7t/BmPr88/1z51XX8RqMxtJY2fVL6heBXjs0XPWS3zdtxpuSMN6ddLGjxcU3o+P1TKVnnIfp59K+8vmiFFixRyVAnJuz+fRy4bdruqV6JpsEuDh3p+OVID+/9HtIH+P2T8qAEy9fX5cuvttWXi1Ddk6IBe0vLxawF/rectZc6c0X4MzxM11v479ewvY17qK67P1/HWB2UIIIBAtAoQMInWPcu8EEAgKAG9JUPv9/9wyesJ2utffgc+3934iVL9mdLZU0dLH/uX1y//+0lVrfzmjLHG5cy6rOnNGePs/yr4vC4aSf+VVX8N4adNK2XL2o9k9NC+ord+TBg10CjXl8YN6sjqTxfLhi+XyhcfLnA+k8JxObyO472FM5zPJWjTsrE2k9+2fS316z5gLOtLvry5Rce48/vP5JctX8qb9rHpZfFapkm/AH387hxddCZtr/04M1wWtL3aVK1SKUFJiVtukvmvjZdNaz6UQ7s3yt6da2XWlFFSrnSpBPXMK+XKlJJli18XfcbCtnXLRW+T0XZ1H6zhrKb9znvtFeOnY3W73339gZQuVdwodzd+LfA1bw2A7P/1W6ffB2+/Jnq1i7bt3qm1YaXb0qTb03/l1jJ3ydO+UIMH7r07QZNVK96WTu2bO/P0WNBfqtHnSehPGOtxtHjuFLmt5C3OOu4WbihwvWhdHd+az5aI/hqGuZ7e8qJBlK3fLDf2g+5j3feOQJM7N9f97s+++XXrVwmOt77PdHaa6vbNY9qz90/7OB82bhEx57tb1i+x7741zfhZZ/2p6PvuqWLcvuS4CkjbuPPVX/VQk1w5s2sVI3V9qpV8v+oD41xb+tZ06dG5jWz48j2jTF92/PSr5MuTW+6rfu1BzJpvTv5Y1KlVXfb99I0xf08/K6x9uqv3v/lTRT9XtNyRRg153n6+jnOsirs6WuhrX9tsNtFA78oP5hmeaqGfHRrA0vaeUvp0aeX1yaOM+fyw/mN58YUexvOFHPX9H88c+zzGiuPY02Pe1+ffmy6fmdntQUD94r5x9TJjPLt3rJbH7QEcx1jcHXeufaRNm0b0eVN6Put+0s92/aUyRx8axNZjJ336q7eWab4eR5qnx5Wuu0vujkPX89zX55G781G3ZZ6D/uqNjsU16b7Uupr0c+Cr5QuN/fzVxwuldfNGmu1MvsZ6f/W7RD+LHNtQ5w5tmjnbs4AAAgjEsgABk1je+8wdAQQQQACBEArobRB6G0Wb/24b8rUpvZ3gsy/XiHG71Mat0q7L86LPPjFf7eWrD3/L123YKJ07tPQrkGP0yQsCCCCAAAIIxJwAAZOY2+VMGAEEEEAAAZFQG5S96yHp0WeoTBo7WPQXc/zd3tPPDBK9Xap91xekaJEbjauV/G0bSL0h/XsZV50E0oa6CCCAAAIIIBBbAgRMYmt/M1sEEEAgWgWifl7uLqu38qT1tiC9DURvKfB3nHq7yM+bvzBuv9Bbtaa8MlRyZM/mb3PqJVHA0+02SeyW5ggggAACCESsAAGTiN11DBwBBKJbgNkhgAACCCCAAAIIIIBAOAUImIRTn20jEEsCzBUBBBBAAAEEEEAAAQQQiCABAiYRtLMYqrUEGA0CCCCAAAIIIIAAAggggED0ChAwid59G+jMqI8AAggggAACCCCAAAIIIIAAAv8JRHHA5L8Z8oYAAggggAACCCCAAAIIIIAAAlEsEJqpETAJjSu9IoAAAggggAACCCCAAAIIIBCcAK0sIUDAxBK7gUEggC73DjQAABAASURBVAACCCCAAAIIIIAAAtErwMwQiEQBAiaRuNcYMwIIIIAAAggggAACCIRTgG0jgEAMCBAwiYGdzBQRQAABBBBAAAEEEPAuQCkCCCCAgKsAARNXEdYRQAABBBBAAAEEIl+AGSCAAAIIIJBEAQImSQSkOQIIIIAAAgggkBICbAMBBBBAAAEEUlaAgEnKerM1BBBAAAEEELgqwCsCCCCAAAIIIGBpAQImlt49DA4BBBBAIHIEGCkCCCCAAAIIIIBANAkQMImmvclcEEAAgeQUoC8EEEAAAQQQQAABBGJYgIBJDO98po5ArAkwXwQQQAABBBBAAAEEEEDAXwECJv5KUQ8B6wkwIgQQQAABBBBAAAEEEEAAgRAJEDAJESzdBiNAGwQQQAABBBBAAAEEEEAAAQSsIUDAJJT7gb4RQAABBBBAAAEEEEAAAQQQQCAiBQIKmETkDBk0AggggAACCCCAAAIIIIAAAggEJEBlEQImHAUIIIAAAggggAACCCCAAALRLsD8EAhYgIBJwGQ0QAABBBBAAAEEEEAAAQTCLcD2EUAg1AIETEItTP8IIIAAAggggAACCCDgW4AaCCCAgMUECJhYbIcwHAQQQACByBVY/N4Kadt1oFSr20YeaNghWSeyedtOqVK7pez46bdk7ddbZ+8v/0JWfLHWWxW3Zf8cOCgvjpoqLZ96Qao91NoY959/H3Bb111m1z4jpFf/Me6KEuWt/Hq91Gr0lJw5ey5RWbAZ4bAOdqzmdtt3/iI1HmknBw8dMWezHEYBNo0AAgggENkCBEwie/8xegQQQAABiwjs//eQjJ82TwrfWEBGDeopY4Y8Y5GRBT+MDz9dLZ99tS7gDg78e1i2/fiz5MmdXUrfekvA7f1tEH/hgkycsUDaNm8gGTOk97eZz3qZM2eUsrcVT9Y+fW40GSrcVrKYVCxbSia9tjAZenPbBZkIIIAAAgjElAABk5ja3UwWAQQQQCBUAv/sP2h0/ViDWnL3HeWkfJmSxnosvpQrXUKWzp0gr7zUR6reUT5kBF+s2iBHjh6Xeg9WD3Ib7psVu6mQTB83UIoUKuC+goVz6zxQTT63uxw+eszCo2RoCCCAAAIIRIYAAZPI2E+MEgEEEEDAwgKDR0+TLs8NN0bYrtsg4xaUsZPflBr128vr89418vXl19/3GmUdeg7RVWd66PEuMnHGfOf66TNnpf9Lr0rNRztKsw59ZOabSyT+wkVnuccFU4H2obfwzF/8kXF7TP0W3Y1tHz12wqi17rutxu1DOsY6j3WRvkMnyPETp4wyfdHbafQWj7UbthjttK+BIyZrUbKmr9d+L807Pi/31X9Seg8cK9t2/Ox3/59++Y2UtwdnMmfK6GzjmPebCz+Q/sMnSb1mXY390L3vqES3qrTu0l/UefaC9+Sxds+K3j6kt/i4uyXHUXfjlh3Ss99oY9/0HjRWfv5tj5w9d06mv7HYvq+eN/J131+8dMk5pmMnTsrUWYvkqWeGGmOp2/Rp6TP4Fdn3135nHV34+puNhrW+d31+pDzYpJO9zz4yftpcqd24k5j71Pp6hc39DZ6UCdPn6aqRqlYpL6lSxcmnXwR+ZZDRAS8IIIAAAggg4BQgYOKkYAEBBBBAwGoCkTKeVo8/It06NDeG26d7W3l1VF9pUr+WVCxTUvTLt1Fgf/l+y4+SOlUq2bnrNzkfH2/PEdm97x/RIEbFsrca6/rSd8gE+XbTdmneuK50bN1E/t5/SEZPnK1FAacF//vIuLVk9uShMuvVIZIlc0b5fNV6eWbAGMmaJbP07dFO2rdsILt+2S2dew+Ty5cvG9t4odeTxu1FepuHzkdT2xYNjLLketm0bacRqLk+by7p/0wHqVDuVhny8nTZvfdvn5vQ4MHGLTulbOnibuvOWvCuZL8uq8ybPkJmvDJIjh4/YQS1tJ25waZtP8k3326WkQN7ysLXR0sF+z4zl5uX9fkxY6e8KdXvriRPP9lU9v75jxFwGTVhtj34cUA6tGokjR55QJZ98pUsfOdjZ9Pz5+Nl16975K7by8ng57tIo3o17fv0oHR6dpgRbHFW/G9h7KQ5cv89lWXx7LEy6LlO8ujDNeXEyVOiAaL/qhhvyz9bbTy7pUHdB4x1fUmXNq2UvOUmWf/9Nl0lIYAAAggggEASBAiYJAGPpggggECAAlSPUoGbCheQYkVvNGZXyv5l9fbyt0mhgtdLhbKl5Iedv4heCSD2Pxu37pAH7q1iXxLR4IkufL/5B32T8mVKGO8aRPh+yw4Z+sLT0rZ5falR9Xb7l+zOUqp4UaM80JfcObPL8/agSM7s2Yw+rlwRGT91vlSyBycmjnxeat93tzR+pJZMGdNP9tqDN3qFhW7j1hJFRa/cuC5rJtH5aLqp0A1alGxp1rx3Rbczbthzcn/1O6R5ozoyZsiz4s/tJD/9/LvhWvzmIm7HU7hgAendtbVkswdNbilaSEa/2FP0tqkPV3ydoP7Zs+eMbRYtUlBuyJ9PcmS/LkG5eeXY8ZMy+eV+0rDu/dLgofuke8eWog+zvWJHHd6/m9xXrbJ0avOY3GvfZ+bgRt7cOUWtWzd7RKrfVVHatWggsycNlfj4C/LJ54kfqnufPVii29CAlgY/9FiqZN9f7330hXk4ousa4ClsP9bMBcVvLiQ//PiLOYtlBBBAAAEEEAhCIC6INjRBAAEE/hPgDQEEvAlULFdKLly4KFt++En0S/X3W36UKreXMR6EuskeFNG2G7f+aAQyMmXMoKv2uruM9zsrlTHeHS933VHWsRjQe9U7yyWo/+sfe42ARMOH70+Qnz9fHrnl5sLy/eYfE+SHcmXL9l1yZ6WE87rJHny6IX9en5v999BRo07O7FmNd9cXVy+dX6GC+WXT1p0Jqpa4pYhkz+a+jwQV7Su3lSomGniyLxr/Fbg+j/F+R8XSxrvj5Yb8eeTvf/51rBrv+mtDTz83XPT2K729qfrDbeXU6TPyp8ttOVq56p0V9C1BerTeA0YQZI89qKUFv/2xT3b9ulsa1L1PVxOkHNmzGVeuaP8JClhBAAEEEEAAgYAECJgExEXlqBdggggggEAyChS3ByD0Kg0Niuz8+Xc5d+683FGxjFQsW0o2/vfFXQMUFcpevbpEN60PMc2VI5vYbDZddSbzF3Vnph8L2bMlvGLinwOHjFb67A794m5OOsa/Dxw0ykP9os9L0dt/crgJeOTwcpWHY1wXLlwwFvUWFGPB5eW6LFlccsS4euTQkYQPQ83hZ7BEO7suSyZ9c6Y0aVIbyxlcfqEndeo0cu781VuutIJebTJ0zAwpVeIm6dSmiYwb1tu4bSt3rhxy7MRprZIg5bTv/wQZ9hW9MkVdFr+/wr4msmjpJ8YtVTWqVTbWzS/p06UzVvV4MxZ4QQABBBBAAIGgBAiYBMUWOY0YKQIIIIBAeAX0KpNNW38yrtzQW1quy5pZKle4zbg6QB9wqlcB6O0WjlHql+JTZ846Vp3vp06dcS4HsuASdxHHVRHdO7YwvrTrs0nMqduTTQPpPui6We3Bh1RxcXL6zLlEfZw8lTiI4FopS+arwYvjJ066Fhnrx08mzncEo4wK/73YbAkDU/9lJ+ubBkxKlyomT7dvJo/UqSF3VS5n3OZ0wvSQ3QQbvJJ4THF2q0YPPyCfrFxjPJx35VfrpH6de41n4iRoa185/p+Ju8CLvZj/EEAAAQQQQMBPgUgLmPg5LaohgAACCCBgDQF9xoQ+5HXDxm1SqfzVB7uWKlFU0qdPJzPf/J+kiouT8qYHjZYrXVz0yoAdP/2aYAL6XJMEGUGuFC18g+TLk0t++uUP40u7PpvEnIoXK+LsOVPG9HLhwrVfe3EWJMOCzWaTsrcVl+82bU/Q2/4Dh4wHqCbIdLNy8003Grmeroj5ZsNWo9zxos8a2bPvb6lQtqQjK8Xe9UqaDOnTJ9jemvWbnQ/+TVDgZaV+3RrGc0/6DH5F9AoWd7fjaHOd64035Et0lZKWkRBAAAEEEIgggbAPlYBJ2HcBA0AAAQQQiGYBvcLk0uXLog9z1YfA6lz1l3LK3VZCNm79UW4tebOkTZNGs42kAZaKZUtJ36ETZeuOXaJXW8xb/KF8vHKNUZ7Ul9SpU8tz3dqIPty107PD5J1ln8m3m36Q95d/Ifpzufru2EaRQgXkx12/yap1m+S7zdvl9z1/Ooq8vuvzWrS+Jv3yrpU1AKTrv/y+R1eN1P6JR41+J86Yb1w1scsexOk1YIzE2YMpRgUvL3ly5ZAb8ueVX3/f67bWwUNHRH/eV7ep83th2ES5Pl9uebh2dbf1Q5lZuUIZ2WTf1/osmwsXLooGS14aNyPBfvdn+3pb1j13VzJ+erlyhdKiz2Vx1+7XP/ZJRdOvLrmrQx4CCCCAQDgE2GakCRAwibQ9xngRQAABBCJKoGjhgsavzeigb//vChNdrlSulL7Zv9gmvuJh9OBeUqZUMek9cJzUavSUrF2/2filG6NBMrzoLSEzxw8SuSLy+tx3pccLo2X+ko/kpsI3SMVyV6+C0c20a9FQ9Cd0x01+Q7r3HSVzFryn2T6TBoi0vqalH31u1B88eprRx9RZi411fdHg0OjBz8iGjT8YD0Pt8txwebjWPaK3r2i5r/Tg/VXlW3tbd/WaN6krhw4fMeb2/JAJki1rFpk6pr/bW1jctU/OvMb1a8rjDWvLkDHT5Z6H29gDOW9In+7tJP/1uQPezH3Vbjfa6K/oGAsuL//aA0W79/4ldR6o6lLCKgIIIBACAbpEIMoFCJhE+Q5meggggAACKSOgt7WsWzFfzLe0OLb82bszRcsymh4O2sL+hV7zOrZu4qjmfM+UMYMMH9BdHO2mvzLQ+AKs9fVneJ0VvSxoH1pffzLYXbVbS9ws2u/HS6YZY1syZ5zoc030qg1HfX1OyIBnO8r7C1416gzr19VR5PVdr6DRbbtL44c/l6DtPVUqyFszR8vaj+fK5++9LuqiP93rWi9Bo/9WGta9T/7ef0j06pX/spxvGdKnlVEv9pJvPpknX74/SyaNfkH0IavOCvaFN6cON5ztiwn+01ukdOxma3d11Urr3efy4FX9OWidj6NT9ejSvqksnTvBcHxv/kTjJ4gXvvayDOzd0VFN9MGu2p/+UpAz02Vh7YYtxjyq3ZX4l3S06ocrVhnHoL9BJ21DQgCBawIsIYAAAmYBAiZmDZYRQAABBBBAIGIE9AG5DR++z+8rXyJmYm4Gqs+weW/5F8atWa2b1jOefeNa7Xx8vCx692N5suWjrkWsx64AM0cAAQQQSIIAAZMk4NEUAQQQQAABBMIr0Lppfbnl5kIBP0A1vKMOfOt629SMN/5n3Nrz6MMPuO3gz78OSMsmD0vVO8u7LY+OTGaBAAIIIIBAygkQMEk5a7aEAAIIIIBAsgi8OGqqVH+4rcek5cmyIZdOdu/92+M2HePROi7NQrqaPVtW0dua0qVNa2z0YSKnAAAQAElEQVTH161IRiUrvfg5Fr3F5+PFU6Vnpyc8/vpN0SIFpVXTen72SDUEEEAAAQQQ8CVAwMSXEOUIIIAAAghYTKBbx+Yyb/pIj0nLQzHkwjfm97hNx3i0Tii2TZ8IIIAAAggggEBKCxAwSWlxtocAAgggEEkClhxrrhzZ5MYb8nlMWh6qgXvbrpaFarv0iwACCCCAAAIIpLQAAZOUFmd7CCCAQFgF2DgCCCCAAAIIIIAAAgj4I0DAxB8lL3XSpEkrVkw2W5xcvnzZkmOzopd5TPHx8bgFcVxfunRZbPbjzmyZIstBjNVK41IzztXgPkc5V4Nz41wNzo1zNTg3/bzlXA3OjnM1ODfO1eDcOFeDd7P6uerlqyxFfggQMPEDiSoIpKQA20IAAQQQQAABBBBAAAEEEAi/AAGT8O+DaB8B80MAAQQQQAABBBBAAAEEEEAg4gQImAS8y2iAAAIIIIAAAggggAACCCCAAALRLhAn0T5D5ocAAggggAACCCCAAAIIIIAAAiIYBCTAFSYBcVEZAQQQQAABBBBAAAEEEEDAKgKMA4FQChAwCaUufSOAAAIIIIAAAggggAAC/gtQEwEELCRAwMRCO4OhIIAAAggggAACCCAQXQLMBgEEEIhcAQImkbvvGDkCCCCAAAIIIIBASguwPQQQQACBmBEgYBIzu5qJIoAAAggggAACiQXIQQABBBBAAAH3AgRM3LuQiwACCCCAAAKRKcCoEUAAAQQQQACBZBEgYJIsjHSCAAIIIIBAqAToFwEEEEAAAQQQQCAcAgRMwqHONhFAAIFYFmDuCCCAAAIIIIAAAghEgAABkwjYSQwRAQSsLcDoEEAAAQQQQAABBBBAIPoECJhE3z5lRggkVYD2CCCAAAIIIIAAAggggEDMCxAwiflDIBYAmCMCCCCAAAIIIIAAAggggAACgQkQMAnMyxq1GQUCCCCAAAIIIIAAAggggAACCIRUwBIBk5DOkM4RQAABBBBAAAEEEEAAAQQQQMASApE0CAImIdxb54/vkR1vPxyWtOudBvLre43Dsm2d87/bF4RQlq4RQAABBBBAAAEEEEAAAUsIMIgoFiBgEsU7l6khgAACCCCAAAIIIIAAAoEJUBsBBBwCBEwcErwjgAACCCCAAAIIIIBA9AkwIwQQQCBIAQImQcLRDAEEEEAAAQQQQACBcAiwTQQQQACBlBEgYJIyzmwFAQQQQAABBBBAwL0AuQgggAACCFhSgICJJXcLg0IAAQQQQACByBVg5AgggAACCCAQDQIETKJhL0bhHDZu/kFWrf02LGnt+o1h2a7OV+cdhbuTKSGAQKQLMH4EEEAAAQQQQCAGBQiYxOBOj4QpP9Wjn9R5tHVYUsPmncKyXZ1vp579I2H3MEYEIl6ACSCAAAIIIIAAAggg4EuAgIkvIcoRQAAB6wswQgQQQAABBBBAAAEEEEhmAQImyQxKdwggkBwC9IEAAggggAACCCCAAAIIhFeAgEl4/dl6rAgwTwQQQAABBBBAAAEEEEAAgYgSIGASUbvLOoNlJAgggAACCCCAAAIIIIAAAghEswABk6t7l1cEEEAAAQQQQAABBBBAAAEEEIh+Ab9nSMDEbyoqIoAAAggggAACCCCAAAIIIGA1AcYTKgECJqGSpV8EEEAAAQQQQAABBBBAAIHABWiBgEUECJhYZEcwDAQQQAABBBBAAAEEEIhOAWaFAAKRKUDAJDL3G6NGAAEEEEAAAQQQQCBcAmwXAQQQiAkBAiYxsZuZJAIIIIAAAggggIBnAUoQQAABBBBILEDAJLEJOQgggAACCCCAQGQLMHoEEEAAAQQQSLIAAZMkE9IBAggggAACCIRagP4RQAABBBBAAIGUFiBgktLibA8BBBBAAAERDBBAAAEEEEAAAQQsLkDAxOI7iOEhgAACkSHAKBFAAAEEEEAAAQQQiC4BAibRtT+ZDQIIJJcA/SCAAAIIIIAAAggggEBMCxAwiendz+SjTWDP3r9k1dpv3aZQ569Z972s/ua7sGxb53b6zJlo253MBwEEEEAAAQQQQAABBMIoQMAkjPhsOkkCNHYjMP/tpVLn0dZhSfWbdpCHm7QLy7Z1zhosckNCFgIIIIAAAggggAACCCAQlAABk6DYQtGIPhFAIFwCu/f8KQ82bB2WVLdxO6n3WIewbFvnPG/R0iSxP9W9X9jG3qBZp7Btu1OPfklyU3f1D0d65PEOosddOLat20xKcJNzNfjDjnM1ODu9gnH4mMkSjjR6/HQZOW5qWLat8z146EhwaLRCAAEEokggdAGTKEJiKgggEN0Cp8+cldXffBuWtGbdd7J2vd7OFJ7t7933V5J27sYtP4TFTffXNxs2hm3bG7dsT5KbuuscwpH0eNPjLhzb1m2eTsLtc6c5V4M+7jhXg6PTY3bE2CkSjvTyhBky6pVpYdm2zvfgocPBodEKAQRiUyBKZ03AJEp3LNNCAAEEEEAAAQQQQCAcAlwNFg51tpncAvSHgAoQMFEFEgIIIIAAAggggAACCCSLAFeDBc84c85boboNy2e/YybO9FlHb9cKRdJ5B69GSwRCJ0DAJHS29IwAAggggAACCCCAAAIhEYjOTmfOWRi227DGTHwtbNt+7Y1F0blDmVXECxAwifhdyAQQQAABBBBAAAEEIl6ACSCAAAIIWE6AgInldgkDQgABBBBAAAEEIl+AGSCAAAIIIBDpAlEVMDl0+Kh07TNC2nUbJP2GTZSz58653T9bt++SNl0HyhOd+8nr895x1nlv+RfS7MnnpErtlnL02Aln/q+/7zXyNF9Tr/5jnGUsIIAAAggggEBMCDBJBBBAAAEEEIgxgagKmEycsUDurFRWZk8aKlmzZpEFS5Yn2p1XrlyRQSOnSJ9ubWTO5GHyxepvZfO2nUa9vLlzytB+XSVXzuzGuvmlYtlSsm7FfCONH/6cuYhlBBBAAAEEIlCAISOAAAIIIIAAAgh4E4iqgMnaDVukbq1qxnzr1qwmazZsNpbNL7t+3S0ZM2aQUsWLSupUqaRWjbtk9fpNRpUqt5eVYjcVMpZ5QQABBBCIMAGGiwACCCCAAAIIIIBAMgpETcBEf77MZhPJni2rwVOwQF45eOiIsWx+OXDwiBTIl9uZpfUO/HvYue5pYceu36RqnVbyZI/Bsm3Hz85qFy7Ei6d08eIFZ71YW7h8+ZJHF09e5ny9EijWzHS+Om+zQ6DL6q79xGLS8y1QL0d9bWtFs5QYkx4zDodg3vWYTYlxWm0bOu9gvBxt1N1qc0qp8ej55nAI9F3bptQ4rbYdPWYC9TLX12PWanNKifHovM0OgS6re0qM04rb0PMtUC9HfW1rxTmlxJj0mHE4BPOux2xKjNNq29B5B+NlhTaXLl0UPeatMBZ3Y7Davo608URNwETh4+KuTcdmu7asZeZki7NHVpwZnus5quS/Po98sOBV+XjJNLnvnjuk96Bxcuas++ejONrwjgACiQTIQAABBBBAAAEEEEAg2QVWf/OdjHplWljSmIkzZfT4GWHZts7Z3UUCyQ4cwx36jhaECefv/f/KrPlLZeiY6dK97yjpO2S8jJ38pnzy+Rq5eOlSolFlyphBLl26LPEXrl7VcfjoMcmdK0eienlz55Cjx04684/Y6+XNk9O57m4hY4b0kiVzJiM1b1RH8uXJJfv+2m9UTZMmrXhKqVOnMerE4ktcXCqPLp68zPk2my0C2JJ/iDabLUlu6p78o4qMHvV8Mx9DgSxr28iYZfKPUo+ZQKxc69psnKuuJv6sq3vy783I6FHPN3+M3NXRtpExy+QfpR4z7kz8zbPZOFf9tTLXU/fk35uR0aOeb2aLQJa1bWTMMvlHqcdMIFaudW02zlVXE3/W13272R6wmB6WNGbia/LyBA2YhGf7x46f9Pr9IfmP8tjq0ZIBk/HT5kqPF0bLhYsXpOytt0jTRx+U+6vfKXqlx+p1m6RV536y8+ffE+2puyqXk5VfrTPyP/3yG6l6RzljWW/X2b7zF2O5+M2FRX9NRwMely5fls+/3iBV76xglHl6OXX6jLNIfzHn6PETUrBAPmde1CwwEQQQQAABBBBAAAEEEEAAAQQQMAQsGTDJmzuXvD1rjHRq85jUf+g+0UBIzXuriF7dMXxAdxkxsKfsd/PckZ6dWsiyFauMnxXeu+8fadGkrjHJP//aL8PGzjCWbTabDOnbRQaOmCxtnh4gFcuXkgplShpl02a/LVVqtzQCKg893kV6Dxpr5C//bLWRX61uGxk3da6MsI9BrzoxCnlBAAEEEEAAAQQQQAABBBBAAIGwCoRi43Gh6DSpfTZv/JDEmZ5H4tpf4YLXS42qt7tmS66c2WXa2AEye9JQGTGwh2RIn96oU7xYEXsA5mrwQzPK3lZc3pjyksybNkI6PNFIs4zUud3jsm7FfGcaO7S3kf9Yg9pG3uqP3jD6L12qmJHPCwIIIIAAAggggAACCCCAAAIhEKBLCwhYMmDicLl48aKs/36rzJ6/VGa+ucSZHOW8I4AAAggggAACCCCAAAIIRIIAY0Qg8gQsHTDp/9Kr8s6ylXL+QnzkyTJiBBBAAAEEEEAAAQQQiF4BZoYAAlEvYOmAybnzF2TMkGelc9vHpWPrJs4U9XuFCSKAAAIIIIAAAgggkMICbA4BBBBAIKGApQMmadOmlgsXLiYcMWsIIIAAAggggAACCPgWoAYCCCCAAAJJErB0wCQ+/qI81r63jJ821/n8En2WSZJmTGMEEEAAAQQQQCAiBRg0AggggAACCKSkgKUDJreWuEnq3H+3ZMqYISVN2BYCCCCAAAIIpIQA20AAAQQQQAABBCwsYOmAifm5JeZlC3syNAQQQACBGBZg6ggggAACCCCAAALRI2DpgMnRYydkwZKPRH8tR9Nb73wsmhc9/MwEAQQQsLQAg0MAAQQQQAABBBBAIGYFLB0weXHUVPlq7fdSoWxJI32xaoMMeXl6zO4sJo4AAkkVoD0CCCCAAAIIIIAAAggg4J+ApQMm+/89KNNfGSiN6tU00vRxA+TPv/f7NzNqIRALAswRAQQQQAABBBBAAAEEEEAgJAKWDpjExSUeXlycLSQQdGoNAUaBAAIIIIAAAggggAACCCCAgBUEEkckrDCq/8ZQrnRJ6dL7JedPCnfuPVxuL1/6v9KIeGOQCCCAAAIIIIAAAggggAACCCAQgQIBBkxSdoZ9urWRerWry559/xipwUM15NmnW6XsINgaAggggAACCCCAAAIIIIAAAjEnwIQtHTDRW3IetgdMhg/oLprq1rpHNI/dhgACCCCAAAIIIIAAAggggEBAAlRGIEABSwZMOj07TH7bvU/03V0KcI5URwABBBBAAAEEEEAAAQSiToAJIYBAaAUsGTBp37Kh5M2dU/TdXQotCb0jgAACCCCAAAIIIIBAGATYJAIIIGApAUsGTG4vf5tkzpRR/jlwSHTZnPbs+9tSgAwG6qS0DQAAEABJREFUAQQQQAABBBBAAAH3AuQigAACCESygCUDJg7Q5Z+tdiw639/76EvnMgsIIIAAAggggAACKSjAphBAAAEEEIghAUsGTL7bvF1mvrlEDvx72HjXZU0Tps+LoV3DVBFAAAEEEEAg1AL0jwACCCCAAAIIeBKwZMDE02CLFikoU8f291RMPgIIIIAAArEuwPwRQAABBBBAAAEEkknAkgETfWZJx9ZNZNSgHqLvjlSv9r2SNUvmZJo63SCAAAIIWF+AESKAAAIIIIAAAgggEB4BSwZMHBTFixWRHT/9Jm8u/CDBrTmOct4RQACBiBNgwAgggAACCCCAAAIIIBARApYOmMxe8J68/OpseW/5F3L4yHH7+5ey768DEQHLIBGIFQHmiQACCCCAAAIIIIAAAghEo4ClAyaffL5aZr06RPLmzikv9HpS3p07Qc6dPx+N+4E5WUeAkSCAAAIIIIAAAggggAACCCAglg6YZMyYUVKnTi3xFy7IpcuXJX26tBJns7HbAhKgMgIIIIAAAggggAACCCCAAAIIBCpg6YBJpgzp5cKFi1Kk0A3y0tiZMmnmAjkffzHQOVIfAQQQQAABBBBAAAEEEEAAAQQiTSDM47V0wOTZp9sYV5f06txSCubPK+nSpZX+zzwZZjI2jwACCCCAAAIIIIAAAggggEDgArSILAFLB0xuKlxAMmXMIJkzZZR2LRtKx9ZNJHeuHJElzGgRQAABBBBAAAEEEEAAgegUYFYIRLWAJQMmnZ4dJt5SVO8RJocAAggggAACCCCAAAJhEmCzCCCAwDUBSwZM2rdsKJpuLHC9XLx4Ue69+3Z5qGY1SZ8uneTKkf3a6FlCAAEEEEAAAQQQQAABzwKUIIAAAggELWDJgMnt5W8TTbt+/UNmjH9Rmj76oDzy4L0yYUQfOXf+XNCTpSECCCCAAAIIIIBAZAswegQQQAABBFJKwJIBE8fkz50/71h0vsfzKzlOCxYQQAABBBBAIOIFmAACCCCAAAIIWFTA0gGTyhXKSOdnh8n/PvhUPl65RnoPGitFChWwKCXDQgABBBBAAAERDBBAAAEEEEAAgegQsHTA5JkuT0iDuvfJ5m0/yZr1m+SB6ndKz04thT8IIIAAAgikmAAbQgABBBBAAAEEEIhJAUsHTGw2mzz0QDUZPqC7kR68v6rYbLaY3FFMGgEEEEguAfpBAAEEEEAAAQQQQAAB3wKWDJjoTwr/tnufx58W9j0taiCAQAwJMFUEEEAAAQQQQAABBBBAINkFLBkw0Z8Uzps7p/HTwrrsmpJdgQ4RsJQAg0EAAQQQQAABBBBAAAEEEAi3gCUDJvqTwpkzZTR+WliXXVO40dh+gAJURwABBBBAAAEEEEAAAQQQQCDCBCwZMJn8+kLxlsJtzPYRQAABBBBAAAEEEEAAAQQQQCC6BTRgYrkZ6tUl3pLlBsyAEEAAAQQQQAABBBBAAAEEELC+ACMMQMCSAZM2zeqLtxTA/KiKAAIIIIAAAggggAACCCAQtQJMDIHQCVgyYOKY7vn4eHlz4QfSs9/oBL+Y4yjnHQEEEEAAAQQQQAABBBCIKgEmgwAClhGwdMBk6MvT5eDho3Lo8DFpWPc+yZwxg5QoVtgyeAwEAQQQQAABBBBAAAEEvAtQigACCESqgKUDJr/v3ie9u7aWTJkySO377paxw3rLn38fiFRrxo0AAggggAACCCAQ+QLMAAEEEEAgRgQsHTDJlCmjsRsuXrwkZ86eM5YvXLhkvPOCAAIIIIAAAgggkBwC9IEAAggggAAC7gQsHTDJnCmTHDtxUu6uXE7adh1gTwMlX56cEsyfxe+tkJadXpBWnfvLqnWb3HZx6PBR6dpnhLTrNkj6DZsoZ89dDdIcPXZCeg8cKzXqt5eXX53jti2ZCCCAAAIIIGARAYaBAAIIIIAAAggkg4ClAyYTRvSRbFmzSLuWDaVfrw7Spf3j0qdHu4CnvWffPzJ30TKZ8cogeXlwLxk+bqacOx+fqJ+JMxbInZXKyuxJQyWrfbsLlix31nmo1j3S4YlGznUWEEAAAQQQSCkBtoMAAggggAACCCCQ8gKWDpis/Hq9XLx09RacsrcVl9vL3yap4gIf8pr1m6T63ZUkU8YMki9vLilRrIh8t2m7uP5Zu2GL1K1VzciuW7OarNmw2VjOni2r3FetsmTIkM5Y5wUBBBBAIEkCNEYAAQQQQAABBBBAwPICgUcfUnBKn3y+Rh5u+rSMnzZXft/zZ9BbPnj4iOTPl9vZ/ob8eeXfQ4ed67pw+sxZsdlENDii6wUL5JWDh47oIgkBBBDwIUAxAggggAACCCCAAAIIRJuApQMmY4f2ljenDpfMmTLKM/3HyBOd+8mS9z8Nah/YTFem2Gz2yIibXuIS1PGP5ty5c+IpnT9/3s1WYiPr4sWLHl08eZnzr1y5EhtQLrPUeZ8/f06CTZcuXXTpMcjVCGwWH38+aDdtG4FTTpYhXz1Xz9rP1+CSHrPJMpAI60TnHex5qu04V4P7nIvlc1WPGT12gk16zEbYaZYsw9V5nzsX3OebttPPyGQZSAR2oseaGgSTtG0ETjlZhsy5Ghzj1XP1nP3vI8Gl2D5Xz3t1C26P0Moh4F9UwFE7DO95c+eUDq0ay//efEVKlywmr0ydG/AocufMIceOHXe2O3L0mOTJlfDhsXq7zqVLlyX+wgWj3mF7ndy5chjL3l7SpEktnlLq1Km8NY3qslSp4jy6ePIy59ts7oNaEuSfSGlms9kkVarUkirIZLPFSaz+iYtLJamCdNO2seqWKlWc/VxNE3Sy2ThXgznuOFeD+5yLi4vd/6/qMRPMseZoY7PF7rmaJk3wn3GpUsVJrP5JnVr/jhucnbaNVTfO1eD2vM1ms/9dRI+54FJsn6upvNoFt0do5RCw/P8F9JdrXpv3jjRq1Us2/7BTunds4Ri73+9V76wgq9dvkvPx8XLk6HH5cdfvckel0kb7zdt2yoULV/9V/q7K5WTlV+uM/E+//Eaq3lHOWPb24viLiKd3b22TUGb5pkn9n4XlJxjCAepfMoJNcaarpEI4REt2HayZo50lJ5UCg+JcDR7ZcewE8865mlqCcdM2we+xyG6px4zOP9gU2bNP2ug9/R3Nn3z9jEza1iO3tT8+3upE7syTNnLO1eD9vB1Pvso4Vz3/Q0Twe4SWKmCRgIkOJXHqPWistOz0gpw6dVrGDestC197WZo1qpO4oo+cQgWvl4Z175f23V+Unv1ell5dWkla+782aLM+g8fL8RMndVF6dmohy1asknbdBsneff9IiyZ1jfyLly5Jldot5eVX58jSjz43lnf98odRxgsCCCCAAAIIIIAAAggggAACCPgrEDn14qw81DoP3CMfLpoivTq3kptvujFJQ32sQW2ZP32kzJ02XKrfVdHZ12fvzpRcObMb6/o+bewAmT1pqIwY2EMypE9v5KdOlUrWrZifIBUvVsQo4wUBBBBAAAEEEEAAAQQQQCCGBZh61ApYMmCy8+ffDfD776ksGqwwVkwvepvOj7t+M+WwiAACCCCAAAIIIIAAAgggkBwC9IEAAlcFLBkwGf3qHBk2ZoZsMj1fRIf7z4GDMmv+Unms3XOiy5pHQgABBBBAAAEEEEAAAQS8CFCEAAIIBCVgyYDJ7FeHSIWyJeW1ue/IfQ2eNJ4Zos8Q6fzsS3Lg38PyxpSX5P577gxqwjRCAAEEEEAAAQQQQCCyBRg9AggggEBKCFgyYKJPl65b6x7R54ms/ugN57ND3ps/Ufo986TceEO+lLBhGwgggAACCCCAAAIpIcA2EEAAAQQQsKCAJQMmFnRiSAgggAACCCCAgN8CVEQAAQQQQACByBcgYBL5+5AZIIAAAgggEGoB+kcAAQQQQAABBGJOgIBJzO1yJowAAgggIIIBAggggAACCCCAAALeBQiYePehFAEEEIgMAUaJAAIIIIAAAggggAACySpgyYDJ2Mlvylv/W55oovMWfyhTZy1KlE8GAghEnwAzQgABBBBAAAEEEEAAAQTCKWDJgMk3326RxxrUSuTS7NEHZfW6jYnyyUAgAgQYIgIIIIAAAggggAACCCCAQAQJWDJgkipVnKROnVpc/2je+fiLrtmsh0WAjSKAAAIIIIAAAggggAACCCAQvQKWDJikS5tWzp47l0j91OkzkiF9ukT5yZJBJwgggAACCCCAAAIIIIAAAgggEP0Cfs7QkgGTBnVryAtDX5WDh444p3Hg4GEZMHySNKh7nzOPBQQQQAABBBBAAAEEEEAAAQRiXYD5h0bAkgGTxo/UklLFi0jjNs9K847Py2PtnpXH2z1nz7tJGj9SMzQS9IoAAggggAACCCCAAAIIIGAFAcaAgCUELBkwUZmOrZvIh4smS7NGdaRt84bGsubZbDYtJiGAAAIIIIAAAggggAACESLAMBFAIBIFLBswUcwsmTNJvdr3Sp0HqkrmTBk1i4QAAggggAACCCCAAALhFmD7CCCAQAwIWDJg8mCTTuItxcB+YYoIIIAAAggggAACKSjAphBAAAEEEHAVsGTAZMrL/cVbcp0E6wgggAACCCCAAAIJBFhBAAEEEEAAgSQKWDJgUrRIQfGWkjhnmiOAAAIIIIBAxAkwYAQQQAABBBBAIGUFLBkwSVkCtoYAAggggEAYBNgkAggggAACCCCAgKUFCJhYevcwOAQQQCByBBgpAggggAACCCCAAALRJEDAJJr2JnNBAIHkFKAvBBBAAAEEEEAAAQQQiGEBywdMzp2Pl63bd8l3m7c7UwzvL6aOQBIEaIoAAggggAACCCCAAAIIIOCvgKUDJrPnL5WGT/SUKbMWySz7siP5OznqRbkA00MAAQQQQAABBBBAAAEEEEAgRAKWDpis+36bLH97iswc/6JMHzfQmUJkEfZuGQACCCCAAAIIIIAAAggggAACCFhDIJQBkyTPMHu2LGKz2ZLcDx0ggAACCCCAAAIIIIAAAggggEDIBKKyY0sHTNKnSycDhk+Wr9Z873x+iT7LJCr3BJNCAAEEEEAAAQQQQAABBBCwiADDQEDE0gGTfw8dkUNHjsqipR/zDBOOVgQQQAABBBBAAAEEEEAgWAHaIYBAwAKWDpiYn1tiXg54ljRAAAEEEEAAAQQQQACBqBJgMggggECoBSwdMNHJX7hwUbbv/IVbchSDhAACCCCAAAIIIBCtAswLAQQQQMBiApYOmKxZv1kebdVTevZ7WcZMmiPd+46Sya8ttBghw0EAAQQQQAABBBBILEAOAggggAACkS1g6YDJlFmL5LWJg+Xmm26UxbPHyZzJw+zLhSJbnNEjgAACCCCAQGQKMGoEEEAAAQQQiCkBSwdMUqdOJfny5BK9LUf3SoliReTM2TO6SEIAAQQQQACBJArQHAEEEEAAAQQQQMCzgKUDJhkzpDdGnu26zPL+8i9Eb9E5euykkccLAggggAACLgKsIoAAAggggMr4tvAAABAASURBVAACCCCQbAKWDpg0qV9Ljp04KV3aN5WVX2+Q+Us+lKdaN062ydMRAgggYG0BRocAAggggAACCCCAAALhErB0wOSB6ndKtqxZpGjhgjJp9AuiPy1cvkzJcFmxXQQQSKoA7RFAAAEEEEAAAQQQQACBCBGwdMDkz7/3G7+M06Ttswbnrl/+kOlvLDaWeUHACgKMAQEEEEAAAQQQQAABBBBAIDoFLB0wGfLyDHmoZlXJmT2boX/LzYVlzbrNxjIvIRGgUwQQQAABBBBAAAEEEEAAAQQQsAtYOmASHx8vD95fVcQmxh+bzSaXr1w2lv17oRYCCCCAAAIIIIAAAggggAACCES/QPLP0NIBkytXRC5evOic9aHDRyVN6tTOdRYQQAABBBBAAAEEEEAAAQQQiEoBJhV2AUsHTB5vWFsGjZwiB/49LDPeWCIdeg2RVo8/EnY0BoAAAggggAACCCCAAAIIIBCYALURiDQBSwdM6ta6R7p2aCb3VbtdTpw8LRNH9JX7q98RacaMFwEEEEAAAQQQQAABBKJPgBkhgECUC1g6YKL2+fPlkW4dW8hz3drIjTfk0ywSAggggAACCCCAAAIIJLsAHSKAAAIImAUsGTDp9Oww8ZbME2AZAQQQQAABBBBAAAG3AmQigAACCCCQBAFLBky2bt8lp06fkTKlikmFMiUSpSTMl6YIIIAAAggggEDECjBwBBBAAAEEEEg5AUsGTOZNGyGVypWS1es3y7Hjp6TK7eWkY+smzpRyPGwJAQQQQAABBEIoQNcIIIAAAggggIBlBSwZMLn5phulZ6cnZMGMkXJX5XKyaOkn0qxDH1n33VavkPqzw137jJB23QZJv2ET5ey5c27r6xUsbboOlCc695PX573jrOOp/a+/75UqtVs6U6/+Y5xtWEAAAQQQQOCaAEsIIIAAAggggAAC0SJgyYCJK26czSYXL16Sy1euuBYlWJ84Y4HcWamszJ40VLJmzSILlixPUK4rV+x96E8V9+nWRuZMHiZfrP5WNm/bqUXirX3FsqVk3Yr5Rho//DmjPi8IIIBA1AswQQQQQAABBBBAAAEEYlTAkgETvaJjwvR5Ur9Fd/nfB5/K/ffcKW/PGiN3Vy7ndTet3bBF6taqZtSpW7OarNmw2Vg2v+z6dbdkzJhBShUvKqlTpZJaNe6S1es3GVX8aW9U5AUBBCJWgIEjgAACCCCAAAIIIIAAAv4IWDJgorfKbNvxi3Ro3VhaNKkrmTKll41bf5TvNm83kruJnT5zVmw2kezZshrFBQvklYOHjhjL5pcDB49IgXy5nVla78C/h8VX+x27fpOqdVrJkz0Gy7YdPzvbs4BAmAXYPAIIIIAAAggggAACCCCAQAgELBkwKXtbcUmbNo0s/2y1zJq/NFHy5BAXd206Ntu1Zdf6tjh7ZMWZea2ep/b5r88jHyx4VT5eMk3uu+cO6T1onJw5e/X5KGfOnBFP6ezZs86txNrChQsXPLp48rqaf9VTb52KNTOdr87b7BDosrprP7GY9HwL1MtRX9vGopnOWY8Zh0Mw73rMaj+xlnTewXg52qh7rJk55qvnm8Mh0Hdt6+gn1t71mAnUy1xfj9lYM9P56rzNDoEuq7v2E4tJz7dAvRz1tW0smumc9ZhxOATzrses9hNrSecdjJejjbrHmpljvnq+ORzcvTvq8R6cwLVoQXDtQ9Jq+riB4i2522imjBnk0qXLEm//oq7lh48ek9y5cuhigpQ3dw45euykM++IvV7ePDnFW/uMGdJLlsyZjNS8UR3JlyeX7Ptrv9FH+vTpxVNKly6diFEr9l5Sp07t0cWTlznfZjMHtSRm/thstiS5qXvMYLlMVM838zEUyLK2dekuZlb1mAnEyrWuzca56mriz7q6x8xB5jJRPd/8MXJXR9u6dBczq3rMuDPxN89m41z118pcT91j5iBzmaieb2aLQJa1rUt3MbOqx0wgVq51bTbOVVcTf9bVPWYOMpeJ6vnmzcilOqsBCgQcMAmw/xStrr+os/KrdcY2P/3yG6l6x9VnnujtNtt3/mLkF7+5sOiv4WjA49Lly/L51xuk6p0VjDJP7U+dPmOU64s+X+Xo8RNSsEA+XRW9KsVbMirF4IvNZvNpg5u4/ePNxVeZzRab/5NVSF82vsq1j1hMNpuNc1WC++PrmPJWbrNxrnrz8VYW3N6K/FY2m41zVYL74+148lVms3Gu+jLyVB7c3or8VjabjXNVgvvj6VjyJ99m41z15BTc3rjWKtaXoipg0rNTC1m2YpW06zZI9u77x3j+ie7gP//aL8PGztBFsdlsMqRvFxk4YrK0eXqAVCxfSiqUKWmUeWq//LPVUqV2S6lWt42MmzpXRgzoLnrVidGIFwQQQAABBBBAAAEEEEAAgUgQYIwIBCQQF1Bti1fOlTO7TBs7QGZPGiojBvaQDOnTGyMuXqyIvD1rrLGsL/qMlDemvCTzpo2QDk800iwjeWr/WIPasm7FfFn90RtG/6VLFTPq84IAAggggAACCCCAAAIIhE+ALSOAQCgFoipgEkoo+kYAAQQQQAABBBBAAIEQC9A9AgggYCEBAiYW2hkMBQEEEEAAAQQQQCC6BJgNAggggEDkChAwidx9x8gRQAABBBBAAIGUFmB7CCCAAAIIxIwAAZOY2dVMFAEEEEAAAQQSC5CDAAIIIIAAAgi4FyBg4t6FXAQQQAABBCJTgFEjgAACCCCAAAIIJIsAAZNkYaQTBBBAAIFQCdAvAggggAACCCCAAALhECBgEg51tokAArEswNwRQAABBBBAAAEEEEAgAgQImETATmKICFhbgNEhgAACCCCAAAIIIIAAAtEnQMAk+vYpM0qqAO0RQAABBBBAAAEEEEAAAQRiXoCASQwcAkwRAQQQQAABBBBAAAEEEEAAAQQCE4jEgElgM6Q2AggggAACCCCAAAIIIIAAAghEokBYx0zAJKz8bBwBBBBAAAEEEEAAAQQQQCB2BJhpJAkQMImkvcVYEUAAAQQQQAABBBBAAAErCTAWBKJYgIBJFO9cpoYAAggggAACCCCAAAKBCVAbAQQQcAgQMHFI8I4AAggggAACCCCAQPQJMCMEEEAAgSAFCJgECUczBBBAAAEEEEAAgXAIsE0EEEAAAQRSRoCASco4sxUEEEAAAQQQQMC9ALkIIIAAAgggYEkBAiaW3C0MCgEEEEAAgcgVYOQIIIAAAggggEA0CBAwiYa9yBwQQAABBEIpQN8IIIAAAggggAACMShAwCQGdzpTRgCBWBdg/ggggAACCCCAAAIIIOBLgICJLyHKEUDA+gKMEAEEEEAAAQQQQAABBBBIZgECJskMSncIJIcAfSCAAAIIIIAAAggggAACCIRXgIBJeP1jZevMEwEEEEAAAQQQQAABBBBAAIGIEiBgEtTuohECCCCAAAIIIIAAAggggAACCESzwNWASTTPkLkhgAACCCCAAAIIIIAAAggggMBVAV79FiBg4jcVFRFAAAEEEEAAAQQQQAABBKwmwHgQCJUAAZNQydIvAggggAACCCCAAAIIIBC4AC0QQMAiAgRMLLIjGAYCCCCAAAIIIIAAAtEpwKwQQACByBQgYBKZ+41RI4AAAggggAACCIRLgO0igAACCMSEAAGTmNjNTBIBBBBAAAEEEPAsQAkCCCCAAAIIJBYgYJLYhBwEEEAAAQQQiGwBRo8AAggggAACCCRZgIBJkgnpAAEEEEAAgVAL0D8CCCCAAAIIIIBASgsQMElpcbaHAAIIICCCAQIIIIAAAggggAACFhcgYGLxHcTwEEAgMgQYJQIIIIAAAggggAACCESXAAGT6NqfzAaB5BKgHwQQQAABBBBAAAEEEEAgpgUImMT07o+lyTNXBBBAAAEEEEAAAQQQQAABBPwXIGDiv5W1ajIaBBBAAAEEEEAAAQQQQAABBBAImYBlAiYhmyEdI4AAAggggAACCCCAAAIIIICAZQQiZSAETCJlTzFOBBBAAAEEEEAAAQQQQAABKwowpigVIGASpTuWaSGAAAIIIIAAAggggAACwQnQCgEEVICAiSqQEEAAAQQQQAABBBBAIHoFmBkCCCAQhAABkyDQaIIAAggggAACCCCAQDgF2DYCCCCAQOgFCJiE3pgtIIAAAggggAACCHgXoBQBBBBAAAHLCRAwsdwuYUAIIIAAAgggEPkCzAABBBBAAAEEIl2AgEmk70HGjwACCCCAQEoIsA0EEEAAAQQQQCDGBAiYxNgOZ7oIIIAAAlcFeEUAAQQQQAABBBBAwJsAARNvOqayxe+tkJadXpBWnfvLqnWbTCUsIoAAApYQYBAIIIAAAggggAACCCCQjAIETPzA3LPvH5m7aJnMeGWQvDy4lwwfN1POnY/3oyVVEEAgeAFaIoAAAggggAACCCCAAALhEyBg4of9mvWbpPrdlSRTxgySL28uKVGsiHy3abvwB4GABKiMAAIIIIAAAggggAACCCAQMQIETPzYVQcPH5H8+XI7a96QP6/8e+iwcz1WF5g3AggggAACCCCAAAIIIIAAAtEqQMDk2p71umSLu0Zls9mcdSvd95h4Snc3fE5az8gon2y66DNpPV8pkvp58eW5UrNmTY82ZjOt55rOnTwoBfNmdaaSt5YWX8lc39Oyrz603FNbc77W85XM9T0tu/ZxJVX6RGauNu7WHZ5LP17l0cnTGMz5ruNxt26u72nZXTvXPE9tzfmubdytO+p37vSUccx583E4ub63frq/81hz9Ofu3d32XfPctXPNc23jbt21jbt1d+1c89y1M+e9/+7iRMecq4+uu3PVPPO56rptd+vmbXtadtfONc9TW3O+axt36+b6npbdtXM9V9XCV1JHR/J0rnoagznf3Xhc88z1PS27tnG37qmtOd9dO9c8c31P56rDxtt7l85P+TxXXbftbt08Hk/L7tq55nlqa853beNu3Vzf07IeM95stMzbMeg4V91t3zXP0xjM+a5t3K2b63tadtfONc9TW3O+axvHuvlc9ebjKFNHc1J3R1+Od/N2PS076np799TWnO+tvaPMXN/TsqOut3fXtu7OVbONp2W19HWuehuHo8x1PO7WHXW9vbtr55rnrb2jzLWNu3Wtq8eMJxvNVx9vSc9V7cdXcrd91zxffWi5axt361rPV3LXzjXPWx+Oc9WbjaNMHV2Tupv7d922u3VzfU/L7tq55nlqa853beNu3Vzf07K7dq7nqquN8MeTgF/516IAflWPzUq5c+aQY8eOOyd/5OgxyZMrp7G+bsV88ZW6v/SB+Eq++tByX31oudbzlbSer+SrDy331sers5bJ8uUf+bTRfrSea9r87Sr5YeNqZ9J6vpK5vqdlX31ouae25nyt5yuZ63ta9tWHlrvauFvXer6SpzGY8331oeXm+p6WtZ6v5KmtOd9XH1ruqL/ys0+MYw6fhJ9JDh9P72tXrQz6PFVr87mq+8O9ZusaAAAQAElEQVRX8jQOc76vPrTcXN/TstbzlTy1Nef76kPL1cJX0nq+knm7npZ99aHlntqa87Wer2Su72nZVx9abm7r6VzVer6StjX35W7ZVx9a7q6da57W85Vc27hb99WHlrtr55qn9Xwlb8eg41z11YeWu27b3brW85XctXPN89WHlru2cbeu9Xwlbz6OMl99aLm77bvmaT1fybWNu3VffWi5u3aueVrPV3Jto+ebw8Xx7qsPLde62ta1P/O61vOVzPU9LfvqQ8s9tTXnaz1fyVzf07KvPrRcfbwlPVe1nq/kaQzmfF99aLm5vqdlrecreWprzvfVh5Z7s3GUaT1fybxdT8u++tByT23N+VrPVzLX97Tsqw8td9dWz7erNh8ZfxfWeuZkfGnlJWgBAiZ+0FW9s4KsXr9JzsfHy5Gjx+XHXb/LHZVK+9GSKggggAACCCCAAAIIIIAAAgEL0AABCwgQMPFjJxQqeL00rHu/tO/+ovTs97L06tJK0qZJ40dLqiCAAAIIIIAAAggggAACIhgggEDkCRAw8XOfPdagtsyfPlLmThsu1e+q6GcrqiGAAAIIIIAAAgggEJUCTAoBBBCIegECJlG/i5kgAggggAACCCCAgG8BaiCAAAIIIJBQgIBJQg/WEEAAAQQQQACB6BBgFggggAACCCCQJAECJkniozECCCCAAAIIpJQA20EAAQQQQAABBFJSgIBJSmqzLQQQQAABBK4JsIQAAggggAACCCBgYQECJhbeOQwNAQQQiCwBRosAAggggAACCCCAQPQIEDCJnn3JTBBAILkF6A8BBBBAAAEEEEAAAQRiVoCASczueiYeiwLMGQEEEEAAAQQQQAABBBBAwD8BAib+OVHLmgKMCgEEEEAAAQQQQAABBBBAAIGQCBAwCQlrsJ3SDgEEEEAAAQQQQAABBBBAAAEErCAQ2oCJFWbIGBBAAAEEEEAAAQQQQAABBBBAILQCUdg7AZMo3KlMCQEEEEAAAQQQQAABBBBAIGkCtEaAgAnHAAIIIIAAAggggAACCCAQ/QLMEAEEAhQgYBIgGNURQAABBBBAAAEEEEDACgKMAQEEEAitAAGT0PrSOwIIIIAAAggggAAC/glQCwEEEEDAUgIETCy1OxgMAggggECkCSx+b4W07TpQqtVtIw807JCsw9+8badUqd1Sdvz0W7L2662z95d/ISu+WOutituyDRt/kJETZknzjs9L9YfbSpO2z8qE6fPk1OkzCer/c+CgvDhqqrR86gWp9lBrY35//n0gQR1vK6/Pe1dq1G/vrYqzbP+BQ3JvvXYp6ufYeNc+I6RX/zGO1WR/V+85b72fqN/tO3+RGo+0k4OHjiQqC0cG20QAAQQQQCCSBQiYRPLeY+wIIIAAAmEV2P/vIRk/bZ4UvrGAjBrUU8YMeSas40mOjX/46Wr57Kt1AXf1xsL35eTJU1Kv9r0yrH83qValgrzzwUrp3PslOR8f7+zvwL+HZduPP0ue3Nml9K23OPNDsTBx5nypXPE2ubVE0eTq3u9+ihYpKEWL3OB3/UArbtr6oyxY8mGiZreVLCYVy5aSSa8tTFRGBgIIIIAAAggEJkDAJDAvaiOAAAIIIOAU+Gf/QWP5sQa15O47ykn5MiWN9ch5Sb6RPt+9nYwY2EOaNaoj99iDJd07tpAenVrIr7/vlTXrNjs3VK50CVk6d4K88lIfqXpHeWd+ci8cPnpMvlrzvTz0wD3J3bVf/fXq/IR0fbKZX3WTu1KdB6rJ56s2iBokd9/0hwACCCCAQCwJEDCJpb3NXBFAAIFoF0jB+Q0ePU26PDfc2GK7boOMW0vGTn5T9HYRvW3EKLC/aMBAb6vp0HOIfe3afw893kUmzpjvzDh95qz0f+lVqfloR2nWoY/MfHOJxF+46Cz3Z0H70G3NX/yRcdtL/RbdjXEdPXbCaL7uu63G7UM6xjqPdZG+QyfI8ROnjDJ90dtk9JaOtRu2GO20r4EjJmuRz1T4xvyJ6lS9s4KRt+fPf4z3QF927/1bOvYaYpiq30efrvK7i+WfrZH06dLKXXeUdbYZPXG21GnSWS5dvuzM04WLFy8a7rr/dP3YiZMyddYieeqZoca26zZ9WvoMfkX2/bVfi51JbznS/bh63SZp1bm/6K0wL786xyh3vSVn58+/yytT35SWnV4QvWWpUetnZMzkNxLdsuToc/33W6V1l/5GXb296b3lXxj96su4KXNl7tvLxLG/dT/Va95Ni4xUtUp5SZUqTj79IvArhYwOeEEAAQQQQAABQ4CAicHACwIIIGBNAUZlXYFWjz8i3To0NwbYp3tbeXVUX2lSv5ZULFNS9NkjRoH95fstP0rqVKlk567fnLem7N73j2gQo2LZW+01rv7Xd8gE+XbTdmneuK50bN1E/t5/SPQL/tXSwF4X/O8jyZghvcyePFRmvTpEsmTOKJ+vWi/PDBgjWbNklr492kn7lg1k1y+7pXPvYXL5vwDCC72eNG4v0ts6dD6a2rZoENjGTbW1f10tdMP1+hZQOnHylHR+dpg9oHNSuj3ZTBo/8oC8t/xLWf7Zar/62fD9NilZvKikTZPGWb/OA1VFgyEaEHJm2he+/uZ7I3Ch5fZVOX8+Xnb9ukfuur2cDH6+izSqV9O+Pw5KJ/t4zp47p1Wc6ezZc/LKtLnStUNTWTpvgjzW8EFnmXnh4OFjcvjIcalfp4YMfeFpuffuirJq7ff2wNYUcf2jfb4+b6l069hcli2cJA/eX9U4Frbu2GVUbfxITal5bxVJnz6dcdzpfnqpf1ejTF/SpU0rJW+5SdbbDXSdhAACCCCAAALBCRAwCc6NVgggEJwArRCIGoGbCheQYkVvNOZTyv7l9Pbyt0mhgtdLhbKl5Iedv0j8hQuifzZu3SEP2L/c6rIGT4z3zT/om5QvU8J437Rtp3y/ZYfxRbpt8/pSo+rt9i/qnaWU/Qu/USHAl9w5s8vz9qBIzuzZjD6uXBEZP3W+VCp3q0wc+bzUvu9uewCilkwZ00/22oM3K79eb2xBn/WROVNGuS5rJtH5aLqp0A1GWaAvGvCY+eb/RNvXqHZ7oM1l8Xsr5Fx8vMwcP1gerfeAMeZpY/s7gzu+Oty+81cpfnOhBNXK3HqLXJ83t3yyMmHQ5ePP1hj5On9tkDd3TsOpdbNHpPpdFaVdiwYye9JQiY+/IJ98vlarONM5e3ClR8eWUrlCacl2XVYpbD8GnIWmBb1NafiA7kZQrfrdlezBkBYyclAP+ebbrbL3z4RXrmifz3R5wthfGuBq37KhFL6xgHy04uq49Ti7Pm8uSRUX59xPZW8tbtqaGHP/4cdfEuSxggACCCCAAAKBCcQFVp3aCCCQUIA1BBBAIKFAxXKl5MKFi7Llh5/kij1S8f2WH6XK7WWMB5xusgdFtPbGrT8agYxMGTPoqr3u1SsH7qxUxlh3vJhvJ3Hk+fNe9c5yCar9+sde0edZNHz4/gT5+fPlkVtuLizfb/4xQX5SVzRYoldjHDpyTEYP7iVx9i/2gfa5bccvcqs9YHRd1szOpqlTp5ZK5a9dleMscFnQ7euDZrNfd51LichDNauKXmGit7NoodbVX5x5uHZ1XXUm/aWgp58bLnrLjd7yorfR6C/+/OlyW06quDjRW2CcDT0saBBk9vylzluitM8O/92mtdflliW9KkavEDF3VeiGfPLXPwfMWV6Xc2TPJno1jI7Za0UKEUAAAQQQQMCjAAETjzQxWsC0EUAAAQSSJFDcHoDQqzQ0KKLPrTh37rzcUbGMVCxbSjZu3Wn0rQGKCmWvXl2iGUeOHpdcObKJzWbTVWfSK0ScKwEsZM+WMFDwz4FDRmt9Rop+UTcnHePfB64+vNaolMQXfT5I36ET5eTJ0zJ93EC5IX/eoHo8bA+26BUbro1z5czmmpVoXa8E0cx06dLqW4JU78F7Ra/+cfwSkF4xcvHSJalbq5qz3qdffiNDx8yQUiVukk5tmsi4Yb2NW19y58ohx06cdtbThSxZMhu3XOmyt6S/prTkg8+kRtXK8ly3NjJhxPPy0n+30Zw4eTJB00yZMiQ6FlKlSmUPgJxPUM/bSvp06YxiPf6MBV4QQAABBBBAIGCBqA+YBCxCAwQQQAABBJIooFeZbNr6k3Hlht6SoldJVK5wm+z6dbds2/Gz8bwMvT3GsZkc2a+TU2fOOlad76dOnXEuB7LgEneRAtfnMZrrL9fo8y5cU7cnmxrlyfEycvzrsu/Pf2SaPVhSpFCBoLvMaQ8gnTmbeP4n/TC5LmsWY7snTl17oK2RYX/R22301pxPVl69tebjlWukfJmSovn2YuM/DZiULlVMnm7fTB6pU0PuqlzOuPXlhOkBuUZF+4urtT3L7X9frNogDevWkFZN68lDD1SzB9FKS748ud3WTY7M4yeuBmHUMTn6ow8EEEAAAQQiQSC5x0jAJLlF6Q8BBBBAIOYFKti/gOtDXjds3Oa8haRUiaLGQzr1uR6p4uKML+kOqHKli4teCbDjp18dWca7PtfEWEjiS9HCN9i/nOeSn375w/jir88mMafixYo4t5ApY3q5cOGScz2QhVdnLpDP7YGBCSOfl2CvLHFsr8ytxezj3W38EowjT69e2bTV9+1DadKkNoJEf//j/sqZB++/W7bu2GU8nFdNdN2xDX3Xh+BmSJ9eF51pzfrNzof2OjMDWNCrWNK79PnFqvUB9JCwasYMGYwrZRLmXlv78+8DcuMN+RJdqXKtBksIIIAAAhEgwBDDLEDAJMw7gM0jgAACCESfQMVypYyfrtWHuepDYHWG+ks55W4rIRvtX/hvLXlzgl9v0QBLxbKlRG9l0S/yJ0+dlnmLPxS9+kHbJjXpsz/0NhB9uKs+W+SdZZ/Jt5t+kPeXfyE9+4023h3b0KtCftz1m6xat0m+27xdft/zp6PI6/vk1xfKwnc+loZ17xO9xUjbOpL+KpCjsT7XxZGvX+o1XwNFmvfL73t01UiPNagtly5dludefEV27/1bDh0+Ki+OnCqegiBGI9OLXjWiz24xZTkX9RdmUsXFSf/hk0SDK/ffc4ezTBcqVygjGpjR59BcuHBRNFjy0rgZCfaZ1gskVS5/qyz75Cs5eOiIcYXRonc/kXc/+iKQLhLULWIPgunYFr+3wthPetyYK/z6xz6paPoVJnMZywgggED4BNgyApElQMAksvYXo0UAAQQQiACBooULij7HRId6u/2Lsr5rqmQPpOh7xbIl9S1B0oejlilVTHoPHCe1Gj0la9dvNn7pJkGlJKzobSUzxw8SuSLy+tx3pccLo2X+ko/kJvsX74rlrj1ItV2LhqK/4jJu8hvSve8ombPgPb+2unbDZqOeBk20nTktXvqJUaYvepWIo2zpR59rlgwePc3Y1tRZi411fdFfh5k5/kW5ePGitHl6gDRo2UPSpU0jTR99UIt9pro1q8nvu/80HnbrWln3TbW7Khg/R4EPWwAAEABJREFU7VytSkXJ9N/Ddx31GtevKY83rC1DxkyXex5uI2PtFn26t5P81wd/C81z3dpK8ZuLSPOOfaXmox1FHyo7dsgzjk0G/K6/uqM/P62Gui8HDJ/s7ONfe1Bm996/xPEzyc4CFhBAIPkF6BEBBKJagIBJVO9eJocAAgggEEqB28vfJutWzBfzLS2O7X327kyjLGOGa7d2tGhS18jTL7qOeo53/dKuPzvraDf9lYHGF17t3/Fzt466nt61D63f+JFabqvcWuJm0X4/XjLNGMeSOeNEn2tivn0mS+ZMMuDZjvL+gleNOsP6dXXbl2vmwtdeNurr9l1Tn+5tndX1ShvXcsf6+OHPOevpgv58rgZNvlo2W9Z8PFcGPveUdG73uHz5/iwt9prKlS4herWM46d4XSuPHNjTGO/w/t1ci4yHuHZp31SWzp1g1Hlv/kS5r1pl0TkO7N3RWb9npydk+dtTnevmhckv9xPzfHLlzG485NWxf+dMHiYV7YEqnftDNe9xNvXUpx4bsycNddbTBf0Jah3TN5/Mk2VvTdIsI324YpVxTOpzWIwMXhAIQICqCCCAAALXBAiYXLNgCQEEEEAAAQSiSKBDq8by9nufJOnZIxJhf/TnlBe9+7E82fLRCBt5yIZLxwgggAACCAQtQMAkaDoaIoAAAggggICVBarfVVH0aps//zpg5WEGODbv1XWuLZs8LFXvLO+9IqUIIIAAAggg4FOAgIlPIioggAACCCAQfoEXR02V6g+39Zi0PBSj3L33b4/bdIxH6wS97RA31NtWihYpGOKtWKd7nWurpvWsMyBGggACCCCAQAQLEDCJ4J3H0BFAAAEErCcQqhF169hc5k0f6TFpeSi2XfjG/B636RiP1gnFtukTAQQQQAABBBAIpwABk3Dqs20EEEDA+gKM0CICuXJkkxtvyOcxaXmohuptu1oWqu3SLwIIIIAAAgggEE4BAiZJ1E+VKpVYMdlsNrly5Yolx2ZFL/OYLl++hFsQx7UebzabLQLsrHXO2mycq+bzL5BlztXgjmXO1eDcbDbO1UDOT3NdztXgjjnO1eDcbDbOVfP5F8gy52pwx5zVz1XhT5IE4pLUmsYSF5fKkknk6v8srDo+K4/r4sVLltynHs0scgxevnxFxH7cWX2cVhufmun/aK02rkgYD+dqcP//4VwNzo1zNTg3/SzhXA3OjnM1ODfO1eDcOFeDd7P6uSr8SZJAXJJa0xiBEAjQJQIIIIAAAggggAACCCCAAALhFiBgEvo9wBYQQAABBBBAAAEEEEAAAQQQQCDCBIIImETYDBkuAggggAACCCCAAAIIIIAAAggEIRDbTQiYxPb+Z/YIIIAAAggggAACCCCAQOwIMFMEAhAgYBIAFlURQAABBBBAAAEEEEAAASsJMBYEEAidAAGT0NnSMwIIIIAAAggggAACCAQmQG0EEEDAMgIETCyzKxgIAggggAACCCCAQPQJMCMEEEAAgUgVIGASqXuOcSOAAAIIIIAAAuEQYJsIIIAAAgjEiAABkxjZ0UwTAQQQQAABBNwLkIsAAggggAACCLgTIGDiToU8BBBAAAEEIleAkSOAAAIIIIAAAggkgwABk2RApAsEEEAAgVAK0DcCCCCAAAIIIIAAAikvQMAk5c3ZIgIIxLoA80cAAQQQQAABBBBAAAHLCxAwsfwuYoAIWF+AESKAAAIIIIAAAggggAAC0SZAwCTa9ijzSQ4B+kAAAQQQQAABBBBAAAEEEIhxAQImMXEAMEkEEEAAAQQQQAABBBBAAAEEEAhEIDIDJoHMkLoIIIAAAggggAACCCCAAAIIIBCZAmEcNQGTMOKzaQQQQAABBBBAAAEEEEAAgdgSYLaRI0DAJHL2FSNFAAEEEEAAAQQQQAABBKwmwHgQiFoBAiZRu2uZGAIIIIAAAggggAACCAQuQAsEEEDgqgABk6sOvCKAAAIIIIAAAgggEJ0CzAoBBBBAICgBAiZBsdEIAQQQQAABBBBAIFwCbBcBBBBAAIGUECBgkhLKbAMBBBBAAAEEEPAsQAkCCCCAAAIIWFCAgIkFdwpDQgABBBBAILIFGD0CCCCAAAIIIBD5AgRMIn8fMgMEEEAAgVAL0D8CCCCAAAIIIIBAzAkQMIm5Xc6EEUAAAREMEEAAAQQQQAABBBBAwLsAARPvPpQigEBkCDBKBBBAAAEEEEAAAQQQQCBZBQiYJCsnnSGQXAL0gwACCCCAAAIIIIAAAgggEE4BAibh1I+lbTNXBBBAAAEEEEAAAQQQQAABBCJIgIBJkDuLZggggAACCCCAAAIIIIAAAgggEL0CjoBJ9M6QmSGAAAIIIIAAAggggAACCCCAgEOAdz8FCJj4CUU1BBBAAAEEEEAAAQQQQAABKwowJgRCI0DAJDSu9IoAAggggAACCCCAAAIIBCdAKwQQsIQAARNL7AYGgQACCCCAAAIIIIBA9AowMwQQQCASBQiYROJeY8wIIIAAAggggAAC4RRg2wgggAACMSBAwCQGdjJTRAABBBBAAAEEvAtQigACCCCAAAKuAgRMXEVYRwABBBBAAIHIF2AGCCCAAAIIIIBAEgUImCQRkOYIIIAAAgikhADbQAABBBBAAAEEEEhZAQImKevN1hBAAAEErgrwigACCCCAAAIIIICApQUImFh69zA4BBCIHAFGigACCCCAAAIIIIAAAtEkQMAkmvYmc0EgOQXoCwEEEEAAAQQQQAABBBCIYQECJjG882Nt6swXAQQQQAABBBBAAAEEEEAAAX8FCJj4K2W9eowIAQQQQAABBBBAAAEEEEAAAQRCJGChgEmIZki3CCCAAAIIIIAAAggggAACCCBgIYHIGAoBk8jYT4wSAQQQQAABBBBAAAEEEEDAqgKMKyoFCJhE5W5lUggggAACCCCAAAIIIIBA8AK0RAABEQImHAUIIIAAAggggAACCCAQ7QLMDwEEEAhYgIBJwGQ0QAABBBBAAAEEEEAg3AJsHwEEEEAg1AIETEItTP8IIIAAAggggAACvgWogQACCCCAgMUEoipgcujwUenaZ4S06zZI+g2bKGfPnXPLvXX7LmnTdaA80bmfvD7vHWed95Z/Ic2efE6q1G4pR4+dcOb/+vteI0/zNfXqP8ZZxgICCCCAAAIIIOBOgDwEEEAAAQQQiGyBqAqYTJyxQO6sVFZmTxoqWbNmkQVLlifaO1euXJFBI6dIn25tZM7kYfLF6m9l87adRr28uXPK0H5dJVfO7Ma6+aVi2VKybsV8I40f/py5iGUEEEAAAQRiQYA5IoAAAggggAACMSUQVQGTtRu2SN1a1YwdWLdmNVmzYbOxbH7Z9etuyZgxg5QqXlRSp0oltWrcJavXbzKqVLm9rBS7qZCxzAsCCCCAQLQLMD8EEEAAAQQQQAABBDwLRE3A5PSZs2KziWTPltWYbcECeeXgoSPGsvnlwMEjUiBfbmeW1jvw72HnuqeFHbt+k6p1WsmTPQbLth0/e6pGPgIIIBA+AbaMAAIIIIAAAggggAACySYQNQETFYmLuzYdm+3aspaZky3OHllxZniu56iS//o88sGCV+XjJdPkvnvukN6DxsmZs1efj3L69CmxYjp79oycO3fOkmOzopd5TPHx8bgFcVyfP39O9LgzWyZ1ORbaqxnnanCfo5yrwblxrgbnxrkanJt+jnOuBmfHuRqcG+dqcG6cq8G7Wf1cdXyn5T04Ad/RguD6TZZWly5fln8OHJStO3aJPnj1+IlTHvvNlDGDXLp0WeIvXDDqHD56THLnymEsm1/y5s4hR4+ddGYdsdfLmyenc93dQsYM6SVL5kxGat6ojuTLk0v2/bXfqJopU2axYsqQIaOkT5/ekmOzopd5TGnTpg2VW1T3my5detHjzmzJsu/PBzXjXPXt5O5Y4lwNzo1zNTg3ztXg3PTc5VwNzo5zNTg3ztXg3DhXg3ez+rlqfGnlJWgBSwZMDhw8LMPGzpQHGnaQTs8Mk0kz35KBIyZJ4zbPyGPtnpXlK1e7nfBdlcvJyq/WGWWffvmNVL2jnLGst+ts3/mLsVz85sKiv6ajAQ8NyHz+9QapemcFo8zTy6nTZ5xFGrg5evyEFCyQz5kXuwvMHAEEEEAAAQQQQAABBBBAAIHoFLBkwKR735FSrvQtsuJ/0+X9Ba/K6xOHyMLXx8hn786U0S8+I99u3C7zF3+UaI/07NRClq1YZfys8N59/0iLJnWNOn/+td8egJlhLNtsNhnSt4s9ADNZ2jw9QCqWLyUVypQ0yqbNfluq1G5pBFQeeryL9B401shf/tlqI79a3TYybupcGTGgu+hVJ0YhLwgggAACCCCAAAIIIIAAAgggEFkCfow2zo86KV5l9qRhUq/2vZI2TZpE2y5SqIAMfr6zNHz4vkRluXJml2ljB8jsSUNlxMAekiF9eqNO8WJF5O1ZV4MfmlH2tuLyxpSXZN60EdLhiUaaZaTO7R6XdSvmO9PYob2N/Mca1DbyVn/0htF/6VLFjHxeEEAAAQQQQAABBBBAAAEEELCCAGNIfgFLBkz0eSS+pupPHV99UI4AAggggAACCCCAAAIIIGBJAQaFQNgFLBkwcaisWb9ZOvQcItUeam3cEqO3y2hylPOOAAIIIIAAAggggAACCESGAKNEAIFIE7B0wGTW/Held9fW8tWHc4xbYhy3y0QaMuNFAAEEEEAAAQQQQCDqBJgQAgggEOUClg6Y5M2TU/RXbVLFWXqYwh8EEEAAAQQQQACByBdgBggggAACCJgFLB2JyJkjm7z74Uo5dfqMecwsI4AAAggggAACCPgWoAYCCCCAAAIIJEHA0gGTd5etlDGT3pCaj3bkGSZJ2Mk0RQABBBBAIDoEmAUCCCCAAAIIIJByApYOmDieWeL6nnI8bAkBBBBAAIEQCtA1AggggAACCCCAgGUFLB0wUbUrV67I77v/MpIuax4JAQQQQMCaAowKAQQQQAABBBBAAIFoEbB0wOT95V8Yt+N07ztSNNVq9JR88MlX0WLPPBBAwPoCjBABBBBAAAEEEEAAAQRiVMDSAZP5Sz6Swc93kWULJxlp0HOdZN7by2J0VzFtBJJDgD4QQAABBBBAAAEEEEAAAQT8EbB0wCR16tRS9c7yYrPZjFStSgWJi7P5My/qxIoA80QAAQQQQAABBBBAAAEEEEAgBAKWDpikShUn677b6pz2mvWbJW3atM71aFxgTggggAACCCCAAAIIIIAAAgggEH6BUAdMkjTDvj3aydjJb0qV2i2NNGH6PNG8JHVKYwQQQAABBBBAAAEEEEAAAQQQSG6BqOvP0gGT20oWk/+9MU4WzBhtpCVzxsmtJW6Oup3AhBBAAAEEEEAAAQQQQAABBKwmwHhiXcCSAZPvNm+XU6fPiL5/v2WHHD561Ei6rHmxvtOYPwIIIIAAAggggAACCCAQsAANEEAgIAFLBkxmzV8qBw4eFn13lwKaIR7peUEAABAASURBVJURQAABBBBAAAEEEEAgKgWYFAIIIBBKAUsGTKaPGyhFCxcUfXeXQglC3wgggAACCCCAAAIIhEmAzSKAAAIIWEjAkgETh0+nZ4c5Fp3vLZ96wbnMAgIIIIAAAggggICVBRgbAggggAACkStg6YCJK+vpM2flfHy8azbrCCCAAAIIIIBAygiwFQQQQAABBBCIGQFLBkxmvrnE+Bnhrdt3Ge+OnxVu2ekFefThB2Jm5zBRBBBAAAEEQi1A/wgggAACCCCAAALuBSwZMOnYuomsWzFfGj9Sy3jXZU1L506QZo3quJ8JuQgggAACCIhggAACCCCAAAIIIIBAsghYMmDimNmzT7dyLPKOAAIIxKgA00YAAQQQQAABBBBAAIFwCFg6YLL3z/3Ss99oubdeuwS35oQDim0igEAyCdANAggggAACCCCAAAIIIBABApYOmAwdM13qPVhDStxSRJa9NUm6PtlM2rdsGAGsDDGWBJgrAggggAACCCCAAAIIIIBA9AlYOmBy7tx5uf+eynL58mXJlTO7tGhSV37f/Wf07QVrzYjRIIAAAggggAACCCCAAAIIIBDzApYOmGTMmN7YQTabTfb9tV/OnY+XI0dPGHn+v1ATAQQQQAABBBBAAAEEEEAAAQSiXyB5Z2jpgEm524rLsRMnpdmjD0nzDs9LjUfaSc0adyavAL0hgAACCCCAAAIIIIAAAgggYEUBxhRWAUsHTLq0byrZsmaRe6tWktXL35R1K+ZLo3o1wwrGxhFAAAEEEEAAAQQQQAABBIIToBUCkSRgyYDJd5u3i7cUScCMFQEEEEAAAQQQQAABBKJWgIkhgEAUC1gyYDJr/lLRNGnmQuned5QMGD5ZRrzyurH8ytS5Ubw7mBoCCCCAAAIIIIAAAuEUYNsIIIAAAg4BSwZMpo8bKJpy58omY4Y8K58smSZL502Q1ycOlkI3XO8YO+8IIIAAAggggAACCHgXoBQBBBBAAIEgBSwZMHHM5cC/R6TqneXFZrMZWbeWuNl45wUBBBBAAAEEEIhVAeaNAAIIIIAAAikjYOmAiS3OJuu/3+qU2PXLH3LsxCnnOgsIIIAAAgggEPECTAABBBBAAAEEELCkgKUDJv2f6SDjpsyVhx7vIk3aPisDR06WXp1aWhKSQSGAAAIIIHBVgFcEEEAAAQQQQACBaBCwdMCkRLEisnj2WJk8ur+MfvEZ+/I4KW7PiwZ45oAAAghEjAADRQABBBBAAAEEEEAgBgUsGTDRnxQ+dfqM8dPC32/ZIYePHjWS5muKwf3ElBFAIBkF6AoBBBBAAAEEEEAAAQQQ8CVgyYCJ/qTwgYOHjZ8W1mXX5GtSlCMQYwJMFwEEEEAAAQQQQAABBBBAIJkFLBkw0Z8ULlq4oPHTwrrsmpLZgO4sJ8CAEEAAAQQQQAABBBBAAAEEEAivgCUDJuElCcHW6RIBBBBAAAEEEEAAAQQQQAABBCJKIKiASahnWP3htuIthXr79I8AAggggAACCCCAAAIIIIAAAiKxbGDJgMnXH84RbymWdxhzRwABBBBAAAEEEEAAAQQQCFqAhgj4LWDJgIl59BcuXJTtO38xfjFHfyFHk7mc5egUOPLrR/Lv9gVhScd+XhKW7ep8dd7RuUeZFQIIIIAAAggggEBoBOgVAQRCJWDpgMma9Zvl0VY9pWe/l2XMpDnSve8omfzawlBZ0K+FBI788pEc3LEwLOnYz++EZbs63yO/LrfQXmAoCCCAAAIIIIBAGATYJAIIIGARAUsHTKbMWiSvTRwsN990oyyePU7mTB5mXy5kETqGgQACCCCAAAIIIICAbwFqIIAAAghEpoClAyapU6eSfHlyid6Wo7wlihWRM2fP6CIJAQQQQAABBBBAIDwCbBUBBBBAAIGYELB0wCRjhvTGTsh2XWZ5f/kXorfoHD120sjjBQEEEEAAAQQQSB4BekEAAQQQQAABBBILWDpg0qR+LTl24qR0ad9UVn69QeYv+VCeat048Sz8yFn83gpp2ekFadW5v6xat8lti0OHj0rXPiOkXbdB0m/YRDl77pxR7+ixE9J74FipUb+9vPzqHCOPFwQQQAABBCwrwMAQQAABBBBAAAEEkixg6YDJA9XvlGxZs0jRwgVl0ugXZPq4gVK+TMmAJ71n3z8yd9EymfHKIHl5cC8ZPm6mnDsfn6ifiTMWyJ2VysrsSUMlq327C5Ysd9Z5qNY90uGJRs51FhBAAAEEUk6ALSGAAAIIIIAAAgggkNIClg6YtHzqBXnrf8uNq0ySArNm/SapfnclyZQxg+TLm0v0WSjfbdourn/WbtgidWtVM7Lr1qwmazZsNpazZ8sq91WrLBkypDPWeUEAgegS+PfgYRk+ZnJKJue2Ro6bKqPHT3eup/Q4Vq39Nkk7c+act8I29jETZ4Zt2zrvpMCpe0rva8f29HjT486xntLvBw8dCZqOczVoOtFjNqX3tWN7kXyu7tn7l+j5Go60Zt33svqb78K2/dNnzgR/wNESAQQQiBIBSwdMBvbuKHv2/S2Pte0tvQeNlS9WfysXL10KmP7g4SOSP19uZ7sb8ueVfw8ddq7rwukzZ8VmE8luD47oesECeeWgH3+pu3z5slg1Xbli3bH5MtN9EKvJl401yy/LlStXjGTV8Xkb14F/D8mIsVPCkka9Ms0eMJkRlm3rnFet3ZCkz7CZcxaGbexjJr4Wtm2/9saiJLmpu/qHI708YYbocReObes2D/x7MGg7ztXLQdtxrgZnN2/Ru1Ln0dZhSfWbdpCHm7QLy7Z1zn/s3hf08fb7H3vlwYatw5LqNm4n9R7rEJZt65znLnw3aDf9u8p3G7fKV6vXhyVpkC5c29Z56/wjMV2x+HeuWP1OlVzztnTApHixIvJCryfl/QUT5e47ysvct5dJvaZdg5q7Le7aVG02e2TETS9xCepcq++mqjPr/PlzYsV04UK8XLhwwZJj88friv3LtxM5HAth2qbO2x8fT3WGjZ4oWa6/NSwpV+EKku2GMmHZts55y7btQR/v8fHnw7THw7/ZS5cuBu2mx6Ees+GfRcqPQOet8w82qXvKj9oaW9TzLVg3bWuNWaT8KPSYCdZN2+kxm/KjDv8Wdd46/2CTuod/FuEZgZ5vwbodPXZMVn/zbVjSmnXfydr1enVOeLb/x+49Sfr/aqee/aVu47ZhSY+26ByW7ep8O/cakCS3YI/V5Gin37ku2L97JUdfoehD+JMkAf+iAknaRPI0jvMQ5PCn99w5c8ixY8edVY8cPSZ5cuV0ruuC3q5z6dJlibcHGXT9sL1O7lw5dNFrypAho1gxpUuXXtKmTeccmxXH6G1MNpv7oJbXnREFhTabLUn7LHXqNFGgENwU0qfPELSdtg1uq5HfSo8Zb+eirzKbjXPVl5G7cnWP/KMnuBno+ebOxJ88bRvcViO/lR4z/hh5qmOzca56svGWr+6Rf/QENwM937zZeCvTtsFtNfJb6THjzcZXmc3GuerLyGrl+p1Lv3tZbVyO8UT+WRXeGVg6YLLrlz9k5PjXpX6LHrJ6/SZp9Xg9WbZosooFlKreWcFofz4+Xo4cPS4/7vpd7qhU2uhj87adcuHCRWP5rsrlZOVX64zlT7/8RqreUc5Y5gUBBBBAAAEEEEAAAQQQQAABBMIiELaNWjpgMmzsTClUML8snjNWxg7tbTx4NXWqVAFjFSp4vTSse7+07/6i9Oz3svTq0krSprn6L/F9Bo+X4ydOGn327NRClq1YJe26DZK9+/6RFk3qGvkXL12SKrVbysuvzpGlH31uLGswxyjkBQEEEEAAAQQQQAABBBBAAAG/BagYKQJxVh7o/BkjpXnjhyRb1ixJHuZjDWrL/OkjZe604VL9rorO/j57d6bkypndWNf3aWMHyOxJQ2XEwB6SIX16I1+DNOtWzBdz0uerGIW8IIAAAggggAACCCCAAAKxLMDcEYhSAUsGTPQXcf7e/69b8uMnTsnYyW/KvMUfui0nEwEEEEAAAQQQQAABBBBIigBtEUAAARWwZMDk4Vr3So8XRsvTzw2XKbMWysw3lxhp6Jjp0qJjXzl77rzUq32Pjp+EAAIIIIAAAggggAAC3gUoRQABBBAIQsCSAZN7q1aSxbPHStsWDSRD+gzOaZW7rbjMmTxUBvbuKNmuy+rMt+rC6TNnZNXab8OSVn/znaxZ931Ytq1z3rP3L6vuFsaFAAIIIIAAAhEvwAQQQAABBBAIvYAlAyY6bZvNJpXK3Srt7EGTjq2biKZH6tSQ3LlyaHFEpN17/pI6j7YOS3q4STt55PEOYdm2znn+20sjYh8xSAQQQAABBCwhwCAQQAABBBBAwHIClg2YWE6KASGAAAIIIICA3wJURAABBBBAAAEEIl2AgEmk70HGjwACCCCQEgJsAwEEEEAAAQQQQCDGBAiYxNgOZ7oIIIDAVQFeEUAAAQQQQAABBBBAwJuAJQMmP/z4i3y55rtE4/581bfy467fEuWTgQACCAgECCCAAAIIIIAAAggggEAyClgyYDJ+2jwpcmOBRNO8qVABmT5nSaJ8MhCIRgHmhAACCCCAAAIIIIAAAgggED4BSwZMjp84JYVvzJ9IpYg9YPLPgYOJ8smICAEGiQACCCCAAAIIIIAAAggggEDECFgyYHLlyhWPgBcvXfJYlrIFbA0BBBBAAAEEEEAAAQQQQAABBKJV4FrAxEIzvKXojbL22y2JRrR63SYpXrRQonwyEEAAAQQQQAABBBBAAAEEEEDATwGq+SVgyYBJ96dayIhXXpORE2bJ519vkE8+X2Nff92+/rp07dDMr4lRCQEEEEAAAQQQQAABBBBAIDYEmCUCoRCwZMAkf748smDGSMmcKYNMnrVQZs1fKtddl0neem203JA/Xygc6BMBBBBAAAEEEEAAAQQQsIoA40AAAQsIWDJgoi7Zrssq3To0l6VzJ8iSOePk6fbNJFvWLFpEQgABBBBAAAEEEEAAgYgSYLAIIIBA5AlYMmCy+L0V4i1FHjMjRgABBBBAAAEEEIgqASaDAAIIIBD1ApYMmGzatlO8pajfK0wQAQQQQAABBBBIYQE2hwACCCCAAAIJBSwZMBk1qKd4SwmnwBoCCCCAAAIIIJBIgAwEEEAAAQQQQCBJApYMmCRpRjRGAAEEEEAgKgWYFAIIIIAAAggggEBKChAwSUlttoUAAgggcE2AJQQQQAABBBBAAAEELCxAwMTCO4ehIYBAZAkwWgQQQAABBBBAAAEEEIgeAQIm0bMvmQkCyS1AfwgggAACCCCAAAIIIIBAzApYOmCy76/9Mm3229Lt+ZHS6dlhzhSze4uJJ1GA5ggggAACCCCAAAIIIIAAAgj4J2DpgMlL42bKdddllZaP1ZX2LRs6k39Ti4FaTBEBBBBAAAEEEEAAAQQQQAABBEIiYKmAiesMs2bJJM0b1ZE7KpaR28vf5kyu9VhHAAEEEEAAAQSxmECFAAAQAElEQVQQQAABBBBAAIHIEYiEkVo6YJI2TRrZvffvSHBkjAgggAACCCCAAAIIIIAAArErwMyjUMDSAZPf9/wlzTr0kSc693M+v0SfZRKF+4EpIYAAAggggAACCCCAAAIWEmAoCCBg6YDJM12ekFdH9ZXuHZs7n1+izzJhtyGAAAIIIIAAAggggAACAQlQGQEEEAhQwNIBE/NzS8zLAc6R6ggggAACCCCAAAIIRJ0AE0IAAQQQCK2ApQMm5+Pj5c2FH0jPfqO5JSe0xwG9I4AAAggggAAC4RZg+wgggAACCFhKwNIBk6EvT5eDh4/KocPHpGHd+yRzxgxSolhhSwEyGAQQQAABBBBAwL0AuQgggAACCCAQyQKWDpj8vnuf9O7aWjJlyiC177tbxg7rLX/+fSCSvRk7AggggAACkSvAyBFAAAEEEEAAgRgSsHTAJFOmjMauuHjxkpw5e85YvnDhkvHOCwIIIIAAAkkVoD0CCCCAAAIIIIAAAp4ELB0wyZwpkxw7cVLurlxO2nYdYE8DJV+enMIfBBBAAAG3AmQigAACCCCAAAIIIIBAMglYOmAyYUQfyZY1i7Rr2VD69eogXdo/Ln16tEumqdMNAghYX4ARIoAAAggggAACCCCAAALhEbB0wERJtu34WRa/t0LK3lZcitxYQPb9uV+zSQhEpgCjRgABBBBAAAEEEEAAAQQQiAgBSwdM9CeFR06YJe8v/9LAvHLligx/5TVjmRdrCDAKBBBAAAEEEEAAAQQQQAABBKJRwNIBk08+Xy1zpw6XLFkyGfa5c+WQ02fOGMsheqFbBBBAAAEEEEAAAQQQQAABBBCIfgGfM7R0wCRd+vSSJk3qBJOwiS3BOisIIIAAAggggAACCCCAAAIIIIBAcgtYOmCS/bqs8uOu34w56+04s+YvlZtvutFY5wUBBBBAAAEEEEAAAQQQQCCKBZgaAmEWsHTA5MXnO8m7H34uO376Te6p20b2/bVfenVuGWYyNo8AAggggAACCCCAAAIIBC5ACwQQiCwBSwdMsmXNIgOe7SjL354iS+dPlMHPd5Zs12WNLGFGiwACCCCAAAIIIIBAdAowKwQQQCCqBSwZMPlu83Yxp59++UP+2POnMy+q9wiTQwABBBBAAAEEEAiTAJtFAAEEEEDgmoAlAybd+44Sb+na8FlCAAEEEEAAAQQQ8ChAAQIIIIAAAggELWDJgEn1uypK8WJFpEv7pvLhosmybsX8BCno2dIQAQQQQAABBCJagMEjgAACCCCAAAIpJRCXUhsKZDujXuwlE0c8L+nSppHnB0+QHi+Mlo9XrpFz5+MD6Ya6CCCAAAIIWF2A8SGAAAIIIIAAAghYVMCSARO1ui5rZnmsQW15feJgafxITRk35U1Z+M7HWuQxHTp8VLr2GSHtug2SfsMmytlz59zW3bp9l7TpOlCe6NxPXp/3jrOOp/a//r5XqtRu6Uy9+o9xtmEBAQQQQMAswDICCCCAAAIIIIAAAtEhYNmAyfETp2TxeyuM4MfMuf+TLu0fl8cb1vaqPnHGArmzUlmZPWmoZM2aRRYsWZ6o/pUrV2TQyCnSp1sbmTN5mHyx+lvZvG2nUc9b+4plSzlvCxo//DmjPi8IIBADAkwRAQQQQAABBBBAAAEEYlLAkgGTvkPGS4MnesiuX3ZLr85PyLxpI+TRhx+QjBnSe91Jazdskbq1qhl16tasJms2bDaWzS+7ft0tGTNmkFLFi0rqVKmkVo27ZPX6TUYVf9obFXlBIIIFGDoCCCCAAAIIIIAAAggggIBvAUsGTL7+ZqMUyJdH/tr/r0yZtUg6PTssQXI3rdNnzorNJpI9W1ajuGCBvHLw0BFj2fxy4OARe9+5nVla78C/h8VX+x27fpOqdVrJkz0Gy7YdPzvbX7x4UbwlZ8UYW7h8+bJXF29mWhYAV9RV1fkHm9Q96kD8nFCwZo52fm4m6qrpMeMwCOY96kACmFAwXo426h7ApqKqqsMg2PeowghgMnrMBGum7QLYVNRV1fkHm9Q96kD8nFCwZo52fm4m6qrpMeMwCOY96kACmFAwXlZoc+nSpSR97wn1HALYBVR1I2DJgMmro/pKj04tpH3Lhm6Tm3kYWXFx16Zjs11bNgpNL7Y4e2TFuX6tnqf2+a/PIx8seFU+XjJN7rvnDuk9aJycOXv1+SiXLl0UT+ny5UvOrfi/EB01r1y57NHFk5c5/8qVK9EBEeAsdN5mh0CXr9jdA9xk1FTX8y1QL0d9bRs1EAFORI8Zh0Mw71c4V4P6rLvCuRqUG+eq579z+Dp/r3CuBnXMXeFcDcqNc5VzNcC/jsgV+2eUr88xq5br8a7JquMLdF9QP6HAtWhBwvzkWwuip9vL3ybekrsuM2XMYP9AvyzxFy4YxYePHpPcuXIYy+aXvLlzyNFjJ51ZR+z18ubJKd7a661AWTJnEk3NG9WRfHlyyb6/9ht9pEuXXtJ5SGnTpjPqxOJLqlSpJZ0HF3/ybTZzUCt2BG02m6RLgpu6x45Wwpnq+RasnbZN2FvsrOkxE6ybtrPZOFfVIdCk7rFzlCWcqZ5vgXo56mvbhL3FzpoeMw6HYN5tNs7VYNzUPXaOsoQz1fMtGDNto20T9hY7a3rMqEGwyWbjXA3WLlzt0qRJK2nt3/vCtX1f203xsy/KNhgXTfO5q3I5WfnVOmNKn375jVS9o5yxrLfbbN/5i7Fc/ObCor+GowGPS5cvy+dfb5Cqd1Ywyjy1P3X6jFGuL/qLOUePn5CCBfLpKgkBBBBAAAEEEEAAAQQQQCBKBZhWbAtEVcCkZ6cWsmzFKuOXdfbu+0daNKlr7N0//9ovw8bOMJZtNpsM6dtFBo6YLG2eHiAVy5eSCmVKGmWe2i//bLVUqd1SqtVtI+OmzpURA7r7fACt0SEvCCCAAAIIIIAAAggggIB1BBgJAggEIBAXQF3LV82VM7tMGztAZk8aKiMG9pAM6dMbYy5erIi8PWussawvZW8rLm9Mecn49Z0OTzTSLCN5av9Yg9qybsV8Wf3RG0b/pUsVM+rzggACCCCAAAIIIIAAAuEUYNsIIIBA6ASiKmASOiZ6RgABBBBAAAEEEEAgBQTYBAIIIICAZQQImFhmVzAQBBBAAAEEEEAg+gSYEQIIIIAAApEqQMAkUvcc40YAAQQQQACBcAiwTQQQQAABBBCIEQECJjGyo5kmAggggAAC7gXIRQABBBBAAAEEEHAnQMDEnQp5CCCAAAKRK8DIEUAAAQQQQAABBBBIBgECJsmASBcIIIBAKAXoGwEEEEAAAQQQQAABBFJegIBJypuzRQRiXYD5I4AAAggggAACCCCAAAKWFyBgYvldxACtL8AIEUAAAQQQQAABBBBAAAEEok2AgEm07dHkmA99IIAAAggggAACCCCAAAIIIBDjAjERMInxfcz0EUAAAQQQQAABBBBAAAEEEIgJgeScJAGT5NSkLwQQQAABBBBAAAEEEEAAAQSST4CewihAwCSM+GwaAQQQQAABBBBAAAEEEIgtAWaLQOQIEDCJnH3FSBFAAAEEEEAAAQQQQMBqAowHAQSiVoCASdTuWiaGAAIIIIAAAggggEDgArRAAAEEELgqQMDkqgOvCCCAAAIIIIAAAtEpwKwQQAABBBAISoCASVBsNEIAAQQQQAABBMIlwHYRQAABBBBAICUECJikhDLbQAABBBBAAAHPApQggAACCCCAAAIWFCBgYsGdwpAQQAABBCJbgNEjgAACCCCAAAIIRL4AAZPI34fMAAEEEAi1AP0jgAACCCCAAAIIIBBzAgRMYm6XM2EEEBDBAAEEEEAAAQQQQAABBBDwLkDAxLsPpQhEhgCjRAABBBBAAAEEEEAAAQQQSFYBAibJyklnySVAPwgggAACCCCAAAIIIIAAAgiEU4CAScrosxUEEEAAAQQQQAABBBBAAAEEEIgggSADJhE0Q4aKAAIIIIAAAggggAACCCCAAAJBCsRuMwImsbvvmTkCCCCAAAIIIIAAAgggEHsCzBgBPwUImPgJRTUEEEAAAQQQQAABBBBAwIoCjAkBBEIjQMAkNK70igACCCCAAAIIIIAAAsEJ0AoBBBCwhAABE0vsBgaBAAIIIIAAAgggEL0CzAwBBBBAIBIFCJhE4l5jzAgggAACCCCAQDgF2DYCCCCAAAIxIEDAJAZ2MlNEAAEEEEAAAe8ClCKAAAIIIIAAAq4CBExcRVhHAAEEEEAg8gWYAQIIIIAAAjEjsGfvX7Jq7bdhSWvWfS+rv/kuLNvWOZ8+cyZm9nM4JkrAJBzqbBMBBBBAIEABqiOAAAIIIIAAAu4F5r+9VOo82josqX7TDvJwk3Zh2bbOWYNF7lXITQ4BAibJoUgfCCCAQKAC1EcAAQQQQAABBBBAAAFLCxAwsfTuYXAIRI4AI0UAAQQQQAABBBBAAAEEokmAgEk07U3mkpwC9IUAAggggAACCCCAAAIIIBDDAgRMYmbnM1EEEEAAAQQQQAABBBBAAAEEEPBXIHIDJv7OkHoIIIAAAggggAACCCCAAAIIIBC5AmEaOQGTMMGzWQQQQAABBBBAAAEEEEAAgdgUYNaRIUDAJDL2E6NEAAEEEEAAAQQQQAABBKwqwLgQiEoBAiZRuVuZFAIIIIAAAggggAACCAQvQEsEEEBAhIAJRwECCCCAAAIIIIAAAtEuwPwQQAABBAIWIGASMBkNEEAAAQQQQAABBMItwPYRQAABBBAItQABk1AL0z8CCCCAAAIIIOBbgBoIIIAAAgggYDEBAiYW2yEMBwEEEEAAgegQYBYIIIAAAggggEBkCxAwiez9x+gRQAABBFJKgO0ggAACCCCAAAIIxJQAAZOY2t1MFgEEELgmwBICCCCAAAIIIIAAAgh4FiBg4tkmQcni91ZIy04vSKvO/WXVuk0JylhBAAFLCDAIBBBAAAEEEEAAAQQQQCDZBAiY+EG5Z98/MnfRMpnxyiB5eXAvGT5uppw7H+9HS6ogkBQB2iKAAAIIIIAAAggggAACCIRLgICJH/Jr1m+S6ndXkkwZM0i+vLmkRLEi8t2m7cKfAAWojgACCCCAAAIIIIAAAggggECECBAw8WNHHTx8RPLny+2seUP+vPLvocOiGU8/M0A8pdHjp0mu3Hm0ms+k9Xwln53YK/jqQ8vt1Xz+p/V8JW+dbNu2TebNm+fRxmym9VzTsWPHEnS/9PvU4islaOBhxVcfWu6haYJsrecrJWjgYcW1j/mfH05k5mrjbt3h+dWaDcYx527feRhCgmx37VzzEjTwsOLaxt26h6YJst21c81zNPjggw+MY86bj8PJ9V3PVUc/3t5dt+1u3Vt7R5m7dq55jrre3l3buFv31l7L9Fx19XC37s5V88znqrvtu+bpNn0l1zbu1n31oeXu2rnmaT1fybWNrp89fyHBuaoWvpLZ1dO56mssWq7b95W0nq/kqw8t99WHlms9X0nrOZKn1271dgAAEABJREFUc9Xs42l52bJljm48vvsai5Z7bGwq0Hq+kqm6x0VffWi5x8amAj1mPLk48r0dg45zVbfnK5k263HRVx9a7rGxqUDr+Uqm6h4XPfVhPle9+TjKHJaOd3V37dvjIEwFrm3crZuqe1x01841z2NjU4FrG3frpurGortz1eHi7V0tfZ2r7rbvmmcMwseLaxt36z66MIrdtXPNMyr6eNE2esz48lEjT0nPVe3HV/IxFKPYVx9ablT08aL1fCUfXRjF3vpwnKueXMz57nzV3dy/sUEfL+b6npZ9dGEUe2przjcq+ngx1/e07K4L13PV1cddG/L8FzAHTPxvFYM1bXHXqGw2m1Mgf94c4ikVL3qDdHyivkx9ua/PpPV8pUD66dDyEXmyRT1j+679BtKPa1vzurd+Hnrgbrl8+bJHG7OZ1nNNO+Jry/fnmjiTLdc94iuZ63ta9tWHln975lHndpPSj6e25nzdnjmlyVU5kZmrjbt1h+e9d5V3u891v3nbX44yrecrOeq6vk8e1UemjH7eONZ99aHlru3drWs9X8nR7vq8uYxjzptPfg/nq56rjn68vfsai5Z7a+8o03qO5OlcddT19u7ow9u7t/ZapueqJxdzvjtXzRv47JPGPte+vI3DUab1fCVHXW/v2sfkUc85t63rrslbe0eZaxt364665vdmDWsmOFfVwlcye3o6V91t3zXPPA5Py65tzOuOc9VTW3O+uZ2nZXN9T8vmttd7OFfzezg/zfnX583pdZ/rdjyNwZyv9Xwlc31ddneu+upDy7Wtr6T1fCU9ZswW7pa9HYOOc9XXWLTc11i0XOv5SlpPk7dz1VcfWq59+Epaz10yn6vefBxlrq7q7tqvr7FouWsbd+taz1vSc1WPO3dtzXne+nCUmet7WnbUdbxf7+Zcze/HeaqWvs5VT2Mw5zvG4e3dXN+xrGbmvwN7a+8oc7T19u6o6+1d2+sx481JfbwlPVe1H1/J2zgcZb760HJHXX33dK5qPV9J2/tK3vpwnKvebBxl7nzV3dy/r7Foubm+p2Wt5yvp8abHnac+NN9XH1qu9Xwlreearnc5V/O7nKfOL66JF8jxQyDOjzoxXyV3zhxy7Nhxp8ORo8ckT66cxnqfZ7qKr9S8eTPxlXz1oeW++tByrafp+We7Sd/e3d2OTev5StqHr+SrDy331YeWaz1fSev5Sr760HJffWh5y5YtU3x/6XY9JR23r+SprTnfVx9abq7vaVnruUstW7aQFi2aG3ae2prz3fXhmmeu72nZtY27dU9tzfnu2rnmmet7WnZt427d3NbTuequnWueuR9Py65t3K17amvOd9fONc9c39Oyaxt3657amvO1na9z1Vzf07L24yt5amvO99WHlpvre1rWer6Sp7bmfG99OM5Vc31Py976cZR5amvOd9T19m6u72nZW3tHmae25nxHXW/v5vq67O5c9dbeUaZtfSVHXW/vvvrQcm/tHWVaz1dy1PX27qsPLXe093auaj1fydGPt3dffWi5t/aOMq3nKznqenv31YeWe2uvZXqu6nGndb0lresreWvvKPPVh5Y76np713q+krf2jjJffWi5o675Xc3MfwfWer6Sub2nZV99aLmntuZ8recrmet7WvbVh5Z7amvO13qO5OlcNdf3tOzow9u7p7bmfG/tHWXm+gmXr30vc9T19u6prTnfW3tHmR5vetyZ27kuO+p6e3dt427dW3tHmWs740srL0ELEDDxg67qnRVk9fpNcj4+Xo4cPS4/7vpd7qhU2o+WVEEAAQQQQAABBBBAAAEEghCgCQIIhF2AgIkfu6BQweulYd37pX33F6Vnv5elV5dWkjZNGj9aUgUBBBBAAAEEEEAAAQRUgIQAAghEmgABEz/32GMNasv86SNl7rThUv2uin62ohoCCCCAAAIIIIBAlAowLQQQQACBKBcgYBLlO5jpIYAAAggggAAC/glQCwEEEEAAAQTMAgRMzBosI4AAAggggED0CDATBBBAAAEEEEAgCQIETJKAR1MEEEAAAQRSUoBtIYAAAggggAACCKScAAGTlLNmSwgggAACCQVYQwABBBBAAAEEEEDAsgIETCy7axgYAghEngAjRgABBBBAAAEEEEAAgWgRIGASLXuSeSAQCgH6RAABBBBAAAEEEEAAAQRiVICASYzu+FidNvNGAAEEEEAAAQQQQAABBBBAwB8BAib+KFm3DiNDAAEEEEAAAQQQQAABBBBAAIEQCFgsYBKCGdIlAggggAACCCCAAAIIIIAAAghYTMD6wyFgYv19xAgRQAABBBBAAAEEEEAAAQSsLsD4ok6AgEnU7VImhAACCCCAAAIIIIAAAggkXYAeEIh1AQImsX4EMH8EEEAAAQQQQAABBGJDgFkigAACAQkQMAmIi8oIIIAAAggggAACCFhFgHEggAACCIRSgIBJKHXpGwEEEEAgZgUWv7dC2nYdKNXqtpEHGnZIVofN23ZKldotZcdPvyVrv946e3/5F7Lii7XeqrgtW//9VmOsOl5zqt24k9v6rpld+4yQXv3HuGa7XV/59Xqp1egpOXP2nNvyUGbeXaeVzH17Wcg24cl/7qJl0rLTC3LlypWQbTtFO2ZjCCCAAAIIWEiAgImFdgZDQQABBBCIDoH9/x6S8dPmSeEbC8ioQT1lzJBnIn5iH366Wj77al3Q83ihZ3t5dVRfZxr9Ys+g+3LXMP7CBZk4Y4G0bd5AMmZI765KSPPK3VZc8uXJmWgbyZXhyf/xR2vLocNH5f2Pv0yuTdEPAggggAACCPwnQMDkPwjeEEAAAQQQSC6Bf/YfNLp6rEEtufuOclK+TEljPQpegp5CqeJF5fbytzlTudIlgu7LXcMvVm2QI0ePS70Hq7srDnnelDH9pVaNu0K+HdcNpEubVu6vfqe8/e7HrkWsI/B/9u4CvomzjwP4L21xd4brcNfhw304w224S9EWCqUFSnG34S8M24YO3QZsuA3XocOdDYf3/k9JSNOkbVJLkx8fLrl77nnunud7uebyv7vnKEABClCAAmEUYMAkjIAsTgEKUIACFDAW8Bo3C93cfVRS+57D1e0o/tMX4+tvOmD+0nUqXV4uXbmu5nXsM1ImDUPNpt0wZc4yw/S//73EsNFTUaVBJzTrOBBzF6/Gm7fvDPNDMyLLkNthlq3ahBFjZ+KbFr3Uuh8/eaaK7zt0Qt0+JHWs0aQbBo+ajKfPXqh58tKy8xCcOnsRfxw4rsrJsjx9p8uscB1+/+MwmncahIrffIcBnv746/SFUC9/269/opAWhIkfL66hzLffuWOg10TDtH5E2iJt2Ln7oEo6e+EKJs5crG5tKV+7HRq26Yfx0xfhxb//qfn6l8mzl0K2z559R9G66zB8Xbc9/KYuVLNNb8kJ7TLbdBumtu/SVRvRuF1/VKjTHm27eyhvtWDtJST/CqWL4uqN27hw+ZqW25H/s20UoAAFKECByBVgwCRyvbk2ClCAAhRwcIHWTeuiZ8fmqpUDe7VTt6A0/qYqiuTPBel7RM3QXg4fPwM3V1ecPX8Zr9+80VKgfvRKEKNIgTxqWl4Gj5yMg0dPoXmjWujUpjH+ufMA46Z8L7OsHpav2aRuV/l++igsmDoSCeLHxc7d+9HPYzwSJoiPwb3bo0PLejh/8Sq6DvDGhw8f1DqG9P1O3V6UN1d21R65taZdi3pqXmhfeg4ag1LVW6FB674YNX427j14FKjo0b/OqkDNF6mSY1i/jihcMA9G+s3G1ev/BMpnbuLd+/c4cvwsCuTLEWh2tYplsO/gCTx7/jn4Ixm27PgDElgpX6qwTOL+wyd4+OgpvqnxNUYN6Y4KpYtgtxa8GTF2Bkz/vXz5ChNnLUGPjt/ix6WT0aR+ddMsajpUy1Q5gWMnz+H0uUuQ27d++H48UqVIqvpt0ffFEpK/BIrks/TnweOflsg3ClCAAhSgAAXCQ4ABk/BQ5DIoQAEKUIACnwSyZEqL7FkzqKncX2ZRt6BkTP8FChfIjZNnL0L62oD278iJ06hc4SttDJDgiYwcPnZS3lAof071LkGEw8dPqx/x7Zp/g6/LFIPXoK6Q21tUBitfUiRLgkFaUCRZksRqGdJP6KSZy1BUC05MGTMI1SqWRqO6VTFj/FBcv3Eb0omqrCJPzqwqwJAoYTzVHrm1JkvGdDIr0GBuQgIxZb8qDAmwjPHsDRn/dc9BdUWLcSBjwdJ1kPVM8HZHpfIl0LxhDYwf2R8PHz8xt9hAaecuXFGuObJlDpRes0oZSDBl664/DenvtSCQXI0it7G4ubmp9HJa/Xw8ekECW+VLF0XPTi0wZnhv/KkFW67fvKPy6F9evX6D3p1aonjhfEicKCEyadtWP8/43ZplSmBq5OBuyJo5vRYsSQYJkMjVLbv/PKwWKS4S4LHkL+3ImCENTp25qPLzhQIUoAAFKECB8BFwCZ/FcCkUoAAFKEABhxMI1wYVKZgbb9++w/GT59QTTQ4fP4OviuVHvjxf4qgWFJGVHTlxRgUy4sWNI5Na3vPqvWTR/Opd/1KqRAH9qFXvZUoWDJT/0t/XVUCifu1KgdLTpE6JL7NlwuFjZwKl2zIhwR0/r35oUq8aJBjRt2srTBkzGNLfyIq1n/vdOH7qPEoWDdyuLFrwKV2aVCGu9t6DxypPsiQJ1bv+JVWKZCicPxeMn+6z58+j6labGpVL67NBgiDfL/tRBXG+/qaDuu2o46dbpa7fvG3IJyOuLi4o81UhGQ12sGaZEuiRvkj0C5RAjASabv5zV58U4rsEwe4+CHzVToiFmIECFKAABShAgWAFGDAJloczKUABCjiSANsSlQI5tACEXCUgQRHp3+LVq9coUSQ/ihTIjSMnzqqqSYCicIGAq0skQYIKyZMmhk6nk0nDID+ODRNWjCRJnChQ7tt3H6hp6SNF+vQwHqSO/9y9r+aH90t+LUiUOmVyXLh8VS1a+kuRqyySmgQ8ZGbSJIHrLGmmw9u3b1WScdBBJWgv1SqVxulzl3Hzn4ArRX7ZtRdfpEqBAnk+374jTzRavX47vi5THO4922Ky7yCMHtZDKw08e/5cvetfEiSIr26l0k9berdmmfHjBQTIjJfl6uqCl9pnxDgtuPHYsWLg9evXwWXhPApQgAIUoAAFrBRwsTI/s1OAAhSwHwHWhALRTECuMjl64py6ckNuaUmUMD6KF86L85euqg5O5TaMogU/918iwYIX/70M0soXLwJ3Rhokg4UEk7gL0n6RUuXs1amFoW8S6Z9EP/T87ls1PyJe5Gob/XITJogHVxcX/PvfK32S4f35i38N45ZGEsSPp2Y9fRY4uCGJlcqVQMwYMbBp2x5t+S/xx/5jqFGljMwyDPKEnfq1vkbrb+ugZuWyWiArH1KnTGGYbzxiamg8z3jcmmUal7N1/Omzf9UtQraWZzkKUIACFKAABYIKMGAS1IQpFIgyAa6YAhRwbOY1060AABAASURBVAG5PUQ6eT1w5C8ULRQQGMmdMytix46FuYvXqKBBofy5DAgF8+WAXIly+twlQ5qMSL8m8h7WIWumdEidMjnOXfzb0DeJ9E+iH3Jkz2xYRby4sfH27XvDdFhGdu87qm4F+jJrJrUYnU6HAnlz4NDRU2pa/3Ln7gPcuBXybSnZsmRQRcxdERMvbhyUK1UEW3f9qQ1/qD5NalT6fDuOFJR+TmLHji2jhmHX7v2GcVtGwnuZ8ULwv3XnHjKHsl8ZW9rDMhSgAAUoQAFnFGDAxBm3euS1mWuiAAUoQAEjgSIFc0M6HZXOXKUTWJklTzcpmDcnjpw4gzy5sqmrISRdBgmwFCmQG4NHTcGJ0+chV1ssXbURW3bsldlhHqSzULkFRTp37dLfG2s3bMfBoyfx8+Zd6DN0nHrXryRzxrQ4c/4yJNhx6NgpXLl2Uz8r2Peh3lMwceZi/HHwOH7/8wjkVpURY6YjRfKkaNawhqFsh1YNIMudMmcZnj57gfNaEKevx3i4aMEUQyYLIym1ZUlfJ5euXDebo0blMrh99z7mL10HuR0oXZrUgfIV14JXG375DfcfPFL9m6xc9wvWbdoVKI+1E+G9zOD8nzx9hgcPH2tBr4AgnLV1ZX4KUIACFKAABcwLMGBi3sVCKpMpQAEKUIACtgtkzZRePW1GllBM+5Eu7zIU1QIp8l6kwOerS2RahnFefZE/d3YM8JyAqg07q1tK5Ek3Mi88hlLFC2LupOHAR2D+knXoPWQclq3ehCyZ0qGI0e1B7VvUV522Tpi+CL0Gj8XC5T+FavXZs2bCr3sOafX3h6fvNOw7dBzVK5XBwumjIB2b6hciwaFxXv1w4MhJ1GzaDd3cfVC7ajnk09quzxPcuyzzoFbWXJ4SRfMjccIEePzkGap9XSpIFvee7ZAjW2Y07zQYVRp0Ulei+I/sFySfNQnhvczg/Pcd+gtx48RWV9JYU0fmpQAFKEABClAgOAGAAZPgfTiXAhSgAAUoYLVAsUJ5sW/rMhjf0qJfyPZ1c9U8+YGrT2vRuJZK69SmsT7J8B4vbhzII2/15WZP9IRcMSHLl8fNGjIGMyLLkPyN6lY1mytPzmyQ5W5ZPUvVY/XCCZB+TeSqDX0B6SfEo38n/Lx8qsrjPTSgU1T9fEvv7Zp/gw0rpqsyuzcuwqrvJ0ACPuY6rpVH8f5v7jj8sWUJdv40H+Iy3W8oJvm4W1q8Ib1+rYr4584DmN6+JBlcXVygb1uDOpUlKdCQPFkS1cmr3njhdG8VLBKzmlXKGfL26dIKm3+YaZg2HpE6t25ax5AU2mUunumjtq+h4KcRWU/Pjs0/TQHB+csVR/KkI+mrxVCAIxSgAAUoQAFTAU5bLcCAidVkLEABClCAAhSggL0JSAe59WtXDPWVL/ZWf1vrc/HKNZw4dR4ttaCbrctgOQpQgALRVYD1pkBECzBgEtHCXD4FKEABClCAApEi0Obbb/Bltox4/eZNpKzPHlZy++5DeLp3RuJECe2hOqwDBSgQNgGWpgAF7EyAARM72yCsDgUoQAEKUMAagRFjZ6J87XYWB5lvzfJCm/fq9X8srlNfH8kT2uWFR74kiRNCbmuKFTNmeCwuWixDbmOqXL5ktKgrK+mMAmwzBShAgegtwIBJ9N5+rD0FKEABCji5QM9OzbF09hiLg8yPCKJMGdJYXKe+PpInItbNZVIgygS4YgpQgAIUcCoBBkycanOzsRSgAAUo4GgCyZMmRoZ0qS0OMj+i2hzcemVeRK2Xyw0/AS6JAhSgAAUoQAHLAgyYWLbhHApQgAIUoAAFopcAa0sBClCAAhSgAAXCTYABkzBSxogRE/Y46HQu+PDhg13WzR69jOv05s0butnwuX7//gN02ufO2JLjIf99EDPuqyE7mfssOce+apuNOS99GvdV20y5r9rmJp877qu22XFftc2N+6ptbtxXbXez9301jD93nb44AyZO/xEgAAUoQIFIFOCqKEABClCAAhSgAAUoEE0EGDCJJhuK1aQABexTgLWiAAUoQAEKUIACFKAABRxTgAETx9yubBUFbBVgOQpQgAIUoAAFKEABClCAAhTQBBgw0RD435EF2DYKUIACFKAABShAAQpQgAIUoID1AgyYWG8WtSW4dgpQgAIUoAAFKEABClCAAhSgAAUiXCDKAyYR3kKugAIUoAAFKEABClCAAhSgAAUoQIEoF4huFWDAJLptMdaXAhSgAAUoQAEKUIACFKAABexBgHVwcAEGTBx8A7N5FKAABShAAQpQgAIUoAAFQifAXBSggLEAAybGGhynAAUoQAEKUIACFKAABRxHgC2hAAUoEAYBBkzCgMeiFKAABShAAQpQgAIUiEwBrosCFKAABSJPgAGTCLR+/fQaTv9QO0qG82vr4dJPjaJk3dLme6eWR6AsF00BClCAAhSggIMIsBkUoAAFKEABuxVgwMRuNw0rRgEKUIACFKBA9BNgjSlAAQpQgAIUcBQBBkwcZUuyHRSgAAUoQIGIEOAyKUABClCAAhSggJMKMGDipBuezaYABSjgrAJsNwUoQAEKUIACFKAABUIjwIBJaJSYhwIUoID9CrBmFKAABShAAQpQgAIUoEAECDBgEgGoXCQFKBAWAZalAAUoQAEKUIACFKAABSgQ9QIMmET9NmANHF2A7aMABShAAQpQgAIUoAAFKECBaCfAgEm022RRX2HWgAIUoAAFKEABClCAAhSggL0I+IyfjnipckXJkCxjISRKmy9K1i1tPnPuor1sBoesBwMmgENuWDaKAhSgAAUoQAEKUIACFKAABShAgUACVk0wYGIVFzNTgAIUoAAFKEABClCAAhSgAAXsRYD1iEgBBkwiUpfLpgAFKEABClCAAhSgAAUoQIHQCzAnBexIgAETO9oYrAoFKEABClCAAhSgAAUo4FgCbA0FKBB9BRgwib7bjjWnAAUoQAEKUIACFKBAZAtwfRSgAAWcRoABE6fZ1GwoBShAAQpQgAIUoEBQAaZQgAIUoAAFzAswYGLehakUoAAFKEABClAgegqw1hSgAAUoQAEKhIsAAybhwsiFUIACFKAABSgQUQJcLgUoQAEKUIACFIgKAQZMokKd66QABShAAWcWYNspQAEKUIACFKAABaKBAAMm0WAjsYoUoAAF7FuAtaMABShAAQpQgAIUoIDjCTBg4njblC2iAAXCKsDyFKAABShAAQpQgAIUoIDTCzBg4vQfAQI4gwDbSAEKUIACFKAABShAAQpQgALWCTBgYp0Xc9uHAGtBAQpQgAIUoAAFKEABClCAAhSIUAEGTCKUN7QLZz4KUIACFKAABShAAQpQgAIUoAAF7EkgYgIm9tRC1iVaChQtVwfxUuWKkiFllmJRsl5pb7HydaPl9mKlKUABClCAAhSgAAUoQAEnFXDgZjNg4sAbl02jAAUoQAEKUIACFKAABShAAesEmJsCegEGTPQSfKcABShAAQpQgAIUoAAFKOB4AmwRBShgowADJjbCsRgFKEABClCAAhSgAAUoEBUCXCcFKECByBFgwCRynLkWClCAAhSgAAUoQAEKmBdgKgUoQAEK2KUAAyZ2uVlYKQpQgAIUoAAFKBB9BVhzClCAAhSggCMIMGDiCFuRbaAABShAAQpQICIFuGwKUIACFKAABZxQgAETJ9zobDIFKEABCji7ANtPAQpQgAIUoAAFKBCSAAMmIQlxPgUoQAEK2L8Aa0gBClCAAhSgAAUoQIFwFmDAJJxBuTgKUIAC4SHAZVCAAhSgAAUoQAEKUIACUSvAgEnU+nPtFHAWAbaTAhSgAAUoQAEKUIACFKBAtBJgwCRabS5W1n4EWBMKUIACFKAABShAAQpQgAIUcGQBBkwceeta0zbmpQAFKEABClCAAhSgAAUoQAEKUMAg4LABE0MLOUIBClCAAhSgAAUoQAEKUIACFKCAwwpEVMMYMIkoWS6XAhSgAAUoQAEKUIACFKAABShgvQBL2IkAAyZ2siFYDQpQgAIUoAAFKEABClCAAo4pwFZRIHoKMGASPbcba00BClCAAhSgAAUoQAEKRJUA10sBCjiFgEMFTB48fIweA33RvudwDPWegpevXpndiCdOnUfbHp5o1XUo5i9da8jz0+ZdaPadO76q1hKPnzwzpF+6cl2lSboMfYeNN8zjCAUoQAEKUIACFKAABaK7AOtPAQpQgAJBBRwqYDJlznKULFoA308bhYQJE2D56s1BWvzx40cMHzMDA3u2xcLp3ti15yCO/XVW5UuVIhlGDe2B5MmSqGnjlyIFcmPf1mVqmOTjbjyL4xSgAAUoQAEKUIAC9iXA2lCAAhSgAAXCLOBQAZM/DhxHraplFUqtKmWx98AxNW78cv7SVcSNGwe5c2SFm6srqn5dCnv2H1VZvipWANmzZFTjfKEABShAAQpQgAL2I8CaUIACFKAABSgQ2QIOEzD597+X0OmAJIkTKsP0aVPh/oNHatz45e79R0ibOoUhSfLdvffQMG1p5PT5yyhTozW+6+2Fv05fMGR7+/YNLA3v3r015HO2kQ8f3lt0seRlnC5XAjmbmbRX2m3sEJ3G379/B/nMR6c620Ndxezdu3dh2l/soR1RUYf378P2dyYq6mwP63xvL/tqMN+f9uBkWgfuq5aPd0ytTKffc1+16W/8e+6rNrlxX3XOfVV+e8ixtDMO8pk3/btrPO2MJuHZZocJmAiKi8vn5uh0n8dlnvGgc9EiK4YEy/n0WdJ8kRLrl0/FltWzULFcCQwYPgH/vTTfP4q+DN8pQAEKUMC5BNhaClCAAhSgAAUoQAHHEgg5WhBF7f3nzj0sWPYjRo2fjV6Dx2LwyEnwn74Yv+zci3famQrTasWLGwfv33/Am7cBV3U8fPwEKZInNc2GVCmS4vGT54b0R1q+VCmTGabNjcSNExsJ4sdTQ/OGNZA6ZXLcuHVHZY0RIyYsDW5uMVQeZ3xxcXG16GLJyzhdp9M5Ixt0Ol2Y3IwNI3vc1dUN8pmP7PVG9/WJmZubmz1ud7uvk6urq93X0R4/n9xXLX9vB7e93LTvdDfuqzbtc9xXbfvMcV+1zc2N+6pN+6n8/YvO+6r89nDKHw9ao+UzL9vP0qBl4f8wCNhlwGTSrCXoPWQc3r57iwJ5vsS3DaqjUvmSkCs99uw7itZdh+LshStBml2qeEHs+G2fSt/2658oU6KgGpfbdU6dvajGc2TLBHmajgQ83n/4gJ2/H0CZkoXVPEsvL/79zzBLnpjz+OkzpE+b2pDGEQpQIDoIsI4UoAAFKEABClCAAhSgAAVCL2CXAZNUKZLjhwXj0aVtE3xTsyIkEFKlwleQqzt8PHrB17MP7pjpd6RPlxbYsHW3eqzw9Ru30aJxLSVx89YdePvPUeM6nQ4jB3eDp+90tO3ugSKFcqNw/lxq3qzvf1CPD5aASs2m3TBguL9K37x9j0ovW6stJsxcAl+tDnLViZrJFwq2cxOOAAAQAElEQVRElQDXSwEKUIACFKAABShAAQpQgAIRJuASYUsOw4KbN6oJF6P+SEwXlSn9F/i6TDHTZPU44Fn+HpDHCvt69kac2LFVnhzZM2sBmIDghyQUyJsDi2aMxtJZvujYqqEkqaFr+6bqscH6xwf7jxqg0pvUq6bS92xaBFl+vtzZVTpfwleAS6MABShAAQpQgAIUoAAFKEABCtiLgF0GTPQ48uSI/YdP4PtlP2Lu4tWGQT/fzt9ZPQpQgAIUoAAFKEABClCAAhSgAAWiqYAVAZPIb+Gw0VOxdsMOvH77JvJXzjVSgAIUoAAFKEABClCAAhSgAAWcUoCNFgG7Dpi8ev0W40f2R9d2TdGpTWPDIBXnQAEKUIACFKAABShAAQpQgAIUCJUAM1HABgG7DpjEjOmGt2/f2dAsFqGAcwpcu34Lu/84GCXD3n2HsefPQ1Gybmnzv/99fpqVc259tpoCFKAABShAAWcSYFspQIGIF7DrgMmbN+/QpMMATJq1xNB/ifRlEvEsXAMFoqfAsh9+RI0GbaJk+ObbjqjduH2UrFvaLMGi6LnVWGsKUIACFKAABQAQgQIUoIDdCdh1wCRPziyoUak04sWNY3dwrBAFKEABClCAAhSgAAUsC3AOBShAAQpEdwG7DpgY91tiPB7d0Vl/ClCAAhSgAAUoEO0EWGEKUIACFKCAkwnYdcDk8ZNnWL56E+RpOTL8b+0WSJqTbSM2lwIUoAAFKECBCBDgIilAAQpQgAIUoEBwAnYdMBkxdiZ+++MwChfIpYZduw9gpN/s4NrDeRSgAAUoQAFnFWC7KUABClCAAhSgAAXCUcCuAyZ37t3H7ImeaFinihpmT/DAzX/uhGPzuSgKUIACFLBfAdaMAhSgAAUoQAEKUIACUSdg1wETF5eg1XNx0UWdFtdMAQo4pMC9+w/hM356xA9m1jFmwkyMmzQ7StYtbd79x8EwbdO5C/8XZXUfP2VulK1b2h0WOHEX/6gY5PMmn7uoWLes8/6DRzbTcV+1mQ7ymRX/qBi4r9r2/cJ91TY3+fsmdlHxWZd1yt932/dUoGi5OoiXKleUDCmzFIuS9Up7i5WvGxY2lqVAhAkEjUhE2KqsX3DBfLnQbcBowyOFuw7wQbFC+axfEEtQgAIRIuAoC5UfcL7+MxAVw9iJs7SAyZwoWbe0d8+fYQ2YrIiyuo+fMi/K1j1v0cowffzFXfyjYvCbPAfyuYuKdcs67z94aLMd91Wb6bSACfdVW/S4r9qiBnBftc2NpShAAfsTsOuAycCebVGnWnlcu3FbDfVqfo3+3VvbnyJr5CgCbAcFKEABClCAAhSgAAUoQAEKUEAJ2HXARG7Jqa0FTHw8ekGGWlXLQdJUzfkSCgFmoQAFKEABClCAAhSgAAUoQAEKUMAWAbsMmHTp743LV29A3gMNWrpM29JQlqEABShAAQpQgAIUoAAFKEABClAgmgjYQTXtMmDSoWV9pEqRDPJubrADN1aBAhSgAAUoQAEKUIACFKAABSgQagFmjH4CdhkwKVYoL+LHi4vbdx9Axo2Hazf+iX7KrDEFKEABClCAAhSgAAUoQAHHEmBrKODwAnYZMNGrb96+Rz9qeP9p06+GcY5QgAIUoAAFKEABClCAAhQIHwEuhQIUoEBgAbsMmBw6dgpzF6/G3XsP1buMyzB59tLAtecUBShAAQpQgAIUoAAFKGBegKkUoAAFKBAmAbsMmFhqUdbM6THTf5il2UynAAUoQAEKUIACFHBgATaNAhSgAAUoEJkCdhkwkT5LOrVpjLHDe0Pe9UOdahWQMEH8yPThuihAAQpQgAIUoEBECXC5FKAABShAAQrYsYBdBkz0XjmyZ8bpc5exeMX6QLfm6OfznQIUoAAFKEABexJgXShAAQpQgAIUoIDjCNh1wOT75T/Bb+r3+GnzLjx89FR7/xU3bt11HH22hAIUoAAF7FuAtaMABShAAQpQgAIUcFoBuw6Y/LJzDxZMHYlUKZJhSN/vsG7JZLx6/dppNxYbTgEKUCCsAixPAQpQgAIUoAAFKEABCoROwK4DJnHjxoWbmxvevH2L9x8+IHasmHDR6ULXMuaiAAWcQYBtpAAFKEABClCAAhSgAAUoECECdh0wiRcnNt6+fYfMGdNhtP9cTJu7HK/fvIsQCC6UAvYhwFpQgAIUoAAFKEABClCAAhSggD0I2HXApH/3turqkr5dWyJ9mlSIFSsmhvX7zh7cWIfQCjAfBShAAQpQgAIUoAAFKEABClAgGgrYdcAkS6a0iBc3DuLHi4v2LeurRwynSJ40Spm5cgpQgAIUoAAFKEABClCAAhSgAAUcX8AuAyZd+nsjuMHxNwtbSAEKUIACFKAABShAAQpQgAIUCFcBLsxKAbsMmHRoWR8yZEj7Bd69e4cKpYuhZpWyiB0rFpInTWJlE5mdAhSgAAUoQAEKUIACFKAABRxPgC2iQMQK2GXApFihvJDh/KW/MWfSCHzboDrqVq+Ayb4D8er1q4gV4dIpQAEKUIACFKAABShAAQpEhQDXSQEK2JWAXQZM9EKvXr/Wjxre3/ApOQYLjlCAAhSgAAUoQAEKUMCeBVg3ClCAAtFZwK4DJsUL50fX/t5Ys34btuzYiwHD/ZE5Y9ro7M26U4ACFKAABShAAQpEXwHWnAIUoAAFnEjArgMm/bq1Qr1aFXHsr3PYu/8oKpcviT5dWoL/KEABClCAAhSgAAXCQ4DLoAAFKEABClDAkoBdB0x0Oh1qVi4LH49eaqheqQx0Op2ltjCdAhSgAAUoQAFnF2D7KUABClCAAhSgQDgJ2GXARB4pfPnqDYuPFg6ntnMxFKAABShAAbsXYAUpQAEKUIACFKAABaJGwC4DJvJI4VQpkqlHC8u46RA1VFwrBShAAQqEgwAXQQEKUIACFKAABShAgWghYJcBE3mkcPx4cdWjhWXcdIgWsqwkBSjgJAJsJgUoQAEKUIACFKAABSjgiAJ2GTCZPn8FghsccUOwTRSwGwFWhAIUoAAFKEABClCAAhSgAAVglwETubokuIHbjQLWCDAvBShAAQpQgAIUoAAFKEABClDAWgG7DJi0bfYNghusbaSD5WdzKEABClCAAhSgAAUoQAEKUIACFIhgATsImFhu4es3b7B4xXr0GTou0BNzLJfgHApQgAIUoAAFKEABClCAAhSgAAXsUyB61cquAyaj/Gbj/sPHePDwCerXqoj4ceMgZ/ZM0UuYtaUABShAAQpQgAIUoAAFKEABxxRgqxxawK4DJleu3sCAHm0QL14cVKtYGv7eA3Dzn7sOvUHYOApQgAIUoAAFKEABClCAAlElwPVSgAKfBew6YBIvXlxV03fv3uO/l6/U+Nu379U7XyhAAQpQgAIUoAAFKEABCoQgwNkUoAAFbBaw64BJ/Hjx8OTZc5QuXhDtenhogydSp0wGW/6t+mkrWnYZgtZdh2H3vqNmF/Hg4WP0GOiL9j2HY6j3FLx8FRCkefzkGQZ4+uPrbzrAb+pCs2WZSAEKUIACFKAABShAgYgX4BooQAEKUCCyBOw6YDLZdyASJ0yA9i3rY2jfjujWoSkG9m5vtc21G7exZOUGzJk4HH5efeEzYS5evX4TZDlT5ixHyaIF8P20UUiorXf56s2GPDWrlkPHVg0N0xyhAAUoQAEKUIACFAgHAS6CAhSgAAUoYKcCdh0w2fH7frx7H3ALToG8OVCsUF64ulhf5b37j6J86aKIFzcOUqdKjpzZM+PQ0VMw/ffHgeOoVbWsSq5VpSz2HjimxpMkToiKZYsjTpxYapovFKAABShAAQpQwJIA0ylAAQpQgAIUcAwB66MPkdjuX3buRe1vu2PSrCW4cu2mzWu+//AR0qROYSifLk0q3Hvw0DAtI//+9xI6HSDBEZlOnzYV7j94JKMcKEABClCAAs4swLZTgAIUoAAFKEABpxSw64CJ/6gBWDzTB/HjxUW/YePRqutQrP55m00bSmd0ZYpOp0VGzCzFJVCe0NG8evUKlobXr1+bWYtzJL17986iiyUv4/SPHz86B5RJK6Xdr1+/gq3D+/fvTJboPJNv3ry22U3KOo9U4JYG7Ksvtf3VtkE+s4GXGB2mwl5Habet+6mU475q2985Z95X5TMjnx1bB/nMhv2TH/2WIO1+9cq2v29STv5GRr9Wh0+N5bMmBrYMUjZ8ahH9lsJ91bZtFrCvvtKOR2wbnHtffR2sm21bhKX0AqGLCuhzR8F7qhTJ0LF1I6xZPBH5cmXHxJlLrK5FimRJ8eTJU0O5R4+fIGXywJ3Hyu06799/wJu3b1W+h1qeFMmTqvHgXmLEcIOlwc3NNbiiDj3P1dXFooslL+N0nc58UAsO/k+n08HV1Q2uNg46nQuc9Z+LiytcbXSTstHaLQyVd3V10fbVGDYPOh33VVs+d9xXbfs75+LivN+r8pmx5bOmL6PTOe++GiOG7X/jXF1d4Kz/3NzkGNc2OynrrG7cV23b8jqdTjsWkc+cbYNz76uuwdrZtkVYSi9g998C8uSaeUvXomHrvjh28ix6dWqhr3uo38uULIw9+4/i9Zs3ePT4Kc6cv4ISRfOp8sf+Oou3bwPOypcqXhA7ftun0rf9+ifKlCioxoN70R+IWHoPrqwjzwvrl4Uj24TUNjnIsHVwMbpKKqT12PN8W+pmq5m+nC3rdIQy3Fdt34r6z44t79xX3WCLm5SxfYtF75LymZH22zpE79aHrfaWjtFCky5/I8O29uhbOjQ+weWJvi0PW825r9ruF9znKaR53Fctn4iwfYuwpAjYdcBkwHB/9SjgFy/+xQTvAVgxzw/NGtaQels1ZEz/BerXqoQOvUagz1A/9O3WGjG1sw2ykIFek/D02XMZRZ8uLbBh6271WOHrN26jReNaKv3d+/f4qlpL9UjhHzftVOPnL/6t5vGFAqEQYBYKUIACFKAABShAAQpQgAIUiGYCLvZc3xqVy2Hjyhno27U1smXJEKaqNqlXDctmj8GSWT4oX6qIYVnb181F8mRJ1LS8z/L3UI8V9vXsjTixY6t0N1dX7Nu6LNCQI3tmNc85X9hqClCAAhSgAAUoQAEKUIACFKCAYwvYZcDk7IUrSr1SueKQYIWaMHqR23TOnL9slBLGURanAAUoQAEKUIACFKAABShAAQpQwPEFrGihXQZMxk1dCO/xc3DUqH8RadPtu/exYNmPaNLeHTIuaRwoQAEKUIACFKAABShAAQpQgALOKsB2R5yAXQZMvp86EoUL5MK8JWtRsd53qs8Q6UOka//RuHvvIRbNGI1K5UpGnAqXTAEKUIACFKAABShAAQpQgAJRIcB1UsBuBOwyYCK9S9eqWg7Sn8ieTYsMfYf8tGwKhvb7DhnSpbYbQFaEAhSgAAUoQAEKUIACFKCAZQHOoQAFoquAXQZMoism600BClCAAhSgAAUoQAGHF2ADKUABCjiJAAMmTrKh2UwKUIACFKAASBk9VQAAEABJREFUBShAAfMCTKUABShAAQqYE2DAxJwK0yhAAQpQgAIUoED0FWDNKUABClCAAhQIBwEGTMIBkYugAAUoQAEKUCAiBbhsClCAAhSgAAUoEPkCdhkw8Z++GP9bszmIxtJVGzFzwcog6UygAAUoQAEKRCsBVpYCFKAABShAAQpQwO4F7DJg8ufB42hSr2oQvGYNqmPPviNB0plAAQpQgAJRK8C1U4ACFKAABShAAQpQwNEE7DJg4urqAjc3N5j+k7TXb96ZJnOaAhSgQHgLcHkUoAAFKEABClCAAhSggJML2GXAJFbMmHj56lWQTfPi3/8QJ3asIOlMoAAFQhLgfApQgAIUoAAFKEABClCAAhSwRsAuAyb1an2NIaOm4v6DR4a23L3/EB4+01CvVkVDGkecWIBNpwAFKEABClCAAhSgAAUoQAEKRKCAXQZMGtWtitw5MqNR2/5o3mkQmrTvj6bt3bW0LGhUt0oEckTdorlmClCAAhSgAAUoQAEKUIACFKAABexHIKICJmFuYac2jbFx5XQ0a1gD7ZrXV+OSptPpwrxsLoACFKAABShAAQpQgAIUoAAFKECBcBFw2IXYbcBExBPEj4c61SqgRuUyiB8vriRxoAAFKEABClCAAhSgAAUoQAEKRKAAF02BAAG7DJhUb9wFwQ0BVecrBShAAQpQgAIUoAAFKEABCoQowAwUoIBNAnYZMJnhNwzBDTa1lIUoQAEKUIACFKAABShAAYcQYCMoQAEKRIaAXQZMsmZOj+CGyIDhOihAAQpQgAIUoAAFKBBJAlwNBShAAQrYoYBdBkzs0IlVogAFKEABClCAAhQItQAzUoACFKAABaK/AAMm0X8bsgUUoAAFKEABCkS0AJdPAQpQgAIUoIDTCTBg4nSbnA2mAAUoQAEKADSgAAUoQAEKUIACFAhewO4DJq9ev8GJU+dx6NgpwxB8kziXAhSgAAWcUIBNpgAFKEABClCAAhSgQLgK2HXA5PtlP6J+qz6YsWAlFmjj+iFcBbgwClCAAnYpwEpRgAIUoAAFKEABClCAAlEpYNcBk32H/8LmH2Zg7qQRmD3B0zBEJRjXTQEK2CjAYhSgAAUoQAEKUIACFKAABaKRgF0HTJIkTgCdTheNOFlVZxJgWylAAQpQgAIUoAAFKEABClDAcQXsOmASO1YsePhMx297Dxv6L5G+TBx3c0Rpy7hyClCAAhSgAAUoQAEKUIACFKAABT4J2HXA5N6DR3jw6DFW/rjFhj5MPrWQbxSgAAUoQAEKUIACFKAABShAAQo4sEDENM2uAybG/ZYYj0cMBZdKAQpQgAIUoAAFKEABClCAAhSwAwFWwS4E7DpgIkJv377DqbMXeUuOYHCgAAUoQAEKUIACFKAABSgQDQVYZQpERwG7Dpjs3X8MDVr3QZ+hfhg/bSF6DR6L6fNWREdn1pkCFKAABShAAQpQgAIUcBwBtoQCFHACAbsOmMxYsBLzpnghW5YMWPX9BCyc7q2NZ3SCzcImUoACFKAABShAAQpQIDIFuC4KUIACFDAVsOuAiZubK1KnTA65LUcqnjN7Zvz38j8Z5UABClCAAhSgAAUoQAHLApxDAQpQgAIUCKOAXQdM4saJrZqXOFF8/Lx5F+QWncdPnqs0vlCAAhSgAAUoQAFnEmBbKUABClCAAhSIXAG7Dpg0/qYqnjx7jm4dvsWO3w9g2eqN6NymUeQKcW0UoAAFKEABCkSEAJdJAQpQgAIUoAAF7FrArgMmlcuXROKECZA1U3pMGzcE8mjhQvlz2TUoK0cBClCAAs4qwHZTgAIUoAAFKEABCjiSgF0HTG7+c0c9Gadxu/7K/PzFvzF70So1zhcKUIACFIhgAS6eAhSgAAUoQAEKUIACTixg1wGTkX5zULNKGSRLklhtoi+zZcLefcfUOF8oQAEKWCvA/BSgAAUoQAEKUIACFKAABUIrYNcBkzdv3qB6pTKADuqfTqfDh48f1DhfKEABkIACFKAABShAAQpQgAIUoAAFIkjArgMmHz8C7969MzT9wcPHiOHmZpjmiKMJsD0UoAAFKEABClCAAhSgAAUoQAH7ELDrgEnT+tUwfMwM3L33EHMWrUbHviPRumld+5ALTS2YhwIUoAAFKEABClCAAhSgAAUoQIFoKWBVwCSyW1irajn06NgMFcsWw7Pn/2KK72BUKl8isqvB9VGAAhSgAAUoQAEKUIACFKAABZxKgI0F7DpgIhsoTeqU6NmpBdx7tkWGdKkliQMFKEABClCAAhSgAAUoQAEKUMAaAealgNUCdhkw6dLfG8ENVreSBShAAQpQgAIUoAAFKEABCjiUABtDAQpEtIBdBkxOnDqPF//+h/y5s6Nw/pxBhohG4fIpQAEKUIACFKAABShAgUgW4OooQAEK2JmAXQZMls7yRdGCubFn/zE8efoCXxUriE5tGhsGOzNkdShAAQpQgAIUoAAFKBBEgAkUoAAFKBC9BewyYJItSwb06dIKy+eMQaniBbHyx1/QrONA7Dt0IljtBw8fo8dAX7TvORxDvafg5atXZvPLFSxte3iiVdehmL90rSGPpfKXrlzHV9VaGoa+w8YbynCEAhSgAAUoQAEKOIkAm0kBClCAAhRwKgG7DJiYbgEXnQ7v3r3Hh48fTWcFmp4yZzlKFi2A76eNQsKECbB89eZA82Xio7aM4WNmYGDPtlg43Ru79hzEsb/OyiwEV75IgdzYt3WZGib5uKv8fKEABShAAQpQIDoLsO4UoAAFKEABClDAsoBdBkzkio7Js5fimxa9sGb9NlQqVxI/LBiP0sULWm6JNuePA8dRq2pZbQyoVaUs9h44psaNX85fuoq4ceMgd46scHN1RdWvS2HP/qMqS2jKq4x8oQAFKEABCtijAOtEAQpQgAIUoAAFKBBuAnYZMJFbZf46fREd2zRCi8a1EC9ebBw5cQaHjp1Sg7nW//vfS+h0QJLECdXs9GlT4f6DR2rc+OXu/UdImzqFIUny3b33ECGVP33+MsrUaI3venvhr9MXDOU5QgEKUIACESfAJVOAAhSgAAUoQAEKUCCqBOwyYFIgbw7EjBkDm7fvwYJlPwYZLGG5uHxujk73edw0v85Fi6wYEj/ns1Q+zRcpsX75VGxZPQsVy5XAgOET8N/LgP5R/vvvP1gaXr58aViLs428ffvWooslL+N0uXXK2cykvdJuYwdrx8VdluOMg+xv1nrp80vZSDKzu9XIZ0bvYMu7fGbtrlGRUCFpty1e+jLiHgnVtMtVyP6md7D2XcraZaMioVLymbHWyzi/fGYjoZp2twppt7GDtePibneNiqQKyf5mrZc+v5SNpGra3WrkM6N3sOVdPrN216hIqJC02xYvfRlxj4Rq2uUqZH/TO5h7t8tKR6NKfY4W2FGlZ0/wRHCDuarGixsH799/wBvth7rMf/j4CVIkTyqjgYZUKZLi8ZPnhrRHWr5UKZMhuPJx48RGgvjx1NC8YQ2kTpkcN27dUcuIHTs2LA2xYsVSeZzxxc3NzaKLJS/jdJ3OOKgFp/mn0+nC5CbukYtlP2uT/c34M2TNuJS1n5ZEbk3kM2ONlWlenY77qqlJaKbFPXK3tP2sTfa30BiZyyNl7aclkVsT+cyYMwltmk7HfTW0Vsb5xD1yt7T9rE32N2MLa8alrP20JHJrIp8Za6xM8+p03FdNTUIzLe6Ru6XtZ22yvwVnZD81jZ41scuAia2U8kSdHb/tU8W3/fonypQI6PNEbrc5dfaiSs+RLRPkaTgS8Hj/4QN2/n4AZUoWVvMslX/x739qvrxI/yqPnz5D+rSpZRJyVUpwg8rkhC86nS5EG7t0Q9T/C84lpHk6nXN+ycpWC8kmpPmyDGccdDod91XY9i+kz1Rw83U67qvB+QQ3z7atFf1L6XQ67quw7V9wn6eQ5ul03FdDMrI037atFf1L6XQ67quw7Z+lz1Jo0nU67quWnGzbGiylF3CogEmfLi2wYetu9Vjh6zduq/5PpKE3b92Bt/8cGYVOp8PIwd3g6Tsdbbt7oEih3CicP5eaZ6n85u171COFy9Zqiwkzl8DXoxfkqhNVyM5fWD0KUIACFKAABShAAQpQgAIUoAAFrBdwsb5IlJYIduXJkyXBLH8PfD9tFHw9eyNO7Ngqf47smfHDAn81Li/SR8qiGaOxdJYvOrZqKElqsFS+Sb1q2Ld1GfZsWqSWny93dpWfLxSgAAUoQAEKUIACFKAABShAAQpEiECUL9ShAiZRrskKUIACFKAABShAAQpQgAIUoAAFzAowMboJMGAS3bYY60sBClCAAhSgAAUoQAEKUMAeBFgHCji4AAMmDr6B2TwKUIACFKAABShAAQpQIHQCzEUBClDAWIABE2MNjlOAAhSgAAUoQAEKUMBxBNgSClCAAhQIgwADJmHAY1EKUIACFKAABShAgcgU4LooQAEKUIACkSfAgEnkWXNNFKAABShAAQpQILAApyhAAQpQgAIUsFsBBkzsdtOwYhSgAAUoQIHoJ8AaU4ACFKAABShAAUcRYMDEUbYk20EBClCAAhEhwGVSgAIUoAAFKEABCjipAAMmTrrh2WwKUMBZBdhuClCAAhSgAAUoQAEKUCA0AgyYhEaJeShAAfsVYM0oQAEKUIACFKAABShAAQpEgAADJhGAykVSICwCLEsBClCAAhSgAAUoQAEKUIACUS/AgEnUbwNHrwHbRwEKUIACFKAABShAAQpQgAIUiHYCDJhYvclYgAIUoAAFKEABClCAAhSgAAUoQAFHF3CBo7eQ7aMABShAAQpQgAIUoAAFKEABClAAoIFVArzCxCouZqYABShAAQpQgAIUoAAFKEABexFgPSgQkQIMmESkLpdNAQpQgAIUoAAFKEABClAg9ALMSQEK2JEAAyZ2tDFYFQpQgAIUoAAFKEABCjiWAFtDAQpQIPoKMGASfbcda04BClCAAhSgAAUoENkCXB8FKEABCjiNAAMmTrOp2VAKUIACFKAABSgQVIApFKAABShAAQqYF2DAxLwLUylAAQpQgAIUiJ4CrDUFKEABClCAAhQIFwEGTMKFkQuhAAUoQAEKRJQAl0sBClCAAhSgAAUoEBUCDJhEhTrXSQEKUMCZBdh2ClCAAhSgAAUoQAEKRAMBBkyiwUZiFSlAAfsWYO0oQAEKUIACFKAABShAAccTYMDE8bYpW0SBsAqwPAUoQAEKUIACFKAABShAAacXYMDE6T8CzgDANlKAAhSgAAUoQAEKUIACFKAABawTYMDEOi/7yM1aUIACFKAABShAAQpQgAIUoAAFKBChAnYRMInQFnLhFKAABShAAQpQgAIUoAAFKEABCtiFQHSqBAMm0Wlrsa4UoAAFKEABClCAAhSgAAUoYE8CrIsDCzBg4sAbl02jAAUoQAEKUIACFKAABShgnQBzU4ACegEGTPQSfKcABShAAQpQgAIUoAAFHE+ALaIABShgowADJrz22oIAABAASURBVDbCsRgFKEABClCAAhSgAAWiQoDrpAAFKECByBFgwCRynLkWClCAAhSgAAUoQAHzAkylAAUoQAEK2KUAAyZ2uVlYKQpQgAIUoAAFoq8Aa04BClCAAhSggCMIMGDiCFuRbaAABShAAQpEpACXTQEKUIACFKAABZxQgAETJ9zobDIFKEABZxdg+ylAAQpQgAIUoAAFKBCSAAMmIQlxPgUoQAH7F2ANKUABClCAAhSgAAUoQIFwFmDAJJxBuTgKUCA8BLgMClCAAhSgAAUoQAEKUIACUSvAgEnU+nPtziLAdlKAAhSgAAUoQAEKUIACFKBAtBJgwCRabS77qSxrQgEKUIACFKAABShAAQpQgAIUcGQBBkwCti5fKUABClCAAhSgAAUoQAEKUIACFHB8gVC3kAGTUFMxIwUoQAEKUIACFKAABShAAQpQwN4EWJ+IEmDAJKJkuVwKUIACFKAABShAAQpQgAIUsF6AJShgJwIMmNjJhmA1KEABClCAAhSgAAUoQAHHFGCrKECB6CnAgEn03G6sNQUoQAEKUIACFKAABaJKgOulAAUo4BQCDJg4xWZmIylAAQpQgAIUoAAFLAtwDgUoQAEKUCCoAAMmQU2YQgEKUIACFKAABaK3AGtPAQpQgAIUoECYBRgwCSXhqp+2omWXIWjddRh27zsaylLMRgEKUIACFKBAeAhwGRSgAAUoQAEKUCCyBRgwCYX4tRu3sWTlBsyZOBx+Xn3hM2EuXr1+E4qSzEIBClCAAhQwK8BEClCAAhSgAAUoQAE7F2DAJBQbaO/+oyhfuijixY2D1KmSI2f2zDh09BT4jwIUoAAF9AJ8pwAFKEABClCAAhSggGMJMGASiu15/+EjpEmdwpAzXZpUuPfgoWGaIxSggAMKsEkUoAAFKEABClCAAhSggFMLMGASys2vc/lMpdPpDKWKVmwCS0Pp+u5oMycufjn6LsRB8oU0RKfljPBbgipVqli0MTaTfKbDq+f3kT5VQsOQK08+hDQY57c0HtIyZL6lssbpki+kwTi/pXHTZXx0jR3EzNTG3LTe88ctuy06WaqDcbppfcxNG+e3NG6unGmapbLG6aZlzE3r83ft0ll95oLz0TuZvrfpPszwWdMvz9y7ufWbppkrZ5pmWsbctGkZc9PmypmmmStnnPbzulVBPnOmPjJtzlXSjPdV03WbmzZet6Vxc+VM0yyVNU43LWNu2ji/pXFz5Uz3VbEIaRBH/WBpX7VUB+N0c/UxTTPOb2nctIy5aUtljdPNlTNNM85vaV/V2wT33q1r5xD3VdN1m5s2ro+lcXPlTNMslTVONy1jbto4v6Vx+cwEZyPzgvsM6vdVc+s3TbNUB+N00zLmpo3zWxo3V840zVJZ43TTMvpp4301OB/9PHE0HsRdvyz9u/F6LY3r8wb3bqmscXpw5fXzjPNbGtfnDe7dtKy5fdXYxtK4WIa0rwZXD/080/qYm9bnDe7dXDnTtODK6+eZljE3LXnlM2PJRtLFJ7hB9lVZTkiDufWbpoW0DJlvWsbctOQLaTBXzjQtuGXo99XgbPTzxNF0EHfj5Zuu29y0cX5L4+bKmaZZKmucblrG3LRxfkvj5sqZ7qumNuC/MAl8jgKEaTGOXThFsqR48uSpoZGPHj9ByuTJ1PS+rcsQ0tBr9HqENIS0DJkf0jJkvuQLaZB8IQ0hLUPmB7eMqQs2YPPmTSHayHIkn+lw7OBunDyyxzBIPpMhyLKN81saD2kZMt9SWeN0yRfSYJzf0nhIy5D5pjbmpiVfSIOlOhinh7QMmW+c39K45AtpsFTWOD2kZch8ff4d239Rnzn6BP6bpPex9P7H7h1B9iVxNR3MuUqa8b5qWsbctKV6GKebK2eaZpzf0rhpGXPTlsoap5srZ5omFiENpmXMTRuv19K4uXKmaZbKGqebljE3bZzf0ri5cqZpxmUt7aumZcxNS1njZZkbN1fONM1cOdM00zLmpk3LmJs2V840zVw50zTTMuamg/sM6vdVc+VM00zXbW7atIy5aXPlTNPMlTNNMy1jbtq0jLnp4Hz088yVM00zt37TNNMy5qZNy5ibNlfONM1cOdM00zLmpk3LyP6md9G/mytnmiZ5pazp8oynTcuYmzbOb2ncXDnTNEtljdNNy5ibNs5vadxcOdM08QlukH3VtIy5aUt1ME43V840zTi/pXHTMuamLZU1TjdXzjQtOBv9PNMy5qaN12tp3Fw50zRLZY3TTcuYmzbOb2ncXDnTNHNlZX/T28i7aRn1o5UvNgswYBIKujIlC2PP/qN4/eYNHj1+ijPnr6BE0XyhKGlNFualAAUoQAEKUIACFKAABShAAQpQwF4EIi5gYi8tDId6ZEz/BerXqoQOvUagz1A/9O3WGjFjxAiHJXMRFKAABShAAQpQgAIUoAAFKECBaC7goNVnwCSUG7ZJvWpYNnsMlszyQflSRUJZitkoQAEKUIACFKAABShAAQpQILoJsL4UEAEGTESBAwUoQAEKUIACFKAABShAAccVYMsoQAEbBBgwsQHNnotcuXYT796/t+cq2mXdHj95hifPnttl3ey5Uq9ev8HNf+7acxVZNwpQgAIUiAIBfq/ahs7vVWvcAuflMXBgj9BOcV8NrVTgfNxXA3s48hQDJg60dYePmYERY2eibXcPrPppqwO1LGKbsm7jDnTqOxI9B42B//TFePnqVcSu0EGWfursRbTsPBhe42ZikNdEBk6s2K5zFq3G1Ru3rSjBrMYCEtzc/ts+BoeNUYIZv3z1BuYtXRtMDs6yJMB91ZJM8On8Xg3ex9LcU/xetUQTYjqPgUMkMpuB+6pZlhATeQwcIpFDZWDAxEE2575DJ5AkcUIsneWLuZNG4NzFv+HhMx0fP350kBZGTDNe/PsfNm/fg9ULJ2DJTB+kSZ0CXfuP5tUmoeCePm8lvp82CvOnjET92pUwYLg/Tp65GIqSzp3l58278Pufh9HD3QdyNsy5Naxv/du37zBizEy4uLhCp9NZvwAnKyFeg0dOxt59R+E3daGTtT5szeW+apuf8fcqv1etM+T3qnVe+tw8BtZLWPfOfdU6L+Pc3FeNNRx/nAETB9nG//73EnJgLM2JGyc2hrt3UQGUuYvXSBIHCwJv3rzFv1rQRGbrdDo0b1QTrZrWxVDvqQw2CUoww9Pnz/HuXcDtXyWLFoCfV394+8/G/QePginFWecvXYP/qP4Y1Ls9eg8Zh8va2X+qBC9w7K+zhgzL12xCnerlUalccdy+cx//W7MZ5y9dNcznSGCBW7fvoUzJQpg7eQSu37zNoElgnmCnzgfdV4PNz5kBAvxeDXCw5ZXfq7aoATwGts2N+6ptblKK+6ooOM/AgImDbOtSxQvi1z0HcfrcZUOLendujl92/YGHj58Y0jgSWCBpkkRIliyp+tGlnyM/xBInjI9f9x7SJ/HdjEDl8l9hzOT5hsBShnSp0fibaljyw0YzuZmkFxjYqx3SpE6Jsl8VRv9ubdStYBcuX1OzT5+7pN758llAbpGTz9nqn7epRBedC3btPoDRE+Zi8qylSJwoPjx8pql5fAkqkClDGvTu3BKxYsbEhNEDcOXqTWUnVx/ee/AI9xjgDIr2KYX76icIK9/4vWolmFF2fq8aYVgxymNgK7CMsnJfNcKwcpT7qpVg0Tw7AybRfAPqqy9XlXgM6IwBnv44fPy0SnZzc0PO7Jnw9NkLNc0X8wIe/Tti2eqN+N/aLYYMBfPlxMNHDDQZQMyMtPm2Dp6/+E/1myMdX0mWwgVyaW6PZZTDJwHphHnxivUYNX42Ll4JCIx8moUKZYqif/e26D14LGYsWKH60JEfsvr5fAfixI6Nmf6eWLthO+QWiVZNa6N86aKoX6si/L0HoHSJwogXN04AFV+VgNySOdR7iurLSr9vygwJmkz0cVdXmnj7z4Fc4XT2wt8yi0MIAtxXQwAymc3vVROQUE7yezWUUCbZeAxsAmLFJPdVK7CMsnJfNcJwglEGTBxoI5cuURASNBkyagq8x89RAYAP7z8gS8Z0DtTK8G9K6pTJMXvCcGz45Vd06e+N9b/8hm2/7kP1SqXDf2UOtEQJyE3QfrC+ev0azToOVD9mJ81cim8b1HCgVoa9KTMXrMSbt29QqVxJFRCZNGsJ3n/4YFiwXNFUTgsAHDp2BlPHDg7UL4chk5OPJE+aGNP9hmlBk51Yv+VXVKtYGnlyZsPNf+6gv+d4DOn7nZMLfW7+g4ePMXHmElT9ujQkWNKm21DVp5U+h/yw8B7aA9t/2w8VfCpVRD+L7yEIcF8NAchoNr9XjTCsGOX3qhVYJll5DGwCEspJ7quhhDLJxn3VBMTBJxkwiWYbWM4+79pzEH8cPG625vKFsXqhP7JmTq8uVffx7G02nzMmSo/WG7f+Dn1fL8YGcjvJkpm+qFu9PP7996V25ro/EsSPZ5zFacf/uXMPcjvEk6fPghjImX0/r34Y3LsDHj5+hgE92iJ/ni+D5PuU4JRve/cfRcfWjSD75ix/D7i4uMBnwlyDxYlT51UfHNO0YAk/cwYWNfL6zRtID/7XbtyGBE2mjRuigiY7ft+vgk5rN+zQgsRdkCNbJpWfL8CBIydRokh+dfVS66Z1MGZ4H4wYOwPGHQz7TpyPIX3ao2blsiTTBEL6XtWyqP/cVxVDqF/4vWqZit+rlm2CmxPSvirfszwGNi/IY2DzLiGlcl8NScg55jNgEs2282j/uZAfYL/tPYRWXYfiytVbQVqQOFFC1XmpHAy7uboGme+MCZu27cas71fh7+u3NLch+G3v4SAMMWK4oWaVcmjWsAYSJ0wQZH7QBMdPkc+XXLEkHbn2GDQG85asMfRZYtz6EkXyoX2LepD+EozTOQ5kSPcFdu7erygkWCL9STx79sKQViBvDjBYongCvciB8cARk3Di1AWMn75I+9E/E3J1hARNlq3aqPpsEstM6b8IVM7ZJ7JlyYDf/jikAkpiIVcYeg3qBk+jp6b5ePRUf+tkPgcgNN+r4sR9VRQ+D/J3rZu7j+pw83Nq4DF+rwb2kCl+r4qCbUNo9lUeAwe13cRj4KAooUjhvhoKJCfJwoBJNNrQj588w+17D9QTcIb166jO6g8bPVmdnZZmyGX+8qP2zPnPHb9KeqgHB84oT9KQH1o9OzZXl/av/HELfty009DiSbOWBpo2zHDykdU/b0WvTs3RrcO3WDRjNJ5oP/Q9fWcYVORqpxFjZxqmORIgIGfzpe8SmWrXvD78py8x7KeS1rJJbWzd9aeMqoFXliiGQC9bdu5FkQK5MXJwN0wfNwSpUyXDnMWrkShhfEwZMxjJkiQKlJ8TAQJytU3a1CnUVUwfPt36levLLEiieV28cl1lih8vrnrnC/DYyu9V7qsBn5q79x9i0sxlyJwhreoLR55SEjDn8yu/Vz9bGI/xe9VYI/Tj1u6roV+y4+fkMbBt25j7qm1c2mFMAAAQAElEQVRujljKoQMmjrbB5EzN7bv31X3p0rY8ObNCbrnxGjsDL1+9gquLCzpoZ/nldhyZz+GzQJw4sXDp7xsqQS7tnzjaHWvX78DZC1dUWoPalVGsUF41zpfPAgnix8WFywE/suRqJfcebSGfwx9+3KoyfVUsPxrUrqTG+RIgMHzMDHU1RNvuHqrTTdlPB/RojR4DfbFm/TbIlRPyZJJsmdMHFOCrWYHbdx4gduyYhnkdWzXE5u171LQETQrlz6XG+RJUYMSgrrh1+x4kgH7j1h3IrU3v379HqhTJgmZ28hT5e8bvVes/BDFjxECvzs3h3rMtCuXPgV6Dx+LFv/8FWhC/VwNxGCb4vWqgsGqE+6pVXIEy8xg4EEeoJ7ivhprKrjJGRGUYMIkI1QhappwVLF44n7p8WL8Kudy6WOG8hrPV8iNCnoSgn8/3AIEm9aph+JjpeP7iX5Ugl/Z3aNUAK9ZuUdMZ03+BdGlSqXG+fBaoW6MCFq34Gecv/m1I7NmxGVauC3CTJ5jIZeqGmU4+su/QCSRJnBBLZ/li7qQRqrNND5/pqFi2BCb7DlIdbTZpPwB/HjyB1t9+4+RawTe/WsWvsHz1Jhz966zKKB2Ych9VFCG+yH45Y/ww5MudDR37eKkfs3JVkwSaQizsZBn4vWrbBk+i/Z2r+nUpVbh7h2bqsyZBYQmayJP6Tpw+D36vKp4gL/xeDUISqgTuq6FiMpuJx8BmWUJMtJN9NcR6MkPECzBgEvHGNq9BbrEZP20RajTphgkzluDBoyfo37017ty7D/cRE/Dk2XO17KRJEiN2rM9nYlWik79IR5HiNsR7Ms5fugo5sCtZND86aT8eLhtdaRI7Viwnlwrc/JNnLqJl5yHo0GsEdu4+qAWRUmNQ7/bqTLXcry6548WLg4QJ2CGuWJgOclm6vlNhCcoNd++iAihzF6+BXGkyZ+JwrF44AV6DunKfNcUzmU6XJjUG9+mAQV6T0K6Hp/rRL7eHmWRz2knTfdUUQq4I69quKX5ZPRvyuStdvKBpFk5/EuD36ieIMLz16dIK+fNkR5d+3vCZOE/1NxSGxTlUUbnK64pRf3Pyt43fqyFvYh4Dh2xkKYd9HwNbqnXUp5t+r3JfjfptYi81YMDEXraEmXqs+Xk7kidLgg3/m4rcObKgu/to7Uz/Vcz094B0atW0vTu8xs3C6XOXUOXTmR4zi3G6pAuXr+HgkZPaD1N/tGxcB97j56j+SeSArm6NitoZ15Hqlokpc5ahfct6TudjqcHyQ3/KnOUYP6ofxgzvjS07dmP0hLkoX7ooxmrTU+f8T/1o7TloDLq2b2JpMU6dXkr7UfrrnoPaPnnZ4NC7c3P8susPPHz8xJDGkdAJfFWsANZrf//kB+3cScORN1f20BV08FyW9lX5gaFv+sGjJ2E8rU/ne4DA/sMnMNBrImYvWoXXr9/wezWAJcRXuYJk5oKVWiBzIv48eDxQ/uqVymh/557Cz6svsmfJGGies048e/4CcuVNPw+/QJ30VyxbnN+rIXwoos0xcAjtiOzZPAa2TdzS9yqPgW3zdLRSDJjY8Ra9eOWaFijJDDc3N9SoXAYTvAfA23827t1/iGH9OmLRDG/1NJzxI/ur/kvsuCmRWrVLf19HxgxpIJdvyln9+VNHqluWdmk/ZOUJOPIDrEGdSpitne1PnTJ5pNbNnlf26MlTuLjo8EWqFEiZPCn8Rw1QV5JMmb0URQrmwbqlk9GhZX1M8hmIkkUL2HNToqxuclWJx4DOGODpD7ksXSoi+2/O7Jnw9NkLmeRgpYDcXiKBEnG0sqjDZg9uX5VGS6Bk2apNOMsOwIUjyLBVC2Au+WEjpE+ms+f/Rtvunnj69Dm/V4NIBU6Qjqw79x2FzBnTQS7x76/9nZNbNvW5pG+rqWMHMViiB9HeN27djdrVy6N/9zbaCYcxuHw1oC81bZbdfq9K3exh4DGwbVuBx8C2uQX3vcpjYNtMHakUAyZ2vDWLF86LRSvWQ/+kA7k0rGfHFpAnbki15Yftl1l5FkcsjIei2o/7TVv3qKcfSHrsWDHh69ELU2YvUx3mSiClQJ4ckEvWZT6HAAHpEPLJ02c4dOxUQIL22rNjc5w8c0ldMeHq4gLpryRe3DjaHP63JFC6REFI0EQexyxXN/1v7RZ8eP8B0t+QpTJMp4A1AqHZV6eOHcwrciyg7tl3DFPHDMLZi1e1wHocyNOYug/0Ube98nvVApqWfODwSS1QUhWVypeABJy8h/bAwuU/Qf7GabPVE63s8MoSqVqUDY2+qYJ2zeuh7FeFIR3k9h48Dpc+Pa1KrtZxdeH3qqWNw2NgSzLBp/MYOHgfS3ND873KY2BLeo6fzoCJHW3jjx8/Qq6C+OPTZa6Vy5eE9ETv7T8XcmZHqipfutdu/COjHIwETp29iI1bf4dcUidXR9SvXQl9ho7Do8dPVa6kSRIh15eZce36LTXNlwCBf+7cw+qft0ECJZIysFd7ePpO1wIkl2QSOp0Ocpn1iVPn1TRfAgRM99WA1M+vEjRZvdAfWTOnR+JE8dXTrD7P5RgFwi7AfdV2Q0/3Tnj2/F/MX7JWC252QvPGtRA3blzI7XS2LzWySkbdeuTvWrVKZTB74SpUrlACcowil6sfOX5KPYkp6mpmv2uWYzj9yRmx6tutNboP9MWBIyfRvqcn5DvYfmsftTWTz5f48Rg45O3AY+CQjczlkP2Px8DmZJhmKsCAialIFE6P1gIje/cfxW97D6FV16G4ev02fDx64uGjJ2jb3QPS6/wvO/eiUP6cUVhL+1v1pm27Mev7VfhbC4a06jpE8zusbh0pXiQvWnQeApkvHb8+efYCWTKlt78GRFGNrly9BbkK4v6DR5DHj85bskadaZUfYn2G+mHu4tW4+c9ddZ96qRKFoqiW9rla031VLE1rKv0MNW9UEzUrl+XVTKY4nLZZQB6Be/f+Q8hZRIfYV22WsL2gPEnu/sPHWjAzAWLEiAH5wd+gVkU0/qaq7Qt1kpJyxaZ0Ypr2i1TqqXOPnjzDBG93iKmTEIS6mfp91bhApXLFVR9gckKnbfN6SJM6pfFspx6fNnc5/KcvNhi4uLjwGNigYXlEjnF5DGzZx9IcOW7jMbAlHaabCriYJnA6agQeawcdt+89gDxVQ/onGdy7A4aNnoxbt+9hsu9ANKhdSTsbtg43tB+w0rt61NTSPtf6vzWbMW3cEMjtI9P9hmHlj1tUJ6/yqEOvQV3w696D6iqKEQO7aAfHbvbZiCio1eqft0KeOtKtw7dYNGM0JKDk6TsD0hndvMleuHv/MaZqBzBtm9VFpvRfREEN7XOVlvZVCcpJjaX/CAlAnWH/EcLhdENENVg+V2MmL8DEmUsgfUfIWdeyJQuD+6pt4jmyZUKC+HFRtmYbFWSvWaWsbQtywlLtW9RXn8Ha3/ZA84Y1nFAg+Cab21fl6lcpJU9SW/3TNngO6KSC6ZLGAdi97ygOHD2F6zdvw2/qQgOJ3ELNY2ADh9kRHgObZQkxkcfAIRIxg5EAAyZGGFE5GiOGG+RsxKvXb1Q1pLNSH8/e8Bo7Q13q2qB2ZRUU6NiqIc/kKKHPL3HixMIlo0cFTxztjrXrd+DshSsoUSS/6rzUo38n1Znp51Ickx8LFy5fVxByybB0gCifQ+m4L1OGNOqAzs+rHwrlz6Xy8CVAQIws7asvX71SHTB3aFFP3Y4TUCJav7LydiKwfsuvkNu7pJNv6QT3nPb3bYj3ZKRLm4r7qo3byMejF/ZtXaa+W9mpcOgRc32ZBb/+vAC/b1wIeTJY6Es6R05L+6rcWh0vbhzISa+aVco5B0YoW5kgXhzISS2/kf0gt51L0ERufZXicqUJj4FFwvwQh8fA5mFCSOUxcAhAnB1IwCXQFCeiTCB+vLgoXjgf5FJ/fSWkk8hihfOqJ7zo0/geVKBJvWoYPma6ujxY5sqTSjq0aoAVa7fIJAcLAnVrVIA84eD8xb8NOXp2bIaV6xzZzdBUm0dCs69KkImXqNtMzIJmBJImSYyOrRth8Yr1SJIoAaaMGYRjf52Dz4R5ZnIziQIUiCqBkPbV/Hm+jKqq2e165TtTOgyWW778vfurpwn5TJwHCZqs3bAdz56/sNu6R3XFeAxs2xbgMbBtbs5aigGTKNrycsnm+GmLUKNJN0yYsUT1zt+/e2vcuXcf7iMm4Mmz56pm8sUrXyBqgi9KYN3GHcpNzq7KbRBVvy6FkkXzo1MfL1w2utIkdqxYKr9Dv1jRuJNnLqJl5yHo0GsEdu4+CHnqkpzpkttHdu7er5YUTzvLkzBBPDXOF8sC3Fct23BOxAiUL1VE9YWzcdvv6NSmEZIlTYwyJQujUd0qEbPCaL5UeSRpN3cftOg0GLMXrbLYGrlabP0vv1mc72wz5NhDvlul37TBIydBnuRiyUBOSvCHbFAd7qtBTaxJiRM7Nib5DMTV6/+ga//R2LB1t+qA3pplOHJe6TBYfzW6tJPHwKIQ8sBj4JCNmMOyAAMmlm0idM6an7cjebIk2PC/qcidIwu6u4/G+YtXMdPfA4kTJUTT9u7wGjdLPa2kihYQiNDK2NHCQ6rKhcvXcPDISaxe6I+WjevAe/wc1V9Jny6tULdGRXTsMxIjxs7ElDnL0L5lvZAW5zTz5f7pKXOWY/yofhgzvDe27NiN0RPmQnrtH6tNT53zP/QaPBY9B41RHdI5DYwVDd1/+AQGek1UP75ev37DfdUKO2YNPwEJlMjl6kNGTUb+PNkht2+G39IdY0ny927C9CUYNbgbFkwbha07/1RnrE1b9+DhY4zSvkMK87ZDA82kmUvRtF511a/V6zfvIJ3QG2YajUi/CQ8ePUbCBPGNUjlqLMB91VjD/Ljx9+rzF/8aMsmVwpXLl8Sr168xbexgJIjPEzmCIw9/GOo9Bd0GjIb0hyNpMvAYWBQsD/KdwGNgyz6cE7IAAyYhG4Ulh8WycvYrd47MkPuma1QugwneA+DtPxv37j/EsH4dtYMVb8gTNuR+dVcXbiY95KW/ryNjhjSQ2yLkh8L8qSPVLUu79hxEs4Y1sF4LQDWoUwmzJw5H6pTJ9cWc/v3Rk6dwcdHhi1QpkDJ5UtWvi1xJMmX2UhQpmAfrlk5WTxaSszolixZwei9TgK27/sCSHzZC+nk5e/5vtO3uiadPn3NfNYXidIQL+Hr0QpLECVTfEQ3r8OoSc+BXrt5A2i9SInHihJDbXIf07YCsmdLjnNHthxIs8RwzQ9un2yFdmlTmFuOUaX9fu4WC+XJCAiJy60jtauVVf2DGGDJProaVjtaN0zkeWID7amAP0ylz36vy1D7JJ8EACaZIh/4MlohIwLB05QaM8+qrHbflUie5jK8A4zFwgJG5Vx4Dm1NhmjUCVv4St2bRzBucQPHCebFoxXp8+PBBZZPbI3p2bAF/7ayYJMgP2y+zZpRRDkYCRbUf95u27sHjJ89UGkGQ+gAAEABJREFUauxYMSEHJVNmL9PORLxRgZQCeXKoS9dVBr4ogVQpkuHJ02c4dOyUmpaXnh2b4+SZSzh97rLqqLRA3hyQDulkHofAAnv2HcPUMYNw9uJV7TMWB0UK5Eb3gT7qVjruq4GtOBWxAkmTJEKnNo1Rt8bXEbuiaLh0/Y+HtFoARM7EjtACIrWqlkXxwvmw79AJrFz3i2qV3HaiD5ZkyZRWpTnzy+s3byBnYMXAzc0V46cvwr8vX6Jd82/w8PETSF8S0mGpzP958y5163C/bm1kkkMwAtxXg8HRZgX3vSrHIpN9B/HKEs3J+P/IId0hx8HyFMiC+XKoq4L1V+bI3z85mchjYGOxgHEeAwc42P7KkgyYRNJnQDqukqsg/jh4XK1RLjWMGSMG5NGQ+gORsl8VVr2Dqwx8MQicOnsRG7f+rg7o5OqI+rUroc/QcXj0+KnKIwclub7MjGvXb6lpvpgXGNirPTx9p2sBkksqg06nQ/VKZXDi1Hk1zRfLAp7unfDs+b+Yv2QtPAZ0QvPGtRA3blz8uueg5UKcQwEbBC5duY4lP2yA9M8UXPFn7AQxCM+YSfOxbNUmLagZF9IR4pVrt9SVdfLdu2DZOnRp19hQZkCPNmCwJIBj09bdGDxqEuRYRPpn2v7rPmTJmB7SV8LIcbPRvcO3hpMQcjUOgyUBbtxXAxxsfeX3qvVy8eLGMRSSk17582RHj4G++PPgcbTv6ak6yTVkcPKRf+7cw+qft6mThUIR6BhYS9DpeAysMfB/KAVcQpmP2cIoIJcF791/VN0P3KrrUFy9fhs+Hj3x8NETtO3uATkb9svOvSiUP2cY1+RYxTdt241Z36/C31owpFXXIZrfYXXrSPEiedGi8xDIfPlh8eTZC+3gN71jNT4Mrbly9Raks0N51y+maME8kC+MPkP9MHfxatz85676ki1VopA+C98tCMgTb+4/fIzEiRIghhboPHL8FBrUqojG31S1UILJFLBeQDpjnj5/JVKnTIYRY2dgx+/7zS7k4NGT8Jkw1+w8Z0z86/QFtO46DMmSJoI8UWPVT1tVwOS7Vg2x+qdtOHnmgupEUn+bZuKECdQtOs5oZdxmuVKzS39vnLlwBU+179DhWkA955dZILdB7NpzAJu370GvTs3xVbEChmJFtO8Rw4QTj3BfDfvG5/eqdYbSh5/cqmRcqm/X1siQ7guM9Jut/aboxc5xP+HIse+QUVMgt3jJgw3mLVmjrgzmMfAnIL5ZLcCAidVk1heQg5Lb9x5guHsX1efB4N4dMGz0ZNy6fQ+TfQeiQe1K2pnrdbih/YCVp5ZYvwbHLSH3SsvBm0TSp/sNw8oft+DHTTu1M17N4DWoC37dexASQR4xsIv2Q9bNcSGsaJk8gWmU/2x1j2ufYeMCdXZYsWxxzJvshbv3H2Pq3OVo26wuMqX/woqlO2/WHNkyIUH8uChbs40K3NWsUtZ5MdjyCBFYsXYzJowegMIFcmtBkxQomDdHkPUc++sslq/ejOEDuwaZ5ywJcum5cVunz18Br8FdIVc+LJ3tq74jftq8C5XKFYe/9wD07txS23fZaaTxrTfiJ9+nlcqVgEf/Tup7IXbsWBg5bha+zJoRPsN6YuTgbsiWJYNk5WAiwH3VBMTGSQvfqzYuzTGLSX9LXfp7Qx4W0bLLEPzw41ZDQ+WE4Vkt4DndbwiyZ8loSHf2kdU/b1XB3m4dvsWiGaMhJ1U9fWeAx8DO/smwvf0MmNhuF+qSMWK4QR5dqH8MmHRW6uPZG17aGUQ5gGlQu7I6o9NROxsmEfdQL9gJMsaJEwuX/r6hWpo8aWJMHO2Otet3QL4gShTJD/9RA9TBnvQjoTLxBTrNoGblMurHw4AebdF78Dhc/mSozUKmDGngOaAT/Lz6oRCfDiEkoR58PHph39Zlan+VDptDXZAZKRAKgWfPn+OuFlyXp38N7tNePUlNnvolt0pIcQmWSN9Xvp69nLq/IXnCl9x6IyYyuOhcEDd2bBlVt+O0a14PMxf8gN37jqo0vgQI/Lz5V8OtN5Ki3OIEuOl0OvT4rhn+OHAM0+f9T2ZzCEbAun01TjBL4ix+rwb/GZih/S1r1bQO+nRtibRfpIIE6/R//9KnTa2efMhgSWBDObl14fJ1lejm6grpsF9+i0mwicfAioUvVgowYGIlmC3ZpRMm6XRObsvRl8+SMR2KFc6rnvCiT+N7UIEm9aph+Jjp0HdqJY+a69CqgfaFsSVoZqYoARcXF3U5ukyU+6owJGgilyTK5ZwPHj3B+l9+k1kcKEABOxCQjpilrwipStmShdGhlxcG9W4HuX1k8/bd6klqcsAnQZNV2lkzZw+WiNPQvt9hy4496upCma5bswJGjJsJ6aBU+gs7f/FvdG7bCJNmLsG7d+8kCwdNQG4hjBsnDgZ7TYJciSh9WC383084c/6yNhfaiYi/Uad6eRw4cgryfaESzb04aRr3VSfd8FHc7PKliqJUsQIYNnoaWjSqid5dWmLOolXYsPU3xNUCngyWBN1AdWtUwKIVP0O+C/Rze3ZshpXr+NtB78F36wQYMLHOK1S55UBk/LRFqNGkGybMWKKepCEdqclj+NxHTID00C8LSpokMeQpLzLOIUBAfjjor8SRlKpfl0LJovnRqY+X4SoJudIkdqxYMptDKAQqlCmKAd3boNfgMWpwc3MNRSnnyyKP+u7m7qP6fpmtHYxYEpCrxRh0sqTDdGsE5Mktq3/ehkHaD9jjJ8+hS7umKFwgF9yHT0TnfqNw6NgZuPdsqxYpQZMxnn2c+soSBaG9PHj4FEUL5cFELSCyZv021KxcFvlyZ0ejNv3QtMMA3Ln3UPvhXwHy6PR37z8gpH/OMv/p84C+vv46cxHSX0n6tKnQ/btm6DbAB3Kp/6yFP6Bp/eooUjA35DYAZ3EJTTu5r4ZGKWgefq8GNbE2RY7h5NYbuWpC+hPKmP4L7aRYVRTKxz4P9ZYntb9pLTsP0U44jID0L5QuTWrtxEN7yMnCnbv3q2zx4sVR3wlqgi8UsFKAARMrwUKTXe4zTJ4sCTb8bypy58iC7u6jtSjnVcz090DiRAnRtL07vMbNUk8rqaIFBEKzTGfIIx3fDvWeoh28jYZxx1Z9urRC3RoV0bHPSMjl6VPmLEP7lvWcgcSqNn78+FGdce3n4Qf5ESGBO/0CihTKjUQJ46Nlk9rqx4U+ne8BAvJIzQnTl2DU4G5YMG0Utu78M1DfLwG5oH5EjBo/B4V5K5OehO82CuzacxDLV29Cfy2Y6ePZSz269cLlq6rvCLlEXW6bk76ZYseKae0aHDr/vQePtDOtkyHB9B8W+GPXnkOQ/krkdpIV8/3g69FbdX4oHYLnzJ6ZJyWMPg19h/ohVcqkWLNoApIkTgTpKLJ8qSLYsGIaBvdujyUzfdTT585d/BvFCuU1Kunco7u4r9r0AeD3qk1sZgulTpUcJ89exKzvf4DPhHmoXrkMJChgNrOTJcrnbMqc5Rg/qp+6PWnLjt2Q2zbLly6KscN7Y+qc/2knC8ei56Ax6Nq+iZPpsLnhJcCASXhJGi1HIuq5c2RWl1LX0P6oTfAeAG//2bh3/6Hq9HXRDG80b1QT40f2h6sLN4GebunKDRjn1Vc7u5VL/XEz7tivWcMaWK8FoBrUqYTZE4ery9X15fgeIOA7ab7qK2dQ7w5YsOwn7Sy1P+Qyfpm74Zff0abZNwyWCIaZ4crVG0j7RUokTpwQcuvckL4d1FM05IeDPruccfUcMwPuPdppByqp9Ml8j3ABx1iB8eX80qLjJ8+iUd2qSJUiGUoXL4henVqov3vy/SH3WPNgWJSg/qb9snNvwIT2evHydRQumAfSF1iGdKnhp31nzFm4Gpu371bfC9JJ6catv+Pq9VvqdkStiFP+l1uRlvywwdB26S9Nrt6Uq3ESJoiv2bTBo8dPtUDdfNXvS95c2XH95h3MW7JWBe3kfn9DYScb4b4aPhv8Cr9XwwdSW4o82WvU4O5wdXVRP/p5G46G8un/oydP4eKig/RlmDJ5UtW3oVxdOGX2Uu33RB6sWzpZPV1zks9AlCxa4FMpvlHAOgH+WrfOK1S5ixfOC+mY78OHDyq/HPj27NgC/toZbEmQnfrLrOzNWiyMh5FDuqOodiDcvUMzFMyXQ0WD9X2XSPBE+oIpkCcH5NJ043IcB549f4H379+rH11yiX+rJrVx+859DPOeArnSRKblQJlWgQXkcyUpadOkUo/2HqEFRGpVLYvihfNBLsFeue4XmQ25jU4fLMmSKa1Ks/mFBZ1SIF7cOFowbg6k41YByPllFuzZf1RG1SC34sgVER4+0/Dy1SuVxhcgZswYuHHrDvT7aq4vM+Po8dOGafleKFE0f6A+N2pXK4++XVs795PTdDo8f/FC3RIs3wGxYsZEzBhuga6cK6m5vX37Vl05J581CdRN9h2kOhuWaWcduK+Gbcvr91V+r4bN0bS03HbYqU1jdZxsOs+Zp+Wkw5OnzyCBTr1Dz47NcfLMJZw+dxmuLi4okDcHb2fV4/DdJgEGTGxiC75Q5fIltQOTGPD2n2s4w1/2q8K4duOf4As6+Vw5SNETyB+7/Hmyo8dAX/x58Dja9/SE3HKin8/3wAJyxnBQ7/b448Bx7eD3ibqCqXG9atrB8lNcuhLQUzgi6F90XuyYSfMhvc3Lj64mmteVa7fUmQq5BHvBsnXo0q6xoXkDerQBgyUGDo5YKZA7R1ZMHjMIcjum3G9dvWJpSH84Azz98eveQxg4YiLkisSCeXPi4JFTVi7dcbMnS5IYHVs3ggSSJBicNEki1KxaHm27e2DLjr3Y+fsBvHjxL+TWTcdVsL5lcmJBTj5s3rZHs5sKOYHTt2srdO0/Wv3N23/4BHbvO4KBvdohhXZW1vo1OG4J7qth27b8XrXeT24rkU5c12/5FTIe3BLkBFlw851h3j937qlb0CVQIu0d2Ks9PH2nawGSSzIJnU4H6dT6xKnzapovFAirgEtYF8DywLS5y+E/fbGBwkWLZvp49MTDR0/UQZ30zSGXFBfKn9OQhyOBBS5cvhao3xKZK2cIM6T7Qt1nLff063Q6SY7oIdouX84gXrt5G+nSpFQHx0dOnIXXoK7IkS1TtG1TRFX8r9MX0LrrMCRLmghrN2zHqp+2QgIm37VqiNU/bdPOTFyAXL4pTyqROsjlsFkzpZdRDhSwSWDdxh0Y5Tcb5UoV1X7ATlNPJJnk445MGdPi58270KBOFdSqWg537z9E5ozpbFqHIxa6+c9dSGfMngM6q76ZpG8SuWLuu1YNsHXXn9i4bTfkqRGO2PawtEluyenYZySqVPwK799/UN+jcpZ14ugBOH3+oroKts23ddXtOGFZjyOW5b5q21bl96ptbrKv9vMYrwV+X+Ly1Zuqw+83b9+aXdj3y3/CT5t+NTvPWRKvXL2FIaOm4P6DR5BOXectWYMiBXJDgiZ9howIZcQAABAASURBVPph7uLVkO8NOdlaqkQhZ2FhOyNYgAGTMALv3ncUB46ewnXth6rf1IWGpckZ68m+A9GgdiXMX7ION7SDvkG92xvmR96Ifa9J+oXo0t8b0lGu9NL/w49bDRWWXsHPXriC6X5DwPs1DSzBjtStXh7bf9uH0jVaI4v2oyt92tTB5neWmfpLhPXtnT5/BbwGd0W/bm2wdLYvfty0U3UcWalccfh7D0Dvzi2RIH48fXa+U8BqAePP3Lv377F01UbMnzIS/bu3xozxQ9XZsL+v3YJ0VjrZdxDy586GwSMnoXiR/MiQLrXV63PEAldv3Mbqn7eiV6fmWnAzMWZPGI7lazZh269/qrOHk7XvWAk68e9c4K0vfZWs3bATFUoXxRcpk2PM8D6QH2XSz5X0VSJPW5o9wROlihcMXNBJp7iv2rbhjd1kCfxeFQXrh+2/7Vf7ovTVlyJZUlQsW0JdpW66pP+t2YwnT5+i9bd1TGc51bT+O6Fbh2+xaMZoPHn2Qvs+naG5Fce8yV7aSYfHmKqdyG7brC4ypf/CqWzY2IgTiH4Bk4izsGnJCeLFgTzJwG9kP3XLjQRN9LeOyJUmDWpXxrRxQ9BRO3MtVwDYtBIHLjRjwQ9o1bQO+nRtibRfpMKKtZvV5cLSZDkIHjO8N4MlghHKIX68uJAnR+zbukx1chXKYg6fTXpMl1tv9A110bkgbuzYalLM2jWvh5naZ1ECoCqRLxQIg4D8YG3XwzPQVXPymdN3pJkuTWpU+bok3EdMxINHT9Sa4sSJjaYNaqB5wxpqmi+AdIy7TvvhnyxJIsWRJHFCzPL3hPxwOHz8tErjS1CBa9dvqbOscgWdzHV1ccHoYT3x4f0HLFj2oyRx+CTAffUThA1v/F61Ac1MEQk8SVBdjlHevHmDlk1q4eSZi1qweJsht/zNu3PvvjrJY0h00pEE8ePiwuXrqvVy66F7j7aqvyo54Sr9MHkO6AQ/r34oxKcZKiOHeYnihrhE8fqj/eplh5SrH2LHiqmdme6Py1dvwGfiPNXfxtoN21VnnNG+kRHYgPKliqJUsQIYNnoaWjSqqS6tnrNoFeRezrjaDwixjcDVc9FOIjC073fYsmOP4QCkbs0KGDFuJh4+fqL21fMX/0bnto0waeYSdSbWSVjYzAgSkO+DeVO8tB/851VnwnJQV7pEAXiPnwN5WomsVu5THz2sB5InTSyT6taIwjzAUxb6l3o1K6JHx+YYPWEe9JeoJ0oYX52EKJiPt7jqnUzfc2TPDHk6nzwlR+71l/k6nQ4e2g8JuepVpjkECHBfDXCw5ZXfq7aoBZSRPoXmL10LCZTI42/X/LwNsq+2b1kf/718hfHTFqFEkfwq87Ubt3Hrzj0GS5QGULdGBSxa8TPkuO1TEnp2bIaV67boJ6PFOysZvQQYMAnH7RVHO2Mt/R5cvf6P6lhtw9bdquOhcFyFwy2qQpmiOH/pKiRi/JUWOMmY/gs0qVcVhXgwbHZb7/h9P77rPQLNOg7Erj0HzeaRRLl3U+4nlnEOwIOHT1G0UB5M1AIia9ZvgzwxSHqcb9SmH5p2GIA79x6iTvUKkEfRvdPOwoL/KBBGgQOH/0K8uLEx1Hsqzpy/jO7fNcPTZ89Rr0VvSN8S8tjbAnlyhHEtjl+8af1qKF+6COTedH3QJEH8eHxaWgibvqD2HTqsX0dI3wjyQ0yy63Q6yFU6Ms7hswD31c8W1ozxe9Uarc95nz57gaU/bIRcETHMe4q63XC4e2fs174z5Bb1bgNGa4Hibw23ZspxsVxF8XkJdjkWYZWSp6RduXrLsHy5QlO6OJD+S3bu3q/S48WLo47f1ARfKBABAgyY2IgqO/Co8bPV1SRyn7V+MXJVhDwl59Xr15g2drAWCIinn8V3CwKpUyXHybMXMev7H+CjnUmsXrkM5A+ihexOm3z56g1IwGSmvweGu3fB7IU/GM66GqPIY0vlizhHdnb2Ki73HjzCsNGTUfXrUup2pV17Dqn+SqTviBXz/eDr0RvSqbB0JplTOzMrZxylHAcK2CqweftuLUhyRT3K0M+rr+qg7tbte5D+caaPH4pObRrCb2R/WxfvdOXk1tbqlUpjycr1Ttf2sDQ4T85s8BrUDZNmLQ3LYhy6LPdV2zav43+v2uYSUim5Zb/noDFIkSIJVi/0R/z48eE1dqa6fWTlAj9If01zJ49A8cL5QlqUU8yXJwL1GOirBX79cMUoaFKxbHGMHd4bU+f8D70Gj4WYdm3fxClM2MioEWDAxAb36zfvoL/neDStXx0pUyRFm65DcfDoSbWkf/97qUWJT0D6LZGzYCqRL8EKyBNIRg3uDldXF8gfPN6GY57rwOGTKFuyMJ5pZydmL1yNmeM91O0kV67dNBSQYMmiFevh69kLztpnjjyqVZ5KpUe5ePk6ChfMgzw5s6ozNn7aD9g5mp8cKMtTcLJlyYCNW3+HnPEf0KOtvhjfKWCTwPLVm7By3VbIU1x0Op32ucsG+cxJh64SXM+aKT2KFcrLKySs1K1bvYJm2tDKUswuQeDxDM6Z/SA41b5qViD0ifxeDb2Vcc73Hz5Af+uNpEt/JR/xUV3lmjhRQnj076ie6CInC2PGiIHcObKa7fBVyjrjsHHrbtSuXh79u7fRAiNjVLcHeoci2nHduqWTVX99cnV/yaIF9LP4ToFwF2DAxAbSn7fswviRAxAvbhwcOnoKPTo2wyCvSTh+8pxKm+w7iFeWWOkqt0d0atMYRbU/gFYWdfjs8gUrjcyYPo16As5Iv9kY0qcDkidLggVL1+HU2UsyG/JEIX2wRD6bKtEJX2LGjAG5AkzvluvLzDh6/DT009LJa4mi+XHh8jWDTu1q5dG3a2vVcZghkSMUsEGgWqXSePX6FQ4eOWUonSN7ZngP7Ykjxz+nGWZyhAIUsFogPApwXw29Ir9XQ29lnFOnTUgfJIO13wjSX4mcSJWOXSVNm6Vu28+f50vVn9q6DTskiYORQKNvqkA65S/7VWG492yL3oPH4dKV6yqHHNO5urioKzmd+ZhXYfAlwgUYMLGBuFObRpB7Cr3GzdR+uH6Hxt9URS4tKix9ltiwOIcvIp0bSieu67f8ChkPrsFy+V1w851tnpydaN11GI7+dRalSxSE3C6SKGEC3PjnDlb9tFX96K9VtZxicXV1VVeWOPsXR7IkidGxdSN4+ExTnbwmTZIINauWR9vuHtiyYy92/n4AL178iz5dWik3vlAgPAWkE9c5E0dg8cr12HfohGHRObJlQsM6VQzTHKGAkQBHo0CA+2ro0fm9Gnor45wu2g/6UUO6Q47bJGgix3R9u7ZCp74j1fGJXOV06NgpSH9D6zbtNC7KcU1ArrqRTtO1UUjnuH27tUb3gb44cOQk2vf0VB3lyjwOFIhoAQZMbBCOFTOmKiUdNyVKGB8Xr1zDF6lSQB5lpWbwxSDw7t07SKdzL168xOWrN9G53yiz/W5Ige+X/4SfNv0qoxw0ATnb0KHXCEhnuJ6+0yGPmfP17I0vs2VUj19+8+YdJo52h6tLwG78ZdaM6gonrahT/7/5z110c/fR9sfOkA5epW+SVk1qQ26R2LrrT2zcthu9u7R0aiM2PmIFkiROqG7LnLN4TaCgScSu1Z6WzrpQIHoIcF8N3Xbi92ronExzPXn6DB37jITORYdn2omakeNmqf5JfDx6QgIl4jrLX37434ccw5mWd+ZpuQ3s7v2HgQgqlSuubt3vM3Qc2javhzSpUwaazwkKRJSAS0Qt2BmW27xRTdT6tjvch09Eh5b1nKHJVrdx+2/7Uap4QTRrWAMpkiVFxbIlzN6f+b81m/Hk6VO0/raO1etwlAJyeaG+La/fvMHSVRsxb9IIdRni1LGDMdR7inqiUOumdbRAyUC0bFILcvZCX4bvgPQRsfrnrarjtGRJE2P2hOFYvmYTtv36J6pXKoPJvgMxyccd6dOmJhcFQi9gQ04Jpk8dMwjSEbgNxVmEAhSIJAHuq8FD83s1eB/TucbHcqvXb0fVr7+CR/9OmKsdzyVKmAByW3WRArnh59UPg3q3x4Ejf2HKnOXo1uFb00U55bRchTNm8gL1VMP+nv7w9p9ruDpd+olc/dM27YRYJ9UPjFMCsdFRIsCASRjY69eqhH1bl+GnZVMY5bTgKF8cct/mslWbIPdtyo/8k2cuYvXP2wwlJFhy59599OvWxpDmbCNyJU7LzkNw5PhpQ9Pd3FwNfWpkzZQepUsWhlxpcufuA/CfeYHjJ89i3YadSJYkkcqQRDvTL2dv5DN22MhWzXTiFzY9cgQSJoiv7q+OnLVxLRSggK0C3Fcty/F71bKN6ZzT5y5j2OhphmQ3V7dAHXx3/+5b7N1/FDO/X2nIo45TJnhAbhEzJDrxiNy+nzhRfEhn1XlzZce5C1cwxHsy5LeE3HIuQaaaVQJuRXdiJjY9kgUYMIlkcGdY3QejXsHlnsM1WnDknzv30L5lffz38hXGT1uEEkXyKwrp+OqWNs+ZgyUC4ebmBr+R/eA1bpa69UZu+yqQN4eyki+JV6/f4PrN22jTrC4mzVoiRTh8FjCM1atZET06NsfoCfPw5u1blZ4oYXx1e0TBfDnVNF8oQAEKUIACFAidAL9XQ+ckueRpfCOHdMMPP27Fo8dPUaNyaSxfsxnyBEOZLycOK5QuhmYNasqkGuSpaXLMpyb4gqSf+qFbvGI9kiRKgCljBml+5yBPEhIe6SRX3jlQIDIFGDCxoC39kkg/CC06DcbsRass5ALkHrv1v/xmcb6zzZB+XZb+sFF9WQzzngK5LWK4e2fsP/wXuvT3RrcBo7UftN+qx7uKjXSe696jrYw6/XD33kPkyZUNvYaMxamzF9GvW2tc04Ik9Vv2RuN2/VGmRCF1S9P9h0+c3io4gKb1q6F86SLoM9TPEDSRnun1HYcFV5bzKEABClCAAhQILMDv1cAelqbkGPjMuctqdjf30YgdOxYG9GgD9xETVcfz7XsOR90aFbSgQMBVsCojXwIJlC9VRF2Vs3Hb75CHbMjviDIlC6NR3SqB8nGCApEpwICJGW15ksuE6UswanA3LJg2Clt3/onLV28Eyfng4WOMGj8HhfPnCjLPGRM+fvyInoPGIEWKJFi90B/x48eH19iZKKT5rFzgh16dmmPu5BGqwytn9Amuzb//cVgLMv0C6T197PDe8Jk4H9du/INpYwdjwmh3fD91JJpogQD/6YshBy7BLYvzgAa1K6N6pdJYsnI9OShAAQpQgAIUCKMAv1dDBpw+fwXkimA5TmtSrxp6uPtCrohY/79p6NW5BSZ4u0OuHg55ScwhgRK/qQsxZNRkzTA75OodqlAgqgQYMDEjf0ULjqT9IiUSJ06I0f5zMaRvB2TNlB7nLv6tcsuLBEs8x8yAe492SJcmlSQ53SAdM81fulbdVyiNl/5KPuKj6ogpcaKE8OjfEdIDuFxGJ48Gy50jq9n0c4NLAAAQAElEQVQOX6Wssw179x9TT1fSt/uvMxcgfeKkSpFM3a40pE8H9Bjoq+W5rnpOT5E8KSbNXIpC+XOiWsXS+mJ8D0agbvUK+K5Vw2BycBYFKEABClCAAqEV4PeqZakR2gnCp8+eo2LZ4iqTBJi+bVAdvYeMhU4HdXJVrqpWM/kSooCvRy8kSZxAPTiiYR1eXRIiGDNEqIAETCJ0BdFp4fKDX+qbVguAnDh9HiO0gEitqmVRvHA+7Dt0AivX/SKz8UT7g6gPlmTJlFalOeOL9vcf127cxmCvSSpoIrc9yP2ZkiYeOp1Oiwp/iYePn2Ddhh2SxOGTQIIEcXHh0jXoP3PSsdWuvQc/zYVyy541I44cP2NIc+/ZFnKwYkjgCAUoQAEKUIACFKBAlAvUrV4ep85egvGjcGtXK69Ohl26EvQq9SivsJ1XIGmSROjUpjHq1vjazmsabavHilshwICJEdaYSfMhT3OJHy8u5FK6K9duwcVFh117DmLBsnXo0q6xIbfck+jMwRKBcHFxwagh3ZEoYQIVNJErTuSWkk59R6qn4CxfvQmHjp3CsH4dsW7TTinC4ZNAgTw5UKl8SciTceSpQV+XKYaXL1+ix6Ax2L3vqPocFimQC80a1vhUgm8UcF4B6cB37uLVaNllCDr3G4UeA30h0/J0KVtVbv5zBwM8/VXfSoePn0aT9v2hD/baukxryh3R1nngyElDkb9OX4Dc325IsKMRsZ6/dF2E1kj6uNJ3jGi8IvkOkXnGaVE5/lW1lpG2ejlRI98J0v7nL/61er1iJ/uK1QUtFNi49XfcuHXHwtzPyb/uPYTveo9A6RqtsfB/P3+eYWZM2mZuu5vJyiQK2LVAkYJ5MH5kP/Qd5gd50IG+srWqlkO+3Nn1k3z/JHDpynUs+WEDzl+6+inF/Nuz5y/MzwiSygQKRJwAAyaarRyotu46DMmSJsLaDdux6qetKmAil/Ov/mkbTp65gEk+A5E6ZXItN5BYCxDILTpqwolfnjx9ho59RkKnBZWeaQdzI8fNUlfj+Hj0VIGSm//cxSx/T+2L4766rcSJqYI0ffz0RTh09BTEaujoqbhw+Rr8RvZHwbw58MO6Lbhy7QZaNa0bpBwTKOCMAt7j5+DoX+cwe4In5kwcjul+Q7W/KZnx8tVrmzk2b9+D3DmzqWUW1Q50h7t3QaqUyWxenrUFj508j6MnzhiKZcmUDnIVmSGBI04vsHjlenRs3UB9RuUKzqgG+WXnH7h1+26I1UiUMD56fNcMVSp8FWJeZqCAIwnk0b5TRmjfJf09J2jHvvfC1jQHLr1z90FMn79S+12VDCPGzsCO3/ebbe3BoyfhM2Gu2XlMpEBkCjhlwER/G4QeWjpp8hrcFf26tcHS2b74cdNO/LR5FyqVKw5/7wHo3bkl7OFgRV/fqHw3tlu9fjuqfv0VPPp3wtxJI9SVJiP9ZqNIgdzw8+qHQb3b48CRvzBlznJ06/BtVFbbrtZ94tR53Lv/EGW/Kgz5cpVOXgeNnITrN2/ju1YNMGP8MMiPt9ixYtpVvVkZCkSFgFz18Zt2xtp7SHfI1X/6OlQoU1T9XZYz797+c9XVJ3LFlvEZbTl7LR0ld3f3gQTFV/+8TRVf/8tv2LhtDzZv3w3JI0OPgWMgT6qSDGfOX0aHXiO0s+ReGOQ1EW17eEJ/FlzWIWfGJJ8MEjSWoLuMy3Kkk7oeA30hQR55rGSrrkPRvNMgNO0wQF05Jvn+vnYLm7R1b931p1q/1OvK1ZsYP22RzFbDgmU/qjZJvaV9+r+9crXHUO8pkCsP5Cz+mMkL1C2RqlAwLyE5GddbguFDvCer9Yvd1ev/GJb88tUrTJixBM06DoI8RU6+Pz98+KDmm7Y/uLzSJ5jU/7veAcbSUaJaiJkXmec+YoLaJuJ9/tMZSXkS1vbf9hlKyEF4r8FjDdP6EbnSQrbhYO3vrLjJFUVyi22NJt3UtukzdFygKyfkKpI5i1ajSz9vdVLg+Mlz+kUZ3uXqJumzQAa5utIw49OIdOQt7ZP19h4yDrLNZZa+LrIN5WqpvsPG496DRzIr0CDG0s6JmrVs/2E+07D9U1uXrNyAr7/pgI8fP6oyzb5zh34byfZo3K4/ummf+d/+OKzmB/cS2m227dc/1ZngaXNXQMqcOH3e4mKlI3x5jLurq2uQPNZs9yCFmRCtBZyl8jmyZ4bXoK5wc3NzliZb3c4VazdjwugBKKz9XkidMoU6WWi6EPnOXb56M4YP7Go6i9MUiHQBpwyYjNailXLrjV7bReeCuLFjq0k5IG/XvB5mLvhB3RqhEvmiBE6fu4xho6epcXlxc3VTj/6ScRm6f/ct9u4/ipnfr5RJNSRJnBCzJnggedLEatrZX/797yV8J82DdIqrt8ijnZEY49kb0hO4PJJOn853ClAA2g/BW0iXJiWk42NzHnMXr8XzFy+wZKYPpowdhJ+0gPfe/ccMWeXH/NRxQ7Bklg/WbdiufpxKX0AVyxaDdMonV63IkDJFEkOZkX6zUKd6ecyf4oW6NSvivFGH34ZMFkZevnqNqWMHw9O9M+LEiQXpuO5/c8dpyxqJXXsO4OhfZ5E5Y1rUqlIO1SqWUlcPNP6maqCl7dpzUAvm7MF0rd7fTx+Fh48eY+HyHw157tx7CAm0zp8yEjqdDrt2HzDMszQSkpNxvectWQf5Xlw6yxeeAzqrOuPTP7k15/379xDvRTNGqyDTqp8CAlGSxXg5weUV45qVy2oumnGN4I3FXx4puWDqSFQuXxLe/nNkVeoxk+s2fr7dU7ZvwzqV1TzTl4uXr6FLu6bKVK4okr7JNvxvKmTbVNW2wxgt8GRcRrbR7ImeGDuiN8ZOWWA8C/J3ursWFMuUIS1GDu4GV5fAh1LSKbyX9hnq1601Fk33RsF8OTFq/GzDMq7d+Aed2jZRV0vVqFwa3y//yTBPP9K/e2tkSJsaQ/t+p22DTihaMDcOf+rT6siJMyrYfvrcJTx49ARPn/+LTBnSYOfu/dj952Es1NY52XcgjAN7+uWae39p9Jm1tM2qfl0KObJlQs9OzdRnVm4rNbeskNKs2e4hLSuK53P1FLAoIPtKyuRJLc539hnPnj/XvjseqBMLg/u0R/JkSSDB53fad4vYSLBk0Yr18PXshXhx40gSBwpEqUDgb/korUrkrVwOQLbs2KP62ZC11q1ZASPGzYR0TipnbOTgrHPbRpg0cwnkLJLk4QDtAC0rRg7phh9+3Ao5cyoHesvXbDaceZUOXyuULoZmDWoauIoVyotYMWMapp19RP7wzxjvgbMXrkDuT9d75NTOSMyZOBxyKbM+je8UoEDIAnJbS/OGNSF9KiVLkhg1qpTBkROnDQXLlSps+EGbMkVy/H3tpmGeuZHHT57hwcMnkKCKzC9dvCCsebJBpXIlVF2kbOxYsXDs5DnIlXfuIyZCln3uwt8yK9jh6ImzqFmlrAqsumln6Ztp7TuipekLFSuUx3C1TeqUyXD56g39LIvvR7Uf2cE5Gdf7uFbnFo1rqWBM6lTJUaFMccNyDxw+qTo27Dl4DGS4eOUa/jK62sB4OZbySsDh3v1HqFerolpu6RLBG2fSAhMliuRXeRvWrYwbN++oDrOl3P0Hj3Bdm5ZBbgMtV6qIymf68mXWjMikBRX06S6uLpi/bB3k6o/1W37DhUtX9bPUu/QxJSPymbp95wH0B/KS1rHPCNSpVh7tmn8jk0GGE6cvat+X2SBPhpOZLRrXVFdnSMBcprNlzoBM6b+QUXyRKgWuhGL7yXfpsb/OqHrcvf9A+3yUwcGjp9WtnTJPFnbsr/OoU/1r9dmQJ9NZCh5JXuMhYJsFHA5a2mbG+W0dt3a727oelqMABexPQK6uO/Cp366yJQujQy8vDOrdDqlTJtdOEOxWV+TI9538rV3181YGS+xvEzp1jQK+IZ2M4MHDpyiqHXBO1AIia9ZvQ03tLJd0yNSoTT912bScvatTvQISJoinHZx8cDIdy82Vg50z5y6rDN3cRyN27FgY0KMN5IdA2+4eqsPCujUqIGmSRCoPX8wLyNU208YOwYwFKwMFTYyvOjFfkqkUcD6BTNqP5Zv/3IP8MDbX+o/4qB1ouRpmyZVvEvjWJxjfFuDi4oJ370L+my75ZNAvQ5apH3d1dYHxLRimQfVYsWLos2Ljtt/V1R+tmtRR/a6U0Q4S/3v5yjDf0ohqk+vnNsWM4YbAbfr81e2i2vTe0qIM6WqZbp+XKW0yXqZxvQPyfr6cPIbxpeU6QK5+kKtyZFg5f7x2YNvbsB7j5cBCXlm+1FsGfUGpj37c9N0tUL1dodNpC9Yy6XQ6NKhTBSvXbVFDQ21cpwuYB22+8f9YJrc49hvmhy+zZlKXzvt59Q3SH46ri5Gxq7bNP535lGVW/bo0Nm3fA7lVSKaDDB8/wk0ro08XPxejeslnSD/PRVvPu3fv9ZMW39OlSYU3b97h972HIVd3yBUyR46fVledSABNCoqrm9HnJrS3BIRmm8nywzpI/aS9MuiXFdx21+fhOwUoEL0F5ATh6p+3YZDXJEhAXq72K1wgF9yHT1QduR86dsbQh5f8DRvj2YdXlkTvTe5wtf98ROBwTTPfILlXeNjoyaj6dSn8sMAfu/YcgvRXIh2UrZjvB1+P3vDx6IVN23ZDzvrHNjnIMr9U50iVe6PlALFp/WpoUq8aerj7qsffrv/fNPTq3AITvN1RIG8O58AIYyuTJE6IGX7DIE8S0vdNEMZFsjgFHFJAru6oUKYYBmoHWqc/BWylob9pPxyfv/gXRQrkwYq1W1RAQa4S3LrrDxQrlE+y2DTIvpk0SUKcOntRlZenHVy9fkuNy0u6tKkh/Q3JuFzR8Pe1z/MkzXi4qs3Ll/tLZMmUVgvUvNcCpMcNs+X2zyfPXhimjUeKFMiNLTv3QJ4OIGfbVqzbAgnyG+cxN37vwSMsXrHe3CyrnArly4W9+46q5bx79w4Hj/6lxuVFrriZs3gNxF6mxVz62pBx08FSXuk4PXmyxJD+nKSMqbGkGQ+X/74BOTspaes27kD6dKnVVRQyXadaOfz2xyHtu/wA6tasIEkhDi9fvcLjp89QpmQhyPa21OGgpQVJX1NfFSsA6atGf9WIcd4Ceb+EfFalvw5Jl8/nl9kyhfkHgHwG5ixehSIFc0MC70+fv1AdBxcrnFdWg8L5c+KPg8fVviAJfxz4/HmT6dAMlraZlI0XN7b2mbT+aT1SVgZrt7uU4UABCkRvgV17Dqpj3f7d28DHsxd8Js7DhctX4TOsJ+T3lueAThgxsAv4eyt6b2dHr73DB0xu372PX3buNWzHi5evo3DBPMiTMysyaAddftqZpTkLV6vLweSysGxZMmDj1t8hB8gDerQ1lHP2Ebm38Omz56hYNuDSbLn3/9sG1dF7yFjtbB+0A7VcVl227uye0n65/Uae9iE/nGSaAwWcSMCqpnq6d8ZXxfJjV8mOjgAACQhJREFUpN9M1XmrdER68e9riBM7Fjq1aYjYsWOjdbdh6D14HGpWKQe5VcOqFZhkHjGwK+Yv/RGyHulfIlPGtEiUMKHK9W396pj5/Q/o0t8bEvCUgI6aYealfu3K6vtHOg/1GjcTX2bNaMhVsVxxPH7yFL2HjDPcHqqfKX9nK5f/Ct0G+KB9j+FIED8+pG8t/XxL79Jnxe9/mu/o0xoneTKL+ErdBnpNRNw4n+8hb9eivnYyIROkTS27DEHbbh6qHebqFFxeL81Y7lEXY+nY9IvUKcwtQqVJsEH6HZNOZrfs+EN1NK5maC/SIftXxQpq27ww5Ae5lhTi/zja56VFo1po9t0g5f/w0ZMQy5hmaN20DuT2n+4DfWEaNEmeLImq4/hpi9CuhyfkMnTPAZ1NF2H1tPRjcuPWXehvT8qXKztixHBFqhTJ1LIqlSuJHNkyqjb18/CzeFWWymzhJbhtJidKtu36E93cfRBcp6/Scb50nLt5+27MXbwaMn7sr7NqjdZsd1WALxSgQLQSkOC2/M3TV/r4ybNoVLeq+jslAdlenVpAOueW2zkzZUiDdGlS67PynQJ2K+DwAZOYMWPgxq076n5n2Qq5vsyMo8dPG6blx2qJovm1aOc1ma2G2tXKo2/X1tqByOdLktUMJ36pW728dsb1Eu7ef2hQEKf6tSrh0pUbhjSOUMA5BdjqiBSIGSOGFhhpjFXfT8CSWT6QJ0l1bNUQcsuB/GD21M5QLZ3li2VzxmiBhW+g/ye3jBQrlFc/iUk+7toP64Jquk+XVmjeqKYalxdZtj74kSHdF5BOM2U9zRrWwKtXr5EhXSrJBrl988clk1XHl/IksMUzfdSVdjLTdH1yG8XqhRMwWzoPHd4Hvp691ZOwJK90COjn1Q9TxgyCdPqaP8+X+H7aKJmlBrmKQdqzRGuvtE++q2RGpzaNlYWMyyA/3Ht2bC6jOKYdmLZp9rn9KvHTizVOcnugXBItdZs4eqDqRFTqI4uSs4BywLt87lgsmz0GG1ZMR8miBWSWMjH2Di6vPElCtocYy9PoxKlQ/lxqOcYvsrxF072Vk6xz3uQRWlAgkyGL3B516co1bVvWMKSZjsgyZNsYp0t71i6eqJbbsXUj/LFliWH2vq3LDOMy8uvPCwx9cRnPE3upWzwznRKWL10UC6aOVHbiKJ3IyrJM6yInb4y3u+TRD/LZEif9dPVKZSDrl2C7pMnnTz63Mq4f5LMgnQ7LdpN3Ccrr55l7Fxepk35ecNusiHaySbbVzPHD1G1B+jKm73JcIPU0HvTbVtoTmu1uukxOU4AC0UNA/h6O9p8DfZA055dZsGf/UUPlCxfIpQXdM8PDZxrkaj/DDI5QwI4FHD5gIh22ycGQ7Jhy/1zSJIlQs2p5SJ8bW3bsxc7fD+DFi38hB892vJ2ivGpyoDR+ZD/0HeYHuXxaX6FaVcupHxD6ab47iACbQQEnFpAnjXxdtz1adR2KsZO/V1cLSHDG3km6d2iG8hY6PbX3uttSP7nlpGXnIZBbYLJmSm/LIliGAhSgAAXCUUA6u56snQjwGjcLJ89cRPWKpSFX+w/w9Mevew9h4IiJqFG5DArmzYmDR06F45q5KApEnIDDB0zkHnO5fNRzQGesWb9N9U3SqkltdZZv664/sXHbbvTu0jLihB1oyXlyZsMI9y7o7zkhUNAkOjSRdaQABSgQWoGaVcrh1/XfY+ksX8ybPAIF8+UMbVHmi0QBufVqxbxx6NetTSSuNfqtav/hE+g6YHSQQdJtbY2UDe9l2loXlqMABexHQPqZGuU3G+VKFVVXkZy98Le6ulNubf158y5IR91yslWuWM+cMZ39VJw1oUAwAg4dMLl64zZW/7wVvTo1R7KkiTF7wnAsX7MJ2379E3Jpq1xyLZeGpk8b7e6fC2aTRuwsuZzWa1BXdSl8xK6JS6cABShAAQpQIKwCcsvULH8PmA6Sbuuypazp8mRa0m1dJstRgALRT8D4wQXSSfnSVRsxf8pI9TS1GeOHwtN3OqRzdHm4xmTfQcifOxsGj5yE4kXyI0O61NGvwayxUwrYScAkYuylo6F1G3YiWZJEagVJEifUDhg88b81m3H4+GmVxhfrBXJkywS5/976kixBAQpQgAIUoAAFKEABCkR3AXlypnRsbdzxtYvOxdAHpHToWuXrknAfMREPPnWuHSdObDRtUAPNG1rudwr85yQC0aeZLtGnqtbXtF7NiujRsTlGT5iHN2/fqgVIZ2nTxg0BL7FWHHyhAAUoQAEKUIACFKAABShglYB0Ej1viheOnzyvnpzl5uqK0iUKwHv8HLx+80Yt6+3bdxg9rId6FLokSAfmhc108C3zov3ABjisgEMHTGSrNa1fDeVLF0GfoX6GoIk8LUB2apnPgQIUoAAFKEABClCAAhSgAAU+C4Rm7MDhvxAvbmwM9Z6KM+cvo/t3zfD02XPUa9EbHfuMxNXrt4J9qlZo1sE8FIhqAYcPmAhwg9qVUb1SaSxZuV4mOVCAAhSgAAUoQAEKUIACziPAloazwObtu7UgyRUUyJsDfl59MWTUFNy6fQ/+3gMwffxQdGrTEH4j+4fzWrk4CkS+gFMETIS1bvUK+K5VQxnlQAEKUIACFKAABShAgWgswKpTIOoElq/ehJXrtmq/rRpAp9MhT85skKCJdOgqD93Imik9ihXKC17RH3XbiGsOPwGnCZiEHxmXRAEKUIACFKAABSgQrgJcGAUoEG0EqlUqjVevX+HgkVOGOsuTNL2H9sSR45/TDDM5QoFoLMCASTTeeKw6BShAAQpQgAL2KcBaUYACFHBUgeRJE2POxBFYvHI99h06YWimPEmzYZ0qhmmOUMARBBgwcYStyDZQgAIUoAAFIlaAS6cABShAAQoYBJIkTgh58uicxWsCBU0MGThCAQcRYMDEQTYkm0EBClCAAtYIMC8FKEABClCAAmERSJQwPqaOGYS4cWKHZTEsSwG7FmDAxK43DytHAQpQIJQCzEYBClCAAhSgAAUiWSBhgvjqSTmRvFqujgKRJsCASaRRc0UUoIA1AsxLAQpQgAIUoAAFKEABClAgKgX+DwAA//++pJ1OAAAABklEQVQDAKU+KhyZSNqkAAAAAElFTkSuQmCC"
+     },
+     "metadata": {
+      "image/png": {
+       "alt": "Bar charts of mean validation information coefficient for every full-coverage linear configuration, one panel per declared label, sharing a vertical scale. Each panel's leading configuration is highlighted in amber and the rest are dark navy; the bars are held in the primary label's ranking order across every panel, so a panel that does not descend is a horizon that orders the grid differently. A dashed zero line runs across each panel."
+      }
+     },
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "def compact(params: str) -> str:\n",
     "    \"\"\"Render declared parameters for a title: `alpha=1000000.0` reads as `alpha=1e+06`.\"\"\"\n",
@@ -716,8 +1572,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5fcec864",
-   "metadata": {},
+   "id": "9c9b4127",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004693,
+     "end_time": "2026-09-11T00:09:07.389383+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T00:09:07.384690+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "### What shrinkage does on its own\n",
     "\n",
@@ -729,10 +1593,263 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "fedc502a",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 12,
+   "id": "e69fe911",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-11T00:09:07.401297Z",
+     "iopub.status.busy": "2026-09-11T00:09:07.401101Z",
+     "iopub.status.idle": "2026-09-11T00:09:09.380459Z",
+     "shell.execute_reply": "2026-09-11T00:09:09.379458Z"
+    },
+    "papermill": {
+     "duration": 1.989113,
+     "end_time": "2026-09-11T00:09:09.383503+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T00:09:07.394390+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.plotly.v1+json": {
+       "config": {
+        "plotlyServerURL": "https://plot.ly"
+       },
+       "data": [
+        {
+         "line": {
+          "color": "#0a1628",
+          "width": 2
+         },
+         "marker": {
+          "color": "#0a1628",
+          "size": 7
+         },
+         "mode": "lines+markers",
+         "name": "fwd_ret_1d",
+         "type": "scatter",
+         "x": {
+          "bdata": "AAAAAAAACMAAAAAAAAAAwAAAAAAAAPC/AAAAAAAAAAAAAAAAAADwPwAAAAAAAABAAAAAAAAACEAAAAAAAAAQQAAAAAAAABRAAAAAAAAAGEAAAAAAAAAcQA==",
+          "dtype": "f8"
+         },
+         "y": {
+          "bdata": "HpCJPvNekD8M8wrA7l6QP2rTRsjQXpA/dDwAcupdkD/n+DRsFFeQP7qO4wO6L5A/Z9XpxvERkD/mURcAyX6QP0rO2zZjF5I/Nuz+gbG5kj8Tbrn/lqaOPw==",
+          "dtype": "f8"
+         }
+        },
+        {
+         "marker": {
+          "color": "#D4A84B",
+          "size": 14
+         },
+         "mode": "markers",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          6.0
+         ],
+         "y": [
+          0.018286489066422905
+         ]
+        },
+        {
+         "line": {
+          "color": "#C87533",
+          "width": 2
+         },
+         "marker": {
+          "color": "#C87533",
+          "size": 7
+         },
+         "mode": "lines+markers",
+         "name": "fwd_ret_21d",
+         "type": "scatter",
+         "x": {
+          "bdata": "AAAAAAAACMAAAAAAAAAAwAAAAAAAAPC/AAAAAAAAAAAAAAAAAADwPwAAAAAAAABAAAAAAAAACEAAAAAAAAAQQAAAAAAAABRAAAAAAAAAGEAAAAAAAAAcQA==",
+          "dtype": "f8"
+         },
+         "y": {
+          "bdata": "KNKTMfHRhD8yyNSf7dGEPznDop7S0YQ/RtO9Q/bQhD9mbq7rjsqEP8rEycpbs4Q/rcy6VySWhD/SR0LWho6EP8jgU1/FIIY/+OKh3ewdgz9MtfrbM5xcPw==",
+          "dtype": "f8"
+         }
+        },
+        {
+         "marker": {
+          "color": "#D4A84B",
+          "size": 14
+         },
+         "mode": "markers",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          5.0
+         ],
+         "y": [
+          0.010804693195027318
+         ]
+        },
+        {
+         "line": {
+          "color": "#10b981",
+          "width": 2
+         },
+         "marker": {
+          "color": "#10b981",
+          "size": 7
+         },
+         "mode": "lines+markers",
+         "name": "fwd_ret_5d",
+         "type": "scatter",
+         "x": {
+          "bdata": "AAAAAAAACMAAAAAAAAAAwAAAAAAAAPC/AAAAAAAAAAAAAAAAAADwPwAAAAAAAABAAAAAAAAACEAAAAAAAAAQQAAAAAAAABRAAAAAAAAAGEAAAAAAAAAcQA==",
+          "dtype": "f8"
+         },
+         "y": {
+          "bdata": "L7II2VnUiz93qFb0WNSLP+ZLoLFW1Is/TXKZcaXUiz+5nJBiZdeLPxBEnrIx2Ys/tKoFnFHviz8CDiyjShWNPxDkT8+aT5E/RHptd41hkz8VXE5ch7qSPw==",
+          "dtype": "f8"
+         }
+        },
+        {
+         "marker": {
+          "color": "#D4A84B",
+          "size": 14
+         },
+         "mode": "markers",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          6.0
+         ],
+         "y": [
+          0.01892682115009793
+         ]
+        }
+       ],
+       "layout": {
+        "height": 520,
+        "legend": {
+         "title": {
+          "text": "Label"
+         }
+        },
+        "margin": {
+         "t": 70
+        },
+        "shapes": [
+         {
+          "line": {
+           "color": "#334155",
+           "dash": "dash",
+           "width": 1
+          },
+          "type": "line",
+          "x0": 0,
+          "x1": 1,
+          "xref": "x domain",
+          "y0": 0,
+          "y1": 0,
+          "yref": "y"
+         }
+        ],
+        "template": {
+         "layout": {
+          "colorway": [
+           "#0a1628",
+           "#D4A84B",
+           "#C87533",
+           "#10b981",
+           "#ef4444",
+           "#94a3b8"
+          ],
+          "font": {
+           "color": "#334155",
+           "family": "DM Sans, DejaVu Sans, sans-serif",
+           "size": 11
+          },
+          "hoverlabel": {
+           "bgcolor": "white",
+           "font": {
+            "family": "DM Sans, DejaVu Sans, sans-serif",
+            "size": 11
+           }
+          },
+          "legend": {
+           "bgcolor": "rgba(255,255,255,0.8)",
+           "bordercolor": "#e8e8e6",
+           "borderwidth": 1,
+           "font": {
+            "size": 10
+           }
+          },
+          "paper_bgcolor": "#FAFAF9",
+          "plot_bgcolor": "white",
+          "title": {
+           "font": {
+            "color": "#0a1628",
+            "size": 14
+           },
+           "x": 0.5,
+           "xanchor": "center"
+          },
+          "xaxis": {
+           "gridcolor": "#e8e8e6",
+           "gridwidth": 0.5,
+           "linecolor": "#e8e8e6",
+           "showgrid": true,
+           "tickfont": {
+            "size": 10
+           },
+           "title": {
+            "font": {
+             "size": 11
+            }
+           }
+          },
+          "yaxis": {
+           "gridcolor": "#e8e8e6",
+           "gridwidth": 0.5,
+           "linecolor": "#e8e8e6",
+           "showgrid": true,
+           "tickfont": {
+            "size": 10
+           },
+           "title": {
+            "font": {
+             "size": 11
+            }
+           }
+          }
+         }
+        },
+        "title": {
+         "text": "Ridge IC against penalty strength, over ten orders of magnitude"
+        },
+        "width": 950,
+        "xaxis": {
+         "title": {
+          "text": "log₁₀(α)  (Ridge penalty strength)"
+         },
+         "zeroline": false
+        },
+        "yaxis": {
+         "title": {
+          "text": "Mean cross-sectional IC (validation)"
+         }
+        }
+       }
+      },
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA7YAAAIICAYAAABaTXIpAAAQAElEQVR4AeydA2AdWRuG3xs1TWrbtm0bW9s2trbbrW27W2xt27ZtM/znO/1venNz0yZtMDd5u/sOzpw55zvPzJ3MdzQ2Li7fPCky4D3Ae4D3AO8B3gO8B3gP8B7gPcB7gPcA7wFrvQdswH9+IMAoJEACJEACJEACJEACJEACJEACeiVAx1avV8Ya7aLNJEACJEACJEACJEACJEACJBAMBOjYBgN0Zhm6CbD0JEACJEACJEACJEACJEACAUuAjm3A8mRqJEACAUOAqZAACZAACZAACZAACZCAnwnQsfUzKkYkARIgAb0RoD0kQAIkQAIkQAIkQAJCgI6tUKBIgARIgARCLgGWjARIgARIgARIIMQToGMb4i8xC0gCJEACJEACvybAGCRAAiRAAiRgzQTo2Frz1aPtJEACJEACJEACQUmAeZEACZAACeiUAB1bnV4YmkUCJEACJEACJEAC1kmAVpMACZBA0BOgYxv0zJkjCZAACZAACZAACZBAaCfA8pMACQQoATq2AYqTiZEACZAACZAACZAACZAACQQUAaZDAn4lQMfWr6QYjwRIgARIgARIgARIgARIgAT0R4AWaQTo2GoQ+D8JkAAJkAAJkAAJkAAJkAAJkID1Evi1Y2u9ZaPlJEACJEACJEACJEACJEACJEACoYAAHdsAushMhgRIgARIgARIgARIgARIgARIIHgI0LENHu6hNVeWmwRIgARIgARIgARIgARIgAQCnAAd2wBHygRJ4E8J8HwSIAESIAESIAESIAESIAH/EKBj6x9ajEsCJKAfArSEBEiABEiABEiABEiABP5PgI7t/0FwRQIkQAIhkQDLRAIkQAIkQAIkQAKhgQAd29BwlVlGEiABEiCBnxHgMRIgARIgARIgASsnQMfWyi8gzScBEiABEiCBoCHAXEiABEiABEhAvwTo2Or32tAyEiABEiABEiABayNAe0mABEiABIKFAB3bYMHOTEmABEiABEiABEgg9BJgyUmABEggoAnQsQ1ookyPBKycQIMWXdCj/8ifliJjnjJYuWbTT+OExoN+YRfSuTRo0RU9B4wK6cX87fKNmTQHpf9q9Nvn88SAJbBo+VrkLFwpYBMNoNRu372POk07Ikn6gkiQOm8ApRq0yQTmM1HP1y4AKTMpEiABfxCgY+sPWIxKAtZMYOmq9YgUL6OXsuYvjzad++HuvYfeipUqRVIkThjfW1hw7WQrUAEjx83wlv3V67dRt1knZMlXDrGT51QvpU3a9MDZ85e9xQuOnYBmJy+1vQeNDo6iBFie8kK+aeueAEvPUkJnzl2C3Ntv3723dDjYwoKi7MFWOLOMQ1NZzYoeaLvT5yzB589fcXL/f7h/5VCg5ROYCZs/E0PCMy0weTHt3yXA80jgOwE6tt85cEkCoYbAhpWzsX7FLHRu1xR3NKe2cZvu8PT09Cp/zy6t0aJxba99PW1s23UA+UtWx+0795WNC2eOQdsWDRAjehSMHD892E3VM7tgh0MDSIAE/EXg0ZNnSJ8mBaJEjuSv8/QUmc9EPV0N2hLqCYQCAHRsQ8FFZhFJwJRA/jzZUSBvDtSpXhHtNKfw9NmLuHf/kVcU865j0qJbo0Fb1RUuZ+HKWL56g1dc48atO/dQrV5rb3HMuysbW1pTZSmG5JkKo1XHvvBPC9vHT5/RqcdgZMucHns3L1eObfHC+VCvZmUMH9ANsyePMJrjY7115340b98LabKXQMrMRdX2y1dvvMXbufcQCpWphXgpc6NYhXr4b9NO1Qr46PFTFU/yHzJqEkpUqo/4qfKouGvWb1XHjAtzdlXrtkbfIWPQqecQpM5WHOlzlcagERPh5uZmPAX/TJil0oyZNLvKr1GrbupYu64DIC2dU2YuUuHSInntxh11zHwh+XTsPhi1m3RQbCWfAcPGe8vH3d0dk6YvRL7i1RA3RW4ULlsb6zfv9ErqyPHTKp/d+w+rY1LG8tWb4tSZC15x/MLAK7K2kTV/ebz/8FF1pxT7hf/9B48ROX4mnL90VYvx4//5i/+F3Buurq4/Ak22xNa/ardCwjT5lJ1yrR5rL/5y70pZJGqitPnVMbnWsh8tUVYsWLoacp4cM7b+b999AKUqN1RpSa+AEWOnQ/jIOSLh+avr9qt73lLZJW2jZi9YjuwFK6hupk3b9sDT5y+Mh/y0dnFxhdyPkoZcq3LVmuLwsVPqXKmokvtt1vxlat+4kK6tch3OXvjeu+HN23fo2nu46v0gaQini1euG6PDeE/I70d4x0qWAwcOn/A6btzwrazC9Gf3nJwv10i6lBqfH3J/rli9UQ75qp+VXU76md2TZyyEXHO5H+T38u7dBznFS3612fy+kt+G/AbzFKui7kH5jU2cvsArXUsby/5dr54jErdQ6VqYt2iVVzR5TsnvX9KQa9ZRe/Z5HTTZkHu135CxaP/3QPVsK1iqJlat3azu59ETZ6seLXJ9TNOW02dp94acKxyEx9B/Jnt7Xsg9NGHafMi5EkdYCbucJt22jd3qZ85b5uu9bPpM9O2ZJuWUFn+xyyh51km5jc9fCZf8xVajPebXTuL86rctcSgSIIGQS8AmAIrGJEiABKyQgLwcrtmwVVlua2v5USAveTUatsObd++xf+sKzJ8+GtPnLMXbtz+6fIojUlOLE8YxzP/j/KM5hTu8xXn+4hUq1miGjOnSYMOqOdj+30JEjBgO1TWH2cPDQ9nwq4V0NRZHplvH5nBwsPcR3dnJyUeYMeDtu3eoVLYEDm5fiRULJyGMgwPqN+/i1VJ949Y91GjQDqWLF8L5o1vQt1tbTJw+33i6Wru4uCBMGEeMG94X545sRptm9dBr4Gjs1BxiFcGXxZIV65E9SwYc2rEKY4f3xlzt5XX1f9+5ixMpL5iD+3TGnQv7sX/bCuTImlGlNGn0AJQtVRhtmtfD24fnlFImT6yOWVosWfmfdm4mnNj3H8aP7IsVazZBXmyNcUeNn4H1W3ZiYJ9OuHxyO7p3bAlxfsVpMcaR9cKlazFmaC8c37sO8ePGQcuOvb04+ZfBqQMbECF8OCyZPV7Zf/nEdiSIHwfFC+fF8n+9V5As0/ZrVi0He3uf1/bDx0+Q7uZyXNifPbQJDWtXgcFgQMIEcbFn01IxHXcvHVD5zJw4TO3LQpzZRvWq4uqpnWjVtA72HTyG9l0HomHdKhD7po0bjOMnz2Hg8AkS3Us/u25+ueclbfOyGxOXHgcbt+5BxzZN0K1jCxw6egojxkw3HvbTuv+wcZg1fwVGDu6h7kfp8lmxZgvIvWwwGFCzSjms3bDDW1qr1m5B+jQpkSl9GhVer1kXfPj4EbMmDcfZw5tRrnRhrRKgJUydCYk4ZtJsjB7SEw+vHkbmjGklyJt8K6tf77lZ85ajZdO6qhy1tQq3lh37QCrUvGVisvOzsptEg7ndUinXZ/AYdGjdCGcObUTu7Fm1yp4FpqfArzab31cTps7F3fsPtQq2kXh0/QiWzZuAuLFjeEvbdEcqalpplXu1qpbHpRPb0KRBdUgF2OIV61S0a2d2oVSxAujQqqG6p8eP6KvCLS1WrN4EWztb/DO0JzJnSotm7XpqlXe98ez5S+1Z1h45smZSacu9YTz//YfP6NK+qXrejRrSA4eOnsbwMVONhyHPk9ETZqKP9iw8e3gTypQojJnzl3sdN25IJYk8l1ctnIp1y2fg9t0Hvt7L/n2mGfOQtV+unV9/25IeRQIkEDIJWH6bDZllDeZSMXsS0AcBqQUXxUiSTdXsVy5fEvHjxbFo3J4DR3Htxm1MGNkfiRLGQ+qUSSFO2Lv3H7ziS5zbdx8qh+97nGQY0rcLTOOIM5chXUr83aEZkidNqMbwDtdaWS9dvgEZH+mV2E82bt+9r45m/7/jp3b8uKhZpTzKlCykuvTJS704mMdOnoW0IksSS1euQ5qUydC9UwsVp2C+nGhYp4oc8pJ0BxT706ZOruJUq1xGi1PVh4MGs3/FCudF7WoV1DnSwly0UF6cOH1BxXry9IUKF2fWySksMqRNpZwvddCfC2nJ7qi9sEeKGAFFC+ZRjvf8Jf+qVL59c8H4qfO0a9dJHYsYITxKFS+ABnWqai2a3+OoiNqiV9c2yJIpHWLHioF2LesrR+nZi5faEShbf4eBOtlkUadGZazQWuXEQZTg6zfvQq6HhMu+uV5presSN1/ubJDyyX3WsG5VZaN5XPP92tXKo3zponDUKl7E0Rw3ZS6aNaqlOX7lES1qZMj91KtrK1XhYHruz66bX+5507TMt121FvtlcyeoXhMtm9SGdP2X8pvH823/y5evmL1gJbq2b44iBfKo6zJi4N+IEzsG5iz87nz8VbGUasE1dVLXrN+CyhVKqmT3HzqufntTxgxE1szpETVKJDSuV1279mmxev02Fce46NG5JbJplTN2dnYI5+xkDP7p2j/3XOP61dR9GTlSRLRuVhcxokXF6XMXLabvl7IbTzS3e8GSNfirQinVy0Pykvs7dapkxujwj83m95X8lhMnio80WnrOWiWb9IqpUrG0V9rmG7M0J1GeSXLt5Z6uV7Myqv9VFjPnLjOP+sv9TBlSa8/fPqhQpphax4kdE/J7+UdzWMuVLoLJYwao63v67PfnjiTYpV0T5M6RRVU8yT0kz74lK9fLIaVFy9aiTo2KkL8PYl/dGpWQN2dWdcx0IRwH9OoI+U3K86tO9Qo4fuqsaZQA2f7VtZNM/PrblrgUCZBAyCRgEzKLxVJZLQEaHugENqycjbVLp2OQ1kqYXmu9Ga+17vmW6d17DyBOb2rNoTXGka7MYcM6GndxT2ulSKA5xtGjRfEKS5o4IcKHc/bal26bO/YcgjjURkl31E+fP6txvl4Rf7JhMBjUUXd3d7X2z+LBw8fo2H0wpBub5B89cTbVVe/Bo8cqmbv3HyFDulRq27hInzalcdNrvezf9ShbtYnqci3pjBg7DQ8ePvE6bmkjrvaSaRoePVpkvHj5SgWJoyvbhcvUVt1KpVVCuu6qg/5cpE+bwtsZGdOnxtNnL/D58xfFWF7apfut2G1U/6HjcEerlDA9MV6cmF670TUHQ3ZevHwtK6XfYaBONFmUKVEQ9nb2kFZLCV60fDXy5sqmKj1k31zy0izHi1esj14D/9FaKpdp990j82gW9zOlT+stXCpqBo+c6O1elK7n0pX0ydPnXnF/dt38cs97JWRhI2mShDD9DSVKEM/rnrAQ3UeQ3K/iuIjzbTwoTmfhArnV+HMJk9+2aNm/G2UXp89exHWtAqGG5jxJwK3b9yC/v2iJsnpjsXXHfh+tpVkstNJKGj+TjN/36z0njphpWjFjRNN4/LjnTI/5pezG+OZ2S0t5wXw5jIfVulD+XGotC//YbH5fSYXBwqVrUKNBWzW8YMv2fV49HSRtc924dRfFtEou03DZv3L91k/PM41v3JbWeuO2wWBAkkQJVCWkMczW1lY9x02HXxw9zw+35AAAEABJREFUcUYNXUiVtZi6/hVrNvd6Xsh5d7Rnfzrt74NsG5XewjMxftzYxsNqHS1qVEgPHbUTgItfXTvJyq+/bYlLkQAJhEwCdGxD5nVlqUI4gT8pnjim8gLcvmUDVKlUGi069PppcnbaS5F5BFubXz86ZIyW8TyDwQBpvTB2qTVdV9VsMMb72TpFssTqsLxwqQ0/LsSOv+q0hDiUS+ZMwLNbJ/D6/hlIl1dXFzc/pgLVwijdD/v1aKe66UoZ+nRrBxdfxoQaE7ax+e6QG/e/rz3VKkb0qDiwbSVqa60cnzQHdPiYaShUumaAvhiKfQbDdxuO7FoNsdtUR3evUbYYFzY2Pq+tMJTj0sr6OwzkXFMJ+7o1K2LFmg2qZWnVmi2Qbsamccy3Vy+eir7d28IxTBiIs5azSGUcPHLSPJqPfcewYbyFGQwGjBnWywcHYSKt1MbINj+5bsY45msjJ/Nw833z35TBYPC3MyNpijMra6PsbO2Mm2otv+9Va787tqvXb1Vj6+PGiaWOGQwGyP0n5TaX9GhQkf6/COvo+P8tv68Mhj+9536e16/KLmdbslucPDlmlOm1MBj8brP5fSW9JHZvWoLcWqvmzdt31XO1dpMOxmwsrn3YYmer7gOD4bsdFk+yEGinnWcaLKfb2NiaBqlu+8b7Uyoaq9Vrgxp/lce2tQvw6t5pbF49V8WX54Xa8OPCxsbGR0xjPj4O+BJgMPgsr6UKTFuzv0Wm106SNhj89tuWuBQJkEDIJODziRQyy8lSkQAJWCDQpH51HDx8EjLbsIXDSJQwPu5rrZ2mLXbXbtyBtG4Z4yfUWpvM48iLk2mclMmT4tDRk5BuhMbz/LuW1peUyZNg8IhJcHFx9XH6J6311yxQ7Uor3I1b9zTnsSJSJk+MMGEccOnqDeVQqQjaIlGCuDh/0ftkRhcuXdOO/Pj/6MmzqitezmyZECtmdHXggtkESCrQnwtprWreqJaaAOvIztUa7yc4+f+uymEcwqgXXb8keeHSdW/Rzl24gpjRo0G6ESZNHF+1EO7ae9hbHP/u/A4DcS48PD18ZFW/VhXs2H0IC5etwecvX/DX/7vI+oj4/wBHxzCq+3C/Hu2xe+MSZM2UHlt37lNHw2jOrmz4Zbx2mpTJsHv/EYn+2/LLPS+J+1Z2OfYnkvtVXvLPX/w+CZQxLem+myRxAuMuqmmVRtJKK93916zfplUulfI6ljJFElWBIse8Av9gw7ysSQPonjM3ya9lNz9P9pNobC5e9v67Pm/yG076hzZnTJcaHVs3wowJQzF/xj+QVlvTIRlig1HJkybSnjnebTlz/pIaEmGME1jr02cvIVrUKKhYtpgaoy730gWz55188s2clXmc37HP0jNNKh3ff/iIr1+/eSV59fpNr23ZSPKLaydxAuK3LelQJEAC1kuAjq31XjtaTgJ/TEC6CzeoUwXSpdZSYoXy5USyJAnQoftAvH7zFuIkdu83QjmHxviF8+dCwvhxVByZ8OXKtZtqptUwmgNpjNO4XlW12ax9T8iLpDggEk9mCPbtxU+dYLKQVr7hA//G/sMnULhsLcyYuxS79h3G9t0HIN1TZWZZk+hem9KtUVqpdu09pMIuX70J6ZYsL3MqQFvUrl4JMhuszI4r5ZTxhzIbsXbI6//0aVLg1NmLioN0Ax07eY7K2yvCb2zIzMsyI6yxEmD/oRNqZtLEieKp1JJo6yvXbkF4qYCfLGQSF5nFVGaaFi5TZi1Co3rV1BnSuiXjMcVm+Z6xlFEqGf5dtwWLV6xTcfyy+B0G0u320pUbPpKXSaSKFMiFPoPHQsaDyrhEH5H+H3BFu6fGTJqDh4++d/uW++zW7XtInPA7p/jxYqt78uJl7879/0/3tpIJc2QW1uFjpkLSEbYy6Yy0RHuL+JMdv9zzcrpvZZdjP5Pci2LPZ60V31I86cbcvFFNDB8zTVUYyfUcNX4mxPFo1rCm1yly30tX2x79R+HN23dqDKbxoIyvlFbGNl36aY7+YeVUyMzMMvOsdFM1xvPr2rysAXXPmefv17Kbnyf7Der8hSUr/lOzjUP7J93qt+86oG19//9PbJbnhVQQSkujaP/B45AKMBnX/T1170u5TjKB2so1myC/2bUbtmHh0rVo3riW94iBsJc2dQo8fvoMF/7v5MvvYaLZDM71alVWrMQusU+eG9t27f9jayw901JplU1SATdv8b8qfblXjdsqQFv86tppURAQv21JhyIBErBeAnRsrffa0XISCBACTRvUwNnzl7Fhyy4f6cmL3vL5k+CqtZAWLF0LRcvXRVWtFUhe2IyRxeFctWgKvn5xQd7i1dRnVKpULAWZoChChPAqmkwwIl3enMKGRb1mnZEobX507jkUt+7ch72dnYrjl4VMciJddxMniq8c2xoN2qFpmx549vwVundqaTEJcWCXzB4HcSJzF62Cmo3aQ2aidXYK6xVfJrSSMmzdsQ/JMxVBpx6D0a5lA3U8YsQIat2wTlWULVkIRcvVRY5ClSFOVKc2TdSx312EC+eEKTMXQT4xJONeW3bsDZnwJbX2oidp1qlRCTKeM0qCzJDj0lou4ZbUWHNiL2itT8JWHPeaVcpBJogxxu3ctjGkG7VM5JU+Z2n1PWCZgdWUgzGub+vfYSCflJoyc6GyXz73Y5p2zarlVSu+zAxrGm6+LffNvoNHkS5nKZVO1gIVULJYAYg9ElcqaDq1aYwKNZpBOBk/9yPHzJU7RxbIOPPjp86jSLk6SJ21OMZMmg0Xlx+tRebnqH2ThV/ueYn+s7LLcd8kLWXDx0zFz7qFDuzVCZXKFUfH7oOQMXcZ7D90HP8tnwEZ326abuXyJdTEXKWKFVSt96bHFswcgxJF8qPXgNFImqEQajXqoKVzDOFMxsfDj/8slTUg7jlL2fu17Obn1qxSXj0n+g8bh0x5y2Llms3o1Nb7b/h3bXb38EBbrZIgasIsEG3athsy27TB4LObrdhVQSZ6GtEHU2cvRtrsJTFh6nwM6tMJdWtUksOBKpngasqYQWjdsS9yFq6MMZNnY1Dvjt7yrFO9Irp2aI4hoyar5/WqtZvRonFtRIgQwVs8/+5YeqbJ73f2lBFYu3GbYle2amOI42+atl+uXUD8tk3z5DYJkID1EaBja33XjBaTwG8RkJl5ZSyd+cmJE8bHmwdn1cyxcmzBjDEYMbC7bCrJ8VWLpuLC0S2Qz7XIi9e5w5shM3iqCNpCXqbXLJ2mPnNx7/JBFCmQW3VzlHO1w+p/+SyLfIZFzr1/5RC2rJmHBTNGw8nph4OpIposTu5fr72ItjAJAVKlSILFs8bh9MGNeHn3FCStOdpLUab/f8LEW+T/72TKkEY5MzLG9PyRzShZNL86r2ypwv+PATWRy94tyyDjzeTzJeJwSzdh4yywMpasb/f26jMh8qmQuVNHolvH5tjz/0/NSEILzNj9q8aFtpdDXhK2Ek8CpMVMxrjKdRHdvXRAe6GrJYeUhJ+UU46JpCu1OmBh4ai1kMu3fCWeXKv+PTtAHDBjVIPBoBzBnesXqeskbNctm6FmPZU48lIo5zo6hpFdJZk1WMJktlMJ8BuD0apbtcQXlS5REA+uHoakI/ePhBl19/5j7XomhXTvNoZZWsu9s37FLJWGpCPXaMKofpBKC2P8Hp1beR2X+0zC5f4oViivbHqTjDOXCdRuX9gH+ayKpC3X1hjpV9dN4vnlnrdU9i7tmqh7X9IwqmLZYrh1/nu3agm7cvWmmsVbWrFk35IcHOwhY7xP7Fuv+G5cNRt5cmb1EbV+rb8Ul/nT//FxTO5tmdFW7sFH14+oe3nlwilIlzqFimvpnlAHLCyMZZXrY7zOBsPP7zlJxtI12r9tBWS2aDluSb8q+8/sbtuiPuTel09GyT0gn9M5tmedVzYGw+/ZLHMW3Di7R7EWBnJd5D7zStjChjxD925epn6P8uxpUNv7TOzLtUrFgb07WTjzR5Cle1UqbmSW4x+xoK6tlN0YVlWroDywfSWO7VmruvZXqVha2W685wwGg/rUkDwLpTzC6smz5169JCQdv9zL8qyTZ57EF/n2TJPf6fZ1C9Xz9/DO1RDHX/KVXgdynkjs/9m1kzjCXGz17bctcSgSIIGQS4CObci9tiwZCQQZAemutmPPQXz4+AknTp1D49bdIRNU/cwRCzLj/JiRdME8deYCpFuwdM3rP2y8+vyJH09nNH8SePX6LWbNW4Ym9av580x9RA/Me/7w8TNahY7lHgj6KD2t+EMCuj9dhiqMGj9Tfe5LfqvTZi+BfAKoUd2quredBpIACYReAnRsQ++1Z8lJIEAJtOncD/FT5UGTtj2RNHECSCtqgGYQyIm9ev0Gpf5qhIRp8mHQyImQ1pOOrRsGcq6hM/lWHfsie8GK+KtiSTSqa52OrVy5wLrnd/y3EBnTpZYsKBIIFgLSG+LI8dPa77QC0uUsiVXrNmPu1FGQ1vCgM4g5kQAJkID/CNCx9R8vxiYBErBAoHL5krh+ZrfqyiZdfaeMHYQokSNZiKnfIOm6++LOSUg3V+me16NzS8gYY/1a/MMyS90RfxzV39a08YMhXQWH9f/bahibUwwJ97x5mbhPAkYC0t1buvRKd+AnN46p7srSZd54nGsdEaApJEACXgTo2Hqh4AYJkAAJkAAJkAAJkAAJkEBII8DyhA4CdGxDx3VmKUmABEiABEiABEiABEiABEjANwJWH07H1uovIQtAAiRAAiRAAiRAAiRAAiRAAqGbQNA4tqGbMUtPAiRAAiRAAiRAAiRAAiRAAiQQiATo2AYiXP8mzfgkQAIkQAIkQAIkQAIkQAIkQAL+J0DH1v/MeEbwEmDuJEACJEACJEACJEACJEACJOCNAB1bbzi4QwIhhQDLQQIkQAIkQAIkQAIkQAKhhwAd29BzrVlSEiABcwLcJwESIAESIAESIAESCBEE6NiGiMvIQpAACZBA4BFgyiRAAiRAAiRAAiSgdwJ0bPV+hWgfCZAACZCANRCgjSRAAiRAAiRAAsFIgI5tMMJn1iRAAiRAAiQQugiwtCRAAiRAAiQQOATo2AYOV6ZKAiRAAiRAAiRAAr9HgGeRAAmQAAn4mwAdW38j4wkkQAIkQAIkQAIkQALBTYD5kwAJkIApATq2pjS4TQIkQAIkQAIkQAIkQAIhhwBLQgKhhgAd21BzqVlQEiABEiABEiABEiABEiABnwQYEhII0LENCVeRZSABEiABEiABEiABEiABEiCBwCSg87Tp2Or8AtE8EiABEiABEiABEiABEiABEiCBnxPQi2P7cyt5lARIgARIgARIgARIgARIgARIgAR8IUDH1hcw+gymVSRAAiRAAiRAAiRAAiRAAiRAAuYE6NiaE+G+9RNgCUiABEiABEiABEiABEiABEIVATq2oepys7Ak8IMAt0iABEiABEiABEiABEggpBCgYxtSriTLQQIkEBgEmCYJkAAJkCPvmCkAABAASURBVAAJkAAJkIAVEKBjawUXiSaSAAmQgL4J0DoSIAESIAESIAESCF4CdGyDlz9zJwESIAESCC0EWE4SIAESIAESIIFAI0DHNtDQMmESIAESIAESIAH/EmB8EiABEiABEvgdAnRsf4cazyEBEiABEiABEiCB4CPAnEmABEiABMwI0LE1A8JdEiABEiABEiABEiCBkECAZSABEghNBOjYhqarzbKSAAmQAAmQAAmQAAmQgCkBbpNACCFAxzaEXEgWgwRIgARIgARIgARIgARIIHAIMFX9E6Bjq/9rRAtJgARIgARIgARIgARIgARIQO8EgtU+OrbBip+ZkwAJkAAJkAAJkAAJkAAJkAAJ/CkB63Fs/7SkgXS+vb0DKH0zsLOzh6urK68T71V4enqqJwF/s/r+zQbF9XFxceEzgc8E7Xlg0J4L4L3Ae0G9J8j7QlA8f5jHn/0N0n64v/3/69evQFkPA/9eaBv/nsD4+iZA60iABEiABEiABEiABEiABCwTiBEjFij9M7B89X4eSsf253x4NGQSYKlIgARIgARIgARIgARIgARCEIFQ49iuXLcNdVv2RP1WvbH/yGmLl/Dlqzdo220YGrfrh16DJ+DL168q3pnzV9Bj0HgUq9wMTTsMwL7Dp1Q4FyQQsgmwdCRAAiRAAiRAAiRAAiRgHQRChWN778ETLFy+ATPG9sOoAZ0wdMxMfP3m4uMKTZixBLmyZcTcSYMQIUJ4LFm1WcVxCuuIrm0bYtvqGWhQs4I6Xx3gggRIgARIgARIgARIgARIgARIINgJhArH9uDR0yiYNxucncIiVsxoSJU8MU6cvgjzf4eOnUXZEvlVcNni+XHw2Bm1nVKLHy1KJNja2CBfrsxqggFja66KwAUJkAAJkMBPCfAgCZAACZAACZAACQQmgVDh2L549RpxYkX34hgvTkw8f/nKa182Pn3+AoMBiBwpguwiftyYePHytdo2XazduAvJkiREWEdH02BukwAJkAAJkMCfEuD5JEACJEACJEACv0kgVDi2wsagtbbKWmQwaB6sbJjJxlscn2jOX7qOJf9uRr+/W3id+fXrV1D6ZvDt21e4ubkGynWStKmvsBYGrq4ukM+8BJS9X79+0e4ryho5uLu7W819G1D3a8hJ58+fOcZ71sXlm/ZM+MbfcSh7lln6Lbi5ufGZoL0vWWKjtzCvl/Bg2rh99yGKVmryW7k/fPwM+cvW/61zedKvCfj03n59jtXFiB41Ct6+fedl9+s3bxEjWlSvfdmQbsru7h5wcXWVXbzS4kSPFkVty0JabyfPXobJo3pqrbmxJEjJ3t4OlL4ZyHfpbGxsA+U62drawZaCrZUwkPvA1tYWtgFkr729vXZfUdbIwWAwwDaA7gOmY33PQeM9a2dnB5FxP0St+Xzy9fls6TdrozVuWApnmP5+3wigf2/evkf2ojXw9PnLAEqRyQQ3AZvgNiAo8s+XKwsOHD2Nby4ueP3mHS5fu42c2dKrrGXGY1dXN7WdJ0cm7Nx7RG1v33MY+XJmUtsyW3LvoZPQq1MzxI75o0uzHOQDT38PPJ/XxBaB9QdLXoio7y+G1sDhu1Nrq15kA8Jen/eaNfweaKNcN3kmBMQ9wDSs5/dveq3kHhDZ2MjfB1vYspIDtqGIgem9YNy20Rxb4zbX+v5dy/s3RQKWCNhYCgxpYQnjx0blskXRpH1/dOw1Cp1a14eDVpMp5ew2YBzevf8gm+jYsg42bNuvPvdz/8ET1KlWVoWv+m87Lly+gVrNuiF3ybpKrN1RaLggARIgARIgARIgARII2QRCXenu3n+EgaOmoUSVZihToxX+mTRPNZCZgpgwYzFKVW2h9O/67V6H3NzdMWnWEpTVzitcoRFGTZwLdw8Pr+PcCDwCNoGXtL5Srl6pJBZPH46F04aiYJ6sXsbtWDMT0aJGVvuynja6j/rcz7C+HbwmiGrVuAaObFvsTbFiRFPncEECJEACJEACJEACJEACJBByCHz89AVZMqTGynljMaxPB5w+fxn/ag1dxhJ+/PQZ9x48xuKZI9GjYxOMn7YIJ898/+LK/CVrce7iNYwa2AWLpo/Ak6cvMGvBKuOpXAcigVDj2AYiQyZNAiRAAiRAAiRAAiRAAiQQQgikS50M5UsVQqQI4ZEpfSrUqFwaJ89e8iqdh9YC26dLC8jnQAvly4FyJQti+/+HM65YuxUdWtRF2lTJIF9iadWkBjbt2O91bqjfCEQANoGYNpMmARIgARIgARIgARIgARIgAasi8OTZC/QYOA7la7dRE0wNHTMD795/9CqDfPYzSuSIXvviwMqcPPL50LfvP6Bxu77qPJmcqk7z7nj6jBNUecEKxI2Q5NgGIiYmTQIkQAIkQAIkQAIkQAIkEBoITJq5FOHDO2PCsJ44sm0J+v3dyluxv3z96s3RfaI5rlE1R1e+smJvb4c1CyfgxK4V3uQtAe4ECgE6toGCVc+J0jYSIAESIAESIAESIAESIAHfCLi6uiJNiiRIkiie+rLGZrOuxLY2Nli2epM6XVpqd+w9jJJF8qr9OlXLYdTEOfjw8ZPal6+yHD15Xm1zEbgE6NgGLl+mbq0EaDcJkAAJkAAJkAAJkECIJ1C+1vfuxtJtWLRu8240a1AVsxatRrMO/dG132jNwY3vjYOzsxPCacpdojbqtuiB5g2qIVvmdCqOTDqbMV0q1GvZA/nL1kfLzgNx/tI1dYyLwCVAxzZw+TJ1EgjRBFg4EiABEiABEiABErBGApEjRfDWVdjYdbhSmSJIkTQRNq+YhlkTBmLskG74u10jzJ00WBUzidaKu2vdHNStXh5Hti/F1n9noGqFEuqYLOSbyE3rVcG6xZNwYNNCzJs8VDm+ckzG4kqYbFMBT4CObcAzZYokQAIkYEqA2yRAAiRAAiRAAiRAAoFMgI5tIANm8iRAAiRAAn4hwDgkQAIkQAIkQAIk8PsE6Nj+PjueSQIkQAIkQAJBS4C5kQAJBBgBD9ePeHdvD56enYunx0biyampeHNrC1w/PQ2wPJgQCZBA0BGgYxt0rJkTCZAACZAACZBAEBBgFiTwKwLvHxzEjc2t8fDoGLy6tgZfnp9WTu3jk1O08FYqDJ4ev0qGx0mABHREgI6tji4GTSEBEiABEiABEiCBICIQKrNx//YODw4Nx4PDI+D29bVFBp4erqoV9/bOrnD58NBiHAaSAAnojwAdW/1dE1pEAiRAAiRAAiRAAiQQCAS+fXiM9w8P+ynlL6+v4+Oz836Ky0gkQALBT4CObfBfA1pAAiRAAiRAAiRAAiQQyAQ83L7i0bExWi6emvz2/9Ozc+Dy8YnfIofmWCw7CeiAAB1bHVwEmkACJEACJEACJEACJBC4BD6/uKQ5qf6bGMrT/RtkPG7gWsbUQwsBljNwCdCxDVy+TJ0ESIAESIAESIAESEAHBNxdP/2WFe4uv3feb2XGk0iABH6bAB3b30bHE0mABEiABEiABEiABKyFgNvXN79l6smX17H26SVc+/Tyt87nSSGTwJYdezFuyhwsXrEODx8FbHf1CdMXoVnH/ti0fb+/4F28chOdeo/01zmWIu8/fBI379y3dMgr7OzFq2jSvi9yFq+F7Xt8H7c+f9k6LF65weu8wNwIXY5tYJJk2iRAAiRAAiRAAiRAArolEC5W1t+ybd6XT2h8fjVyHZqKyNsHoeCRmWhxYS0m3j2MHS9v4tHX97+VLk+yTgIfP31GoTI1Ua1ea/QdPAYtO/RClvzlsHuf786df0r6+OlznD5/BbPGD0TZEgX8c2qAxT18/Cxu33340/Qcw4RBq0Y1UDhfjp/GC8qDdGyDkraV5EUzSYAESIAESIAESCCkEbANFwvuNvb+LlahRIVQPmZqJHWKAoN29vkPT7HyyQX0v74T1U8vRbr945Fo9yiUPTEff1/ZgrkPTuLo2wf44O6ixeb/IY3AxGnzcPK099myP3/+gqZtu/9xUd09PNB94Djce/BYtdiOmbIAS1ZtVOmOmTIfLToPVNvHTp1Hr8ET1LY4oTWbdEXjdn2xYeseFebbYuiYGRgwcgpadR2MGfNX4tWbt+g5aBxqNfsbjdr2hrT4Xr91F/sOncCsBauUDWKLpfRSJU+MbJnTwdbWpzsprbSV63VAqy6DcO3GHUunB0qYT0sCJRsmSgIhjgALRAIkQAIkQAIkYCUENj2/ipyHp2OZfTR/WRwuVha0TVcZCzNWw8l8bfGkWG/sydUMU9JVQOuEuVAoahLEcHDGO7evOPzmPmY/OIEuVzaj9PF5SLBrBNJrTm+N08sw8MYurNKc4YsfnsHV0wP8px8Cm7ftQbhYafysof9Mtmj88xev4BzT7+lUq9/aRzq2NjYY2L0NkidNqFpsixbMiXOXrql4l6/dwrdvLnBzd8e5i9eQKX1KtT1o1DT07tIccyYOwvOXr1Xcny2+ubhiyqjeaNGwOiZMX6ylkxrLZv2DAVq+fYdNQoqkiVAwb3Y0a1BN2ZAwfpyfJefj2K27D7Bq3TbMmzIEowZ2Uc6yj0iBFEDHNpDAMlkSIAEhQJEACZAACZBA8BG48P4pih2bg7pnV+L259e4G78gDBES+MkgG/twiJuzo7e4YWxskSlCbNSOkwlDU5bA2qx1ca1QF9wp0g3/ZauH4SlLom7czMgSIQ6cbO3x8Ot7bH95A+PvHELzC2uR/8gMxNk5DLkPTUOT86sx5vYBbHlxHfe/vPWWD3dIQAikS50cFy5dxzcXFzg4OCB9mhS4ojm44thmyZgGjx4/Q7SokVS4wWBAlQrF5bSfqmCebLDRHGiJdPrcZWzfcwgynneI1pr78vUbvHj5a+dYzvVNZy9cRdGCuRApQniED+eM4oXz+BY1wMPp2AY4UiZIAiRAAv4kwOgkQAIkQAIBSuDJtw9oeWEdChydiVPvHiGVc3Ssy1oPyzRHNEnuv7W8DJp+/n+cbK1h5xjl55H+fzSSnSMKREmMlglzYlLa8tiVqykeFu2J0/nbYXGm6uiZrBAqxEyNZE5R4eHpiaufXmDN00sYcnMPap9ZjowHJiK+1sJbXHPCO1zeiBn3j+Pg67t4q7UE/z8LrgKJQJmShfHx6WU/q3unlhYtiRI5Ej4983s6qxZOtZiOaaCdrS0SaC2mG7bsRab0qZAxXUqcOnsZ9x8+QbLECVRUWy2O2tAWdrZ22vLn/9vbe48zZkg31TIrY3oPbFqI6NH8ds//LBdvNtnZ/ixqgB6jYxugOJkYCZAACZBAYBFguiRAAiTwKwKf3F2Vs5jlwCSseHIe0R2cMT5NORzK2xIFoyZWpzuEi4XwcXNp254m0jblf83plFXYyEngFC21bP62xHVOHDYyysZIhW5JCmBBxmo4ka8NHhfrhb25mmFquopokzA3CkdNgpgO4fDR3QUnNSd84cPT6HF1K8qfXIjEu0ch1d6xqHxqMXpf246lj8/i7Psn+Obh/ttZMrCwAAAQAElEQVR28cQ/I9C8cW2Lzt/A3p3+LGFfzhZndvGqDciYNiUyZ0iFdZt3qa7KEj1unJh49fot3rx9L7uQsbdqw4+LnNkyYOqc5fD8/31/4sxFdWbYsI54//6j2vbvIoPWqnxSS8fDw0Ole/zUBf8m8dvx6dj+NjqeSAIkQAIkQAK6I0CDSCBUEtBeobFAcwgzay2fY24fgKf2X+fE+XAmf3s0iJcFNmrap+9oHhwajg+Pjmg74noatJdvbVOLr97tDRIGfHlzG3f39IRHILSYSnfmjBFio1acjBiSsjjWaK3IVwt1Vt2Z12erj+GpSqJe3MzIGjEunG3t8czlI/a+uo2p946izcX1KHx0FmLvHIpsByej/rlVGHFrH9Y/u4Kbn19BOEhpqMAjECtGdNy5eBDS4jq4bxdMnzAMF49tR6O61QIlU3Fonz57qZzaqFqrsMFgg0zpUqm8pEW3T9cWkLGxbbsNxc3b91S4XxftmteBi4sLajfrhtLVW2L1+h3q1LLFC+DwibNqsirfJo86oh3PXrQG5FM/vYdMQKHyDdW5Mj64aIFcaN11MDr0HKH9vqQCSR0K9IVNoOfADEiABEiABEiABEhAVwRoTEgicOj1XTVmtePljXjh8glVY6XDqXzt0Dd5EeUYmpb19c3N+Pj0tGkQDAZxZg3a2lswXD4+xdOzs70HBuKedGfOHyURWibIiYlpy2NnziZ4ULSn5py3w5JMNdArWSFUipkGKZyjQbMWtz6/xgbNoR2pObYNNAc3+8EpiLtzOAppjm+bi/9hyr0j2P3qFp5++/hTq6WV+5/b+1WX6Kbn10BmdQ46V+Snpun6YOkShdCpTRPUrVEJiRLGCzBbkySKp7oGGxPMmzMzju5YhjAODipo7aIJqF+zgtqWRa5sGTF5VG+lSSN7Y9zQ7hJsUb27tIA4ncaDMg5WJo1aNvsfbFk5HSP6d1KHkiVJgLFDumHG2P5IGD+OCjNf5M6eCSd2rfDS3g3zvaI0rF0J07VzJ47oiQVTh6Fu9fJexwJzg45tYNJl2iRAAiRAAiRAAiRgrQR0bve1Ty9R9dQSlDu5ENe1bWnh3JGjMWZl+AtxHSNYtP7NrS0Ww30LfHtnFzzdg++zPQbNsERhI6NMjJT4O0kBzMtYFcfytsaT4r2wL3dz1Z25baLcKBI1KWKFCYevHm449/4Jlj4+hz7XdqCKxif1vrFIsucflD+xAN2vblUt2yfePYQ4tNL9ufDRmRh2c6+axGr104vocmUzWl5Yq+XM/0nAugjQsbWu60VrSYAESIAESIAESCBUE5BW2baX1iPXoanYpbVIJnCMiPmawyctnNkixfOVjevnF/j69o6vxy0d8PRwxedX1ywd8goLjg0Hgy0yhI+lujMPTlEcq7PWwZWCnXG3SDdszN4AI1KVUt2Zs0eMh7A2dnjj+gUH39zDzPvHIS3bJY7NRbxdw5F+/wTc+PTKRxFWPrkA+TSRjwMMsAoCi1asR/NOA7xJwn7HeDkvoNL6nfz9c46NfyIzLgmQAAmQAAmQAAmQAAkEBwFpjZTxszIx1JJHZxHe1gEDkhfF8XxtUTFmml+a9OnZuV/GsRTh0/PzloJ1GRbRzhF5IydEiwQ5VHfm7Tkbq8mqzuZvjyWZa6B3ssKoHCstUjpHg63BoBxe3wpy7dML3w79TjjPCUIC9WpUwMxxA7xJwn7HBDkvoNL6nfz9cw4dW//QYlwSIAESIAESIAESIIEgJ7D88XlkPTBJzXgs3Wcbx8+GMwXao0PivJDJmMwNunPvAbZs34t/JsxEo1ZdkbNwRVRt2M08mp/2bTQH2k8RdRwpYdhIKBM9JbomyY+5GargaN7WeFm8LxrFy+qr1TJTs68HeSCQCDDZPyFAx/ZP6PFcEiABEiABEiABEiCBQCNw8u1D5D8yA60ursPjbx9QLFoyNcZ0TOoyiGrvhMdPnmHn3kOYOG0eWnbohQKlqiN64ixIl6MEqtZrhQHDxmHlmk24ePk6bj1z/y07HSMl+a3zrOGkarHTWzQzgl0YpA4fw+IxBpJAsBPwxQA6tr6AYTAJkAAJkAAJkAAJkEDwELj/5S3qnl2J4sfnqrGeyR2jYJBjdhQ944lJAyahWPk6iJM8B5JnKoSKNZqi54BRWLR8LU6duYDPn7+oWWrLlCyMbh1bYP700Ti+dz2uXziJ8HFz+qtADuHjwTlmBn+dY02R80ROgFYJc8Le8MMliKg5tTJGVyoOrKkstJUEftzFZCEEKBIgARIgARIgARIggWAi8ODtKzTavwiZ90/EpudXYffFDY6rLuFi9SnoUa0zuvQagrkLV+LI8dN49/4DYsWMjqIF86Jdy4aYNn4o9m9diZd3z+DS8R3qO6P9e3ZEtcplkTZ1ctjb2yN2lpYw2Nj5uXTuMcpp8e39HN8aIw5LWVJ9VkhmWT6Rrw1uFe6mJqWyxrLQ5tBNgI5t6L7+v1l6nkYCJEACJEACJEACv0/gy5evOH32IhavWIdeA0ehQu3miNeuHtLtHot1X+/A3dUNbhsu4VP7tXi//jwiR4iAPDmzommDmhg3oi+2rVuIR9eP4db5/Vi/cjZGDOyO+rX+QtbM6RE2rKOvhtk7RUe01NV8PW56YN/5jyhSaxBOnraeyaNM7ffPtoxTzhA+FpI5RVWTSvnnXMYlAb0QoGOrlytBO0IeAZaIBEiABEiABEI5AVdXVzW+Vca5ynjX6g3aqPGvMg42f8lqaNG+JyYe24F9pSLgU/nksAkXBhGuvEG5A+4YmqYU1i+Yjpvn9ikndsf6xZgwqj+aN6qNfLmzI1JEy9+qxS/+xUhXB/Hz9IBtGMvnG2zsESNDAxx/mVm1CpesXB/7Dh77Rao8TAIkENwE6NgG9xVg/iQQygmw+CRAAiRAAtZPwMPDA9dv3sG6jdsxbPQU1G3aEVnylUXUhJnVjMQyM7HMULxp627IjMW2trZIWjADYkyoBvuO+WETKwLSOUbD9hyNca/DOCweORTtWzVCsUJ5ETtWwE9iFCF+PiQvPR1xc3ZC1BQVETZGJkROWhpxsrVB8jLTEF1r1Z03fSxaNK6Nr1+/oUKNpvhv0w7rv1AsAQmEYAJ0bEPwxWXRSIAEQgwBFoQESIAEApzA0+cvVFfgcVPmQBxOd/dfzxrs6emJu/ceYvO2PRg9cSYat/4buQpX0hzYTMictwzqNOmAof9MxtoN23Dtxm2Iw5s4YXyULVXEayKnTbuWo/qWgXjQNC3eRrFDfMeImJ3hLxwo0BrZI8UL8HL6lqC02EZKVBSxMjdDrJw9ETtra+Xc2jvHUqcYDAaMHd4Xg/p0hpubG2o3bo95i1epY1yQwNsrB/Fk70K8PLkRLm+fBiiQCdMXoVnH/ti0fb+/0r145SY69R7pr3MsRd5/+CRu3rlv6ZBX2Iate9G4XV8UKt8QHXuNwB3tuWA8OGriXJSs2hzVGnU2BvlYB5StpgnTsTWlwW0SIAESIAErJkDTSYAE/Epg977DyJynjOoK3GfQaFRv0AZFytXGx0+fvZJ4bOFTOjGSZEXaHMVRrX5r9B86DitWb8SFy9fg4uIK40RO0tI6fcIwHNi2Ci/unMbF49uxcsEUdO3WBlfShUXNpxvx79OLCG/rgH7Ji+BEvraoEisd9PqvS7tmmDlxOAwGA9p26adapPVqK+0KfAIe3z7j8uRGuD6/Ex5smYTbqwbi/OhqeHfjGALi3+Onz3H6/BXMGj8QZUsUCIgk/Z3G4eNncfvuw5+eFytmNEwb0xdbVk1HimSJMGX2Mq/4GdKmwLC+Hb32g2qDjm1QkWY+JEACJEACJKAHArQh1BOQltlWnfrg/YeP3ljIJElFy9f+5ad0IkeKiLy5sqFZw1oYP7Iftv+3CI9vHPeayGn4gG6oV7MysmRKpyZyctdaeec9PIVMByZg3J2DcPXwQMN4WXGmQHt0SpwPYWxsvdmhx506NSph1cKpcHCwVy3SbTr3hbRe69FW2hS4BJ7sX4yPDy56y8TD9StuL+/nLex3dty130b3geNw78FjSIvtmCkLsGTVRpXUmCnz0aLzQLV97NR59Bo8QW2LE1qzSVfVerph6x4V5tti6JgZGDByClp1HYwZ81fi1Zu36DloHGo1+xuN2vaGtKJev3UX+w6dwKwFq5QNYoul9LJnTocwDg4I6+iIfDmz4NnL117RShXNh2hRInntGzf8Y6vxHP+sbfwTmXFJgARIgARIgARIIDQQCMllfPjoKR4+emKxiBcuXvP6lI6TU1jlnIqTKs7qfytmq4mcHl47qpxZcWrFuRUnN2KE8BbT2/nyJvIdno7OlzfhpctnFIiSCAfztMC4NGUR1d7J4jl6DSxdohA2r54P4TJ/yb9o2LKL6qKsV3tpl98IvLm8H8e7Z/ezHu2YaTFh14+vtTSyafJbWtfn++yma2tjg4Hd2yB50oSqxbZowZw4d+mayu/ytVv49s0Fbu7uOKf9TjOlT6m2B42aht5dmmPOxEF4buJcqpMsLL65uGLKqN5o0bA6JkxfjEzpU2PZrH8wQMu377BJSJE0EQrmzY5mDaopGxLGj2MhFe9B4nznyprBe6DZntjtX1vNkvjlLh3bXyJiBBIgARIgARIgARIIGQRevX6L6XOW+FqYRAniqpbJC8e2qW7E0p1YuhVL9+JiPidy8jWdax9foOyJBah2eimufnqBlM7RsCpLbfyXrT5Sh4vh63l6P5A7RxbI7MxRo0TCv+u2oHr9NpBPF+ndbtpnnQTSpU6OC5eu45uLCxy01tH0aVLgiubgimObJWMaPHr8DNGiRoKEGwwGVKlQ/JcFLZgnG2w0B1oinj53Gdv3HFIts0O01tyXr9/ghR+cYznXqEUr1uPt+w9oWr+KMcji+ndstZjQTwJtfnKMh0iABEiABEiABEiABEIAgSvXbqJ1pz5InqkgJkyb62s3WpnkqUzJwkiSKMFvlVpaZdtf2oDch6fh8Jt7qlV2dOoyOJSnFYpFS/ZbaertpEzp02DP5uWIGycWtu3aD/kc0IePn35iJg/pmUDkNAWQY+QJPytO0SYWi2PnFFFL46Qmv6WVouFYi+mYBtrZ2iKB1mK6YcteZEqfChnTpcSps5dx/+ETJEv8/Tdqq8UxnmNna2fc9HVtb+89zpgh3VTLrIzpPbBpIaJHi+LrueYHpEv0ybOXMGlkL9Ut2fy4+b5/bTU//1f7dGx/RYjHSYAESIAESIAESMAKCciMxBs270Spyg2QrUB5LFi6WnVlTJ82JWpXr+TVamMsmrzQdu3Q3Ljrr/VXDzf8c3s/ZBztokdnYG+wRftEedQ42ibxs8FWa03yV4I6j5w0cULs37oSKZIlxqkzF1C0bC08f/FK51br3DwrMS9mnmqwc47sw9p4pdv6CAuIAHFmF6/agIza7zZzhlRYt3mX6qosaceNExPSC+PN2/eyC3E01YYfFzmzDRxsLQAAEABJREFUZcDUOcu9KrpOnLmozgwb1hHv339U274tzl68ijmL12DkgC5wsLf3LZpX+J/a6pXQTzbo2P4EDg+RAAmQAAmQAAmQgLURkEmhJkydh7Q5SqBmo3Y4cPi4mtG3XOmi2LJmAY7t+Q+zJ4/A5RM7MGPicAzp1xUr5k/GtdN7EDN6NH8V11OLvfzxeWQ9MAnDbu7FJ3dXVIqZBifzt8XAFMXUzMdalBD5f6yY0VXLbdbM6XHp6g0ULF0d9+4/CpFlZaF+ELAPHw1Z+m1HCq3FNX7pdkhSrT8ydl+HGDkq/YgUgFvi0D599hLi1EaNHAkGgw0ypUulcpAW3T5dW0DGxrbtNhQ3b99T4X5dtGteBy4uLqjdrBtKV2+J1et3qFPLFi+AwyfOqsmqfJs8auKMJThz/gryl6mH7EVroFLddupcWTRu1xdVG3bCXe33IMcWr9yAP7VV0v2V6Nj+ihCPkwAJkAAJkAAJkIAVELh5+y46dBuIpBkKoNfAUbj/4BEiRgiP9q0a4eqpXcp5LZA3h1dJ4seLg7o1KqFTmyYQpzdMGAevY37ZOPrmPgocmYFWF9fh8bcPyBoxLnbkaIx5Gauqb9P6JQ1rjxMpYgRsW7sQRQrm0Xg/Vs7txSvXrb1YtN8PBCKlzo/YheojWrZyCBMlrh/O8FuUJIniqa7Bxth5c2bG0R3LvLr6rl00AfVrVjAeRq5sGTF5VG+lSSN7Y9zQ7l7HzDd6d2mBogVyeQVH0p4PMmnUstn/YMvK6RjRv5M6lixJAowd0g0zxvaHb5NHzZ00GCd2rfDSusWT1LmyMD9Wt3p5CfaXreoEfy5MHFt/nsnoJEACJEACJEACJEACwUpAPjmzdec+VKzRFBlzl8bsBcvx+fMXpEyeBDJr8a3z+zF8QDfEixs7wOy88+UN6pxZgdIn5uPih2eI5xgBszL8hZ05myBbpHgBlo+1JCTdNtcunYEKZYqpiXekW7J8Osla7KedJBBSCNCx9e+VZHwSIAESIAESIAESCGYCnz5/xrTZi5UzW6VOS+zce0hZVLJoAchneU4f3KS+MytOlzoQAIu3bl/R4+pW5Dg4BZtfXEM4Wwf0SVYYJ/K1RdVY6QIgB+tNws7ODkvnTkTDOlXx8dNnNaHUrv9fE+stFS23VgIyU3HzTgNgKgn7nfLIeabpyLaE/U5agX0OHdvAJhxK02exSYAESIAESIAEAp7A/QeP0a3vcCRNXwBdew/FrTv3EM7ZCS2b1MHF49uxRms5LFYob4Bm7OrpgSn3jiDT/gmYcf84PDw9UT9eFpzO3w5dkuSHo41dgOZnrYkZDAZMGTsYvf9ui69fv6Fy7RZYtXaztRaHdlsxgXo1KmDmuAHeJGG/UyQ5L6DS+p38/XMOHVv/0GJcEghYAkyNBEiABEiABPxEYPe+w6harxXSZC+GKTMXQj4vkyRRAowa3BM3z+/HmGF9kDhhfD+l5Z9I/z27jOwHJ6PPtR145/YNBaIkwsE8LTAhTTlEd3D2T1KhJm6vrm0wecwguLu7o2HLLpg+Z0moKTsLSgLBSYCObXDSZ94kQAJ+IMAoJEACJBA6CUir39yFK9WnespXb4It2/eqz3IULpAb/y6ahvNHt6JN8/oIHy7gHcwL75+i2LE5aHjuX9z78hYpnKNhRZZa+C9bfaQOFyN0XhB/lLpR3Wqqa7J0Ue7SawgGj5zoj7MZlQRI4HcI0LH9HWo8hwRIgAT0RoD2kAAJhBgCT54+R59Bo9Xsxu3+7o8r125Cxso2rl8dZw5txsZVc1G6RCEYDIY/KvPOlzfR5uJ/qH56KXpd2w6Z2fjh1/doen4NChydiVPvHiGKfViMSl0ah/O0Qoloyf8ov9B2csWyxbF+xWw4OobBiLHT0KZzX1UxEdo4sLwkEFQEbIIqI+ZDAiRAAiRAAsFNgPmTgJ4JHDp6ErUbd0CKzIUxbsocvH33HvHjxcGQfl1x+8IBTPpnIFIkSxwgRZh89wiqaQ7t0sfnsENzcKfdO4osByYqrX56EfYGG7RNlBtnC3RAs/jZYfuHTnSAGG2FiRTMl1N9DihihPCYv+Rf7fq2h6urqxWWhCaTgP4J0LHV/zWihSRAAiRAAiQQlASYVxAScHFxxaLla5G7SGWUqFgP/23aDg8PD+TNlQ1L507A5RM70KlNE0QIHy7ArHL39MTwW3t9pPfNwx2unu6oEDM1judrg8EpiiO8rYOPeAzwH4FsWTJgz+bliBkjGtZv3okKNZriy5ev/kuEsUmABH5JgI7tLxExAgmQAAmQAAmQAAmYE/iz/afPX2DQiAlInqkgWnbohfOXriJMGAfUq1kZJ/dvwPb/FqFi2RKwsQn4V7Vbn1/hs7vlVsOU4WJgQcZqSBQ28p8VkGd7I5AyeRLs37oSMuHX/kPH1eeApEXeWyTukAAJ/BGBgH9a/pE5PJkESIAESIAESIAEQi6BE6fOoWHLrkiZuQhGjpuOl6/eIFbM6OjXowNuntuH6ROGIXXKZIEKIGYY31t/k4aNErB5MzUvAvHixsbeLSuQIV1qnDpzAYXL1MTTZy+8jnODBEjgzwjQsf0zfjybBEiABEiABEiABH5KQMZUrli9EQVKVUchzZlZtXYT3NzckD1rRsyfPhrXTu9G904tESVypJ+mExAH3Tw9MPr2AV8nMcoZOeA/GRQQdoeUNKJGiYSd6xcjV/bMuH7zjron5FvEIaV8oakc217cwMS7h7Hs8TnIpGsBWfYJ0xehWcf+2LR9v7+SvXjlJjr1HumvcyxF3n/4JG7euW/pkFfYstWbkb1oDS/NX7bO65jphoQvXrnBNCjQtunYBhpaJkwCJEACJEACJBCaCUhr7PAxU5EqS1E0bv23aqWTz7/UqFIOh3etwd7Ny1GtcllIWFBwevz1PUoemwuZOCqsrT1iOHhvuS0dPQWaJ8gRFKaE6jycnZ2wefV8lCpeEI8eP0Wh0jVw8cr1UM3Ej4XXRbSP7i4ofnwuap1djgE3dqHNpfXIdXgq9r66HSD2PX76HKfPX8Gs8QNRtkSBAEnTv4kcPn4Wt+8+/OVpzepXxYldK5Qa1qr0y/iBHYGObWATZvokQAIkQAIkQAKhisDFy9fRvF1PNX52yKhJkPG00aNFQc8urXHj7F7MnfoPMqZLHaRMZObjvIen4/T7x0gfPhaO5mmFa4U643yBDtiVqynuFemOpZlrwtHGLkjtCq2ZyXjqVQunonb1inj95h2Klq2FI8dPh1YcVlXuKfeOqk9hmRotY9ZbXLTcYmka71fb7h4e6D5wHO49eKxabMdMWYAlqzaq08ZMmY8WnQeq7WOnzqPX4AlqW5zQmk26onG7vtiwdQ8AFWxxMXTMDAwYOQWtug7GjPkr8erNW/QcNA61mv2NRm17axUsN3H91l3sO3QCsxasUjaILRYT+0mgtNJWrtcBrboMwrUbd34SM2AP0bENWJ5MjQRIgARIgARIIBQScHd3x9oN21C8Ql3kLFwRS1aug8x4nCl9GsycNBzXz+xFn27tECN61CClI12P+17fob5V+9btq/p0z85cTZDQKbKyI75jRGSJEAcR7MKofS6CjoBMDDZr0gh0adcMHz99RpkqDbFl+96gM4A5KQJbXlxHlB2D/awRt/ap88wXL1w+Icr2QfBrWrXPrjBPArY2NhjYvQ2SJ02oWmyLFsyJc5euqXiXr93Ct28ucNOeNecuXkOm9CnV9qBR09C7S3PMmTgIz1++VnF/tvjm4oopo3qjRcPqmDB9sZZOaiyb9Q8GaPn2HTYJKZImQsG82dGsQTVlQ8L4cXxNbvHKjchftj669P3HK+9bdx9g1bptmDdlCEYN7KKcZV8TCOAD/nJsAzhvJkcCJEACJEACJEACVk1AZrYdM2kW0mQvjrpNO+LwsVOwtbVF5fIlsXPDEhzauRp1qleCg4N9kJfTtOtxOFsHLM1UA6NSl4aDwTbIbWGGvhMY1KczxgzroypCqtVvjVVrN/semUdCFYF0qZPjwqXr+ObiAgcHB6RPkwJXNAdXHNssGdPg0eNniBY1kgo3GAyoUqH4L/kUzJPNa7b10+cuY/ueQ6pldojWmvvy9Ru88INzLJmULJIXu/+bA3GK5XNkA0dOlWCcvXAVRQvmQqQI4RE+nDOKF86jwoNiQcc24CkzRRIgARIgARIggRBOQCb+ade1P5JmKIB+Q8bi4aMnavInaX2TyaAWzx6P3DmyBBsF867HB3O3QOkYKYPNHmb8cwItm9TB/OljVKSGLbtg+pwlapuLwCcgY8tfF+8Lv6prkvwWjYpsHxavS/TzczpLtYomiwmZBNpplWQJtBbTDVv2ai2rqZAxXUqcOnsZ9x8+QbLECVRMqUhTG9rCzvbXQwns7b3HGTOkm2qZlTG9BzYthAyb0JL65f9RIkeEzA8QL05MdGnTANKibDzJm012QVeRRsfWeAW4DmICzI4ESIAESIAErIuAp6cnNm3djbJVGyFz3jKYu2glvn79hrRaq8rkMYPU+FlpfYsdK0awFcy863GT+Nlg2vU42Axjxr8kUK1yGci4W2nd79JriKow+eVJjBDkBJpqv6loDk4+8u2frIiPsIAIEGd28aoNyJg2JTJnSIV1m3eprsqSdlzNqXz1+i3evH0vu5Cxt2rDj4uc2TJg6pzlXrOknzhzUZ0ZNqwj3r//qLZ9W0j3eeOxnXuPIE3KpGo3g9aqfFJLx8PDQ6V7/NQFFR4UCzq2QUGZeZDA7xLgeSRAAiRAAsFO4MPHT5g8YwHS5SyB6g3aYO+BozAYDChbqoia3fb43vVoVLcaHB3DBKut5l2P52esitGpy7DrcbBeFf9lXrpEIXVPhXN2gnRxb9auB8RB8F8qjB2YBGI6hMP1gl0gLa4DkhfFlLQVcCZfO9SPFzg9NMShffrspXJqo0aOpD17bJApXSpVRGnR7dO1BWRsbNtuQ3Hz9j0V7tdFu+Z14OLigtrNuqF09ZZYvX6HOrVs8QI4fOIsZLIq3yaPkq7H8rmfguUaKId6QPfW6lwZH1y0QC607joYHXqOUM6tOhAECzq2QQCZWZAACQQuAaZOAiRAAoFB4M69B+jccwiSpi+A7v1G4O69h5CxZO1aNsTVU7uwcsEUFMyXMzCy9neapl2P04SLAel6XDFmGn+nwxOCn4B0Yd+1aZnqErp05X+Qcbeurq7Bbxgt8EagVPQUaJ8oD2rFyYiEYSN5O/YnO0kSxVNdg41p5M2ZGUd3LEMYBwcVtHbRBNSvWUFtyyJXtoyYPKq30qSRvTFuaHcJtqjeXVpAnE7jQRkHO6B7Gyyb/Q+2rJyOEf07qUPJkiTA2CHdMGNsf/g2edQ/g7qqz/zs27gAw/t1UverOllbNKxdCdO1cyeO6IkFU4ehbvXyWmjg/0/HNvAZMwcSIAES0AMB2kACJGBCQByFq9dv4cLla1qLhXenYceeg6hcq8U3ArYAABAASURBVDnS5SiBGXOX4NPnz0iRLDHGjeiL2xcOYMTA7ogXN7ZJasG3ad71uGG8rNidq5nXrMfBZxlz/hMC6VKnwL4tKyHjK7fu2IcKNZri06fPf5IkzyWBEE+Ajm2Iv8QsIAmQAAmQgN8JMGZoILB732Eky1gQuYpURoGS1ZEobV4sXr4OM+ctRaY8pVGpZjNs331AoShRJD/WLZ+FM4c2o3mj2ggb1lGF62Fh2vXYydYe0vV4XJqyCGMTdJO16IFDSLUhYYK4yrmVSpX9h46jWIW6kPGUIbW8LFfAEVi0Yj2adxrgTRL2OznIeQGV1u/k759z6Nj6hxbjkgAJkAAJkAAJAFbM4NHjp6jZsB1evnrjVYp37z+gefue6Nh9EG7cugtnJye0aFwHF49vx9plM1G8cD6vuHrZMO96vD9Xc7DrsV6uTsDZESN6VOzZvBxZM6fH+YtXUKh0DTx99iLgMmBKIZJAvRoVMHPcAG+SsN8prJwXUGn9Tv7+OYeOrX9oWVFc+QZVs7Y91GcIYifLjpKV6uPshctWVII/N1W6mQ0bPQUZcpVC/NR5katwJaxau+nPE7ayFLbt2o+8xaogeuIsSJO9GAYMG6dm8bSyYvyRufJZjr9qt0DidAWQInMR1GzUDo+fPPujNK3xZBkfuHDZGoyfOhc79x4K0gkdrJEXbQ5ZBOT+P3T0JP6ZMFN1LTYvncEAyOcrRg3uiVsX9mPs8D5InDC+eTR/7QdGZPOuxzJhjXQ9TuocNTCyY5o6IBApYgRsW7sQpYoVxO2795G/ZDXI3zUdmEYTSEBXBOjY6upyBIwx7u7uqFC9CZau+k/V6r3/8BEHj5xAiQr1cOuO/2ZLCxiLgieVXgP/wdB/Jqs/AvI5BhlH1bBl11Dl3G7ZsRfi0EmlxufPX3Dv/iP1Utf+7wHBc1GCIdfXb96iSNlaEAf/7bv3eP7iFTZs3qkqe0ynqg8G04I0S6nUyZyvDFp17I3e2m+jYo2mqFijmY+xhUFqFDMjgQAi8PT5C5w6cwHrNm5XsxfLPV6nSQcU1n77MvGTc8zUSJujOEpUrIdZ85f5mmutahXRpnl9hA/n7Guc4Dxg3vV4ZvrKmJCmnLV3PQ5OpFaTt3SBX71kOmpWLa8qZuXv2plzl6zGfhpKAkFBgI5tUFAO4jzkj/v5S1d95CqTX7Tp3A/SiikaPmYqRCPGToNo5LjpEI0aPwMiqdU2avTEmRDJ1POisZNnQzRuyhyIpAVINGHqPIgmTpsH0aTp8yGSzySIpsxcCNHUWYsgmjZ7MUTT5yyBSCbpEMk4J5G8gIhmL1gO0ZwFKyCau3AllBZpa03zFq+CUfOX/AvRPC3cBwQtYKjWirt4xTosWfldUgEgWrZqPUTL/90A0YrVGyFauWYTROIYiP5dtxmi1f9tgWjN+q0Qrd2wDSJ5sRL9t2k7ROs374BInCnRxi27YJR8D1G0edseiLZs3wslzSEVp3Trzn0QiVMmkjFfIpnYRCStbqJd+w5BJOPGRHv2H4FIrp9WZB//L/t3vUpXKjxE0oohOnzsFERHjp+G6OiJMxAdO3EWouMnz0J04tQ5iE6ePg+R3HOi02cvQiR/bJXOX8IZTeJYi85dvAKj5B4VSYWD6OLl6xBdunIDostXb0B05dpNiGSSF9G1G7chktpqkXQbFN28fRciqbwRSa22aKb2Evvm7TsfDOTYSu0aP3j4GKKHj55AJN0URdKia9STp88hku5fStpLtLxIP3vxEiJxlkXSU0IkXRxFMhZK9PrNW4jeaHaIxMEWSfdHkVQ+ieSTIiJxuEXymxV91iolRF++fIVIKmpEPgrlS4Ck1bpzXx9OrNwz8jsD/5GAjgnIb0SeDfLMk78Dg0ZMQNO23VH6rwbKWRWnVZzXAqWqQ5xZmb1Y/h7Jc1ieV/JbleJFjRIJWTKlQ/asGWXXonJmy2QxXA+Bpl2PUzhHg3Q9rhY7vR5Mow1BQuB7JnOmjELrZvUgf0ukN96+g8e+H+CSBEgAdGxD4E1w7eYdX0slkw9IK6ZoyKhJEA0eOREieVkQDRw+HiLpsmpU/6HjIOo3ZCxEfQePgajPoNEQSe24qNfAURD1HDAKoh79R0IkLxqibn2HQ/R3n2EQde09FKIuvYZAJJ9VEHXqMRiijt0HqTFPHboNhKh9twEQtfu7P5S6amtNbbv0g1FttBf41p364MvXbxY5XL95Gy3a90Tzdt8lXbZF8qIkatKmG0SNW/8NUaNWXSGS1l5RgxZdIKrfvDNE9Zp1gqhu044QyYuVqHbjDhDVatQeopqN2kFUo2FbGFW9QRuIZCp/UdV6raBUV1trqlKnJUTS6iqSWTpFMrGJqKJqdWuqtdB/V3mtpV5UrlpjiI5qDqolCPJNPElP/iiKpBVDVLxCXYiKla8DUdFytSEqUq4WRNL6ISpUpiZEBUvXgEheKEXSPUqUr0RVKBXX1pqkK7QoT9G/YFTuIpUhki7iopyFK0KUo1AFiLIXrABRtgLlIcqavxxEWfKVhShz3jIQyUQvooy5S0MkXc9F6XOWhGjQ8AmWEKiwtl37IVXWokopsxSBKEXmwhAlz1QIRiXLWFBNNJM0QwHVvV9eokVJ0uWHKHG6fBDJBDSihGnyQJQgdW6I4qfKDVG8lLkgipsiJ0RxkueASIYLiGIlzQZRzCRZIYqROCtE0o1cFC1RZoiiJswEkbzQ+0UxEmeBOMaq0GaLwSMmKt5yPctWbaQ+KyH3eWvtNyS/TfndS4WXVFBJZZJU+kgFjTjFUvkhFRVSoSCO/7v3H+Du7m6Wg752xd5O2vOlVqMO6lkiFTH6sjB0WSNDRqSSSf42SWWj3GvttGe6POfk9y+/B/mNyLNBnnkdtL8FEkcqIeUc6V4sxOSbn6lTJlNjYeV7sn27t8eMicOx6d95OH90K948OI/7V47gwLZV2LVhCdKnSSmneVOM6FFRrlRRb2F62DHvelw3bmbszd0c7Hqsh6sTPDb8M6QX+vXoAKn4rKC9B0iFePBYosNcaVKoJkDHNgRe/pTJEvtaqvx5sqF7p5ZK3Tq2gOjvDs0h6tq+OURd2jWDqHPbphB1atMEoo6tG0PUoXUjiNq3agRRu5YNIWrbogFE0o1LJDWKolZN60LUskkdiGRCDqOaN6qtZpls1rAWRE0b1ISoSYMaEDWuXx1K9bS1JnlhETWsUxWiBrWrQFS/1l8Q1atZGd/1F+zt7CxyiBEtmurKI915alQpB1H1v8pCVK1yWYiqVioDUZWKpWHUXxVKQVS5fEmIKpUrAVHFsiUgqlCmOETlyxSDqFzpohCVLVUEojIlC0NUukQhKBXX1ppKFSuoxs2ULFoAIpmBUySTlYiKFcoLUdGCeSEqUjAPRIUL5IaoUP5cEBXMl1N9T1HWBfLmgChq1MgWGUhgDq1lIneOLMiVPbNSzuyZIJJwUfasGVXLRrYsGWBU1szp1QQW0uohypwxLZQyaGtNmdKngShjutQQZUibCiJ5iRSlS5MCorSpk0OUJlVyiOSFVJQqRVKIUiZPAlEK7V4WJU+aCKJkSRJBlDRxQoiSJEoAUeKE8SFKlDAejEqYIC5EUbRWGimvJUWNEhlxYsdUih0rBkSxYkaHUgxtrSlm9GgQyUuvKHq0KOpbbdE0tqKoWvqiKJEjQRQ5UkSIZEyUKGKE8BDJty9F0sVRJC/iRslENSInp7AQSZczkaNjGIjChHGAyFIZ/jTsw6dPqoVcWuD3Hjiqeg5Iz4QFS1er3hTSU2OQ1kImFVRSmSSVPjW1SpoK1Zuqyg+pqJAKBXH+xQGJECcdxNkWRz2pVhEglQu5CldSFSPltYqXGlrFjlQUSUWUVHJJpZr0EJGeHNLrQnpHSC8GsUV6CUhrvjg+0lIurdp/Ut7tuw+oGXCllXrXvsOq94dU1Ej4n6TLc30n8PjJM9XLQ3q3SG8eqSyR+yefVuEllUCR4mVQFVCltdZXqWyUe23uopWQayI9NqQHg6Quv2t5ptWqVkH93Zowqj/+XTwNx/b8h0fXj+HZ7VM4uX8DZPbiyWMGoUfnVqhbo5J6NsqzwsHBXpJRsrW1xZa1CzCoT2f1DJfnsjjCh3euUb83FUknC0tdjyelLY+wNpb/vunEbJoRBATkXW7SPwPh5uYGqRCXnmpBkC2zCCEEQmox6NiGwCsrzoe8BJgXzcbGBmOG9YXU8on69+wI0YBenSAa2LsTRPLHXjS4bxeIhvTrCtHQ/n9DNKx/N4iGD+gGkXzPTzRyUA+IZOINkdQoikYP7Q3RmGF9tPz7QCbkMEq+CSgaP7IfRPKyIpo4agBE8tBWGj0QkzTJC4toytjBEE0dNwSiaeOHQjR9wjCIZkwcpjmq5cwRqP0+3dpCuvKI5k79B6J500ZDNH/6aIgWzBgD0cKZY2HUolnjIFo8ezxES+ZMgGjp3AkQLZs3EaLl8yZBtGL+ZIhWLpgC0aqFUyH6d9E0KGkvZfJiJmNmRGuWzoBIZuAUyQua6L8VsyFav3I2RBtWzoFo46q5EEmLhGjz6vkwasuaBRCN1ZirQpstxNHeu3k5dmotF7s2LoVo98ZlEO3ZtAwiOS7at2UFjNq/dSVE0uohOrj9Xyjt0NaaDu1cDdHhXWsgOrJ7LURH96yDSF5CRcf3rofoxL71EMkLqejUgY0QnT64CSL5vIbo7OEtEJ07sgUiaYERXTi2DSKZuVR06fgOGHX5xE6IJF1LTqE4qXLOjbN7Ibp5bh9Et87vh9IFba3p9sUDEN25eBCiu5cOQXTv8mGIpBVI9ODqEYgeXjsKkbxsix7fOA7Rk5snIHp66yRE8iJu1PM7pyB6cec0RC/vnoHo1b2zEL2+fw6iT8+u4Hf0XEvX9MXe9Hbo0r6ZukZyD8j9JPeu/Cbk9ya/Z3lWSMWXVFJJZZJU/IgjIJUqObJlUhUVUqkQK0Z0b+MSxQkVZ/T23fsQ51ScVOkmL93wxXkVJ1acWRkGIT1ExMkVZ1ecXunFIK3H0ktAnGJxjpNqTrI4y+I0i6TlO3mmQsiUp7SaHE16HEiLXq1G7SE9L6RnR88Bo1RvFBk+IUMdpKXWTXsJNC2/7PfoOwJ37z2EtDpLl3HfWrdNz7PmbekuLy3x0hukWdsevz3vgHSzlxZwGS4hQ0ikF4+09su1kJ4Qcp3kGknlgfRukd48MvREWvxliILYIRylIknuJakwlEpSue/kmSrPGpnESe55+V3LM2325JHq71bTBjVRWqsYlIoyqUCSdPwjqXySClx53i/RnuniCEvFln/SCOy47Hoc2IStP32p+Jf3ESlJm8591ZAx2aZIILQSCGDHNrRi1Fe5pTZaHnTSemh82ZRWOXHK5CVAX9YGnjWD+3VRrb/y0i2OjZRdHHd5OQ+8XPWVsjghUukgrabSApggflzVwu2bw6sv6wPGGvkNLJ07UbXcSMuptLgWL5xPq3yYrFrSOj3HAAAQAElEQVRSAyYXfaciLcN/d2jhw8i4cWKpXhpyf8gzQpzV8mWKqV4MjetVVz0wpFVggFb5JZVUUpkkjsAqrZJGnGCpAJGKCqkgEAdEHHZxQqTbpzj3N7RKA6mQkMqOHesXQypqpPJHnBOpuJKKMWkpEwdDenNIrwvpISE9GqTngfQUkBZ9aXmXighnJycYDAZVjjdv36kJVGR8tYzfljHiMgZTxrNLN1UZiy/j/MVxluETXXoNwZ2799W55ourN26psZrS6ixdxqXbtzhl0poYK2k21a1cuqdLF/cchSqoGUmly760QFet20qN65SWbHmx7NxziBqOIc665C1jPcWpFkde7JJx+DKeXrpyi80yNl3Gj0p3bhnrLWO1pVLAxcXV3MwA2RfHXcoweuJMNc5+6ar/IM6oDDsxzeDbNxcIW6mMkJm0ZV6G1p36qGEPmfOWUbOsSzd7abEXB1nKLfMuSGu/lEvKIulJLwbpvSGVIdJDRypLpRJR7ocrJ3fh/eOLqiJJ7iX5uyXPK+n5I71gpJJWfr+STmiSedfj2nEygl2PQ9Md4L+yVi5fUlVqOzmFVUPGOvcc7L8EGJsEQhABOrbBcTGDIM/MGdKq1kPjy6a0xki32SDIWjdZSPdRaf2VFr2HVw+rLmvS1drOly7KujE8gA2RFhBpNX2ptQJeOblTtXDHixs7gHPRd3LS3Vtate9eOqC1zu5RDpZ0u9a31QFrXa+ubSCt39KzQXpeSK+AS8e3B4pzL63D0iIm3bylC7l0T8+TMyukQkEq3KQ7aZMGNdRQBmkpG9Sns+rNIbZJDwnp0SC9D6SnwIl961XLu7SWP9datj8+vaxataW1/IrmGEmLvLTsbV27ENLzQSrwpNeG9AqRnia9/26rhk401Vr4nJ2dLEK1s7dH/HhxIM6zdBc3RpLxn9IVViYCe/T4qZpVXiY2k3G5MsmaOH1bduzFuo3b1YRz0hVQWi6ly+2o8TNUa7HMPSBOtbRGS0uyjMOX8fQVqjdVM/TK2PSchSuq8eHSyiljtaVlOnL8DKpLd5QEGdU4bAmX49JCnatwJcjY9lKVGyhHU9Kr16wTpPVVxqdKd1/JV+ZSEDvEwZfu19K9vGWH3mpmcGMZjet/JsxCueqN1dh4ce4lX8mrfPUmaiZtSUvOF4f8+s07asy2vEinSJZYDZGQSglhLT1opNJD7jWp5JBeDNJ7Y5VWGSK9c2R4S/W/ykLuhwTx48DW1hb894PA46/vUfLYXEy+ewSONnaQWY+npKvIrsc/EHHLAgGpCNy+bpEaBjNj7lK0aN/LQiwGGQk8f/4UlP4ZGK+Xf9Z0bP1Di3GDlAAzIwESCFgC4oSIAyJj5WUct73m0AVsDkGTmjhUMr5ZHCMZmy0te/nzZFdj1WUcvIyzl3H8ndo0gTj0MnRCKrn+Kl/KooHVKpXG1VO7VFfzJzdPeOvuLd3IpSu6ONHirEklkTjc29YthAwRkGEG4ozPnDRcDZeQYRfiUPfp1k7NXSAVS9JSKXMByHh+aYmUihYZF58vd3Y1Rl1apZMkSqDGest4bWlhNxoqLacyKZe05EorqLSiStdumY38wOHjEEdTWoBlZnZpfZXxqdLdV1qKh42eAmk5li7Z0g27tdbiunHrLmPSZmtP7N57BDKbubTqysEE8eNCbBS7/+7QHOKYynAJYSAO64s7p1VliQyRmDZ+qGIt5ZSWf7nXJA3K7wTMux7vzdUMnPXY7/xCe8zMGdNi96Zl6jmyeMVaNUllaGdiqfxRokQFZT0MLF3Dn4XRsf0ZHR4jAf0ToIUkQAJ+JCBOrnRvNo0u3bD7de9gGuRtW7qvS++PBFrrojhrEl/SEIdPJnWT8epVKpZGneqVIN23ZaI8cah7dmkN6cItXWvFIZSWTBm7LGNHpWVZehCIc3xw+79qnLn0LLlxdq+auVfGXktrp0icR3EiZfz3peM71Bh06dq9e+MyNY5eHE0ZFz1/+mg1v4A48DJGVYZdSAuqdPOWyfyaaC3kdWtURqIE8byVz3RnaP+ukHH1kpfkfeXkToiNYreURRx0meBOGEgXY9Nzuf37BMy7HleNlQ7i1KYMF/33E+WZoZKAPKPkN5wyeRLIfAbSq0N6nYRKGCx0qCRAxzZUXnYWmgRCGwGWlwSgZsmW1lbpxrx1zTw1KZi0PsoYXr3ykdZpcSJlYiOZFFBmDZeu3dKVXmYJFkdTxkXLeHppqW7aoKYaGy3DLsSRl27eMpmfjGmWSfX6dG9nsajSDbtNs/pqJnTJy2IkBgY4AfOux5PTVsCsDH8hrK19gOfFBEMHAZk7Ycf6JciQLjWkV0fRsrUgE72FjtKzlKGdgC4dW/nG5uYd+9G2+3D8Vb8T8pdtiJJVW6JO8x4YNnY2Hjx6GtqvG8tPAiRAAgFPIJSkKN2Y5XNV0hIbSorsVcwaf5VTnzIzGL5PwiUHZIImaVGWsdGyTwUNAdOux0mcoqhW2jpxMwVN5swlRBOIGiUSdq5fDKn8unT1BgqVroGHj56E6DKzcCQgBHTp2DZu3x8nzlxGverlMGF4d+xeNxvLZo1Ev24tkTJ5QnQbMA679h0T+ykSIAESIAESCFIC1pyZTNYknzJ7dvsk5JNd0r355vl96tM51lwua7Jduh73u74T1U8vxVu3r5Cux/tzNQe7HlvTVdS/rTJZ3voVs1GhTDHIZ9dkorprN27r33BaSAJ/QECXjm339o3QX3Nic2ZNj/hxY8He3g5RIkdEymSJUKV8cSycOhTx4sb8g2LzVBIgARIgARIIvQScnZyQJVM6SPdmg+FH620AEmFSFggYux5PuntYzXo8IU05SNdjZzsHC7EZRAJ/RsDe3h7yuTv5zOGz5y9RuExNyMRzf5YqzyYB/RLQpWObOkWSnxKz1xxdcXJ/GokHSYAESIAESIAESEAnBMy7Hu/M2QT142XRiXU0I6QSMBgMmDJ2MLp3agmZYb1k5frYd5C9HkPq9Q7t5dKlY2u8KA8ePcW0uSvQrvtwtOwy2EvG41yTAAmQAAmQAAmQgJ4JmHc9rhAjNaTrcdrw7Hnm5+vGiH9MoF+PDhgzrA++fv2GCjWa4r9NO8B/JBDSCOjasR0yZiYiRoyAutXLokndyl4KaReB5SEBEiABEiABEgh5BEy7HoexscW4NGWxIFM1sOtxyLvWeijRr2xo2aQO5k8fA09PT9Ru3B7zFq/61Sk8TgJWRUDXjm2E8M6oXaU0cmbNgOyZ03nJN8IvX71B227D0LhdP/QaPAFfvn61GPXcxWto2LYv6rXqhdmLVnvFWbd5N2o1/Ru5S9bFm7fvvcJv3r6vwiRc1Kn3P17HuEECJEACJEACJEAC5gTMux7vytkUDeNlNY/GfRIIUgLVKpfB2qUz4OgYBm279MOIsdOCNH8dZEYTQjABXTu2Dvb2uHv/sZ/xT5ixBLmyZcTcSYMQIUJ4LFm12ce5UkvVb/gUdGvXEPMmD8buA8dx5vwVFS9m9KgY1KstokWNrPZNF1kzpsGRbYuVxg392/QQt0mABEiABEiABEhAEWDXY4WBCx0TKFooL7atXYiI2rvy4JET0a5rPwwfMxXV6rdGw5ZdMXvBctWqq+Mi0LRAJ2CdGejasb197xFqNeumWlb9Msb20LGzKFsiv7oSZYvnx8FjZ9S26eLazbtwcgqLNCmTws7WFiUK58GBo6dVlNzZMyJ5koRqmwsSIAESIAESIAES8A8B067HDgZbjEldhl2P/QOQcYOMQLYsGbBn83JE1Rpz5ixciSGjJmHztj1YtXYTOnQbiKZtuweZLcyIBAKKQJA7tv4xvHPrepg4ogfaN6/tNb5WxtpaSuPT5y8wGIDIkSKow/HjxsSLl6/Vtuni2YvXiBsruleQxHv2/JXXvm8bl67dQr7S9dG0wwCcv3TdK5qHhzso/TPw9PTgdeK9ynuA94DJPcBnAv92Bezfru3PryHv4ek4/f4xEjhGxK6cjdEwbmaTey5g8+P1C1ieofE9IXnShGjTtJ72/qy9QHu92X7fWP7vBpy9cEmX9+93C7kkAZ8EdO3Ymo6rNd32WYzvITY2P4pjMPzY/n70x9JgY/oD9j2e8Yw4sWNg/ZKJ2LJqGooUyImu/cbg85fv43ddXFwQCGKaAczV3d2dTAOYqTXe925ubhBZo+20OWCftW5ufCbwnnJRzwM37bnwJyw+f/uKPld3oMbZFXjr9hVlo6XAriwNkcwhEv/uWNHfndD6nnDv4UPj666P9eUr13V5D/swlAEk8H8Cv/bq/h8xOFaXrt5E176jUaZGa6W/+4/Bpau3LJri7BQW7u4ecHF1VcdfvXmL6NGiqG3TRczoUfDm7QevoNdavJgxonrtW9pwCuuI8OGclWQyq1gxokE+RSRxHR3DggouBn7P187OnteJ9yocHMIo8Tfr999OSGXl4MBnQki9tv4p158+E17DFRXPLcO0h8chXY9HpS6NxVlqIlq4iPybY2V/c+xC6XtC3Nix5XXWouLFjavL+9iisQwkAY2Arh3boWNnIWH82JgyqrdS/LixMHz8bM1sy//nyZEJO/ceUQe37zmMfDkzqW3ppnzxyg21nTJZIsjsyeKYunt4YNe+Y8iXK4s65tvi46fPXodkhuQ3795DbPEK5AYJ6JkAbSMBEiABEghwAqazHicIGwk7cjZGs/jZAzwfJkgCgUmgUP5cFpOPED4c0qRKbvEYA0lArwR07dh6enqiXfM6SJwwrlJ7bVu6C/kGs2PLOtiwbb/63M/9B09Qp1pZFfXho6cYPHqG2jYYDBjYozX6DpuMhm36IGvmNMiSIbU6Nm3uCvVZH3F8pZW4a7/RKnzzjgMqPH/ZhhgzdSGG9WkPacVVB7kgARIIEQRYCBIgARLwCwHzWY9LRU+Bg7lbIEOE2H45nXFIQFcE8ubKhjbN68Pe3t7LLpktefSw3ha/EuIViRskoEMCNjq0ycskD61F9Y3J92TF4fQ6aGFDPtMzbXQfyOd+hvXtgLCOjipWyuSJsWLOdydVAjKmS4n5U4Zg0bRhaFavigQptWpcQ33Ox/hZn9GDuqrw6pVKqvADm+ZD0k+fhjVYCgwXJEACoY0Ay0sCoZqA6azH9gYbjEhVCssy10R4uzChmgsLb90ERg3uiWe3TuLQztU4e3gLHlw9gjrVK1l3oWh9qCSga8e2VpUyqNHkbxg/9VO7eQ/UrVYuVF4oFpoESIAESMBaCNDOkEjAtOtxPMcI2JmzCVokyBESi8oyhUICYcI4IFP6NEieNBFsbW1DIQEWOSQQ0LVjW6lMEa31dSCKFcypJC2xFUoXDgncWQYSIAESIAESCN0ErKT0lrset2TXYyu5fjSTBEgg9BDQtWMrlyFenFioWqGEUrw4MSWIIgESIAESIAESIIFAJ2Da9djOYIPhKUuqrscR7b8PdQp0AwAwDxIgARIgAb8R0KVjm7tkXVy4aKYPDAAAEABJREFUfENN2CTb5vJb0RiLBEiABEiABEiABH6PgHnX4605GqFlwpy/lxjPCmwCTJ8ESIAEoEvHViZvkgmaZG1JvG4kQAIkQAIkQAIkEBgEfOt6nDVi3MDIjmmSQBASYFYkELIJ6NKxNSIfM2WhcdNrPXj0TK9tbpAACZAACZAACZBAQBEw73o8JGVxdj0OKLhMhwSshQDttFoCunZsb9y+5wPs5as3fIQxgARIgARIgARIgAT8SsADnph27yiaXlyLhhdXY8KdQ9j0/BryHp6O0+8fQ2Y9lq7HbRLm9muSjEcCJEACoYqAHgurS8d2/da96hM/N2/fV2vj534atO6NJIni65EjbSIBEiABEiABErASArXPLEeva9ux/sVVbHl5AwNu7EIdLeyN2xcUi5oUB3O3BLseW8nFpJkkQAIk8H8COnRsgSwZUqNJ3cqIFSOaWsu2aHi/Dhjap/3/TeeKBEiABEiABEiABPxHYM+r29j2wmfvL4PBgOqxM2BV1jrgrMf+Y8rYJEACJKAHArp0bOWzPtkzp8PiGcMha6PixIqhB2b6sIFWkAAJkAAJkAAJ/JLAg6/vsFdzZqfeO4q/r2xBtyubfT0niVMUX4/xAAmQAAmQgL4J6NKxNSL75uKCBcvWo2OvkTB2R5a18TjXJPArAjxOAiRAAiQQ8gl88XDDqXePsOrJBQy7uReNzv2LQkdnIfL2QciwfwIqn1qM3te2Y/aDE7jx+ZWvQCLahfH1GA+QAAmQAAnom4CuHdtBo6bjxas3ePnqLSqXLYJwTmGRKnkifROldSRgfQRoMQmQAAnonoCnZuH9L2+x69UtTL9/DF21ltcKJxcizb5xiLNzGIodm4PmF9bin9v7se7ZZZx7/0Q7AwhrY4f04WOicqy06JakAEakKgUHG1t1zHxRIGoS8yDukwAJkAAJWAkBXTu2t+8+QNe2DeDsHBYli+TF6MFd8fDxMytBSzNJgARCFgGWhgRIICgIfHJ3xZn3j7HiyXkMvbkHDbXW13yHpyvnNeOBiah6agl6Xt2GOQ9O4sDru3jy7YMyK75jRBTWHNPmCXJgVOrSWJu1Li4U6IhHxXphf+4WmJuhCnomK4SWCXJiWMqSCGfroM6ThaPm/P6tOb1pw3HIk/CgSIAESMAaCdjo2WhnZydlnpubOz5/+aq2XV3d1ZoLEiABEiABHRKgSSTgBwLyuZ27X95gx8ub6rM7nS5vQvkTC5Bq71jE2zUcRY7ORssL6zD69gH8p7W+Xvr4HF893BBec0YzR4iD6rHTo5fmpM7LWBUHNKf1abHeOF+gA9ZozuxIrUW2WfzsKKQ5ufLZHoMFe5rEz4bbRbrhQI5m2J2tMe4V7a7SsxCVQSRAAiRAAlZCQNeObThnZ7x9/wF5c2RCo7Z9NPVFrBhRwX8kQAIkQAIkYM0EQovtH9xdcPLdIyx7fA6Db+xG/XOrkPvQNMTeMQyZD0xC9dNL1Wd35j88hYNv7uGZy0fYwIDEYSOjRLTkaJ0wF8alKYuN2RvgaqHOuF+0B3bnaooZ6StDWlgrxUyDdOFjIowvXYt/xtneYIOUztEgrbQOBtufReUxEiABEiABKyBgo2cbxw/rhkgRwqNx3cro1akZWjepgW4dGuvZZNpGAiRAAiRAAqGKgLS+3v78Wn1CZ/LdI+hweSPKnpiPFHvHIMGuESh+bA5aX/wPY+8cxIZnV3D10wu4eLojsn1Y5IgUD7XjZEL/5EWxOFN1HM3bGk+L98bp/O2wIkstDE1ZAg3jZUXeyAkR0yFcqOLKwpIACZAACfiPgK4dW9OiZEyXUn36x9bGakw2NZ/bJEACJEACJKALAi9dPmOQ1npa4/QytLq4DqufXvSTXe/dvuH424dY+vgsBt7YhbpnVyLnoamItWMosh6cjJpnlqHv9R1Y+PA0Dr+5jxcun2CntYomd46KMtFTon2iPJiUtjy25GiEm4W74nbhv7EtR2NMSVcBHRPnRdkYqVQLqrSk+skgRvo/Aa5IgARIgASEgC69xNwl6+JnEsOpnxOQ2SMXPzqDpufXoPaZ5Rh+cy8+urv8/KQQePTg67tor7Ue1Lm4Gj2ubsW1Ty9DYCl/XiSZWKXXte2qy18brdVk58ubPz8hBB6VsXkT7hxCw4tr0PTiOky/dwzunvIrCYGF/UmR5FMo4siIQyOOjTgeP4ke4g7JFZ/14ATyHJ6G5EcmKqdsyr0jkPAQV1hfCvTG9Ysq/zit9XT7yxtY/vi8+jsh3YTlFPld3Pz8CptfXMPEu4fR7tIGlD4+D8n2jEbC3SNR8vhctLm4HuO139Om51dxXXumunp6ILqDM/JEToD68bJgcIriWJa5Jk7mawsZ+3o8bxssyVwDA1MUQ924mZErUnxEtf8+h4bkSZFAkBBgJiRAAiGegC4d2yPbFkNUo3JJ1K5SGgunDcWqeWPQqlENVCpTJMRflIAoYMsLa9ULidTEb3lxHaNu70eRo7NClXMrY7rKn1wIcfD3vr2LGfePo/CRmbj4IfTMrC3dA3NrLSrT7h1Vk7QsfXwO1U4vxeS7RwLiNrOKNFw83VHy2FwM0FqYtmgv8utfXEXPa9tQ5+xyq7A/oIyUFjb5FIo4MuLQjNMcm/yHZ0AcnYDKQ+/pTNd+B92ubMGVjy8g3z0Vp6zPtR2ak3ZQ76YHmH3y27dUoSHdhDMdmIhoOwYj+8EpqHNmBfpf36men0ffPsAr18/KBvlsTvmYqdE5cT5MTVdRtbg+KNoD1wt1wabsDTEhTTm0TZQbpaKnQFKnKLA1GNR5XJAACVgHAVpJAtZMQJeOrRHoqXNX0K55HSRPkhDx4sRE/Zrl8fb9e+Nhrn0hcOPTK6x8csHHUQkfeH0X9r++40P7tDBz7X11G+bao4WZa/erW7Ak+daguaS10FwyK6a55MXbXNte3FBjuEzXWzWn3VziyIt6a86LOQR5mW13ab1qjdj8/BosSVohzLVRa5kwl4wVM9f6Z1dgLpnR01zyjUVzrX16CeZao4VZklRYmOvfpxdhLinrO7dv5hgw+OZu1VIj94lIPqthLnGAzCWVBX7V0sdnVZdF0/WSR2dhLql4MNeiR2dgLuneaK4FD0/DXPMfnoKpul7ejPMfnvpgIPdR72vbMffBSW+ST4iYa7bWymcuafkz10yt8sRcUqFirun3j6nvcHpba63I080kFRKWNFVz0MwlLY/mEidGNPzmPky4c9gHA5mop+G5VaplTlrnTCUt3OYar7XSmUscZEsSR8lcY24fgLlGa2Hmku+Qmksq58w18tY++EUjtHii0bctO7DjtHKJg9vr2jZ0v7pVfR9VZultr7VWSuuktHJLpUCT86vVp2fqnV2pHD/peiuTH1U5tQSVTi6CVKSVO7EApbQWThlXKjP7FtQq0/IfmaFaSaXbbraDk9WkSRn3T0C6/eORet9YNRZVWkQT7x6lWkVlVuDYO4ch8vZBAa6xvjCQm+Pe5zeyQuww4VEgSmI0jp8NQ1IWx+qsdXA2f3u8KdEP8tmchRmroW/yIqgVJ6MaI2v62RyVABckQAIkELIJsHQ6JaBrx9bFxQVv3/1wZL9+c8HrNz/2dco02M06/+GJrzbIi3hF7QXMXPJSZq7KpxbDXH9pYeaSlzpLkm8NmktaC80lL4bmkq6S5pKXSHPVOrMc5pKu17XPLNNaor5/Isocxtn3T9RLaZ2zK7RWO5+ScWPmkhdZc8nsnuZqoDkJ5mp47l/1Mmy6bqSFmaux9tJsLnmRtiTpYm6uZufXwFyH3tw3L77ad/FwRyutVb/F/9Xywjr1aQ3TtbzMm6v1xf/UJDB+Wbe5uF51WTRdt9UqFczVTnMezCUOhblkQhpzdby8EeYSh8RU4iCrQltYTNFarrtc2QxTddX2zfW31spnLmn5M5c4ReaSLvDmkm9w+pDmVElLsql6aY63JfXWws0ljpm5+l7focY8jrq1F57afxYQYP+ru6plTlrnTDVAa+E2l7T6mku6NFuSdG0115Cbe2CuoVqYuYbd3AtzDdfCzCXOql9kdH5fuXy2hADvXb9BKgWmaRULUjEhFRtSOSL3jlTMSAWPdOOWSiappJJKrs0vrqmKNqmUk4o9qRiUoQ+H3tzDMa2FU2YClm+xSqWK9BKRVmJpIb71+TXkMzf3v77Do6/v8fTbRzUWVVpE37p9hYxjle+4Svd5i8ZqgY42dnC2tYd8+iainSOi2IeFdAWOFSYc4jpGQALHiEgUNrJqMU3hHA2pw0WHzBycIXwsRHHwvQvwjAx/4XGxXrhcsBP+y1YPY1KXQZuEuVEkalIkDBsJ/EcCJEACJEACficQ9DF17djWr1EBNZp0Q+8hEzF07CzUbPI3KpYpHPSUrCzHn80cmUB7OZHZJfNFTggfipII+cyUX9u3pAJabb65Cmph5pLvCJqrcNQkMJe8OJmrqPYyZa5i0ZLBXMW1MHMVi5rc16sW0d4RJaMn95J0mTNX6egpYC6Z/MRcZWOkhE+l0sK8q1yMVLAk6dJnrgoxU8NcFWOmgbnkMxfmqhwrLUz1s3uhvJZmlVjpYFRVbdtc1WKnhyXJNyTNVSN2BpirZpwMMJe08pirttby41OZ1GypMmOqUXXiZoK5ZMyeJdWLmxmibBHj+novFIiaGA3iZfEhmYXVXI3iZYW5pEXLXPJ9THM1jZ8dltRMCzdX8wQ5YK4WWpi5WibICXO1SpgTPpUL1bTr4BuElOGjq0+qiANjLulSakntEuWBudprYebqkDgvzCWTBJmrU+J8MJd0dTVXlyT5Ya6uWpgl/Z2kAMwV0T6MRQzRNGdPxn9K6+TwlCUh30EdrTl18pmZiWnLQyY3mpauEmamr4w5GapgfsaqWJSpOpZkqqHGkq7MUhvSqrlOcwY3ZKuvuuRuzdEIO3I2UZ+m2Ze7OeRbq4fztMKxvK0hY0/P5G+Hc1or6IUCHZUjea1QFzWh0p0i3XCvSHc8LNoTTzQnU1pJzSXhcvx+0R64q8W/VfhvSFfgKwU746KW3rkCHSDpSz6Sn+Qr+YsdQ1OWsMhAHONKsdIgrOY0W4zAQBIgARIgARLQOQEbPdtXtkQBzJs8CJkzpELKZAkxfWxflCmWH3q2WQ+2ZYwYBxHswlg0RcY/yfcAN2RvAB/SXsjkpcxU67UwS5LafHPJS5251matC3Ot0cLMtTprHfViaLr+Vwsz1yrtBdJc8lJprlVZa0MccksQxNlZnrkWjJJJTsy1NHNNmEsmPzHXYu3F1qeqq89WLNZefI2Sl2BLki595lqQsRrMJS/S5pqnvVyba6720m2qNolyWUKADOFjYWGmapid4S8vzdK2zSUv8pYk35A01/T0lWAucQbMJePyzDUlXUXNeTBXBS3MuyanrQBzySyrliQOiWhcmnIWGch3LyXf8dpxc4lDY66xacrCXNKiZS5xiMz1T+rSsKRRWri5xKky1yLAFxIAABAASURBVIhUpWCu4alKwlzDNKfMp0pgcroKiOHgbJFDx0R5Ic7OkJTFVbdT07VMAmRJg1IUg7nEMTTXgORFYS75rIu5+iUvAnNJV1dz9UlWGObqrYVZUq9khWCuVgkt/x7qxsusZuwVx76lVjkgFQtSOSGVG/K8qB0nE6SCplrs9PhLqzySSiapqCqjVWxJpZhUrEnFnFTsSeVgnsgJkDNSfEilSuYIcdTvTVpMpeVUWlBl7Km0qEpFYzythTV2mPDq+kS1d0IkrQVWnt/SIistsxYv2h8EGstgMEkjpkM4TNJ+W/yWqwkUbpIACZAACVgdARu9WxwnVgxUrVBCKVaMaHo3Vxf2Sfe0EalKqe5pRoNkAg9pyZGWUmNYSF8PSlEc8hJpWk55+ZTWItOwkLwtL+jS8mxaRnmhHq45SqZhIXlbHAppuTN1EmRM4FDNCYzvGDEkF92rbOKwiIMvDowxUBwbcdLE0TGGhfR120S5VQtyKufokPshuXNU1cLdNUn+kF50r/LJ3wJpdX5QtKdqTZaxs1cKdVY9WLwicYMESIAESIAErJCALh3bll0G49bdB5C1JVkh5yA3Wbp63ijcFSfytYF0P5OXGGnJCXJDgjHDTBFiq25/F/J3wIaMtSFd/KRFWFpFfpgVsrfk5V1anqVr465cTXH+/10UpUUpZJfce+mk5e5e0e7Yna0RDuRohttFukFa5BCK/knrojgw4sjs1u4FeSaIgyOOTmjBIBUa0oJ8JG8r3MzdHvIZGnkuSnhoYWAsp7QIZ9ZakxOGjQSp5DCGc00CJEACJEAC1kpAl45tk7qVETN6VMjakqwVdlDbbaO9riRziqq6wYXmcVMymUqW8LEhXfyC+hroJT/p2phFe4n97RZKvRTkD+yQVsu04WIgpdZKZ2+w+YOUrPdUcWDEkRGHRhwb6y0JLScBEiABEiABEiAB7wR0+XaXPXM6hHN2gqwtyXsRuEcCJEAC+iBAK0iABEiABEiABEiABIKHgC4d2ybt++NnCh5UzJUESIAESCAACDAJEiABEiABEiABEghwArp0bDu2rIufKcApMEESIAESIAES0BUBGkMCJEACJEACJOAfArp0bNOnSY6fyT8FZFwSIAESIAESIIEQSoDFIgESIAESIIH/E9ClY/t/2/DNxQULlq1Hx14jvc2QbDzONQmQAAmQAAmQAAmQwM8J8CgJkAAJhAYCunZsB42ajhev3uDlq7eoXLYIwjmFRarkiULDdWEZSYAESIAESIAESIAEgo4AcyIBErByArp2bG/ffYCubRvA2TksShbJi9GDu+Lh42dWjpzmkwAJkAAJkAAJkAAJkIA1EqDNJKBfArp2bJ2dnRQ5Nzd3fP7yVW27urqrNRckQAIkQAIkQAIkQAIkQAIkoDsCNChYCOjasQ3n7Iy37z8gb45MaNS2j6a+iBUjKviPBEiABEiABEiABEiABEiABEjAegkEtOW6dmzHD+uGSBHCo3HdyujVqRlaN6mBbh0aBzQDpkcCJEACJEACJEACJEACJEACJGDFBHTt2I6evAC37z1UeDOmS4nsmdPB1sYvJqtTuCABEiABEiABEiABEiABEiABEggFBHTtJcaJFR3d+o9FvVa9sHjlJtUtORRck6ArInMiARIgARIgARIgARIgARIggRBAQNeObe2qZfDv/LHo0KIObty+h0p1OqDX4AkhADuLYE0EaCsJkAAJkAAJkAAJkAAJkIC+CejasTWiy5YpLZrW+wvFC+fGnoMnjMFckwAJ6IcALSEBEiABEiABEiABEiCBYCOga8fWzc0N23YfQuu/h6J5p0FwDBMGi6YNCzZYzJgESIAE/owAzyYBEiABEiABEiABEggMArp2bCvW7YBd+4+hSvni2LBsErq0qY9kSRIEBgemSQIkQAIkoBcCtIMESIAESIAESIAE/ElA146ttM6OGtAZRQvkgJ2trT+LxugkQAIkQAIkEHIJsGQkQAIkQAIkQAI/COjSsV3672Z4enoiSuSIPyw12dq1/7jWknvUJISbJEACJEACJEACJOCDAANIgARIgARCCQFdOrbPXrxE9cZdMXvRahw+fhYnzlxU2rhtH9p2H44Z81cgdszooeQSsZgkQAIkQAIkQAIkEJgEmDYJkAAJWD8BXTq2nVrVx4Th3VWr7fI1WzFn8VqlE2cuoVyJ/Fg6axTSpExq/fRZAhIgARIgARIgARIgAesgQCtJgAR0TUCXjq0QixMrBprVr4qJI3pg+pi+SgN7tEapovk43lYAUSRAAiRAAiRAAiRAAiSgMwI0hwSCi4BuHdvgAsJ8SYAESIAESIAESIAESIAESCAQCTDpQCBAxzYQoDJJEiABEiABEiABEiABEiABEiCBPyHgv3Pp2PqPF2OTAAmQAAmQAAmQAAmQAAmQAAnojECodWx1dh1oDgmQAAmQAAmQAAmQAAmQAAmQwG8S0KVjO3ryAsi3bM3LtGjlRkyds9w8mPuBR4ApkwAJkAAJkAAJkAAJkAAJkIDuCejSsZVv11avVMIHvFp/lcKBI6d8hDOABIKXAHMnARIgARIgARIgARIgARIITgK6dGxtbW1gZ2cH838S9s3FzTyY+yRAAtZAgDaSAAmQAAmQAAmQAAmQQCAR0KVjG8bBAV++fvVR5I+fPiOsYxgf4QwgARIggZBCgOUgARIgARIgARIgARLwPwFdOraVyhZGz0ET8eLla68SPXvxCn2GTkKlskW8wrhBAiRAAiQQKgmw0CRAAiRAAiRAAiTgjYAuHduqFUogTcrEqNqwC2o3747qjbugRuO/tbAkqFqhuLcCcIcESIAESIAESMASAYaRAAmQAAmQQOghoEvHVvA3b1ANG5dPRq0qpdGodmW1LWEGg0EOUyRAAiRAAiRAAiTw5wSYAgmQAAmQQIggoFvHVuiGD+eM8iULoXSxfAjn7CRBFAmQAAmQAAmQAAmQQBATYHYkQAIkoHcCunRsS1VriZ9J71BpHwmQAAmQAAmQAAmQQKgjwAKTAAkEIwFdOrZTRvXGzxSMvJg1CZAACZAACZAACZAACZDAbxPgiSQQOAR06dgmTRwfP1PgoGCqJEACJEACJEACJEACJEACJKADAjTB3wR06dj6uxQ8gQRIgARIgARIgARIgARIgARIIFQRMC0sHVtTGtwmARIgARIgARIgARIgARIgARKwOgJ0bH29ZDxAAiRAAiRAAiRAAiGTwLt7e/Hg8Ajc2NQcV1ZXxe0dnfHk1DR8e/8wZBaYpSIBEgjxBHTp2B46fhY/U4i/KtZUQNpKAiRAAiRAAiRgNQQ83b/h0fFxeHh0NN4/OAiXj4/h4fYVX15fx+ubmzQHt5MKt5oC0VASIAES+D8BXTq2K9duw8/0f9u5IgGrIUBDSYAESIAESCC4Cbh8eIxbWsvs2zu7fDXFw+2Lasl9emYWPD3cfI3HAyRAAiSgNwK6dGwnDO+On0lvEGkPCZBAgBBgIiRAAiRAAoFI4P3DQ/j27p6fcnh9aytcP7/wU1xGIgESIAE9ENClY2sKxtXVDRev3MCJMxe9ZHqc2yRAAiQQugiwtCRAAiTgfwJf397B84tL/Hyi6rJ8bCy0Zls/n8OIJEACJBCcBHTt2B48egZ/1e+Ijr1G4Z9J89C+xwhMnrUsOHkxbxIgARIgAWsgQBtJgAS8EXh7Z4fmo/qva/Hnl1fw9d1db+lwhwRIgAT0SkDXju2UOcsxa8IAJEuSACvnjsG8yYO17YR6ZUm7SIAESIAESMCqCNDY0EPA9cub3yqs22+e91uZ8SQSIAES+AMCunZs7exsEStGNEh3ZCljquSJ8fnLZ9mkSIAESIAESIAESCAoCFh1Hm6f3uDNpb348vTOb5XD1sH5t87jSSRAAiQQ1AR07dg6hXVUPCJFDIf/Nu+GdE1+8/aDCuOCBEiABEiABEiABEjgBwEP16/4cPsUnuxbhOsLuuLM0DI4NbC42v5w89KPiP7YsrUJ58fYjEYCJEACwUtA145ttYol8Pb9B7RuUhM79x3D4lUb0aJB1eAlxtxJgARIgARIgARIILgJeHrg89ObeHF8He78OwQXxtbEiT4FcHl6C9zfNEG10rq8ew7bsBEQMWVuREtX2t8We3x1xZkRfynH+N31o4Cnp7/T4AlmBLhLAiQQaAR07dgWK5gLkSKER9JE8TFpZE9MH9MXmTOkDjQYTJgESIAESIAESIAE9EhAnNTXF3bj/uaJuKI5ryf6FlTO7G3NqX2uObfi5BpsbOAcLw1i5qmOpDUHIWO3Ncg2cDdSNZmEhKV7wDlmRn8Vzd4mvoovXZmvzm6Ls6Mq48nehXD7/E6Fc0ECgUWA6ZLA7xDQtWPr5uaGoyfPYe7itZi5YJWXfqegPIcESIAESIAESIAErIGAh8sXvL91Eo/3zId0KT49pJTqVnxjUTflWL6/fQoSJ0zUeIiaqRQSVuiKtG3nI/uQA0jXfiESVeqGaFnKwDFagh/FNdggXq6usHOM9CPsJ1uREhVFqnqzkaX3JsQt1hT24aPh26uHyrE+PbgUbi3ri493z/0kBR4iARIIZAJM3oyArh3b3kMmYvWGnfjm6mJmNndJgARIgARIgARIIAQQ8HDH58fX8PzYGtxeNQjnx9TAib4FcGVGSzzYMll1KXZ9/9KrS3HcYs2QsvEE1RKbqfs6JKs9BLHy1US4BOlgsLX/KRA7x8hIUmwMnGOkh6//DLaInrYW4mRvp6LYR4iOeCVaInPvjUhebyQiJMsOT3dXvDyzBZemNlGtxs+P/Av3b59UfC5IgARIILgIWHZsg8sas3y/fnPFPwO7oFWjGmjeoJqXzKJxlwRIgARIgARIgASsgoDL26d4fX4n7m8cj8vTmmpObEFcGF8Hd1YPw4sT6/Hl2S0YbGzhHD8tYuatgaS1BiNjt7XKkZUuxfFKtECkVHmVo/s7BbZ3jolEhYdpjmsHRIifDw7h4sDGzhFho6RAlGRlkbTEOMRIV0ezwc5b8gYbO0RJXxSpm0/T7FmDWPlrazaEV+N876wdgdNDSuPOmuFq39uJ3CEBEiCBICKga8fWwcHO61M/QcTDX9kwMgmQAAmQAAmQAAn4RsDj22e8u3EMj3fPxfX5nXF6UAmcGVYONxb3wJP9i/HhzlnITMaqS3HmUkhYsSvStpv/vUtxuwVIVPFvRMtcGo7Rvo919S0f/4cbEDlJccTP0wPJy85E6ir/IknxsYidtRUcIyX5ZXLSxTlh+c7I2ncrklTvD3HCpazPj65WLbiXpjTGy9Ob4enGHne/hMkIJEACAUZA146ti4sbqjfpinHTFoJjbP15zT09tZrf/3BzaW/IH9OH26dD/uj4M5WAiB6sacgYJZkt8s7iv3Hvv9H48vxOsNoTHJm7vn+BexvG4trcDri9cgDeXTuM0PbP0+0bHu9dgNtLeuL2sj54enAZ4OEe2jDg2+tH2nNBg9BzAAAQAElEQVRhPeRTIJzhNNRdfhY4sAloz5RPj67i2ZF/cWvFAJwbXVVrjS2Aq7Pa4MHWqXhzeT9cP76GnVNEREyZB/GKN//epXjQXqguxbWGIFbemggX/9ddigO7KH5N32AXBtGzlUc6zQlP33EJYuSoBBt7R3y8dx63lvdTrbgyQ7OMzfVrmoxHAiRAAr9LQNeObdpUSVC6aF44O4X93fKF2vPkD8rtVYPx6uw29cf00c7ZuDCxfqhybl+e2qjGKL048R8+3jyOp4eW4+KEevj8+LoO74vAMenrywfay1U1PD2wFG+vHsKLkxtxdU571VIQODnqL1UZC3ZxShM82DwJ767sx9uLu3Fv/RhcW9BFf8YGokXyLDj3T1XcXjUI8qIpM5xendMOwicQs9Vd0jKW8e66kbi7pLvqNvnp4WXd2UiDrIOAVBTJ70oqDqWF8nif/NrfmLq4u3YE5O/P1+d3IWNexVEVh9XYpTjrgF1I1WQi4mqOrepS7BjOOgr8Cyud4qRE4qp9kEVrxZWW5rAxEkNmT5aKtLMjK0GeOTK7cmisVPwFOh4mARIIIAK6dmxNx9Wabv9O2Veu24a6LXuifqve2H/ktMUkXr56g7bdhqFxu37oNXgCvnz9quK9efseXfuORuGKTTBq4jwVpufF1xd3IZM6mNso4fe3TMKH26fMdFrbN9OdM/jgTWe1fRPd1bZNJDMjepNWWys1tl66fwEfvemitm+iB9q2mT49uARv0l5A5SX0h67g00MTaTXlUltu1L1N480RqC5fd/8bpTm31zRd964nN/DZXE9vqvFC8hkF0Rdt35ue3VLjoWRM1Hfd1vZNpLUQSyuxUfKi403atZLr8kP38PWFmV7ex1dveqDt/5DUhPumB9r1dv/60QeHh9um4durB/j25jFc3jzxqbdP4fIzvXsGF296ru3/kLQSe9dLyOQnXvqg7XvTK7h+MJPWsiGtG0a5fXoDN296C7dPJvqsbXvTO/VS9eLUJnzW7g1zCG+vHMTbKwfg/uXDd2mchNVP9e0TZIIUo6QXhDe5fIHMVOol16+Qboa+SVqSTWVuY0Dti423tYoucydWWm2fHV4VUNnoPh3prXBxYgNImT/ePAbpNnlpcuNQ14tBfksyKdG1uR1xa0V/VQGq+4sXCAbKc+HFsTV4cWQlPmp/f36WhTwX3l07gkc7Z0G4nexfGGdHVFS9oqTiUP7WSbdbxxiJEDVzKXyfpXgecgw/oroWSxfjwOlS/DOrg+eYreaoy9jgDF1XIU3LmYiSoZgyRJ431xd0xelh5fBox0zI3wN1gAsSIAESCCACunZs32gO5ZJVmyCzI4uWrt4CCfNv2e89eIKFyzdgxth+GDWgE4aOmYmv33yO+5gwYwlyZcuIuZMGIUKE8FiyarNXVmVKFECzelW89vW88enRNV/Ne3ZoJS5Pb2Gm5tq+maY1w2Vvaqrtm2iqtm2iS1ObqNkRvdZTGkNqsL00uREueVNDbd9Ek7RtM12c1ADepLU4X/Smerg40UQT6qra8ouyHl8Hbh/fWuTw4fYZNVHHhfG1tbWJxtXCBXONrYkLJjqvbXvTmBpqBkuZxfK7qmv7JhpdDedNJF3TvElrQZNWtB+qgnP/mGnUXzjnTZW1/R+SmnDf9Pr8bosMPFy/QZ0zvALODC/vU9qLh4wD81VDy+KMN5XR9n9IJhHxrlI4PcREg7VtbyqJ04PNNKgEZDyaUacGFod3FdP2TTRA2/amojg1oCjuaA6dRQhaoPEFVV5ST/YrhF+qb0GcNJHMXOpNffLjhKl658OJn+h4r7ww1bFu2RAQMk/jRN/8ysHWiuzj/3sbxysbVbm0l/VTGkPFXLteco3PaveH3CvqHtTu1/Njqn//TWi/Mfn9XZLfrfZ7vzy9Oa5oz5YrM1uplhnpGXBtXkdcn98F1xf+rcYU3lzSS3ME+kD1KFk5QGs9How7q4fijtbCdXfdKK0lfTTubRinWpTF8ZLumzKMQpyJR7vmQD598njvAtXjQJyJp4eWKydVHNTnx9epbtbSUiYVe9KSJhP0vL6wW80qK5UY0lLv6eHmjYHs3/1vND7ev6hVlF3Gp0dXIb06VEXWs9tQFVFaZZOqPHr9CC5S4aNV6shLuVTGqMqVz+++V45oFR9SqSGVFd4y0dGOtKCd155bwvLt1YNay+Im7Zr0xoOtU3RkZeCbIvfRBe1vxYP1/+DhpvGQ+1haWo05S0Ws3F83l/WBPLPl2SA9HB5unwHhJhVi4sBJl2KZpThVk0nINmgvMnb9F8mkS7GapTi9MblQuw6fJAuS1x2BLP22I36p1nCIFEtzaF/goebYyt8EcXTF4Q21gFhwEiCBACWga8e2/4ip2HvoJLJkTK20e/8xDBw13d8ADh49jYJ5s6kuzbFiRkOq5Ilx4vRFmP87dOwsypbIr4LLFs+Pg8fOqO3IkSKgSP4cCBs2jNrX+8I+fFRfTXSIHAvhE2dC+ETeFS5RRnhTwgwIZ64E6RHOm9Jp+yaKr22byDl+WjWhhNc6Xho4e1Nqbd9EcVPB2URO2rYPxUkJ6e70Qym0fRPFTg4npWS+MrCxD4uwsZJ9V8ykCOtNSbR9M8VIDOlSZZTUyHtT9ERw9KaE2r6JoiWATLTxQ/G1/R+SSUN+qShxEcZUkeMgjDfF1vZ/SF4eRAZ7B185OISPAYeIMf8v2f4h+byDT0WDfQQThde2vSkq5N7zUrgosDeRnXNkeFckbd9ETtq2N0WEjEUzlW3YCPCu8Nq+ibSWAnnZNJWNve+/W4N2zCaME7zkEBY25rJ3VGPGbHxZyxgz73KAwe6HfL0Aejng6a6cXtUKrbVeu31+C9VK/v4lpFX+m9aiL06d6jXw4q7qkSBOn3TplR4T0tIlrVUfbp/G+9un8P7mCciL6rtrh7UW8YN4c3kf3lzco2aBfXVuu9Y6uBUyqcyLkxs1R/Q/PD+2FvKpkGeHV+LpweV4emCJGgMsjpdMuCPDKMSZkF4GytndPAkym+y9DWPVuHnpViwzscpY+turBkHGNt5a1lc5azJBj3z3U16er83rhC+ag2qC3WtTynZpckOtoqy+qhy7IJVeUomlOfHi1Ehlkzj30kKnKnu0Sh15KZfKmFMDi6kKFFU5olV6SMWGVFaYVy4Y94/3yqMqEqRCRJylk/2LaOcX+16Jo1X2nBlaBpLHjwoFrRJLKhSkgkyzSVW+aQ6ZV6WCVBhqFYuXTSsWZrWBOGEyrl7K7VW5sKi7qoCU6+tV+P9vPN49H1LhIM7dj0qGsYr1/c0TodhvnQq5FtLa9mjXbMj1kev0ZO/CH5UN2jWUaynjTJ9rraFeFQ7a9X55ahNendmq3QPb1P3w+sIuSNdUuUdUD4qrh7TW8yOQyZZkfgTVu+jOGajeQPcvfO/B8/CKVvFwDdK7RvWeeX4HX7X78uvLB5D7VPVA0SofVI8R6RXy8TXknnb/8h7S6urx7bNWiXFelef/Rfdaic3nR1dVlUuXNK4yL4PYK5UbEilcgnSIla8WktUZDjVL8aC9SNVkIuKVaIGIKXPDVnv+SDzKJwH5WxCnSGNk7rURKRuNR6TU+VQkuf7SRVl+X/Lbd9eeQeoAFyRAAiTwGwR07dg+ff4C08f2RZXyxZWmj+mDh4+f+ruYL169RpxY0b3OixcnJp6/fOW1LxufPn+BwQBE1pxY2Y8fNyZevHwtm1Yn53ipff0Dm6RqX6RpNRtpWntX2tZz4E1t5iKtudrOQ1pvmq/tm6idtm2idO0WqAklvNbtFyKdNy3S9k3UYTHSmSi9tu1DHZdAJqj4oaXavok6LUN6UecViJA0m8VrFzNPVWTovPy7uqxABm9aqe2bqesqSJcqo6RG3pv+/hcZvWm1tm+ibmu0lyBTrdX2f0gmDfmlevyHTKbquR6ZvGmDtv9D8vIgil+ipUUGUmGQue8WZO696f/arK1/KEufLfCprVqYifpq2960DVn6mkiroZdaeqOy9t8B79qp7ZtogLbtTbuQdYB3ZRu4W33y4sd6j7ZvIu1FU1pNTJVWuw8tQRDnM9Pfq5F98P4fGnJAzUaa3XQ99CCy/0Q5hh2Cdx3W9n8o56iTCG5lH3wAMtbPEof4pdoi2+B9imNWjb+6Xn22aveDdm/01O6p7uu0+1W7f7WWKPmtpNd+O/L7S9d+EdK2m6+eE+qZ0nIG5DMgqZpOVi/78vKaouEYpKj/j2qxSVZnmGrJSlpjIJJWH4Ak1foicZXeSFy5BxJV6qa6biYs3wkJynZA/NJtIa078u1MaQ2LW7QJ4hRuiNiF6iN2gbrKuZAxizHzVEOMXFXUhDXRs1dAtKzlIN09o2YqCen+GCV9EUROW0h7ic4PGcso19wSA4OtnVbJlgbyu3CKk+L/lV5J4Bg9EaRCSlU8aRVJDpFiaRVBMb5X8GiVNnbOkaAqWjSHRlWO2DtqlRphLGXhFSbdVT1cv6r5DsTRctccLnG8XDUHzFVzxFzePYe0Cv+oUHigHDc1nOHpTeXQSRdar0oFzeH7ePccPphWLNw4phzEt5qjKC3V4jiqygXNkfz67I6XLd43PFXrrTh34ph+r2RYiif7F+OJ5riKAyuOrLSeS2vbw23TtVbeqcpBFMfXq7Jh/Wjc1VrfxUG+s3oYvCocVg6AdHuWFlCZ1PB7pUN3XF/QFde1Vv1r8zpCHHFxyGWypSszWuLy9Ba4PK2ZcsbF0VQ9eCbWw4XxdSAOvuo9ozn8qsfLqMoQ50j1QBlWDqeHlMZpraJAeh+cGlAMUoFwsl8hSIWCpAVPT+/F///el+d31ZZUXn7vUtxF3efyG07bdr52n3ZB1IzFtfsivorHhf8JiFMrzwf5GxWnSCOI0yuVEvc2jNOuU2HtPhmgVT5c8H/CPIMESCDUE9C1Y2tj49M8GxvDb100g82PtAwGy2mY5mcw/Ij/sww/f/4MvembuwFxSrfXWrsi/TDdxhbRclWDfbwMurM3sPjFKNoCYaIn/MFA2wqXNDsi5aweahhEyFIeEVLm1Ur+438HreU3Vok2oYYBIsZFjAINYLD74XCIExK7ZFu4hYkYKjh8dYfGoN6Pm+D/W/YRYiB8prKQZ8Y3T1u4wAGuNo5wtXOCm314xcc9bBR4OEWDR7gY8AwfG4gQB4gUH4YoCWETNQlsoieDbcwUsI2VGnZx0qpnjH38THBImAVhEmVHmCQ54ZgsD8Imz4ewKQvAKXVhOKUpAue0xREufUmEy1hGs6EcImSpgAhZKyNi9irqNxopV01EzlMbUfLVQ5T8DRC1YGNEK9QU0Yo0R/RirRC9eGvEKNEOMUt1QMwynRGrbFfELt8NsSv2RJxKvRH3r36IW2UA4lUbhPg1hiJ+zeGIlK7I/0vufRUpbREkaTodSZvNRNLms5Gs5VwkazUfydssRPK2i5Gi3VKk6LAcKTuuRMpO/yJV5zVI1XUdUv+95JodpQAAEABJREFUHmm6b0SaHpuRtudWpO29Hen67ED6AfstSo5JnDQ9t6hz5FxJQ6XVZa2W7mqk6rQKKTuuQMr2y7R8lyBF20VI3noBkreah+SaXclbaPY11+xsptnbZCqSNJ6MJI0mIXGD8UhcfxwS1R2NxJoS1RmJRLVHIGHNoUhYYwgSVBuI+FUHwClRJu+FN9mLnr8u4pTugNil2iN2yTaIVaI1YhVviVjFWiBmkaaIWbgJYhRsCPk9Sdzo+eogWt5aiJ6nJqLlro5oOasiao6/ECV7JUTJWgGRs5RD5MxlEDlTKUTKUEJTce0aFEXEtIURMU1BREiVXz2fwqfIjfDJc0Gez+GSZEO4xFkQLlFmOGu2OiVID6d4aRA2bmqEjZ0CjrGSwzFmUjjGSAJHreIhTLQEkIoHh8hxVDdXuaftwkeDXbiosHOODDunSFrlQ3jYSuWD9MawdzQpsc9NsVeuZ/LWCxGnYi9EyFJR3ee//Dulw3cBvdvs5hABUQs0gtz/8av2h3PCDOqCvDy1EVL5cG5sTTw8sBwf374Kkue0i4trkOSj9+tiDfapG4ULErBAwG/em4UTgyIoU/rUaN11CIyf+mnVdSiyZ07v76yjR42Ct2/feZ33+s1bxIgW1WtfNmTmZXd3D7i4usouXmlxokeLorZ/tnB0dIQeFStnJWTWWtPSd1ml1TYvRNaBe5C40t+6tDWw+EVOkhEZtPJn6LEeiRtPRZb+O5G62RSEixor1HAIGy4iUjYahywDdiNNm3nI2P0/ZOy2FlFTas6GTu/dwLgfEpZpo/0GdiNFq7lI1X4xsvTbibj5a4aa+0CYJijZEum7rETiqn0Rv0x7pGg0Hhm11ljnSNFCDYf4GgOZodb0mS4ttPFLtw4SBvJ7dAofCc4Ro0K4O0eOoZ5H4aPFQbjocRE+RnyEj5kQEWIl1uoPkmp1MskRMV5KREqQGpESpkWkROkQKXEGRE6SCVGSZkGU5NkQNUUOyO85Wuo8iJYmL6KnK4BomqKnL4zoGYogRqbiiJG5BGJmLY1Y2cogVs7KpsX32pZWs4Qah7gF6yBeobqIV7gB4hdpiPhFGyN+sSZIUKI5EpRsAYmTUPs9JSrbHonKdUBirZU9UYXOSFyxKxJX7oYkf/VA0iq9kLRaHySr3g/JagxAspqDkLz2EE1Dtdb74UhRb6RqyU+ptejL8ylV4wmqlV+ez6mbT0XqFtORuuUMpGk5E2lbz4G0lKqeP9KLp+OS//fKWa7u5wzSk+DvNepezqg96zP12ojMvTcjc58tyNx3GzJLz5H+u9QzMOugfcg6eD/StF3gVW7zjehZSqtrI78ZKuDfb3xjGitbWUjPD3lGxchTXVVEfH16E482jMbVMX/h2baJ8Hz3OFB/p3Z2toGavm9lZ7j/7zPz3y33ScBIQNeObbd2DVG+ZEHI5E+iSmUKo0ub+kbb/bzOlysLDhw9jW8uLnj95h0uX7uNnNm+O8hnzl+Bq6ubSitPjkzYufeI2t6+5zDy5cyktn+2kFZe3crWDk4xEyNc/DSwk3GEWqu1bm0NRNscI8dGuARaS5JzJITG8kuZ7Z0iIHzC9HCMGjfUMrC1DwPnuCm130QS2No7hEoOTjGTIEaOiohTqD4ip84X6jiEjRoP0n06q1bJlaTpVNV1Pn3HpZBw+Z2EBonjFjVjCcCk55K91sKZpFo/7X4IEyp+F+ETpINiAO//wifOhMgpc4cKBnq91+UZlbhSN+23uRVJqvbRntmpIOP/ZRz+xXE1cXVGc7w5vx0GT/eQfJ1Ytl+8E3r/5XKPBH4QsPmxqb8tefCW0xzboX3aQ1S2RAH1Y/evpQnjx0blskXRpH1/dOw1Cp1a14eDvb1KptuAcXj3/oPa7tiyDjZs2w/53M/9B09Qp1pZFe7m7o7cJetCPvWzdtMutX3txh11jAsSIAESIAHrImCnVXI5xU0DmejMuiwPAGttbCHjnbNrLZfp2i+EjN2X8fQy7jEAUreaJIRBunYLEL/C34hXtqNqLZQWQ6spQAg31MbeEdFzVPo+74Z2naJnK6+Gk3y4cxY3l/ZRY6jl2+QyWVgIR8Hi+UqAB0jAJwEbn0HBH9Kyy2DcuvsAsrak37GweqWSWDx9OBZOG4qCebJ6JbFjzUxEixpZ7ct62ug+kM/9DOvbAWEdHVW4na0tjmxb7E0pkydWx7ggARIgARIgAWsjILN/O8dLgzBR4sK09Rah6J9z/LSInvMvRM9dHdJaG4qKblVFleuUpHp/ZO27FQnLd4Zj9ISQz2w93rsAZ0ZUgHxa7M3l/YCnh1WVi8aSQJAQCGWZ6NKxbVK3MmJGjwpZW1Iou0YsLgmQAAmQAAmQAAmEagK2YcMjVv7a6qsDqZtPQ5T0RbU6GVvIp8Wuz++MM8Mr4NGuOepzZaEaFAtPAqGYwO86toGKLHvmdAjn7IQnz15Ctk1178HjQM2biZMACZAACZAACZAACeiXQIRk2ZG83khk7r0R8Uq2hEPEmOozWQ+3TcOZIWUgn5OSbyHrtwS0jARIIDAI6NKxNRZ0844Dxk2v9bpNe7y29b9BC0mABEiABEiABEiABAKDgEx8FrdoU2TuuR4pGo5BxJS54enhhtfnd0K+hXzun6p4enAZ3L98CIzsmSYJkIDOCOjSsT1x5qL6xM+z56/U2vi5n/HTF+kMH80JEAJMhARIgARIgARIgAR+l4CNLSKnKYhUTSZpTu4GxC5UH3ZOkfD1xV3cWz8GpwaXwu2VA/HpwaXfzYHnkQAJWAEBXTq2vnFLmjg+po7u7dthhpNAiCbAwpEACZAACZAACfycgEPk2EhQpj2y9N2CpLUGI1yijPB0+4YXJzfg4qQGuDihLl4cXwcP168qIeX8/jcadxb/jTv/DgG7MCssXJCAVRLQpWMrY2qbN6iGEf06QNZGlS9ZCBHCh7NK0DSaBEggSAgwExIgARIgARKAwdYe0TKXRtrWc5Chy0rEzF0VNmGc8OnRVdzWHNjTWivuzSW9cWF8HTw9tBwfbx7HixP/qS7ML09tJEESIAErJKBLx9bIcf3WfXj77r1xF6/evMWYKQu99rlBAiRAAiTwOwR4DgmQAAmEHgJhYyZBoso9kLXvNiT+qyecYieH+9ePeHVuq9Zy+80HiPtbJvsIYwAJkID+CejasT174SoiRYzgRTFq5Eg4eeaC1z43SIAESIAESCDQCDBhEiCBEEXAxiEsYuSqgvSdliFN69mwsQ9rsXyu719ywimLZBhIAvomYKNn8z5/+YovX7+PgRA7P376rO27yCZFAiRAAiRAAiSgAwI0gQSskUD4RJngGC2+ZdMNNrAN42T5GENJgAR0S0DXjm3ObBnQa/AkyCzJoj5DJyNfriy6hUnDSIAESIAESIAESMACAQbpkECEZDksWhUhifauaWNr8RgDSYAE9EtA145tt3YNUTh/dkyYvkSpWMGc6Ny6nn5p0jISIAESIAESIAESIIHfJBC0p8Ut0ggRU+TynqkBiFu8hfcw7pEACVgFAV07tjY2NqhQqhAWzxiuVK5kQUiYVZClkSRAAiRAAiRAAiRAArolYOccCamaTka2gbuRtOk0OMdPC3gCH++e0a3NyjAuSIAELBLQtWP78PFTtO8xAtUadVHGX7txB9Pnr1TbXJAACZAACZAACZAACZDAnxKwDRsBTvHSIN7/W2qfHFgK43du/zRtnh98BJhz6COga8d24KgZKFM8H2Q2ZLk0KZIlwsEjrEUTFhQJkAAJkAAJkAAJkEDAEYiYMjfCxkwKt09v8fz4uoBLmCmRgH4JhCjLdO3Yuri4oFTRfIAB6p/BYICHp4fa5oIESIAESIAESIAESIAEApJAvBLNVXKP98yHp7ub2uaCBEjAOggEnmMbAOX39ATc3H48VF6+egN7O7sASJlJkAAJkAAJkAAJkAAJkIB3ApHTFUGYqPEh37J9eXqz94PcIwES0DUBXTu2NSqXRL/hU/Ds+SvMmL8KzToNRP0aFXQN1L/GMT4JkAAJkAAJkAAJkIA+CBgMBsQr2kQZ82j3PHh6sKeggsEFCVgBAV07tmVLFEDbZrVQJH92vP/wCROG9UDRgjmtACtNDGACTI4ESIAESIAESIAEgoRA1MylYB8hGr69eoA3F3cHSZ7MhARI4M8J6NqxleLFiRUD7ZrXQec29eEhfZMlkCIBErBAgEEkQAIkQAIkQAJ/SsBga4e4RRqrZB7umKXWXJAACeifgK4d2xET5uLjp89aa+1H1G7WDe26DcXCFRv0T5UWkgAJ6JcALSMBEiABEiCBXxCInqMy7Jwj4cuzW3h37fAvYvMwCZCAHgjo2rG9fPUWwjk74ciJc8idPSOWz/kHW3bs1wM32kACJEACIZoAC0cCJEACoZmAjZ09YheoqxA82j1XrbkgARLQNwFdO7Y2tt/NO33uCjKkTQlnp7Cw5azI+r6jaB0JkAAJhB4CLCkJkEAIJhAzT3XYOITFhztn8eHuuRBcUhaNBEIGge+eo07LEi92TPQeOgnHTl1A9sxpVbdkeOrUWJpFAiRAAiRAAiRggQCDSMA6CdiGcULs/LWV8Y92zVFrLkiABPRLQNeOba/OTVGpTGFMHd0b4cM54+2792hQi5/70e/tRMtIgARIgARIgAR+iwBP0iWBWAXqwmAXRo2z/fz0pi5tpFEkQALfCejasXUK66i11KaDzIy8bPUWxIsTC8UL5f5uOZckQAIkQAIkQAIkQAKhikBQF9YubHjEzPWXyvbRztlqzQUJkIA+CejasTVFtmbjTtNdbpMACZAACZAACZAACZBAoBOIXbA+YGOL1xd24evL+4GeXwBkwCRIIFQSsBrHNlReHRaaBEiABEiABEiABEggWAk4RIyO6NnKA56eeLxnfrDawswDkgDTCmkErMax/atcsZDGnuUhARIgARIgARIgARKwAgJxizYBDAa8OLUJLu9egP9IINQQsKKCWo1jmztHJkh3ZBdXVyvCS1NJgARIgARIgARIgASsnUCYyLERNUNxwMMdT/YusPbi0H4SCJEEgtOx/SXQhm37qk/8PHz8DJ16jcThY2cxdMysX57HCCRAAiRAAiRAAiRAAiQQkATiFG2sknt2bC1cP75R21yQAAnoh4CuHVsZyxDO2QlHT55D+VKFMHpwV1y/dVc/9ILEEmZCAiRAAiRAAiRAAiQQ3AScYiVDpNT54On2DU8PLg1uc5g/CZCAGQFdO7YeHp74+s0Fp85dRtpUSZXpNgZdm6xs5CIYCDBLEiABEiABEiABEghkAvGKt1A5PD24HO7fPqttLkiABPRBQNdeYsG82VCneQ88fPwcWTOmxrMXr+DoGEYf5GgFCVghAZpMAiRAAiRAAiTw+wSc46VGhCRZ4eHyBc8Or/z9hHgmCZBAgBPQtWPbpG5lrF4wFoumDYOdnR3CONijd5dmAQ6BCZIACZCACQFukjCju0wAABAASURBVAAJkAAJkICvBOIUaaSOPdm/GB5unNRUweCCBHRAQNeO7fVb9/Dl61eFadP2/Rg9eSEc7O3UPhckQAIkQALBSYB5kwAJkEDoJBAxRS44xU0Ft09v8eLYmtAJgaUmAR0S0LVjO+if6bC3t8elq7ewYu02pE6RGEM4K7IObyOaRAIkQAIkYJEAA0mABEIkgXhFm6hyPdozD57ubmqbCxIggeAloGvH1t7ODna2tjh++iLKlyqIOtXKqs//BC8y5k4CJEACJEACJBCQBJgWCVgbgUhpCyFM1Phwff8SL89ssTbzaS8JhEgCunZsPTXkd+8/xpETZ5E+TXJtD3B3d1drLkiABEiABEiABEggFBFgUXVEwGAwIF6xpsqiR7vmwtNT3lrVLhckQALBREDXjm2jWhUxYsIcpEiaCKmSJ8b1W/cQPWqUYELFbEmABEiABEiABEiABPRNIOisi5qpJBwixcK3Vw/w5uLuoMuYOZEACVgkoGvHVj73M31MX3Rt20AZnyJpQkwc0UNtc0ECJEACJEACJEACJEACwUXAYGuHOIUbquwfbp+p1lazoKEkEAIJ6NqxffP2PZas2oTeQyYqLV29BRIWAq8Di0QCJEACJEACJEACJGBlBKJnrwg750j48uwW3l07YmXW09xfEeBx6yKga8e2/4ip2HvoJLJkTK20e/8xDBw13boI01oSIAESIAESIAESIIEQScDGzh6xC9ZTZXu0e65ac0ECoYyAboqra8f26fMXmD62L6qUL640fUwfPHz8VDfwaAgJkAAJkAAJkAAJkEDoJhAzdzXYOobDhztn8OnhldANg6UngWAkoGvH1sbGp3k2NoZgxMWsSYAESIAESIAESIAESOAHAdswToiVt6YKeLh9hlpzQQIkEPQEfHqOQW+DrzlmSp8arbsOwcwFq5RadR2K7JnT+xo/tB5guUmABEiABEiABEiABIKPQKwCdWCwC4O3Vw/i89ObwWcIcyaBUExA145tt3YNUb5kQdx78ESpUpnC6NKmfii+XCz6HxDgqSRAAiRAAiRAAiQQKATswoZHzNxVVNqPd81Ray5IgASCloBuHVs3d3e0/nsoymmO7dA+7SEqW6IAbGx0a3LQXjnmRgKBQoCJkgAJkAAJkAAJ/A6B2AXqQT4B9Or8Tnx78+R3kuA5JEACf0BAt16ina0t7Ozs8OXr1z8oHk8lARIggUAgwCRJgARIgARIwIyAQ8ToiJ61HODpiUc7Z5sd5S4JkEBgE9CtYysFF+e2WsOuGDlhrhpjaxxrK8coEiABEiABfROgdSRAAiQQ2gjEKdoEMBjw4tRGuLx7Af4jARIIOgK6dmzTpEyMCqULInKk8EFHhDmRAAmQAAmQQNARYE4kQAIhiECYyLERNWMJwMMdT/YtDEElY1FIQP8EdO3YNm9QDZakf6y0kARIgARIgARIIOAIMCUSsB4CcYo0UsY+O7oGbl8+qG0uSIAEAp+Arh3bfybNx9t3770ovHrzFmOmsPbLCwg3SIAESIAESIAESMBIgGtdEHCKlQyRUueHp9s3PN2/WBc20QgSCA0EdO3Ynr1wFZEiRvC6DlEjR8LJMxe89rlBAiRAAiRAAiRAAiRAAv4hEBRx4xVvrrJ5cmAp3L99VttckAAJBC4BXTu2n7989TYr8sdPn7V9l8AlwtRJgARIgARIgARIgARI4A8IOMdLjQhJs8HD5QueHV75BykF26nMmASsjoCuHduc2TKg1+BJOHHmolKfoZORL1cWq4NMg0mABEiABEiABEiABEIXAeNY2yf7F8PDzTV0FT7UlJYF1RMBXTu23do1ROH82TFh+hKlYgVzonPrenriR1tIgARIgARIgARIgARIwAeBiMlzwiluKrh9eosXx9f5OM4AEgg1BIKooLp2bG1sbFChVCEsnjFcqVzJgpCwIGLDbEiABEiABEiABEiABEjgtwnEK9ZUnft47wJ4urupbS5IgAQCh4CuHVs/FJlRSIAESIAESIAESIAESECXBCKlKYgwUePD5e1TvDq7VZc20igSCCkE6NiGlCv503LwIAmQAAmQAAmQAAmQQFATMBgMiFe8mcr24c458PT0VNtckAAJBDwBOrYBz5QpWisB2k0CJEACJEACJEACAUwgaqZScIgUC99ePcCbi3sCOHUmRwIkYCRAx9ZIgmsSIAE/EWAkEiABEiABEiABvxMw2NggbuGG6oRHu+eqNRckQAIBT0DXju3Bo2fQrONA5C/TALlL1vVSwGNgiiRAAiQQoASYGAmQAAmQAAl4EYiWvSLsnCPh86OreHf9qFc4N0iABAKOgK4d2zmL16Br2wbYu3Eejmxb7KWAKz5TIgESIAESCD4CzJkESIAEQgcBGzt7xCnUQBX28e55as0FCZBAwBLQtWMbM0ZUpEyWCLY2ujYT/EcCJEACJEACgUaACZMACYQIAjHzVIOtYzi8v30Knx5eCRFlYiFIQE8EdO0xRo0SCWs27sTHT5/1xIy2kAAJkAAJkAAJ6IwAzSEBvROwsXdErHy1lJkPd8xQay5IgAQCjoCuHds1G3bin0nzUfyv5l7ja2WsbcAVnymRAAmQAAmQAAmQQKghwIIGM4FY+WvDYBcGb68cxOenN4PZGmZPAiGLgK4dW9NxtabbIesSsDQkQAIkQAIkQAIkQAL6IRB4ltiFDY9YeaqpDDjWVmHgggQCjICuHdsAKyUTIgESIAESIAESIAESIAEdEIhdqAEMtnZ4dW47vr15ogOLftMEnkYCOiOga8f2/sOn6NhrJAqVb8yuyDq7cWgOCZAACZAACZAACZCA/wnYh4uM6NkqAJ6eeLxrjv8T4BlWRYDGBh0BXTu2g/6ZjvKlCiNVisTYsHQS2jathSZ1KwcdHeZEAiRAAiRAAiRAAiRAAgFMIE6RRoDBgBenNsLl3QvwHwmEcgIBUnxdO7Zfv35D0QI54OHhgWhRI6NOtbK4ffdhgBSciZAACZAACZAACZAACZBAcBAIEzk2omYqCU93NzzZvyg4TGCeJBDiCOjasXVyclTADQYDHjx6iq/fXPD6zXsV5ucFI5IACZAACZAACZAACZCAzgjEK95cWfTsyGq4ffmgtrkgARL4fQK6dmwzpUuJt+8/oNZfZVC7WXcUrtAYxQvn+v3S8kxfCfAACZAACZAACZAACZBA0BFwjJYAkdMUhKfbNzw9sCToMmZOJBBCCejasW3dpCYiRQiPQvmy4cDmBZBP/lQpXzyEXgoWywoI0EQSIAESIAESIAESCDACcYs1VWk9Pbgc7t8+q20uSIAEfo+Arh1bF1dXzF2yDv1HTFWlu333EXbtO6a2uSABEtArAdpFAiRAAiRAAiTgFwLO8VIjQrLscP/6Ec+P/OuXUxiHBEjAFwK6dmwHjpqOp89e4v7D79/4ihM7OhauWO9LURhMAiRAAlZEgKaSAAmQAAmQgEYgbpHG2hJ4vG8hPNxc1TYXJEAC/iega8f27r1H6NW5KcKEcVAlc9TWrm5uapsLEiABEiCBkE+AJSQBEiCBkE5AWmyd4qaC26e3eHHiv5BeXJaPBAKNgK4dWzs7W28Fd6NT640Hd0iABEiABEgAACGQAAlYOYF4xZupEjzeMx/yCSC1wwUJkIC/COjasc2QNiUWrdyIjx8/4/jpC+jabwwK58/hrwIyMgmQAAmQAAmQAAkAZEAC+iUQKXUBhI2ZFC5vn+LVue36NZSWkYCOCejase3cuh6iRokIe3s7jJu2GEUK5ESTOpV1jJOmkQAJkAAJkAAJkIAVE6DpwULAYDAgbpFGKu+HO2bB09NTbXNBAiTgdwK6dmwNBgPKFMuPeZMHY9mskahQqhBsbHRtst/JMyYJkAAJkAAJkAAJkIBVEggMo6NkLAGHSLHw7dUDvL28LzCyYJokEKIJ6NJLnLlgFX6mEH1FWDgSIAESIAESIAESIIFQR8CgNd7ELfp9huSHO2eHhPKzDCQQpAR06djOW/of9h46idPnr1qUb4RevnqDtt2GoXG7fug1eAK+fP1qMeq5i9fQsG1f1GvVC7MXrfaK49v5N2/fR+6Sdb3Uqfc/XudwgwRIgARIgARIgARIgAQCgkC0rOVhHyEaPj+6inc3jgVEkkxD9wRoYEAR0KVj2755HTiGCQOnsGHwV7mimDiiB6aP6esl3wo/YcYS5MqWEXMnDUKECOGxZNVmH1FlzEK/4VPQrV1D1cV594HjOHP+ior3s/OzZkyDI9sWK40b+reKzwUJkAAJkAAJkAAJkAAJBBQBGzt7xC5QVyX3ePc8teaCBEgAgB8g2PghTpBHqVWltHJO2zarjWs37qCB1rI6ePRM3Ln36Ke2HDp2FmVL5FdxyhbPj4PHzqht08W1m3fh5BQWaVImhZ2tLUoUzoMDR0+rKH45X0XkggRIgARIgARIgARIgAQCgUDM3FVh6xgO72+dxKeH3xtfAiEbJkkCIY6ALh1bI+UkCeOhUZ3KqFaxJPYdOoEzF3z/cX/6/AUGAxA5UgR1evy4MfHi5Wu1bbp49uI14saK7hUUP25MPHv+Cr86/9K1W8hXuj6adhiA85eue53v6uoKSv8M3N3dA+U6ubm5grIeBnIfuLu7Bdg1429f/799366Rh4dHoDwTfMuP4fq8V9zc5HngxnshlL3LWPq77eHhHmB/Gyyl758wD4MtYuarqd41H+6YqRu7/FOGwIyrwHBBAhYI6NKxddOckH2HT6Hn4PGo2aQb7j18jNkTB+GvcsUsFOFHkOmMyQaD70Uz2GgesNdpP+L5dn6c2DGwfslEbFk1TX1ySL6n+/nL9/G7np4eCB2y5nLKlPmegXKd3N09QFkPA3FmPDw8A+ya8bfvESi/q6Di6qE5t5QHQiODH/dY4P19+JGHh1X/TkJiOSz93fbQ/jZ4aM8ES8eCIyxqjqqwcQiLt1cO4OPjmwH2dys4yhLQeXq9wnODBMwI/PDqzA4E5275mm2xYNl/yJMjE1YvHItOreojUfzYPzXJ2Sms+tG7aLWOEvHVm7eIHi2KbHpTzOhR8ObtB6+w11q8mDGi4mfnO4V1RPhwzkq1q5RGrBjR8ODRU5WGg0MYUHpn4ABbW7tAuU5hwoSBN3Ff1zzs7e0hCqhrxt9+mED5XQUFV3kmBNR9wHTC6Pp3b+n6GO8xeR7Y2dlb7X1sLAfXYfx1DS3dE3Z2dioNS8eCI8wpUjRIl2Ro/14eXGJ1v7HAZKYh4f8kYJGALh3bt+8/4Mr12xg2djYKlW/sNRuxcWZiiyXRAsUR3rn3f+zdCYBN1R/A8d/MWMaSdTC2JAkh6x8hshcVKuRvKWsoUdqQkBDiT9GC7KK0WiqKLEWrLCEtSvZ1xpbBmPnfc3gzz8y8ubO8mXeXbzn33XvPcs/5nGf5vXPnvk3GnsiqrzZK/dpV9b66zfiXXb/r/XI33SDq6ccqML1sfDK3et13Ur9OdZ3nq/5zkj3OAAAQAElEQVTZc//qfLVRT0iOOHVaShYPV4ckBBBAAAEEEEAAAQT8LlC0YVcJMj6YP7F1pVyIOOT39mkQAacJWDKw9Tx92Nerr0kY2KeTLFu5Xn/dzz/7Dkmndq100f3G6uqoV97S+0FBQTLyuX4ybMxUefjR56VGtVuk+q0VdJ6v+p9+sUEH17e3elgmvj5Pxjz/uKhVXF3Jrhv6jQACCCCAAAIIIGBZgay580uhWm1EYmPl4JpZlu0nHUPAKgLBVumIP/oRVjC/vPHK86K+7mfMsAGSIzRUN1uubGl59+1X9L7aVKlUTuZMe0nmvzFGenW5X53SyVf99m1a6K/52bBijm6/8i1ldXk2zhdghAgggAACCCCAQKAEit3xkEhwiBz7cZlcOhsRqG5wXQRsIeCowNYW4nQSAecJMCIEEEAAAQQQyACB7PmLSljVFhJ7OVoOrZ2bAVegSQScI0Bg65y5ZCQIIGBpATqHAAIIIIBA6gWKN+2pKx3euESiz5/R+2wQQCCxAIFtYhPOIIAAAggESoDrIoAAAghcIxAadr3kr3iHxEZfkMMb3rkmjwMEEIgXILCNt2APAQQQQAABWwjQSQQQcJdA8SY99IAPf71IYi5F6X02CCBwrQCB7bUeHCGAAAIIIICAMwQYBQKOEchVooLkLVtbLkedlSMblzhmXAwEAX8KENj6U5O2EEAAAQQQQAABWwnQWbsIFGvcTXf14Nq5EhN9Se+zQQCBeAEC23gL9hBAAAEEEEAAAQQQSCxggTN5ytSUnMXLS/S5SDn+41IL9IguIGAtAQJba80HvUEAAQQQQAABBBBAIEmBks0f0ecPrJktsTExet9KG/qCQCAFCGwDqc+1EUAAAQQQQAABBBBIoUC+CrdLjiJl5GLkYTmxdWUKa1HMYgJ0J4MECGwzCJZmEUAAAQQQQAABBBDwt0DxJt11k/tXTZfY2Fi9zwYB5wmkfkQEtqk3owYCCCCAAAIIIIAAAgERKHBrM8mWL1wunNgnkTvXBaQPXBQBKwq4MrC14kTQJwQQQAABBBBAAAEEzASCgoOleNOeutj+L2fqVzYIICBCYMu7wJcA5xFAAAEEEEAAAQQsKFCoxt2SNU+Y/HvgVzn9xw8W7CFdQiDzBQhsM9+cKzpKgMEggAACCCCAAAKZKxAUkkWKNeyiL3pgzSz9ygYBtwsQ2Lr9HcD4EcgMAa6BAAIIIIAAAn4VKFznfgkJza1XbM/t3+XXtmkMATsKENjacdboMwIIOFKAQSGAAAIIIJBSgeCsoVK0QWdd/AA/a6sd2LhbgMDW3fPP6BFAAAG7CdBfBBBAAIGrAkXqdZDgbDkkYuc6iTr+z9WzvCDgTgECW3fOO6NGAAEEEHC0AINDAAE3CGTJcZ0UqdtOD/XAFzP0KxsE3CpAYOvWmWfcCCCAAAIIuF2A8SPgAIGiDbqIepjU8S2fy4WIQw4YEUNAIG0CBLZpc6MWAggggAACCCDgCgEGaW2BrLnzS+FabURiY+XgV3Os3Vl6h0AGChDYZiAuTSOAAAIIIIAAAgi4QiCggyx6x0MiwSFy7IdP5NLZiID2hYsjECgBAttAyXNdBBBAAAEEEEAAAQT8IJA9f1EJq3anxF6OlkNr5/qhxYxqgnYRyDgBAtuMs6VlBBBAAAEEEEAAAQQyRaB4kx76Ooc3LpHo82f0PhubCtDtNAkQ2KaJjUoIIIAAAggggAACCFhHIDTseslfqZHERl+QI98stk7H6AkCGSSQsFkC24QiHCOAAAIIIIAAAgggYEOB4o27614fWr9QYi5F6X02CLhFgMA2yZnmJAIIIIAAAggggAAC9hLIVaKC5L25jlyOOitHNr1vr87TWwTSKUBgm05AV1dn8AgggAACCCCAAAKWEijeuJvuz6H1CyQm+pLeZ4OAGwQIbN0wy4wxoAJcHAEEEEAAAQQQyCyB626sITmLl5dLp4/L8Z+WZdZluQ4CARcgsA34FNABBBAQERAQQAABBBBAwE8CJZv30S0dWD1LYmNi9D4bBJwuQGDr9BlmfAgg4CABhoIAAggggIC5QL4K9SVHkTJyMfKwnNy2yrwCJRBwgACBrQMmkSEggAACCHgJsIsAAgggIMWb9tAKB1bPltjYWL3PBgEnCxDYOnl2GRsCCCCAAAI+BDiNAALOFihQualkyxcu54/8KZG7Njh7sIwOAUOAwNZA4BcCCCCAAAIIIJCEAKcQsK1AUHCwlGjaU/d//xfT9SsbBJwsQGDr5NllbAgggAACCCCAQIYLcAGrCoTVuFuy5gmTfw/8Kqf//NGq3aRfCPhFgMDWL4w0ggACCCCAAAIIIIBAMgIByAoKySLF7nhIX/nA6ln6lQ0CThUgsHXqzDIuBBBAAAEEEEAAAdcLFK7dVkJCc8vpP76Xc/t3Wd6DDiKQVgEC27TKUQ8BBBBAAAEEEEAAAYsLBGcNlaINu+heHlj9tn5lY3sBBpCEAIFtEiicQgABBBBAAAEEEEDAKQLh9TtKcLYcErFjrUQd/8cpw2IcCFwjkDiwvSabAwQQQAABBBBAAAEEELCzQEj2nBJer4MewoEvZ+pXNgg4TYDANo0zSjUEEEAAAQQQQAABBOwiEH57J1EPkzq+ZaVciDhkl27TTwRSLEBgm2IqCqZBgCoIIIAAAggggAACFhDImju/FK59n0jMZTm4dq4FekQXEPCvAIGtfz1pDYE0CFAFAQQQQAABBBDIeIFijbqJBIfIse8/lktnIzL+glwBgUwUILDNRGwuhQAC6RCgKgIIIIAAAgikSyBb3kJSqPpdEns5Wg6tn5+utqiMgNUECGytNiP0BwEEEEiHAFURQAABBBBITqBY4+46+8jGJRJ9/ozeZ4OAEwQIbJ0wi4wBAQQQQCA1ApRFAAEEXCsQGna9FKjcRGIunpcj37zrWgcG7jwBAlvnzSkjQgABBBBAwA8CNIEAAk4VKN6slx7aofULJOZSlN5ng4DdBQhs7T6D9B8BBBBAAAEEAifAlRGwoUDO8Jskb7nb5HLUWTn67Qc2HAFdRiCxAIFtYhPOIIAAAggggAACCPhRgKasJ1D86s/aHlw3Xz9Myno9pEcIpE6AwDZ1XpRGAAEEEEAAAQQQQCAjBDK1zetKV5PcpW6VS6ePy7GflmfqtbkYAhkhQGCbEaq0iQACCCCAAAIIIICAxQWKN+mhe3jgy5kSGxOj962/oYcIJC1AYJu0C2cRQAABBBBAAAEEEHC0QL7y9SRHkTJyIfKQ7HlvuBz97kM5f/QvR4/ZNYNz4UAJbF046QwZAQQQQAABBBBAAAElkCXndRJk/H9882fy1wdjZNukB0V9x63KIyFgJ4G0BLZ2Gh99RQABBBBAAAEEEEAAgSQETm77Us78teXanJjLsnfpRLlwYv+15zlCwOICBLYZNkE0jAACCCCAAAIIIICAdQXO/J0gqL3a1diYaPn38B9Xj3hBwB4CBLb2mCfn9pKRIYAAAggggAACCCCAAALpFCCwTScg1RHIDAGugQACCCCAAAII+Fsg9/WVk24yKEg/VCrpTM4iYE0BAltrzgu9QgCB1AtQAwEEEEAAAQRSIVDw1qaSs1i5RDXC63aQ0LCSic5zAgErCxDYWnl26BsCCCDgdwEaRAABBBBA4KpAcIhUHrBAKjzyppS65wkpff8QqTzwHSnV+qmrBXhBwD4CBLb2mSt6igACCCCQWQJcBwEEEHCLQFCQ5ClTU8Jv7ySFa99nrODe7JaRM06HCRDYOmxCGQ4CCCCAAAKZJcB1EEAAAQQQsIoAga1VZoJ+IIAAAggggIATBRgTAggggEAmCBDYZgIyl0AAAQQQQAABBBBIToA8BBBAIH0CBLbp86M2AggggAACCCCAAAKZI8BVEEDApwCBrU8aMhBAAAEEEEAAAQQQQMBuAvTXnQIEtu6cd0aNAAIIIIAAAggggAAC7hVw3MgJbB03pQwIAQQQQAABBBBAAAEEEHCXQMYEtu4yZLQIIIAAAggggAACCCCAAAIBFCCwDSA+l0YAAQQQQAABBBBAAAEEEEi/AIFt+g1pIWMFaB0BBBBAAAEEEEAAAQQQSFaAwDZZHjIRsIsA/UQAAQQQQAABBBBAwL0CBLbunXtGjoD7BBgxAggggAACCCCAgCMFCGwdOa0MCgEEEEi7ADURQAABBBBAAAG7CRDY2m3G6C8CCCCAgBUE6AMCCCCAAAIIWEiAwNZCk0FXEEAAAQQQcJYAo0EAAQQQQCBzBAhsM8eZqyCAAAIIIIAAAkkLcBYBBBBAIN0CBLbpJqQBBBBAAAEEEEAAgYwWoH0EEEAgOQEC2+R0yEMAAQQQQAABBBBAwD4C9BQB1woQ2Lp26hk4AggggAACCCCAAAJuFGDMThQgsHXirDImBBBAAAEEEEAAAQQQQCA9AjarS2BrswmjuwgggAACCCCAAAIIIIAAAtcKBCqwvbYXHCGAAAIIIIAAAggggAACCCCQRgEC2xTCvffxSuncZ7B07TtU1m/anMJa6S1GfQQQQAABBBBAAAEEEEAAATMBAlszISN/775DMm/xMnlr0gsyfsQTMnridIm6cNHI4ZclBOgEAggggAACCCCAAAIIuFqAwDYF0//1t5ulYb2akitnDgkvEibly5aWHzb/IvyHgJ0E6CsCCCCAAAIIIIAAAk4VILBNwcweO3FSioUXiitZolgROXr8RNwxOwgg4BgBBoIAAggggAACCCBgQwEC2xROWlBwPFVQUFBcrZqN24tZatasmZglszZUvlkbKl+VM0uqnFkya0Plm7Wh8lU5s6TKmSWzNlS+rzaaN28urVu30XOgypklX+14nzdrQ+V7l/e1r8qZJV91vc+btaHyvcv72lflzJKvut7nzdpQ+d7lfe2rcmbJV13v85426t7ZRW5r0TnJ37Pe5X3te9pJ7tVXXe/zydX35HmX97XvKZvcq6+63ueTq+/J8y7frFnSf6Z5yib3apV2Gt7TXb8PrNIfbdaonf5zyqxPuqzJ3z1mbah82mkmLVu2lFatWiXpjk/Sv8/Ve0clp/mofyeofy84bVxqrlRy0rji/hHODgIJBOKjtQQZHMYLFCpYQCIjT8WdOBkRKYXDCurjTSsXiFn69NMVYpbM2lD5Zm2ofFXOLKlyZsmsDZVv1obKV+XMkipnlszaUPlmbah8Vc4sqXJmyawNlW/WhspX5cySKmeWzNpQ+WZtqHxVziypcmbJrA2Vb9aGylflzJIqZ5bM2lD5Zm2ofFXOLKlyZsmsDZVv1obKV+XMkipnlszaUPlmbah8Vc4sqXJmyawNlW/WhspX5cySKmeWzNpQ+Um2keDPflUu2bRqoenfFeo6ybZx9e8kVc4s0U7yfzfjg4+v94DZ7y2V76uu93lVzix5l/e1b9aGyvdV1/u8KmeWvMv72jdrQ+X7qut9XpVLKul/gLNBIAkBAtskUBKeql+numz4drNcuHhRSJ6apgAAEABJREFUTkackp2790jtmpUTFuMYAQQQQAABBFIpQHEEEEAAAQT8IUBgmwLFUiWLSttWTaTH48Nl4JDx8kS/rpIta9YU1KQIAggggAACCCCQbgEaQAABBBAwESCwNQHyZLdv00IWvDlW5r0xWhrWreE5zavNBFasWi+9Bo6Upm17yaBhE+SvvQdsNgK6m1aB9z5eKZ37DJaufYfK+k2b09oM9Wwu8Prbi+XBnk/L3Q8+Ji9OeFPfiWPzIdH9dAhERJ6Wxq17yhuz3k1HK1S1jkDaerL0s6/kgYef1M9gGDJqStoaoRYCCARcgMA24FNABzJToEjhgjJ1/GBZtug1KVumlLw5m3/MZKZ/oK61d98hmbd4mbw16QUZP+IJGT1xukRduBio7nDdAApUqVxeFs+coD+kVD9a8tHyNQHsDZcOtMDEafOkepXyIvHPhBT+c5fA1h275Y3ZS+Tp/t3km8/mSe+H2zsfgBEi4FABAluHTizDSlqgZtWKkj1bNskRGir1alWTI8cjki7IWUcJfP3tZmlYr6bkyplDwouESfmypeWHzb8I/7lPoF6tqnrQBfLnlapGkMtXt2kOV262/rJbcuTILhXLlxWJdSUBgzYEln2+Tjq0bSG1a1SW4OBguaFkUeMsvxAQwcB+AsH26zI9RsA/Aos++FRqV6/kn8ZoxdICx06clGLhheL6WKJYESGgieNw5c75qChZvnKd1OLPAFfOf3R0tLw2Y5H079XRleNn0PECh48cl9//3Ct3tesrHXs9I5t+2BqfyR4CCJgJWCqfwNZS00Fn0iswYPA46f3EyERp87Zd1zS9cMkKiTx9Vrp3bnvNeQ6cKxBkfBLvGV1QEPcdeizc+BobGyvPj35NGt9eS+rUrOJGAtePeeGST+W+e5pInutyu97C7QCXY2I0weK3J8gLT/eR0RNnyNlz/+pzbBBAwF4C1g1s7eVIby0iMPr5/jJx1FOJUvVbK8T18PvN2+WnrTtk8phn9G3JcRnsOFagUMECEhl5Km58JyMipXBYwbhjdtwlMHP+B/p29H49HnTXwBltnMDX3/0soya8pR8WNH3uEpn37jKZ/Ob8uHx23CNQMH8+fedG3jy5pcLNN0rBAnnlwKGj7gFgpAg4SIDA1uaTSfevFcidK6dclztXouQppR4SMfudT2TMsIF8ZZMHxQWv9etUlw3fbtZPwD0ZcUp27t4jtWtWdsHIGWJCgXc/WinHT0RKr64PJMzi2EUCMyYPl00rF+jU+6F20rXDPTKwTxcXCTBUj0CDutXlp627JMZYuVW3JR8/GSnFixb2ZPOKAAI2EiCwtdFk0dU0C8RVnDpjsWzZ/qs0ure7/qRePd4/LpMdxwqUKllU2rZqIj0eHy4Dh4yXJ/p15YMNx86274FFX76sV+WWfr5W//6/rUVnGfXKdN8VyEEAAccLNLvjNsmfL4907TdUBo+aom9HVh+SO37gDBABBwoQ2DpwUhmSbwHvT+nVp/Xvz5nku7Drcpw94PZtWsiCN8fqr3lpWLeGswfL6JIUyBISolfo1O99Txr2VO8ky3LSPQLd/tta+nbv4J4BM9JrBIKCguSJvl303w+zp44S9XTkawpwgAACthEgsLXNVNFRBBCwhACdQAABBBBAAAEEELCcAIGt5aaEDiGAAAL2F2AECCCAAAIIIIBAZgoQ2GamNtdCAAEEEEAgXoA9BBBAAAEEEPCTAIGtnyBpBgEEEEAAAQQyQoA2EUAAAQQQMBcgsDU3ogQCCCCAAAIIIGBtAXqHAAIIuFyAwNblbwCGjwACCCCAAAIIuEWAcSKAgHMFCGydO7eMDAEEEEAAAQQQQACB1ApQHgFbChDY2nLa6DQCCCCAAAIIIIAAAggEToArW02AwNZqM0J/EEAAAQQQQAABBBBAAAEnCGTiGAhsMxGbSyGAAAIIIIAAAggggAACCPhfwM6Brf81aBEBBBBAAAEEEEAAAQQQQMB2AgS2tpuy1HaY8ggggAACCCCAAAIIIICAswUIbJ09v4wupQKUQwABBBBAAAEEEEAAAdsKENjaduroOAKZL8AVEUAAAQQQQAABBBCwogCBrRVnhT4hgICdBeg7AggggAACCCCAQCYLENhmMjiXQwABBBBQAiQEEEAAAQQQQMB/AgS2/rOkJQQQQAABBPwrQGsIIIAAAgggkCIBAtsUMVEIAQQQQAABBKwqQL8QQAABBBAgsOU9gAACCCCAAAIIOF+AESKAAAKOFiCwdfT0MjgEEEAAAQQQQACBlAtQEgEE7CpAYGvXmaPfCCCAAAIIIIAAAggEQoBrImBBAQJbC04KXUIAAQQQQAABBBBAAAF7C9D7zBUgsM1cb66GAAIIIIAAAggggAACCCBwRcBvWwJbv1HSEAIIIJB+gYZ3d5MLFy+mvyGTFrbv/F2GvvSqSSmR6MuX5b+9n5XI02dMy3oKzJz/gby/dJU+/GPPP1L/rq7SZ9Ao6dxnsDz27Fj5fvN2nac2AwaPk2++26J2EyVV5+dtuxKdt8sJ77mcYZjExMT4revLV66TfQcO+629lDT005Yd8t1P8XP3w8+/6HlNqu7f+w5J7ydGJpXFOQQQQAABBDJEwNmBbYaQ0SgCCCBgf4GpMxdJ5/Z3mw4kS0iItGnZWBa8t9y0rCpw9ty/suzzddL6rsbqUKdcuXLKmxOHyYI3x0qNKrfIK1Pn6PNq82jPB6VihTJq19FpzjufSExsrN/G+Pnqb+TAoSN+ay8lDf28fbds3rozJUXlhpJFpWCBvPLN90l/aJGiRiiEAAIIIIBAKgQIbFOB5dSijAsBBKwpsO6bH6XngOHy8GPDRK1s/rX3gO6oWvl7dfpCad99kDz69GiZYASKjz0zRuelZKNW+o6fiJQKN98YV/yNWe9K175D5cnnx8vve/bKw48+L8eOn9T5TRvWkRWrNuh9s83qdd9KzWqVJGvWLEkWvb1ONaPdiLi8aTMXy45df+rjX3//S4+354AR8uyISRJ1IX7leufuP6XH48ON/Ct5ysSzmqvG89zI/0nnRwZLl75D5LMvv9btJdxMn7tEnntxsiirjr2elSGjpsStRJ+PipKJ0+aJOt+p93OiAn/lrNroY6w2vzJ1rrZWRks+ubIarfIWf/i53NW+n17VHjhkXJKrqJ62Hnt6jF7hPH32nK5z/ES8g2p/1sKPVZPXJLUqOmjYBOne/wVp2raXrNv4k6z6aqPs/uNveW36It3e1h27RY1t8KgrY1N+aqX9vY9Xag9losZ6IiJSt63KqmO1eq7eX2Mnv61X5lXmyYhT2l6trqv3lio3c/6Hot57K75YLyvXbNTX9BioOVJl1PtFtXf06ntGtdWkQR1ZvnKt2iUhgAACCCCQ4QIEthlOzAUcIsAwEMhUARX0jBj/hjzZr6vMmTpKqlYuLy9OeFP34UsjeNz0/RaZ9doomTL2WVG3++oMY/Pxp2t0cDbv3WXGkejbmsdMminjpszSQZE6qVbdKlW4Se3qtHrdd7Jz9x6ZPW2U9O/VSZ4bOUVCQ7NLobACOr9A/rxyXe4c8uff+/RxcpvN236VKhXL+iyy8Yet0rxR3STzRxrjbdn0dpk5ZYTca6z47jYCXU9BlXfPnQ2v5BkryN55w19+XRrUqykL3horr738nMxZ9LEO/Dx1vV/37jsoLw8fKItmjJOiRcJk1oIPdbYK3i5fvizzXh8tc6a9JEeOnpD3Pl6l89RGBbmvjhss894YLR8u+0I8AVyt6pVl2TuvyjvTx0nzxnVFBYmqvHd6rGdHCQ4OlqkThuiV6zy5c0nLpvXkoxWrdbHzRlC92pjT++5poo+9N1NnGMFrt/bGXL8oyxdP07bKr9xNN0j/3h11e1UqltNV/v7noIwb8YQ2UrcMqyD0NaPP898YI+r9M954D+iCxuawMb6XXxhglB0pQUFBsmb9d8ZZkbfmvi/Zs2cXVWf4s31l89VbwUuXKi6tmjWQFsYY1ep7u9bNdXnl2fvh9tpMrcZ7B+dVKt4sPxvvB12QDQIIIIAAAhksQGCbwcA0j4C7BBitvwS27vhdKpa/SW4pV0Y32aldSx2snfv3vGzZvltaNm8ouXPllCxZssj99zTVZdRG3Tbcq+v9alcnFdw0rF9Tnh3QXa/0qZMHDx+TIoWuBK3qePP2XVKrRmUJCQ4WFcCEhARJkwa1VVZcKlIoTPbtPxJ37GtHte0JiD1lTp85K7e16KzTwiUrkrwF+tTps3L02Elp06qxrlavdlUpVbKo3o+IPC1qhfneO+/Qx/Vqxeeptnf9tkeWfrZW1Mrqcy9OkXPnomTbjt902YSbWtUraTd1vrGxoqhur1X73/24XX7Z9Yf0f26sTmrVepuxEqryVGpQt7r2UfuFDYu/9u5XuxIcEiwzjeB4wOBxug+//fG3Pm+2ade6hS6vAuYVq9Zr/3x5rktUrXqVCqJW02fM/0C27/xN8uXNk6iM50Td/1SRXDlz6MNvf9gmkafOGB9STNYuapV3284/dJ7a/KdaxTiH8MIF4z60UGN+8L47dbBb2Phg4476tVRxn+nGUiVE3XasCtQw+rrH68MP9T44c/ZfUbenq3wSAggggAACGSlAYJuRurSNAAIIJCWQknOxsZLFCJo8RbMaAWywsbLmOc4SEuLZ1cFt3EGCncNHjkmYseKqTl+IuiCxRrvqNuFL0dHqlE6xMdf+7GeO0FCpcHNpnefZXLx0SbJmS/r2Yk8Z9Zotaxa5FH1Z7calPNfllk0rFxgrjlOlfu1q8sLYabofcQWMnViJlWAjsFbJONS/soTEX0+dV0lnGBtPXojhkMWweX3CUL16qVYTly+eKu2urigaRVP2K0hk0KNd49pYPHOCjBk2IK6uuo7nQPUjOjpGHz45dLzcXOYGGWGsbo43VkvPG8Y6w2QTbqwWlzeM12z4Xj5Y+oV0vP+uJGsMeKSzXrUvUbSITJo2V5Z+7vvW3uzZs8W1ERQUa6yw3h43nplTRspn770elx8SEv/Xf7DhHu01Z8rTU1C97zz7Sb2q95LnfIgxF97tqPeaCtxDvfrlKcsrAggggAAC/haI/5vN3y3THgIIIIBAmgWqVLpZdvz6p6ifO1WNLPrgM7n5phv0ilzVyuXk2x+3qdM6+XqqsMosGl5IDh05oXYlOCRYr8TdVLqU7D8Yv/pa+Zay8uPPO3QZ9bOse/YekN/+3KuPPZt/9h2SW7x+JtdzPuHrTTeWvKZt7/yC+fPJk0bweOTYCVG3U3vnqdXKsIL5ZOsvu/Xpg4ePyt//XPmZ4vz58kiB/HmMFdXfE+WpFcryZUvLq9MXigqiVIE//9pnrPBGqN1Eae3XP+rbiFXQ9e5Hn0v1W8vrMmoVWN2Ge+bsOX2sfh5V/RyrPvCxOR8VJRGnTkv9OtVE9THhmLyrqX6qFVTvcw/c20ymvLVQQo0PEtQYvPM8+2olu0SxcLmradVoXpgAAAhlSURBVH25s8nths9vOitXzlA5feZKX/WJBJu6tarKR5+ukT1XV5bVBxOe24oTFL3m8NaK5WTj91v0uWjjw4/vN8e/z9QdApHGyrrOTMFG3RqtVnO9A+UUVKMIAggggAACaRIITlMtKiGAAAIIZKhAWMH88vyg3jLhtTnS7bFhon5mcthTj+hrqoc5lSldQj9Q6qlhr+iV3bx5cus8FbjNmPe+fPLpV/LuRyv1z7P+/tdemf/ecmnVvKEuo27zVUHH5atfP9Os0W1SvGhhUQ8/Gjr6NXnlxUGyZsMPcQ9hUmXL3Hi9Dt50A8lsWjSuJ1u2+/6Knlw5c8gjDz2gf7ZVBZfeTY14pq/MWbRUP6Rp0rR5ooJyT/5wI2/m/I90nvo5zhtKFZe8efLo7JHP9TUC2VPSpc8QaddtkAwbO1U8Y9MFvDYVyt0ogwyzjr2eERW4devUVueq1/Jlb5A+T175WqKH+z0vEZGndJ6vjVrZ7vRAK+nY81k9FydORvoqKr0ful/GTJou6nZp9cAlVbB2jVslW9asxupyM3WYZHrkyZHS7L7eoub5N/VQr4736nLt27SQVWs2Sr+nR4t6eJQ+6bWpU7OK9OjcVl6c8JZ+EFirDo/K9h1XPhjwKpZoV82N+jBF3Vqtvg6qVMliki/vlfdW4wa1tInK8zw8KlEDXifUw72a3lHX6wy7CCCAAAIIZJxAcMY1TcsIIIAAAqkVWLd8tmTPduWW0ob1asrbr46U2VOvPCSqtBHMqfaCg4OluxGQqQdHjX1hoMTExkqVSlceIHRH/ZqyaMZ4+WDuJOnQtoVuq1eX+6VL+7ulYd0aqrp+YnGThrVl/caf9LG6rfmZx7vJ5DHPykfzJkvtGpVl6rjBepVQFVi2cq082PZOtWua1M8Eq5+rPH41yLvJCIhXvn/loVeeyq1bNpZFMyfo1WM1BhVoq7xyxsrr/0Y/LdMmDJVXRj0lS2ZPlGq3VlBZcn2Jokb/ntF56rbdqKgLxrkiOq9YeGF5aehjsnD6y7qOepBTkUIFdV7CzY2GoXowkudWY7VSrMqo22Uf791Jt6G+lmjZoqmigkOVp25v/k+1SmpXJ9VHT597drlPW6tx9Or6gHzz2TxdRm285/KBe5vLpJee0bcGq2upfLVyHRwcJM2SCf5UP7/4cLr2GD20v5QsHq6qSo2qFfU5dQt2FWOVtfdD7YzguZ3O82zUz1vPMd47c6a9JKqNhzpeCYoTlu3a4R7p3+u/ulqOHNkNy/76oWSDn+wlh43V/qqVrqxqq5+5HT/iSZ2nbvVWJspGVzQ2FcuX0Q+5Mnb1r1VfbZI2rRrp/cBv6AECCCCAgNMFCGydPsOMDwEEHCmgvnamffdB0qXvYB28eh66lNLBdu1wr3huu02ujlr5DCuQX99um1w577xB/bqK5zZi7/Pp2V+/8UdpdG93Y7xD5OXJs/Rqtp1vcZ39zid69bZPt3b6g4b02PizrnpIV6N7e+ivTlJfT3T/PU1EfTiR2mscPnpcOtx3p6jbz1Nbl/IBFODSCCCAgI0FCGxtPHl0HQEE3Cvw4bz/yXuzJopa0XvqsYf0La2p0ciZI1Q8TxlOrl5IcLDPBxv5qqcCoZrGiqKv/LScb9msgXy1dJb+GpoZk4eL+vqa1LaTcKUytfX9Wb7bf1vr1XH1Xa/+bDe9bakV4Q0r5uivTlJfn6RW19PSZnjhMGlU/z9pqUodBCwvQAcRQMCaAgS21pwXeoUAAggggAACCCCAgF0F6DcCmS5AYJvp5FwQAQQQQAABBBBAAAEEEEDAnwIEtv7UpC0EEEAAAQQQQAABBBBAAAH/CaSwJQLbFEJRDAEEEEAAAQQQQAABBBBAwJoCbg9srTkr9AoBBBBAAAEEEEAAAQQQQCDFAgS2KaZyc0HGjgACCCCAAAIIIIAAAghYV4DA1rpzQ8/sJkB/EUAAAQQQQAABBBBAICACBLYBYeeiCLhXgJEjgAACCCCAAAIIIOBvAQJbf4vSHgIIIJB+AVpAAAEEEEAAAQQQSIUAgW0qsCiKAAIIIGAlAfqCAAIIIIAAAghcESCwveLAFgEEEEAAAWcKMCoEEEAAAQRcIEBg64JJZogIIIAAAgggkLwAuQgggAAC9hYgsLX3/NF7BBBAAAEEEEAgswS4DgIIIGBZAQJby04NHUMAAQQQQAABBBCwnwA9RgCBQAgQ2AZCnWsigAACCCCAAAIIIOBmAcaOgJ8FCGz9DEpzCCCAAAIIIIAAAggggIA/BGgj5QIEtim3oiQCCCCAAAIIIIAAAggggIC1BHRvCGw1AxsEEEAAAQQQQAABBBBAAAG7ChDYms0c+QgggAACCCCAAAIIIIAAApYWILC19PTYp3P0FAEEEEAAAQQQQAABBBAIlACBbaDkua4bBRgzAggggAACCCCAAAIIZIAAgW0GoNIkAgikR4C6CCCAAAIIIIAAAgikToDANnVelEYAAQSsIUAvEEAAAQQQQAABBOIECGzjKNhBAAEEEHCaAONBAAEEEEAAAXcIENi6Y54ZJQIIIIAAAr4EOI8AAggggIDtBQhsbT+FDAABBBBAAAEEMl6AKyCAAAIIWFmAwNbKs0PfEEAAAQQQQAABOwnQVwQQQCBAAgS2AYLnsggggAACCCCAAALuFGDUCCDgfwECW/+b0iICCCCAAAIIIIAAAgikT4DaCKRKgMA2VVwURgABBBBAAAEEEEAAAQSsIkA/PAIEth4JXhFAAAEEEEAAAQQQQAABBGwpkGxga8sR0WkEEEAAAQQQQAABBBBAAAFXCRDYpn+6aQEBBBBAAAEEEEAAAQQQQCCAAgS2AcR316UZLQIIIIAAAggggAACCCCQMQL/BwAA///+NpYZAAAABklEQVQDAE2UrxuG/JJoAAAAAElFTkSuQmCC"
+     },
+     "metadata": {
+      "image/png": {
+       "alt": "Line chart of mean validation information coefficient against the base-ten logarithm of the Ridge penalty, one line per declared label over ten orders of magnitude, with each line's highest point marked in amber and a dashed zero line across the chart. A line that is flat at the left is a penalty too weak to bind; where it turns over is where shrinkage stops recovering signal and starts eroding it."
+      }
+     },
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "ridge = (\n",
     "    catalog.filter(pl.col(\"model_class\") == \"Ridge\")\n",
@@ -812,8 +1929,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fd78a0e1",
-   "metadata": {},
+   "id": "0180d067",
+   "metadata": {
+    "papermill": {
+     "duration": 0.009049,
+     "end_time": "2026-09-11T00:09:09.401475+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T00:09:09.392426+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "## 5. What to notice\n",
     "\n",
@@ -865,6 +1990,39 @@
    "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.14.3"
+  },
+  "ml4t_provenance": {
+   "executed_at": "2026-09-11T00:09:25.960933+00:00",
+   "executor": "local-uv",
+   "library_digest": "32651423c51ba5960fe1ff9889614d58633015b6da902804833071f1b16d9350",
+   "outputs_digest": "ca2265adf042f7c5de0996cb4f83eaa8757d07587b64fd3c5099173168d3a7a0",
+   "parameters": {},
+   "production": true,
+   "source_py_blob": "4d38b319fc7811073e986089f36b41dfcc4e1fd7"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 388.348929,
+   "end_time": "2026-09-11T00:09:12.956250+00:00",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "~/ml4t/public-s6-us_equities_panel/case_studies/us_equities_panel/.06_linear.build.369355.ipynb",
+   "output_path": "~/ml4t/public-s6-us_equities_panel/case_studies/us_equities_panel/.06_linear.papermill.369355.ipynb",
+   "parameters": {},
+   "start_time": "2026-09-11T00:02:44.607321+00:00",
+   "version": "2.7.0"
   }
  },
  "nbformat": 4,

--- a/case_studies/us_equities_panel/06_linear.py
+++ b/case_studies/us_equities_panel/06_linear.py
@@ -111,7 +111,20 @@ CONFIG_NAMES: list[str] = []
 DIAGNOSTIC_CONFIG_NAMES = ["ols"]
 POPULATION_NAME = ""
 SUPERSEDES_POPULATION: str = ""
-SUPERSEDES_SETS: dict = {}
+
+# A candidate set is sealed once written, so a run whose members differ from the recorded
+# generation has to name the set it replaces, keyed by the full set name because that is what
+# the refusal prints. These two moved when 04_model_based_features was rebuilt at production
+# scale on 2026-09-10: every stage-06 training run registered before that pinned the superseded
+# `model_based` artifact, so the whole catalog refitted and both 2026-08-18 generations went
+# stale. `fwd_ret_5d` and `fwd_ret_21d` have no recorded generation and need no entry.
+# Resolved through `candidate_set_supersedes` rather than passed straight to `freeze`, because a
+# reader's clean clone has no generation to supersede and `create` refuses a first version that
+# claims to replace one.
+SUPERSEDES_SETS: dict = {
+    "us-equities-fwd-ret-1d-linear-v1": "454f73021f33",
+    "us-equities-fwd-ret-1d-linear-diagnostics-v1": "29155b2c69f1",
+}
 
 # %%
 study = open_study("us_equities_panel", execution_tier=EXECUTION_TIER, workspace=WORKSPACE or None)


### PR DESCRIPTION
`06_linear` is the first `us_equities_panel` model stage executed since `04_model_based_features`
was rebuilt at production scale. Every stage-06 training run registered before 2026-09-10 pinned
the superseded `model_based` artifact, so nothing on disk was reachable and all 48 configurations
refitted from cold: 768 folds, 78 minutes, 30.1 GB peak.

## What this changes in the source

Publishing that catalog stopped on a sealed name:

```
ValueError: a changed candidate set named 'us-equities-fwd-ret-1d-linear-v1'
must explicitly supersedes 454f73021f33
```

A candidate set is immutable once written, and `us-equities-fwd-ret-1d-linear-v1` plus its
diagnostics twin carry generations written 2026-08-18. `SUPERSEDES_SETS` now declares both hashes
in source.

Declaring in source rather than passing a run parameter is the shape
`fx_pairs/14_portfolio_management.py` and `cme_futures/06_linear.py` already use, and here it is
also the only shape that renders: `SUPERSEDES_SETS` is not in `PRODUCTION_SAFE_PARAMETERS`, so a
run that passes it is not production and `nb-run.sh` executes a scratch copy which never stamps the
committed notebook.

`fwd_ret_5d` and `fwd_ret_21d` have no recorded generation and need no entry.
`candidate_set_supersedes` withholds a declared hash wherever offering it would be refused, so a
reader's clean clone still resolves to a first version.

## The render

The committed outputs come from the re-run that followed, which reused all 768 folds in 390 s at
23.8 GB and froze all six sets. The two 2026-08-18 generations are now recorded as superseded:

| set | generation | supersedes |
|---|---|---|
| `us-equities-fwd-ret-1d-linear-v1` | `55d64275dfd6` | `454f73021f33` |
| `us-equities-fwd-ret-1d-linear-diagnostics-v1` | `ed1840bfaeb8` | `29155b2c69f1` |
| `us-equities-fwd-ret-5d-linear-v1` | `e7b744f380d5` | first |
| `us-equities-fwd-ret-5d-linear-diagnostics-v1` | `5514968cd0bb` | first |
| `us-equities-fwd-ret-21d-linear-v1` | `6e8179623f0a` | first |
| `us-equities-fwd-ret-21d-linear-diagnostics-v1` | `636c1c2425aa` | first |

`notebook_provenance.py check` reports 0 stale, 0 test-mode, 0 contradicted.

## Known gap, not fixed here

`scripts/check_supersedes_literals.py` exists to catch exactly this before a chain is queued, and
it reports `0 declared literal(s)` for this case study. It resolves declared hashes through
`official_populations`, so candidate-set literals are invisible to it. That is the latent fault its
own docstring describes, with the cost it describes: the refusal fires on the run that has already
paid for its fit, which here was 78 minutes. Worth extending to candidate sets in its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
