### PR TITLE
Give chapter 11's logistic sweep the budget it measures, so ch11-12 stops alternating

### DIFF
--- a/tests/overrides.yaml
+++ b/tests/overrides.yaml
@@ -462,7 +462,17 @@
 11_ml_pipeline/03_logistic_classification:
   parameters:
     MAX_SYMBOLS: 10
-  timeout: 300
+  # Not the 300s default. The L1 cell sweeps five C values through eight
+  # walk-forward folds on liblinear, and the cost sits at the weakly regularized
+  # end: single-threaded at MAX_SYMBOLS=10 (46,551 rows, 57 features, 8 folds)
+  # the five values cost 0.34s, 1.29s, 11.39s, 114.07s and 80.54s - 207.63s in
+  # total. That fits 300s on this workstation and does not fit it on a hosted
+  # runner, which is why ch11-12 alternated pass and fail rather than staying
+  # red. Nothing here fails to converge: n_iter peaks at 81 against
+  # MODEL_MAX_ITER = 1000. Cutting the universe instead was measured and not
+  # taken - MAX_SYMBOLS 6 costs 115.2s and 4 costs 44.4s, both keeping 8 folds -
+  # because 01, 02, 05, 06 and 08 all read these same features and labels at 10.
+  timeout: 900
 11_ml_pipeline/04_nested_cv_hpo:
   parameters:
     ALPHA_GRID_POINTS: 10


### PR DESCRIPTION
`ch11-12` has been failing intermittently on `11_ml_pipeline/03_logistic_classification` with a papermill per-cell timeout in the L1 cross-validation loop, and passing on the runs in between. Alternating rather than staying red is the shape of a cell sitting on the budget boundary, and that is what it is.

## What it costs

Measured single-threaded, as the harness runs it - `tests/pm_helpers.py:116` pins every papermill kernel to one thread - at the override's own `MAX_SYMBOLS: 10`, giving 46,551 rows, 57 features and 8 walk-forward folds:

| C | wall clock | n_iter (max over folds) |
|---|---|---|
| 0.001 | 0.34s | 9 |
| 0.01 | 1.29s | 18 |
| 0.1 | 11.39s | 35 |
| 1.0 | 114.07s | 60 |
| 10.0 | 80.54s | 81 |
| **total** | **207.63s** | |

207.63s fits the 300s default on this workstation and does not fit it on a hosted runner. The cost is liblinear's coordinate descent at the weakly regularized end of the path, not a convergence failure: `n_iter` peaks at 81 against `MODEL_MAX_ITER = 1000`, so no fold is hitting the iteration cap.

## Why the budget and not the universe

Cutting the panel was measured and not taken:

| MAX_SYMBOLS | rows | folds | L1 sweep |
|---|---|---|---|
| 10 (current) | 46,551 | 8 | 207.6s |
| 6 | 28,022 | 8 | 115.2s |
| 4 | 18,506 | 8 | 44.4s |

Either would fit 300s. Neither is right here: `01_ols_inference`, `02_regularization_paths`, `05_shap_analysis`, `06_conformal_prediction` and `08_ml_backtest_intro` all read these same ETF features and labels at `MAX_SYMBOLS: 10`, and 03 would become the one that disagrees in order to fit a default that was never calibrated for a five-point liblinear sweep. The notebook is already reduced 14x from the 2,884s it costs at the full universe.

`timeout: 900` leaves 4.3x headroom over the local measurement, in family with the 1800s `10_text_feature_engineering/04_bert_finetuning` carries.

## Verification

`tests/test_chapter_notebooks.py -k 03_logistic_classification` against `ml4t/third-edition-test-data`:

```
tests/test_chapter_notebooks.py .                                        [100%]
225.13s call     test_chapter_notebook[11_ml_pipeline::03_logistic_classification.py]
1 passed, 286 deselected in 247.73s (0:04:07)
```

Same command on the unchanged file failed at the 300s cell boundary.

The diff is one entry in `tests/overrides.yaml`; no notebook source changes, so nothing re-renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
