### PR TITLE
Let a carried-forward spec declare the universe it trades, like a built one already can

### DIFF
--- a/case_studies/utils/backtest_presets.py
+++ b/case_studies/utils/backtest_presets.py
@@ -328,6 +328,7 @@ def ensure_backtest_spec(
     prices: pl.DataFrame,
     prediction_hash: str,
     initial_cash: float,
+    traded_universe: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Normalize ``strategy_spec`` to the canonical backtest spec form.
 
@@ -341,6 +342,17 @@ def ensure_backtest_spec(
     always populated in ``strategy.rebalance`` — taken from ``execution.*``
     when present, otherwise from ``case_config`` (which sources them from
     ``setup.yaml::backtest.rebalance.default``).
+
+    ``traded_universe`` is the same declaration ``build_backtest_spec`` takes, for the
+    same reason and with the same rule: build it with ``traded_universe_declaration``
+    when the price panel was deliberately reduced, and it lands in ``strategy.signal``,
+    which is hashed whole, so the reduction reaches ``backtest_hash`` instead of hashing
+    like the full run over the same predictions (ml4t/agent-workspace#911, #1119). It is
+    written only when a caller declares one, on both the carried-forward and the projected
+    path, so every existing call site produces byte-identical specs and no registered
+    backtest re-keys. A declaration handed here overwrites one inherited from the spec
+    being normalized, because the panel this run was given is the universe it trades;
+    ``apply_traded_universe`` then checks that claim against the panel in the runner.
     """
     if is_backtest_spec(strategy_spec):
         spec = deepcopy(strategy_spec)
@@ -356,6 +368,8 @@ def ensure_backtest_spec(
         rb = spec.setdefault("strategy", {}).setdefault("rebalance", {})
         rb.setdefault("min_weight_change", float(getattr(case_config, "min_weight_change", 0.005)))
         rb.setdefault("min_trade_value", float(getattr(case_config, "min_trade_value", 100.0)))
+        if traded_universe is not None:
+            spec["strategy"].setdefault("signal", {})["traded_universe"] = deepcopy(traded_universe)
         if "backtest_config" in spec:
             # Always overwrite metadata.prediction_hash with the caller's
             # argument — the spec may have been cloned from another run
@@ -411,6 +425,8 @@ def ensure_backtest_spec(
     }
     if case_study == "sp500_options":
         strategy["signal"].setdefault("schedule_contract", SP500_OPTIONS_SCHEDULE_CONTRACT)
+    if traded_universe is not None:
+        strategy["signal"]["traded_universe"] = deepcopy(traded_universe)
     if "allocation" in strategy_spec:
         strategy["allocation"] = deepcopy(strategy_spec["allocation"])
     if "risk" in strategy_spec:

--- a/tests/test_max_symbols_reduces_a_vectorized_backtest.py
+++ b/tests/test_max_symbols_reduces_a_vectorized_backtest.py
@@ -590,3 +590,89 @@ def test_the_refusal_runs_after_papermill_injects_its_overrides() -> None:
         "these refuse a reduced canonical run from inside the parameters cell, which papermill "
         f"overwrites after: the guard reads the default and never fires: {too_early}"
     )
+
+
+# `ensure_backtest_spec` normalizes a spec carried forward from an earlier stage rather than
+# building one, and it had no `traded_universe` parameter, so the 21 call sites that reduce a
+# panel on that path - every `*_holdout_backtest`, plus `16_risk_management` and `17_costs`
+# across several case studies - had a reduction that reached `backtest_hash` through nothing
+# (ml4t/agent-workspace#1119). The four tests below hold the same two halves the
+# `build_backtest_spec` group above holds: a declaration gets its own identity, and no
+# declaration is byte-identical to before the parameter existed.
+
+
+def _ensure_kwargs() -> dict:
+    return dict(
+        prices=_prices(["A", "B", "C", "D"]),
+        prediction_hash="pred1",
+        initial_cash=100_000.0,
+    )
+
+
+def _ensure(strategy_spec: dict, **kwargs) -> dict:
+    import case_studies.utils.backtest_loaders as bl
+    from case_studies.utils.backtest_presets import ensure_backtest_spec
+
+    config = bl.get_backtest_config("us_firm_characteristics")
+    return ensure_backtest_spec(
+        "us_firm_characteristics", config, strategy_spec, **_ensure_kwargs(), **kwargs
+    )
+
+
+def test_a_carried_forward_spec_can_declare_the_universe_it_trades() -> None:
+    """The holdout path: the spec is already canonical, so it takes the passthrough branch."""
+    from copy import deepcopy
+
+    from case_studies.utils.registry.specs import backtest_hash_from_parts
+
+    without = _ensure(deepcopy(SPEC))
+    declared = _ensure(deepcopy(SPEC), traded_universe=_declaration(["A", "C"]))
+
+    assert "traded_universe" not in without["strategy"]["signal"]
+    assert declared["strategy"]["signal"]["traded_universe"] == _declaration(["A", "C"])
+    assert backtest_hash_from_parts("pred1", without) != backtest_hash_from_parts("pred1", declared)
+
+
+def test_a_projected_spec_can_declare_the_universe_it_trades() -> None:
+    """The other branch: a flat strategy_spec projected into the canonical envelope."""
+    flat = {
+        "signal": {"method": "equal_weight_top_k", "top_k": 2, "long_short": False},
+        "execution": {"mode": "vectorized", "cadence": "daily", "step": 1},
+    }
+    from copy import deepcopy
+
+    from case_studies.utils.registry.specs import backtest_hash_from_parts
+
+    without = _ensure(deepcopy(flat))
+    declared = _ensure(deepcopy(flat), traded_universe=_declaration(["A", "C"]))
+
+    assert "traded_universe" not in without["strategy"]["signal"]
+    assert declared["strategy"]["signal"]["traded_universe"] == _declaration(["A", "C"])
+    assert backtest_hash_from_parts("pred1", without) != backtest_hash_from_parts("pred1", declared)
+
+
+def test_ensure_backtest_spec_declaring_nothing_is_what_it_was() -> None:
+    """The compatibility half. All 21 existing call sites pass nothing and must not re-key."""
+    from copy import deepcopy
+
+    from case_studies.utils.backtest_presets import serializable_backtest_spec
+    from case_studies.utils.registry.specs import backtest_hash_from_parts
+
+    without = _ensure(deepcopy(SPEC))
+    explicit_none = _ensure(deepcopy(SPEC), traded_universe=None)
+
+    assert serializable_backtest_spec(without) == serializable_backtest_spec(explicit_none)
+    assert backtest_hash_from_parts("pred1", without) == backtest_hash_from_parts(
+        "pred1", explicit_none
+    )
+
+
+def test_two_universes_of_the_same_size_do_not_hash_alike_on_this_path() -> None:
+    """The digest covers the symbol list, so {A, C} and {A, D} are two different portfolios."""
+    from copy import deepcopy
+
+    from case_studies.utils.registry.specs import backtest_hash_from_parts
+
+    ac = _ensure(deepcopy(SPEC), traded_universe=_declaration(["A", "C"]))
+    ad = _ensure(deepcopy(SPEC), traded_universe=_declaration(["A", "D"]))
+    assert backtest_hash_from_parts("pred1", ac) != backtest_hash_from_parts("pred1", ad)


### PR DESCRIPTION
`ml4t/agent-workspace#1119`.

#911 closed the reduction-without-an-identity defect by adding `traded_universe` to `build_backtest_spec`: `traded_universe_declaration(prices)` digests the sorted symbol list into `strategy.signal`, which is hashed whole, so a reduced run can neither be served nor serve a full-universe row, and `apply_traded_universe` reads it back in the runner.

That hook existed on one of the two entry points.

## What was open

`ensure_backtest_spec` normalizes a spec carried forward from an earlier stage rather than building one, and had no such parameter. Its 21 call sites include every holdout backtest -

- `etfs/19_holdout_backtest`
- `sp500_equity_option_analytics/19_holdout_backtest`
- `cme_futures/18_holdout_backtest`
- `crypto_perps_funding/18_holdout_backtest`
- `fx_pairs/18_holdout_backtest`
- `us_firm_characteristics/16_holdout_backtest`
- `nasdaq100_microstructure/19_holdout_backtest`

plus `16_risk_management` and `17_costs` across several case studies. A reduction on that path reached `backtest_hash` through nothing, so a preview taken at a reduced `MAX_SYMBOLS` hashed identically to a full run over the same predictions in the same workspace. The canonical tier is closed separately, by the notebooks' own guards; this is the preview half.

## The change

`traded_universe: dict[str, Any] | None = None`, keyword-only, written into `strategy.signal` on both branches - the carried-forward one where the spec is already canonical, and the projection one where a flat `strategy_spec` is folded into the envelope. It is emitted only when a caller declares one, which is the rule `build_backtest_spec` already follows and the reason all 21 existing call sites produce byte-identical specs. Nothing re-keys.

A declaration handed to `ensure_backtest_spec` overwrites one inherited from the spec being normalized: the panel this run was given is the universe it trades, and `apply_traded_universe` checks that claim against the panel in the runner rather than trusting it.

## Verification

Four tests, appended to the file that already holds the `build_backtest_spec` halves:

| test | holds |
|---|---|
| `test_a_carried_forward_spec_can_declare_the_universe_it_trades` | the passthrough branch gets its own identity |
| `test_a_projected_spec_can_declare_the_universe_it_trades` | so does the projection branch |
| `test_two_universes_of_the_same_size_do_not_hash_alike_on_this_path` | the digest covers the symbol list, not its length |
| `test_ensure_backtest_spec_declaring_nothing_is_what_it_was` | omitting the argument is byte-identical to passing None |

All four fail against the unpatched module with `TypeError: ensure_backtest_spec() got an unexpected keyword argument 'traded_universe'`; the file's other 18 pass either way.

```
tests/test_max_symbols_reduces_a_vectorized_backtest.py    22 passed
test_backtest_presets, test_backtest_runner_helpers,
test_warmup_does_not_choose_the_universe,
test_crypto_holdout_backtest_contract                      36 passed, 1 skipped
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
