### PR TITLE
nasdaq100_microstructure: stages 08-11, the deep-learning notebooks

### DIFF
--- a/case_studies/nasdaq100_microstructure/08_dl_nlinear.ipynb
+++ b/case_studies/nasdaq100_microstructure/08_dl_nlinear.ipynb
@@ -2,8 +2,16 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "3739d4b4",
-   "metadata": {},
+   "id": "a110debd",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001426,
+     "end_time": "2026-09-10T18:45:52.322787+00:00",
+     "exception": false,
+     "start_time": "2026-09-10T18:45:52.321361+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "# NLinear - NASDAQ-100 Microstructure\n",
     "\n",
@@ -42,9 +50,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "56091e03",
-   "metadata": {},
+   "execution_count": 1,
+   "id": "b3ef9512",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-10T18:45:52.328775Z",
+     "iopub.status.busy": "2026-09-10T18:45:52.328599Z",
+     "iopub.status.idle": "2026-09-10T18:45:56.327260Z",
+     "shell.execute_reply": "2026-09-10T18:45:56.326690Z"
+    },
+    "papermill": {
+     "duration": 4.001356,
+     "end_time": "2026-09-10T18:45:56.327894+00:00",
+     "exception": false,
+     "start_time": "2026-09-10T18:45:52.326538+00:00",
+     "status": "completed"
+    }
+   },
    "outputs": [],
    "source": [
     "\"\"\"Fit the declared NASDAQ-100 microstructure NLinear population on the walk-forward folds.\"\"\"\n",
@@ -65,9 +87,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "824cefb4",
+   "execution_count": 2,
+   "id": "6fcab677",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-10T18:45:56.333038Z",
+     "iopub.status.busy": "2026-09-10T18:45:56.332577Z",
+     "iopub.status.idle": "2026-09-10T18:45:56.336889Z",
+     "shell.execute_reply": "2026-09-10T18:45:56.336096Z"
+    },
+    "papermill": {
+     "duration": 0.007234,
+     "end_time": "2026-09-10T18:45:56.337439+00:00",
+     "exception": false,
+     "start_time": "2026-09-10T18:45:56.330205+00:00",
+     "status": "completed"
+    },
     "tags": [
      "parameters"
     ]
@@ -86,9 +121,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "2cdd0ebe",
-   "metadata": {},
+   "execution_count": 3,
+   "id": "e28af1b1",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-10T18:45:56.341692Z",
+     "iopub.status.busy": "2026-09-10T18:45:56.341527Z",
+     "iopub.status.idle": "2026-09-10T18:46:37.212013Z",
+     "shell.execute_reply": "2026-09-10T18:46:37.211294Z"
+    },
+    "papermill": {
+     "duration": 40.873348,
+     "end_time": "2026-09-10T18:46:37.212607+00:00",
+     "exception": false,
+     "start_time": "2026-09-10T18:45:56.339259+00:00",
+     "status": "completed"
+    }
+   },
    "outputs": [],
    "source": [
     "study = open_study(\n",
@@ -101,8 +150,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "76d7a21e",
-   "metadata": {},
+   "id": "efae5b38",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001464,
+     "end_time": "2026-09-10T18:46:37.216055+00:00",
+     "exception": false,
+     "start_time": "2026-09-10T18:46:37.214591+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "## 1. Which labels, and which model\n",
     "\n",
@@ -120,18 +177,51 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "c5ad0c12",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 4,
+   "id": "37ba164e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-10T18:46:37.219776Z",
+     "iopub.status.busy": "2026-09-10T18:46:37.219612Z",
+     "iopub.status.idle": "2026-09-10T18:46:37.253719Z",
+     "shell.execute_reply": "2026-09-10T18:46:37.253155Z"
+    },
+    "papermill": {
+     "duration": 0.036612,
+     "end_time": "2026-09-10T18:46:37.254207+00:00",
+     "exception": false,
+     "start_time": "2026-09-10T18:46:37.217595+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "('fwd_ret_15m', 'fwd_ret_5m', 'fwd_ret_60m')"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "declared_labels(study, \"deep_learning\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "224a8439",
-   "metadata": {},
+   "id": "bcca371d",
+   "metadata": {
+    "papermill": {
+     "duration": 0.000898,
+     "end_time": "2026-09-10T18:46:37.256697+00:00",
+     "exception": false,
+     "start_time": "2026-09-10T18:46:37.255799+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "`nlinear` is this notebook's slice of the declared family. The menu declares four\n",
     "architectures and each has its own notebook, because each is a different claim about what\n",
@@ -148,10 +238,54 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "3bdbc802",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 5,
+   "id": "ee2a0d02",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-10T18:46:37.259375Z",
+     "iopub.status.busy": "2026-09-10T18:46:37.259197Z",
+     "iopub.status.idle": "2026-09-10T18:46:37.313886Z",
+     "shell.execute_reply": "2026-09-10T18:46:37.313343Z"
+    },
+    "papermill": {
+     "duration": 0.056696,
+     "end_time": "2026-09-10T18:46:37.314299+00:00",
+     "exception": false,
+     "start_time": "2026-09-10T18:46:37.257603+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div><style>\n",
+       ".dataframe > thead > tr,\n",
+       ".dataframe > tbody > tr {\n",
+       "  text-align: right;\n",
+       "  white-space: pre-wrap;\n",
+       "}\n",
+       "</style>\n",
+       "<small>shape: (3, 5)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>family</th><th>label</th><th>config_name</th><th>model_class</th><th>params</th></tr><tr><td>str</td><td>str</td><td>str</td><td>str</td><td>str</td></tr></thead><tbody><tr><td>&quot;deep_learning&quot;</td><td>&quot;fwd_ret_15m&quot;</td><td>&quot;nlinear&quot;</td><td>&quot;&quot;</td><td>&quot;architecture=nlinear, dropout=…</td></tr><tr><td>&quot;deep_learning&quot;</td><td>&quot;fwd_ret_5m&quot;</td><td>&quot;nlinear&quot;</td><td>&quot;&quot;</td><td>&quot;architecture=nlinear, dropout=…</td></tr><tr><td>&quot;deep_learning&quot;</td><td>&quot;fwd_ret_60m&quot;</td><td>&quot;nlinear&quot;</td><td>&quot;&quot;</td><td>&quot;architecture=nlinear, dropout=…</td></tr></tbody></table></div>"
+      ],
+      "text/plain": [
+       "shape: (3, 5)\n",
+       "┌───────────────┬─────────────┬─────────────┬─────────────┬─────────────────────────────────┐\n",
+       "│ family        ┆ label       ┆ config_name ┆ model_class ┆ params                          │\n",
+       "│ ---           ┆ ---         ┆ ---         ┆ ---         ┆ ---                             │\n",
+       "│ str           ┆ str         ┆ str         ┆ str         ┆ str                             │\n",
+       "╞═══════════════╪═════════════╪═════════════╪═════════════╪═════════════════════════════════╡\n",
+       "│ deep_learning ┆ fwd_ret_15m ┆ nlinear     ┆             ┆ architecture=nlinear, dropout=… │\n",
+       "│ deep_learning ┆ fwd_ret_5m  ┆ nlinear     ┆             ┆ architecture=nlinear, dropout=… │\n",
+       "│ deep_learning ┆ fwd_ret_60m ┆ nlinear     ┆             ┆ architecture=nlinear, dropout=… │\n",
+       "└───────────────┴─────────────┴─────────────┴─────────────┴─────────────────────────────────┘"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "SEQUENCE_CONFIG = \"nlinear\"\n",
     "declared = load_model_configs(study, \"deep_learning\", config_names=[SEQUENCE_CONFIG])\n",
@@ -166,8 +300,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "114890de",
-   "metadata": {},
+   "id": "5d8f46db",
+   "metadata": {
+    "papermill": {
+     "duration": 0.000973,
+     "end_time": "2026-09-10T18:46:37.316459+00:00",
+     "exception": false,
+     "start_time": "2026-09-10T18:46:37.315486+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "`LABELS` and `CONFIG_NAMES` narrow the run below this notebook's own slice, and a narrowed run\n",
     "declares a different member set than the published population does. A population is immutable\n",
@@ -183,10 +325,32 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "6a0fbeb6",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 6,
+   "id": "6c3597a3",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-10T18:46:37.319320Z",
+     "iopub.status.busy": "2026-09-10T18:46:37.319174Z",
+     "iopub.status.idle": "2026-09-10T18:46:37.322721Z",
+     "shell.execute_reply": "2026-09-10T18:46:37.322253Z"
+    },
+    "papermill": {
+     "duration": 0.006049,
+     "end_time": "2026-09-10T18:46:37.323495+00:00",
+     "exception": false,
+     "start_time": "2026-09-10T18:46:37.317446+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "training device: gpu\n"
+     ]
+    }
+   ],
    "source": [
     "PUBLISHED_DEVICE = \"gpu\"\n",
     "device = DEVICE or PUBLISHED_DEVICE\n",
@@ -205,8 +369,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f8c6145a",
-   "metadata": {},
+   "id": "3236a243",
+   "metadata": {
+    "papermill": {
+     "duration": 0.000988,
+     "end_time": "2026-09-10T18:46:37.326504+00:00",
+     "exception": false,
+     "start_time": "2026-09-10T18:46:37.325516+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "## 2. Binding the declarations to the data\n",
     "\n",
@@ -239,10 +411,59 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "e8a26719",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 7,
+   "id": "1d5fdd5f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-10T18:46:37.329542Z",
+     "iopub.status.busy": "2026-09-10T18:46:37.329351Z",
+     "iopub.status.idle": "2026-09-10T18:50:00.891426Z",
+     "shell.execute_reply": "2026-09-10T18:50:00.889156Z"
+    },
+    "papermill": {
+     "duration": 203.564506,
+     "end_time": "2026-09-10T18:50:00.892055+00:00",
+     "exception": false,
+     "start_time": "2026-09-10T18:46:37.327549+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div><style>\n",
+       ".dataframe > thead > tr,\n",
+       ".dataframe > tbody > tr {\n",
+       "  text-align: right;\n",
+       "  white-space: pre-wrap;\n",
+       "}\n",
+       "</style>\n",
+       "<small>shape: (3, 8)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>label</th><th>config_name</th><th>feature_count</th><th>eligible_rows</th><th>folds</th><th>checkpoints</th><th>validation_start</th><th>validation_end</th></tr><tr><td>str</td><td>str</td><td>i64</td><td>i64</td><td>i64</td><td>i64</td><td>datetime[μs]</td><td>datetime[μs]</td></tr></thead><tbody><tr><td>&quot;fwd_ret_15m&quot;</td><td>&quot;nlinear&quot;</td><td>90</td><td>6453961</td><td>2</td><td>20</td><td>2020-06-30 11:26:00</td><td>2021-06-30 15:43:00</td></tr><tr><td>&quot;fwd_ret_5m&quot;</td><td>&quot;nlinear&quot;</td><td>90</td><td>6711664</td><td>2</td><td>20</td><td>2020-06-30 11:26:00</td><td>2021-06-30 15:53:00</td></tr><tr><td>&quot;fwd_ret_60m&quot;</td><td>&quot;nlinear&quot;</td><td>90</td><td>5325226</td><td>2</td><td>20</td><td>2020-06-30 11:26:00</td><td>2021-06-30 14:58:00</td></tr></tbody></table></div>"
+      ],
+      "text/plain": [
+       "shape: (3, 8)\n",
+       "┌────────────┬────────────┬────────────┬────────────┬───────┬────────────┬────────────┬────────────┐\n",
+       "│ label      ┆ config_nam ┆ feature_co ┆ eligible_r ┆ folds ┆ checkpoint ┆ validation ┆ validation │\n",
+       "│ ---        ┆ e          ┆ unt        ┆ ows        ┆ ---   ┆ s          ┆ _start     ┆ _end       │\n",
+       "│ str        ┆ ---        ┆ ---        ┆ ---        ┆ i64   ┆ ---        ┆ ---        ┆ ---        │\n",
+       "│            ┆ str        ┆ i64        ┆ i64        ┆       ┆ i64        ┆ datetime[μ ┆ datetime[μ │\n",
+       "│            ┆            ┆            ┆            ┆       ┆            ┆ s]         ┆ s]         │\n",
+       "╞════════════╪════════════╪════════════╪════════════╪═══════╪════════════╪════════════╪════════════╡\n",
+       "│ fwd_ret_15 ┆ nlinear    ┆ 90         ┆ 6453961    ┆ 2     ┆ 20         ┆ 2020-06-30 ┆ 2021-06-30 │\n",
+       "│ m          ┆            ┆            ┆            ┆       ┆            ┆ 11:26:00   ┆ 15:43:00   │\n",
+       "│ fwd_ret_5m ┆ nlinear    ┆ 90         ┆ 6711664    ┆ 2     ┆ 20         ┆ 2020-06-30 ┆ 2021-06-30 │\n",
+       "│            ┆            ┆            ┆            ┆       ┆            ┆ 11:26:00   ┆ 15:53:00   │\n",
+       "│ fwd_ret_60 ┆ nlinear    ┆ 90         ┆ 5325226    ┆ 2     ┆ 20         ┆ 2020-06-30 ┆ 2021-06-30 │\n",
+       "│ m          ┆            ┆            ┆            ┆       ┆            ┆ 11:26:00   ┆ 14:58:00   │\n",
+       "└────────────┴────────────┴────────────┴────────────┴───────┴────────────┴────────────┴────────────┘"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "requests = model_requests(\n",
     "    study,\n",
@@ -268,8 +489,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c4d34245",
-   "metadata": {},
+   "id": "5b78d592",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001192,
+     "end_time": "2026-09-10T18:50:00.894797+00:00",
+     "exception": false,
+     "start_time": "2026-09-10T18:50:00.893605+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "## 3. Fitting the population\n",
     "\n",
@@ -308,10 +537,4470 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "887c8fc2",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 8,
+   "id": "233f7138",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-10T18:50:00.900643Z",
+     "iopub.status.busy": "2026-09-10T18:50:00.900410Z",
+     "iopub.status.idle": "2026-09-10T22:35:17.108924Z",
+     "shell.execute_reply": "2026-09-10T22:35:17.108121Z"
+    },
+    "papermill": {
+     "duration": 13516.231119,
+     "end_time": "2026-09-10T22:35:17.128042+00:00",
+     "exception": false,
+     "start_time": "2026-09-10T18:50:00.896923+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Fold-major CV: 2 folds × 1 configs × 60 lookback\n",
+      "\n",
+      "  Fold 0: creating sequences...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    train=210,028 seq across 105 symbols\n",
+      "    val=3,216,387 seq across 115 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    nlinear:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.071826\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.007165\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.002773\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.001119\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.000521, val_loss=0.000050, IC=+0.0013\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.000225\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.000143\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.000075\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.000059\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.000039, val_loss=0.000010, IC=-0.0030\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.000036\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.000028\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.000026\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.000025\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.000025, val_loss=0.000008, IC=+0.0004\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.000025\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.000024\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.000023\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.000023\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.000023, val_loss=0.000008, IC=+0.0045\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.000023\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.000023\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.000022\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.000022\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.000022, val_loss=0.000008, IC=+0.0019\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.000022\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.000022\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.000022\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.000022\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.000022, val_loss=0.000008, IC=+0.0008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.000022\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.000022\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.000022\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.000022\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.000022, val_loss=0.000008, IC=-0.0044\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.000022\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.000022\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.000022\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.000023\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.000023, val_loss=0.000008, IC=+0.0029\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.000023\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.000023\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.000023\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.000023\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.000023, val_loss=0.000008, IC=-0.0012\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.000023\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.000023\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.000023\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.000023\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.000023, val_loss=0.000008, IC=+0.0029\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.000023\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.000023\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.000023\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.000023\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.000023, val_loss=0.000008, IC=+0.0013\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.000023\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.000023\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.000023\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.000023\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.000023, val_loss=0.000008, IC=+0.0022\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.000023\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.000023\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.000023\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.000023\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.000023, val_loss=0.000008, IC=+0.0008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.000023\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.000023\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.000023\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.000022\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.000023, val_loss=0.000008, IC=+0.0003\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.000023\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.000022\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.000023\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.000022\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.000022, val_loss=0.000008, IC=-0.0016\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.000022\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.000022\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.000022\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.000022\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.000022, val_loss=0.000008, IC=+0.0033\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.000022\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.000022\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.000022\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.000022\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.000022, val_loss=0.000008, IC=+0.0061\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.000022\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.000022\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.000022\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.000022\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.000022, val_loss=0.000008, IC=-0.0003\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.000022\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.000022\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.000022\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.000022\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.000022, val_loss=0.000007, IC=+0.0008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.000022\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.000022\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.000022\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.000022\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.000022, val_loss=0.000007, IC=+0.0042\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=85, IC=+0.0061 (2233.5s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Fold 1: creating sequences...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    train=214,324 seq across 113 symbols\n",
+      "    val=3,237,574 seq across 115 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    nlinear:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.056125\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.005633\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.001337\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.000494\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.000180, val_loss=0.000978, IC=+0.0014\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.000038\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.000018\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.000012\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.000009\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.000008, val_loss=0.000011, IC=+0.0043\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.000008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.000008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.000008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.000008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.000007, val_loss=0.000008, IC=+0.0017\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.000007\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.000007\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.000007\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.000007\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.000007, val_loss=0.000007, IC=+0.0086\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.000007\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.000007\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.000007\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.000008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.000008, val_loss=0.000019, IC=-0.0014\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.000008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.000008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.000007\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.000007\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.000008, val_loss=0.000013, IC=+0.0013\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.000008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.000008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.000008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.000008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.000008, val_loss=0.000007, IC=+0.0045\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.000008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.000008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.000008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.000008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.000008, val_loss=0.000009, IC=-0.0027\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.000008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.000008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.000008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.000008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.000008, val_loss=0.000018, IC=-0.0019\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.000008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.000008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.000008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.000008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.000008, val_loss=0.000007, IC=+0.0008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.000008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.000008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.000008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.000008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.000008, val_loss=0.000022, IC=-0.0002\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.000008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.000008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.000008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.000008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.000008, val_loss=0.000008, IC=-0.0007\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.000008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.000008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.000008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.000008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.000008, val_loss=0.000011, IC=-0.0070\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.000008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.000008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.000008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.000008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.000008, val_loss=0.000015, IC=+0.0016\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.000008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.000008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.000008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.000008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.000008, val_loss=0.000007, IC=-0.0016\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.000007\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.000008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.000008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.000008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.000007, val_loss=0.000008, IC=-0.0047\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.000007\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.000007\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.000007\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.000007\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.000007, val_loss=0.000013, IC=+0.0068\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.000007\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.000007\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.000007\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.000007\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.000007, val_loss=0.000009, IC=-0.0058\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.000007\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.000007\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.000007\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.000007\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.000007, val_loss=0.000007, IC=-0.0033\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.000007\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.000007\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.000007\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.000007\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.000007, val_loss=0.000007, IC=+0.0023\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=20, IC=+0.0086 (2120.5s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  nlinear: best_epoch=20, IC=+0.0066 (4354.0s)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Best: nlinear @ epoch 20 (IC=+0.0066)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Saved to ~/ml4t/public-nasdaq/case_studies/nasdaq100_microstructure/run_log/training/372a7347c7e9/diagnostics\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Fold-major CV: 2 folds × 1 configs × 60 lookback\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Fold 0: creating sequences...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    train=655,498 seq across 105 symbols\n",
+      "    val=3,346,183 seq across 115 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    nlinear:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.026557\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.000741\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.000056\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.000013\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.000008, val_loss=0.000003, IC=-0.0003\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.000008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.000008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.000008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.000008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.000008, val_loss=0.000003, IC=-0.0012\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.000008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.000008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.000008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.000014\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.000011, val_loss=0.000003, IC=-0.0021\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.000009\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.000009\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.000018\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.000009\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.000016, val_loss=0.000006, IC=+0.0016\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.000096\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.000014\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.000009\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.000008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.000008, val_loss=0.000004, IC=-0.0007\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.000008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.000008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.000010\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.000012\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.000009, val_loss=0.000006, IC=-0.0025\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.000022\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.000009\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.000009\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.000008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.000011, val_loss=0.000005, IC=-0.0015\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.000010\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.000036\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.000009\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.000008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.000008, val_loss=0.000003, IC=+0.0012\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.000008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.000009\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.000014\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.000050\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.000013, val_loss=0.000004, IC=+0.0035\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.000011\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.000009\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.000008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.000008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.000009, val_loss=0.000004, IC=-0.0017\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.000008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.000008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.000008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.000008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.000012, val_loss=0.000004, IC=-0.0006\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.000012\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.000008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.000008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.000008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.000008, val_loss=0.000003, IC=-0.0009\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.000009\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.000009\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.000009\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.000008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.000009, val_loss=0.000003, IC=+0.0009\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.000008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.000008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.000009\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.000008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.000008, val_loss=0.000003, IC=+0.0004\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.000008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.000008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.000008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.000008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.000008, val_loss=0.000003, IC=-0.0014\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.000008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.000008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.000008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.000008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.000008, val_loss=0.000003, IC=-0.0020\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.000008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.000008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.000008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.000008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.000008, val_loss=0.000003, IC=-0.0014\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.000008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.000008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.000008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.000008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.000008, val_loss=0.000003, IC=+0.0008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.000008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.000008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.000008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.000008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.000008, val_loss=0.000003, IC=-0.0003\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.000008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.000008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.000008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.000008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.000008, val_loss=0.000003, IC=+0.0016\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=45, IC=+0.0035 (2910.2s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Fold 1: creating sequences...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    train=669,014 seq across 113 symbols\n",
+      "    val=3,365,481 seq across 115 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    nlinear:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.024863\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.000378\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.000010\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.000003\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.000003, val_loss=0.000004, IC=-0.0009\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.000002\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.000002\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.000002\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.000002\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.000003, val_loss=0.000003, IC=+0.0037\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.000003\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.000003\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.000003\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.000003\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.000003, val_loss=0.000017, IC=+0.0005\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.000003\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.000003\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.000004\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.000031\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.000005, val_loss=0.000003, IC=-0.0014\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.000003\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.000004\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.000004\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.000004\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.000003, val_loss=0.000005, IC=-0.0003\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.000004\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.000006\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.000005\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.000019\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.000004, val_loss=0.000020, IC=-0.0007\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.000003\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.000003\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.000003\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.000003\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.000003, val_loss=0.000004, IC=-0.0022\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.000003\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.000003\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.000005\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.000004\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.000006, val_loss=0.000006, IC=-0.0019\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.000003\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.000003\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.000003\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.000005\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.000003, val_loss=0.000009, IC=-0.0024\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.000003\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.000003\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.000004\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.000003\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.000003, val_loss=0.000048, IC=-0.0020\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.000003\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.000003\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.000003\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.000003\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.000003, val_loss=0.000005, IC=-0.0028\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.000003\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.000003\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.000003\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.000003\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.000003, val_loss=0.000003, IC=+0.0000\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.000003\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.000003\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.000003\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.000003\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.000003, val_loss=0.000011, IC=-0.0014\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.000003\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.000003\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.000003\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.000003\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.000003, val_loss=0.000007, IC=+0.0026\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.000003\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.000003\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.000003\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.000003\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.000003, val_loss=0.000016, IC=+0.0008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.000003\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.000003\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.000003\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.000003\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.000003, val_loss=0.000010, IC=+0.0009\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.000003\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.000003\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.000003\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.000003\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.000002, val_loss=0.000003, IC=-0.0003\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.000002\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.000002\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.000002\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.000002\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.000002, val_loss=0.000003, IC=+0.0010\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.000002\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.000002\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.000002\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.000002\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.000002, val_loss=0.000002, IC=+0.0042\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.000002\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.000002\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.000002\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.000002\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.000002, val_loss=0.000002, IC=+0.0033\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=95, IC=+0.0042 (2438.2s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  nlinear: best_epoch=100, IC=+0.0024 (5348.4s)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Best: nlinear @ epoch 100 (IC=+0.0024)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Saved to ~/ml4t/public-nasdaq/case_studies/nasdaq100_microstructure/run_log/training/343a697c3d5d/diagnostics\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Fold-major CV: 2 folds × 1 configs × 60 lookback\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Fold 0: creating sequences...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    train=43,237 seq across 105 symbols\n",
+      "    val=2,649,390 seq across 115 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    nlinear:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.199270\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.059035\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.026136\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.015110\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.009982, val_loss=0.002729, IC=+0.0022\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.007063\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.005318\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.003970\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.003187\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.002590, val_loss=0.000460, IC=+0.0004\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.002122\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.001784\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.001494\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.001302\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.001142, val_loss=0.000161, IC=-0.0007\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.000970\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.000804\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.000708\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.000638\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.000559, val_loss=0.000092, IC=-0.0017\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.000492\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.000444\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.000409\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.000361\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.000336, val_loss=0.000066, IC=-0.0019\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.000294\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.000269\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.000249\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.000223\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.000210, val_loss=0.000051, IC=-0.0028\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.000196\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.000188\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.000171\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.000168\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.000152, val_loss=0.000044, IC=-0.0018\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.000142\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.000144\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.000130\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.000127\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.000131, val_loss=0.000040, IC=-0.0026\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.000122\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.000113\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.000111\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.000110\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.000104, val_loss=0.000038, IC=-0.0019\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.000102\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.000100\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.000099\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.000098\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.000095, val_loss=0.000036, IC=-0.0019\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.000093\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.000091\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.000091\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.000091\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.000090, val_loss=0.000036, IC=-0.0035\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.000091\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.000088\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.000086\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.000086\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.000087, val_loss=0.000036, IC=+0.0007\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.000086\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.000086\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.000082\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.000083\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.000083, val_loss=0.000035, IC=-0.0005\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.000083\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.000083\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.000083\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.000084\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.000083, val_loss=0.000035, IC=-0.0011\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.000084\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.000083\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.000083\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.000082\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.000082, val_loss=0.000035, IC=+0.0000\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.000083\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.000083\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.000081\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.000082\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.000082, val_loss=0.000035, IC=-0.0009\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.000082\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.000080\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.000079\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.000081\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.000080, val_loss=0.000035, IC=-0.0003\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.000080\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.000081\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.000081\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.000083\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.000082, val_loss=0.000035, IC=-0.0004\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.000079\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.000081\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.000081\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.000079\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.000080, val_loss=0.000035, IC=-0.0004\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.000081\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.000081\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.000079\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.000082\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.000081, val_loss=0.000035, IC=-0.0004\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=5, IC=+0.0022 (826.5s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Fold 1: creating sequences...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    train=44,185 seq across 113 symbols\n",
+      "    val=2,675,836 seq across 115 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    nlinear:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.165817\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.044594\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.025041\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.021656\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.015014, val_loss=0.128373, IC=-0.0029\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.010835\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.007510\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.005714\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.003829\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.002781, val_loss=0.040287, IC=-0.0027\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.002033\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.001502\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.001122\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.000876\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.000667, val_loss=0.029937, IC=-0.0021\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.000506\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.000454\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.000341\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.000266\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.000260, val_loss=0.025471, IC=-0.0060\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.000184\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.000152\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.000162\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.000112\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.000101, val_loss=0.023645, IC=-0.0023\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.000089\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.000079\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.000075\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.000072\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.000067, val_loss=0.021457, IC=-0.0035\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.000063\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.000057\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.000058\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.000054\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.000054, val_loss=0.019672, IC=-0.0077\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.000051\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.000054\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.000071\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.000049\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.000048, val_loss=0.018067, IC=-0.0045\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.000047\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.000045\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.000044\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.000044\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.000044, val_loss=0.016447, IC=-0.0016\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.000044\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.000041\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.000043\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.000042\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.000042, val_loss=0.015253, IC=-0.0106\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.000041\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.000040\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.000042\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.000040\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.000041, val_loss=0.014170, IC=-0.0049\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.000054\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.000040\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.000040\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.000038\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.000038, val_loss=0.013271, IC=-0.0054\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.000038\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.000051\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.000040\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.000039\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.000038, val_loss=0.012300, IC=-0.0091\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.000039\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.000049\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.000037\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.000039\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.000037, val_loss=0.011695, IC=-0.0041\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.000038\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.000038\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.000047\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.000038\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.000036, val_loss=0.011074, IC=-0.0042\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.000036\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.000037\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.000037\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.000036\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.000044, val_loss=0.010829, IC=-0.0023\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.000037\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.000037\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.000037\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.000037\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.000038, val_loss=0.010587, IC=-0.0055\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.000037\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.000046\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.000036\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.000043\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.000044, val_loss=0.010424, IC=-0.0062\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.000036\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.000042\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.000043\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.000036\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.000042, val_loss=0.010394, IC=-0.0054\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.000043\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.000036\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.000037\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.000036\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.000035, val_loss=0.010391, IC=-0.0050\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=45, IC=-0.0016 (1253.7s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  nlinear: best_epoch=5, IC=-0.0004 (2080.2s)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Best: nlinear @ epoch 5 (IC=-0.0004)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Saved to ~/ml4t/public-nasdaq/case_studies/nasdaq100_microstructure/run_log/training/28b54b31be55/diagnostics\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "3 configurations: 3 trained, 0 read\n",
+      "population nasdaq100_microstructure-nlinear-validation-v1: 60 prediction sets\n"
+     ]
+    }
+   ],
    "source": [
     "population_name = POPULATION_NAME or \"nasdaq100_microstructure-nlinear-validation-v1\"\n",
     "execution, population = run_model_population(\n",
@@ -330,8 +5019,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "266f6754",
-   "metadata": {},
+   "id": "144c5149",
+   "metadata": {
+    "papermill": {
+     "duration": 0.011211,
+     "end_time": "2026-09-10T22:35:17.155173+00:00",
+     "exception": false,
+     "start_time": "2026-09-10T22:35:17.143962+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "`reused` is not zero on a second run. Every identity is re-derived from the inputs, the\n",
     "registry already holds the matching rows and the saved weights, and the runner returns the\n",
@@ -340,8 +5037,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b126ae41",
-   "metadata": {},
+   "id": "6d43b07f",
+   "metadata": {
+    "papermill": {
+     "duration": 0.010237,
+     "end_time": "2026-09-10T22:35:17.178495+00:00",
+     "exception": false,
+     "start_time": "2026-09-10T22:35:17.168258+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "## 4. What came out\n",
     "\n",
@@ -358,14 +5063,65 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "f6063f24",
+   "execution_count": 9,
+   "id": "bd1736da",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-10T22:35:17.206951Z",
+     "iopub.status.busy": "2026-09-10T22:35:17.206763Z",
+     "iopub.status.idle": "2026-09-10T22:35:17.218230Z",
+     "shell.execute_reply": "2026-09-10T22:35:17.217386Z"
+    },
+    "papermill": {
+     "duration": 0.032288,
+     "end_time": "2026-09-10T22:35:17.220897+00:00",
+     "exception": false,
+     "start_time": "2026-09-10T22:35:17.188609+00:00",
+     "status": "completed"
+    },
     "tags": [
      "results"
     ]
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div><style>\n",
+       ".dataframe > thead > tr,\n",
+       ".dataframe > tbody > tr {\n",
+       "  text-align: right;\n",
+       "  white-space: pre-wrap;\n",
+       "}\n",
+       "</style>\n",
+       "<small>shape: (60, 5)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>label</th><th>config_name</th><th>checkpoint_value</th><th>ic_mean</th><th>complete</th></tr><tr><td>str</td><td>str</td><td>i64</td><td>f64</td><td>bool</td></tr></thead><tbody><tr><td>&quot;fwd_ret_15m&quot;</td><td>&quot;nlinear&quot;</td><td>5</td><td>0.001349</td><td>true</td></tr><tr><td>&quot;fwd_ret_15m&quot;</td><td>&quot;nlinear&quot;</td><td>10</td><td>0.000653</td><td>true</td></tr><tr><td>&quot;fwd_ret_15m&quot;</td><td>&quot;nlinear&quot;</td><td>15</td><td>0.001047</td><td>true</td></tr><tr><td>&quot;fwd_ret_15m&quot;</td><td>&quot;nlinear&quot;</td><td>20</td><td>0.006559</td><td>true</td></tr><tr><td>&quot;fwd_ret_15m&quot;</td><td>&quot;nlinear&quot;</td><td>25</td><td>0.000257</td><td>true</td></tr><tr><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td></tr><tr><td>&quot;fwd_ret_60m&quot;</td><td>&quot;nlinear&quot;</td><td>80</td><td>-0.001618</td><td>true</td></tr><tr><td>&quot;fwd_ret_60m&quot;</td><td>&quot;nlinear&quot;</td><td>85</td><td>-0.002896</td><td>true</td></tr><tr><td>&quot;fwd_ret_60m&quot;</td><td>&quot;nlinear&quot;</td><td>90</td><td>-0.003306</td><td>true</td></tr><tr><td>&quot;fwd_ret_60m&quot;</td><td>&quot;nlinear&quot;</td><td>95</td><td>-0.002873</td><td>true</td></tr><tr><td>&quot;fwd_ret_60m&quot;</td><td>&quot;nlinear&quot;</td><td>100</td><td>-0.002707</td><td>true</td></tr></tbody></table></div>"
+      ],
+      "text/plain": [
+       "shape: (60, 5)\n",
+       "┌─────────────┬─────────────┬──────────────────┬───────────┬──────────┐\n",
+       "│ label       ┆ config_name ┆ checkpoint_value ┆ ic_mean   ┆ complete │\n",
+       "│ ---         ┆ ---         ┆ ---              ┆ ---       ┆ ---      │\n",
+       "│ str         ┆ str         ┆ i64              ┆ f64       ┆ bool     │\n",
+       "╞═════════════╪═════════════╪══════════════════╪═══════════╪══════════╡\n",
+       "│ fwd_ret_15m ┆ nlinear     ┆ 5                ┆ 0.001349  ┆ true     │\n",
+       "│ fwd_ret_15m ┆ nlinear     ┆ 10               ┆ 0.000653  ┆ true     │\n",
+       "│ fwd_ret_15m ┆ nlinear     ┆ 15               ┆ 0.001047  ┆ true     │\n",
+       "│ fwd_ret_15m ┆ nlinear     ┆ 20               ┆ 0.006559  ┆ true     │\n",
+       "│ fwd_ret_15m ┆ nlinear     ┆ 25               ┆ 0.000257  ┆ true     │\n",
+       "│ …           ┆ …           ┆ …                ┆ …         ┆ …        │\n",
+       "│ fwd_ret_60m ┆ nlinear     ┆ 80               ┆ -0.001618 ┆ true     │\n",
+       "│ fwd_ret_60m ┆ nlinear     ┆ 85               ┆ -0.002896 ┆ true     │\n",
+       "│ fwd_ret_60m ┆ nlinear     ┆ 90               ┆ -0.003306 ┆ true     │\n",
+       "│ fwd_ret_60m ┆ nlinear     ┆ 95               ┆ -0.002873 ┆ true     │\n",
+       "│ fwd_ret_60m ┆ nlinear     ┆ 100              ┆ -0.002707 ┆ true     │\n",
+       "└─────────────┴─────────────┴──────────────────┴───────────┴──────────┘"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# Scoped to this population's own members. `catalog_rows` is the study's whole prediction\n",
     "# table, so an unfiltered height check would compare this run against every sequence row the\n",
@@ -383,10 +5139,291 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "41c39793",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 10,
+   "id": "abad4aff",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-10T22:35:17.246187Z",
+     "iopub.status.busy": "2026-09-10T22:35:17.246055Z",
+     "iopub.status.idle": "2026-09-10T22:35:18.960250Z",
+     "shell.execute_reply": "2026-09-10T22:35:18.959108Z"
+    },
+    "papermill": {
+     "duration": 1.727403,
+     "end_time": "2026-09-10T22:35:18.961251+00:00",
+     "exception": false,
+     "start_time": "2026-09-10T22:35:17.233848+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.plotly.v1+json": {
+       "config": {
+        "plotlyServerURL": "https://plot.ly"
+       },
+       "data": [
+        {
+         "mode": "lines+markers",
+         "name": "fwd_ret_15m",
+         "type": "scatter",
+         "x": [
+          5,
+          10,
+          15,
+          20,
+          25,
+          30,
+          35,
+          40,
+          45,
+          50,
+          55,
+          60,
+          65,
+          70,
+          75,
+          80,
+          85,
+          90,
+          95,
+          100
+         ],
+         "y": [
+          0.0013490780406613936,
+          0.0006528898296079542,
+          0.0010465539608667013,
+          0.006559401075890649,
+          0.00025700469637359715,
+          0.001032471924532595,
+          7.844533708364129e-05,
+          0.00010940269017260243,
+          -0.0015437944985181853,
+          0.0018094434512170188,
+          0.0005321252604602591,
+          0.000776835030674146,
+          -0.003101173771430021,
+          0.0009654392505826454,
+          -0.001559510011106499,
+          -0.0006822719219488386,
+          0.006440649918759358,
+          -0.003053842100198386,
+          -0.0012487922189621304,
+          0.0032170499954080754
+         ]
+        },
+        {
+         "mode": "lines+markers",
+         "name": "fwd_ret_5m",
+         "type": "scatter",
+         "x": [
+          5,
+          10,
+          15,
+          20,
+          25,
+          30,
+          35,
+          40,
+          45,
+          50,
+          55,
+          60,
+          65,
+          70,
+          75,
+          80,
+          85,
+          90,
+          95,
+          100
+         ],
+         "y": [
+          -0.0006004145515262183,
+          0.0012291890241574138,
+          -0.0008007219562465731,
+          8.041929625139958e-05,
+          -0.0004904990896577241,
+          -0.0016073701297886663,
+          -0.0018601591344441222,
+          -0.00036218987924363294,
+          0.0005247040355616901,
+          -0.0018466172088371909,
+          -0.00169225734080379,
+          -0.0004183375965748832,
+          -0.0002974747212413461,
+          0.001491939318735312,
+          -0.00029121666431981445,
+          -0.000597490107259358,
+          -0.0008593075259357482,
+          0.000918370202392056,
+          0.0019394163570021505,
+          0.002417787940988526
+         ]
+        },
+        {
+         "mode": "lines+markers",
+         "name": "fwd_ret_60m",
+         "type": "scatter",
+         "x": [
+          5,
+          10,
+          15,
+          20,
+          25,
+          30,
+          35,
+          40,
+          45,
+          50,
+          55,
+          60,
+          65,
+          70,
+          75,
+          80,
+          85,
+          90,
+          95,
+          100
+         ],
+         "y": [
+          -0.00034996286522018184,
+          -0.0011427482165435765,
+          -0.0014196351515107794,
+          -0.003840380278061446,
+          -0.0020943750880211337,
+          -0.003171777598823049,
+          -0.004746446809328519,
+          -0.003540381113194482,
+          -0.0017786819352075159,
+          -0.006253697953319802,
+          -0.004191233661112409,
+          -0.002340422668592763,
+          -0.004803802103200437,
+          -0.00262680525935722,
+          -0.0020783629784065206,
+          -0.0016175958403965506,
+          -0.002896004795796168,
+          -0.0033059820870319366,
+          -0.002873189923157071,
+          -0.00270723676289385
+         ]
+        }
+       ],
+       "layout": {
+        "shapes": [
+         {
+          "line": {
+           "color": "#94a3b8",
+           "dash": "dash",
+           "width": 1
+          },
+          "type": "line",
+          "x0": 0,
+          "x1": 1,
+          "xref": "x domain",
+          "y0": 0,
+          "y1": 0,
+          "yref": "y"
+         }
+        ],
+        "template": {
+         "layout": {
+          "colorway": [
+           "#0a1628",
+           "#D4A84B",
+           "#C87533",
+           "#10b981",
+           "#ef4444",
+           "#94a3b8"
+          ],
+          "font": {
+           "color": "#334155",
+           "family": "DM Sans, DejaVu Sans, sans-serif",
+           "size": 11
+          },
+          "hoverlabel": {
+           "bgcolor": "white",
+           "font": {
+            "family": "DM Sans, DejaVu Sans, sans-serif",
+            "size": 11
+           }
+          },
+          "legend": {
+           "bgcolor": "rgba(255,255,255,0.8)",
+           "bordercolor": "#e8e8e6",
+           "borderwidth": 1,
+           "font": {
+            "size": 10
+           }
+          },
+          "paper_bgcolor": "#FAFAF9",
+          "plot_bgcolor": "white",
+          "title": {
+           "font": {
+            "color": "#0a1628",
+            "size": 14
+           },
+           "x": 0.5,
+           "xanchor": "center"
+          },
+          "xaxis": {
+           "gridcolor": "#e8e8e6",
+           "gridwidth": 0.5,
+           "linecolor": "#e8e8e6",
+           "showgrid": true,
+           "tickfont": {
+            "size": 10
+           },
+           "title": {
+            "font": {
+             "size": 11
+            }
+           }
+          },
+          "yaxis": {
+           "gridcolor": "#e8e8e6",
+           "gridwidth": 0.5,
+           "linecolor": "#e8e8e6",
+           "showgrid": true,
+           "tickfont": {
+            "size": 10
+           },
+           "title": {
+            "font": {
+             "size": 11
+            }
+           }
+          }
+         }
+        },
+        "title": {
+         "text": "Validation IC by checkpoint - nlinear"
+        },
+        "xaxis": {
+         "title": {
+          "text": "training epoch"
+         }
+        },
+        "yaxis": {
+         "title": {
+          "text": "information coefficient"
+         }
+        }
+       }
+      },
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAArwAAAH0CAYAAADfWf7fAAAQAElEQVR4AeydB1xV5RvHf5c9REBEEBwoKuLee8/KNEutzDQrZ9OVmSM1tdS0MjO3WWpmavV3Z+69t4IKCMhGFBWQzf887+VcGRe4XO5gPHx43/Oe97zzew7c5z7neZ/XJDk5KYMDM+BngJ8Bfgb4GeBngJ8Bfgb4GSitz4AJ+IcJMAEmwAQAMAQmwASYABMorQRY4C2td5bnxQSYABNgAkyACTABbQiUwjos8JbCm8pTYgJMgAkwASbABJgAE3hOgAXe5yw4xQSYgOYEuCQTYAJMgAkwgRJDgAXeEnOreKBMgAkwASbABJhA8SPAIyoJBFjgLQl3icfIBJgAE2ACTIAJMAEmoDUBFni1RscVmYDmBLgkE2ACTIAJMAEmYDwCLPAajz33zASYABNgAkygrBHg+TIBoxBggdco2LlTJsAEmAATYAJMgAkwAUMRYIHXUKS5H80JcEkmwASYABNgAkyACeiQAAu8OoTJTTEBJsAEmAAT0CUBbosJMAHdEGCBVzccuRUmwASYABNgAkyACTCBYkqABd5iemM0HxaXZAJMgAkwASbABJgAE8iPAAu8+dHha0yACTABJlByCPBImQATYAJ5EGCBNw8wnM0EmAATYAJMgAkwASZQOgiUNYG3dNw1ngUTYAJMgAkwASbABJiAxgRY4NUYFRdkAkyACZQmAjwXJsAEmEDZIcACb9m51zxTJsAEmAATYAJMgAmUSQL5CrxlkghPmgkwASbABJgAE2ACTKBUEWCBt1TdTp4ME2ACeiLAzTIBJsAEmEAJJsACbwm+eTx0JsAEmAATYAJMgAkYlkDJ7I0F3pJ533jUTIAJMAEmwASYABNgAhoSYIFXQ1BcjAkwAc0JcEkmwASYABNgAsWJAAu8xelu8FiYABNgAkyACTCB0kSA51JMCLDAW0xuBA+DCTABJsAEmAATYAJMQD8EWODVD1dulQloToBLMgEmwASYABNgAnolwAKvXvFy40yACTABJsAEmICmBLgcE9AXARZ49UWW22UCTIAJMAEmwASYABMoFgRY4C0Wt4EHoTkBLskEmAATYAJMgAkwgcIRYIG3cLy4NBNgAkyACTCB4kGAR8EEmIDGBFjg1RgVF2QCTIAJMAEmwASYABMoiQRY4C2Jd03zMXNJJsAEmAATYAJMgAmUeQIs8Jb5R4ABMAEmwATKAgGeIxNgAmWZAAu8Zfnu89yZABNgAkyACTABJlAGCLDAm+Umc5IJMAEmwASYABNgAkyg9BFggbf03VOeERNgAkygqAS4PhNgAkygVBFggbdU3U6eDBNgAkyACTABJsAEmEBOAtoLvDlb4nMmwASYABNgAkyACTABJlAMCbDAWwxvCg+JCRSWQK3GXfC/3QdEtWs3feFQpTEexDwS5+oi/3tBokxoWIS6yxrnadKXxo0ZoODpc5fEvBMTk3TaW0GNDXz7A8xZ8GNBxYp03RB90AA9G3VWPWt0XhxDYf8eiuMceExMgAnolgALvLrlya0xAY0JpKSkgISHxUvXqq2zfuM2uNdpi8dPnqq9nlemrY01unRsA3Nzs7yKaJU/ZMQ4TPtqUba6+uorWyfSye9bdwhBVUqqftPS0vDdT2vR5cXBqNmwswgvDXgP3y9bB2KrKsgJnRJo06opnCo4aNzm5as3xb2LffxE4zq6LGioZ1SXY+a2mEAJJlBsh84Cb7G9NTyw0k7A3Nwcb73eD5u3/k/tVDdv24n+L/eEfXk7tdfzyvSsUR3/bF5Z6Hp5tZdfviH7yjqO9PR0vPrWGElruhStWzbGwjlT8PP3c9Cre0f8d+gETp65mLU4p3VIYNOaH9ChbQsdtqjfpoz1jOp3Vtw6E2AChSXAAm9hiXF5JqBDAsMGD4RfQBBOnL6QrdU7foE4e+EKBg/qh1u+fpg84xu07voqqnm3xytvjsLVGz7Zymc9UWdmcOjYKXTt8xaqeLVFj35DcePW3axVEBefgLkLl6JX/2GoWrcdurw0GH/t2Kcq8/GkWdi97zCWrdoAMpegcPvuPajra/O2HaI+aadJ+/rLhq2qdigxUHq9P2PuYoz/Yi68W/REwzYv4qv5PyI1NZUuaxR+Xr0Rx06eAwlfC76agoH9X8QLPTph3AfvYs/2dWjRrFG+7Rw7dU5ohokHaYVJC0kVMjIy0LxjX6xY+zudqgLdD5rzDZ87qryciYNHT6Hv6yPEPWrdtT+mzv4WCQnPVMXS0tLznfOj2MeYNO0bNOvwsrgHr701Fjn7CwgMxjujJ6Fey16o26wHPpzwJXxu+6v6yJogPh71O6ruI71JePG1d8WzRHOka+998Hk205fk5BTxHLTs3E+M4eVBI3Dq7MWszYq3ErL5jGwiIj9f9OwQg4uXr4s6QcGh4rmjE+qPGI76ZCqdah0qejTHhj/+xqChHwjWHXoOwpbtu/JsL+czWtCY5YZ87wTg7ZHjBefaTbpi7LgZyKql3nfgGGgudC+8mnYX6axmRHI/VI7+nlxrtcLxU+fl5vnIBJiAgQmwwGtg4NwdE8hKoLZndbRr3TzXB/aGP7ajVs3qQpP2+MkTNKxfF3/++hNO/rcV3Tq3w2uSdjMiKjprU3mm7wXdxxvvfIJmjRvg2pm9+Hz8aHw577ts5ZOTk2FpaYXvv5mBq6f34MORQyWBbREOHDkpyi1dNAt9XuiKD0cNRWzIVRG8atcQ17JGO/YcEILB4IF9cfP8v3j/ndeFkLdxyz9Zi2HTlh1oKQmlNJ/vvpmGdZJQvP1/zwXsbIXVnJBw2aFtS7zUu4uaq0A5Wxu1+XLm8jWbQP1ePrkb3l61hLaYBE6FQoEhb/THb5u3y0XFkbTwrVo0RgPvOuI8Z3T0xFmQDW3Pbh1x4dgO/L5uifTavwJSsgjxf0hCWWpKqtBGD5IE9B9X/Iqscx46ciKexsVh9dJvcOXUHrz8Yldxn2U766joGPR6ZRhsbWywfeNynDq4De0lTeuTp7lNXnbuPYihIydg3fIFeK3fC6rhXpAE0ZiHj0FvAHZtW4uw8Ei898Fk1fWZX3+P1eu3YIGkMafnoG4dT+kL1mjc9Q9SlVGX+O33v7F43lScO/IPqrq7Ycy4aaAvD9WruePwbuWXh8Cbx8Vzs+rHr9U1Uai81b/8gTEj3hbP6luvvyL1Nx2BQSGFaiOvMVMjxPqVN0aicYN62Ll1Lfb/7zfY25fD6+98BHq7QGViHz9G/z69cGL/n9jy21JYWlhg2KiJYt50XQ6Ll67BorlfIMT3FJo2ri9n85EJCAIcGY6AieG64p6YABNQR2DwoL6SFu5fxCckiMtkf7r1r70YOvg1cd62VTMMffNVkPBQtYobPh07HA3qeWHPv4fF9YKijZI2zLliBcyf/RkqODqgZ9cOeGvQK9mqUf5nn45Efe/aosygV1/C8CED8ce2nSjMz+r1fwghdPR7b8HBvrwY9+uv9cGqdZuzNdOja3tpDP1EXzSe7l3a4/wlpVYwW8E8TvzvBaNRA688rhacTYJ7syYNQFy+mfWZsHf+e+e/ouIwiTtpr2WtLwk4m7fuxOABfcV1ddH3y9Zh8MB++GTMO6jk7AR6jT7x4/eR1RylUX0v0BeHvi92x5dTPkGPLu1w7uI10RxpY6m/ZYtno3nThpKw7ID3hr6OZk3qY/sO5bh+2bhNtPfjt19KQrqnYPeW9AagdYsmog1JVodCoQBp2D+d/BW2/LoU3Tq1E9fkyNTURAj69ByR8E5zp75JS/zsWSLW/PonJn0yStSjZ4KeGbfKlbD2tz/kJtQep076UBprA1R2rYSPxwwTAnJk9AO1ZXWR+d6wQejeuR0cHezxwci3UamiEy5dvVGopvMbM30Bo+eL/iboS2mN6lXxzazJuCm9GaH7RB29KT0P9IWLODVpWE9wpbcypBmm63KYMmGMeONgZmZW4BcxuQ4fmQAT0D0BE903yS0yASZQGAKv9esNEkT+yhRs6BVodMxDDJE0VwDEa/H5361AlxcHw7lGC2FSQBrF+yHhGnVzLygUHdu1lIQ6c1X5bp3aqNJyggSlPgPfF6+J6dXz/O+WQ9M+5Dbu+gdKglx7+VQce0jCrM8d/2yaL/fKLuKaHDlXdET0gxj5tMCjiYkCJiba//tqJGnMkfljYWEuCfp1EBB4X+RUdHJEX0koJR6U8e+B45LmNR6vD+hDp2rD7bsBaNW8kdprciZpkuU0HekLzAPpPlPaPyBIfOGh1/XEXg77/jsGWXPpFxAohGESnKhOzpCRAZCG/ZPPvsI/f6xEm5ZNcxZBrRrVhdAsX2goCeEKhQL3pLkHBoeKxX70ZUS+Tn117dQWAdIXDDlP3bGK2/P76SwJn1Qm+sFDOmgUHj95Kp5red7jpszJt55bjufHpVJF6fnRvD9qPL8xkxeT/w6fzDYmx6pNxD26l6lJvh8ShnGfz0GLTv1EOfrbpIWU90PDqHlVaMZaXRULTjABYxLQ/hPDmKPmvplAKSJAr6hfe+UFbNm+W8zqj+078fILXUGCF2VMnb0IV67fxNLFs3Dn8kGQSQFpt5JTUuiyRsHM1DRbORJksmZskV63L/h+paR5/Fi8lqY+pk/+GIXpQ27PNFdfpkLYVSgUchFJWH2eVmVCktien+SbquPpAbIPzbdQIS/SK3i5ytDBrwpzA3Jf9sf2HXilT09hSiBfV3tUN6UsBc3Mst8DhYIqKOesUChAmmHinjOQ6UWWZvJMSk2gRdPGqF7VDaTVz7Ngjgv0LGSdO51nLWJmapb1VG1a3ZePrG2qrZQlkzTh5478T3r2lIG0olku50qq7y9XsXwz1Lfx/H4MeOVF8beW834M7P+ieJ5fGzJGekPgiE1rlyDS/zweBl8WXypTkrPboltbWeU7Dr5YCAJclAkUgQALvEWAx1WZgK4IDJFeTZ84fR70upS0eoOzmBzQ4peXX+iOhvW8xCvcpKRk3PTNvugsv3HUqO6Oazd8sxW5ej37orczF66gfevmoNfjri7Oouz1m9nrWFpYig96cTGPqLYkiF67cTvb1cvXbqKeV61seUU9IWGE7FRpsZS6tmgRnrp8OY8WMsnp5OQU3PS5gxrVq8hZ0iv9tiCTjA1//IVd+w4Lbxqqi2oSXrVr4nymeYKaywVmedWpCbIbpfufV+FaNT1w6cqNfBf3uVV2xv/+WIX9h06IxWk52/K7F5TNzd31m7eFVreGR1V4VHOX3jSYSs/KrWzVyFSgZo1q2fIKc2JpaSmKk2mISOQR1anlATm4VlI+g3kU1Xu2V21PnDxzAWTmoa6z8IgoYbZB9sNky25paSH+JskcSV15zmMCTMD4BFjgNf494BHojkCJball88ZCoB0+9jOQwNmza3vVXOi1M9lZkheDBzGPMHb8jGxCi6pgHglahOUrvXInDS61ceHSNSxfuylb6Yb16uCiJEw9fBQrBCDyb7v/0PFsZWp6VBEeAfITXEYOf1PY/f75317v+wAAEABJREFU127Qinayi6XFQaPeG5ytraKevDHgZZCv4QFDPhCC3bZ/9ooV8KvXbwZ5XaA55tfHwh9WCuGRXrtPmblQmnMqBvZ/SVVFoVBIQm5/fDnvB9SqWU0sHkQ+P+M/fA+/b90BWohGgiu9El+8dK3G94nstElr/+HEL0FCPGmWaVHiTyt/w5nzl0XP7749UDAlkwWyuaV7RX2S3agokBm5u7nif5tXYfe/RwSbzGxxUCgUmPDFPNDrePIA8cWsb9GpfSvUq1sL1tZWGPXum/hm8XIh7FH7C39YBRKK6b6KBrSIqlapDBIIb9y6o0Vt41R5b+hA0fHIT74AfTmiZ97ntp/wJkLmF2RCQZwPHjkpyt3y9QOZN+R8uyEucsQEmECxIMACb7G4DTwIJgBJwHpFvKYf8no/oWmTmXw98zOxMrxdjwHo9MIb8JK0id06t5UvF3is6VENW3/7CfsOHEWrLv0xZtx0kKeGrBVpgVqf3l3Q/eW3pTKvgoST8R++n7UISHAOCg5BhWpNhc3i7bv3sl2nk34v9cD386fj5zUbUb9lbyz5eT2+mj4eb7/Rny7rNGzf+DNmfP4xzl24Jgl280HusH7fulP44m3fpnm+fU34cASGjBiPBq17w/eOP/7+fQVIo5u10tA3+wsN3xsD+mbNVpvu3KE1/pQY791/RNh0Nu/YD0dPnIG5WcHmAHKDv65ajF7dOmLqrEXwbNQFg9/9FMdOnkW5cragHzJ52LV1HciTw6tvjRYbbXz/0xrY2FjTZUn7DilkiDTZB+/Ysgo79hyU2Hwj8iiixVUNpC83bboNQJ8B74kvV6t/en599tTxIN/P4z7/Co3bviT1f07SGK8Ui/CovjbBThr/eOkLQb83RoJsdMmVlzbtGLIOLYb79+9fYWNtLbxdeNTvKL4o+N8LFveUBNtNa74XO8617T4Ab777CSaPGw3a5MKQ48y/L77KBJhAVgIs8GalwWkmYEQCY0cMAdkL0urxrMMgQWfNT/OFfeOt8/uFsEr+Z+d9OUlVzO/qEbzSp4c4pwVZ1I5sA0yZpA0l91CXTuwSbrPIVRWVIS0VXSd7xhmff4LLJ3eJsO7nBdIH+CiVSykqU6N6VVB9qkeBXuWq64u8MhzZsxmhd07jyN7NeOetAVRdFbYJQfUT1Tkl5s/+HL+uXExJtYG8EVCfWS+S0DHho/dFHwHXjwp2NMdxH7wL2tQja1k53bZVM1HuhZ6d4HPhP5DtJfntVecuirS0ZM/6pqRNluvndyRvE3v/+gXBPidFHzu2rFYJo5rMmVypzZo6DmcO/SXY0Vz+/G1ZNldodevUxIbV38H34gHRx/mjO8SbARpXzj7IUwSVWzjnC7qsCiR80r0JunUC61d8CxfniqprFhbmINttave+7yns2roG5DZPVUBK+F87qnrWZJ5WVpbSFeUvPXd0r+jZUOYAUyaMFeOl/KK6JXsQeDHXwshj/27BmPffkrtDfn8Pmo6ZvjTQWK+e2iPuKd3bX1cuUt3TJo3qYeefa3D64HZcO70Hvbt3FOXIfR8NRF0/lM+BCTAB4xBggdc43ItFrzwIJsAE1BOg1fbf/7RWeGvI6RFAfQ3OZQJMgAkwgeJMgAXe4nx3eGxMgAkYnMCGP/6Ga63WkibPBvO/mmzw/rlDoxDgTpkAEyjlBFjgLeU3mKfHBJhA4QgMffNVRN+7gJyv+wvXSvErPfHj90Gv5YvfyHhETIAJMAH9E2CBV1PGXI4JMAEmwASYABNgAkygRBJggbdE3jYeNBNgAkzAeAS4ZybABJhASSPAAm9Ju2M8XibABJgAE2ACTIAJMIFCEdCTwFuoMXBhJsAEmAATYAJMgAkwASagNwIs8OoNLTfMBJgAEwDAEJgAE2ACTMDoBFjgNfot4AEwASbABJgAE2ACTKD0EzDmDFngNSZ97psJMAEmwASYABNgAkxA7wRY4NU7Yu6ACTABzQlwSSbABJgAE2ACuifAAq/umXKLTIAJMAEmwASYABMoGgGurVMCLPDqFCc3xgSYABNgAkyACTABJlDcCLDAW9zuCI+HCWhOgEsyASbABJgAE2ACGhBggVcDSFyECTABJsAEmAATKM4EeGxMIH8CLPDmz4evMgEmwASYABNgAkyACZRwAizwlvAbyMPXnACXZAJMgAkwASbABMomARZ4y+Z951kzASbABJhA2SXAM2cCZY4AC7xl7pbzhJkAE2ACTIAJMAEmULYIsMBbtu635rPlkkyACTABJsAEmAATKCUEWOAtJTeSp8EEmAATYAL6IcCtMgEmUPIJsMBb8u8hz4AJMAEmwASYABNgAkwgHwIs8OYDR/NLXJIJMAEmwASYABNgAkyguBJggbe43hkeFxNgAkygJBLgMTMBJsAEiiEBFniL4U3hITEBJsAEmAATYAJMgAnojoAxBF7djZ5bYgJMgAkwASbABJgAE2ACBRBggbcAQHyZCTABJqA/AtwyE2ACTIAJGIIAC7yGoMx9MAEmwASYABNgAkyACeRNQM9XWODVM2BungkwASbABJgAE2ACTMC4BFjgNS5/7p0JMAHNCXBJJsAEmAATYAJaEWCBVytsXIkJMAEmwASYABNgAsYiwP0WlgALvIUlxuWZABNgAkyACTABJsAEShQBFnhL1O3iwTIBzQlwSSbABJgAE2ACTEBJgAVeJQeOmQATYAJMgAkwgdJJgGfFBMACLz8ETIAJMAEmwASYABNgAqWaAAu8pfr28uQ0JsAFmQATYAJMgAkwgVJLgAXeUntreWJMgAkwASbABApPgGswgdJIgAXe0nhXeU5MgAkwASbABJgAE2ACKgIs8KpQcEJzAlySCTABJsAEmAATYAIlhwALvCXnXvFImQATYAJMoLgR4PEwASZQIgiwwFsibhMPkgkwASbABJgAE2ACTEBbAizwaktO83pckgkwASbABJgAE2ACTMCIBFjgNSJ87poJMAEmULYI8GyZABNgAsYhwAKvcbhzr0yACTABJsAEmAATYAIGIlDsBF4DzZu7YQJMgAkwASbABJgAEygjBFjgLSM3mqfJBJhAiSPAA2YCTIAJMAEdEWCBV0cguRkmwASYABNgAkyACTABfRAoepss8BadIbfABJgAE2ACTIAJMAEmUIwJsMBbjG8OD40JMAHNCXBJJsAEmAATYAJ5EWCBNy8yGuabm1sga4iLi8dbbw3Jlpf1Oqez8yoKj4yMDHGXitIG19XkfpgjJSWFn+kcf+v6eHb4mdbkedRNGX6mdcOxoL8DYzzT4oNBg+jhwxiU0lAm5qXBLc5WhAXebDj4hAkwASbABJgAEygrBCpVcgWHksdAm+eTBV5tqHEdJlDSCfD4mQATYAJMgAmUIQIs8Jahm81TZQJMgAkwASbABLIT4LOyQYAF3rJxn3mWTIAJMAEmwASYABMoswRY4C2zt54nrjkBLskEmAATYAJMgAmUZAIs8Jbku8djZwJMgAkwASZgSALcFxMooQRY4C2hN46HzQSYABNgAkyACTABJqAZARZ4NePEpTQnwCWZABNgAkyACTABJlCsCLDAW6xuBw+GCTABJsAESg8BngkTYALFhQALvMXlTvA4mAATYAJMgAkwASbABPRCgAVevWDVvFEuyQSYABNgAkyACTCBvAgsWbEBI8fNxO79x/Iqojb/ho8fxk9boPZaYTL97gXj2KkL+Va5csMX738yA617Dsb+w6eyle3e/3207P6GCB37DMt2zZAnLPAakjb3xQSYABNgAnkR4HwmUGIJnDl/GT8u/wWbt+7Aw0exOptHWEQULl3zweofZqNPr046a7cwDQUEhuDUuSv5VrGytMTYd99A1w6tcpUzNTXB+YNbRDi++7dc1w2VwQKvoUhzP0yACTABJsAEmECpI/DRxC/Ro+8QTJ39LUZ+PAUNW/dGQGBwkeeZlp6Oz2d/j6D7YULDu3jZr9i0dZdod/Gy9Rg9YbZIn714DVPnLBFpEkzffH8S3vt4BnbuOyzy8ormLV6JWQuWYeykOVi5/k/EPIrFF199j8EjP8O7H00DaYip7tqN23H05HkxhpzaW7pOoW7tGmjRtAFIuKVzTcJrwz7FYmlOQ8dMwVujJuOufxA+/GwuKP+fPYc0aaJQZUqWwFuoqXFhJsAEmAATYAJMgAloTsD/XhC+XrRM4zB19kKs37QtWwePnzzF+x9M1rgN6o80w9kakU5MTUww+/MPUduzutDwdu/cGldv3pauALdu+yMpKRmpaWm4euM2mjT0EumvFi7HtImjsPbHrxD14KEom1+UlJyCZQunYfTw17FkxUapHW9sXv0tZkn9zvh6qaj6/tsD0Ll9SzGGXl3bibzCROmS4N7xpaEYOHw8duzNLoTXrlkNG1bMR+vmjSTh+2fMnzke65fNw5rfton5FKafgsqywFsQIb7OBJgAEyiGBHhITIAJ6J6A/73gQgmqS37+Re0gzl28Wqh2/vxLqblV21hmZgPv2rh+8w6SkpNhYWGBhvXqwEcSfEngbda4HkLDIlHRyUHkKxQKDOjXM7Nm3ofO7VrARBKsqcSlq7ew//BJkL3wXEn7++DhI0RrIDRT3fwCCdCHd67HmHffwE9rfgfZ+8rl27dpKpIN69VGTY8qsCtni/J25aR5OCIqOkZc01XEAq+uSHI7BiWQJn2r9bntB7+AIGRkZBi0b+6MCTABJsAESicBzxrVMHXShxqHj0e/oxZE21bNNG6D+nv9tZfVtpM108zUFNWqumHn3iOSJrYuGjfwwsUrtxAcEo5a0riprKlUho4UzEzN6JBvMDfPXmbx3MlCk0s2w2Rv61yxQr71NblIbdDYe3Rug97dOqhMJaiuuZmyfxK6zTLTlE/nKSmplNQkaFSGBV6NMHGh4kTgyPEzqNOkK9r1GIgWnfqhcdsXpW+5fsVpiDwWJsAEmAATKIEEPGtUL5SgOv+rKRg+ZGC2mdqXt8Oqpd8Uqp3Bg/playOvExJyN27dicb1vdC0UV38s+egMHmg8u5uLoh5GItHsU/oFGTbKxIaRq1bNMLPa/9QKZHOX74hatpYW+Hx0ziRLmwUn/AMZItM9WKfPMUFqc0G3rXo1OCBBV6DI+cOi0pg0rR5iIiKVjVDNlczv/5edc4JJpCLAGcwASbABPRE4KfFX+HAzk34euZnWL10Pq6f/Vd6PV9NL72RoBsR+UAIu06ODlAoTNCkQV3RF2lRp08aDbK9/WjyPPEGVFzQMPp41BAkJyfjrZGT8eLrY7B9x3+iZvMm9ZCelg5qM69Fa6fPXxFux+j6tLlL0KXvcFH3vqR9btd7iLg2ZvxsvDWwj2q8ooABIxZ4DQibuyo6gbj4BNy+G5CroWs3fHPlcQYTYAJMwFAEaGHOH9t24t2xkzDk/U+xev1mSXhIMVT33I+RCbRp2RSfjH0XpKmtIAmiuhoO2bWu/kHpjYHabN+6Kc78txmWFtwAo0QAABAASURBVBZ0ir83LMGwN59rh9u0aIyfFk4TYemCafh+3ueiXNZITk+bOBrdO7WRT+EgaaZpsdrmNd9i758rQAvI6KK1lRUWzJog2sxr0Vrblk2E2zHZ/diRneupKurWqYmz0ngp/4+1i9D3hS4in6K/flsi7HUp3aV9S8ycPJaSIqxbOgfVq7qJtK4iFnh1RZLbMQgBaytL2NpY5+qL/lBzZXIGE2ACTMBABL77aQ3e/3Ay/vxrN/7ZtR/jPv8KE6fNNVDv3A0TYAIFETApqABfZwLFiQAZ5A96rU+uIQ189aVceZyhLQGuxwSYQGEJbPt7T64q6vJyFeIMJqBnAhu27MCo8bOyBcrTpluqp6u2tOm/KHVY4C0KPa5rFAKL501Hq+aNhWE9eWgY+uZrmPDRCKOMhTtlAkyACRCBoPuhdMgWnjyNy7beINtFPikZBErBKIe+0Q+rvp+VLVCeNlOjerpqS5v+i1KHBd6i0OO6RiFgYWEuHG4rFAooFAqUK2cDcmFilMFwp0yACTABiUDH9rm3VPX2qgXXSs7SVf5lAkzA2ARY4DX2HeD+C02AFofc9L2rqud7x1+VNkKCu2QCTIAJYPbU8XCr7KIi4Whvj0XzpqnOOcEEmIBxCbDAa1z+3LsWBEjYTU197pCaBV4tIHIVJsAEdEqAtLlTJ32oMrWaMeVjdOnYRqd9FP/GeIRMoPgSYIG3+N4bHlkeBK7fVLog6929kygRHhEFclcmTjhiAkyACRiJgH9AkDCzUigUCAuPMtIouFsmwATUEWCBVx0VztMbAV00LPvcbdKoHkirQm3evHWHDhyYABNgAkYjcDcgUNV3aHiEKs0JJsAEjE+gVAm8D2Ie4aPJX+O9j7/E1DlL8CwxUS3hqzduY/hHMzB07FSs2bBdVSa/+jd9/USdDi8Ow0tvfKDaKk9VmRMGI3Dtho/oq2G9OvCqXVOkfe74iSNHTIAJMAFjESANr9x3aFiBAq9clI9MgAkYgECpEniXrNwE2mVk3dKvUL68HTZtze0XkdxYffnNMkz+eDh++WkODh0/h8vXlAJUXvXjE55h/LRv0a93Zxz4Zw2WL5oBE+mVlQHuD3ehhsCVa7dEbn1vL9St4ynSbMcrMHDEBJiAEQn43wtS9R4aFqlKc4IJMAHjEyhVAu/Js1fQp1dHQbVPz444cfaySGeNbvsFwsbGGvW8PEH7TtM2ecfPXBJF8qp/9NQFeNepidf69oCVpQWqV60s7LREJX1G3HYuAvdDwvD4yVPYS19oPKq7qwTe2+ypIRcrzmACTMBwBEJCw5GcnAK7crai07AIFngFCI6KTGDJig0YOW4mdu8/Vqi2bvj4Scq6BYWqo66w371gHJPkIHXX5LzN2/egZfc3VGH95n/kS8XmWGoEXtLCktLV0aG8gFvV3QXRDx6KdNYoMvoh3F2f+0WkcpFRMcivflh4tGhi8IjPhDnDb1t2inOKUlKSkTPklZ+zHJ/nZlcQk0tXbhBe1Peug9TUFHjWqCrOb932y3UfCmqLr2vOPy0tlfmq+VvX9TNEzzQFXbdbGtrT9Rx0/Uz7ZppVNW5YD9bWVnj2LFH6DHpQ5v9u6HmmoOv7l1974kPBwFHCAx/E3P4bj4MOIy35qc56D4uIwiXpLfTqH2ZLCr1OOmu3MA0FBIbg1LkrBVYZOWwgzh/cIsLwwf0LLG/oAqVG4CVwWTcfUCjynprCREHFM8PzcnnVz8hIR3hkFObPnIDffp6Hoycv4OKVm5n1+WBIAtcyPTQ0rF9HdFunlgfovpF2hT01CCQcMQEmYAQCAZIWjLr1rFEN1apUpiTYrEFgKPVR+IWlCDw0GZFX1yH07He4u3skkuPCizzvtPR0fD77ewTdDxMa3sXLfsWmrbtEu4uXrcfoCbNF+uzFa2LdEp2QYPrm+5Pw3sczsHPfYcrKM8xbvBKzFizD2ElzsHL9n4h5FIsvvvoeg0d+hnc/mgbSEFPltRu3S3LPeTGG/YdPUZbGgdZGDRw+HlOkeQzKPF68egu0PfFrwz6Fz50AjdsqakGTojZQXOrb2lgjLS0dySkpYkh045wrVhDprJGLcwU8in2qynoo3WCXSk6wtcm7vlMFB3jX8RSmDBWdHNGwXi3c9g8WbZibWyBnoAs58/g8NydtmJAPXuLbpFEDmJmZw9LSCrVqVqcsBNy7n+teaNMH18l9r0xNzZitmr91XT8r9ExT0HW73J7+n+l7waHi/1DtWjXg7qYUeCOjY8r83w09zxQM+QyKG6FllBwXhuibv2scIiUh91HA/my9pafES4LvYo3boP5IM5ytEenE1MQEsz//ELU9q4M0vN07t8bVm7elK8Ct2/5ix9HUtDTQQvwmDb1A6a8WLse0iaOw9sevEKXmLbeonCVKSk7BsoXTMHr461iyYiOaNPTG5tXfYpbU74yvl4qS7789AJ3btxRjIDNQkakm2vjnLnTsMwwTZ3ybrW/SUo9593VsXrsIDx4+wp7/jmH54i+lcY7Gz2s3q2lJP1mlRuAlPO1aNcGBI6cpCfoW0qF1E5Emc4UbPndF2quWB+gbx/3QCOFp4eDRs+jQppm4llf9jtL1O/6BwtdrUnIyrt/yQ93aHqIOR4YlIHtoaNSgrqrjunVqibQP2/EKDhwxATACgxO4639P9Fm7pgfcM3dcC2VPDYJJSYqSn4ZLgupmjUOM719qp/cs5rbGbUTf3IzHQUfUtpM1s4F3bVy/eQckh1hYWEjKtzrwkQRfEnibNa4n3ihUdHIQ+QqFAgP69cxaXW26c7sW4i0pXbwkaV73Hz4JsheeK2l/SThVZxpKZXOG3t3a49D/1gphubxdOcxe8LOqiJtrJXhUcxfrpurWroEGdWvB1MREGmdtBEraa1VBPSdKlcA7bswQ7Pz3mKTK/xLB98MxZFAfgS9EEm7nLFop0gqFArOnfIAZX/+E4R9OR/Om9dCskbe4lld90hQPff1ljBw3GyM+nYXunduo6oiKHBmEQELCMwRJWhSFQoH6dWur+vT28hRp39t+4sgRE2ACTMDQBPwkpQj1WbNGNUnD60pJhIXzwjUBogRFFnaV4Vx/sMahgtcramdnU9Fb4zaoP/vqXdS2kzWTFtpXq+qGnXuPSJrYumjcwAsXr9xCcEg4aknPHZU1NTWlgwhm0ps5kcgnMjc3y3Z18dzJQpO7+ofZOL77N5D8k61AHicVHO2lt65mqOLmgokfviM00HJRc7PnfZAJotwnpVNT0+RiejvKDZvIidJwrOjkiOWLpmPd0q/w9YxPYW1lJablJX2j2CKp0sWJFNFDsn7ZXGxY/jVGDh0g5Sh/86pPV1/q2Un65rJA1HlrwIuUxcHABC5dvSF6rC99yzU3NxdpimQNry9reAkHBybABAxMIE16reyvsuGtLml4lQIva3gNfCN00J1FOTdJUH1L4+DaZCQca/bK1rOJuS3cWo3XuA3n+m/BvnrXbG3kdULyy8atO9G4vheaNqqLf/YcFCYPVN5dEjZjHsbiUewTOgXZ9oqEhlHrFo3w89o/kJGRIWqcv6z8zLWxtsLjp3EiL68o6xqaA9KbdvKElVdZY+WXKoHXWBC5X8MQkHdYa1RfqZGXe62bqeH1yVwlLefzkQloRoBLMYGiEQgOCUN6ejqquFeGpaUF3CTBg1oMZV+8hKHUh8otPoZHt4Vwafwe3FtPQO0+q2FRrrJe5k2CbkTkAyHsOjk6QKEwQZNMEz/SAE+fNFp6g70UH02eB7+AoEKN4eNRQ5CcnIy3Rk7Gi6+PwfYd/4n6zZvUQ3paumiTzEVFZo6ITBjILVnnl98Rgvaszz/IUcL4pyzwGv8e8Ag0JKDOfpeq1s3cbS0wKET8sVIeBybABJiAoQjIgoW8gNbdLVPDy9sLG+oWGL0fMmFw8npVaGpNLex0Np6aHlWEiYHcYPvWTXHmv82wtLAQWX9vWIJhb/YTaYratGiMnxZOE2Hpgmn4ft7nlK02TJs4Gt07tVFdcyhvh1mff4jNa77F3j9XYP7M8eIavS1fMGuCaDOvRWvffjUJ5JLs6K5f8c2XknY702kAvTmn9kRDUjThg3fwcm+l+QYJ6NSPlG2QXxZ4DYKZO9EFAZWGt0F2Da+F9Idf06Oa6OIW2/EKDhwxASZgOAL+mZo0z0yPMW6uLqJztuEVGDhiAsWCAAu8xeI28CAKIkCvC2WXZI0bZhd4qa5s1uB7259OOeiPALfMBJhADgJZPTTQJXJlSYuHnjyNAy22pTwOTMBYBDZs2YFR42dlC5SnzXionq7a0qb/otRhgbco9LiuwQiQsJuamips5BzslbvpZe3cO9M1mS/b8WbFwmkmwAQMQEDW8Naq+dxdZfWq7qLn+6FF34BANMRRMSRQMoY09I1+WPX9rGyB8rQZPdXTVVva9F+UOizwFoUe1zUYgbzsd+UByBpeH/bUICPhIxNgAgYiINvwyiYN1K3Kjpd98RIODkzA6ARY4DX6LeABaEJAtt9tnMN+V66r0vAWM5MGeXx8ZAJMoHQSIJdkQfdDQT5FPTN9odJMyUUUHUPZFy9h4MAEjE6ABV6j3wIegCYECtLwkm9eaicgMJg9NRAIDkyACRiEQEDgfeGSjDYEILtduVP3ypmeGljDKyPhIxMwKgEWeI2KnzvXlMDV6z6iaE4fvCJTishTQ7Wq7uKD545foJTDv0yACTAB/RPwC1D+v6lVo3q2zp5reCOy5fMJE2ACxiHAAq9xuHOv6gjkkXc/JAyPnzyFtbUVPKpXyaMU4F3HU1zjhWsCA0dMgAkYgIBqwZrn8wVr1K2s4Q3jzScIBwcmYHQCLPAa/RbwAAoiINvvNmvcIN+i8sI1X164li8nvsgEmIDuCNz1z9TwZvHQQK27VS6aL15qgwMTYAK6I8ACr+5Yckt6InD1RqY5Q+b2iXl1UzfTNZkPbz6RFyLOZwJMQMcE/O8pt2/N6qGBulBtL8y7rREODkzA6ARY4DX6LdB2AGWn3rWbvmKyjfLw0CAuStFzkwZ/6Yx/mQATYAL6J+CXuctarcxd1uQeXZwrghaxxTyMBfkQl/P5yAQKS2DJig0YOW4mdu8/VqiqN3z8MH7agkLVUVfY714wjp26oO5Strx/dh9E/7c/Rsvub+DzWd+prl257ouhY7/AW6MmY9WvW1X5hk6wwGto4txfoQkU5KFBbtC7bi2RvON3D+QqSJxwxASYQOknYKQZJiUlg9YYkEsyeaMJeSgKhQKyWUNwSJiczcdSSiAu8CrCj23Eg0t7kJrwWGezDIuIwqVrPlj9w2z06dVJZ+0WpqGAwBCcOncl3ypXbvhi2do/MGXcSJz9bzPGvv+mKJ+RkYFpc5dgyqfv47fl3+DgsTO4dPWWuGboiAVeQxPn/gpFgLblDAoOhUKhQP26tfOtW87WVnzApKenQ7ary7cCX2QCTIAJFIFAQGCwqF3To5rQ5op0C4P4AAAQAElEQVSTLJF7ph1vKC9cy0Kl9CXvbZ+HW8tH4P7uJQjYMhNXF/RHUkxIkSeaJn2WfT77ewTdDxMa3sXLfsWmrbtEu4uXrcfoCbNF+uzFa5g6Z4lIk2D65vuT8N7HM7Bz32GRl1c0b/FKzFqwDGMnzcHK9X8i5lEsvvjqewwe+Rne/WgaSENMdddu3I6jJ8+LMew/fIqycoUdew9j8IAX0aZFI+GT2qOqmyjje/cebG1tpM/vWjAzNUXvbu1x7PRFce21YZ9isTSnoWOmCO3vXf8gfPjZXFD+P3sOiTK6jMqKwKtLZtyWAQlcunpD9EZ+ds3NzUU6v0jegOL2XTZryI8TX2MCTKDoBGQPDbVzeGiQW+bd1mQSJeeY+OA+Qv9bpXEI3vUDos/9k22CaYlx8N88Q+M2qD/SDGdrRDoxNTHB7M8/RG3P6kLD271za1y9eVu6Aty67Q96w5CaloarN26jSUMvUPqrhcsxbeIorP3xK0Q9eCjK5hclJadg2cJpGD38dSxZsVFqxxubV3+LWVK/M75eKqq+//YAdG7fUoyhV9d2Ii9nFB4RLSmagtDz1REY9O4ElUY4MjoG7q6VVMWrursiMuqB6rx2zWrYsGI+WjdvJAnfP2P+zPFYv2we1vy2TcxHVVAHCRZ4dQCRm9AfAdlDQ6P63hp1UtfLU5Tzkf4ZiARHTIAJ5CDAp7oicDfTB2/OBWty+yqBNzxCzuJjMSeQFCMJvAdWI1TDEHF8o9oZxQVf17gN6ivmyj617WTNbOBdG9dv3kFScjLI93zDenVAn3Uk8DZrXA/0JqGikwMoX6FQYEC/nlmrq013btdCaGTpIpka7D98Umhy50ra3wcPHyFaA6GZ6pI2mo7bfv0Bs6d8CBK84+ITKAsKE4U4UqRQZBc727dpStnSmGujpkcV2JWzRXm7cqjo5IgoSVgWF3UUZe9ZR41yM0xAVwQ0td+V+6ur8sXLGl6ZCR+ZABPQDwFZw5tzwZrcG5s0yCRKztHSqSrce4zUOLh2GKx2cuU8GmvcBvXn1OQFte1kzSSTgGpV3bBz7xE0aVgXjRt44eKVWwgOCUetzG2taaGkXMfM1ExO5nk0N89eZvHcyUKTSzbDx3f/BueKFfKsm/VCxQqOaNWsIezLl0M9L09JYHVASFgkXJyd8Cj2iaooLeJ0qVRRdW5upuyf7ODNMtN0kc5TUlIpqbOgVuDVWevcEBMoIgGVhrcADw1yN95etUTSl12TCQ4cMQEmoD8CsocGzxy7rMk9yovWwiIi5Sw+FnMCVhUlgbfnKLhrGKr1nQjnVv2zzcrUqhw835itcRvUV8VmL2VrI68TEnI3bt2JxvW90LRRXfyz56AweaDytLsfCZSygEm2vZSvaWjdohF+XvsHaKEZ1Tl/WWlSaGNthcdP4ygrz9CpXXNcvHpL7HYaEfkA0TGPUMXNBXVr1wBpie+HRoC0wAeOnEbHts3zbEefF1jg1SddbrtIBGjx2U3fu6KNxg29xbGgqKH0T4DK+N4NoAMHJlBUAlyfCeRJwC8gUFyrVdNDHHNG8m5roWFs0pCTTWk6rzFgGuqNXYOqfT5FTUnQbfz5P7B0yntX0KLMnQRdEihJ2HVydIBCYYImmT7qSQM8fdJokO3tR5PnwS/TZZ6m/X08agiSk5Px1sjJePH1Mdi+4z9RtXmTekhPSwe1mdeiNVqM5uhgjyGjP8fkWYsxe8pHKGdrA4VCgbnTPsHUOT+AFqe1aNYAzRvXE+0aOmKB19DEuT+NCZCwS/4rq7hXhoN9eY3qlbO1lV6hVERKSgr8Mx3Cg3+YABNgAjomQAuGwiOiYGFhDnrNrK550rhRPm8vTBRKdyAThsqd3gZpas1s7HU2WbJrXf2D0hsDNdq+dVOc+W8zLC0s6BR/b1iCYW/2E2mK2rRojJ8WThNh6YJp+H7e55StNkybOBrdO7VRXXMobwdarLZ5zbfY++cKsYCMLlpbWWHBrAn4aeE05LVoTaFQYOKH74gFb+R+rI2kLaa6FMj8YsOK+fh91UKMfmcQZYnw129LhL0unXRp3xIzJ4+lpAjrls5B9apuIq2riAVeXZHkdnROoLD2u/IA5IVrvrxwTUbCRybABHRM4I7/PdFiXuYMdNHdzZUOiIiKBn15FyccMQEmYBQCLPAaBTt3qgkB2X63sYb2u3Kbqi2G7/jJWXw0EAHuhgmUFQLygrW8PDQQB4VCAVcXZ0qCtMEiwRETMDCBDVt2YNT4WdkC5WkzDKqnq7a06b8odVjgLQo9rqtXAtpqeL29lK7JfO+wpwa93iBunAmUYQJ3/TPtd/NYsCajkbW8oeGRchYfywaBYjPLoW/0w6rvZ2ULlKfNAKmertrSpv+i1GGBtyj0uK5eCVy97iPa19QHrygsRbKGl00aJBj8ywSYgF4I+GcuWMtPw0sd88I1osCBCRifAAu8xr8HPAI1BGh/+sdPnsLa2goe1Qu32lX2xXvD546alotRFg+FCTCBEktAXgGfl4cGeWLywjX21CAT4SMTMA4BFniNw517LYCAbL/brHGDAkrmvkyOsis42gtPDUHBobkLcA4TYAJMoIgEZC8wtWpWz7cl2aQhLCIq33Jl/SLPnwnomwALvPomzO1rReDqjUxzhkz/goVtxNurtqjiwwvXBAeOmAAT0B2Bp3HxYttTCwtzyJtL5NW6m6uLuMQaXoGBIyZgNAIs8BoNPXecH4FrN33F5UYqDw3iVONI5ZqMF65pzIwLMgEmoBkBv0z7Xa9aNQusoDJpCOfNJwqExQWYgB4JsMCrR7jctPYEtPXQIPfoXYe3GJZZ8JEJMAHdEvDL9NBQ0II16lU2aQgN06GXBmqYAxNgAoUiwAJvoXBxYUMQSEh4BrK9VSgUqF9XaZpQ2H7lhWs+rOEtLDouzwSYQAEE/DK3bC1owRo1U9W9Mh2EH96MjAyR5ogJMAHDE2CB1/DMDdFjie7j0tUbYvz1vWvD3NxcpAsbeXspNbw+vrz5RGHZcXkmwATyJyAvWNNEw2tmZoaKTo5IS0tDZNSD/BvmqwYnEBUVAQ4lj4E2DwoLvNpQ4zp6JSB7aCis/92sg6LdjWxtbBCfkIDQMLady8qG00ygbBHQ/Wyfa3jz99Ag98y+eGUSxetYoYITOJRcBoV9mljgLSwxLq93AkW135UH2KB+HZFkswaBgSMmwAR0RMC/ECYN1KWbW6anBl64Rjg4MAGjEChVAu+DmEf4aPLXeO/jLzF1zhI8S0xUC/XqjdsY/tEMDB07FWs2bIdcqKD6j2KfoNsrI7B83Ra5Ch/1QECl4dXSQ4M8JF64JpPgIxNgAroiQC7JHj6KRTlbG1RydtKo2eca3kiNynMhJsAEdE+gVAm8S1ZuQpsWjbFu6VcoX94Om7buyUWMFg18+c0yTP54OH75aQ4OHT+Hy9eUPl8Lqr942W9o1rguoAD/6IlAeno6bvreFa03bugtjtpG8sI1X164pi1Crlf2CPCMCyBwO/P/SW3PGgWUfH5Z9tUbFs4C73MqnGIChiVQqgTek2evoE+vjoJgn54dceLsZZHOGt32C4SNjTXqeXnCzNQUvbq2w/Ezl0SR/OqTVtja2lLpNYAX2gpe+ohI2E1NTUUV98pwsC9fpC7qygvXbvsVqR2uzASYABOQCdwthEsyuY7KNRmbNMhI+MgEDE6g8AKvwYeoWYfxCc+gkDSvjg5KIamquwuiHzzMVTky+iHcXZ1V+VQuMioG+dUnAWzp6s34eORgVT1O6IeArux3aXTedTzpgOs3b4sjR0yACTCBohKQPTTUqqnZgjXqz71ypg0v++IlHByYgFEIlBqBl+iZmDyfjkLxPE3XsgaFiSQZqzKel8urPplGvNa3O8rblVPVkhOJic+QM9C1nHl8npuTOiaXrmS6JKtbOxfXnOWTk5NAIWe+fF7RyQG2NtbSl5kEBAYHF9ieXI+Pue9VSkoK81Pzt67rZ4WeZwq6bpfb090zfftuAP2LR7WqlTX+m6D/RVQpJDRc4zql5Z7R80zBkPMh1hyYQE4Cz6W9nFdK2DkJNmlp6UiWPphp6DGPYuFcsQIlswUX5wp4FPtUlUeLD1wqOQnBKK/6ZBox59uVaNv7baz6dSt+27ITP6zYINogP7E5A13Imcfn5sKnbkEcbvrcIXxo0si7wPKmpmYwNTXNt5y8xXDAvfv5litoXGX9uqmpCfMz1+wZLsqzYqrBM12U9rnu83uo7TN9LygY9ONVy1PjvwmP6lWoCu5LAm9ZuwfGeKYFbI4MTaDY91dqBF4i3a5VExw4cpqS2H/4FDq0biLSZK5ww0e5EMqrlgfIG8P90Aikpafj4NGz6NCmmSiXV/3VP8zE6X83ijDqnUEY9kZfjBszVNRR/jGT4PU80AV1+Zz3nFFeLGQPDU0aNoCp+PDPr44pTAso411HuVPbHb9AmBZQlq/nzdrEpGDWzC9vfpqzYc6asyoab22f6bvS/xL6H1+ndk2Yavg/xa6cHezL24nNJx5JChdN65WOcoZ/pun+cGACOQmY5MwoyefjxgzBzn+PCbdkwffDMWRQHzGdEEm4nbNopUgrFArMnvIBZnz9E4Z/OB3Nm9ZDM0mbSBfzqk/XOOifwP2QMDx+8hTW1laQNSJF7VXW8PrwwrWioix6fW6BCZRwArQuJC4+Qbgkq+DoUKjZ8MK1QuHiwkxA5wRMdN6iERus6OSI5YumC7dkX8/4FNZWVmI0XrVrYMvaRSJNUeMGXli/bC42LP8aI4cOoCwR8qovLmZG7771Csa+90bmGR90SUDW7jZr3EBnzbJrMp2h5IaYQJknIC9Ykz3AFAaIvHAtjBeuFQZbqS3LEzM8gVIl8BoeH/eoSwJXb/iI5ho1qCuOuoi869QSzfje8RNHjpgAE2AC2hKQXZIVxkOD3Bf74pVJ8JEJGIcAC7zG4c69qiFw7aavyG1UxB3WRCOZEZlG0CIRstuOeRibmVsSDjxGJsAEihsB/4BAMSTPGpq7JBMVpIhNGiQI/MsEjEiABV4jwueusxO4pgcNL/VQv65y4ZrPbeXCRcrjwASYABMoLAG/gCBRpbanhzgWJpI1vKFs0lAYbMqyHDMBHRBggVcHELmJohNISHiGoOBQKBQK5W52RW9S1YK8cM03c0tQ1QVOMAEmwAQKQcA/U+CtVbPwAi9reAsBmosyAT0QYIFXD1C5ycITuHQ1c8MJ79rCt2UhW8i3eF2VHa9/vuX4IhNgAkwgPwK+d5X/Q2ppoeF1r+wqmg4NixBHjpgAEzAsARZ4Dcube8uDgOyhoVF97zxKaJ8tbzHMGl7tGXJNJlDWCURERiM5OUVsaGRXzrbQONzdXESd+6Hh4qi/iFtmAkxAHQEWeNVR4TyDE9CX/S5NRDZpYF+8RIMDE2AC2hCQPTRos2CN+nOwLw/yMf7sWaLwN055HJgAEzAcARZ4Dce62PRUHAeiqZ+1jwAAEABJREFU0vDq0EODPM8a1asKMwnS0MTFx8vZfGQCTIAJaEzAL9NDgzb2u3InVdzYrEFmwUcmYGgCLPAamjj3l4tAeno6bvoqPSg0bqh7kwZTU1PQ5iPU8c1byn4ozYEJMIEyT0BjAKoFa1rY78qdyJ4awiKi5Cw+MgEmYCACLPAaCDR3kzcBEnZTU1NRxb0y6LVf3iW1vyIvXPPhDSi0h8g1mUAZJuB3T+mSTJtNJ2RsvHBNJsFHJmB4AizwFsScr+udgD7td+XB163jKZK8cE1g4IgJMIFCEpA1vJ41qxey5vPi7pkL18qCp4b7IWEYOnI8ajXugrrNe+DDCTPw8BFv/vP8aeCUoQmwwGto4txfLgKy/W5jPdjvyp15e2VuMXybtxiWmfCRCRSWQFkuL9vwetWqqTUG2RdvWHik1m2UlIqfTp6Nv3bsQ8zDWND6ifWbtmHWNz+UlOHzOEshARZ4S+FNLWlTkjW8TRrW09vQVQLv3QC99cENMwEmUDoJkEaWXJKRDa6lpYXWkySzLapM7dGxtIa0tDScOH0h1/T2HzyeK48zmIChCOhY4DXUsLmf0kTg6nUfMZ1GetTwetVWamXoNVtcfILojyMmwASYgCYEiuqSTO6jsmslkQwvA4vWTEwUYq4cMYHiQoAF3uJyJ8roOEgAffzkqfBPWa2qm14pyHa8t3mLYb1y5sYzCfCh1BCQzRmKsmCNYMiL1kr75hPkGadd6+Y05WyhV/eO2c75hAkYkgALvIakzX3lIiDb7zZr3CDXNV1nyAKvDwu8ukbL7TGBUk3AL0DpoaEoC9YIkHPFCiBhMPbxEyQkPKOsUhuWLJwJMgHJyMhAebtyGD5kIGZ9Ma7Uzpcnlj+B4nCVBd7icBfK8Biu3pDNGerqnYLKjpcXrumdNXfABEoTAb+AQDGdWjW099AgGpCiqlUqSzEQFlG6F65VreIG8rGuUCjw7z+/Ytl3c1DB0UHMnSMmYAwCLPAagzr3qSJw7aavSOvTfld0IEWyhpddk0kwit0vD4gJFF8CunBJJs/OzdVFJEPDIsWxtEZBwaHCO0M5WxvIyobSOleeV8kgYFSBd/Gy33JRmrNoVa48zii9BGQPDY0a6F/Dy5tPlN7niGfGBPRJwE82adCBhld2TRYaHqHPIRu97dPnLokxqLPlFRc4ypsAX9ELAaMKvHcz/4lkndkt37tZTzldigmQDRtpARQKBerXra33mdap5QETExMEBoUgOTlZ7/1xB0yACZR8AveC7otX8+RSrCguyWQS7pXLhob31LmLYsptWjURR46YgLEJGEXg3bHvCMZMnAO/gGBxpDSFdz6YhpoeVY3NhPs3EIFLV2+Inup714a5ublI6zOysLCQnq9qootbJduOV8yBIybABPRPQNbu1vb00ElnKg1vWOnW8J7J1PC2bsECr04eHG6kyASMIvA2a+SN999+Fa6VKoojpSl88+WnmDf9kyJPihsoGQRkDw2N6nsbbMB1vTxFX763/cWRIybABJhAfgT8M99EeurAnIH6UW0vXIpNGp7GxeOmz13hkaJV88Y0bT0GbpoJaEbAKAJvFTcXtGzaABtXfiOOlKbglumUW7Ohc6mSTsCQ9rsyK+86mQLvHT85i49MgAkwgTwJ+MkeGmoW3UMDdSL74g0rxYvWTp1VmjM0b9oQZmZmNG0OTMDoBIwi8MqzPnHmMkaOm42OL72Dtr3fVgX5Oh9LNwGVhlePO6wRwazh+cI11vBm5cJpJsAE1BOQNby1aurYpKEUa3hlc4a2rZqqh8q5TMAIBIwq8K7d+BcmffQOjuz6Baf/3agKRuDAXRqYAPlnvJm5QLFxQzZpMDB+7o4JMAENCfjJJg060vC6ujiLnqMfPERqaqpIGzAySFenz10W/bRt2UwcOWICxYGAUQVel0pO8KrlAVMTow4D/GN4AiTs0j97WvnsYF/eYAOo51VL9BUQGMyeGgQJjpgAE8iLQFpaGgKDQ4R3F88aygWveZXVNF+hUIgdyKh8afTFS//Xz128QtNDuzYtxJEjJlAcCBhV0nSq4IC/dh1AXHxCcWDBYyACBgrXDLjDWtYpkacGj+pVhJuhO37K3ZOyXuc0E2ACTEAmEBCodElWvao7TE1N5ewiH93dXEUbpdEX75Vrt5CUlAwyAaHPeDFRjphAMSBgVIH3r50H8O3S9ej52iiV/S7Z8hYDLjwEPROQ7XcbG9B+V56Sdx2llteXF67JSPjIBJiAGgJ+Ol6wJnfx3BdvhJxVao6nM92RtWvdDElP7iPWfy8e39uPlPjSN9dSc9PKyESMKvBmtdvNmi4j7Mv0NI2l4SXodVWeGnjhGvHgwASYgHoC8oI1Tx3Z78q9PNfwlr7thU9n2u/2a20Nv70fIPraGkReXoE7u0fhaegZGQEfmYDBCRhV4KXZJiUnw+dOACVLYOAha0vg6nUfUdWQPnhFh1JUN9OO14c3n5Bo8C8TYAJ5EfDLXLBGr+fzKqNNvuyaLLQUbj5x/NRZgaS65U3pmCGFzN+MdET7bM084QMTMDwBowq8p85dQf8hn2Lm/GVi5r5372Hc1AUizVHpJXA/JAyPnzyFtbUVyJ7W0DN97ouXNbyGZs/9lWICpXBq/veCxKx0r+F1Ee2GljJfvAGBwXj46DGa1nFARspTMcesUdKT+1lPOc0EDErAqALvT2s2Y/WSWajg6CAmXbd2DUQ/eCTSHJVeArL9brPGDYwySa86NUW/d/zugVZhixOOmAATYAI5CDzX8FbPcaVop89NGiKK1lAxq3353EHMHloJKz9ykkaWRbsrndGvZfmqdODABIxCwJACb64JmpuZoYqb8puufDEDuf9I5Gt8LB0ErhrJQ4NMr5ytLcgdGvkCvuvPnhpkLnxkAkzgOQH6Mhx8P1S4JCMvDc+vFD1V2kwa4iOvIOjoDNTN2I4XW9ohLcMUNhVJoaF4DkthAmfvQc/POcUEDEzAuAKvuZl4/SHP+dI1H5W2V87jY+kjcO2mr5hUIyN4aBAdSxGbNUgQ+NeIBLjr4k6A3gDRGMn/ri5dklGbbpUr0QHhEVHIyCihSp6MdDwOPgb//Z8i8Mh0xEVcRlxiBlbvfYjEGpNRo/sC1HrxZzg3GgGXpmNQp88q2Lm3EfPmiAkYg4BRBd5JHw3HV9+ugF9AMMZMmIP5P6zBJ6PeMgYH7tOABIzpoUGeJi9ck0nwkQkwAXUE/PW0YI36MpPeblZyptf+EEIv5ZWUkJGWhId3d+HO7pEIOb0QiY/8YW7jDMd67+Cl6fewbv8TNGveWkyHTBgcPF+EfY1eMLd1FXkcMYFcBAyUYVSBl2x2v5v7GWZ9/gEG9e+JzWu+RR3P6lpP/UHMI3w0+Wu89/GXmDpnCZ4lJqpt6+qN2xj+0QwMHTsVazZsV5XJq/5lSfM85asf0OPVkRjx6SwcPXVRVYcThSOQkPAMQcGhUCgUqF+3duEq67B0XXZNpkOa3BQTKH0E/O7pZ8GaTKqkmTWkJcch+ubvuL3jXYRfWoGU+EhY2ldHlTYTUeflNbga4YzE5Ay0btEEJNDL8+QjEyguBIwq8BIEExMTdGjTFN07tYGpSdGGs2TlJrRp0Rjrln6F8uXtsGnrHuoiW6DXR19+swyTPx6OX36ag0PHz4EEWiqUV30bayuQNvrf7Svxzpv9MG/xKirOQQsCl67eELXqe9eGubm5SBsjkjefuH3H3xjdc5+FI8ClmYDBCTzX8GqvhMlv0G5uLuJyaHikOBbXKCUhSgi4t3e8g6gbvyMt+QlsnOujeqeZqPXCMthX7wooTHH67CXQT9tWzejAgQkUOwJFkzC1nA7tpnb91l3QUV3QslmcPHsFfXp1FNX79OyIE2cvi3TW6LZfIGxsrFHPyxNmpqbo1bUdjp9R/qHmVd+rdg1UrOAAUxMTIZynpKTkqT3O2hencxOQPTQYw/9u1tHUr6fULvveDciazWkmwASYgCDgFxAojp419CPwFncNb9LjQNw/tQB3do0AmTBkpCXDzr0tavb8HjW6LUC5yi0FHzk6nbnDWlsWeGUkejpys9oSMIrAS7uqNZQEDjqqC9pMJl56Va5QAI4O5UX1qu4uiH7wUKSzRpHRD+Hu6qzKonKRUTHQtP7fuw6iVs3qsLayUrXBCc0JXDOyhwZ5pOVsbeHq4gz68iL72pSv8ZEJMAEm4Jdpw1vb00MvMNxVGl7juiaLvvUH7u4ZDZ/tA3Hv0BTE+P6NwCPT4LfvIzy5fxwKhQkca/ZC7T4rUa3DNFhXUCoLskJJTU3F2QtXRFaHdtkFYZHJERMoBgSMIvDK8/a/d18ImvJ5XHwC/APvy6eFPpJ5hFyJ/kjldM6jwkSSjFWZzxEUVP/azTvYtG0PvvxstKp2fHwcsoaEhHix6jZrHqefM7py7ZZgV6eWRzZu2jBKTHyGZ8+ead1OnVo1xFiuXL2hdRvajFvfdfTRfnJyEjPK8beuD85Ffab1MabS2mZ+z/TDhw8RFh4JCwtzVHAsr5dnn94a0j+goOBQvbSvyX2LursfUdc3IvlpKNJTE5EQfQMRV9cgPvIqTMysYe/ZF1W6/wT7eu8hRZE3hxOnzgmf5vQ/1USRkW0+xnimiSsHJpCTwHNpL+cVA5zPnP8zLLLYcZqbm2HmNz9r1bOtjbX0B5eO5JQUUT/mUSycK1YQ6ayRi3MFPIp9vgPMQ6mcSyUnFFSftMW0UcZPC79AVffnq01tbGyRNVhb20ChUGTLy3q9LKetrKzhk2kz26pF0yIzsrS0gpWkadeWaX3vOuLRCAgKKfJYtB1DSalnbm5RohgpFKa4fTcQT+ISStS4i/pMl5TnqTiMM79nOiQ8SvxvIHMGfY21hkd10Udk1AOjPaMpD2n7XzGMLJECDjV7o07f9XBvPgp2ju4Fju9y5lbx7du0yFXWGM90lslwkgmoCBhV4E1NSwUJufJoLC0skJScLJ8W+tiuVRMcOHJa1Nt/+BQ6tG4i0mSucMPnrkh7SZpF8sZwPzQCaenpOHj0LDq0URrZ51Wfyk+btxRTx49EZek1uGgoM1IoFFAosge6pFBkz1Mo+PzWbT+kSq++aNMHRwf7XNwUCsMyUi1cuxtg9LEoFIadu0JRevtbsXYTqtRtg469B6FWo854edB7eBoXz/e4FN9zhUK3z3PAvWD6Nw7aUlih0G3bCoWyPdmkISwi0mjPJjLSxTxzRg7Vu8DUwlbjcZ05f1k00bZ1M43rKBRKDgqF7o9iMBwxgRwEjCrwKhQKnL14TTWk0+evZtP4qi5omBg3Zgh2/nsM5JYs+H44hgzqI2qGSMLtnEUrRVqhUGD2lA8w4+ufMPzD6WjetB6aNfIW1/Kqv/V/+0GL7AaPnKxaaBchfSsXlTjSmEBxsd+VB1zXyxOQTnxv+0sx/5YGApHRD/DFrIVISnr+xfnI8TNYt+HP0jA9noOBCPgFKBes1bIpD5sAABAASURBVNLTgjWahke1KnQAfT6R9yBxYsAoPTUJ8TG+uXo0tSwP6wq1cuXnl3HqzAVxmResCQwcFVMCJsYc1/SJo7B42a8YM3GOCD+s2IBpE0dqPaSKTo5Yvmi6cEv29YxPIS8sIy8LW9YuUrXbuIEX1i+biw3Lv8bIoQNU+XnVH/veG8i5uM61UkVVPU5oRkD20NC0UX3NKui5lLeX8p+6zx0/PffEzRuKwFXp1SotRMzZ36UrSnd4OfP5nAmoIyBreGvpacEa9WlmZoYKjg5IS0sDvUWkPEOFtJRnCDwyDSlx4TAxt4J5OVeYmFnBxrkBqrWfJqWtNR4KfTl4+OgxKjk7oaZHNY3rcUEmYGgCJobuMGt/9evWEptNvN6/NyhsXr1QuAvLWobTpYeASsNbv26xmBR92NA/6cTEJATfDysWY+JBFI2ASx5fRPPKL1pvXLu0Erjrn6nhremh1ym6V5Z98RrOU4NS2J2KZ5J218y6Ajx7/4w6fdbAe8A21Og2X/jYLcykT59TmjOQ/W5h6nFZJmBoAkYVeGmypiYm6NaxlQhZvSTQNQ7FjUDRxiNreBs3VJqQFK013dSWtby+d/110yC3YlQCDbzrQN5FL+tAkqQvNVnPOc0E8iMga3j15ZJM7pvWM1A6LCySDnoPaSkJkmZ3KhIf3oW5jTNqdF8EC9tKRer3DPvfLRI/rmw4AkYReMmEgdyP0VFdMNz0uSdDEbgfEobYx09gbW2FqlXcDNVtgf3UqVVTlLnlq1zUKE44KrEETE1Nsejr6WL8tAj2hZ6dQfaRazf8iX8PHhP5HDGB/AiQ/XdEVLRwSUa+uvMsq4MLlV2VwmZIWLgOWsu/CSHsHvpcp8Iu9Xgy0363TcumdMqBCRRbAkYReN9/+1W4ODshLi4BlM4Zii0tHpjWBGTtbrPGDbRuQx8VvVUL19iOVx98jdHm6bMXRbcjhr+J7RtXYM6MieJ86IjxuON3T6Q50h2BlIQoJD7yR0Z6qu4aNWJLt24rv/x6ZX4Z1udQ3GSTBj1reNOS4xBIwm7sPZVm19zGqchTi3kYCzL/sLS0QHF6c1fkiXEDpZKAUQTen1ZvRjlbG5QrZ4OWTRvkCqWENE8jC4GrxWSHtSxDEsm6deSFa/7inKOST2DnngNiEi/16iqOEz8eiZdf6I74hAS8OngU4uLjRT5HRSOQmvgI/vvH4c7O96Tjp/D9ZwgeBx8tWqPFoLZ/5g5r5JJM38Nxd1P6dA8Nj9BbV2nJT3FPFnZtK6Fmj0WS0Ft0YZcGLJsztGreBGZmZpTFgQkUWwJGEXiTkpNx/vINkIaXjjlDsaXFA9OawLWbSvc3jRoUH/tdmozsmszHlzW8xKOkh4jIaNCzZlfOFh2zbHG6fsUi1KtbC4HBIXhb0vSSmUNJn6uxx//AZ6uk2X3+d5OeEo+wC8uAjDQ1Qys5WX6ZAq++7XeJiMoXb7h+bHhTkx7j3sHPkfQ4SBJynVGj27cws9aNsEvjP5X5NqVd62Z0yoEJFGsCRhF4X+rZCWs3/g3yZUvHnKFYEzPS4OgD2i8gEGRrSm5sjDQMrbtVeWhoUDw8NMgTcXGuCFsbG6H9Cw3Tn5ZF7o+P+iXw985/RQcv9e4KsucVJ1JkbW2Fv39fBUcHe/x36Dhmf/ODlMu/RSGQ8ED5JTZrG+kpCUh6qn971Kx96jr9XMOrXw8NNG43Vxc6IFQPJg1pSbEgM4akJ8GwKOeqU82uGLQUnT5/SYqBNq1Y4BUgOCrWBIwi8LZoUg8rFs9ArZrVxJHSWUOxJmaEwV2/dRuN274oQsvO/VCnSVecOH3eCCPRrsuEhGcICg4VO/DUr1tbu0b0WKtRphDuc4fNGvSI2SBN79yrNGcgE4acHdKK+D9/WwbyBvPtklWQy+Ysx+eaETCzdlRb0NzaQW1+Scn0uxckhlqrZnVx1GekL5OG1MRY3Ds0BUlPQiRhtzJqdF+oU80uMUlNTcWFS9fF/3XecIKIcCjuBIwi8C788ZfizqVYjW/WvO/hn/lPmAZGK4gnTZ1HyRIRLl1VOv2v710b5ubmxW7MKtdkt5+/ni12g+QBFUjgydM4HD91XjxjL/TorLZ8u9bNsXDOF+La8DGTcNPnrkgXs6hEDKe8e+tc47Ry8ICJeblc+SUpw89f6YPXU4+7rMk8ytuVE55rnj1LxKPYx3J2kY6piQ8lYffzTGHXTRJ2F8DMqkKR2lRX+fyla2LTDPq/TiZE6spwHhMoTgSMIvCmpKRi+botiIyKwapft+YKxQlQcRiLLDBmHctN37vin03WPO3SGYiPuo6Y23/hcfAxpEuvJLVrJ+9asoeGRvWLl/2uPGLZb6sva3hlJCXyuOffw0hPT0eXDq1hY2Od5xzGjngbb73+ChITk/DqW6Pw8FFsnmX5Qt4EEmNJMMyQhCl7WDt6SgUzkCppFjPSkqR0yfx9GhcvngdaVE2b0hhiFtUy3TTqwqwhJSEGAQc+Q/LTUJjbuuhN2CUusv1um5bN6JQDE9ATAd01axSBd8n8KaBvtrqbRuluyb68Xa4JKhQKREXH5MovbMb9k/MRePgLRFxZh5DTC3Fn1wikJEQVtpl8y8v2u00a1cu3nLEuyhpeH9bwGusW6KTfXfsOinb6vthDHPOLVi+dj6aN6yM0LAJDR47PryhfU0Mg6WkYYu7ukq4oUL3LN6jZawmsK3gJgTfq5hYpv2T+3s780lu7Vg2DTUA2awiPLNr/XRJ27x2chJT4SCHs1uyxSPoy4qi3eZzO3HCC3prorRNumAnokIBRBN6KFRwwZFAfvDukP0a9MyhX0OH8SkVTb7/5aq55kP1Usw59sHHLP7muaZqR/DQET0JOZiuelvwED/32ZMsr6oms4W1Qz6uoTemlvqzhvX7ztl7a50b1S4BaT05Oxr4DSpdYfV7oRlkFhm0blqOikyOOHD+Dz7+cX2B5LvCcQPjFn4GMdDh6vggr+2riQuUWH4kjvS1Kji+a8CYaMkLkl+mhoVZN/S9Yk6fnnumL935ImJxV6CPxFsJuQrRBhF0a4PGT5+gAtt8VGDgqAQSMIvDKXF7o3h7rNv2DmfOlf55SZkBgKA4ePSul+DcrgQkfjcDaZQvx+mt90P/lXvjy80/QvGlDPHkah9GffIH+g0chMvpB1ioapZOe3FdbLq98tYULyKRXzGR+QcWKq2Nycv5um+mpgeyjaawcShaBIyfOguwgSWvr6uKs0eCpHG1MQf5Df1r5K7b9o9svehoNogQWehp2FvGRV2BibgOXhkNVM7B2rAmHGj0kOTgVkVdWq/JLUkJeK2GIBWsyF1nDG6ala7LkuAjcOyBpdiVh17J8FdTssVivml0aN5l/xcUngP6GqlUtPjtn0tjKeODp50PAqALv7IUrEBH5AMEh4WKIbpWd8duWHSLN0XMCtKr8zYF98cvyRdi0dgk+nzAWR/duwTezJsPKylK4WWre4WVs2U6vGJ/XKyhlWb6q2iJ55astnE9m7OMn+H7ZWqSkpEqatApwsC+fT2njXqrnrfQe4XvbX68DCb4fhivXbyE5OUWv/ZS1xmVzBnXeGfJj0aJZI/z83RxRZOTHU3BVujfihCO1BDLSUxF+cYW4VqnBEJhaZv+bdmn0LkzMrPEk5DTio5SLVUXhEhL5BQSKkRpiwZroSIrcK7tKMYR5jUgUIhLC7qHJoIVqFnbu8OhGC9QcCtGCdkVlc4b2bVpo1wDXYgJGIGBihD5VXQYGhWLqhBGwtLQQeVbSMSW1dGxPKSakx4iE4E/GvotzR/4Hso2lFb7vffAZBg39ANEPHmrUs4VdFVjYumQvqzBBhVovZc/T4owEuwatJG303O+gUAAPYh4Wa1tJ7zq06AYgzYUW0y2wCtmKdug5EN4tuqN9jwHwqN8ef+3YV2A9nRcopQ3u2ntQzOzlF7qLY2GiIW/0x8jhg8WXkFffGq3x309h+igtZWPu/A8pkiaR/nc41Xkl17TMrOzhXH+wyA+/tFwcS1LkpzJpqG6wYVeuXEn0VVgNb/LTMNw7+BlSnz2EJWl2u0vCrqW9aEvf0Zlzl0UXbM4gMHBUQggYVeA1MzPNhonsUrNl8EmBBEgTcfK/7Zg1dbwou2f/YTRp9yL+t3u/OM8vSnoSjOR45WYLFeu+CnpFifQ0qHMon1876q6t+fWPXG52/pIEvDt+99QVN3qevHDt9t0AvYxl0Y+rcfnaTVXbj588xaeTZ4OfeRUSrROXrtxAZNQDVKvqjgb16mjVzg8LvgQtvqF2Br/7sVZtlPZKqYmPEXXjdzHNys1Gi+Pe/Ucw+pOpGDTsA/E2h7wcONXpJ3y/Jj0OwkOxsE0ULRGRn79Sw2vIRWvkH5rghEVE0UGjQP51Aw6SZvcRZM2uqaX+Nbvy4GQNb7s2zeWsEnnkQZctAkYVeBvV98KGP3chLi4B5y5dx6QvF6Nrx1Zl6w7oaLaffToKl07sRrMmDRD7+Aneeu9TkJ/R/FwuhV34WepdAfqAcmn8Pio1eBukjo289isyMtKh7c+FS9ewNQ97SHkVtLZt66teXa9aomnfO/rxxavOtRzdm9CwSNEvR9oT2P3vIVG530s9xFHbaPMvS0HCB32Y05cRbdsprfUir64DuRyzc2uFcq5NsfXv3Rg4dCw2bvkb5BJu+leL8Pb7n0JhYgbXpqMEhsjrG5CWHCfSxT2KeRgr1kU4VXCAIc2vqri5CjShYUrlgzjJEaUl0ZeNTQg+Phv3Ty1AwIEJSEuKFcKu2FTCQJpdGha9QSRbZ1r30LhB8XQ1SePkwARyEjCqwDvhg6FwqmAPc3MzfL98I7p1ao33h7yac4x8riEBr9o1cfzfrSptL30gkScH0sLkbIIWniRE35C0urbSK8i3xGVacW1m5SDc2jwOOiLyNI1osdd3P61B844vo/OLbyAoOERtVa9M0wG1F42YWU8l8PpnGYXukk+kLyHqWrO3t1OXzXmFICDvmNb3xe6FqJW7KHlsoJ3YyC6e3lCs2/Bn7kJlNOfZowDEBh4EFKZwaTIC9LNVzZfaA0dOii/cdm4tYevSBOkp8YiShF4qX9yDrN31NKCHBmLi6GAPa2sr0Fuf+IQEysoeJOUD7ZoWfXMznoadx5P7xyWuCcIczdDCLg3s7HmlOUOblk3plAMTKDEEjCrwKhQKvNSjI375aQ42r16Afi90gYmJUYdUYm5cfgMlbe/5ozvQpGE9YY9IWpgRH30uPojkehGX14pkJVp4YlFOpE1MzVXCb/TN30VeQdH2/+3Fq4NHwbNhJ8yYsxi+mX4sSfjIufvOa/1eQB0D+rdEIX5Is0cfOlHRMSDNayGq5luUPsTode9tNaYcGRkZWL5mY771+WL+BAKDQsRuafbl7dChbcv8C2twtbGksVq55GtR8uNJM3Em88NdZJThKOz8j2L2Fb36w9LOTaTv5GH+I+e7NR8ryj30241xp0trAAAQAElEQVSkx0EiXZwjv3tKc4ZaBthhLScHN1cXkRWq5o1P4uNAJD25L65njWwqNYCZATW7yOz81LmLItWmFQu8AgRHJYaAUaXLR7FPsGnrbkyb+6MIv2/fC8orMfSK8UDr1a2No/u2YNpnH8HMzAybt+5A03Yv4dCxU4i5swPJcWHS6zA3Yc6QdRq0YM3cxlm6HoHYeweyXlKlL1+9iQlfzEUVrzYYNmoC9h86Lq41bVwfZAsZdvcctvy6DL6XDmH9ikX4euZk7P3rV2xY/b0oV1wj2R/vLd+7Ohkirfhv1eUV8bqXXJ/N/XIS3n7jVbzUuytef+1lmJqaYu7CpRLLOSDhVyedlrFGduz5T8z4xV5dxFEX0cD+L+HTD94VTb3xzoeIiIwWaX1GyckpWL1+M94ZPQkjPpqCP7btFLvG6bNPTdt+HHQYiY/8QG9/nOu/qarWs1tHVVpOlLcrJ8yq6JxsS528XqMkwi8pPTuIk2IayRremjWUfoUNOUz6/0D9hYQqPRZRWg5kryunsx6T44xjDnXyTKbAyxrerLeD0yWAgFEFXvK/e+TkBTRr7C3CoWNnMXth8f/HWALuqxgiCbpTJ32I0wf/Ai3KinoQg7eGjUTw+TXiumuT98UxZyR/qEVe34iM9DRxmTSfS37+BS0790OHXgOxct0m6cvJY9Br4I9Gv4MLx3bixP5tYrU7aduoEtnBDXq1jxAeOrUv/rbZ3nVq0bBVWmpxomW0bNVv6Pzim6APMBIMzh35H8Z/+D5W/vg1tv72M35Z/i3+2bwKFhbmEsvfMXzMxGIj4Gg5ZaNU27VPab/7shbeGfIb8NwZk9ClQxs8iHkE8tyQlJScX/EiX5s4bS7Gff4Vduw5gG3/7MX7H04GmQgVueEiNpCemih2YaRmXBq9AxMza0qKMPGTkajqXlmkKaIvbR+MHCa+YNM5BfpfYmpZHvFR14WrMsorrsEYHhpkFu5uLiIZqsYXr22lRlCYZF/gTYXJlpqOhgyJiUkghYdCoRCLPA3ZN/fFBIpKwKgCL9l9rvhuBgb07SnCisXTERKWt+F+USdbVuuTtvfCsZ2YMmEsRr7oCAuzdNwMTsMFP/UL0xw8esDMuiJSnz3A4f8twcC3x6JGgw6YOnshZO3niz274Pd1SxB06xQWfDUFJFCXdL7edYsu8D5+8hRvvvsxJs/4BikpKZgzY6IQbCs45l5B3b1Le+zZvh60+IOEnNclbWJJZ2jI8dMio5NnLogue3XPrW0UF7SMyLRqk/R8e1Svgms3fDBm3FQtW9Ks2ra/9+QqqC4vVyE9Z0Tf2oLUxEewcqgBhxo9s/XmWskZ5Mc4IwNwdXWWrikQEBgkHZ//mtLmFI2Gi4yIy6uQnpYi0sUx8s90SaYbDw2Fm2EVN+UXB3WuyUwt7WFqYQcQ6MxmbV0ao4LnC5lnhjtcvHIdaWlpwlyObN0N1zP3xASKTsCoAi99qOScgomJImcWn+uIwOQPBuKNLo7S/80MfLUhFC8Peg+Dho1Fz35vo1KN5sKd2fzvluPKdV8cumOv7DVyP/47dESkabtNEuD8rx/Dto3L8UqfXiK/tERF1fBeunIDbbu/ip2Slo52IDqwcxNol7z8+LRt1Qz/7dwIRwd70OLCF159B0/j4vOrwtcyCew7oHwue0mv1ulLQ2a2zg4O9uVB2w/b2Fjjz792g7T2umqchHUyx6Avke16via8A+RsO+h+aM4sg54nx0fhge9fok9522BxkiWibZklZR9+XbGYHLwITqQVz1JECMokMKckRCPm9t9ZLxWr9N0ApQ1vbU/DbSssA3BXaXhzK3we+e+VvnTEwtTSDh7d5sPrlQ3w6DIPJtKXCbm+oY6nz10SXbVh+13BgaOSRcCoAm+Tht74YNJcrPp1qwhjJ81Dy6YNSxZBLUdrjGqRV1ZDgQyhGRjwxrtC8N297zBOnb2I+IQE3PUPxJwFP6J9zwH4bNF+hD5IgYujGeZ/2gWHd2/G1dN7QQIcaXaMMX599ylrqeWFd4Xpb/majejYexCCgkPRQ9LcnjuyA21bNdOoCVoodWTvH3B3c8XxU+fwQv9h4lW6RpXLcKGdmZtN9H2xh94o0DPxy8/fivZJa08CnjgpZORz2w+//r4dH038EuQ5pZp3Wwx+9xOQmdDVaz7ZzADkpskvsJw2xpE0sshIg331LrBx8so1hJs+d4VZEz23tGCQbNOp0G+bt9NBFRQKBWSBmTTGKc8eqq4Vl0Rk9AMkJDyDi3NF8cbF0OOSd1vLqeFNS0kAuYmk8bg2GQFb5wYws3KkU6MEecMJYz+bRpk8d1riCRhV4J388XD07d0ZQffDRej/UldM/HBYiYdaHCdANnTk0kZhaolKDYdh9rTxWLJgJhQK9Rr1ju1aIdW5l5hKt7pP0aJpfZEuzRG9vra0tEB4RJRajZu6uZMJAwkuk6bNE5dpA5D/bVkD8uUpMjSMSHt+ZM8fINdyV67fQveX39Jqq1ENuysmxTJAu0WJFfwZ6s1r8hvogcMnxOWXXugqjvqKXn6xu1j8Se0Pef9TXLh8XdgxPnuWSFlqw9nzV4Qw+8bwj8Tizhad+uKD8dPxy8atuH03APW9awt79/UrFsHv6lHs3rYOWb9IksZ/lvQ3qrZxA2TGR93A09AzoP8XLo3fU9sjfTmjC2TrTMeRwwfTAWt/2yKOWSMSmElwzkhLQuTVX7JeorTRg7xgzbNmdaOMxS1TwxuWw0tD1PUNINdulvZkUqK/L3aaTlrW8LLAqykxLlecCBhV4CWThpclgXfe9E9AoU+vTuyWTA9PBy0mCb/4s2i5Uv03JQ2B0lwhL5+4bwzoK7wqvDhoPCzsqojXabEB+0T90h551aoppujj6yeO+UXkhYFMGOjVdCVJM3Rw1+8gl3D51cnvGq3U/m/HJjRq4A0/6fUqaYzJwXt+dUrqtcTYe7i7ezTu7hkFv30f4vaOd5AQfUPj6dBGByRwNmvSIJugqHEDhSz4xcQP0KVTW6HR7PzC62LhprtXa+FWjkxQ9h86jq/mLwGZpDhVb4JuLw8WNu+05XFcfAJatWgiFi2SiQR5MTknvQEgjya0qLOyayXhUu3OlcNY8cNc8ealhkdVNKyXW6tayGFrVZwWqoZfXCbqOtcbBHPrCiKdMyKPL5TXsb1yQWrPrh1A7v3IVdy/B4/RpWyBBGcSoMnrQ0LM7WzXjH1Cb7doDJ5G8NBA/dIzQMeQsHA6iJD0NAzk0o1O3Fp+TAejhlu+dxH7+AmqVnGDq4uzUcfCnTMBbQgYVeB9/5OZ4g9IHnjMo1iM+HSWfPr8yKkiEYi9t1/4cSR3YxW9B6naatq4PsjLgiojM0E+dCmpUJjApeHblET0rT+lt5vJIl2aI++6tcT0fO/6i2NeEZkwtOsxAGTC0L1ze5w/ugO6cMROmuH/dmwEebWIjHqAzi+8IbSJeY2jpOZHXvsNyXFhquHTwqjwSytV5wUl9uw/LIro05xBdJAZKRQKcU8UiudvRMhzw6RpX8PFsznIF/WC71cIkxT6Ik/PxIzPP8G+v39DbMg1YRJEbunIfZrsxSSzadXB1NQUbwx4GeS/+tKVGxq/ZVA1oKME2YwmPbkP+n/hXO/NPFs9fvKcuNa9cztxVCgUktZaWV6dlpcE50r13xBlwy8uF8fiEgXcCxZDMcaCNepY1u6TbTedUxBfOqQ3Hw41usPGqQ5lGTWcyfRJ3b5Nc6OOgztnAtoSMKrAmyC9EnSwL68au5OjA57GlYxtKFWDLuaJ9NRn0ivEX8UoXZu8J45yRB+sv6/7UWiXbG1sUNvTA/QhTRtEyGXKV+0AS3sPScv7SNI25F5JLpcrLUdvr9piKnnZ8T55Gie2bZZNGGZ+MQ47/lyj9ouDaEiLqJytjdCw932ph9Ao9u4/DEdPnNWipeJb5dnDu7kGl/g4SHp9m5ArX12GvJ2w/OVMXRld5928dUdNkxkob1cO/V7qiYVzvhCu+aLvXRLPBHlF6diu8JthdOqg1JgePX4G6n70mZeWHIdI6TU69eHadCQd1IarN3yEQF6jelXQmwm50LDBA0Ry975DwiWfOMkSVfR+XQjSiY/8kJef7yzFDZb0y/TQUMtIJg000WpV3emAwKAQPA07h/jIq1CYWsKl0bsi39jR6bPKBWvtWjU39lC4fyagFQGjCrykIQnJYrMUEhaB1NTC2/JpNfMyUok0s2nJT2Dt5I3yVXO7bmrfpgX+/ec3RN27iCun9grXZTnRqLS8PtskLW9Szsul6rxubaVJg+/t3CYNl6/dRJtu/fG/3fvF4hbiNnncaL3N/49flmLY4NdACwpfGjBceH/QW2cGbtjU3DpXjyZmVhqtPCdNU1R0DEjY8vZSauRzNaaHDJdKFdW2+u8/G7D5lx/x4ahhaCq9NVFbqBCZXTq0EaUPHTstjoaMZJtRG+cGKF9FqblV17+s3aU3EVmvV3J2woBXXhRZZK8sEjmiys2UfzOR19aDvpDnuGyUU/97Sg8NnjU8jNI/depe2YUOCA2PQMTlVSJdqcFbMLNyEGljR7L9bhsNF+Mae7zcf5kgUKhJGlXgHfZmX4ybukB4aCBPDeOmLsTwt/oVagJcOG8CKQlReOCzVRRwa678kBEnhYzs3NvAytETaUmxiLm7q5C1S1Zx2a75Vg6Blzba6NZnsDBh6NqxLc4e+Z/QjOt7dj9/Pxej33tLdDP4vU+wacs/Il2So0cB/yI5izmDPBf7ap3kZL5HsoulAn1e6EYHg4VB/V/K1RftztfAW7evm2nBKHV08MhJOhgsJEkadpXNaPOx+fZ7OFMYl8eatfCId94Up6t++V1SYKSKdNaI/p/QZgqpibGIvrkl6yWjpe/43RN901sukTBCJGvKnwXvk/4+ImBu64qKdQcYYSS5uyRTi3tB91FOevvk7eWZuwDnMIESQMCoAm//l7rhu7mT8TTumQg/fP05+vbuUgKwlYwhRlxZJwZqX72LJLAWTRNWqYHSlveBpOWl3ZdEw6Uw8qxRDQqFAvdDwhAcEio9l/GglfkTvpiLlJRUTJ/8MXZuXQvnihUMMnuFQoHvvpkBMp2gxYejPvkCK9ZuMkjfuu8kQ+zaFXZ+qdS0CRxr9AAJuQoTC+kcsKvcQhwLirbv2CuKaLS7miipm4gWnpF99XvDXgdtvDJ10ofCRtfUNPcuWEXpkQQKer787wWpNQsoStv51Q3LXNjq6PkiLO2r51mUnsPjp86L6926tBPHrBFpfWt6VMPDR4/FznFZr8lp12ZjAIUJHtz+G7Q4C0b8CQkNR3JyCmjhGHlpMdZQSOB1sDWBc9oFMYTKzUaJY3GIjp08K4ZBrhbJRl2ccMQEShgBowq8xKpaFVeQKzIKVTJds1A+h6IRSHjgiyf3T0ifKWZwaVx0GzA7t5bSh2ANpCU/RcydHUUbXDGuPX3OYqRnZAih17t5nJQ3kAAAEABJREFUD9Rs2BH/7NoPelVLu6LRan2F4vnCJUNNhUwnln47W3Q3cepczJz3vUiXlIi+JAUd+woxt/8CmS54dJkHt1bjUKXtZOn5fEdMQ5O3B3f9AxF8PwyODvbQxj5WdFSEiNwx0X2gjVemffaR3r749Oqm1HYbyqzhScgpJETflO6NNWgL4fwQ0day8QkJwubfxVm9mcfYEcovyOoWr1HbVvbVUKFWHyAjDZFX1lCW0YK/vGDN03jmDDT5qu6V8WE/J5iZpIJ2UjPG1sE0DnXhTOaCtXZtNPtSqq4NzjM+gbI+ApOyDqC0zj88U1tTse5AmFs76WSark2UgvMD320gAUYnjRajRi5duYEfl/+CrOIsOaP3ruOJc0d2iFX6xhwuaRZpkaGZmRkW/bgKIz+eIlxYGXNMmvRNHhgCDkxCXPh5mFlXQI0e30kf6I1UVR1q9ITC1BLxkVdA3gFUF9QkyAUcZb/QszMdSm3o0klpx3vQAGYN6WkpiLi8WrCs1HAoTC3KiXRe0eHjStti2R2ZunJvv/kqLCzMQRt1kKZaXRnqy8TcVizQiou4rK6IQfL8pC9R1JFnjby12nRd38GjkgKvtC2PtHTArcVH+u6uUO2fOntRlNeFJxrREEdMwAgETIzQJ3epZwKPgw4jMTYAppblUdF7oM56K+faDNYVaouV9DHSq0idNVxMGrp09YbakbzYq6veNHlqO8wn85U+PbF90wpYW1vh9z//h7dHjMundGEv6b58Yuw9+O//FEmPA6U3BB7w7LUEpN3L2pOpuQ0qePYWWTG387dRNoZ3BjEwA0fdOilNBY5kCpf67D5G0rqnJETDolxlpda1gM6OZXoMkRfXqStOniveeO1lcWnVL5vFMWdE913WJodLX9DJ/2/OMoY49w8MEt3UMraGFyfFOA7dMhP3QpwUg4i+9JMygIbSomlDOnBgAiWSAAu8JfK25T1ooa258oso4Nr4PekVpZVI6ypyaTRcNEW2d2nJ8SJtjCjpcRBi/ffi8b39SEmI0skQ8no9m9fqfJ10qkUjPbq0x76/fgX5cyVzixdfewePHj3Gleu3QK/7tWgyzyq00r511/6oVq8DOr3weqE8RcSFXwJpdlOfPYSta1PU7LEIZlaOavuqUFu5WDU28CBSk56qLUMLZ2gHM3Nzc/Ts2lFtmdKSSY7960pvFh7EPMK1m756mxZt80ueXKiDys0/gMLElJJ5htTUVBw7pfS/2y3T/25eheXFa79u2gbyyKOunCPZC5eviuS4cDz0M86CWHnBmqdHNXVDNEje46AjME0KwaO4NKzZ89AgfWrayflL10TR5pKwa2NjLdJlIuJJljoCRhd4E5OScfXGbZy/fEMViiPlP//5F2+P+QLDxk7DsdNKf4TFcZwxvtuQmvgQVg41Ye/RXedDJNsyG+f6RtXyPry7C7Q7V/S1NYi8vAJ3d4/C09Ci+yzt3LFNLn+69FqWfKzqHGQRG2zRrBH+27FJjPfoiXOoXq8d2vcYAO8W3dGh50BEREUXsQeAhMuPJn6JG7fu4NmzRFy8fB3DRk/A/ZDnG0bk1UnMnf8h6NhMZKQlwaFmb1TvNDvfL18W5Vxh59YaGempoI0PoOZn594DIpcE/rLwwSsLlEcyPSKIyes4iry6TtwjYl9O+lJSUPMXpf/TyckpIHdwZEedX3l6RhvVrysWfv759261RRUKBSo3/1Bci7q+EWnJcSJtyMjYm06kpyYi4spaMeWf/heDeyFF/9sVjekoUtnvtmb/uzpCys0YiYBRBd51G//Gq0PHYdnaP7BWSsvBSCzy7Dbofjh++2MnVn73JRbOGo95i1eBBPU8KxjpAgm60ZluyCo3HwOFIqs1qu4G5dp4uGhMqeVVr40TBfQURd/6I1vLJCTJ8852oZAn9Br22L6tYgvY3t07gRbenNi/HdWquqlryeh59b1r48DOTTAxUSAtPV01nsvXbmLMp9Owccs/WPPrH/hp5a/C5vfrRcsw/atFoE0zPp40EyM++lyYRAwcOhZ9X38fPfu9jQ69BqJl535o2Lo3+r05QtWmnEiWhB35A1DOy3kMu7As0yY0A7R5gXvLj6VnseB/NU5e/UVTD+/uFMec0a59B0XWS726imNpj2SBV3YBpuv5PovxAWkWqV26T3QsKBzNXK2vzh2ZurqjMl3q0XOo7jrl2VZqgPJVO4B88pJvXsozZLh9N0B0Rxp1kTBw9MB3u6SkeARy/XghSKlBDQ2LMPAo8u7uzDmlgqdd62Z5F+IrTKAEECj4U0iPkzh94Rr2bFmGVd/PxIrFM1RBj11q1fSJM5fQuX0L2Eqvc1xdKqJu7Ro4f0m9vSeM+BN57VdJW5OM8lXawqZiPb2NhDaxsHVpIvWVhAe+f+mtH3UNp6fESR8OsbkuFbTYKVeFPDKqV3MHbQH71+8rsWjeNJBQmUfRYpGdnp4BchOVczD7Dx7D6E++wKeTZ+PzL+cLrw7zvv0J3y9bC9oWed2GP7F56w78vfNf7N1/BIeOngItTKEV+Ld87yIgMBhxcfE5m833nASWoKNfCg2twtQC1Tp+Cac6r+RbJ+tF20oNQe6wUhMfqQQx+Xp8QoIYJ52/9ELZEHhlofL4aaULMJq7LkPYxRWiuYp1B4A07OKkgOjoCeWblG6d2hZQUnn5jddeFlslX5Bei5PJjTI3d+za5H2R+ch/HxJj74m0ISLZBIj+7g3RX84+UhKiEX1zs8h2az4W7m6uIl2cBF76v0CDatMyP4GXSnBgAsWbgFEFXkcHO0nzox8tpC6xR8c8hJurs6rJKm4uiHoQI859bvsha7jrHwhL63LZ8u7fv4+CQtY28krn10ag7ynE3juIhAwHPLHrla3/nO3l1458LWednOfx9j3F/B/c/h+CA3zynF/OeurO5T7zO8r1bgdE4JmiopgnzVUOcSmW8Du9CveD/PMcC7Uvt5PfkcoVFPKrL18rqA26LpfN70jl8gopyYniPjg7OyNr8K7rhbdefxXD334do94dgg9HD8fHo4dh0icjMG3SB/hq2jgsmD0ZP8yfjuXff4Vffl6AX1d8i7U/Pw9fThmfrU1q38WlEqq5u+RiHOR3Fbf3foq4iEswsSiPDM/xCHlaodDPoUklpR/usOt/ij5kLlu27xZj6dShrbBXlvPpmBebrPlUrqCQtXxe6YLaoOt51c2aT+XUBdI2+t4JENwePYxBs8b1hTnJ9n92Cx5Z26C0ujZy5lG5nCHg4p9IfOQv7lWSfQfRX856Oc+pDXm3LY9qlTUaT9D9UAx8ta+4dyvXbRb9UDs5Q0RMIiyr9hHPcuDpJaJczv5znudsQ915zjpZz2/fvQf5ywTtcqauvpyXtV5eablsfsecdW8cWy3+lyU7dkbgAzNUcVduL3z1+k21fOW2c7aj7lwum99RXb2seXukL8Nx8QmoXtUdSYkJeY4pa52c6duSBp2e6fzGIV/LWVfduVw2v6N4kDhiAjkIGFXgtbK0xPR5P+HIiQso7ja8CpPnqBSK50L6nqOXkTUcu3gXDVr3zJb35ZdfoqCQtY280vm1cffoQnFrzyf2xb4zgdn6z9lefu3I13LWyXm+73wUAqItgPRkHPoz7/nJ9fI7yn3md1TWv4TjZy/gekpv3EjrowrXpfT11JeQFLwDYUfGY+uqzzDzyxlqmSvbyX7PcuZ9aYD7JfeRs29153JZdcfFi76Fa0V7vPPeiGxh0Btvom7Dpqjp1QBVanrBpUpNRN6/g2C/G7h76xJuXD6Di2eP4dSxAzj83x7s3fU3du/YjtCYZ6pgZuuI0WPH4t0RI1VtDx3+PhYs/DYb22WLvkDkqelITwjDgzhT/PyvGfadj4C6uWTNUzefr3/ajWfJCqTHB2PFd1NUbYQ9ShZj6Ni1hypPbktdOznz5LL5HXPWUXeeX335mrp6OfPksjmP/564jv0npTdf0v8VqpOU8Fj8XX+z8LtszOkahZz11Z1TuaxhzuzpiLm1QbS752IGZs7+OhdTde2M+XAcaPGZvZ01vlu8SOPxVPOsK+5dpaq1sfvIJbX1aHzz15xFXKIJ0p744cCJiwWOieoUFNTNQ847eOYWgqMTBIeIsJA8x0V9yHXyO1K5gkLW+vuPX8KVmBq4ntoHh4Oqi/nWa9xcjOeX9b8ZfDxZxyanr94NF+NRSP/n85ubXF7dUX6m86svX1NXP2eeXDa/oxg0R0wgB4HnUlyOC4Y4jXrwEA8ePsIff+8t1ja8zk4VEBv7WIXk4aNYVKroJM4njhqErOH913vi4pG/s+X98ssvKChkbSOvdF5tLJkzEm4OqTAxt8XoIX2z9a2urbzayZqvrl7OvJ5vLxIMWnmmYvWKJWrnmLOOuvOs/eaV/uTtLuhX5RDaW25ExwrHMKi7F/o0s0bflnYY+mp3vPVyO9g4N0A5q3T0bhCHqa9b48d5Y3KNSV3/OfPyGkPW/Jx11J1nLZ9XWl29nHl51ZXzr5w9CAfLFNy6cgYRgb5o06Aapnw4ONdzIJfP75iz7y+kdmaOexufjxmAlKcRWLTgG0TEpmDdunWCLT17wzrEw9YyAzaVGqLDsD+wdMVvufrO2S6dqxvHmnXrUa3pm+K5GjOooWhnwsiB+GnJ96Lv/j1aijyqLwd17eTMk8vmd8xZR915fvXla+rq5cyTy+Y8fvLuK/jk3f5ijlTnh8XzBQub8k6CN+VlDTnrqzvPWp7Scz7uDBuLDFg51MDEuZtFu+rq5cxr17GrGMuQNweKOtRWzpCzDp1PHvsGThzaJ+6frWlynnXp3nt3+0z00aviLox/X8mB2lAXcvat7lxdPTnvg6F9EBMWIPobNeLdPMdF7cp18jtSuYJCZn3QM93H/TBamW1Cv+Zm0vnr4p5bK56J8XTq0s2g45HHlfN458ZFMZ6J4z/SejzyM10QG7qes39151SuoCAGzRETyEHAJMe5QU+z2u1mTRt0EBp01qFNMxw/cwlJycliu8xbtwPQukVDDWrqv0hGemrmAiHApdEwkG9L/feq7MHKoSbs3FsjIz0FD25tUWbqIX4Wcwf+/36C5KchQqiijQvKuTaDg+eLsK/RC+Y2lWBlXx01us1HtY4zYVm+qtjAIPj4HAQc/AzPHt7Vw6iKT5N25WzFQrutv/2MlT9+jRd7ddHL4GZM/gS0/enV6z5YsXYTHvhsxf2TX4v7b1+9Gzw6z5WeP+si912h1kuAwgRP7p9ESsIDnDh9Qaz0p8WD9erWRln6adW8MWxsrIWHjHjp1XJR507b+JIZErVTucVHdNA4HD1xVpTt3L61OBYmkl2U/bx6Q77VylftKH1xrQ+y447x3ZpvWV1c9A8IEs3U8vQQR0NFsQH/iv9R5jbOcPJ6VdWte2VXkS4uNrynz10W42nbiu13BQiOSjQBowq8j2KfYNPW3Zg290cRft++F5RX3IhWr1oZr/bpjhB6jEsAABAASURBVPc/mYlxUxdi/AfDYGFurr9hFqLlmDs7JKEgGhblKsOx5guFqKmborJf3od+e5Dy7JFuGs3SyuP7J3Dv0GSkJT+FJkKVnVtL1HphmdipyMzKAc8e+CDgv/G4f2o+yNcn+EdrAtbWVlj+vSTUSv81nt1dB1okSY25NB6OKm0mSDKqKZ0WOZhZOcK+WmepnQyQxwbZO8MrfXpJeWXrl3bV69SulZj0gSMnxFGbiBYUPnt4BxGXlgMZabCv3gU2Tl4aN0WmDLJ3ji6Zu8BpXFkq+Fq/F1DB0V4shjx+6ryUk/ev7KYs+tafIF/OKTrys62uRz9Z4K1pOIE3LSUBEVd/EcOp3GyM9HdjJtIUubu50AGh4RHiaMwoPCJKuCAsZ2sj3NAZcyzcNxPQBQHpo0sXzWjXxsz5P+PIyQto1thbhEPHzmL2whXaNabnWq/3742NK77Bb8vnoXO75nruTbPm05LjVCt8lf84dSNwaNa7shRpU8tXaS+0fA98dKvljbqxCSGSoEpa7EIJVZJ20NHzBdTuswbO9QdDYWopaQtP4O6eMQi/tEISnp8oB89xoQl0bd8Uf86sj97NbJCapkDV9lNRse7AQrdTUAVZ60VfpPbt/08Uf/mFbuJY1qKumR4RDh09rdXUI6+uh89fbyDgvwmIE1v4mkhvg4YXqi1aqZ+WloYmDeuhnK1toepSYUtLCwwd/BolsXr9ZnHMK7KyrwZblybif0rQsS9xZ+d78N8/DqnPHuRVRat8mk9gcAhMTExQ06OqVm1oUyla+r+WnhIvzbGxeEOWtQ13lZeGyKzZRkmfPHNB9Nsx8wuXOOGICZRgAkYVeMk5/orvZmBA354irFg8HSHFyP9gcbmvqQmPEbBtLi7NfQEXZ/XA3Y1TkBwbgajrv4E0N/R6v1xl4wnhlRoOEahoQ4jUxKLvEpSRliw0suSuR0HurTpM00qoMjGzQqUGQ1Dn5dVwqNFTaLZojPQBSr58M9KSxLg5ypsA7WgXfmkVIs7OR/iFn+D/78eo6pgodoR6//tgnPfLyLtyEa5YO9aETcX64vlu6PZUuLZq36ZFEVosuVW7dW4nBq+NP97ER3544LtNevbTRRvKKB3PYnyVSQ3jY5n+dzt3LLw5g9zF2PffFsl/du0H7ZonTtRFkgaaxg08XxxM59G3tkKXPyTspqenCw8Epqamumw6z7boLRNtykIFKjcbS4dsoap7ZXFO2lV17gbFRQNFp89dEj21adVUHDliAiWdgFEFXvpmnROgicnzf3I5r6k/L/259/f9jOhz/yDlyQOkJsTi4bUD8P/zS5D2i2bv2nQEHYwWLMtXE69IaQDRN7fQQeuQmhiLgIOThUbW1LK8sMu1c2+rdXtU0cyqAtxbfYpaL/6McpVbSEJUovRlYSPu7BqBRwH/UhEOagjQq2T//Z8Ks4JnUZfx0H8fUhIiYWnnBj9Ff/gEJ2PMuGmIi49XU7voWU5er4hG3uxsD9rtTqFQiPPSGpEv6Vj/vXh8bz9S4p+/0q5XtzacK1aA/70ghIQqV81nZZCeEofE2HuIC78g7lXktfXiC2PAgc9w79AXWYuq0s8e+qnSmiTkDSc6tdde4K1axQ3dJOE9TdIUr/0t7/8TSU/DpbcwcbmG9STkFBIe3MyVr21GQOB9UbVWzeriaIgo/OJy0Y2TV39Ylq8i0lkjMzMzsXsiMYqM0q1GO2s/mqTPZNrvtmttPGWKJuPkMkxAUwJGFXibNPTGB5PmYtWvW0UYO2keWjYtHovBNAVoiHKxvidzdRMXeE3S2mSgQq0+0j/OarmuGzqjUn3lyvqHfrsloShaq+4TpQ9t0iCSNseyfFV49loC6wp1tGpLXSUSzKt3mgWPLnPFCvXUxEcIO79UZ1sTq+uzJOc9DjoqvVZOzTEFhTATeefdUWjSqB7CwiMx6+sfcpTRzWn5Ku3wME6BGq6WGNSzpm4aLaat0JsHv70fIPraGrFd9p0s22XTq/yh/ZqgV/NyuHl0BcIv/oygY7NA22v7bB8En7/eFJp3ygu/tBIPfLaJL4zPYnykL3cJamdsZu2oNl9dJtnvXrh0XVzq0LZoWvYR77wh2iGBNy8Nprm1gyiTM0qV3h7dO/i5NN83EHruezHH9JSEnMU0Pg+4pxR4PQ0k8MaFn0dcxCWYWtqLN095DdTN1UVcor8tkTBClJiYhKs3fECab1o4aYQhcJdMQOcEjCrwTv54OPr27oyg++Ei9H+pKyZ+OEznkyyNDaanpcLE1BqyOYGx52hhVwUOHt3FMKK18NjwNOwsAg5MEquzbV0ao2aPxaAVzKJBHUdkH+jZeyncW4+HmbUTkuPCEHxiLu4d+hwxvtuFreOtbQMkgeKjMq0BTnoSopY8eU5QKBRY9eN80Fua5Ws24sq1W2rLFiUzIjIav/0XLZrwtAsWx9IaRd/6Q5paFvOQjHShpb255WXc3jEcbzYJwtx3XFDF9CLozU6cpM0lcxMyaZIqwszKAdZOdVG+agdh/lO52WjhsaRG1wWSgGVHRVRBYWIG2o1RlVFA4tipcyCNY4tmjbSy383afN8Xe6CSc0Whqd534GjWS6q0iXk5kJmWKiMzQW96rBxqID0lHrTJzv1T8yXh93UEHv4CD3z/En/HmUU1OpDGnArW9qxBB72H8MurRR8ujd6BiZm1SKuLntvxRqi7bJA8stmmLyQtmjWEmZmZQfrkTpiArgnkbM8kZ4Yhz01MTPCyJPDOm/4JKPTp1Ul8gBpyDCWhL4e67XMPMyMDivgKIKE390Xj5NACMer5Eb36jtd80UXM7b9ALsQy0pLgUKMHPLrMg4m5DTWl10ACep0+q6UvDUNhYmaFhOgbiLi6DrSancaS9DhQaIBJU6bXgRTTxu3cWqodWTnXpiK/vndtfDhqmEiP+OhzIRSJEx1FO/cewI7TT5AkKZnJpCIvAVxH3RmtmfSUOOmLXmyu/sndn5xpau2Ks74J2HfxGcgunUx06O+kdp9VqP/GLni9shE1eyxC1XZT4NJ4OCrU7gu6fzaVGsCz5w+SEDwAZM5D+fTmxNymktx0gcdjRXBHlrNx+p///rDXRfaa9STki2SuqGr7L6R5vCvNoTUcanSXhPcvUa3DdNAX1Tp9f4Fr05Fi0RdVjI+6jkjp7/aupBW/u2cUIq6sFX/LdC2/IJs0GELDG3P7byQ/DYOVoycca/bKb1hwU3lq0Px/aL4NanHxzPnLolbbluyOTIDgqFQQMIrASyYMEVEPhBkDpXOGUkFWh5Oo+sIHcGrWG2a2djCxsISJrfSN28QEj2nHrKXDkfTIeJqArNO0KOcq/TPvKbKibub9YSYKZEb0ajLiyjpx5tL4Xbi3GifShooUphZwrvcG6ry8TvoAJUFOkavrp+GXcuWVhYy05HhhNqOaq8JEEpwGSh/atVRZM6d8Knzz+tz2w08rf1Pl6yKxa+9BxCVm4JGirmhOXuwjTnQSFY9GSKNpZlku12As7T2EIEsCbd1+a7B0vxW+/DUMYRlN4FCjp/S8NoZFObdc9XJmmNu6COGRzHlI82tpXz1nkXzPVfa7HVrnW07TiyOHvwmFQgHS8N4PCVNbzUTSgFasOwDVOs6Q/ieMlwTfVqpy9ObHqc4r4oux92t/CiHfwaMbqA4JlSRc3js0BWTuQVrg2MCDQissN5CRnoonIafRsFIY2nlbo1aNKvIlvRzTkmIRdeN30bZb8zHimF9UHHzxygvW2rL/3fxuFV8rYQSMIvCWMEZGH+6zRz5IMrkOq7q2sGnoCBsvJ7j26g+rSh5ICLuN69+/gVg1dr7GGLhz/bdEt7H3/sv3FWNacpwwIaBXk1SBNDr0AUdpYwRTy/JwqN7FGF0Xyz5pwVrEldWQJBO4tfgAbh3nwfu1LZLgNBxZf6ytrYRvXsr7asES6MphfkLCMxw9eY6aRYNOykWZJLjQcyMyS1GU+iwG6ampub5cuDQcCjMrB9VMu3bS3luDqpFCJmhB4sXL14UtZ8e26jX+hWwSLpWc8VLvrqLaml+3iKO2Eb0JIjMO99YT4D1gqxCCSRg2t3WVmD4Tdr6hZ78HuWUj+9/om7/j7u4RuH9yHoZ1scAPY92QcfdHiX26tkMosF7k9Y1iLPbVu8LaybvA8u6ya7Jw4ygy0tPTIbska8sL1gq8X6WmQBmYiFEE3lHvDIJrpYro3K4FKJ01tG/Nr1ByPnfRPluz/0OWtCOJT33Q8NONcGrSG2mJ8bi97lPc37MUSE/LWd2g56R9cfR8UfQZdWOzOOaMaMc0WpyWEH0TJGjW7PkdyldRY7aRs6Kez20rNYTCRNKe5+jH1MI2R07pPw05sxjpqYkgu0m6n5YOtYQGTd3Me3TtgL4v9QAtdBkzbpq6IoXO2/vfEaSkpKBl88ZwqVIXdm6tQO7qyFym0I0V4wo0p6Djc5CelghzSVtbscE7cGk6BnX6rIKde5tsI+/eOVPgPXoqW74+T46fPC+ab9msESwtLURaF5G889q6DVuQSsK+LhqV2iD7f9emI6U3NmtAG9CQvay1k/INAXl4IN/eKQnZvR+QCVNc5BWptu5/E2PvgZ5ZhfQmybVx9i+LefXmXlm5aC00LDKvInrNv3bTF7RQsbanB5wqPP/CpddOuXEmYAACRhF45Xl9v2KjnFQdv/l+jSrNCSUBclekTD2PUxPJ5i8Vtd6ahxqvfQGFqTnCjvyKm8tHIvlp9n/oz2sZJiV7bHgcdFgaS0i2TuMjr8L/vwnCk4PSE8MP0KUnhmydFfKEXv1Wbfe5GI/C1BKmFuWlFjIQee03JDzwkdJl45deCdOXEdIuurf6WJ50vsclC76ErY0NDknC2F879uVbVpOL8u5qfXorN5sgrR3Vi7m7kw6lJoSeXwrySkJmDTW6zoFj7X6wr9ELpKHMOckuHZUC8LFT53QqJObsJ+u5bM7QWUfmDHLbPaUvSVXcK+Pho8cgv7xyvi6PZLpR0XsQyLa5bv/f4dbyU5hYOqvtIuTsj9Lf+XrhRYHs99UW0iKTPGpQNfqfaGbtRMkCg0rDaySf9LI7MjZnKPBWcYESRsAoAm+I9M31/OUbiItLAB3lcPTURSQlJ5cwhPofLgmGOXshYYQ+JCm/UpsBqP/RL7BwcEFc0DVc/+5NPAm4SJeMEugfe4XaL4u+ozJt1+iENB2BR6aBXAnZVmokPojMC7F4htrQd7BzbwvSONcbuB11X/0d9BoyIy0ZQUdnCF+n+u7f2O3Tl6uIK2vFMGhhlFLoF6f5Ri7Sa+rZ08aLMpOmzsPTuHiR1jba999RUbXvi93FkTR35FaOXv8/Dj4m8kp6RDbJ9KWQ5lGtwzS1Qi5dk4OtrQ1at2yC5OQUnDprGLvy45lmJZ07KIVteSxFPSoUCox+7y3RTFHNGkQjBUSmluXF+gKfR9XUlkxLfCDcuQUd/RLkoSXgwGeIur4B8ZHVbeUIAAAQAElEQVRXxJsFaPFDzyl9UTa3rYSK3sqFepo0I28vHB4ZpUlxnZeRF6y1K6MbvWgGlEuVRAJGEXgvXfPB2o1/gxau0VEOR06cx/SJo0oiR72O2VnSUkCR9VYp4FzvzWx92rrXRcPxW2Dv1Q6p8bHwWTkWoQclwSUjI1s5Q50413sDNObHwUfhs30Abu94B2HnfwL90AITj65fw8Tclk6LdXBvNR62Lk2RLr3eDzwyHclxxrGrMwSkjPQ03D+1QHTlWLMnylVuKdKaRmNHvI2mjesjMvoBZsxZrGm1XOWOHD+DJ0/jUNOjGurW8VRdlzeieOCzVZVXUhP0Cj3i8hoxfFpIZlupoUgXFHXt2FYUOXL8tDjqM6IvLVeuK93N6VrDS+MeNngAHXBc0ljfvhsg0vqOTvqmI+RBdqWKT1AiLse2gFOdfrByqCENQQHyzBJ9awsCpb95n79eBy2CI/vfhOgbyEhPlcrk/5ueloKITDdklZuOzL9wjqu20psSB/vywkTo4SN6k5ejgJ5PT5w+L3po07KpOHLEBEoLgaxSlMHm1O+FLlixeAY+GT1EHClNYebkMWjcwMtg4ygpHdm5txE2fW4tPkLlZmNQ68WfIWtQs87BzLoc6r7/I6q+8IHIDvl3OXxWf4jUhMfi3JARuQqSPhmkLhWSsJgE0sxBkQHnBkPg3nqClF8yfhUmpqjecTpsKnojLekxAo9MVc6lgOGXxMvRNzcj6XEgyA7btal2XzxXLvkGJiYmWL1+M85d1M4ucseeAwLfy5naXXEiRQ7Vu8LUwk5o2p/F3JZySuYvfWm6f3K+NPgMkLeFCrX7SmnNfrt2aisKHjiSezMacUGH0ZFjSqG6g44Wq+UcWkUnRwx6tY/IXvXL7+Koz4j8ygaHPcTr80Lw2ZoI/PjPA4xbHob3vg9FvdYDQc+8Z++loMWZ1TrOhJPXa7ByrCX9G0sVbs7obRUJvuT9IfDwVJBATBpc1Zgz0kEa+5DT3yJg/ydITXwEG+eGsJPeGqnKaJio7FpJlAwxsFkDec0Ij4hCBUd7kA2vGARHTKCUEDCKwCuzI8E3JSUVN3zuQjZroKN8nY/PCZBNn6PnC0LQVWfi8Lwk4NbtPXiPXg4zWwc88TuHa9+9ibjgG1mL6D0dF35RTR8K2GX6cFVzsdhmKUwtUb3zV7CStD8p8VGS0DsNaclPi+14tRkYLdyJFpsfAFXaTAK5eNKmHfLNS5peqjvyoyla2Zr+s+tfqo6XX1Da74oTKVKYWqBCrZekFEDmACJRwiJ6UxB8/CuQ711aTEVmI4WZAmndLCzMcfHydcQ+flKYqoUuqy/73awDkXde27TlH7FQKus1XaYTEp5h4NCx2LP/MNLSM3D0Wjw2HnqMM7eT8OHod9GsSQNVdybmNrBzawnXJu/Bs9cPIO8P1TvNREXpTRvds4z0FMRHXRMmD/cOfiZMIMgUgna6o8We9FaLTIOoQTMrezoUOjxfuGbYN0qyqYyOzRkKPX+uwAT0QcCoAu+JM5fx2rBxGDd1Ib5d+gs+mTIfP63erI95lrk2y9dsjoYT/kC56o2Q8iQat34egYgTf5Q5DrqaMAmAHl3mwNzWBbQBQuCRGZLmOlFXzRu1nYy0JIScXiTGQFotG+f6Iq1tNHvqeLhVdoFfQBC+X6b0saxpW/QKPTLqgdAwtVPjEqlC7T6iKbKPFG8NxFnJiUggSnoSDLJzr95xRqEHbmZmhi6Z9rRHT5wpdP3CVDh28qwo3lnHC9ZEo5kRaY9relQTNt+/b/1fZq5uD2Ri0/WlN0F24WQqcHj3H7jvexr7//kVYXfP4ZtZk/Pt0MTMWpj3kMcHWgBH9v0eXeZKAvDrkga3Pujvh7YMppCzIXV5OcuoO3fPdE0WFhap7rLe8tj/rt7QcsPFgICJMcewbO0fWL1kFmrVrIY/1y3GLz/NkdLVjTmkUtW3hV1F1B+7GpU7vS1eywXtWITb6yeA3Jjpe6LlKjfP1QUtHLG098iVjxKSY2rpgBpd54EWDCY+8kPwibkoDT8RV9cjOS4M9OaAtFpFnZN1Ft+8Xy/6CYFBIRo3uXvfIVH2pV7doFAoRDprZGZVQSwkpLyYu7voUGICmYw8DT0N0lRXlzSGppb2Wo29W6Z7skNHT2tVX5NKj2If46b05o20ya1bNNGkitZlPhg5VNRdtuo3cdRldP3WbbTvMUB6i3hHfLac+G8bWjZvjAqODsLe3K6cbaG7U0hvfGxdmsCl0TDU6LZA7HTn0fVr6b6a52orPSVBmDbkulBAhizwhhrYF++Zc8rFkO14w4kC7hBfLokEjCrwmpmZCn+8KSmpgl3d2jWQ8CxBpDnSEQETU1R7eRzqvLMYJpY2iL11DNe/H4yEcD8ddaC+GftqnVCp4duwsHOXXo9bSZqQBqjWfppIq69RMnLJtMQjc+tjWsFd0oXe+MireJjp6qtK2/w1XYW5Q+Sbl2xwyaPA6E+/0Lgq7a5Ghfu80JUOakNFr/4i/5H/XqFdEyfFPHoaegbkA5aGWaX1BFg51KSkVsEQG1DQwkEaXPs2LWBmZkZJvYUhb/QHCda0Wx+Zauiqo737j4A0u2STSi62jv27FTWqV9VV89naIa8z5VybZcujE/IsYmblSEmNAxWkNyR0DDWghvdpXLz4YmBpaYFmWUw8aBwcmEBpIGBUgddG0gQRRAf7cvjfnkMgE4dHsaXLNpLmVxyCY/3OaDh+M6xdPZH0KAw3lr6D6PP6eYUoz5c8SdR+aSW8B2yTNCHzJaG3aK/K5XaNfbS0rw6PznOhMDEHCTK0k5Oxx6RN/2mS9inkzCJRtVKDIZIQRivUxalOou++ng4rK0ucOH0Bf2wr2H9uRGQ0yOm9ubk5enTpkOcYrBw9Ye3kjbTkODy6dzDPcsXlApnAyJzJDpR2BivK2BrUqwPnihXgfy8IIaHhRWkqz7pHTyjNGTq11812wnl2JF0ob1cOgwf2k1IQix1FoojRj8t/waBhH+DZs0QM7P8i9v61Hvbl7YrYav7VXRq9g6xbPZOgSx448q+l/qoxNLzkjowW9jVv0lDvX3LUz5pzmYB+CRhV4B30Si/EPnmKD95/EweOnsXGrbsw+p2B+p1xiW9d+wlYVXBHg082wKlJb2SkJiFg6xzc/W0S7u9bhtu/jMO97V/j6T3tVtZrP6qSWdPaqQ6qkQ2mwgSxgQcRfmlViZtI+MXl4nUrCZAVyY2cjmdAH9pkz0vNfjZ9Hh5Lf+uUziv8vVO5WK1Hl/awsbHOq5jIr+j1ijg+8N0O+pAWJ8UwSkuOR9CxmcLeu5xrc+mtxzDo4qdrp7aimQNHToqjriOV/a4BBF4au7zz2pa/doFc0lGeNiEtLQ0fTpiBL2YtFM/FjM8/wa8rvwN9idKmvcLUIW1u7T4rUfulVaj1wjJ49fsV5D+6MG3IZd0ru4pkqAG9NKjMGdTYzovBcMQESjgBowq8PTq3gYP0rdvToyqWLvhCuChr2si7hCMt3sM3MbMQu7PVHDgdClNzPLx+GGGHfkGszwlEnf0Lt5aPQFzw9eI9iWIyunKuzVC17ediNA/v7sADn60iXRKiJ9IrdnKhRFrqqu2mQCEJ7voYN3lsqFe3Fh4+eowpX87Pt4td+5Ta2j45vDOoq2RXpR3MrJ2QEh+J+IhL6ooYPS8jIx33T34txkimPVUE59x2ydoMVJ9mDZHRD0B+cS0szNG8aQNthlfoOvQKvUmjemJTjd9+3655/Swl6QvVy4Pew/pN24SA+/u6HzFlwtgsJQyRVMDCzg30FghF+JuSN5+4rycNvjoS8oK1Nq3Y/646PpxX8gmYGHMKqdK38bMXr2Hdxr+x6tetqmDMMZWVvp1b9UfNgdMARe4P4JgrSk0b+KdAAuWrtkfl5kq/x5HXfpVesR8osI6xC6QmPoZshuHa5D1YlKustyGZmppi1Y9KQfe3zX/l6ZuXtHrHMnf16vdSzwLHo5CECdoogAoWVxdlkVfXIz7qKkzMbVC902yYmuevtaa5aBpe6NFZFP3v0HFx1GV09LjSnKGzpN3Vt/1u1nGPHD5YnK5c97s4FiYi/7Gdeg8CPUNOFRzw3/824JU+BT9HhenDkGUd7MvD2tpKmGTQ34a++w6LiMSpsxeFVryDnvwu63sO3D4TKIiAUQXeT6fMx29/7MSzJL25dypo/mX6ekZGhtr5R537B4H/+xaPbhxGWmKc2jKc+ZwA+YZ1rq/8sA47twRP7p98frEYpkLOLkJ6SjzIKX5hNj3Qdiq0+xppeql+Xr559/x7GOnp6WjVoglIYKGyBQVHzxehMLUEuX6izRwKKm/I6+Q2Leb2X1KXClRtP1X6UqF8RS1l6OS3krMTatX0EGYiV2/46KRNuRHZnKFTh9ZylkGOZMdLXhMCAoMh2xBr0vH5i1fRvucA4QavVs3qOPnfduGJQZO6xbmMIcwakpKS0Wfgu6jduAto8bjCRIH1G0vOm6rifP94bMWPgFEF3oioGCz7dho+fH8wRr0zSBWKH6bSOSIHr3aAQoGcP+lJzxB5cgvu/PYZLnzZBTd+HIb7e5bi8e3TkqDEX05y8qJzWvRFAhiQgfunF0iaveJpFvIo4F/ER1yGiZk1qrT9jIZukDBr6jhUcq4ohJKFP6zM1adszpBzs4lcBbNkmEqaU8ca3UUO2fKKRDGInj3ylzTo34mRuDYdgXIuTURa15Hsnuxw5o5oBbevWQlZ2CQNr2Y1dFOKvAOQxwZqbfX6zXQoMPxv93/o+cpQxDyMRdtWzUCeGKpWcSuwXkkoIJs1hIZH6m24xFn2yCE6kXQgX8xaCDJrEeccMYFSRMCoAm9ll4pFWqBQiu6DUaZibueE6i+Pg8LMQtV/+Vot0WjiFnj0nwzHep1gYmmD+JBbCDvyK3zXfiwE4FsrRiH0wGo8DbyCjPRUVd2yniDTBrsq0peIjHTQrkvPYu4UKyTJ8VGqxXWVm4+BuXUFg42vnK0tflw4U/Q379ufcMfvnkjL0YHDJ0RSE3MGUTAzoo0yKBkbeAjkdYLSxgxkLhJ8bJb4u7D36AanOsrFdfoYU/fO0rMmNSxvASwli/wbJglXAYHBIE1r86YNi9xeYRsYmWnWQAsYCxK6vln8M9567xNJM5mCYYNfw4Gdm/TuiaGw8ylK+aruSsGd7klR2smv7jlJO57zOr35u3pdt28NcvbB50zAGASyCbyGHsCIoa9h2NhpGDNxTrZg6HGU5f5cOw5Bi9mH0OCTDWg2Yx+8Ry2HtWstuLR7HXWGfyeu1RuzCm7d3oNtlXrSB3kangZcQsj+lbj18whJAO4qCcKfIPzoBiSE+gJZzCTSnj0F2QOHH9uIJ/4XSj1mhUJ6fd32c9i6NEVGWhICj85A4uOgYjFv+hALOb1QjMvOrTUcPJSaUUMOru9LPdC9S3vR5aiPvxBHivYfOg7yAVqtqhtqe3pQfmOnCQAAEABJREFUlsbBopwraJMT4v3Ib4/G9fRRMEP68hd8fJbwfGFdoTbcW36ij25UbcqeGo6ePIvUVN188TySuXtbh7YtVf0YMlG3jifkHfZ+2aD+1XpycjLeGT0BcxcuFUObPW08lv8wT6RLU1TZ1VlMR1+u56hxl0oV6ZAr5JWfqyBnMIESRMDEmGP9ac1m6QOuGgYPeAnvv/2qKhhzTGWxbxNzK0mY9Ya5Xe5/fgoTM9jVbIaqL3wgCcW/ocWsQ6g15Bs4t3wFFvYuSE9+hse3TyF49xJcX/I2LszqjrsbJiP04Fpc/qYv/H6fhuBdP8Bn5Rjc3Til1ONVmJgKd2VWksBDdrKBh6ciJSHa6POOuf03nsX4wtSyPNxbjzfaeJZ/P1f45j1/6SpoERsNRDZneLVvbzotdJC1qDF3d0rft9ILXT+PCoXODj3/I549vAszK0fpGZgF+tspdCOFqGBra4MWzRoJzwYnz1wsRM28ix5T+d9tlXchPV+Rtby0eC09Pfv9fBT7WJgwbPtnLywtLUCeGCZ9MkrPIzJO8+TWj3rWp4b3NTV/c/Slo4F3HeqaAxMoVQRMjDmbx0/i8O3siejcrjlaNm2gCsYcE/edPwFTazs4Ne6JmoNmoOm03Wg08U9U7zcR9l7tYCIJzmnPnuDh9UMI+Xd5rgVvD68dQGJ0YP4dlIKrJqYW8Og8B+SXMy3pMe4dmiJp/WKNNrOkJ/cRdf030X+V1pNgalFOpI0R0Yf4rC/Gia4/n/GNsL3cvVe5nXDfF3uI/MJG5B7Owq4KUp/F4Ml9pWlEYdsoavmHknb5ceAhIeRW6zRLEnrti9qkRvW7ZfrjPXzslEblCyp0RBZ4DbxgLeu4XuvXGxUc7REV/QD7/juqunTXPxAdeg7EhUvXxMLGgzt/L9GeGFQTyyNhiEVrN3zuSF8SM2Bvb4cXe3bB1EkfYt/fv8HU1DSPUXF22SRQOmZtVIG3ZnV3XL91t3SQLKOzsHapCdcOg1H3/R/Rct4JYRLh1nU4TK3UC1XPokq/wEuPAgmVHl2/hpl1ReGHlTS9acmG93iRkZ6G+6cWIEN63e5Qo4f0+r8ZDc+o4eMxw9G4gbfwMNCk3QsIj4yCrY01aIcnbQdW0au/qGoMF2UJMXcQfmmF6N+99QRYO3qKtCEi2UTk8PEzRe4uKDgU5N7L0cEeTRrWK3J72jZgZmaG4UMGgcxwps9ZhI1b/sHfu/ajU+9BCAwOAWkgT+zfDvL+oW0fJaGeu7vSs0d4RJRehvv4yVPMWfAjFAoFtqxfhm0bl2PaZx+JXfz00iE3ygSMTMCoAm9k9EOMGj8bb436nG14jfwg6Kp7WvRW9cWP4NJ2oNomrSsVzkZTbSMlJNPMykFsqWxqaY+kJ8G4d/gLkJeEmNv/iFffMMBP1I1NSHocCHMbZ1RuNkZvPRa24TatmooPWtqQQqFQID7hGSZOm1vYZlTl7T26g75kPIu5jWePAlT5+k6kPHsIsttFRjoq1h0A+2qd9N1ltvbJ1tZG+rJAWs/HkgCT7WIhT46dOidqdGrfWhyNGcXGPhHPB22AMfqTLzDkvU/EF6QuHdvg8J4/QPbeRRlfasJjPAv1QVpSfFGa0WtdlYY3PFIv/dCiP/JuQbb1HdsZx2ZbLxPjRplAHgSMKvB+OOJN/Dh/CsaPHaqy3yVb3jzGytkliIBLmwEwtS6fbcTlPBrDyrnsCLw0eVpURZpehakFkmIDEHZ+KSKurEHAf+MReXUdFdFbePbQT7X7W5W2k2FiZqW3vgrb8Ck1Nqfb/tZ+0ZmJqTkcPV8Uw4jx3SaO+o7S01JAHhnSkp6gnGtzVGr0jr67VNt+hzYtRP7RzAVn4kSL6Hjmxh+d2rfSorbuqsQnJODXzduzNahQKFDToxp2b/sF5e3Uvz3KViGfE7/fp+PirO7wWz1GLLqlNQb5FDfapYpOjqLvh49ixQYU4kRHkV9AIJauWC9a+2bWZHHkSGcEuKFiSsBoAi/tsrZ249/Iarsrp4spKx5WIQhYOFZG0yn/Q6235sGxnqT1ysiQBC7LQrRQeopa2VeHbUVvaUIKKTz/fXD7H6SnJj7P0GEqIy0JIacXSC1mCNdYNqJ/6bSY/AbdD801EtpRKiIqOle+phlOtV8WRWnTB7LnFSc6jtJT4kDtx9z+SxJ2ZyJR+hJjYeeOqu2nSBpJ4/w77Zppx3vo6OkizfZIpsDcsZ1xBV6/gCCkpaXlmks5W5tceYXNeHTzCGKu7HteTdLMkxcZcr34PLP4pGpUryoGExahWy3vlJn0vwEY98F7kPsQHXHEBEoxAeP8h5aAmpmawszMDM8S9fOBL3XBv0YmIBa4NekNzze/gsLcCk/8ziExqmzY8OZEnyppAVV5ckL6sA08PAVkdhAfeQUZacnylSIfI67+guS4cFjYVYGLkTSP+U2iXevmuS43rOcF10rOufI1zTCzdoJsUhBzd5em1TQul5IQhTu7RkhfJBZKWvp1iI+6BihMUL3jTOnLnDWM9dMlU+A9eET7Hf787wUhNCwCDvblUd+7trGmIvqtVbO62kVTXnWKbhv9xO+C6CNnFH//Vs6sYnFe2bWSGEdIaIQ46iI6ePQU9u4/Iu715xPG6qJJboMJlAgCRhN4iQ4JvYOGT8KCJeuw6tetqkDXOJQeAqZW5eDcsq+YUMSpLeJY1iLL8kpNTfZ5ZyAh5i6ib25G4JHpuLXtNQT8NwGR19YjLvy8pP19lr24hmfxkVfxMFPgq9p2EsicQsOqBis2a+qneKu1C6Z2sMTMzpZ4u7kDFs39vMj9O2UuXnvkv1f6ApFU5PayNvDAZxtyLTyUvrQA6VmLGTzdqH5d0OvvgMBgaOuz9Wimd4ZumZtZGHwSWTq0tbHBx6Ozm4dYWVnikzHDs5QqXDIxOgj3/p6PiBOb1VY0L19Rbb6xM6tkLlzTpWuyz6bNE9OaM31ikc1DRENFjLg6EzAUAaMKvPW8aqDfi53h6GBnqPlyP0Yi4Nr+DdFz9PmdSEuME+myFDlJglhOwdPBoxsqN30fdu5tQAuuiMezh3dAglXQsdnw2T4I/vs/RcTl1XgSciq3sEUVcoT0lASEnP1O5FZqMARWjrVEurhFTlFnMaJuHHp4mqGzhxnea5AC94jDRR6mdYU6sHaqK7F6iuhbW5Ca+KhQbaYkRIO+MJDAHClpyYOPfwW/vWNxc8vLeOi3W21bSU/uq803ZGaXjm1Fdwe01PLKAq+x7XfFJKRo3szPcPzfrZg/+3Os/PEb3Dz/H7TZ+Y02vLmzfgKufjsAUae3SS2r+83Itd5AXSlj5Lm5uohuQyTtu0gUMVqxdhNoIWBdSVv+7tBBRWyNqzOBkkXAqALvqHcGQV0oWQh5tJoQsK5UA+VrtUR6SiKiL+zUpEpmmdJxIEGszstrxaYPrk1GoGbP76X0RDh5vYZqHaaj7qt/wLP3UlRuNhrlq3YAeXigmSc+8ge52rp/8mv4/v0m/PZ9KFxgPQ4+irSkWCoC8sIQdGyWEJBv7xiG1GcPhGss5/qDxfXiGMVc+TfXsGKu7s+Vp02GVfkqQAYkgfdP3P7fUAQemSY9dwmqpogPmSM88t+HyKvrEXx8jiTUfoBbW1/FnZ3vivJhF5bhge92PA07BxJoyVyCPF2oGsmSUK+9z1LAAMmumWYNh6TX1dp093zDidbaVNdLnWZNGoBc2L39Rn+4FtLUJebKPlz/YYjY8ObRrWNifI4NuqLeh2vRaMIfcG3/Juxqt4FlBXdxjTbISY1/JNLFKSK/1TQeMjehY1HC07h44YaM2vhhwUwoFApKcmACZYaAUQXeR7FPsGnrbkyb+6MIv2/fC8orM/TL2ERdO7wpZhx56k9xLGuRmZUjHDy6S0Juf9DWsznnb+VQAxVq90XVdlPg9cpG1HrxZ1Ru/oGwS6W6VD7pcZAwVwg5/S18/3kbd3ePwr2DnyMu/IIwgVAuglPAtlJjKl5sQ9Kj8FxjI81/ytMHufILk5GaGIvYoCOQPs0h/5DGNuDgZ/D/92Mh1N7eMRzkFznswk+SULtNEmrPSkJtMEzMrECL+xwkzXulhsPEffDs9QPqDfwLXv1+RY3uC1WaeLlt+nJCdtLyubGO3TNNEQ4cLvzGG753/BH1IAaVKjrBq3ZNlNQfen4ijm/C5Xl9QJ4YEsJuw8TSBq4d30LTL3aizrBvYefRRGydXv2VSfAYsgANx/8OK+nLeMqTaNz57bNiN3V3N6WGNzQ8Qjm2IsSzv/kBsY+foM8L3cBuyIoAkquWWAJGFXhnzv8ZR05eQLPG3iIcOnYWsxeu0Brmg5hH+Gjy13jv4y8xdc6SPBfEXb1xG8M/moGhY6dizYbn7m/yqn/5mg+mfPUDerw6EiM+nYWjpy5qPcayXNGhbkdY2FdC4oP7iPUt/AdzWWNHO7VVqPUSqrSdDK9XNoA0xFXaTIKj5wuwJC2mBCQ5LhRpKbl9iSY8vCNdLb6/dh65BXKbyrVhblexSIMmjThtspGzkcTYQCTG3gMJwmTmUV7SopMGnDaKqNnjW3i/9qekZd8sCbXfSpr3CXCu97rQtFNZ2RTF3KaSdA/WiPvh2uQ9eHT9BvTlBMXgp2oVN3jWqC581V694VOoER07eVaU79yxjTiWtCj5cSTItRgJukE7vwedWzq6oXrfCWg+fZ84WjhWVjstU0tbeL37A0ytbPH03hX4b5mptpyxMmWThvDwqCINgRYl0lbNZmZmWDR3apHa4spMoKQSMKrASy6IVnw3AwP69hRhxeLpKIqt0pKVm9CmRWOsW/oVype3k7THe3LdF9q958tvlmHyx8Pxy09zcOj4OZBASwXzqm9jbYVJHw3Hv9tX4p03+2He4lVUvDiGYj0mhYmJ0LbQICNOlk0tL81d22Bu6wL76l3g1uIjSfu7AnX7b0LlZiVzlbVN5ToShgwpKH9NzK3g8UrRNWxm1o7KBnPEDtU6gLS0pK0lrS0JqpUaDAFpc62dvGFirpnLKxPzciBPEGSKYlupYY5ejHsqmzUcPlY492TFzX5XU4oJob5Ck0uCLrkWo00kylVvhNpDF6DJFzvE/xoTScNbUHtWTlVQ++0FotiDi7sRdfYvkS4OkcqkoYga3klT5yE9PR0fjByKalXdi8PUeAxMwOAEjCrwmpjk7t7ERHu7opNnr6BPr44CYp+eHXHi7GWRzhrd9guEjY016nl5grxE9OraDsfPXBJF8qrvVbsGKlZwgKmJCTq0aYqUlJQ8tceiIY7yJODcqj8UpuZ4fPsUEmNC8izHFwomQDu4kQbYsnxuDxB2lVsU3ICRSqQ9e4LIM9tAdraVWr8qjSIDlg6usKvZTEoX7dfK3gPqeDh5vQqywy1a68W7drfOyoVrh46cKtRAjxw/I8p37lB87HdpQBlpKSChNjmr+UtGBsgm99aKUbi+5G2lT10TUzg1eQENP92I+grKvGEAABAASURBVB+uQ4WG3ak6AM0P9nXaoFqfT0WFe3/NF9pecWLkSHZLFhUdg9TUVK1GQ27I9h86LtyQfTHxA63a4EpMoDQQyC1xGnBWTRp644NJc1XuyMZOmoeWTbXTmsQnPKO3lXB0KC9mUNXdBdEPHop01igy+iHcXZ1VWVQuMioGmtb/e9dBkJ9IayvlrlX0TyhnoMZz5vF5qvIftpkVKjZ7iRAh7NgmkactG3JOT0Hb+urqxUcHI3DXD/Bd+wnu/b0QT0N8izRGdX3oNC8tHZVbTYSta3OYmFnD3LYSHGu/AvuaL+l03KQd0tW4A3ctQdqzp7Cr1QpVXyFXZAo8iw5EUvzjoo9Z4lG101w4eb+BcpVbwL5GL1Tr8jXM7WsVvW1J4NAVg7zaoeeZQl7X88tv36aF+Ls6fvocEhMTNZrvlWu3QHadzhUroLqk+cuvfUNei778Ly7O7imE2svf9MX1H95CyMG1uLpoIO6sn4CnAZdAfr5dOw1Fo8n/wOP1WbBwKdw9zvlMO7cfDEcSljPScVvq49nDCI0Y6pMLPQtulZV2vEHBoYUeT1JSEj6dPEs8F7O+GAd6W6nP8aprm+ZAQd01feWJCXPEBHIQMMlxbtDTyR8PR9/enRF0P1yE/i91xcQPh+U5hk+/WIBR42fnCpeuKW3WsmqMFYq8p6bI1CIrO3perqD6127ewaZte/DlZ6OVVaWY/pBzBilb7BSUM5/P0wQXpzYDCREeXtqDlMR4kacNG/rASpMEHG3qqquTLAlcvj+/h8hjG4UGOur0n/BZ9i6ePQjReozq+tF1nlm5qqjcZipqvrwR1Xsuh1P9YUiHqU7HrGStvH9FGX+c9AXiwfn/iftf5eXxYozlqjcW50/8L4rzorRPdWFWDo5er8O19RdwbjwaFg5eOmmX2tZ3UHJO12q8duVs0bRxfSQnp+DE6QsatSHb73bv3F6j8vqeP7WfmpKE4P8tBC1CEw+GFCWE3UHovz8jMToIFhXcUeXliaj/2T9w7TkGJrYVtBq7knX2Z7r661/Bxk16XqS3EHd/naBVuzQHXQZZ4L0fGlbo8ZDd7r3A+2Ix4tDBrxa6vi7moeSs3TOtbf/SI8O/TCAXgefSXq5L+sv4+rs1ovFd+4/hZUngnTf9E1Do06sTsgqdolCWaN70j7F4zqRcoVkjb9jaWEt/zOlITkkRNWIexYK0FuIkS+TiXAGPYp+qch5K5VwqORVYn7TFP63ZjJ8WfoGq7q6q+paWlsgZ6GLOPD5/zsm+qjfK12wOsrl7cu3fXPw0ZWVubg4LC3Ot6+fsJynkOlLjY+n2qUKG9Fo1/u4pnfWRs8+Scm5mZqYTBqG7Fgu2rh2HoLx7HdFm+ZpNRV5i6C1xXlKY6GOcRX2mSXAlmMdPndeI5cmzygW4XTq11ai8Puacs008jUZqwmOaRrZgalkOXu9+j6ZT/gf3ToNhXc6+SGPO65mu+94SmJergGfhd3B/2+wi9ZFzbtqcV3FTft7QZ1Bh6ic8S8SC71cIhksWzoKV9FayMPV1Vbaoz7Q24xCT5ogJ5CBgFIH3+q3bSE1Lw57/jucYTv6n5WxtQFqMnEGu1a5VExw4olywsf/wKXRo3URcInOFGz53RdqrlgfIG8P90Aikpafj4NGz6NCmmbiWV30qP23eUkwdPxKVXZxFWY6KRsCl/RuigeK0eO1ZVKAYU84or/yc5fg8fwIPLu9FXPB1mNk6okqvUarCdh7Kv9OngVdVeZzQjoC8cO3QsYLteGkB7+Gjyv+Xndu30q5DHddKT0pA9MVdalst79kCDt7KNRpqC+gok3ZdqzNc+cWMfEOHHflVRy1r18zzhWuRhWpgzoKlIHOVl3p3BbshKxQ6LlxKCWgu8OoQQK9uHdB7wGiQe7C2vd9GzqBtV+PGDMHOf48Jt2TB98MxZFAf0VSIJNzOWbRSpBUKBWZP+QAzvv4Jwz+cjuZN64E0xHQxr/pb/7cf12/dxeCRk1VjjYgqmr9Q6q8shwoNuyldlEUH4vGdM8UChX1t9R/6Fg6VisX4SvIg0pOfIXjXEjGFan0+AbmDEidSVK660m4/7v5N6Yx/i0Kgbatm4q3HpSs3hLCTX1vkviw+IQHVq7kXi5X75Gnh8jf9EHZ4PZCRkWvoTk165crTV0a5ag1R8/WZovn7e5YKEydxYoTIvbJSw1uYzSfIDdnq9ZtBWuzF86YZYdTcJRMofgRMjDGkd996BQf/WYPGDbxw+t+NuYK2Y6ro5Ijli6YLt2Rfz/gU8sIy8rKwZe0iVbPU7/plc7Fh+dcYOXSAKj+v+mPfeyPXGF0rVVTV44R2BFzavS4qRpz8QxyNHZF7IoWZBbJ92Eqfu2GH1gvNpLHHV5L7DzmwGrSpBPnadW7RN9tUzGzsYeXsgYzUZMQFXct2rbie6GNcz6LuIfrMdpCNc9LDUK26sLS0QMe2yi9usveFvBqSd1fr3L51XkX0np+Rnoooac6X5r4ofSH6AakJsShXrQHqjlmFai99Asd6neDc4mVhyuDUpLfex5O1A2fpOaUd2Sjv7qYvjOZVxq2y8gt3WLjmGt5xk2ezGzK6cRyYQBYCRhF45f5XLJ4hJ/lYBgmQSyqFqTlifU4gKTbC6ATu7/tZCF02VbzR4ONf0XT6PpSXtL7pKYnwWfUBEsLvGn2MJXEA5H4u4tgmMfQaA9Rrm+wyN6Ioq2YNtPvgtcWvI2TXdwj+ZwGuLHwNj24eEcwKG3WV3ZMVYNbw3P+uEQReSYNLJi5Xvx2Ie399A9rpzMatDrzeW4L6H62HvWdzVO4yDHWGfydpWmfBEKYM6jhX6zse5aRnMy0xHrfXfYq0pAR1xfSaV1iThr3/HcGhY6fhYF8eX7AbMr3eG25cECgxkVEF3hNnLmPkuNno+NI7KlMBMm8oMfR4oEUiQJq9is1eFG1EHP9dHI0VxYfdQeTpbaL7moO+hG3V+rAoXxG0SIY0TvRK/taK0XgWeU+U4UhzAve2f42M9DRUbP6y0N6pq2lXo4nILqsCb+jBtdnfLEi8xKt9QaVwkWzHK9vnqqtN9ru0sI2udevSjg4GCyTIX/vuTfhvnoGkmBBYOlVBrbfmoeGnm+BQt73BxqFJRwoTU3hJQreFvYvwEHF34xQQO03q6qpMYUwayKvB5OnfiK5nTxuP8nblRJojJsAEAKMKvGs3/oVJH72DI7t+yWYywDem7BBw7TBYTDb6/A6QJlWcGCEK+meh6LVSq/6wlTRN4kSKTMwt4T3yZ5Sr2gBpz55Imt4x4kNausS/GhCI9TmOJ37nYGJhLb2i/jjPGuVrNBXXyqLAm/bsKVKexoj5Z420XSzZpGE92Je3Q0BgMEJCw7M2qUpfvHwdZL/rWaM6XJwrqvL1mSBb/Rs/DsWdXydJXxz9YW5XETVe+wJNPv8HTk16AwoFiuMPfTGvO+JHmJhbCVve0P0rDTpMdzelH96w8MgChe3lazaK+163jifeH6ZcGGzQwXJnTKAYEzCqwEvuwMhrgqmJUYdRjG9P6R8a2XTaeTRBWmIcHlzYZZQJx1zeh6eBV4Qj+6ovfZJrDCaWNvAa8ROsXWsJwYQ0vcXBBCPXQItZRnpaKu79PV+MqkrPUTC3cxJpdRFp+UiwSI1/hMQHweqKlNo82kBBHRvrSh5az7l7l/ai7n+HT4hjzujoybMiq7MBdleLu38LN39+H75rPkJ8iI/y7+zFj9Bkyj+o1Ob5GgoxoGIaWbt4wnPwXDG60INr8PCGduYmooFCRrTwrJKz8m8nPCIqz9qPYh9jzoIfxfUfFsyUvj8Uzy8QYoBlOOKpG4+AUSVNpwoO+GvXAcTFG94uynjIueecBFw7vCmyIk79KY6GjEirHLT7B9Fl1d4fwMymvEjnjMysy6HemBWwrlQDyY8j4bvqA6TEPcxZjM+zEIg4thHJsZGwqlgNlTsPzXJFfdIuU8sbF1j2Fq45CndbGdnAuHUdnu28MCcqs4Zjp9VWkxesddKjO7KECD/Qrmg3lw5DXOBV0IJQty7voOmUHaC5mUgaU7WDK6aZFRp0QZVeyk2H/DdPB83PUEPVxKxh1tc/iM9SdkNmqLvC/ZQ0AkYVeP/aeQDfLl2Pnq+NYhvekvbk6HC8jg26wYwcvUcG4InfeR22XHBTof+tRsqTB7Cq5CFpm17Lt4KZjQO8x6yCpVNVoYW8tWIUUhNyO8jPt5ECL5aOAskS09ADq8VkPF79XBwLiuSFa0/uXS6oaKm7/vjuWZC461C/C4QgmJEB2vxA24n27NpBVD2gRsObmpqKY6fOies9MsuJEy2j5EfhSAj1RUaactMf8jDht2kqrn/3Jh7dOgaFiRkqtR2IplN3oepLHwsNr5ZdGb2ae4+RcKzfWZhf3V77qcH+/t0yzRpCwyPVMvC57Yd1G/6EmZkZ5s/W7O9NbUOcyQRKMQGjCrzqXJJRXinmzVNTQ0BhYgLX9kp7s4iTW9SU0E8WeQ8g35/Ues0B06UPZlNK5hvMyzmi3tjVEItYogJxa8VoGGPldr6DLAYXg3d+JwkFSXDw7gD72pp5AZAF3qeSNrAYTMFgQ4g4sRlJktBo5VQNHm98hUr0t6BQoCibslSt4oYa1avi8ZOnuHL9Vra5XLh8HcnJKWK7WUcH+2zXCnOS8vQBbix5G5e/6Yvr0vHirB7wWTlaeJigDRuoLacmL6Dx5O2o8eqUIgnw1FZxCbTAjkwc6E3P7fUTQAsy9T22gjS8n2a6IRs74m2QXba+x2Ow9rkjJqBDAkYVeHU4D26qhBNwkTRA5KLs0a2jBnNRJnsPoA9lu0wvAZpgJO8N3mNXgewun0mvbX1Xf4C05ERNqpaJMk/vXQEJPAoTU1TvN0njOdtWqQdIdRKjA5GWGK9xvZJcMDUxDiHSWwaag0e/CSBmzm0GAgoFYq79h5T4WGj7I7snO5zDrEF2R9a5Qxttmxb1yItEfKivSFOUlhSPJ/4XJQEwFeRtodHEP1HrrbmwrOBOl0tNMDG3gtf7SyRNdXlhqhEkfbnT9+SyLlzL2dfufYdw8swFkBuyqZM+zHnZqOe68C1t1Alw56WKgFEE3jET58A/8D7oqC6UKsI8GY0ImNnYK1dqS69yySepRpUArYvRq9Yn5D1A+vCq3ndcoduxkj7ESdNrZuuIuOAbuPvrxEK3UVorBGYuVKvcZRhoMw9N56kwNYNd9Yai+NMyYtYQdnCt8P5R3rMFHIQdL0BfpBzrdwHS0xB1ZpvgoU3UrZPS3VhO92THTupmwVpc0A21w6o9eC7In661S02110tDpqWDK+oMXSCmEnlyC6Iv7BRpfUVulV1E0zlNGlJSUjBlpnIcxc0NGf0f15VvaTF5jphAEQmYFLG+VtXff/tVuDg7gY7qglaNcqUST0BevBZ19h/pdbh+NaZB/1skeFXpNVoSMCqKdGEjWoxVb/RyoekhG8w70uvNwrZx/4pZAAAQAElEQVRR2sqTL2NazGNeviLcu79f6OmRxw6q9DTwCh1KdSDb1/CjG8Qcq78ySRzlSDbxIZ5yXmGP8sK146fPISkpWVQn+91TZy+KdFE9NJBgLhrKETnU7ZAjp3Selq/VEh79PxeTC/hzNuLuq/8CIAoUMcrLpOHn1RuzuCFTmoUVsSudVRc2/JICQ9Wg9AWO3gqozjnBBAxMwCgCb8umDVDO1gZ0VBcMzIC7KyYEbN3roly1hkLj9eDyPr2NitwKJT0KE69aXToMLlI/1q61UG/MSpCfWdIa35E0vRnp6UVqs6RWTk14gvv7lonhV+vzKUwk7bk4KURUrnojUZrMIkSiFEfBe5aK2dEWtjbScyROMiPS+JIpAC2ofHjtQGZu4Q70irtpo/rCXvf0uUui8pnzl8V5g3p1UBT7XWrMqUkvOmQL9nXaSF8A7bLlleYTl3aDULF5HzHF2+vGgRZrihMdR7JJQ2h4hKrlR7GP8fWin8S50dyQSQItbR4S63McYUd+hf+WWSBfy+endUBK3CMxtqzRs6jArKecZgIGJWAUgdegM+TOVARKQkLW8kboaec1WmgSevAXgaLmwGkwkV6ji5MiRORL2HvUz1CYWeLRzaO4t21OEVoruVVJ2KVNFOhLS8Wmyh30CjsbeeFaXEj2hVaFbae4l4+X5kd2zjTOqi98SIdcoXKnISIv8tRWcdQmkrW8sh3vsZNK7wyd2rfWprlsdSwdK0vnGVAoFHDwaodqL32C2pmv+aULZebX843Z0hf1BkiNj8WdX8YJDy7PIv2FSYquIHhUqyKaCgmNgLzT25fzvkNcfAJe7NUFHdu1FNe1iejLJa1nuC2NPWT/SmkeuQVVajcxOkj6/3YEYYd+gd/m6bj+wxCckwTbKwv64/Yv43Ff+gL34OIu4WuZ3D1KDwZy/lhX0t63dM62+JwJFJYAC7yFJcbl9UqgQsPuMMt0UfY04JLO+wra+T0yUpNANpLla7XSWfsk5NUdsVQSei2EPV/ANqWTep11UMwbig+7g6gz28UoPV77Qhy1iciWm1zEZaQmIy7omjZNlIg6gf98K8ZJbq7I/EOc5Igqtugnackt8STgIhIiA3Jc1exUFngPHTslKqgWrOlA4A09uFZqUwHXjkPg9f6PqNxlGEwtbaW8EvGr00HWGf496NmND/XB1YWv4driN3BpXh880ZGbRTMzM6GRT0tLQ/SDhxBuyH5TuiFb8NUUrecSF3wdt5aPQNTZvxDrcwJkhnDzp3fx8Op/CD24Bn6/T8P17wfj3NR2uPrtANz5dZJ4i0Ob9SSE3Rb/S2nedjWaoFLr10CmOfTlv9mMffB45TNkE3pNTIX/ZfAPEzASARZ4jQSeu1VPQCFpXF3bvS4u6tpF2VNJcKDXwwozC+mfcXabSdFhEaPyNZvB653FopXoc//g/l7l60aRUcojeaFapdavwtatTpFmW96jiaj/tJQKvA+vHwIJGuZ2FSUB4B0xV3WRqYUVnFv2E5doYZRIFDLq1lm5cO3SlRuIjH6AE6fPixa6dGorjtpGCdIXnFjfk6J65U5vi2NZjszLOcLGxVNCoJCC8pfctgX+T/nFRplTtLiKm6toICwiEp9Oni3SH4wcWiQ3ZDFX/hXtZI3IXePdTVMQ8u8K0PWE8LuSYJssTFXsajRFpTYDlILt6BUgwbb5rIOoN3YNagyYCtf2b4IUCfRsu0j/x8lTR5WXJ6Ba/8/RZPJfIEVD1r44zQQMScDEkJ2VqL54sEYjUKnNa6Lvh9cPIvlxlEjrIrr390LRjHvX4bBwUH54iAwdRvZebVFn+HeiRVqgQa//xEkpjkjbQ9pYU6tyyOv1fGGmbycLvPdK58K14D0/ChxVX/hA0uBaiXRekWs75UKkBxd3Iy0xLq9i+ebLQu/8xctFObLrpTUU4kTLKOzIr6ImafXy0lCLAmUoehad2z6V3HIlxz63uy0KDvdMgXfVut9Vbsi+mPiB1k0+vnNGCLTqGrCuVAMu7d+AR//J8CbB9sv9aDH7sCTYrkYN6Q2OEGw9W4AEW3X15Txqx1kSkCu2fEWsmZDz+cgEjEHAxBidcp9MID8CtMOUbAMaeVp7+8WsfUSc+APPIv2FoOvW9Z2sl3SedqzXCbXfni/aJbvWiJN/iHRpjMhWT96auUrvMTCzdSjyNMt5NBZtkG2hSJSiiJ5DWuRDdt+y9ja/6ZF5By1gI87RF3blVzTPa106Kv3trvrld1GmoxbbCYuKmRGNnzR/dOrWZRgdOEgE1HqtyMjA5a9fhv+WmSiKqz0yY4iMegDajm/9pm3CjlcbN2T0pYk2OiGzC981HyHl6UNp5Dl+FQpJyF0pvQX7DKSlpeeP/ifnKMWnTKDEEWCBt8TdsrIxYJcOSs1W5OntSE9VulTSdua0Wvj+vz+L6h79JkJhZinS+owqNOoBWsxCfZALNNLQUbq0hZD/VoE8CZBg5tJ2kE6mZ1WxKsguMDUhFrRQRieNFoNGlJtMrBIjqV6IDTlc2g4UdUhQkRcsiQwNI+86tYSARHUpVM9cAKVh9VzFQg+vF3lOjXvB0km5mEpklPHIqUnvXARoR0ayY6W//1vLR+LqooGgBbm0uDNX4TwyyG73hVeH4fK1m4BC+pUEUoVCgfp1a0PTn2eRAbi3fR4uzXkBQTsWi4V19EamUrtBKJfp+5raUphZoPrL4yTNrROdcmACpYqAjgTeUsWEJ1MMCJSr2gA2lesIF2UxauzMCjPE+3uXIj0pQdiWOTboWpiqRSpL7opqDJgm2vD/cxZoVT75Xk0I9UVGWorIL8kR2fpFHNskplBzwHTQLmHiRAeRXY2mopWngVfFsTREYQfWiOeZ/NSW92yu8ZQcG3SDeTknJD0MxRPpNbTGFaWCT57GYez4aVAoFKrwxcz5CL4fJl0t/G/y42g8uKjUNLt1f6/wDZTiGqTt9hw8B05NXgAtvvV4dQqaTPkHTafuhnuPETAv74zEqEAE7fwOF7/qBb/fp4PWFRSE5IbPHfje8c9V7PdtO3LlZc3ISEsF/e+89fMIXFv8OqLO/i38m9u41UGNAVOF/W0NaYz1P/xFpBt8sgEtZh8SixCztsNpJlBaCLDAW1ruZCmcR+XOb4tZ0WtgkdAiol3Qos/vAAlj9E9eiyaKVIUWcVWn1coZ6fDb+AUuf9MX15e8jYuze4IW0BWpcSNXJldGGelp0od7N9jVaKLT0cjuyUqkwKuGRNLDMJCGVnoQUb3fBDUl8s5SmJhIr5aV2vOIU1vyLqjmytHjZ/AgJrubqeTkFOzY85+a0gVnhR/bKH1ZS4VD3fbI6Tu44NqlvITCBGSKVeutuSD3bKSZV5iaw8K+Eqr0GoNmU3cJ+34H7w6gv5uYK/twa8Vo4f2AuKYmPFYL6M7dgDzy76nNp8VyIf+uwOWv+0hC9TQ8DbwCGgeNrf6H69Bw3O/Co4KJuZWqPtni2lbxRtY81UVOMIFSQsCklMyDp/F/9s4DMIpq6+P/2fRKekISSmihSlWQYkEBBeVZsSCIPEVQEGw86SCCBfSJoAgoIIiiqJ+KT0VRinSVjoi0QGghhATS+zf3JruE3ZTdZHezO/uPzp07t57zu8Pu2Tt3ztUgAfHI1M0nEML9TUY1Z/rEYzyBJqr7Q/CupcevUd0egDTgFEWIIg+xlu74V6+qX3wF8trZAuFo/vKRHRBfpPXvsMyAM0dXyUstmF7NcVerOtT/4imDMHLEC5lihz5LhYsQyxp0bhCuo3IteAnq0JHyjaWK0iuTqyA7HUlbv5BFontydleCsCRQx0+s749/7G10mPg9YnsNU43hSIhlOye/exs7p/fBkRXjcfnoH1e1ekP3zvDw8LgqTVwI/7virD9EvcPLx0p3aMKlWH56CryCo1Gv7ygIbwpi9lm/sYu+Ds8k4EoEaPC60mg7ma6KcFGmGotC7HObLZvZEnXEzK5wqSNeJhFfLiKtto7iwiKTrsWMTp4VvVCYdGDDhIRvZsvWo28eon6pRsm4NQPxxSzWE+YkJ6AgK82aTdu9rczEA0jZ8zN0Xr6op870VUcAD78ghF7TS1ZN2vK5PJsT3HJTt3KL9byha7nplSUmbfoUxQW5CIhrD/0PksrK12aeo/ctZlRjVIO3/YT/IX7o25CzvmIJwp6fcHDBcIjNHISXl/yMi4gMD8OrU8ciwMcDzUJ0CFEnZsWLiEMHDUBhbiaE/2uxNljUEy7voD51ETPwwrBuN+5bRN/0qFwTD/6RgIsToMHr4jeAo6sfef29UsQU9YtAvBwlL8wIxBfBye/nypL17xgjjQ15UUuBm49/uT27eweUm+7IieKLWKwn9awTiZieQ2wmqn+9lrLtjBP75NlZg4Rv35Six6izojXxYhHVtWRZw/ntX8v2zAmEC7LnRj4One7KR/2Ae/qhf99bzaluKCO8RJzdtFJex/R8TJ4ZWIeAWNMtjNMOE3+A8HTiWScCwhOG8OO98+XeOPzxS7gt9BS+fdgf79/pgy8e8MMbNwMXfnwLO1/uA/GkSKwNFi96CuO2/bjVqhE9RxrR1pGQrZCANghc+RTUhj5masFizkJAzISElr79nLSt5HGqObKfWjMfBZmp6kxUO7muzpw6tiwT3ulOk+a9wxtIZ+4mGQ6ckH85GafXfiAlFGtRFRt6vAho2E7248zLGsSMW8aJvaXu8Gr240C4axPuzAqzL8vd/CQcM4Lpk57HmcM7sPHHz5H491YsmT8bbm5usORPLGUQ/fpGx6NOfFdLqrKsmQTES20xtzyO9hO+R/N/vyPXxouqYtez81tXqbPrV7zVZKg/ApN3fAPxQ0Q8DRHLFcQGEGL5gmdwXVGNBwmQgBEBGrxGQHjpeASiuj8ohTq/7St5rioQ/nb1L7o1vGtsVcXtkh+qGu3xj/0X4Z3ugNiRDcXFyLl4Vs7k2EUAK3Vy4rs58ks2sFFH9Qv5Fiu1Wn4zVwze3eUXcILUk6WbTNTvO9Iq0or14KIh/f0t4uYcAf5+6Ni+DUKCy/GTbEYD4qUqUYyzu4KC7Q/xo6LpoDfk2tvw6/qrHV5Z/69eyP+9w2LR5rmVEC+iiRfSZCIDEiCBCgnQ4K0QDTMchYB//TYQbxCL9WxiV6+q5Eoo3VEtUn0E7Btds21uq+rLkvygFj3QaMBUtBi+ENHisXBhHo6uetmSJmq1bHrCbog3y4UQDe96UZxsegQ0vEa2n5H4lzw7WyCMUvFo2i+2JULb3WYV8UPb3wY3b/+SFzlP2mepx/kdX5f4Wg6rD+Ff2iqKsBGzCIgnXGJXs/IKBzbpTE8Z5YFhGglUQMAcg7eCqkwmAfsRiOr6gOzszIbl8lxRkLLnZ1w+9ifcfAIQ23tERcVqPT2m15PSaX/6sZ1I2rKq1uWpTICCrEvIOvUXjn4+TRaL7DoAPlFNZNyWgfDQITa0KC7IQ8aJvbbsyuptX7XJxL9e2EOfgQAAEABJREFUsFr7wm2Ufoe2c5ssf5HTUkGKi4oMS1iiuauapfisUl64f/OJiDNpK/xa02VSJoWYQAIkYCBAg9eAghFHJhDSrrdqxAaWzmztL1fUwrwcnPh2tsyr33cU3H0DZdwRA527B5o89IoUTTz2dkhvDUWFEM7x/5x6K45+MAK5ySehc/dUf0gMl3LbIwho2E524zjbDEtxqgz0m0yEtOmJgAYlM9VVVjKzgPjBIYqm7P0Z+Zm29WBxce9PyEs7B4/AMIR1vEN0y8PeBHRuaDliIWJufUK+iBbR+R71+gOIJ1/2FoX9kYAzE6DB68yj50KyC0NLOHIXKp/bXPK2uIiXPc78uhjC96R4sSf8urvLZjlk3L9+a0R2ewBFedk4+tkUh5Px4v51hiUMUjhFQZE625qbWr1dumQbFgYBDdvKGulO5I9Xv8mEohoq9fuNkfJbMxD+pOs06wKoP0jOW/AiZ3VkOP3LElkt+sZBUNzcZZyB/Qm4+wWrPzSfhPDmIDbQCYgr+SFof0nYIwmUIeBkURq8TjZgriyu3i2TWMcr1vOWZZF78TSEwSvS4u6dAEUxfclD5DnaIWaiPYOicPnI7xa9eW8PPTJPHSy3G+HbuNwMGyQGxrWXraY70ZKGxB/fhdhkQvyY8QqJlvJbO9Cv60wq3QjC2u2L9tL+3gTxAqi7bx1EdClxDyjSeZAACZCAMxKgweuMo+aiMnsEhhtemjH22KDfCEF4QRAzp86CSKzJbDxgihT3xDezIdx+yQsHCMQ66PLEcPcx23dwedUtSvMKjYW7b5B0MZdz4aRFdWujcOapv9RZ8TVy+Y0tNzsJatFdujoTvqkv7vvFJqrq3c9FdX8Q4j61SSdslARIgATsRIAGr51AsxvrENDPbJ3b8jmKC0u25b10eDvEVrdyJ6u+o63TkR1bCWxyLcKv/ZfcNenYFyXreu3YfYVdeQZGAMXFV+W7+wUhsHGnq9JsfaF/fOsM63gTvp4lccTe+jiENwV5YaNAeCERTZ+rxi6Eol5lh3iZMuPkfgg/y5HdStwCVlaeeSRAAlURYH5tE6DBW9sjwP4tIiCMH/HmfkHGRaQdWCeN3uNfzpRt1Os9HB7+wTLubEH9O56Fu18w0v7ejAu7fqh18cWyheNflXD1i2mBgKZdUPemwWj9zDKbG3LGyosxF2mOvo5XbjJxch+E4/+IrgOEyDY9xI8kxc0DwjjNSjpm1b5O/7pYtieWEdlzRl92yoAESIAEbECABq8NoLJJ2xKIvnGw2kExzqxdiGMrJ8nNG4QRLNZMqhlO+b+7jz8alS5tELOEwhVYbSmSl34Bfy8aCbGLU3CbW9DqmY/QcODrqN/3GXgF22ZNamW6BjjBi2tF6tOGE9/9V6rRQP3xorPDC14e6mx7WPs+ss8kK87yZp07gkv/bIOi6lD3pkdl+wxIgARIwNkJ0OB19hF0QfkLczPUR+1A3sUzuPTXBkABwtrfBvFWPJz4L7hFd7lBgdjC9diq6bWiifAYcejDZ5CfkQK/2JZo8tDLUBQVcK1IU9Kpf/026qN1T+QkJ6A2fwiUSFN+eH7rF8hLPQsxGy1ckZVfyvqp+iU+F/78Hwpz1H8XVujidOnW0eGd+jvtExMrYGATtUuAvZOA1QloyuC9kJKKkWNnYuioyRg/fQ6yc3LKBbZn/yEMGTkJg0aMxwfLvzSUqap+atpl9PzX45i/2PYO3w1CMWJC4My6j6BaYbjypyDt4KYrl04ca3jXixAbLqQeWI+Le9faVROxycChj55H1pl/4FknAvH/fsdhXlbyr9dSsnDEZQ1XbTLR/wUpp70C35jm8KvXSs7GJ/+xusbdihcD5Utw6o8cuRtgjVtkAyRAAiTgGAQ0ZfDOWbACXTq1xeK5LyMwMAArVn1vQrm4uBiTX30XY0cNwZJ50/Hrbzuwa2+J+6Wq6r/57jJ0aNscqN0JL7jyX2F2OoSvXRhByD6fYJTinJfCBVTcPeOk8Alfv4HC7Msybo/gxDdv4PLhHXDz8kPzJ96FeGRuj37N6UO/AYUj7rh25pcP5TiFdegLP9UANUcfa5aJ6layC6E1duyTPybVz8jQtn3gFVzXmmKyLRIgARKoVQKaMng3b9+Nfr17SKD9evXApu27ZLxscOhIAnx9fdAyvjHc3dzQ++au+G3bTlmksvpiVtjHxwutmjeVj9NlBQZ2JyBcZXkEhJr06xPR0CTNWRNC2/ZCUPNuEL6Gj6tGrz30OPfbCkifrooOzR57Cz4Rcfbo1uw+AkrX8V4+bvpv2uxGbFBQbjLx2ydyyUW920fZoIeqmwy55laIH0pidlasva26Rvkl8i4lI/nP72RmdM8h8szAOQhQShIggaoJaMbgzczKhvoUDsFBgVLrejGRSL5wUcbLBknJFxETFW5IEuWSzqegsvoFBQWYu+hTjHriIUM9RmqPQMwt/76qc8XNHdE3a+sLWrzA5ubtB7HJRqqNl2ukHvwNJ757WzJtdN9EBDbqKOOOFATEdZDiCFdZend0MqGWg8Qf5kJsMlG3x8PwrHPlc8WeYuncPRHRuWRnwZq4KDu74SOI3duCmneHb1QTe6rAvkiABEjA5gScyuAdPe51DHt2msmxs3RJgk53RR1FnamqiJ6iK7sm4UqdiuqLpRH33HkLAgP8TZrMzc2F8SEKGafV7rWpjM4sT1DHf6H5qOWI7jsa0Xe8gBajV8K3yfUm4+DMOhZ5+CHm9mfErYRjn09F1qUUm+iXemw3Di//D6A+xo7o/jACr+lTbj/iR19t8ixQ3OEV3gDCIEs9uqtcGe0tX+rxvUjZ8zPEU4ew7oOsIlN+fj7y8vItbiuoY39A/cUv/FGnnz9pcf2stAtI2vYVxF/ETY9ZXN/e7K3RX23f09bQwRnaqO49XRPdxH3MgwSMCVyx9oxzHPB6xsRReHP6CyZHh2tawM/XB4WFRchTvzCE6CmpaQgPCxHRq47I8BCkpqUb0i6q5SIjQiutL5ZGTJ+1ANf3eQQLP1qFZZ+txtvvL5dtCCPZ+BAZxmm81sGaDMQMVOh19yDs2v7wDo2xatvWlLMmbYV16o+ARp1QkJmGMz/OtbqOBekXcHTZ8yguyENgfDfE3Daywj4URakwryY6WlLXv0FbiL+sxP21LouQ+/R3bwlxENNrONy9fa0ik6IoajvisOzfi3dwXYiZWah/KTu+UtuwrP6FrZ/J+8C/YTuIFwSFfpo91IkRoZuiKBZzEvV4WHZvKYrgLA7L6tWEM/hHAuUQcCqD19/PFwH+fiaHXq+u17XD2vVb5eVP67age+d2Mi6WK+w/eFjG45s0hPDGkHj6HAqLivDLhu3o3qWDzKuo/qK3p2Drmo/lMezR+zH4gTsxZvggWcfDwwPGh8gwTuO1KaeaMnF3d4c4atqOI9dvItyCuXsh5c/vkJWwy+Req67sSmEujiwdjcKsS/CLbYH4wa/D09Ozwvbd3NwqzKuuDJbWq9OovfinBWHwWlrXWuXPb/wIf739IHZPuRGZifvgERiOqK73WY2NuJ/F4VHO50pVafqX11L+WA03pdhsmXRF+UjavFKyjb1lqNn1qpLH0fMd4Z52dEbWkE/cz+KwRlvmtiFvZgYkYETAqQxeI9lNLscMH4jVazZCuCU7mXgWA+/vJ8ucUo3b6bMXyLiiKJj20lOYNHMehjw9ER3bt4SYIRaZpfVN6os8HiRQGwSEe7AG/Z6RXR/9bAoKc7NkvCaBWHP6z5LnkHM+AaL9+H+rs8ce3jVp0i51A9TZR9FResJucbL7kbLnJ5xa8z5ykk+gSJ0VBxQU5WVBbNABB/gLbNoZXiEx0lexWPttrkhJW1ehKC8bPpGNUSe+q7nVWI4ESIAEnIqAzqmkrULYsNBgzJ89EcIt2cxJo+HjXfIlHt80Dp99ONtQu23reCx99xUsnz8TTwy615BeUX1DATXy2MP/woihJW6A1Ev+TwI2JyB2kBPGXv7lZCR+/06N+zv+5QykH98JR3Q/Vply3mH14OEfIg06YXRWVtYWeWl/bzFptjAnE5mnDpqk10aCoiiI6vGQ7NqSl9fObihZnhXb6wlZ9+qAVyRAAiSgDQKaMni1MSTUggRMCQivDSJVuA5LP1biRk9cW3qcWbcUyb9/K6s1HfQ6HM39mBSsksC/1D1Z+om9lZRy3azwjndAcfdC1plDEB4tqiJxftuXco24d1h9CPdmVZVnPgmQAAk4K4EaG7zOqjjlJgFnIiBmN+vdPlKKfGTlZFTnMbrYQSvxh3myjUb3T0adZl1k3JmCAL3Be9z+yxqCmps+7nf3C5JroB2FoZu3P8I7lizlOle6Lrci2cTOeqd/XSKzo28aLM8MSIAESECrBGjwanVkqZfmCNS9cRB86zZDXto5JP74nkX6iRnRI59MlHXq3vAIwq/tL+POFhgM3lpYxxvc8kboPLxUZMXyHNCoA5oNniWXhqiJ4n+HOCK7PyjlSNnzM/Iz02S8vCBl94/yXvIIDEOYOjNcXhmmkQAJkIBWCNDg1cpIUg/NE1B0bmj88CuAej732ydmPbIWUMRuYIcWj0ZxYT6E66p6/UaLZKc8/GJaqI/sPeWLY5UZc7ZQLmnzZ+rMeq7KsAeunbEZLYcvREBciecIW/RX3TZ9IxupcrWTPovPb/ui3GaKi4tx6udFMi/6xsFQ3NxlnAEJkAAJWIeA47VCg9fxxoQSkUCFBIQxE9PzMZl/5NOJKCrIl/GKgoKsyzi46GkUZqfLR+9NB70GRVEqKu7w6cIwE35ihaAZJ/aIk12OovxcnFn/kewrts9weXbkILLrACle0uZVEEsX5EWZIO3gRuSmJEIsgYjock+ZHEZJgARIQJsEaPBqc1yplYYJxNzyuHzZLDflFE7/vKBCTYsKCyBmdoVh44juxyoUvIqMAIN7MvsZvOc2fSq9Q4gZcr+Y5lVIWPvZIa17wsM/FPkZKUg9sM5EoFOls7t1bxgInUeJNxuTQkwgARIgAQ0RoMGrocGkKq5BQMxyyqUNik6ddVyGzDOHylX82GdTkHFynzRomj/+Ljz8gsot52yJV9bx2sfgFb6PDa67nGB2V4ynuEf0M7dJmz8XSYbj8tE/kHX6bwhvDpHdStb7GjIZIQESqA0C7NMOBGjw2gEyuyABaxPwi45H3R4PQ31ejaOfTESxOptbtg+xQULK7jWAahQ3e/RN+ETGQSt/AXElOyMKt1vGettCR7F2tyDrEpxldlfPIOL6ewGdGy4f+xNZScf0yTj9y2IZj+p6P9x9AmScAQmQAAlonQANXq2PMPXTBoFytIi97Wl4BkUh+/xx1Yj50FDiwq4f1esP5HWj+yaiTrPOMq6VwM3bDz4RqgFfVIjMxAM2VUvM7p5Zv1T24Qxrd6WgpYFnQBhCWt8sr5K2lMzyik0yLh/ZATEDXPemR2UeAxIgARJwBQI0eF1hlKmjJgno3P8LqSEAABAASURBVD3Q5KFXUKz+d/rnhTi4YDgOfTgKx1ZOkvpG9RjotO7HpAKVBPZa1pC0eSXEbmrONrurRxfV7QEZvfDHd6oeGeoPoZIfRuGd+sPDP1jmMSABZyNAeUmgOgR01anEOiRAAo5BICCuHbzUWV4oCsTazLRDWyFcTvnFtkCDO591DCFtIIXQWzQr/AuLsy2OotwsnN24QjYd23uYPDtbEBDXHj6RjVGYly1/DKXuXyfvj2huNOFsQ0l5SYAEakiABm8NAbK6IxJwHZmEu7G8tCQThcXjbJNEDSVc8dSw22Zand30yRXPDLEtbdaPTRsuKkRRfrb6e0hB+ol9UCNw9/SF2CEO/CMBEiABFyJAg9eFBpuqao9AdnJCuUplXzhZbrpWEr1CY9VH8iEoyExDjg10LczNdPrZXTHWlw7vgNh4RMT1R6FqAMsXGvUJPGubALUjARKQBGjwSgwMSMA5CYilC27e/ibCB8Vfb5KmtQT/hm2lSukJ1ndPJvzuitlzuXbXWWd3VTrihUb1ZPJ/RekmBZlAAiRAAhohQINXIwNZAzVY1YkJKDp3xN3zktwxS6+G2Bgh+uYh+kvNng0vrh3fZVUdhWcGZ/O7WxEA6c2inMyK0sspyiQSIAES0AQBGryaGEYq4coEQtvdho5Tfkab0R+j/bjVaK2ePQLCNI/EYPBaeYb33MaP4cyeGcoOfJ2m18G/fpuySfAKjkZouz5XpfFCT4BnEiABrRKgwavVkaVeLkVAcfOAb0xzeAbXhav8+cW0gOLuiZzkE8jPTLOK2gXZGTj72wrZlrP53ZVCGwc6N7R6+kPED52D+n2fQbPBs3DNC59f9UTAuAqvSYAESECLBGjwWjiqLE4CJOAYBBQ3d/jXK/GekHHCOut4z/2mndldwygpOgQ174a6Nw1GcOubofPwNmQxQgIkQAKuQkDnKopSTxIgAe0RuOKerOYGr5zd1fvd7TNce7CsrxFbJAESIAGnIUCD12mGioKSAAkYE7CmwSvW7hblZauzod3hF9PcuCtekwAJkAAJODEB2xq8TgyGopMACTg+AbGTmJAy4+R+FBcWiGi1Djm7q6W1u9WiwEokQAIkoF0CNHi1O7bUjAQ0T8DN2w/SxVZRITITD1Rb37MblsHWs7vVFo4VSYAESIAEakyABm+NEbIBEiCB2iSgd092OaF62wyL2V2x0YTQQROeGYQiPEiABEjAcQnUimQ0eGsFOzslARKwFgH9Ot6MavrjPbvhI87uWmsw2A4JkAAJOCgBGrwOOjAUiwRcmoAFyvs3bCtLp1fD4C2Z3V0p63N2V2JgQAIkQAKaJECDV5PDSqVIwHUIeIfVg7tvHRRkXUJOcoJFip9dv5SzuxYRY2ESIAF7E2B/1iFAg9c6HNkKCZBALRLQe2uwZJZX7M52bvNnUmrO7koMDEiABEhAswRo8Gp2aKmY6xCgpgFx7SQESwxeemaQyBiQAAmQgEsQoMHrEsNMJUlA2wT0L66Za/DK2d1NXLur7buC2rkkASpNAhUQoMFbARgmkwAJOA8BsTOa4u6JnOQTEMZsVZKfXf8RigvyuKtaVaCYTwIkQAIaIUCDVyMDSTXMJsCCGiSguLnDv14rqVnGiT3yXFEgDGKu3a2IDtNJgARIQJsEdNpUi1qRAAm4GgH9BhRVLWs4u24pZ3dd7eagvhUQYDIJuA4BGryuM9bUlAQ0TcCwjvd4xTuuydndLZ9LDvTMIDEwIAESIAGXIECD1yWGufpKsiYJOAuBgLj2UtSMxAMoLiyQcePgzK9LwLW7xlR4TQIkQALaJ0CDV/tjTA1JwCUIuHn7wSciDigqREbifhOdxexu0tZVMp2zuxIDA8sIsDQJkIATE9CUwXshJRUjx87E0FGTMX76HGTn5JQ7NHv2H8KQkZMwaMR4fLD8S0OZyuof+PuIrNP99sHo+8BTKCwqMtRjhARIwDEIVLaO98wvH3J21zGGiVKQAAmQgN0JaMrgnbNgBbp0aovFc19GYGAAVqz63gRocXExJr/6LsaOGoIl86bj1992YNfeg7JcRfUzs7Lx7IRZ6N/nRqz9+gPMnz0JOkWRda4KeEECJFCrBPTreDMSrvbUkJd+AUnbvpSycXZXYmBAAiRAAi5FQFMG7+btu9Gvdw85gP169cCm7btkvGxw6EgCfH190DK+Mdzd3ND75q74bdtOWaSi+hu2/IEWzRrhnjtvhbeXJxrUqwtFocEroTEgAQci4N+wrZTG2FPD2V+XcnZXkrFfwJ5IgARIwJEIaMbgFbOwwgYNDgqUfOvFRCL5wkUZLxskJV9ETFS4IUmUSzqfgsrqnzmbLMs/9PiLcjnDss9Wy2sGJEACjkXAO6we3H3roCDrEnKSE6RwJbO7X8g4Z3clBgYkQAIk4HIEatHgtZz16HGvY9iz00yOnaVLEnS6K+ooypW4cU+Kruzs7JVyFdUvLi7C2aTzeG3Kc1j23gxs2PwH/tx9QDabnZ0F4wMoNkkzLsNrU26WMsnNzUVubg5Zl3MPWsqyqvL5+XlOw9m3Qcksb8o/v0uZT/60CMJrQ2Cz66ELqS/TqtK3tvJzeU/bbXyc6Z6urfvRGv3Wxj0tv5wZkIARgSvWnlGGI17OmDgKb05/weTocE0L+Pn6oLCwCHn5+VL0lNQ0hIeFyHjZIDI8BKlp6Yaki2q5yIjQSuuHhgShRbPGcilDWGgw2rRsgkNHT8o2vLy84WV0AAq8jNJ4bcqppkw8PDzg4eEJL7KGl40ZuLt7wMvGfVir/aDGHSD+ck4fhC4vExf/+EZcIrbPU/ByVB1K5eI9bf3PiYrG3Jnu6Yp0cIb02rin5T94BiRgREBndO3Ql/5+vgjw9zM59EJ3va4d1q7fKi9/WrcF3Tu3k3GxXGH/wcMyHt+kIYQ3hsTT56SnhV82bEf3LiVfkBXV76Hm/3M0ARmZWcjNy8O+v46gedOGsj0xK2x8iAzjNF7rQAbOy0BRFKcZv4C4kn/3GSf24uy6xXJ2N6h5dwTUa+E0OvDfiu3/rSiK89zTvB8sux/AP6cmYCvhncrgrQrCmOEDsXrNRumW7GTiWQy8v5+scko1bqfPXiDjiqJg2ktPYdLMeRjy9ER0bN8SYoZYZFZUX8wUDxpwB54YMw2Pj56KW27sYqgj6vEgARJwHALeITGA4oac5ONI2vw5UAzE9n4S/CMBEiABEnBdAjotqS6WG8yfPVG6JZs5aTR8vL2levFN4/DZh7NlXARtW8dj6buvYPn8mXhi0L0iSR4V1ReZfXvdgE8XvS7rPHzv7SKJBwmQQK0QqKTTokL8NX+YauQWqoUUQBGHellU/s5r4B8JkAAJkIBLENCUwesSI0YlSYAEKiSQde4Iss8fN8lP2b3GJI0JJEACJOD0BKiA2QRo8JqNigVJgAQcnUD2+RJXZMZyVpRuXI7XJEACJEAC2iRAg1eb40qtSEBPwKXOgY07QXFzN9G5TtPOJmlMIAESIAEScB0CNHhdZ6ypKQlonoBHQCjq3zEGirunQdfAJtciovPdhmtGSIAEXJUA9XZlAjR4XXn0qTsJaJBAVLcH0Wnar2j9zHJ0mPQjWgybDzdvfw1qSpVIgARIgATMJUCD11xSLOcSBKikNgjoPLzhF9sCHgFh2lCIWpAACZAACdSIAA3eGuFjZRIgARIgARLQJAEqRQKaIkCDV1PDSWVIgARIgARIgARIgASMCdDgNSbCa/MJsCQJkAAJkAAJkAAJOAEBGrxOMEgUkQRIgARIwLEJUDoSIAHHJkCD17HHh9KRAAmQAAmQAAmQAAnUkAAN3hoCNL86S5IACZAACZAACZAACdQGARq8tUGdfZIACZCAKxOg7iRAAiRgZwI0eO0MnN2RAAmQAAmQAAmQAAnYl4CjGrz2pcDeSIAESIAESIAESIAENEuABq9mh5aKkQAJaIMAtSABEiABEqgpARq8NSXI+iRAAiRAAiRAAiRAArYnUIMeaPDWAB6rkgAJkAAJkAAJkAAJOD4BGryOP0aUkARIwHwCLEkCJEACJEACJgRo8JogYQIJkAAJkAAJkAAJODsByl+WAA3esjQYJwESIAESIAESIAES0BwBGrw1HNL8/DyUPfz9/fDJJyuuSiubz/jVvGrCQ1EUOXo1acPV65qnfz48PDx4Txv9WzePnWX3u6LwnrYF1/La5D1t2b1ZHkNz0hTF/ve0/GJgQAJGBGjwGgHhJQmQAAmQAAmQgMsRoMIaJ0CDV+MDTPVIgARIgARIgARIwNUJ0OC14h1wISUVI8fOxNBRkzF++hxk5+RYsXXXbup/P23EE2Om4da7n8Dzk2bh+InTBiB79h/CkJGTMGjEeHyw/EtDutUjLtbgkKcnSuZ6tQsKCzHjrUUQ6cOenYZTZ87ps3iuJoFvf1iH+4Y8h+v7PCI/M/TN8J7Wk7DO+evvf8WjT03AwGEvYerr83HpcoZsmPe0xFCjYM+BQxCfB91uH4y1G7ah7N/nX6/BI8PHYfCICdi4dachi9+VBhSM2JEADV4rwp6zYAW6dGqLxXNfRmBgAFas+t6Krbt2U5ERoZj3xjis/nQumjZugPeXfCaBFBcXY/Kr72LsqCFYMm86fv1tB3btPSjzGFSfgDAQIsJDULr8Tja0+sf1uJiahqXvvoL7+vfCa28vlukMqkdAGArzl6zCi6Mew+YflmHYkAGyId7TEoPVgozMLCxY+gVemzJG3rs56kTEd2s2yPZ5T0sM1Qr0lby9vPDko/fhpm6d9EnyfCLxLJatXI0Fb03GG1OfxYw3FyInN0/m8btSYmBgZwI0eK0IfPP23ejXu4dssV+vHti0fZeMM6g5gU7tWsHL0xM+3t7odl17JF1IlY0eOpIAX18ftIxvDHc3N/S+uSt+23ZlJkEWYmARgcvpGfj2h/V4+N6+V9XbvG0X+qr3tUjseUNnHDh0FJlZ2eKSRzUIrP5xAx64uw86d2wDnU6HhvXqylZ4T0sMVgvEDwioP4wVRYGiU2S7URFh8sx7WmKoURDfpCE6qp/P4h4u29Am9XP4RtUI9lM/n6Miw9C8aRx+37kf4o/flYICD3sT0Nm7Q632J774FfWzNDgoUKpYLyYSyRcuyrhrBrbT+tMvv0fnDq1lB0nJFxETFS7jIhDck86niCiPahKYs+ATjB4+EOILTLUTDK0kp6Qipm6kvBY/LoTRcF7lLxMYWEzgXNIFHD56ArffPwIPPTEWW3/fI9vgPS0xWC0I8PdTf6h1x92DxqBH30eRX1CAnjdcJ9vnPS0x2CRITrmI6DKfzbHRkTh/IUX+SOZ3pU2Qs9EqCNDgrQKQJdnCQNCXVxSi1bOw5nnFqv8h7XIGhj5yt6FZpXTWpiSB3Es4VC888PdRWbFtq3h5Ng4URf1VV5qoKxMvTeLJAgKFRUWy9MoPZ2Hyi8PVR76LIB6/i0Te04KCdQ7xLsXBwwlYseB1/LB5qQVeAAAN40lEQVRqPgIDAiCW7OhbVxQ73NP6zlzsrKhPLvQqK0oZzlel8zNbz4hn2xLgnWYlvuKxTWFhEfLy82WLKalpCA8LkXEG1iGwY+c+/LnnAN6eOVYubxCtRoaHIDUtXUTlIdaYivW+8oKBxQQ2bvkD3/+8Ub5E9eRzL2P/wcPyZR/RUHhoMC6mXhJReVxMuwyxzldeMLCYQGhwEK5Tn1TUCfRHi2aNEBpSB6fPngfvaYtRVlrhz90H4ePtiUYNYxAUGIAundpgz/5/ZB3e0xKDTYLw0BCkpZX5vFC/EyPCQsHvSpvgZqNmEKDBawYkc4t0va4d1q7fKov/tG4LunduJ+NmBCxSBQHxgs+ST77BzElj4OnhYSgt1o+JN34TT5+DmDH7ZcN2dO/SwZDPiGUERgx9AFvXfCwP8bJJ6xZN8dF7M2QjXdX7ea3KV1xs/3MfGjWIkV9e4pqH5QRu6NpB/QF3EEXqTK9Y3nDhYhpi6kaA97TlLCurER4ahH+OnkTapcuS9Y6dB9C0UX1Zhfe0xGCTQHwOi/cpcvPy5A/lvw4dQ2f1x4bojN+VggIPexOgwWtF4mOGD8TqNRulW7KTiWcx8P5+VmzdtZuat2gldu/7Gzf3HypnH+8b8pwEoigKpr30FCbNnCfdZXVs3xIdrmkh8xhYl0D/22+GTqdIzh9+/BX+M/rf1u3AxVrrddP1CA4KxOCnJmDc9DlyWYO/ny8UxdXvaeveCPFN43DD9R1x1yNjpHssby9P3H9Xb9kJ72mJoUbBtj/2yM/ktRu2yc9h4TpSNNigXl3c3e8W/PuZKRgz/g08+9Rgw2QFvysFIR72JqCzd4da7i9MfeQ7f/ZE6ZZs5qTR6mM0by2ra1fdFr09Rc466mcfv1j6lqH/tq3jIVxlLZ8/E08MuteQzkjNCFzTqhkEd30r4kW1Cc89IVkv/O8U1I+N0mfxXA0CiqLg2RGD8PH7r0K41BPeGvTN8J7Wk7DO+cVRQ7B+9WJ8vOBViLj+KRHvadT4T7ji1H8ui/Pa/1tkaHPAXX0g7u9l82fgxq4dDen8rjSgYMSOBJzS4LUjH3ZFAiRAAiRAAiRAAiTg5ARo8Dr5AFJ8EiABlyZA5UmABEiABMwgQIPXDEgsQgIkQAIkQAIkQAIk4MgEKpeNBm/lfJhLAiRAAiRAAiRAAiTg5ARo8Dr5AFJ8EiAB8wmwJAmQAAmQgGsSoMHrmuNOrUmABEiABEiABFyXgMtpToPX5YacCpMACZAACZAACZCAaxGgweta401tScB8AixJAiRAAiRAAhohQINXIwNJNUiABEiABEiABGxDgK06PwEavM4/htSABEiABEiABEiABEigEgI0eCuBwywSMJ8AS5IACZAACZAACTgqARq8jjoylIsESIAESIAEnJEAZSYBByRAg9cBB4UikQAJkAAJkAAJkAAJWI8ADV7rsWRL5hNgSRIgARIgARIgARKwGwEavHZDzY5IgARIgARIwJgAr0mABOxBgAavPSizDxIgARIgARIgARIggVojQIO31tCb3zFLkgAJkAAJkAAJkAAJVJ8ADd7qs2NNEiABEiAB+xJgbyRAAiRQLQI0eKuFjZVIgARIgARIgARIgASchYD2DF5nIU85SYAESIAESIAESIAE7EKABq9dMLMTEiABErA/AfZIAiRAAiRQQoAGbwkHhiRAAiRAAiRAAiRAAtokABq8Gh1YqkUCJEACJEACJEACJFBCgAZvCQeGJEACdiDw3ZoNSDx9rlo97T3wD4aOmlxlXXPLmTTkAAm/79qP4c9PdwBJKAIJkAAJaIsADV5tjSe1IQGHJvDjL5tx+mxStWRs1DAWL44aUmVdc8tV2RALkAAJkICLEtCi2jR4tTiq1IkEHJDAT+u24NCRBMxd+Kmcxdxz4BAWfrQK46a/jZFjZ+Lx0VNRUFiIiTPm4c6HRuLBx1/EjLcWITsnR2pzLOEUZs1dKuNiJnTIyEkYP30OnnzuZTw7YRbOX7go88wtV1RUhHcWrsCAoc/j6RdnYNa8pVIO2YhRIGalX5r2Xzzy5DgMGjEeP6zdZChxfZ9HVJ1WYNiz0/CQKvPP67ca8jZs/kPVawqErKPHvY7jJ04b8r5c/TMefWoCBo+YgD73DcfF1EsyLyc3T+o15OmJGPmfVw16yUwGJEACJEAC1SJAg7da2FiJBFydgOX69765K+KbNMSoYQ/h/TcnoW2reNlIwskzeH3qs/hgzlS4u7lh8IN3YvWn8/Dxgtfk9cer/ifLGQcnEs9g2JABWPDWZNx+azcsXvG1cRF5XVG5tRu2YeuO3Vg8dzrmvPofHDl2UpYvL5jy2nu4oVsnVaZXMfe1l7D006+l8a4v26BeNBb+dwreeW0c3np3GVJS03AhJRVT35iP554ajKXzpqNdm+Z4edb7sspmtd+ln3yDGROfwbL5M/DhO1Ph7+8r8/TyLn33FXRs27JCvWRhBiRAAiRAAmYRoMFrFiYWIgESsBWBrte2hZ+vj6H5y+kZeOu9jzD6pdew76/DOHT4uCGvbKRJXH00rFdXJtWNDMexhEQZNw4qKrd73yH07X0j/P184e7ujnvvvNW4qrwW8hz85xi+/WG9nJl+6eU5yMzMgVgrLAuoQc8bOqshEB4WgubNGmHfgSPYc+AwWjVvgpbxjWXewPv7SiM5Mysb237fi/6334TY6EiZFxsdBU8PDxlv1CDWoFfHti0q1EsWZkACJFD7BCiBUxCgwesUw0QhSUC7BLy8PA3KnUg8i1dmL0Sfnt3w5isvYugjdyMnJ8+QXzbi5nbl40un06GgoLBstiFeWTkxo6wvKIxefbzs2U2ddRZ5782aIGemxez0dyvn4f5/9S5bzDReXKzOUF+R0UM1qnWKYijn7l5i4BoSSiMeHu6lMUD0XZFehkKMkAAJkAAJVEngyqdxlUVZgARIoJoEWK2UgJ+vNy6nZ5ZemZ4ST59DbEyUnBn1Vg3hXzZuNy1kpZR2beKx7Y+9htY2b99tiJeN+Kmzz82bxsn1vmLdr8g7ejxRLlkQcXGs/OpHcZKz0fv++gdtWjVB29bNcODvo/i7dIb60y9/QLMmDeVsdpdrr4HwWHHqTMkLfHn5+RCHbIQBCZAACZCA1QnQ4LU6UjZIAiRQEYEBd/XBT79uwVMvzlAf+R8yKXZdx9Zw0+nki1zPTXwDwXUCTcpYK+HWG7ugcVwsxMtkL0yaLWdj6wT6l9v8tJdGqAbuJQwaPh73P/Y8Jr06D4VFRYayWdnZeHjYfzD19ffwn9FDERochLDQYEx8fph80e6xkZOw/c99mPTCk7JOt+va4YG7+2D89HcgXoLrdfcwZGRkyTwGJKBtAtSOBGqHAA3e2uHOXknAJQl0bNcKs6e/ALE8QLy0NuzR+yEOPQxPDw/5Apl4keutV8bihZGPYt4b42X2Na2aYfHcl2X82vat5fICeaEGrZo3NuSZW04sgxg68G7Z36uTx6CouBhtW5e8SKc2edX/0VEReGXCSKxY+BpWLXkTnyx8HZHhoYYyzwwbKNM+/WAWet10vSH9xm6d8OE707Bk3nTZT1yDGEOeMP6Fnsvnz8SG75YgJLgOKtPLUJEREiABEiABiwnQ4LUYGSvYmgDbJwF7ERAuwQYMfV6dZR0HL09P3NWvp726Zj8kQAIkQAJ2JECD146w2RUJkIBjEfhq2X/x+eI3sVKdmRWzyWKG2VIJt6752NIqLE8C5hJgORIgASsRoMFrJZBshgRIgARIgARIgARIwDEJ0OB1zHExXyqWJAESIAESIAESIAESqJQADd5K8TCTBEiABEjAWQhQThIgARKoiAAN3orIMJ0ESIAESIAESIAESEATBFzM4NXEmFEJEiABEiABEiABEiABCwjQ4LUAFouSAAmQgGYIUBESIAEScCECNHhdaLCpKgmQAAmQAAmQAAm4IoHKDF5X5EGdSYAESIAESIAESIAENEaABq/GBpTqkAAJ2IIA2yQBEiABEnBmAjR4nXn0KDsJkAAJkAAJkAAJ2JOAk/ZFg9dJB45ikwAJkAAJkAAJkAAJmEeABq95nFiKBEjAfAIsSQIkQAIkQAIORYAGr0MNB4UhARIgARIgARLQDgFq4igEaPA6ykhQDhIgARIgARIgARIgAZsQoMFrE6xslATMJ8CSJEACJEACJEACtiVAg9e2fNk6CZAACZAACZCAeQRYigRsRoAGr83QsmESIAESIAESIAESIAFHIECD1xFGgTKYT4AlSYAESIAESIAESMBCAjR4LQTG4iRAAiRAAiTgCAQoAwmQgPkEaPCaz4olSYAESIAESIAESIAEnJAADV4nHDTzRWZJEiABEiABEiABEiABGry8B0iABEiABLRPgBqSAAm4NAEavC49/FSeBEiABEiABEiABLRPgAbvlTFmjARIgARIgARIgARIQIMEaPBqcFCpEgmQAAnUjABrkwAJkIC2CNDg1dZ4UhsSIAESIAESIAESIAEjAtU2eI3a4SUJkAAJkAAJkAAJkAAJOCQBGrwOOSwUigRIwIkIUFQSIAESIAEHJ0CD18EHiOKRAAmQAAmQAAmQgHMQcFwpafA67thQMhIgARIgARIgARIgASsQoMFrBYhsggRIwHwCLEkCJEACJEAC9iZAg9fexNkfCZAACZAACZAACQBkYEcCNHjtCJtdkQAJkAAJkAAJkAAJ2J8ADV77M2ePJGA+AZYkARIgARIgARKoMYH/BwAA///CduxPAAAABklEQVQDANUY3bhE8VDhAAAAAElFTkSuQmCC"
+     },
+     "metadata": {
+      "image/png": {
+       "alt": "Validation information coefficient against training epoch, one line per label, with a dashed line at zero."
+      }
+     },
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "fig = go.Figure()\n",
     "for _label in catalog[\"label\"].unique().sort().to_list():\n",
@@ -412,8 +5449,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "23eeb875",
-   "metadata": {},
+   "id": "3c0f6f91",
+   "metadata": {
+    "papermill": {
+     "duration": 0.019661,
+     "end_time": "2026-09-10T22:35:19.001950+00:00",
+     "exception": false,
+     "start_time": "2026-09-10T22:35:18.982289+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "## Key takeaways\n",
     "\n",
@@ -444,6 +5489,39 @@
    "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.14.3"
+  },
+  "ml4t_provenance": {
+   "executed_at": "2026-09-10T22:35:33.529941+00:00",
+   "executor": "local-uv",
+   "library_digest": "f9a16f95cf154ea046dd00a4fd8e2a9e4a63e8adc229ce6316cbaf4da24ede29",
+   "outputs_digest": "431f85cadc248a13eaa902b2e0cad502eab98c9af3871a8bd88e214424ca04d1",
+   "parameters": {},
+   "production": true,
+   "source_py_blob": "1d631cd0e63c0ad0486d7a43227278deeed0e68a"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 13770.60692,
+   "end_time": "2026-09-10T22:35:22.214286+00:00",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "~/ml4t/public-nasdaq/case_studies/nasdaq100_microstructure/.08_dl_nlinear.build.1954472.ipynb",
+   "output_path": "~/ml4t/public-nasdaq/case_studies/nasdaq100_microstructure/.08_dl_nlinear.papermill.1954472.ipynb",
+   "parameters": {},
+   "start_time": "2026-09-10T18:45:51.607366+00:00",
+   "version": "2.7.0"
   }
  },
  "nbformat": 4,

--- a/case_studies/nasdaq100_microstructure/08_dl_nlinear.ipynb
+++ b/case_studies/nasdaq100_microstructure/08_dl_nlinear.ipynb
@@ -405,8 +405,10 @@
     "four million near-identical overlapping sequences - neighbouring windows would share 59 of their\n",
     "60 observations. `modeling.dl.train_sequence_stride_horizons` in `config/setup.yaml` declares\n",
     "the spacing instead: one window per label horizon, so consecutive windows of a symbol carry\n",
-    "labels that do not overlap - the window ending at t is scored on the return from t to t+H and\n",
-    "the next one starts at t+H. It is declared in horizons rather than in windows because the\n",
+    "labels that do not overlap. [`02_labels`](02_labels.ipynb) takes the decision on the bar\n",
+    "closing at t, enters on the next bar's VWAP and holds for the horizon from that fill, so two\n",
+    "decisions H observations apart have return intervals that abut rather than share bars - the\n",
+    "exit of one is the entry of the next. It is declared in horizons rather than in windows because the\n",
     "horizon differs by label: `fwd_ret_5m` strides 5 observations, `fwd_ret_15m` 15 and\n",
     "`fwd_ret_60m` 60, each spacing its own labels exactly, where a single window count could only\n",
     "have been right for one of them. The spacing travels in the training identity; **how many\n",
@@ -5517,8 +5519,8 @@
    "outputs_digest": "431f85cadc248a13eaa902b2e0cad502eab98c9af3871a8bd88e214424ca04d1",
    "parameters": {},
    "production": true,
-   "source_py_blob": "a2142e64ed47b4340394bba2c85c1491a16b5f94",
-   "notes": "prose synced from the .py at 2026-09-11T09:00:58.939813+00:00 without re-executing; every code cell is identical to blob 8f61df01abf6"
+   "source_py_blob": "e44e01b13df95a9724ac96828f65121700216ea7",
+   "notes": "prose synced from the .py at 2026-09-11T09:02:33.929623+00:00 without re-executing; every code cell is identical to blob a2142e64ed47"
   },
   "papermill": {
    "default_parameters": {},

--- a/case_studies/nasdaq100_microstructure/08_dl_nlinear.ipynb
+++ b/case_studies/nasdaq100_microstructure/08_dl_nlinear.ipynb
@@ -5463,8 +5463,9 @@
     "## Key takeaways\n",
     "\n",
     "1. **A checkpoint is part of a configuration, not a detail of how it was fitted.** Scoring one\n",
-    "   fit at twenty points produces twenty candidates, and keeping the best of them after seeing\n",
-    "   the results is a selection decision. Selection happens in\n",
+    "   fit at twenty points produces twenty candidates, and keeping whichever of them scores\n",
+    "   highest on this page would be a selection decision taken on the wrong statistic: the\n",
+    "   curve below is an information coefficient, and selection is validation backtest Sharpe in\n",
     "   [`14_backtest`](14_backtest.ipynb), over the population published here.\n",
     "\n",
     "2. **How many windows are drawn is part of the model.** On a minute panel the cap decides what\n",
@@ -5476,8 +5477,9 @@
     "\n",
     "**Known limitations.** The window is fixed at sixty observations, so nothing earlier than the\n",
     "trailing hour reaches the model whatever the architecture can represent. The declared sequence\n",
-    "cap is a compute budget rather than a derived quantity - `config/setup.yaml` says so, and\n",
-    "ml4t/agent-workspace#1015 is where that argument goes."
+    "cap is a compute budget rather than a quantity derived from the data - `config/setup.yaml`\n",
+    "says so - so the same declared count covers a different share of the panel whenever the\n",
+    "panel's size changes."
    ]
   }
  ],
@@ -5509,7 +5511,8 @@
    "outputs_digest": "431f85cadc248a13eaa902b2e0cad502eab98c9af3871a8bd88e214424ca04d1",
    "parameters": {},
    "production": true,
-   "source_py_blob": "1d631cd0e63c0ad0486d7a43227278deeed0e68a"
+   "source_py_blob": "8f61df01abf60cf17a62f8a081444c22b9d1d724",
+   "notes": "prose synced from the .py at 2026-09-11T04:40:07.001320+00:00 without re-executing; every code cell is identical to blob 1d631cd0e63c"
   },
   "papermill": {
    "default_parameters": {},

--- a/case_studies/nasdaq100_microstructure/08_dl_nlinear.ipynb
+++ b/case_studies/nasdaq100_microstructure/08_dl_nlinear.ipynb
@@ -400,13 +400,18 @@
     "- **`validation_start` and `validation_end` bracket the development sample.** The held-out tail\n",
     "  must not appear; it is scored once, at the end of the case study.\n",
     "\n",
-    "**How many windows are drawn is declared, not left to the tier.** Every row of this panel\n",
-    "starts a window, and the panel is minute bars, so an uncapped fold would build about four\n",
-    "million near-identical overlapping sequences - consecutive windows share 59 of their 60\n",
-    "observations. `modeling.dl.max_train_sequences` in `config/setup.yaml` declares the cap, which\n",
-    "makes it part of the training identity rather than a property of how the run was invoked. A\n",
-    "preview may lower it and cannot raise it above the declaration, because a preview that fits on\n",
-    "more windows than the canonical run is not rehearsing it."
+    "**How far apart the training windows sit is declared, not left to the tier.** Every row of this\n",
+    "panel could start a window, and the panel is minute bars, so an unspaced fold would build about\n",
+    "four million near-identical overlapping sequences - neighbouring windows would share 59 of their\n",
+    "60 observations. `modeling.dl.train_sequence_stride_horizons` in `config/setup.yaml` declares\n",
+    "the spacing instead: one window per label horizon, so consecutive windows of a symbol carry\n",
+    "labels that do not overlap - the window ending at t is scored on the return from t to t+H and\n",
+    "the next one starts at t+H. It is declared in horizons rather than in windows because the\n",
+    "horizon differs by label: `fwd_ret_5m` strides 5 observations, `fwd_ret_15m` 15 and\n",
+    "`fwd_ret_60m` 60, each spacing its own labels exactly, where a single window count could only\n",
+    "have been right for one of them. The spacing travels in the training identity; **how many\n",
+    "windows it yields is derived at run time** from the eligible rows of each fold rather than\n",
+    "declared, and is printed below."
    ]
   },
   {
@@ -5468,18 +5473,19 @@
     "   curve below is an information coefficient, and selection is validation backtest Sharpe in\n",
     "   [`14_backtest`](14_backtest.ipynb), over the population published here.\n",
     "\n",
-    "2. **How many windows are drawn is part of the model.** On a minute panel the cap decides what\n",
-    "   was fitted, so it is declared in `config/setup.yaml` and travels in the training identity\n",
-    "   rather than arriving with the invocation.\n",
+    "2. **How far apart the training windows sit is part of the model.** On a minute panel the\n",
+    "   spacing decides what was fitted, so it is declared in `config/setup.yaml` as one window per\n",
+    "   label horizon and travels in the training identity rather than arriving with the invocation.\n",
     "\n",
     "3. **A sequence family is measured on fewer rows than a tabular one.** A prediction needs a\n",
     "   full window behind it, so the samples differ and the comparison has to say so.\n",
     "\n",
     "**Known limitations.** The window is fixed at sixty observations, so nothing earlier than the\n",
-    "trailing hour reaches the model whatever the architecture can represent. The declared sequence\n",
-    "cap is a compute budget rather than a quantity derived from the data - `config/setup.yaml`\n",
-    "says so - so the same declared count covers a different share of the panel whenever the\n",
-    "panel's size changes."
+    "trailing hour reaches the model whatever the architecture can represent. The window spacing is a\n",
+    "modelling choice rather than a compute budget - one window per label horizon is what stops two\n",
+    "training examples carrying the same return twice - so the number of windows a fold yields\n",
+    "follows from how many eligible rows it holds, and a panel of a different size changes the count\n",
+    "without changing the declaration."
    ]
   }
  ],
@@ -5511,8 +5517,8 @@
    "outputs_digest": "431f85cadc248a13eaa902b2e0cad502eab98c9af3871a8bd88e214424ca04d1",
    "parameters": {},
    "production": true,
-   "source_py_blob": "8f61df01abf60cf17a62f8a081444c22b9d1d724",
-   "notes": "prose synced from the .py at 2026-09-11T04:40:07.001320+00:00 without re-executing; every code cell is identical to blob 1d631cd0e63c"
+   "source_py_blob": "a2142e64ed47b4340394bba2c85c1491a16b5f94",
+   "notes": "prose synced from the .py at 2026-09-11T09:00:58.939813+00:00 without re-executing; every code cell is identical to blob 8f61df01abf6"
   },
   "papermill": {
    "default_parameters": {},

--- a/case_studies/nasdaq100_microstructure/08_dl_nlinear.py
+++ b/case_studies/nasdaq100_microstructure/08_dl_nlinear.py
@@ -40,7 +40,7 @@
 # **Book Reference**: Chapter 13
 #
 # **Prerequisites**: [`05_evaluation`](05_evaluation.ipynb)
-
+#
 # **What it writes**: one training run per label and one complete validation prediction set per
 # label and checkpoint, in `run_log/registry.db` and under `run_log/training/` and
 # `run_log/predictions/`, grouped under a population this notebook alone publishes.

--- a/case_studies/nasdaq100_microstructure/08_dl_nlinear.py
+++ b/case_studies/nasdaq100_microstructure/08_dl_nlinear.py
@@ -171,13 +171,18 @@ if (narrows or device != PUBLISHED_DEVICE) and not POPULATION_NAME:
 # - **`validation_start` and `validation_end` bracket the development sample.** The held-out tail
 #   must not appear; it is scored once, at the end of the case study.
 #
-# **How many windows are drawn is declared, not left to the tier.** Every row of this panel
-# starts a window, and the panel is minute bars, so an uncapped fold would build about four
-# million near-identical overlapping sequences - consecutive windows share 59 of their 60
-# observations. `modeling.dl.max_train_sequences` in `config/setup.yaml` declares the cap, which
-# makes it part of the training identity rather than a property of how the run was invoked. A
-# preview may lower it and cannot raise it above the declaration, because a preview that fits on
-# more windows than the canonical run is not rehearsing it.
+# **How far apart the training windows sit is declared, not left to the tier.** Every row of this
+# panel could start a window, and the panel is minute bars, so an unspaced fold would build about
+# four million near-identical overlapping sequences - neighbouring windows would share 59 of their
+# 60 observations. `modeling.dl.train_sequence_stride_horizons` in `config/setup.yaml` declares
+# the spacing instead: one window per label horizon, so consecutive windows of a symbol carry
+# labels that do not overlap - the window ending at t is scored on the return from t to t+H and
+# the next one starts at t+H. It is declared in horizons rather than in windows because the
+# horizon differs by label: `fwd_ret_5m` strides 5 observations, `fwd_ret_15m` 15 and
+# `fwd_ret_60m` 60, each spacing its own labels exactly, where a single window count could only
+# have been right for one of them. The spacing travels in the training identity; **how many
+# windows it yields is derived at run time** from the eligible rows of each fold rather than
+# declared, and is printed below.
 
 # %%
 requests = model_requests(
@@ -314,15 +319,16 @@ show_plotly_with_alt(
 #    curve below is an information coefficient, and selection is validation backtest Sharpe in
 #    [`14_backtest`](14_backtest.ipynb), over the population published here.
 #
-# 2. **How many windows are drawn is part of the model.** On a minute panel the cap decides what
-#    was fitted, so it is declared in `config/setup.yaml` and travels in the training identity
-#    rather than arriving with the invocation.
+# 2. **How far apart the training windows sit is part of the model.** On a minute panel the
+#    spacing decides what was fitted, so it is declared in `config/setup.yaml` as one window per
+#    label horizon and travels in the training identity rather than arriving with the invocation.
 #
 # 3. **A sequence family is measured on fewer rows than a tabular one.** A prediction needs a
 #    full window behind it, so the samples differ and the comparison has to say so.
 #
 # **Known limitations.** The window is fixed at sixty observations, so nothing earlier than the
-# trailing hour reaches the model whatever the architecture can represent. The declared sequence
-# cap is a compute budget rather than a quantity derived from the data - `config/setup.yaml`
-# says so - so the same declared count covers a different share of the panel whenever the
-# panel's size changes.
+# trailing hour reaches the model whatever the architecture can represent. The window spacing is a
+# modelling choice rather than a compute budget - one window per label horizon is what stops two
+# training examples carrying the same return twice - so the number of windows a fold yields
+# follows from how many eligible rows it holds, and a panel of a different size changes the count
+# without changing the declaration.

--- a/case_studies/nasdaq100_microstructure/08_dl_nlinear.py
+++ b/case_studies/nasdaq100_microstructure/08_dl_nlinear.py
@@ -176,8 +176,10 @@ if (narrows or device != PUBLISHED_DEVICE) and not POPULATION_NAME:
 # four million near-identical overlapping sequences - neighbouring windows would share 59 of their
 # 60 observations. `modeling.dl.train_sequence_stride_horizons` in `config/setup.yaml` declares
 # the spacing instead: one window per label horizon, so consecutive windows of a symbol carry
-# labels that do not overlap - the window ending at t is scored on the return from t to t+H and
-# the next one starts at t+H. It is declared in horizons rather than in windows because the
+# labels that do not overlap. [`02_labels`](02_labels.ipynb) takes the decision on the bar
+# closing at t, enters on the next bar's VWAP and holds for the horizon from that fill, so two
+# decisions H observations apart have return intervals that abut rather than share bars - the
+# exit of one is the entry of the next. It is declared in horizons rather than in windows because the
 # horizon differs by label: `fwd_ret_5m` strides 5 observations, `fwd_ret_15m` 15 and
 # `fwd_ret_60m` 60, each spacing its own labels exactly, where a single window count could only
 # have been right for one of them. The spacing travels in the training identity; **how many

--- a/case_studies/nasdaq100_microstructure/08_dl_nlinear.py
+++ b/case_studies/nasdaq100_microstructure/08_dl_nlinear.py
@@ -309,8 +309,9 @@ show_plotly_with_alt(
 # ## Key takeaways
 #
 # 1. **A checkpoint is part of a configuration, not a detail of how it was fitted.** Scoring one
-#    fit at twenty points produces twenty candidates, and keeping the best of them after seeing
-#    the results is a selection decision. Selection happens in
+#    fit at twenty points produces twenty candidates, and keeping whichever of them scores
+#    highest on this page would be a selection decision taken on the wrong statistic: the
+#    curve below is an information coefficient, and selection is validation backtest Sharpe in
 #    [`14_backtest`](14_backtest.ipynb), over the population published here.
 #
 # 2. **How many windows are drawn is part of the model.** On a minute panel the cap decides what
@@ -322,5 +323,6 @@ show_plotly_with_alt(
 #
 # **Known limitations.** The window is fixed at sixty observations, so nothing earlier than the
 # trailing hour reaches the model whatever the architecture can represent. The declared sequence
-# cap is a compute budget rather than a derived quantity - `config/setup.yaml` says so, and
-# ml4t/agent-workspace#1015 is where that argument goes.
+# cap is a compute budget rather than a quantity derived from the data - `config/setup.yaml`
+# says so - so the same declared count covers a different share of the panel whenever the
+# panel's size changes.

--- a/case_studies/nasdaq100_microstructure/09_dl_lstm.ipynb
+++ b/case_studies/nasdaq100_microstructure/09_dl_lstm.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "4d054979",
+   "id": "96dfdf23",
    "metadata": {},
    "source": [
     "# LSTM - NASDAQ-100 Microstructure\n",
@@ -47,7 +47,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4f5d4fcd",
+   "id": "b613a7e0",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -70,7 +70,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "317e9bdb",
+   "id": "8b0cf1f3",
    "metadata": {
     "tags": [
      "parameters"
@@ -91,7 +91,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "abfc03f5",
+   "id": "37f5b2ba",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -105,7 +105,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0f851882",
+   "id": "9bedf9d6",
    "metadata": {},
    "source": [
     "## 1. Which labels, and which model\n",
@@ -125,7 +125,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "73056a89",
+   "id": "e40c8fad",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -134,7 +134,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5b4c9176",
+   "id": "541d5596",
    "metadata": {},
    "source": [
     "`lstm_h64` is this notebook's slice of the declared family. The menu declares four\n",
@@ -153,7 +153,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e33c56ca",
+   "id": "1b80a81e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -170,7 +170,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "30e62c78",
+   "id": "ef76952b",
    "metadata": {},
    "source": [
     "`LABELS` and `CONFIG_NAMES` narrow the run below this notebook's own slice, and a narrowed run\n",
@@ -188,7 +188,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "307f16b7",
+   "id": "29bd5575",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -209,7 +209,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5c894537",
+   "id": "3a339712",
    "metadata": {},
    "source": [
     "## 2. Binding the declarations to the data\n",
@@ -244,7 +244,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "92583cc9",
+   "id": "3ecf572c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -272,7 +272,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "465bdd7f",
+   "id": "1b11a02d",
    "metadata": {},
    "source": [
     "## 3. Fitting the population\n",
@@ -313,7 +313,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6c32a4f2",
+   "id": "705e1955",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -334,7 +334,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a8530468",
+   "id": "c4fedaea",
    "metadata": {},
    "source": [
     "`reused` is not zero on a second run. Every identity is re-derived from the inputs, the\n",
@@ -344,7 +344,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "67b3e719",
+   "id": "b179f1be",
    "metadata": {},
    "source": [
     "## 4. What came out\n",
@@ -363,7 +363,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "df34ceb3",
+   "id": "5ea90975",
    "metadata": {
     "tags": [
      "results"
@@ -388,7 +388,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9171e4c0",
+   "id": "9cf9ad2c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -416,14 +416,15 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5b69ff87",
+   "id": "2c0ba9cb",
    "metadata": {},
    "source": [
     "## Key takeaways\n",
     "\n",
     "1. **A checkpoint is part of a configuration, not a detail of how it was fitted.** Scoring one\n",
-    "   fit at twenty points produces twenty candidates, and keeping the best of them after seeing\n",
-    "   the results is a selection decision. Selection happens in\n",
+    "   fit at twenty points produces twenty candidates, and keeping whichever of them scores\n",
+    "   highest on this page would be a selection decision taken on the wrong statistic: the\n",
+    "   curve below is an information coefficient, and selection is validation backtest Sharpe in\n",
     "   [`14_backtest`](14_backtest.ipynb), over the population published here.\n",
     "\n",
     "2. **How many windows are drawn is part of the model.** On a minute panel the cap decides what\n",
@@ -435,8 +436,9 @@
     "\n",
     "**Known limitations.** The window is fixed at sixty observations, so nothing earlier than the\n",
     "trailing hour reaches the model whatever the architecture can represent. The declared sequence\n",
-    "cap is a compute budget rather than a derived quantity - `config/setup.yaml` says so, and\n",
-    "ml4t/agent-workspace#1015 is where that argument goes."
+    "cap is a compute budget rather than a quantity derived from the data - `config/setup.yaml`\n",
+    "says so - so the same declared count covers a different share of the panel whenever the\n",
+    "panel's size changes."
    ]
   }
  ],

--- a/case_studies/nasdaq100_microstructure/09_dl_lstm.ipynb
+++ b/case_studies/nasdaq100_microstructure/09_dl_lstm.ipynb
@@ -409,8 +409,10 @@
     "four million near-identical overlapping sequences - neighbouring windows would share 59 of their\n",
     "60 observations. `modeling.dl.train_sequence_stride_horizons` in `config/setup.yaml` declares\n",
     "the spacing instead: one window per label horizon, so consecutive windows of a symbol carry\n",
-    "labels that do not overlap - the window ending at t is scored on the return from t to t+H and\n",
-    "the next one starts at t+H. It is declared in horizons rather than in windows because the\n",
+    "labels that do not overlap. [`02_labels`](02_labels.ipynb) takes the decision on the bar\n",
+    "closing at t, enters on the next bar's VWAP and holds for the horizon from that fill, so two\n",
+    "decisions H observations apart have return intervals that abut rather than share bars - the\n",
+    "exit of one is the entry of the next. It is declared in horizons rather than in windows because the\n",
     "horizon differs by label: `fwd_ret_5m` strides 5 observations, `fwd_ret_15m` 15 and\n",
     "`fwd_ret_60m` 60, each spacing its own labels exactly, where a single window count could only\n",
     "have been right for one of them. The spacing travels in the training identity; **how many\n",
@@ -5527,8 +5529,8 @@
    "outputs_digest": "eff79cb73179b6d2947fbb241db72b8349c6d8bc7c8f1323e888eb6c44a89c36",
    "parameters": {},
    "production": true,
-   "source_py_blob": "1306d0244b38c46333e23e3b833ae90b9822f1f4",
-   "notes": "prose synced from the .py at 2026-09-11T09:01:00.378927+00:00 without re-executing; every code cell is identical to blob 84534a00e2b7"
+   "source_py_blob": "7a712c7aedc2051874796f9c8f79923061ea33f5",
+   "notes": "prose synced from the .py at 2026-09-11T09:02:35.766951+00:00 without re-executing; every code cell is identical to blob 1306d0244b38"
   },
   "papermill": {
    "default_parameters": {},

--- a/case_studies/nasdaq100_microstructure/09_dl_lstm.ipynb
+++ b/case_studies/nasdaq100_microstructure/09_dl_lstm.ipynb
@@ -404,13 +404,18 @@
     "- **`validation_start` and `validation_end` bracket the development sample.** The held-out tail\n",
     "  must not appear; it is scored once, at the end of the case study.\n",
     "\n",
-    "**How many windows are drawn is declared, not left to the tier.** Every row of this panel\n",
-    "starts a window, and the panel is minute bars, so an uncapped fold would build about four\n",
-    "million near-identical overlapping sequences - consecutive windows share 59 of their 60\n",
-    "observations. `modeling.dl.max_train_sequences` in `config/setup.yaml` declares the cap, which\n",
-    "makes it part of the training identity rather than a property of how the run was invoked. A\n",
-    "preview may lower it and cannot raise it above the declaration, because a preview that fits on\n",
-    "more windows than the canonical run is not rehearsing it."
+    "**How far apart the training windows sit is declared, not left to the tier.** Every row of this\n",
+    "panel could start a window, and the panel is minute bars, so an unspaced fold would build about\n",
+    "four million near-identical overlapping sequences - neighbouring windows would share 59 of their\n",
+    "60 observations. `modeling.dl.train_sequence_stride_horizons` in `config/setup.yaml` declares\n",
+    "the spacing instead: one window per label horizon, so consecutive windows of a symbol carry\n",
+    "labels that do not overlap - the window ending at t is scored on the return from t to t+H and\n",
+    "the next one starts at t+H. It is declared in horizons rather than in windows because the\n",
+    "horizon differs by label: `fwd_ret_5m` strides 5 observations, `fwd_ret_15m` 15 and\n",
+    "`fwd_ret_60m` 60, each spacing its own labels exactly, where a single window count could only\n",
+    "have been right for one of them. The spacing travels in the training identity; **how many\n",
+    "windows it yields is derived at run time** from the eligible rows of each fold rather than\n",
+    "declared, and is printed below."
    ]
   },
   {
@@ -5478,18 +5483,19 @@
     "   curve below is an information coefficient, and selection is validation backtest Sharpe in\n",
     "   [`14_backtest`](14_backtest.ipynb), over the population published here.\n",
     "\n",
-    "2. **How many windows are drawn is part of the model.** On a minute panel the cap decides what\n",
-    "   was fitted, so it is declared in `config/setup.yaml` and travels in the training identity\n",
-    "   rather than arriving with the invocation.\n",
+    "2. **How far apart the training windows sit is part of the model.** On a minute panel the\n",
+    "   spacing decides what was fitted, so it is declared in `config/setup.yaml` as one window per\n",
+    "   label horizon and travels in the training identity rather than arriving with the invocation.\n",
     "\n",
     "3. **A sequence family is measured on fewer rows than a tabular one.** A prediction needs a\n",
     "   full window behind it, so the samples differ and the comparison has to say so.\n",
     "\n",
     "**Known limitations.** The window is fixed at sixty observations, so nothing earlier than the\n",
-    "trailing hour reaches the model whatever the architecture can represent. The declared sequence\n",
-    "cap is a compute budget rather than a quantity derived from the data - `config/setup.yaml`\n",
-    "says so - so the same declared count covers a different share of the panel whenever the\n",
-    "panel's size changes."
+    "trailing hour reaches the model whatever the architecture can represent. The window spacing is a\n",
+    "modelling choice rather than a compute budget - one window per label horizon is what stops two\n",
+    "training examples carrying the same return twice - so the number of windows a fold yields\n",
+    "follows from how many eligible rows it holds, and a panel of a different size changes the count\n",
+    "without changing the declaration."
    ]
   }
  ],
@@ -5521,7 +5527,8 @@
    "outputs_digest": "eff79cb73179b6d2947fbb241db72b8349c6d8bc7c8f1323e888eb6c44a89c36",
    "parameters": {},
    "production": true,
-   "source_py_blob": "84534a00e2b7f015a6c15d0c86a9556443ef0b61"
+   "source_py_blob": "1306d0244b38c46333e23e3b833ae90b9822f1f4",
+   "notes": "prose synced from the .py at 2026-09-11T09:01:00.378927+00:00 without re-executing; every code cell is identical to blob 84534a00e2b7"
   },
   "papermill": {
    "default_parameters": {},

--- a/case_studies/nasdaq100_microstructure/09_dl_lstm.ipynb
+++ b/case_studies/nasdaq100_microstructure/09_dl_lstm.ipynb
@@ -2,8 +2,16 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "96dfdf23",
-   "metadata": {},
+   "id": "abbf4d0c",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001144,
+     "end_time": "2026-09-11T04:46:43.927581+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T04:46:43.926437+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "# LSTM - NASDAQ-100 Microstructure\n",
     "\n",
@@ -46,9 +54,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "b613a7e0",
-   "metadata": {},
+   "execution_count": 1,
+   "id": "ead66143",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-11T04:46:43.930451Z",
+     "iopub.status.busy": "2026-09-11T04:46:43.930279Z",
+     "iopub.status.idle": "2026-09-11T04:46:47.247655Z",
+     "shell.execute_reply": "2026-09-11T04:46:47.246797Z"
+    },
+    "papermill": {
+     "duration": 3.319633,
+     "end_time": "2026-09-11T04:46:47.248161+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T04:46:43.928528+00:00",
+     "status": "completed"
+    }
+   },
    "outputs": [],
    "source": [
     "\"\"\"Fit the declared NASDAQ-100 microstructure LSTM population on the walk-forward folds.\"\"\"\n",
@@ -69,9 +91,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "8b0cf1f3",
+   "execution_count": 2,
+   "id": "9dcb228b",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-11T04:46:47.251114Z",
+     "iopub.status.busy": "2026-09-11T04:46:47.250869Z",
+     "iopub.status.idle": "2026-09-11T04:46:47.253349Z",
+     "shell.execute_reply": "2026-09-11T04:46:47.252976Z"
+    },
+    "papermill": {
+     "duration": 0.004285,
+     "end_time": "2026-09-11T04:46:47.253619+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T04:46:47.249334+00:00",
+     "status": "completed"
+    },
     "tags": [
      "parameters"
     ]
@@ -90,9 +125,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "37f5b2ba",
-   "metadata": {},
+   "execution_count": 3,
+   "id": "231301ef",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-11T04:46:47.255927Z",
+     "iopub.status.busy": "2026-09-11T04:46:47.255847Z",
+     "iopub.status.idle": "2026-09-11T04:47:28.440505Z",
+     "shell.execute_reply": "2026-09-11T04:47:28.439971Z"
+    },
+    "papermill": {
+     "duration": 41.186531,
+     "end_time": "2026-09-11T04:47:28.441112+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T04:46:47.254581+00:00",
+     "status": "completed"
+    }
+   },
    "outputs": [],
    "source": [
     "study = open_study(\n",
@@ -105,8 +154,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9bedf9d6",
-   "metadata": {},
+   "id": "4ea58ced",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001166,
+     "end_time": "2026-09-11T04:47:28.443536+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T04:47:28.442370+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "## 1. Which labels, and which model\n",
     "\n",
@@ -124,18 +181,51 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "e40c8fad",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 4,
+   "id": "bfe5df0a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-11T04:47:28.446441Z",
+     "iopub.status.busy": "2026-09-11T04:47:28.446353Z",
+     "iopub.status.idle": "2026-09-11T04:47:28.466581Z",
+     "shell.execute_reply": "2026-09-11T04:47:28.466190Z"
+    },
+    "papermill": {
+     "duration": 0.022044,
+     "end_time": "2026-09-11T04:47:28.466926+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T04:47:28.444882+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "('fwd_ret_15m', 'fwd_ret_5m', 'fwd_ret_60m')"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "declared_labels(study, \"deep_learning\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "541d5596",
-   "metadata": {},
+   "id": "3f6dc3ab",
+   "metadata": {
+    "papermill": {
+     "duration": 0.000946,
+     "end_time": "2026-09-11T04:47:28.468949+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T04:47:28.468003+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "`lstm_h64` is this notebook's slice of the declared family. The menu declares four\n",
     "architectures and each has its own notebook, because each is a different claim about what\n",
@@ -152,10 +242,54 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "1b80a81e",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 5,
+   "id": "5d2aeb05",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-11T04:47:28.472471Z",
+     "iopub.status.busy": "2026-09-11T04:47:28.472348Z",
+     "iopub.status.idle": "2026-09-11T04:47:28.520659Z",
+     "shell.execute_reply": "2026-09-11T04:47:28.520317Z"
+    },
+    "papermill": {
+     "duration": 0.050776,
+     "end_time": "2026-09-11T04:47:28.521018+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T04:47:28.470242+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div><style>\n",
+       ".dataframe > thead > tr,\n",
+       ".dataframe > tbody > tr {\n",
+       "  text-align: right;\n",
+       "  white-space: pre-wrap;\n",
+       "}\n",
+       "</style>\n",
+       "<small>shape: (3, 5)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>family</th><th>label</th><th>config_name</th><th>model_class</th><th>params</th></tr><tr><td>str</td><td>str</td><td>str</td><td>str</td><td>str</td></tr></thead><tbody><tr><td>&quot;deep_learning&quot;</td><td>&quot;fwd_ret_15m&quot;</td><td>&quot;lstm_h64&quot;</td><td>&quot;&quot;</td><td>&quot;architecture=lstm, dropout=0.1…</td></tr><tr><td>&quot;deep_learning&quot;</td><td>&quot;fwd_ret_5m&quot;</td><td>&quot;lstm_h64&quot;</td><td>&quot;&quot;</td><td>&quot;architecture=lstm, dropout=0.1…</td></tr><tr><td>&quot;deep_learning&quot;</td><td>&quot;fwd_ret_60m&quot;</td><td>&quot;lstm_h64&quot;</td><td>&quot;&quot;</td><td>&quot;architecture=lstm, dropout=0.1…</td></tr></tbody></table></div>"
+      ],
+      "text/plain": [
+       "shape: (3, 5)\n",
+       "┌───────────────┬─────────────┬─────────────┬─────────────┬─────────────────────────────────┐\n",
+       "│ family        ┆ label       ┆ config_name ┆ model_class ┆ params                          │\n",
+       "│ ---           ┆ ---         ┆ ---         ┆ ---         ┆ ---                             │\n",
+       "│ str           ┆ str         ┆ str         ┆ str         ┆ str                             │\n",
+       "╞═══════════════╪═════════════╪═════════════╪═════════════╪═════════════════════════════════╡\n",
+       "│ deep_learning ┆ fwd_ret_15m ┆ lstm_h64    ┆             ┆ architecture=lstm, dropout=0.1… │\n",
+       "│ deep_learning ┆ fwd_ret_5m  ┆ lstm_h64    ┆             ┆ architecture=lstm, dropout=0.1… │\n",
+       "│ deep_learning ┆ fwd_ret_60m ┆ lstm_h64    ┆             ┆ architecture=lstm, dropout=0.1… │\n",
+       "└───────────────┴─────────────┴─────────────┴─────────────┴─────────────────────────────────┘"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "SEQUENCE_CONFIG = \"lstm_h64\"\n",
     "declared = load_model_configs(study, \"deep_learning\", config_names=[SEQUENCE_CONFIG])\n",
@@ -170,8 +304,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ef76952b",
-   "metadata": {},
+   "id": "e3983efb",
+   "metadata": {
+    "papermill": {
+     "duration": 0.000913,
+     "end_time": "2026-09-11T04:47:28.523146+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T04:47:28.522233+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "`LABELS` and `CONFIG_NAMES` narrow the run below this notebook's own slice, and a narrowed run\n",
     "declares a different member set than the published population does. A population is immutable\n",
@@ -187,10 +329,32 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "29bd5575",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 6,
+   "id": "96bbc7bd",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-11T04:47:28.525470Z",
+     "iopub.status.busy": "2026-09-11T04:47:28.525388Z",
+     "iopub.status.idle": "2026-09-11T04:47:28.527747Z",
+     "shell.execute_reply": "2026-09-11T04:47:28.527460Z"
+    },
+    "papermill": {
+     "duration": 0.003991,
+     "end_time": "2026-09-11T04:47:28.528056+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T04:47:28.524065+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "training device: gpu\n"
+     ]
+    }
+   ],
    "source": [
     "PUBLISHED_DEVICE = \"gpu\"\n",
     "device = DEVICE or PUBLISHED_DEVICE\n",
@@ -209,8 +373,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3a339712",
-   "metadata": {},
+   "id": "b1375081",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00084,
+     "end_time": "2026-09-11T04:47:28.529879+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T04:47:28.529039+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "## 2. Binding the declarations to the data\n",
     "\n",
@@ -243,10 +415,59 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "3ecf572c",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 7,
+   "id": "cd89911e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-11T04:47:28.532276Z",
+     "iopub.status.busy": "2026-09-11T04:47:28.532197Z",
+     "iopub.status.idle": "2026-09-11T04:50:41.431586Z",
+     "shell.execute_reply": "2026-09-11T04:50:41.430952Z"
+    },
+    "papermill": {
+     "duration": 192.909086,
+     "end_time": "2026-09-11T04:50:41.439880+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T04:47:28.530794+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div><style>\n",
+       ".dataframe > thead > tr,\n",
+       ".dataframe > tbody > tr {\n",
+       "  text-align: right;\n",
+       "  white-space: pre-wrap;\n",
+       "}\n",
+       "</style>\n",
+       "<small>shape: (3, 8)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>label</th><th>config_name</th><th>feature_count</th><th>eligible_rows</th><th>folds</th><th>checkpoints</th><th>validation_start</th><th>validation_end</th></tr><tr><td>str</td><td>str</td><td>i64</td><td>i64</td><td>i64</td><td>i64</td><td>datetime[μs]</td><td>datetime[μs]</td></tr></thead><tbody><tr><td>&quot;fwd_ret_15m&quot;</td><td>&quot;lstm_h64&quot;</td><td>90</td><td>6453961</td><td>2</td><td>20</td><td>2020-06-30 11:26:00</td><td>2021-06-30 15:43:00</td></tr><tr><td>&quot;fwd_ret_5m&quot;</td><td>&quot;lstm_h64&quot;</td><td>90</td><td>6711664</td><td>2</td><td>20</td><td>2020-06-30 11:26:00</td><td>2021-06-30 15:53:00</td></tr><tr><td>&quot;fwd_ret_60m&quot;</td><td>&quot;lstm_h64&quot;</td><td>90</td><td>5325226</td><td>2</td><td>20</td><td>2020-06-30 11:26:00</td><td>2021-06-30 14:58:00</td></tr></tbody></table></div>"
+      ],
+      "text/plain": [
+       "shape: (3, 8)\n",
+       "┌────────────┬────────────┬────────────┬────────────┬───────┬────────────┬────────────┬────────────┐\n",
+       "│ label      ┆ config_nam ┆ feature_co ┆ eligible_r ┆ folds ┆ checkpoint ┆ validation ┆ validation │\n",
+       "│ ---        ┆ e          ┆ unt        ┆ ows        ┆ ---   ┆ s          ┆ _start     ┆ _end       │\n",
+       "│ str        ┆ ---        ┆ ---        ┆ ---        ┆ i64   ┆ ---        ┆ ---        ┆ ---        │\n",
+       "│            ┆ str        ┆ i64        ┆ i64        ┆       ┆ i64        ┆ datetime[μ ┆ datetime[μ │\n",
+       "│            ┆            ┆            ┆            ┆       ┆            ┆ s]         ┆ s]         │\n",
+       "╞════════════╪════════════╪════════════╪════════════╪═══════╪════════════╪════════════╪════════════╡\n",
+       "│ fwd_ret_15 ┆ lstm_h64   ┆ 90         ┆ 6453961    ┆ 2     ┆ 20         ┆ 2020-06-30 ┆ 2021-06-30 │\n",
+       "│ m          ┆            ┆            ┆            ┆       ┆            ┆ 11:26:00   ┆ 15:43:00   │\n",
+       "│ fwd_ret_5m ┆ lstm_h64   ┆ 90         ┆ 6711664    ┆ 2     ┆ 20         ┆ 2020-06-30 ┆ 2021-06-30 │\n",
+       "│            ┆            ┆            ┆            ┆       ┆            ┆ 11:26:00   ┆ 15:53:00   │\n",
+       "│ fwd_ret_60 ┆ lstm_h64   ┆ 90         ┆ 5325226    ┆ 2     ┆ 20         ┆ 2020-06-30 ┆ 2021-06-30 │\n",
+       "│ m          ┆            ┆            ┆            ┆       ┆            ┆ 11:26:00   ┆ 14:58:00   │\n",
+       "└────────────┴────────────┴────────────┴────────────┴───────┴────────────┴────────────┴────────────┘"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "requests = model_requests(\n",
     "    study,\n",
@@ -272,8 +493,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1b11a02d",
-   "metadata": {},
+   "id": "f481b7f4",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001564,
+     "end_time": "2026-09-11T04:50:41.444858+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T04:50:41.443294+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "## 3. Fitting the population\n",
     "\n",
@@ -312,10 +541,4476 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "705e1955",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 8,
+   "id": "a600d486",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-11T04:50:41.448912Z",
+     "iopub.status.busy": "2026-09-11T04:50:41.448744Z",
+     "iopub.status.idle": "2026-09-11T08:58:19.761546Z",
+     "shell.execute_reply": "2026-09-11T08:58:19.760488Z"
+    },
+    "papermill": {
+     "duration": 14858.336004,
+     "end_time": "2026-09-11T08:58:19.782258+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T04:50:41.446254+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Fold-major CV: 2 folds × 1 configs × 60 lookback\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Fold 0: creating sequences...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    train=210,028 seq across 105 symbols\n",
+      "    val=3,216,387 seq across 115 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    lstm_h64:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.000873\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.000048\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.000033\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.000028\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.000026, val_loss=0.000010, IC=+0.0024\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.000025\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.000024\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.000024\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.000023\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.000023, val_loss=0.000008, IC=+0.0026\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.000023\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.000023\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.000023\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.000023\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.000022, val_loss=0.000008, IC=+0.0003\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.000022\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.000022\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.000022\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.000022\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.000022, val_loss=0.000008, IC=-0.0001\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.000022\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.000022\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.000022\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.000022\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.000022, val_loss=0.000008, IC=+0.0003\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.000022\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.000021\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.000021\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.000021\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.000021, val_loss=0.000008, IC=+0.0030\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.000021\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.000021\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.000021\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.000021\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.000021, val_loss=0.000008, IC=-0.0005\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.000021\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.000021\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.000021\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.000020\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.000020, val_loss=0.000008, IC=+0.0040\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.000020\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.000020\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.000020\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.000020\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.000020, val_loss=0.000008, IC=+0.0001\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.000020\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.000020\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.000020\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.000020\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.000020, val_loss=0.000008, IC=+0.0003\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.000019\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.000019\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.000019\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.000019\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.000019, val_loss=0.000008, IC=-0.0023\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.000019\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.000019\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.000019\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.000019\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.000019, val_loss=0.000008, IC=-0.0006\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.000019\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.000019\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.000019\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.000019\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.000018, val_loss=0.000008, IC=+0.0013\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.000018\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.000018\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.000018\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.000018\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.000018, val_loss=0.000008, IC=-0.0004\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.000018\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.000018\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.000018\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.000018\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.000018, val_loss=0.000008, IC=+0.0019\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.000018\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.000018\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.000018\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.000018\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.000017, val_loss=0.000008, IC=-0.0002\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.000017\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.000017\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.000017\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.000017\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.000017, val_loss=0.000008, IC=-0.0012\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.000017\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.000017\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.000017\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.000017\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.000017, val_loss=0.000008, IC=-0.0004\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.000017\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.000017\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.000017\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.000017\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.000017, val_loss=0.000008, IC=-0.0008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.000017\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.000017\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.000017\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.000017\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.000017, val_loss=0.000008, IC=-0.0006\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=40, IC=+0.0040 (1685.5s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Fold 1: creating sequences...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    train=214,324 seq across 113 symbols\n",
+      "    val=3,237,574 seq across 115 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    lstm_h64:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.000154\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.000013\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.000010\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.000009\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.000009, val_loss=0.000008, IC=-0.0005\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.000008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.000008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.000008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.000008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.000008, val_loss=0.000007, IC=-0.0000\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.000008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.000008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.000008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.000008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.000008, val_loss=0.000007, IC=+0.0022\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.000007\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.000007\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.000007\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.000007\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.000007, val_loss=0.000007, IC=-0.0049\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.000007\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.000007\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.000007\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.000007\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.000007, val_loss=0.000007, IC=+0.0016\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.000007\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.000007\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.000007\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.000007\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.000007, val_loss=0.000007, IC=+0.0022\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.000007\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.000007\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.000007\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.000007\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.000007, val_loss=0.000007, IC=+0.0011\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.000007\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.000007\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.000007\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.000007\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.000007, val_loss=0.000007, IC=-0.0058\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.000007\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.000007\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.000007\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.000007\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.000007, val_loss=0.000007, IC=-0.0076\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.000007\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.000007\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.000007\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.000007\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.000007, val_loss=0.000008, IC=+0.0072\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.000007\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.000007\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.000007\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.000007\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.000007, val_loss=0.000007, IC=-0.0021\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.000007\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.000007\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.000007\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.000007\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.000007, val_loss=0.000007, IC=+0.0011\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.000007\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.000007\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.000007\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.000007\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.000007, val_loss=0.000008, IC=+0.0048\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.000007\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.000007\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.000007\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.000007\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.000007, val_loss=0.000008, IC=+0.0026\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.000007\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.000007\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.000007\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.000007\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.000007, val_loss=0.000008, IC=+0.0006\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.000007\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.000007\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.000007\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.000007\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.000007, val_loss=0.000008, IC=-0.0004\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.000007\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.000007\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.000007\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.000007\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.000007, val_loss=0.000008, IC=+0.0003\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.000007\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.000007\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.000007\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.000006\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.000006, val_loss=0.000008, IC=+0.0027\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.000006\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.000006\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.000006\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.000006\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.000006, val_loss=0.000008, IC=+0.0021\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.000006\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.000006\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.000006\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.000006\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.000006, val_loss=0.000008, IC=+0.0011\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=50, IC=+0.0072 (1416.3s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  lstm_h64: best_epoch=50, IC=+0.0038 (3101.8s)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Best: lstm_h64 @ epoch 50 (IC=+0.0038)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Saved to ~/ml4t/public-nasdaq/case_studies/nasdaq100_microstructure/run_log/training/916e36d66d02/diagnostics\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Fold-major CV: 2 folds × 1 configs × 60 lookback\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Fold 0: creating sequences...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    train=655,498 seq across 105 symbols\n",
+      "    val=3,346,183 seq across 115 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    lstm_h64:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.000292\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.000011\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.000009\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.000009\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.000008, val_loss=0.000003, IC=+0.0024\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.000008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.000008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.000008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.000008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.000008, val_loss=0.000003, IC=+0.0000\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.000008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.000008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.000008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.000008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.000008, val_loss=0.000003, IC=+0.0008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.000008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.000008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.000008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.000008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.000008, val_loss=0.000004, IC=-0.0010\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.000008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.000008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.000007\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.000007\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.000007, val_loss=0.000003, IC=-0.0002\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.000007\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.000007\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.000007\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.000007\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.000007, val_loss=0.000003, IC=+0.0006\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.000007\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.000007\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.000007\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.000007\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.000007, val_loss=0.000003, IC=+0.0017\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.000007\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.000007\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.000007\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.000007\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.000007, val_loss=0.000003, IC=-0.0004\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.000007\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.000007\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.000007\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.000007\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.000007, val_loss=0.000003, IC=+0.0009\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.000007\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.000007\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.000007\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.000006\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.000006, val_loss=0.000003, IC=+0.0015\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.000006\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.000006\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.000006\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.000006\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.000006, val_loss=0.000003, IC=+0.0000\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.000006\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.000006\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.000006\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.000006\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.000006, val_loss=0.000003, IC=+0.0010\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.000006\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.000006\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.000006\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.000006\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.000006, val_loss=0.000003, IC=+0.0001\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.000006\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.000006\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.000006\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.000006\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.000006, val_loss=0.000003, IC=-0.0006\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.000006\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.000006\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.000006\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.000006\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.000006, val_loss=0.000003, IC=+0.0005\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.000006\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.000006\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.000006\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.000006\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.000006, val_loss=0.000003, IC=+0.0014\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.000006\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.000006\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.000006\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.000006\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.000006, val_loss=0.000003, IC=+0.0012\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.000006\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.000006\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.000006\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.000006\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.000006, val_loss=0.000003, IC=+0.0015\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.000006\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.000006\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.000006\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.000006\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.000006, val_loss=0.000003, IC=+0.0016\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.000006\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.000006\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.000006\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.000006\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.000006, val_loss=0.000003, IC=+0.0015\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=5, IC=+0.0024 (3547.9s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Fold 1: creating sequences...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    train=669,014 seq across 113 symbols\n",
+      "    val=3,365,481 seq across 115 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    lstm_h64:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.000050\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.000004\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.000003\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.000003\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.000003, val_loss=0.000003, IC=+0.0015\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.000003\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.000003\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.000003\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.000003\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.000003, val_loss=0.000002, IC=-0.0009\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.000003\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.000003\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.000003\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.000003\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.000003, val_loss=0.000003, IC=+0.0023\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.000003\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.000003\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.000003\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.000003\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.000003, val_loss=0.000002, IC=+0.0026\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.000003\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.000003\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.000003\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.000003\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.000002, val_loss=0.000003, IC=+0.0021\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.000002\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.000002\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.000002\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.000002\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.000002, val_loss=0.000003, IC=+0.0064\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.000002\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.000002\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.000002\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.000002\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.000002, val_loss=0.000002, IC=-0.0002\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.000002\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.000002\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.000002\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.000002\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.000002, val_loss=0.000003, IC=+0.0018\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.000002\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.000002\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.000002\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.000002\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.000002, val_loss=0.000002, IC=-0.0009\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.000002\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.000002\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.000002\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.000002\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.000002, val_loss=0.000003, IC=+0.0027\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.000002\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.000002\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.000002\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.000002\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.000002, val_loss=0.000002, IC=-0.0014\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.000002\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.000002\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.000002\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.000002\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.000002, val_loss=0.000002, IC=-0.0006\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.000002\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.000002\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.000002\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.000002\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.000002, val_loss=0.000002, IC=+0.0007\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.000002\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.000002\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.000002\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.000002\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.000002, val_loss=0.000003, IC=+0.0015\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.000002\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.000002\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.000002\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.000002\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.000002, val_loss=0.000002, IC=+0.0009\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.000002\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.000002\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.000002\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.000002\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.000002, val_loss=0.000003, IC=+0.0011\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.000002\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.000002\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.000002\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.000002\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.000002, val_loss=0.000003, IC=+0.0009\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.000002\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.000002\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.000002\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.000002\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.000002, val_loss=0.000003, IC=+0.0012\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.000002\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.000002\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.000002\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.000002\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.000002, val_loss=0.000003, IC=+0.0008\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.000002\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.000002\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.000002\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.000002\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.000002, val_loss=0.000003, IC=+0.0012\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=30, IC=+0.0064 (3982.5s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  lstm_h64: best_epoch=30, IC=+0.0035 (7530.4s)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Best: lstm_h64 @ epoch 30 (IC=+0.0035)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Saved to ~/ml4t/public-nasdaq/case_studies/nasdaq100_microstructure/run_log/training/06d9679f288e/diagnostics\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Fold-major CV: 2 folds × 1 configs × 60 lookback\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Fold 0: creating sequences...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    train=43,237 seq across 105 symbols\n",
+      "    val=2,649,390 seq across 115 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    lstm_h64:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.003634\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.000297\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.000156\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.000129\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.000116, val_loss=0.000050, IC=+0.0012\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.000108\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.000102\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.000096\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.000093\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.000089, val_loss=0.000037, IC=-0.0003\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.000086\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.000085\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.000083\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.000083\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.000080, val_loss=0.000033, IC=-0.0009\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.000080\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.000078\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.000078\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.000077\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.000078, val_loss=0.000032, IC=+0.0000\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.000077\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.000075\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.000078\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.000075\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.000076, val_loss=0.000031, IC=-0.0013\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.000074\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.000075\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.000075\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.000076\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.000074, val_loss=0.000031, IC=+0.0012\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.000074\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.000073\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.000074\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.000072\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.000072, val_loss=0.000031, IC=-0.0018\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.000072\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.000072\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.000071\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.000071\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.000071, val_loss=0.000031, IC=-0.0024\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.000071\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.000070\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.000070\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.000070\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.000070, val_loss=0.000031, IC=-0.0006\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.000070\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.000069\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.000070\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.000070\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.000069, val_loss=0.000031, IC=-0.0004\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.000069\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.000069\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.000070\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.000069\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.000068, val_loss=0.000031, IC=-0.0002\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.000068\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.000068\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.000068\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.000068\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.000068, val_loss=0.000031, IC=-0.0002\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.000068\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.000068\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.000067\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.000067\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.000066, val_loss=0.000031, IC=+0.0003\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.000067\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.000067\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.000067\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.000067\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.000066, val_loss=0.000031, IC=+0.0001\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.000068\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.000067\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.000066\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.000068\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.000066, val_loss=0.000031, IC=-0.0002\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.000066\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.000066\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.000065\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.000066\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.000066, val_loss=0.000031, IC=-0.0003\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.000065\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.000066\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.000065\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.000065\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.000066, val_loss=0.000031, IC=-0.0001\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.000065\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.000065\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.000065\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.000065\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.000065, val_loss=0.000031, IC=-0.0000\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.000065\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.000065\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.000064\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.000065\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.000066, val_loss=0.000031, IC=-0.0001\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.000065\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.000065\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.000064\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.000075\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.000064, val_loss=0.000031, IC=-0.0001\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=30, IC=+0.0012 (1414.7s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Fold 1: creating sequences...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    train=44,185 seq across 113 symbols\n",
+      "    val=2,675,836 seq across 115 symbols\n",
+      "    creating datasets...\n",
+      "    datasets ready\n",
+      "    lstm_h64:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   1/100: train_loss=0.000622\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   2/100: train_loss=0.000085\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   3/100: train_loss=0.000049\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   4/100: train_loss=0.000041\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   5/100: train_loss=0.000037, val_loss=0.000033, IC=-0.0012\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   6/100: train_loss=0.000035\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   7/100: train_loss=0.000033\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   8/100: train_loss=0.000032\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch   9/100: train_loss=0.000031\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  10/100: train_loss=0.000031, val_loss=0.000030, IC=-0.0007\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  11/100: train_loss=0.000030\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  12/100: train_loss=0.000030\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  13/100: train_loss=0.000030\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  14/100: train_loss=0.000029\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  15/100: train_loss=0.000029, val_loss=0.000030, IC=-0.0033\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  16/100: train_loss=0.000029\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  17/100: train_loss=0.000029\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  18/100: train_loss=0.000029\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  19/100: train_loss=0.000028\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  20/100: train_loss=0.000028, val_loss=0.000030, IC=-0.0063\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  21/100: train_loss=0.000028\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  22/100: train_loss=0.000028\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  23/100: train_loss=0.000028\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  24/100: train_loss=0.000028\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  25/100: train_loss=0.000028, val_loss=0.000030, IC=-0.0036\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  26/100: train_loss=0.000028\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  27/100: train_loss=0.000028\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  28/100: train_loss=0.000028\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  29/100: train_loss=0.000027\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  30/100: train_loss=0.000027, val_loss=0.000029, IC=+0.0015\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  31/100: train_loss=0.000027\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  32/100: train_loss=0.000027\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  33/100: train_loss=0.000027\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  34/100: train_loss=0.000027\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  35/100: train_loss=0.000027, val_loss=0.000029, IC=-0.0060\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  36/100: train_loss=0.000027\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  37/100: train_loss=0.000027\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  38/100: train_loss=0.000027\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  39/100: train_loss=0.000027\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  40/100: train_loss=0.000027, val_loss=0.000029, IC=-0.0025\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  41/100: train_loss=0.000027\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  42/100: train_loss=0.000027\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  43/100: train_loss=0.000026\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  44/100: train_loss=0.000026\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  45/100: train_loss=0.000026, val_loss=0.000030, IC=-0.0052\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  46/100: train_loss=0.000026\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  47/100: train_loss=0.000026\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  48/100: train_loss=0.000026\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  49/100: train_loss=0.000026\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  50/100: train_loss=0.000026, val_loss=0.000030, IC=-0.0034\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  51/100: train_loss=0.000026\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  52/100: train_loss=0.000026\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  53/100: train_loss=0.000026\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  54/100: train_loss=0.000026\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  55/100: train_loss=0.000026, val_loss=0.000030, IC=-0.0034\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  56/100: train_loss=0.000026\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  57/100: train_loss=0.000026\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  58/100: train_loss=0.000026\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  59/100: train_loss=0.000025\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  60/100: train_loss=0.000025, val_loss=0.000030, IC=+0.0007\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  61/100: train_loss=0.000025\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  62/100: train_loss=0.000025\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  63/100: train_loss=0.000025\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  64/100: train_loss=0.000025\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  65/100: train_loss=0.000025, val_loss=0.000030, IC=-0.0052\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  66/100: train_loss=0.000025\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  67/100: train_loss=0.000025\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  68/100: train_loss=0.000025\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  69/100: train_loss=0.000025\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  70/100: train_loss=0.000025, val_loss=0.000030, IC=-0.0054\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  71/100: train_loss=0.000025\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  72/100: train_loss=0.000025\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  73/100: train_loss=0.000025\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  74/100: train_loss=0.000025\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  75/100: train_loss=0.000025, val_loss=0.000030, IC=-0.0039\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  76/100: train_loss=0.000025\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  77/100: train_loss=0.000025\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  78/100: train_loss=0.000025\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  79/100: train_loss=0.000025\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  80/100: train_loss=0.000025, val_loss=0.000030, IC=-0.0049\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  81/100: train_loss=0.000025\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  82/100: train_loss=0.000025\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  83/100: train_loss=0.000025\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  84/100: train_loss=0.000025\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  85/100: train_loss=0.000025, val_loss=0.000030, IC=-0.0035\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  86/100: train_loss=0.000025\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  87/100: train_loss=0.000025\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  88/100: train_loss=0.000025\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  89/100: train_loss=0.000025\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  90/100: train_loss=0.000025, val_loss=0.000030, IC=-0.0029\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  91/100: train_loss=0.000025\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  92/100: train_loss=0.000025\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  93/100: train_loss=0.000025\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  94/100: train_loss=0.000025\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  95/100: train_loss=0.000025, val_loss=0.000030, IC=-0.0036\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  96/100: train_loss=0.000025\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  97/100: train_loss=0.000025\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  98/100: train_loss=0.000025\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch  99/100: train_loss=0.000025\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      epoch 100/100: train_loss=0.000025, val_loss=0.000030, IC=-0.0037\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      best_ep=30, IC=+0.0015 (1407.7s, 20 checkpoints)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  lstm_h64: best_epoch=30, IC=+0.0013 (2822.4s)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Best: lstm_h64 @ epoch 30 (IC=+0.0013)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Saved to ~/ml4t/public-nasdaq/case_studies/nasdaq100_microstructure/run_log/training/eef2949eea8d/diagnostics\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "3 configurations: 3 trained, 0 read\n",
+      "population nasdaq100_microstructure-lstm_h64-validation-v1: 60 prediction sets\n"
+     ]
+    }
+   ],
    "source": [
     "population_name = POPULATION_NAME or \"nasdaq100_microstructure-lstm_h64-validation-v1\"\n",
     "execution, population = run_model_population(\n",
@@ -334,8 +5029,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c4fedaea",
-   "metadata": {},
+   "id": "a59b8cd7",
+   "metadata": {
+    "papermill": {
+     "duration": 0.011705,
+     "end_time": "2026-09-11T08:58:19.820266+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T08:58:19.808561+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "`reused` is not zero on a second run. Every identity is re-derived from the inputs, the\n",
     "registry already holds the matching rows and the saved weights, and the runner returns the\n",
@@ -344,8 +5047,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b179f1be",
-   "metadata": {},
+   "id": "b75c9efe",
+   "metadata": {
+    "papermill": {
+     "duration": 0.010724,
+     "end_time": "2026-09-11T08:58:19.841117+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T08:58:19.830393+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "## 4. What came out\n",
     "\n",
@@ -362,14 +5073,65 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "5ea90975",
+   "execution_count": 9,
+   "id": "ef5bd459",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-11T08:58:19.872818Z",
+     "iopub.status.busy": "2026-09-11T08:58:19.872416Z",
+     "iopub.status.idle": "2026-09-11T08:58:19.881152Z",
+     "shell.execute_reply": "2026-09-11T08:58:19.880688Z"
+    },
+    "papermill": {
+     "duration": 0.030697,
+     "end_time": "2026-09-11T08:58:19.883467+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T08:58:19.852770+00:00",
+     "status": "completed"
+    },
     "tags": [
      "results"
     ]
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div><style>\n",
+       ".dataframe > thead > tr,\n",
+       ".dataframe > tbody > tr {\n",
+       "  text-align: right;\n",
+       "  white-space: pre-wrap;\n",
+       "}\n",
+       "</style>\n",
+       "<small>shape: (60, 5)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>label</th><th>config_name</th><th>checkpoint_value</th><th>ic_mean</th><th>complete</th></tr><tr><td>str</td><td>str</td><td>i64</td><td>f64</td><td>bool</td></tr></thead><tbody><tr><td>&quot;fwd_ret_15m&quot;</td><td>&quot;lstm_h64&quot;</td><td>5</td><td>0.000946</td><td>true</td></tr><tr><td>&quot;fwd_ret_15m&quot;</td><td>&quot;lstm_h64&quot;</td><td>10</td><td>0.001299</td><td>true</td></tr><tr><td>&quot;fwd_ret_15m&quot;</td><td>&quot;lstm_h64&quot;</td><td>15</td><td>0.001245</td><td>true</td></tr><tr><td>&quot;fwd_ret_15m&quot;</td><td>&quot;lstm_h64&quot;</td><td>20</td><td>-0.002491</td><td>true</td></tr><tr><td>&quot;fwd_ret_15m&quot;</td><td>&quot;lstm_h64&quot;</td><td>25</td><td>0.000949</td><td>true</td></tr><tr><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td></tr><tr><td>&quot;fwd_ret_60m&quot;</td><td>&quot;lstm_h64&quot;</td><td>80</td><td>-0.002577</td><td>true</td></tr><tr><td>&quot;fwd_ret_60m&quot;</td><td>&quot;lstm_h64&quot;</td><td>85</td><td>-0.001804</td><td>true</td></tr><tr><td>&quot;fwd_ret_60m&quot;</td><td>&quot;lstm_h64&quot;</td><td>90</td><td>-0.001486</td><td>true</td></tr><tr><td>&quot;fwd_ret_60m&quot;</td><td>&quot;lstm_h64&quot;</td><td>95</td><td>-0.001821</td><td>true</td></tr><tr><td>&quot;fwd_ret_60m&quot;</td><td>&quot;lstm_h64&quot;</td><td>100</td><td>-0.001889</td><td>true</td></tr></tbody></table></div>"
+      ],
+      "text/plain": [
+       "shape: (60, 5)\n",
+       "┌─────────────┬─────────────┬──────────────────┬───────────┬──────────┐\n",
+       "│ label       ┆ config_name ┆ checkpoint_value ┆ ic_mean   ┆ complete │\n",
+       "│ ---         ┆ ---         ┆ ---              ┆ ---       ┆ ---      │\n",
+       "│ str         ┆ str         ┆ i64              ┆ f64       ┆ bool     │\n",
+       "╞═════════════╪═════════════╪══════════════════╪═══════════╪══════════╡\n",
+       "│ fwd_ret_15m ┆ lstm_h64    ┆ 5                ┆ 0.000946  ┆ true     │\n",
+       "│ fwd_ret_15m ┆ lstm_h64    ┆ 10               ┆ 0.001299  ┆ true     │\n",
+       "│ fwd_ret_15m ┆ lstm_h64    ┆ 15               ┆ 0.001245  ┆ true     │\n",
+       "│ fwd_ret_15m ┆ lstm_h64    ┆ 20               ┆ -0.002491 ┆ true     │\n",
+       "│ fwd_ret_15m ┆ lstm_h64    ┆ 25               ┆ 0.000949  ┆ true     │\n",
+       "│ …           ┆ …           ┆ …                ┆ …         ┆ …        │\n",
+       "│ fwd_ret_60m ┆ lstm_h64    ┆ 80               ┆ -0.002577 ┆ true     │\n",
+       "│ fwd_ret_60m ┆ lstm_h64    ┆ 85               ┆ -0.001804 ┆ true     │\n",
+       "│ fwd_ret_60m ┆ lstm_h64    ┆ 90               ┆ -0.001486 ┆ true     │\n",
+       "│ fwd_ret_60m ┆ lstm_h64    ┆ 95               ┆ -0.001821 ┆ true     │\n",
+       "│ fwd_ret_60m ┆ lstm_h64    ┆ 100              ┆ -0.001889 ┆ true     │\n",
+       "└─────────────┴─────────────┴──────────────────┴───────────┴──────────┘"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# Scoped to this population's own members. `catalog_rows` is the study's whole prediction\n",
     "# table, so an unfiltered height check would compare this run against every sequence row the\n",
@@ -387,10 +5149,291 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "9cf9ad2c",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 10,
+   "id": "d8bbfa69",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-11T08:58:19.915395Z",
+     "iopub.status.busy": "2026-09-11T08:58:19.915106Z",
+     "iopub.status.idle": "2026-09-11T08:58:22.006448Z",
+     "shell.execute_reply": "2026-09-11T08:58:22.005016Z"
+    },
+    "papermill": {
+     "duration": 2.108212,
+     "end_time": "2026-09-11T08:58:22.008334+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T08:58:19.900122+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.plotly.v1+json": {
+       "config": {
+        "plotlyServerURL": "https://plot.ly"
+       },
+       "data": [
+        {
+         "mode": "lines+markers",
+         "name": "fwd_ret_15m",
+         "type": "scatter",
+         "x": [
+          5,
+          10,
+          15,
+          20,
+          25,
+          30,
+          35,
+          40,
+          45,
+          50,
+          55,
+          60,
+          65,
+          70,
+          75,
+          80,
+          85,
+          90,
+          95,
+          100
+         ],
+         "y": [
+          0.0009461948413963753,
+          0.0012992332243900167,
+          0.0012450225149119502,
+          -0.0024911685961139817,
+          0.00094939163245254,
+          0.00262256172041928,
+          0.00031790282339850813,
+          -0.0009437124766789508,
+          -0.003748690271351191,
+          0.0037592283762883545,
+          -0.0022315150349223184,
+          0.00021877053387066964,
+          0.0030708393134049033,
+          0.0010967902134708298,
+          0.0012326142356955988,
+          -0.0002609719978487484,
+          -0.00045759968452279223,
+          0.0011266518757777394,
+          0.0006304937321779629,
+          0.00025656141469100965
+         ]
+        },
+        {
+         "mode": "lines+markers",
+         "name": "fwd_ret_5m",
+         "type": "scatter",
+         "x": [
+          5,
+          10,
+          15,
+          20,
+          25,
+          30,
+          35,
+          40,
+          45,
+          50,
+          55,
+          60,
+          65,
+          70,
+          75,
+          80,
+          85,
+          90,
+          95,
+          100
+         ],
+         "y": [
+          0.0019523674795012514,
+          -0.00043673918171887726,
+          0.0015636872752724015,
+          0.0008037314216208663,
+          0.0009665368288547276,
+          0.0035215749393643285,
+          0.0007261459841180202,
+          0.0007199913976484586,
+          -1.0073038663563328e-05,
+          0.002132328651456612,
+          -0.0006854470065727567,
+          0.00022281938359836599,
+          0.0004174539792090042,
+          0.00043173119395612696,
+          0.0007225720841227076,
+          0.0012678658287106422,
+          0.0010491779583195792,
+          0.0013780423706164003,
+          0.0011534133967860498,
+          0.0013874902844743494
+         ]
+        },
+        {
+         "mode": "lines+markers",
+         "name": "fwd_ret_60m",
+         "type": "scatter",
+         "x": [
+          5,
+          10,
+          15,
+          20,
+          25,
+          30,
+          35,
+          40,
+          45,
+          50,
+          55,
+          60,
+          65,
+          70,
+          75,
+          80,
+          85,
+          90,
+          95,
+          100
+         ],
+         "y": [
+          -4.178694952067588e-05,
+          -0.0004888612675990586,
+          -0.0020901363949182034,
+          -0.0031359482263582086,
+          -0.0024646460675010655,
+          0.001330825330824321,
+          -0.0039196668597980535,
+          -0.002460775615998963,
+          -0.0029106670451353204,
+          -0.0019192452137704434,
+          -0.0018225453373554583,
+          0.00020497201050496744,
+          -0.0024552402325524435,
+          -0.002655245850888153,
+          -0.0020545032777644027,
+          -0.0025772296557760696,
+          -0.0018041388307250274,
+          -0.001485992487458917,
+          -0.0018208567827677734,
+          -0.0018887836545510477
+         ]
+        }
+       ],
+       "layout": {
+        "shapes": [
+         {
+          "line": {
+           "color": "#94a3b8",
+           "dash": "dash",
+           "width": 1
+          },
+          "type": "line",
+          "x0": 0,
+          "x1": 1,
+          "xref": "x domain",
+          "y0": 0,
+          "y1": 0,
+          "yref": "y"
+         }
+        ],
+        "template": {
+         "layout": {
+          "colorway": [
+           "#0a1628",
+           "#D4A84B",
+           "#C87533",
+           "#10b981",
+           "#ef4444",
+           "#94a3b8"
+          ],
+          "font": {
+           "color": "#334155",
+           "family": "DM Sans, DejaVu Sans, sans-serif",
+           "size": 11
+          },
+          "hoverlabel": {
+           "bgcolor": "white",
+           "font": {
+            "family": "DM Sans, DejaVu Sans, sans-serif",
+            "size": 11
+           }
+          },
+          "legend": {
+           "bgcolor": "rgba(255,255,255,0.8)",
+           "bordercolor": "#e8e8e6",
+           "borderwidth": 1,
+           "font": {
+            "size": 10
+           }
+          },
+          "paper_bgcolor": "#FAFAF9",
+          "plot_bgcolor": "white",
+          "title": {
+           "font": {
+            "color": "#0a1628",
+            "size": 14
+           },
+           "x": 0.5,
+           "xanchor": "center"
+          },
+          "xaxis": {
+           "gridcolor": "#e8e8e6",
+           "gridwidth": 0.5,
+           "linecolor": "#e8e8e6",
+           "showgrid": true,
+           "tickfont": {
+            "size": 10
+           },
+           "title": {
+            "font": {
+             "size": 11
+            }
+           }
+          },
+          "yaxis": {
+           "gridcolor": "#e8e8e6",
+           "gridwidth": 0.5,
+           "linecolor": "#e8e8e6",
+           "showgrid": true,
+           "tickfont": {
+            "size": 10
+           },
+           "title": {
+            "font": {
+             "size": 11
+            }
+           }
+          }
+         }
+        },
+        "title": {
+         "text": "Validation IC by checkpoint - lstm_h64"
+        },
+        "xaxis": {
+         "title": {
+          "text": "training epoch"
+         }
+        },
+        "yaxis": {
+         "title": {
+          "text": "information coefficient"
+         }
+        }
+       }
+      },
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAArwAAAH0CAYAAADfWf7fAAAQAElEQVR4AexdB2BURRP+7tIr6Qmh1xB671WUIoIgoBQpioC9YgULdlF+KyoqFgQREVSKWADpvffeSW+k9/xv9t273F0uyV1yLckEtu/Ozn7v3d28ebOz6tzcnCIOjAHfA3wP8D3A9wDfA3wP8D3A90B1vQfU4D9GgBFgBBgBAAwCI8AIMAKMQHVFgAXe6npleV2MACPACDACjAAjwAhUBIFqOIYF3mp4UXlJjAAjwAgwAowAI8AIMALFCLDAW4wF5xgBRsB0BLgnI8AIMAKMACNQZRBggbfKXCpmlBFgBBgBRoARYAQcDwHmqCogwAJvVbhKzCMjwAgwAowAI8AIMAKMQIURYIG3wtDxQEbAdAS4JyPACDACjAAjwAjYDwEWeO2HPc/MCDACjAAjwAjUNAR4vYyAXRBggdcusPOkjAAjwAgwAowAI8AIMAK2QoAFXlshzfOYjgD3ZAQYAUaAEWAEGAFGwIIIsMBrQTCZFCPACDACjAAjYEkEmBYjwAhYBgEWeC2DI1NhBBgBRoARYAQYAUaAEXBQBFjgddALYzpb3JMRYAQYAUaAEWAEGAFGoCwEWOAtCx1uYwQYAUaAEag6CDCnjAAjwAiUggALvKUAw9WMACPACDACjAAjwAgwAtUDgZom8FaPq8arYAQYAUaAEWAEGAFGgBEwGQEWeE2GijsyAowAI1CdEOC1MAKMACNQcxBggbfmXGteKSPACDACjAAjwAgwAjUSgTIF3hqJCC+aEWAEGAFGgBFgBBgBRqBaIcACb7W6nLwYRoARsBICTJYRYAQYAUagCiPAAm8VvnjMOiPACDACjAAjwAgwArZFoGrOxgJv1bxuzDUjwAgwAowAI8AIMAKMgIkIsMBrIlDcjRFgBExHgHsyAowAI8AIMAKOhAALvI50NZgXRoARYAQYAUaAEahOCPBaHAQBFngd5EIwG4wAI8AIMAKMACPACDAC1kGABV7r4MpUGQHTEeCejAAjwAgwAowAI2BVBFjgtSq8TJwRYAQYAUaAEWAETEWA+zEC1kKABV5rIct0GQFGgBFgBBgBRoARYAQcAgEWeB3iMjATpiPAPRkBRoARYAQYAUaAETAPARZ4zcOLezMCjAAjwAgwAo6BAHPBCDACJiPAAq/JUHFHRoARYAQYAUaAEWAEGIGqiAALvFXxqpnOM/dkBBgBRoARYAQYAUagxiPAAm+NvwUYAEaAEWAEagICvEZGgBGoyQiwwFuTrz6vnRFgBBgBRoARYAQYgRqAAAu8OheZs4wAI8AIMAKMACPACDAC1Q8BFnir3zXlFTECjAAjUFkEeDwjwAgwAtUKARZ4q9Xl5MUwAowAI8AIMAKMACPACBgiUHGB15ASlxkBRoARYAQYAUaAEWAEGAEHRIAFXge8KMwSI2CIwJSZs/Dia/O01U3a9sMf6zZoy8Yy7Xrejl9WrTPWZFadKXOZRdDKnYMadsKGzTusPIs++fmfLsLQu+7Tr7RwyRZzEMtTZj6DF159j7J2CYb3ul2YMJh0196D8KvbDtnZOQYtXGQEGIGqggALvFXlSjGfVRKBSdOfxph7HzbK+9nzl8WP6KatO422l1XZvWsHBAb4ldXF7LbPFi7GgGETSoyzxlyGk1y9FiWw2L5rv17Tn39vxh1jH0Bk59tQp3kPwd/zr7yL+IQkvX5csBwCLZo3QaMG9cwiWD+yF9b99Z9ZYyzRubR71hK0K0IjJycXL819H13734nABh3RuE0/LFn+u1FSBw4dQ3CjzojoMNBoO1cyAlUUAYdlmwVeh700zFh1QGDC2DuxcctORMfElVjOshV/oF7dcAzo06NEW3kVS7/5CL17dC6vm0XabTmXLsNvf7AAE6Y9AR8fT7w062H88NUHmDB2OBKTUrBo8XLdrpy3IAIvPvMwZt5f8sHHglNUW1Lj7nscq1b/jXFjRmDFj59h0YJ3Uad2aIn1pqVnYPpjL2L0iCFQqVQl2rmCEWAELI8AC7yWx5QpMgJaBAbf2gehwUH48Wd9LU9hYSGWrViDSeNGISMzC2/O+xSDRk5GvRY90f/28dKP5l9aGsYyhmYGl69cxz1THgVp2roNGIWfV64pMezr75cJbXPDVn3Que8IvPX+Z8jPzxf9flqxGnPemI9DR06AXt1S+H7Jr6LNcC7STI0cPxMNWvZGx953iHFZWdmiL0XKq/evvluGLv1GCC3XA4++gJi4eGoGTIhpjnkffYWHp9+LZd9+InC6tX8vTJ86Ht989i4ee3BKmVToAYN4JDx73zZWz7TjsVmvgV7bQ+ePrkfbHreDeNap1stevHxVGjcLLbsMQouOt+KRp1/BqTMX9Pp888PPpa65oKAAn365GMSPoq1e/ecGvfGpaenCnIBwo2tJ1/SfTdv0+iiF6zeixXV8+sW3UFRUBOW1Oz0M9B86HnUjeuD20feDrqkyhtJlv64G3WPEA/X77scVVK0NhI2uSQOZiPz4828YO+lhcX8R/8tXrtX279RnOIjviQ88Ke4dwkfbaIEMYXTXhIfE/Ub3JfEeFR2Lsu5ZhWdlHL1lOXj4OBISk/HUi28Kreptd07Gzj0HzOJw975D4i0D3VfD734AdJ8qBIhPekPxx89f4+lHp+GWvj0xoK/0VkIKSh8lpXvwntHD0bplc3HtlHpOGQFGwHoIqK1HmikzAoyAWq3GvePuFK81SShREPl7wzbExidg8vhRyM3NhZubOz5852Uc2fUnHpk+SXot+oHJdqgkSN0z9TEk30zF1r+W4/svP8CXi35CSkqqMp1IU9My8czjD+Do7vWY9+YL2LH7IN6Z/7lomzB2BN58+Rl0aNcKKdePiDD13jGiTTe6ERWDEffMQFhIMA5sW4PP5s+VBPfVmDX7bd1uOHzsJEgoWbH4c/z+80JcvHwN787/Uq9PWYWNW3bBy9MTLzz9kNFu1Ga0QVP52cIf8MDke3B879+YNvluzHj8JWzdsVe03jtuJNZKr99J+BEVUrRh8w7ESgL5PaPvkEol/8fFJ2LQnZMFTyuXfIGdG39FL0nDnpqWpu188dJVQffJR6bhuSdnSvge0FvzvI8WYvX6DZg75ymc3P8Pnn/yQbz29kf4a8NWLY2J056UBNST+PSDuVKffzH9vvG4ebN4DqXjmXOXMFQSZseMHIr/vTNbT0v4k/QgRXWHdqwDmSeMmvAgUqR7g8aSUPbQky9j/JjhOLFPwmbK3UIALO21O42h8PV3P+PBB+4V9+eEu+/Eg0/OAT1kURvdB74+3qA3AXTvnNz3D1VbJJAmdNojL0ga0zvE3IelNU2dMFqst7x7lu6BLp3a4JP3X0O+9LBx/yPP47FnXxUPoPPefBEuzs54WHpooYcdU5mlh7C7hg/Bh+++jKzsHAmH2VqBlYTnHl074Ovvf0bTdv3Rqutg6XPxDtIzMvXIf7/0V1yXPkfPPjFdr54LNRMBXrXtEGCB13ZY80w1FIFJ4+7C1Ws3tAIXwfDzytUg7W9YaDAC/P1AP36tIpuJ/NhRt2PqxDH4+deSWloY+ftv226cOXcRH7/3Kho2qIvIiCZ4Y87TuJmqLyg989g09OjaESSckPbp+admYukvq41QLL1q8bJV8PbylH7w5yAo0B89u3XCy88/JtH5Q8+u1t+vFl576UnBT9tWLTDx7hHYe+Bw6YQNWkh4bNakoeDVoMmk4h1DbsEdQ29BLV8f3DdpLIYNGQDinQZ369weRFsX359/XYsRt98q+lMfw/CdpO0mWp+8/4rAl64ZCVxES+mbJ2nLl337sbTWO/HgtAnCLGDPfnnNOTm5+Ojz76Tr8hQG9usp5hlyW19Mka7zDz/JmvRtO/eBwucfvo7uXToInG+VtNp0PyhzqFQqHDl+CneMvR9PPDTF6APBi888hI7tWyM4KADvzn0OLi7O2jcGJIzdPri/4M2vlq/QnN991zB89e0yZQqj6f2Txwq+6bqS1j0kKBAHjxw32teSlYmSRjYvL0+Y7xC/dH/Tg1jtsJBypxk3ZgRefOZh3DnsVsx740WQgN63ZzcJswdF3duvzhJ19GBWLjFNh1dffFx6uzAZY6QHjXek8ecuXJEelBJE6zVJ407X+8y5C3jrlVniwfW/rTsx/bEXRDtFp86cl97mfIavP30b9DBMdRwYAUbANgiwwGsbnHmWGoxAg/p10L9PdyxfuU6gQJpF0jCOH3OnKFNEr5mHjZkmXhnTa9t3//cFrl2PBkCtZYfLV66BbIFJ0FV69unZBR4e7kpRpPQ6dsK0J9Ci062gOe4cNwMxsfHIzMwS7aZEFyQtZp9e+rRvG9BbDL14+apIKapXpzYl2hAUGAjSkmorysmQMKB2qvjXU+uWLfRmaNsqUmiZlcr7JSH4pxV/iCI9GKz7exPGjx0uysai8xcvo1OHNnCWtILG2qmuSeMGepg3rF9XeghIpCZcunIdJPQOGTVVYE/4U3j1rQ9x6fJ10ef8hcsIrx2KJo0aiLKx6PLV6xg+9gHMnvUIHpgyzlgXtJUeMJQGV1cXtIpsrl37OWmOWyUhWmmnlMqnzl7QaiqpzjAQX7p1oSFB0tqSdKvKzQ8aOVm79m4DRpXbnzqQgNure2eQ+QFtBvv6+2W4cvUGNZUbIiOaavs0alBH5HU/I/S5pEr6PFJqSiAslX4NNRv74hNlHEhTrFKpsHTRR6A3BfRg8Narz2L9P1ukz3IUyHzo/oefx5xnH4W5mwKVOTllBBiBiiNQ8V+Uis/JIxmBGofAhLEj8Me6f5GRmSk0t8GBAbh9UD+Bw/KVa/HehwvxyguPYe/m30Gvhec89xhyJc2W6GBC5OzkVKKXk7r4433h0hWMnfQI7rlrOP7+7QckXjmIP1d+K8aYMw8NcDKYy8m55NxqnblpDAVdkw4qlxWaNmkA0oqTEFFWP3PadOcngYSE0P0Hj2LZijUICQ6q0OZB3fkNr4FKpdIKkSqVSnTdtXGluL50jZWwe9Mq0UaRSiX3o7yxQIJnz+4dsXzVOhi+KjfWX6nTXbvh9XOWrh+1q1Slz238eirUTUu//uQd6f7+Q4Sfv//EtEFSr5VLPpfeIjwKdzc3LJM08d1uGQWylZWayvxP61I6qFTy2nTXrlLJdbR2pV95qe41Vqn0x4eGBIPe2NAbFIVOM+k+pjxpf+l6kYb3yRfe0Ar+ZDdPpk308PPTitXUlUNZCHAbI1AJBIp/EStBhIcyAoxA2QjQ63J3d1es/OMv/CRpFu8ZPUx61ewiBu2WXnv36tYJ3Tq3B/1gUuWxE6cpMSmQpunq9Sg9jduZc5f0BKKDh08gSBKy6fUuabboh//YiTN69N0l/ooKi/TqDAtNGtXH0eP6vB06fFJ0a9ywvkgtEY284zbBP2m6jdGjBwdj9Urd8ZP6PB49cUpPq0bmCWPuHCoEqMXLVopX+yqVLMAoNHTTpo0b4uDh40JLp1tvar5Jo3pC+7tx885SkirLlwAAEABJREFUhzRt0lDYPetqyg07u7q4YPHC/8FT0t7TAwwJUYZ9jurcO7m5eThx6qy09rqiG5lyHD2uf90PHT2BljraUNHRzMjD3R2FRYVljqL7rnnThqBgjobT3d0N40YPlx4IH8emtUvRqX0b/LVhi5jL3YR7VnS0QUSfYdosSW8MlOnOXbgisnVqhwkTlTW/fAPdMH3qeGHGRHW39Osh+nLECDAC1kGABV7r4MpU7YOAw87qLv1oky3m/E+/wcnT5zHh7pFaXtu0bI4DkjCVlJwCslf832eL8E8pO/O1g3Qy/Xt3Q9PG9fHE83NBNOhHl3zVurm5anvRq9iomFgcOykLO+Qz9ZMvf9C2U6aRJLCS4KxscKI6wzBp3ChJ8xqF19/9ROx437v/CN6Y94mwWyWbUcP+FS2T8PzUI9Mw76OvMP7+x0FeArZs34Pf1/4L8vjwqQHvhvOQJpDWeDM1Dd/++IvwETt14mi9bhPvuVM8fND1IBtjvUaDwn33jgHh8vizrwvPDIQzaeTIZtOgq9EimULMenwG6NrSOBpPni1+/X292NBIg8gMhVzN0aYyMj8hYXbD5h1Y8duf1KwNZKZAr83JNteY0Dvvo4VCOCdfxS+8Ok+6p/IxZuTtYvz0qePEGwY6kITW89uav7H4p98w4/7xor2iEZlznDh1rqLDSx1HGtH5ny4CeaSgTmSHe+HiFa0Ab8o9S+NsEe4cdpt4qHzkmVcEv+TBgTYlDh86ECTs0z1A11g3NKgXDto8R3VhkobYFnzyHIxATUWABd6aeuV53TZHYPzYEcL+sHePLoho1kg7P21QGza4PwbecS+69h+F4yfPgoQ9bYdyMvRD+vP3nyJP0ub1GzoeA4ffKwk4QxEWGqwd2bJFUyyY/zoefvJlkP3k/M++weuzn9S2U2ZAn+5o27oFyG0ZvWJV3JJRmxLq1qmNtSu+wf5Dx4RLsgefnI2B/Xvig7deUrpYLKVNdT8t+hhpaZl4+4PPQTbHr779IUKCAzFt8j1lzvPckzPwwadfC1dW3y5ega8+eRt9e3XVG0MbwxrUq4NBt/RGnfAwvTbDAs25dsW3SEtPx6gJM4WrtQ8lDD09PQy7llp++tH7JS3lY5IAvgJtug1Fn8F3C2HXS4fG4q/mS9cgUrg8I7diDzzyAnTNOpTX7+7SA9TP38lmAST06tphP/3IA5j4wFNo3W0wTp+9gN9++hK04YsYozcNH747B59/swStugzGx59/j9fnPIV77yl+AKN+5obHZk7Bgq8Wi1f1lnRL5unhgS3bd0trGSJod+o7AoNv7Qv6zBCPptyz1M8WgR5E1q1YhPT0TPQdMg7kFYK0tgs/fssW0xuZg6sYAUZAFwEWeHXR4DwjYEUE2rWOBNltksCoOw3ZR778/OM4tGOtCN9+/h5IYPtv3U/abj8s/ADvvPactnzh6Bax01ypoFfEK378HMd2rwe5hSIB5sjOP0E78JU+Y0YOxbZ/fsGe/34Tr4ZHS6/0iR9FGCI+fl+2UPBI9bQbnsYazkWuy1Yv/xpXT+3Awe1r8cacZ8TreupLgbxBrF/1HWW14c5ht4LoaCsMMvUlTRfN2btHZ72W2wf3FwL2qf3/Cr5oTW+/+qzwQKDXUaeQcPmAEIgIP6K5/d8VejgoXUlIpE179CCi1JWVtmjeGD9+/T+cPrBB8LJvy2q0aRkhhpiyZpVKJfjasPpH3Di7C/u3rgbhPWr4YEGDIn+/Wnj/zReEyzfi/fKJbSB7Y2oznIOEbcKZAuWpD4X+fbqB8Iq9sE/YadP1onol0D2x+c9lgofN65dhyoTRSpNIf1g4H+/OfV7kKSI8b+3fi7LasPXv5Xhw2gRteeigfrh2eqfAhe4/bUMFMj/o3OukGaV7jbCgQLbnH897BWSSQ6RLu2cNeaaHQhpPmlQaR4Hue6ozxIfaDEOPrh3F2uhBQ2kLCvQXdbqbBBs2qAu6phePbYFyr+peG2Wskj46czLOHNqoFDllBBgBKyLAAq8VwXV00swfI1CTEfj8m6UgAeaOIbfUZBh47YwAI8AI1AgEWOCtEZeZF8kIMAIKAuSxgkw2Nm3Zie+/fB8uLvLmQaWd05qHwMNPvQK6J4yFh596peYBwitmBKohAizwVsOLyktiBBiB0hFo0qiBeBVNbtnIjrf0nlWrxdhr96q1AvtxS4d9kHmDsUBt9uOMZ2YEGAFLIcACr6lIcj9GgBFgBBgBRoARYAQYgSqJAAu8VfKyMdOMACPACNgPAZ6ZEWAEGIGqhgALvFXtijG/jAAjwAgwAowAI8AIMAJmIWAlgdcsHrgzI8AIMAKMACPACDACjAAjYDUEWOC1GrRMmBFgBBgBAAwCI8AIMAKMgN0RYIHX7peAGWAEGAFGgBFgBBgBRqD6I2DPFbLAa0/0eW5GgBFgBBgBRoARYAQYAasjwAKv1SHmCRgBRsB0BLgnI8AIMAKMACNgeQRY4LU8pkyREWAEGAFGgBFgBBiByiHAoy2KAAu8FoWTiTECjAAjwAgwAowAI8AIOBoCLPA62hVhfhgB0xHgnowAI8AIMAKMACNgAgIs8JoAEndhBBgBRoARYAQYAUdGgHljBMpGgAXesvHhVkaAEWAEGAFGgBFgBBiBKo4AC7xV/AIy+6YjwD0ZAUaAEWAEGAFGoGYiwAJvzbzuvGpGgBFgBBiBmosAr5wRqHEIsMBb4y45L5gRYAQYAUaAEWAEGIGahQALvDXrepu+Wu7JCDACjAAjwAgwAoxANUGABd5qciF5GYwAI8AIMALWQYCpMgKMQNVHgAXeqn8NeQWMACPACDACjAAjwAgwAmUgwAJvGeCY3sQ9GQFGgBFgBBgBRoARYAQcFQEWeB31yjBfjAAjwAhURQSYZ0aAEWAEHBABFngd8KIwS4wAI8AIMAKMACPACDAClkPAHgKv5bhnSowAI8AIMAKMACPACDACjEA5CLDAWw5A3MwIMAKMgPUQYMqMACPACDACtkCABV5boMxzMAKMACPACDACjAAjwAiUjoCVW1jgtTLATJ4RYAQYAUaAEWAEGAFGwL4IsMBrX/x5dkaAETAdAe7JCDACjAAjwAhUCAEWeCsEGw9iBBgBRoARYAQYAUbAXgjwvOYiwAKvuYhxf0aAEWAEGAFGgBFgBBiBKoUAC7xV6nIxs4yA6QhwT0aAEWAEGAFGgBGQEWCBV8aBY0aAEWAEGAFGgBGongjwqhgBsMDLNwEjwAgwAowAI8AIMAKMQLVGgAXean15eXEmI8AdGQFGgBFgBBgBRqDaIsACb7W9tLwwRoARYAQYAUbAfAR4BCNQHRFggbc6XlVeEyPACDACjAAjwAgwAoyAFgEWeLVQcMZ0BLgnI8AIMAKMACPACDACVQcBFnirzrViThkBRoARYAQcDQHmhxFgBKoEAizwVonLxEwyAowAI8AIMAKMACPACFQUARZ4K4qc6eO4JyPACDACjAAjwAgwAoyAHRFggdeO4PPUjAAjwAjULAR4tYwAI8AI2AcBFnjtgzvPyggwAowAI8AIMAKMACNgIwQcTuC10bp5GkaAEWAEGAFGgBFgBBiBGoIAC7w15ELzMhkBRqDKIcAMMwKMACPACFgIARZ4LQQkk2EEGAFGgBFgBBgBRoARsAYClafJAm/lMWQKjAAjwAgwAowAI8AIMAIOjAALvA58cZg1RoARMB0B7skIMAKMACPACJSGAAu8pSFjYr2Liyt0Q3p6BiZMmKhXp9vOeX28KoNHUVGRuEqVocFjTbkeLsjLy+N72uCzbo17h+9pU+5Hy/The9oyOJb3ObDHPS1+GEyIkpISUU1DjViXCZdYrwsLvHpwcIERYAQYAUaAEWAEagoCISFh4FD1MKjI/ckCb0VQ4zGMQFVHgPlnBBgBRoARYARqEAIs8Nagi81LZQQYAUaAEWAEGAF9BLhUMxBggbdmXGdeJSPACDACjAAjwAgwAjUWARZ4a+yl54WbjgD3ZAQYAUaAEWAEGIGqjEC1EngTEpPx6HNv4/7HXsFLb3yMrOxso9fmyPEzmProy5j00Ev45seV2j7ljU9OScUtdz6AL75drh3DGUaAEWAEGAFGoMYgwAtlBKooAtVK4P144VJ079wO3376Onx9fbB0xZ8lLgu5SHnlnQV47rGp+O6zN7Bp214cOnpK9Ctv/PwFi9GxXQtABf5jBBgBRoARYAQYAUaAEagiCFQrgXfHnsMYNqiPgH7YbX2wfc8hkdeNzpy/DE9PD7SMaAJnJycMGtAT23YfFF3KGk9aYQ8PN7Rq0QyQ3b+KMRyVQIArGAFGgBFgBBgBRoARcCgEqo3Am5GZBZWkefX38xUA16sTiviEJJHXjWLjk1AnLFhbRf1i4xJR1vj8/Hx8+vUyPDZ9vHYcZxgBRoARYAQYgbIR4FZGgBFwFASqjcBLgKrVxctRqYrz1KYbVGpJMtZWFPcrbTyZRtw1fCB8fby1o5RMbm4ODAO1GdZxuSROlcWETkrKy8stgX9l6fL4kteqoCCfcTbyWbf0vZKXl4c8vqdtcq/xPV3yc27p+5no5dnhnqbfYA6MgCECxdKeYUsVK3t5eqCgoBC50oeLWE9MTkFwUABl9UJocACSU9K0dUlSv9CQQJQ1nkwj3nh/IXoMvhdf/bACi5evwUdf/ihoqFQqqFT6gRpUKv06lcp4WaXiepWqohigBPYqVUVp8TiVqnQMIP2pVKW3q1TcplJZAgPwPW0RHMu/FpD+VKry+6lU3EelqgwGsPk9jWr297Ekb0x/8lWs+2erWSs7fuo8npr9nlljjHU+f+kqtu7cb6xJW3f4+GlMe/xldLttPP75b6e2njIDR05Dl4H3iNBn2GSqskuoNgIvodeza3ts2LyLsgLw3t3aizyZKxw/dU7kI5o2BHljuHYjBgWFhdi4ZQ96d+8o2kob//VHr2LX30tEmDFlLCbfMxxPPjhJjHFxcYVhoAbDOi6XxKmymDg7u4BCZenw+PKvjZOTc4n7nHErHzdzMaL7mYK546pJf5veY3xPW/7+NXYf0v1MwVibteroN9jWYfe+Q/jki++wbMVqkCLNUvNHxcTh4NFT+PqjuRg2qK+lyJpF5+Ll69i593CZY9zd3PDQffdgQO+uJfo5Oamxb+NyEbatW1yi3VYV1UrgffLBiVjz91bhluzqtWhMHDtM4HhdEm7f+GChyKtUKsx94WG8/PZnmPrIHHTq0BId20aKttLGi0aOGAFGgBFgBBgBRoARMEDg0Wdewa3DJ+Klue9j+mMvoE23wbh4+apBL/OLpJR7fu6HuHItCqThnb/gByxdsVYQmr/ge8x8eq7I7zlwFOSKlQokmI6bNkuSg17Gmr/+o6pSw1vzF+K19xbgoVlvYOH3v4DejL/4+ocYP/1Z3PfobJCGmAYvWrISW3bsEzwYam+pnUKLZo3QuUNrkHBLZVPCXZOfwHxpTZMefAETZnN4zWUAABAASURBVDyHcxeu4JFn3wTV//7nJlNImNVHbVZve3cuZ/6gQH988cEc4Zbs7ZefgIe7uxgRIV2I5Ys+EHmK2rWOwPcL3sSPX7yN6ZNGU5UIpY0XjZrovgl34qH779GUOGEEGAFGgBFgBBiB6oLAhUtX8PYHC0wOL82dh++X/qq3/JupaZj28HMm06D5SDOsR0QqOKnVmPv8I2jWpIHQ8A7s1w1HTpyRWoCTZy4gJycX+QUFIC9S7dtEiPzr877A7GdmYNEnryPOyMZ9MVgnysnNw4J5szFz6t34+MslaN8mEsu+fh+vSfO+/Panoue0e0ejX68uggfybCUqzYgKpbfpfW6fhDFTn8Lq9fpCeLPG9fHjl++iW6e2kvD9Od599SlJPnsL3yz+VazHjGnK7VqtBN5yV8sdGAFGgBGoJgjwMhgBRsDyCFy4dNUsQfXjz78zysTeA0fMovPLqrVG6ehWto5shmMnziInNxeurq5o07I5TkmCLwm8Hdu1xI2oWAQF+ol6lUqF0SNu0x1uNN+vZ2eoJcGaGg8eOYl//tuB6U++ijcl7W9CUrJRb1fU15xAAvR/a77Hg/fdg8+++Qlk76uM79W9g8i2adkMjRvWhY+3l3AQECQpMOPiE0WbpSIWeC2FJNNhBBgBh0EgKysbh46cQExcvMPwxIwwAoyA4yPQpFF9vDTrEZPDYzOnGF1Uj64dTaZB89191x1G6ehW0tkB9euFY836zZImtgXobfWBwydx9Xo0mkp8U18nJydKRHB2chZpWZGLi36f+W8+JzS5ZDNM9rbGNv+XRc9YG9Eg3m/t1x2Db+mtNZWgvi7O8vwkdDtr8lRP5by8fMqaEkzqwwKvSTBxJ0aAEagqCHzxzRLUieiG3oPGoEmbvhg25j6kpqVXFfaZT0aAEbAjAk0aNTBLUH339RcwdeIYPY5r+frgq0/fMYvO+LEj9GiUViAhd8mKNWjXKgId2rbA739uFCYP1L9OeCgSk1KQnJJKRZBtr8iYGHXr3BafL/oZdCItDdl36Dgl8PRwx80KfoeS0wCyRSZCKalp2C/RbB3ZlIo2Dyzw2hxynpARYASshUBsfAJefG2esG1T5ti8bTe+/fEXpcgpI8AIMAIWReCz+a9jw5qlePvVZ/H1p+/i2J6/pdfz9S06h0KMBN2Y2AQh7Ab6+0GlUqN96xaimbSoc2bNBNnePvrcWzh/8YqoNzV6bMZE5ObmYsL05zD07gexcvW/Ymin9i1RWFAIolnaprVd+w4Lt2PUPvvNj9F/+FQx9pqkfe45eKJoe/CpuZgwZpiWX9HBhhELvDYEm6diBBgB6yJw5NgpkKN7w1kOHpY1FYb1XGYEGAFGwBIIdO/SAY8/dB9IUxsgCaKWoEk0yK6VzAsoT6FXtw7Y/e8yuLm6UhG//fgxJo8r1g5379wOn82bLcKn783Gh289L/rpRkp+9jMzMbBvd6UIP0kzTZvVln3zPtb/8iVoAxk1kgOA9157WtAsbdNajy7tobgeo3Tzmu9pKFo0b4w9Er9U9/OiDzB8SH9RT9GqxR8Le13K9+/VBa8+9xBlRfj20zfQoF64yFsqYoHXUkgyHUaAEbA7AqEhQUZ5KK3eaGeuZAQYAUaAEah2CLDAW+0uKS+IEagsAlV3fOvI5pJGoUmJBYwdeXuJOq5gBBgBRqAmIPDj8tWY8dRreoHqKrJ2GmcpWhWZvzJjWOCtDHo8lhFgBBwKAdqh/Ndvi0GvF1EksaYC/l29BF07y6cuSjX8nxFgBBgB0xGoBj0n3TMCX334ml6guoosjcZZilZF5q/MGBZ4K4Mej2UEGAGHQ4Bc4DRr0hCQhF0Sels0bwL+YwQYAUaAEajZCLDAW7OvP6++8ggwBQdEICExWctVdEy8Ns8ZRoARYAQYgZqJAAu8NfO686rtgEB+djJSLm9E4pnfkZV0zg4c1Jwp4xOTtIuNionV5jnDCDAC1kSAaTMCjosAC7yOe22Ys2qEQFbSWZxdOw039nyImMPf4OK/TyH2yLfVaIWOtZQEHYE3OibOsZhjbhgBRoARYARsjgALvDaHvGZPWFNXT1rdooJcveUnSJrewvxsvTouWAaBhAQdDW80a3gtgypTYQQYAUag6iLAAm/VvXbMeRVCICf1WkluiwqRmx5Vsp5rKoUAnRSUnpGppcEaXi0UnHEsBJgbRoARsCECLPDaEGyequYi4OZbr+TiVWq4elv2JJmSk9S8mrj4RL1FR8eySYMeIFxgBBgBRqAGIsACryNfdOat2iAQGDESKrWz3nqCpDq1s7teHRcqj0BicooekSg2adDDgwuMACNQtRD4+MsfMf3JV7Hun61mMX781Hk8Nfs9s8YY63z+0lVs3bnfWJO2btnKP9Fl4D3a8P2y37VtjpJhgddRrgTzUa0R8Ahojlr1+8lrLCqCk5sfQtvdL5c5tigC8Rr73Q7tWgm6MbHslkwAUcUjZp8RcGQEMhNOIfHMb7h55T8U5KZZjNWomDgcPHoKX380F8MG9bUYXXMIXbx8HTv3Hi53yPTJY7Bv43IRpo4fWW5/W3dggdfWiPN8NRaB7JSL8tpVKhTkpCA/W18TKTdyXFkElA1rkc2bClJswytg4IgRYASshED0/k9xedNzwvPOjT3/w7l105GbHl3p2QoKC/H83A9x5VqU0PDOX/ADlq5YK+jOX/A9Zj49V+T3HDiKl974WORJMB03bRbuf+xlrPnrP1FXWvTW/IV47b0FeGjWG1j4/S+gt2Mvvv4hxk9/Fvc9OhukIaaxi5asxJYd+wQP//y3k6pMDgmJyRgz9Sm8IK1jrCY9cOSkOOb4rslP4NRZze+iyRQr3lFd8aGONpL5YQQcFwF64s9OuQSV2gWewbLmkTQC4D+LI5CgcUkWHByAOuFhgj4LvQIGjhgBRqAcBHLToxB/4ieTQ+yRb5F88R89qoV5GbixZ77JNGg+0gzrEZEKTmo15j7/CJo1aSA0vAP7dcORE2ekFuDkmQvIyclFfkEBjhw/g/ZtIkT+9XlfYPYzM7Dok9cRp3nbJQaUEuXk5mHBvNmYOfVufPzlEolOJJZ9/T5ek+Z9+e1Pxahp945Gv15dBA+DBvQUdcaiJb+sRZ9hk/HMy+/rzU1a6gfvuxvLFn2AhKRk/PnvVnwx/xWJz5n4fNEyY6SsUscCr1VgZaKMgD4CmfEnRYVnUAt4BskCb1biKVHHkWURUATeoMAA1A4LEcRrnB2vWDVHjAAjYC4CuWnRkqC6zOSQeHqV0SmyEs+YTCP+xDLcvLLZKB3dytaRzXDsxFnk5ObC1dUVbVo2xylJ8CWBt2O7lrgRFYugQD9Rr1KpMHrEbbrDjeb79ewMtSRYU+NBSfP6z387hCb3TUn7S8KpYiJG7WWFwbf0wqY/Fglh2dfHG3Pf+1zbPVz6Hm5Yvw6cnZzQolkjtG7RFE5qtcRnM1yWtNfajlbOsMBrZYCZPCNACGTEH6cEnsGtQUIvFTITTlPCwcIIJEiv0IgkCbzhYaGUBWt4BQwcMQKMQDkIuPrURnCr8SaHgIg7jVL0DIo0mQbNV6tBf6N0dCtJYKxfLxxr1m9G+zYt0K51BA4cPomr16PRtFF90dVJEipFRoqcnZyluOz/Li76fea/+ZzQ5JLN8LZ1ixEcFFA2AU1rgH8tODs7o254KJ55ZIrQQGua4CLVK3kSrpU5KZ+fX6A0WS1VCLPAqyDBKSNgRQQy4o4J6l7BreARGCHymZIGoKgwX+Q5shwCcQmyW7KgAP9iDW9MrOUmYEqMACNQbREgV5HBrSZIwqppIaz9dPg3HqSHh9rFC+FdnzKZBs1Xq8EAPRqlFUjIXbJiDdq1ikCHti3w+58bhckD9a8jCZuJSSlITkmlIsi2V2RMjLp1bovPF/2MoqIiMWLfIY2ixsMdN9PSRV1pka7v8w2bd6FlRJPSutqtngVeu0HPE9cUBAryspCdfAFQqeER1BLObrXg6l0bKCpAtrKRDfxnKQTiNXZrwZJmIrx2iCBbtoZXdOGIEWAEGIEKIVC782NoeMs84XmnTren0WzY1/J3fIWolT2IBN2Y2AQh7Ab6+0El/a60b91CDCIN8JxZM0G2t48+9xbOX7wi6k2NHpsxEXRwz4Tpz2Ho3Q9i5ep/xdBO7VuisKAQRLO0TWtkwkBuyfrdMUUI2q89/7AY60gRC7yOdDWYl2qJgGyrWwSPgGZQO7mKNXoEyl9QbNYg4LBopHhpCJIE3tphssAbFc2HT1gUZCbGCDACegiQCUNgxCiQptbJ1UevrTKFxg3rChMDhUavbh2w+99lcHOVf0t++/FjTB43QmlG987t8Nm82SJ8+t5sfPjW89o2w8zsZ2ZiYN/u2mo/Xx+89vwjWPbN+1j/y5d499WnRJuHuzvee+1pQbO0TWvvvz5LuCPbsvYHvPOKpN2Wvn9pcFCgv6BHeQpPPzwFdwyWzTdIQKd5qN4WgQVeW6DMc9RoBDLi5NdCXsGttTjQlyMVshJPU8LBgggkaLw0BNGmtVBZ4GUNrwUBZlKMACPACFRBBFjgrYIXjVmuWghk6mxYUzj3DNJoeKuewKsswSFTeh2XmpYOFxcX+Hh7Iby2ZtNaLGt4HfKCMVOMACNgdQR+XL5a+L2d8dRr2pTqKjIxjdOlQ3mqqwgtW49hgdfWiPN8NQqBwoJcZAqhVgXy0KAs3q1WQ6icXJGXEYf8nJtKNaeVRIA2bBAJst+ltNikgTetER4cGAFGwJIIVA1ak+4Zga8+fE0vUF1FuKdxlqJVkfkrM4YF3sqgx2MZgXIQyEo8AxQVwt2vIZxcPLS9aaOBp+KtQeOjV9vImQojEK8xZwgOlF3p1PL1gYeHO1JupiI/v2Z6xFjz5wb0HXI3ghp2QLcBd+K7JSvAf4wAI8AI1DQEqpXAm5CYjEefexv3P/YK6Ji9rOxso9eTnDRPffRlTHroJXzz40ptn9LGnzh9AbfdNQM9Bt+LKQ/PxvoN27VjOMMIlIWAMXMGpb+HZuNaltAAK7WcVgYB7YY1jcBLtBRfvFevR1GxRoUrV29g8synceDQMWRlZeP4ybN49JlXsGff4RqFAy+WEWAEGIFqJfB+vHCp2KH47aevw1fS7Cxd8WeJK0z+5V55ZwGee2wqvvvsDWzatheHjp4S/UobX69OKFYt/hDb1y/GrEen4uOFS1CaMC0IccQIaBBQDpzwCmmjqSlOtHa8fABFMSiVzCVID71EIjhY1vBSXrHjjYmNp2KNClt37kVubl6JNW/YzA/tJUDhCmsjwPQZAbsiUK0E3h17DmPYoD4C0GG39cH2PYdEXjc6c/4yPD09hFNkcolBLja27T4oupQ2no7Jow0wTmo16BUpvY4uLCwSYzhiBEpDoKiwAJkacwXP4JICr1bDm3wORUWFpZHhejMQSFBMGoICtaPCNb54o6LZjlcLCmcYAUaAEahhCFQbgTcjMwsnTjjlAAAQAElEQVQqFeDv5ysuIWllFQf0okITxcYnoU5YsKYEUL/YuESUN560wGTSMH76c3hrzmPwkoRmLRHOWAaBakYlmwTZwjy4+daFs1tJv4zObrVAB1AUFeTKB1NUs/XbYznxmlPWAgP8tdOHhcqf95oo8Pbt2RWuri5aLJTMrf17K1lOGQFGgBGoEQhUG4GXrpZa0sBSSkGlKn1pKrUkGVMnEYr7lTW+Q9tIYdKw6JO5eP+Tb5GULO+sz8hIh27IzMyQtHVFenW67ZzXx6syeGRnZyErK8thsU6+cUDcYa7+EaXy6FKrqehzM/pIqX0qg5Glxubm5jg0f8o6YzTux3y8PbX8BgX4CYyvXLuhrVP6O1pq6Xs6KLAWvvjfG2L9RUVFoH/DBg9A65ZNHR4La18bR7+nrb1+W9G39D1tCt/ihueIETBAoFjaM2ioakXSuBYUFCI3T7ZXS0xOgeKaSHctocEBSE5J01YlSf1CQwKFxra88U5qNVo0a4TQkCCQaQQR8fLyhm7w9PSCSqXSq9Nt57w+XpXBw93dAx4eHg6LdV7KebpFUKt2h1J59A2TD6PIT71Uap/KYGSpsa6ubg7Nn7LOm6kZAvP6deto+W3YoL6oI5dlSj9HTa1xTzdu1ECsX6VSgf7FJyZrsXFUHGzBV1W5p22BhTXnsMY9XR6/4obniBEwQEBtUK7SxZ5d22PD5l1iDXTec+9u7UWezBWOnzon8hFNGyJB+sK/diMGBYWF2LhlD3p37yjaSht//uJVZGZliz7Xo2Jw8coNNGss/4iKSrtEPKkjI1BUVIjM+GOCRc+QtiI1FnlqPDXIvnqN9eA6cxCIi08Q3QM0Wl0q1A4LoQQ3pM+uyNSwaO+BI2LFk8aNEune/YdBwr8ocMQIMAIOj8DHX/6I6U++inX/bDWL1+OnzuOp2e+ZNcZY5/OXrmLrzv3GmvTqfl+3ESPvfQxdBt6D51/7n7bt8LHTmPTQi5gw4zl89cMKbb2tM9VK4H3ywYlY8/dW4Zbs6rVoTBw7TOB5XRJu3/hgocirVCrMfeFhvPz2Z5j6yBx06tASHdtGirbSxt+IicedEx8XbskmzHgB4+4aiqDAYhtBMZgjRkAHgZybl1GYnw0XrzC4eATotOhn3fwaQeVEB1DE8gEU+tBUqJSg2bSm+/msXcOPF1YE3lv69UK/3t0Ern+s/Uek1SbihTACdkYg/fIRRG9dgoSDfyI/86bFuImKicPBo6fw9UdzMWxQX4vRNYfQxcvXsXNv2a4MDx8/jQWLfsYLT07Hnn+X4aFp48QURUVFmP3mx3jhiWlY/MU72Lh1Nw4eOSnabB2pbT2hNeejH7kvPpgDckv29stPwMPdXUwX0awRli/6QOQpatc6At8veBM/fvE2pk8aTVUilDa+X89O+HfVV9j19xJsXfs9JoweKvpzxAiUhkBGnKzd9QppVVoXUa9SqaEcQJGVYJ8vAcFINYkSpLc3tJQgHT+8deuEURVqoh9eWvie/fIPVZdObTF86K1UhTXrN4iUI0aAEag8ApdWvoWTXzyAa+s+xsXlr+LIeyORk3i90oTpLfTzcz/ElWtRQsM7f8EPWLpiraA7f8H3mPn0XJHfc+CoOHuACjslwXTctFmS4u9lrPnrP6oqNbw1fyFee28BHpr1BhZ+/wvIFPTF1z/E+OnP4r5HZ4M0xDR40ZKV2LJjn+CB3p5TnWFYvf4/jJdko+6d24L2QzWsFy66nD5H5nqeaNWiKcgz1uBbemHrrgOi7a7JT2C+tKZJD74gtL/nLlzBI8++Car//c9Noo8lo2ol8JYBDDcxAjZFIDP+uJjPK7i1SMuKPJQT1xLOlNWN28pBgDQJySmyZsWvlq+2t7OzMwL8/VBQUAClXdtYzTP0AHD9RjQCA/zQqEE9jBo+GPT337bdoIMoKM+BEWAEihHITriGG/9+ZXK4uvYjxO/9vZiAlCvITseFZS+bTIPmI82wNFTvv5NajbnPP4JmTRoIDe/Aft1w5IT8O3HyzAXk5OQiX/peo8O02reJEPnX532B2c/MwKJPXkdcQpIePWOFnNw8LJg3GzOn3o2Pv1yC9m0isezr9/GaNO/Lb38qhky7dzT69eoieCBXrqLSIIqW3oSTwHrbqAcw9r6ntRrh2PhE1NGYldGQepICIjZONj2jMpmH/vjlu+gmPZC/9t7nePfVpySF5Fv4ZvGvYj3Ux1KBBV5LIcl0GAEdBBQNr6cJAq9nYKQYmZl4SqQcVQyBWI39bpjGDZkuldoaV4TR0utB3frqnt+1R9akdO3UXiyVsOnQthXy8vLw5z9la3/EAI4YgRqGQE6iJPBu+Bo3TAwx25YYRSj96jGTadBciYf/MkpHt7J1ZDMcO3EWObm5cHV1RZuWzXFKEnxJ4O3YriVuRMUiKNBP1KtUKowecZvucKP5fj07C40sNZKpwT//7RCa3Dcl7W9CUjLiTRCaaSxpoyn99YePMPeFR0CCd3pGJlVBpeMZi95qikpN1Kt7B5Fr07IZGjesCx9vL9DZB0GB/oiThGXRaKGIBV4LAclkGAEFgZzUayjITYezuz/Iz65SX1rqEdRCNGUlnUNRUaHIc2Q+AgkJyWJQsI45g6iQovCwUCkGyB5OZGpIpNjvdunUTrviO4YOFPnVf24QKUeMACNQjIBbYD3UuXW6ySGs9/jiwTo574btTKZB8wW2H6Iz2niWTALq1wvHmvWbJU1sC5B55oHDJ3H1ejSaNqovBjk5OYmUImcnZ0rKDC4u+n3mv/mc0OSSzfC2dYuNersyRjAowB9dO7ZBLV9vcbBXkCR4X5cE8NDgQOnNWqp2CG2YDQ0J0pZdnOX5yQyC3sYpDVTOy8tXihZJjQq8FqHMRBiBGopApmLOEFLydDVjkMgHUIShqCAXOSkXjXXhOhMQSFA2rAUFlOiteGqoaRpercDbsa0WE8WO9+8NW4SZh7aBM4wAIwD3IEngvW0G6pgY6g9/BsFdR+oh5+TujSb3zDWZBs0V1PF2PRqlFUjIXbJiDdq1ikCHti3w+58bhckD9a8THgoSKJNTZAGTbHup3tTQrXNbfL7oZ0nxUiSG7Dskm+Z5erjjZlq6qCst6tuzEw4cOYnCwkLExCaA3B/Wlfhp0awRSEt87UaM8IxFnrT69OhUGhmr1rPAa1V4mXhNRCAjTvMlYYI5g4KPh2LWkHBKqeLUTAS0Aq8xDW9tjYbX/OOFzeTCcbrTD8/+Q0cFQ511BN5W0mtR0hKlpWdg01bZjaPoxBEjwAhUCIFGo2ej5UPfoN6wJ9BYEnTbPf873ALrVohWeYNI0CWBkoTdQH8/qFRqtG8tvyUkDfCcWTNBtrePPvcWzl+8Uh45vfbHZkxEbm4uJkx/DkPvfhArV/8r2ju1b4nCgkIQzdI2rdFmNH+/Wpg483k899p8zH3hUXh7eUKlUuHN2Y/jpTc+Am1O69yxNTq1ayno2jpigdfWiPN81R6BjDhZyPAKaW3yWhVPDZmJ8oYEkwdyRy0CCVoPDf7aOiVTEzW8x0+dRXZ2Dlo0byJs4hQsKFU2r61hbw0EBwdGoNIIkAlD7b73gjS1zp61Kk1PIdC4YV1hYqCUe3XrgN3/LoObq6uo+u3HjzF53AiRp6h753b4bN5sET59bzY+fOt5qjYaZj8zEwP7dte2+fn6gDarLfvmfaz/5UuxgYwayePVe689jc/mzUZpm9ZUKhWeeWSK2PBG7se6S9piGkuhfZsWoI1pP301DzOnjKUqEVYt/lj73dS/Vxe8+txDop6ibz99Aw3qhVPWYoEFXotByYQYASAvIwb52clwcvWGm69sU6Xgsv6fzZj5+EsYO/lhfLhgEUjDprR5aux4MxNOK1WcmolAgmLSYETDW1vjizcqJtZMqlW3+7798oETXXXsd5XVKGYNa9dvVKo4ZQQYAUagWiPAAm+1vry8OFsjkBF/QkzpGdxGpEq04rd1GDPpISxZ/hv+/Ps/zHn9A9w77QmlGW5+jaFyogMoJIE5R3atpW2sQhl7shqXkCimDwkKFKluFK4xaYiuQV4atPa7RgTe7l06IMC/FmLjErBPcxKbLl6cZwQYgeqDwI/LV2PGU6/pBaqryAppnKVoVWT+yoxhgbcy6PFYRsAAgQztgROt9VqW/PybXpkKGzbvQMpNeXOBSqWGR0BzqkYW2/EKHMyNFC8NQUGlmzRE1SAb3n0HZQ2vrocGBVOVSoU7hw0SxTWs5RU4cMQIWBgBhyE36Z4R+OrD1/QC1VWEQRpnKVoVmb8yY1jgrQx6PJYRMEAgU/HQEKx/wtqZ85cMesrFs+cuyhkp1po1JLJZgwSH2f8TkzRuyYxoeMM0vnljYuPNplsVB9xMTcMZ6d7y9PRAm5YRRpdwh8Y92dq/Nhpt50pGgBFgBKoTAizwVqeryWuxKwJ5WUnITY+B2tldmCjoMjP0tv66RZEP8PdDx/bFmmDPQHmnLdvxCnjMjuI1Jg2BAf5Gx9akjWv7DsobJzu11zet0QXmlr494O7uBhKMz5byQKbbn/OMACPACFRlBFjgrcpXj3l3KAQU7a5ncGuoVPofrVmPT0ctXx8tv+RU++N5r8JZ43SbGjyC5BPXspLOgg+gIETMC8Wb1owLvDXJjlexyzW2YU1B1dXVFcqD2Oo/ZfdDShunjICtEeD5GAFrI6D/q2zt2Zg+I1CNEVAEXi9J4DVcpru7O+g1c1ER4OrmgoKCQvTu0UWvm7NbLbh48QEUeqCYUSCH69Q9wN+PkhJBEXhrglnDfo2GtyyBlwAaeYdsx7v2r01U5MAIMAKMQLVFgAXeantpq9vCHH89GZoDJ7xC9O13iXPy0kDphLtHoH+v7lCpgP+MOP3X2vGyezKCy+QQn5Ak+oYEl/TQIBqkKCwkWIqBG9ExIq3O0Y7d+8XyunftKNLSokED+4LeNpBGuCY8CJSGA9czAoxA9UeABd7qf415hTZAID8nDTmpV6FSu8Ddv3mJGckdGVWOHzsCt/TrSVls2rJTpLqR1o6XD6DQhaXcfLE5Q8ljhZXBioa3ursmO3/xsvDxXK9uOIIC/ZXlG019fbwxoE8P0cab1wQMVSNiLhkBRsBsBFjgNRsyHsAIlEQgK+G4qPQMipSEXieRV6Iz5y7i0JEToE1Tt/TtKQm8vUTT3xu3iFQ38tQcQJGVeEq3mvPlIKBoeIODShd4CX8iU91dk+07IG9Y66JznDCtu7QwYtitomnNnxtEyhEjwAgwAtURARZ4q+NVBXhVNkag2Jyh5K74H5etEtyMHzMCKpUKrSKbgQQzEtJIGBaNmkg5gIK8PeTzARQaVMpPTNPwhghC1V3Du1dzkER59rsCDCm6Y8hAKQY2bd2F1LR0keeIEagpCMTFxYBD1cOgIvcnC7wVQY3HMAIGCGRo/O+ShwbdpqKiIvz48ypRde+4USKlaGB/WctraNagUtEBFM2oC7LY6J+yQwAAEABJREFUjlfgYEpkisBbW3u8cJwpJKtsH7LHJea7dmpPSbkhLDQYnSVtcGFhIf7eUPKtQ7kEHL4DM8gIGEcgICAQHKouBsavaum1LPCWjg23MAImIVCQl4Xs5IsACauB+k7+N27ZiYTEZOFvN6JZYyh/ih3vxi07lCpt6hkYKfKZbNYgcDAlIoypX1k2qzXBhjcvLw+Hj50U7u46ti+5eZIwMhaGaw6hWMOnrhmDh+sYAUagGiDAAi+AanAdeQl2RCAr4YQ0exE8JWFX7eQq5Yv/L13+myhMvHukSJXotgF9RHbL9j3Iz88XeSUqtuM9o1RxWg4CZB5CXchUhFJjwa+WL5ycnJCccrME5sb6V8W6/YeOgd4qtG3dAi4uLiYvYezIYaLvur83ITc3V+Q5YgQYAUagOiHAAm91upq8FrsgUJo5Q3pGBv5Y96/Qto0bM1yPN3KfFRnRFJmZWVBOxVI6KAdQZCaekYSXQqWa0zIQSEiU3ZIFBZa+aY2G168bTgmu3YgWaXWL9u4/IpbUpWM7kZoaNahfB82bNkJ2dg7+27bb1GHcjxFgBBiBKoMAC7xV5lIxo46KQEYcaXgBwwMnVv7xF3JycjHktn4g7aIh/4pZg6Edr3wARSiKCnKRk3LJcBiXjSBgqsCrmDVUV08New8cFuiYumFNdNZEw4fK3hrWslmDBhFOGAFGoDohYL7AW51Wz2thBCqJQKEklGYlkemBCh5BLfWoLV3+uyjfa2DOICqlaEBf2f+pcTveFlIPIDPxtEg5KhsBU0waiILimqy6empQ3hZ07WyehpewUex4f1/7t/RmoYiqODACjAAjUG0QYIG32lxKXog9EMgigbSoEO7+TeDk4qFlgTSIdNpVLV8foeHVNuhk+vbsKmxK9x88hoyMTJ0WQLHjzWRPDXq4lFZIMNGkQdHwWkrgLY0fe9QnJCbjRlQMfLy90LhhfbNZ6NKpHUJDgpCUfBOKaYTZRHgAI8AIMAIOigALvA56YZitqoFApsYdmVdIaz2Gv1/6qyiPGzOi1M1DXl6e6N6lAwoKCrDZwG7SMyhSjM8igVrkOCoNAdqkpWh4AwP8UJBzE3HHl+LqtrmI2v8ZMhNkkxMaXztUPl44Kqb6uSbbsXsfLRG9uncWaUUixaxhzXo+hKIi+PEYRqAGI+DwS2eB1+EvETPoyAhkxB0X7Bna7y7Reme4U7SXFil2vOS+TLePm19jqJxckZsejXxJgNNt47w+AqSRpBpySaZCES5tegHxJ5YhLWofki/8hUsbn4fy4FCdNbyKVpZ86hIeFQnDb5fteFeuXl+R4TyGEWAEGAGHRYAFXoe9NMyYoyNQVFggaQ9PCTY9gop9nu7ccwBXrt4Qu947dWgj2kuLBvbrKZo2GfjjFQdQ+GsOoKguWl6xUstHCTrmDNk3LyMn9VqJSW5e3SrqFBteMjkRFdUoqoz9rgLDgD7dhUnE1WtROH32glLNKSPACDACVR4BFnir/CXkBdgLgezkcygqzINbrYZwdvPRsvHTL3+IvO7JaqLCSETaOE9PD5y7cBlx8Yl6PRSzhswE2hSn18QFHQR0Bd6c1Os6LcVZpV4ReKubDW9hYSEOHD4mFmyuSzIxSBM5OTlh6KD+orSGvTUIHDhiBKyBANO0PQLVSuBNSEzGo8+9jfsfewUvvfExsrKzjSJ65PgZTH30ZUx66CV88+NKbZ/Sxh86egovvP4Rbh01HQ888Rq27DygHcOZmotARpwsYHgFF2t3s7Nz8MuqdQKU8WNGiLSsSKVSYWD/XqLLXxu2iFSJPIMiRDYrUdYiiwJHJRBI0Gp4/eEV0hYqtXOJPl6h7UWd4of3yrUbolxdoqMnTgsfunSan6+Pd6WWxXa8lYKPBzMCjICDIlCtBN6PFy5F987t8O2nr8PX1wdLV/xZAnba4PLKOwvw3GNT8d1nb2DTtr0ggZY6ljbe08Mdsx6dir9XLsSUcSPw1vyvqDuHGo6AcuCE7oa1Nes3ICMzE7f06wnFXrQ8mIrNGnbqdAU8NG7OMvkACj1cDAsJCcmiig6dcHb3Q2jbqUBRsVstj4BmCGgyRPRxdnYWPpFpo2DKzVRRVx2ifQfkAycq4n/XcP1Db+svNloeOHQMMbHxhs1cZgQYAUagSiJQrQTeHXsOY9gg+cjWYbf1wfY9h0pclDPnL4NeIbeMaAJn6fXdoAE9sW33QdGvtPERzRohKMAPTmo1enfvgLy8vFK1x4KQVaIi5KZFIefmFenHnE/fsgrEZhAtKipEZry8+98zRNYe0nDFnGHC2LI3q1FfJZBwTPl/Nsp2ppSnIB9AESIfQHHzMlVxMIJAXIJsCkKn11Gzm29dQAXNXxFqNRgAtYunpgztg0h1suPdd+CoWF9lzBkEASnykB7wlYew1X/+K9Xwf0bAzgjw9IyABRCoNgJvRmYWVNKPnL+fr4ClXp1QxCckibxuFBufhDphsmsiqqd+sXGJklbOtPG/rd2Ipo0bwMPdnYZLwm9uiUANeXkl6ytal55wFufWzcC5P2fg/F+P4MzqKUiNPlRi3orSr6rj8vPzQMEe/GdI16QwPxuuPrVRpHYT1yI6JgYbNu+Al6cH7hgyQNSZwlv9urVRp3Yobqam4eCRY3rj3P1ls4b0uBN69abQtWSfgoJ8u85f1lri4mUtpL+fj+Dx5o290kdQBWePIJFmxJ8S9QqNsBD583/txg29eqXdnindzxTM5WHvAfnhvkP7lhZZ09BB/STsgNV/brAIPXPXY4v+jnxP22L9tpqD7mcKtpqP5hE3L0eMgAEC1UbgpXWp1cXLUamK89SmG1RqSTLWVhT3K2/80RNnsfTXP/HKszO1o22RSTixVLinUubKz05G3JFFSpFTwOYYZCacFHN6BBafrvbTijWgzUN3DhsEd3c30W5qdOuA3qLrf1t3i1SJPAKbi2xW4hmRclQSgYTEFFFJJg2USY/aQwmCWt4j0uzksyJVotqaB97oGFlQVuqrapqalo5zF66Ie65VC9mzR2XXopy6tmX7HhD9ytLj8YwAI8AI2BuBYmnP3pxUcn7SqhUUFCI3L09QSkxOQXBQgMjrRqHBAUhOSdNWJUn9QkMChVaurPGkLf7sm2X4bN6LqFcnTDvexcUVhoEaDesqU85OvkAk9UJO6lW4ODujMnSr+lhnZxdQsMc6shNPievhHdpOew2W/PybqJs0/i5tnam8KQLvlm179MZ6aw60yE46q1dvKl1L9XNyctx7LUn6DBPwoSEhKMqOR35WIpzcfBHYdChUTpL2PSMW6sJsLX51wuXPb5z0tsdS+FiKDt3PFMyhd+CwbFrTuUNbuLm5a9dpDg3DvoQlHYpCD3Ab/ttpEZqGc9i77Mj3dOWwKfmbZE96dD9TsCUP9H3AgREwRKDaCLy0sJ5d20uvlHdRFv9IX9K9u8m2lWTucPzUOVEf0bQhEhKTce1GDAoKC7Fxyx707t5RtJU2nvrPfutTvPTUdNTWnNQkBtgocnL1KjGT2tkdUFWry4eq9JcZr++h4fCxkzh7/hLI7VWfnl3MXopix7tt117k5ORqx7v7NYJKHEARhYK8TG09Z4oRSNB6aQgQh01Qi0+4fA08NRpyRSNPbXSNKI2uJqet7T8o2+9aYsMa4aKEEbffJrJr1m8QKUeMACPACFRlBKqVxPTkgxOx5u+twi3Z1WvRmDh2mLg21yXh9o0PFoq8SqXC3Bcexstvf4apj8xBpw4t0bGtfIxraeNX/PEPjp08h/HTn0OPwfeKEBOXIOjZIvJvJJ9+pDtXrfp9dYtm5blz5RAg7XpBbjqc3f3h4hUqiC1d/rtIJ0vaXZVK12RGVJcb+dXyRYe2rZCbm4dde+VNlDRIpXaGh39T0F9mvHyqG+U5FCOg9dIQ5I+06P2iwad2F5F6BMo20Jk6h3eEh8nXLComVvSp6tHe/YfFErp0aitSS0Uj7xgkSK3/d7N0XxY/hIlKjhgBRoARqGIIqKsYv2WyGxTojy8+mCPckr398hPajWXkZWH5og+0Y9u1jsD3C97Ej1+8jemTRmvrSxv/0P33YNffS/RCWAhtiNEOtWomqMVo1O3+DLxC2oDcLTl7BqN2xwetOicTLx2BDOU44VD5DUJBQQF+WbVWDJg8vvh+EhVmRIqWd9MWffdknkEtBJXMhNMi5UgfgZg42RY3yM8bGXGStlN68+EV2kF08gyUscvSsYGubhre3fvkDWs9u3UWa7ZU1KB+HbRs0Uz49920dZelyDoaHeaHEWAEaggC1UrgrbbXTPoBJ9dK9fu+DqidkJ8Zj8IC2Va52q7ZgRemaFq9NAdO/L1hqzCT6dq5PRo2qFthzksTeD0C5TcQWTpaygpPUs0GJqfcFCsK8PdDZpyk6SwqhGdQJBQzIA8pTx0yJYGXXMlRXvGPXB3ckp27cBlp6RmoEx4GemCn9VkyjLhdfru0lk9dsySsTIsRYATsgAALvOWB7kDtaicX8WMO6S8zTnY0L2X5v40RyFBOWNNsKFuiMWe49+6RleKkR9eOcHV1waGjJ5CicyiCZ7DsCSJTEngVoa1SE1WjwQmJyWI1JOwZmjNQg7NbLWF2UlSQi5ybl6kKYRo7/OiYOOmFSfEBFaKxikV7D0hCvsSzpe13JZLi/x1DB4r0j3X/VHmsxEI4YgQYgRqLAAu8VezSe2teo6fHssBrj0uXmx4Ncgvn5OoNV5+6QjBd9/cmODs7Y/TIoZViyc3NFX17dhU0dM0aZKEtRHMAxRXRzpGMQILehrW9otInvLNIlcgzUGPHqzEJUalUWqE31oa2+Ao/lkz37pe/B6wl8JJdeWhIEJKSb4JMJyzJO9NiBBgBRsCWCLDAa0u0LTCXV6i8MSWDBV4LoGk+Ca05Q0g7MXjFb+uQn58P8ltKG89EZSWiW/r1EqN1BV6qUGxRMxNOUZGDBoEEzeEyLRt6IT8rCc4eAXCr1VDTKidk4kC5rMRiX8bVxY5XOVK4S6d2tESrhFHDBwu67K1BwMARI8AIVFEELCzwVlEUqhDbHgEtQDv3yVMAaRqrEOvVgtUMjacELwNzhomVNGdQwBnQr4fI/rNpm0iVyMPI5iulrSan8RoNb9sGMgo+4bKGXC7JsTFPDbXDQkRjVbbjzcrKxtETp8Xbhc4d2oj1WCMaoXFP9tuav61BnmkyAowAI2ATBFjgtQnMlptEpXaCV4hGy0s70i1HmimZgEBG3AnRyzO4NS5fuQ7ygUr2o4MG9hH1lY3atmoBOjDlRlQMLl6+qiXnqXhqSGQNrxYUKZOgseFtGpghlQDFHZkoaCJ3v8aAygm5aTe0vowV12TRsXGw2p+VCR88clzY1bZpGQEXFxerzda7R2f4eHvh6rUonDwt+zO32mRMmBFgBBgBKyHAAq+VgLUmWa9Q+fUlmzVYE+WStPOkV+Z5GTFQO7uDDoT4fukK0WncmBFwcnISeTWkDr4AABAASURBVEtEA/rKWl5ds4ZioS1KK7RZYq6qTiNB0vB6uasR6H4T9OZD+WzorovqPTUHUGRpjoSuDhrevQdk+11rmjMQjnRvDx8qe2tYw94aCBIOjAAjYCYCjtCdBV5HuApm8uCtEXh545qZwFWye6ZyupqkYS8qKoLinWHC3XdWkrL+cMWOd+PmYn+8ukJbZrysZdYfVTNLJPD2iPSASlUE0rrTw4gxJBSTkEyNHa/imow8NRjrXxXqrL1hTReD4bfL3hrW8KlrurBwnhFgBKoQAizwVqGLpbDq5tcEahcv5GXEIjfDcV/Jxp/8Gef+nIlTK8fg0qYXUNUFNcUdGQlWm7ftBglLzZs2QrvWsp9c5fpUNh08UD5Fb8v23eKVtULPQ+uPtzqaNSirNC+NT0hCz5ZeYpBPuHy6migYRJ4aTw1ZifLhHdVBw7tj9z6xyi4WPmFNEDWIbhvQR5hNHDpyAjGx8kEfBl24yAgwAoyAQyNgV4F3/oLFJcB544OvStRxhT4CKpWq2I7XQb013Ly6FXHHlgi7ycL8bEnYPY6rO94C5fVXU3VKmTob1n765Q/B+NSJY0VqySgkOBARzRrjZmoaDhw6BuWv2I73jFJV41Py0tCrlafAwae2vjsyUamJPOmUQimvnFZX1W14ycY7MSlF2NY2bazvlUJapsX/e3i4Y5DGTp188lp8AibICDACxQhwzioI2FXgPXexpE9R3hRh2nX2DmsvOmY46AEU6dEHBH+6UUFOqtb5v259VcgL3lOvQ+XkCpVnA6xcvR5qtRqWNmdQsFDseDduKTZr8AySD6DI0ryWV/rW5NTXJQX+3k5QuwfD1adOqVCQL2NnjyDpgSsLOdJ1rB0WLPpGx1RNbaViv0uHlYiF2CBS7HhX/7nBBrPxFIwAI8AIWBYBtWXJmUZt9V+b8eAzb+D8xasipTyFKQ/PRuOG9UwjUsN7eYW0EwhkOKiGVzBXjaLMBNlulo4T/vWP9cjJycWt/XsJjwrWWOZAI/54nd394OIVIglt2VX2wcHSWEXWzhMk/ep1F2lZkaIhz0o8hQB/P7HRMCk5RfhRLmucI7btO2ibDWu6a7990ADxkLd1x16kpqXrNnGeEWAEGAGHR8AuAm/HtpGYdu8ohIUEiZTyFN555Qm8NedxhwfNERh0860LZ/cAceoXaawcgSddHrxrd9ItynmVCi6eIXK+isUZcccFx17Sq/Gly38T+Yn3VO4oYUGklKhf725CINu196AQrpVuxQdQnFaqamxKQlf3Fm5i/WXZ74oOUuQZJNtaKxvX6tWtLdUC12/EiLQqRdoNa53lNz224D0wwA+9undGYWEh1v21yRZT8hyMgAkIcBdGwDQE7CLw1g0PRZcOrbFk4TsipTyFcI0zeNNY515e2lPXDjkcGLXq9wUJh0ARyHewykkSTAqLcH3PfIfj1RSGlA1rmaraIA2Xl6cn7hgi71w3Zby5fby8PNG1UzsUFBRg8/bd2uHaQxT4xDXEx95A64buyC8ogmdwGy1GpWU8ApqLJuW0utqh8sNXVEysqK8qEQmch47KbxzoHrEl33SiIM23ht2TEQwcGAFGoAohYBeBV8Fn++5DmP7kXPS5fQp6DL5XG5R2TstGQDFrSI89WnZHO7UW5NJrTxUa9n8LzW7/Ek7uvsiIPYLYI9/alKPKTlaQl4XslEuQJHf8vF7eRHb3XcPg7i4J8bDe3y39egriuv54i7WUrOG9eX0XVCoVTke7QO3kIrAqK/IIaAaonJBz8yoK83NQVV2THTl2CtnZOSAPIb4+3rDl3+g7h4rp/t64Bbm5uSLPkW0QKCrIQXbyefFWzzYzVn6WnNRrSLmwHjcv/YO8jKr3JqXyCDAFR0LArgLvoiWrMOvRKdi89jvs+nuJNjgSQI7Mi5fGH29G7CE991WOwHNuRqwQEtXOHvAIagUXz2DU7/MaSOBIOL0K5MUBVeQvK4HMGYpAwub3P60SXFvTnEFMIEXG7Hjd/RqDMMzVOTUMNfQvP0l++Lh609ckBFRqZ3j4NwGktw5ZiadRVV2Tae13O8p2/NKCbPY/LDQY5IaPBO6NOn6ibcZADZ0o6dwanFo1Dhf+eRJn/piEy5tnozAvsyJo2GxM0rm1OL/+YcQf/Qaxh77E2XUzkHaj+G2VzRjhiRgBDQJqTWqXJDQkEBFNG8JJbVc2UFX/XL1C4OIVJmmrspGTcsGhlqF8sfnW6ym0cMScZ2BzhHd6iLK4vmue0FaIgoNHGXHy6+OU/BBcuXoDDerXQUV2x+elJSBh/1rEbFuKjOsny111187t4OnpIY5zjYtPFP1JaPNUfMomlE9DDKqmkVvuJbGyxLxwkZoSeQa1EN3IjlcReKNj40RdVYkUDw10f9iD5zuGDhTTruFDKAQO1o7ys1MQc3gRigrlDZo0H70pS7rwF2UdNpAfdnq41DJYVIj4Uyu0Rc4wArZGwK6SZmCAH1at3YD0jExbr7vazFfZU9foxDCySf348++w4rd1SLXQ7mutwFunhx7W/k2GIKDpMFF3Zetc6fVcisg7cpShOdns3z03BJv33jNKpOZEGddO4NA7d+LCL6/hypoPcfyTybi67uMySahUKmjdk23eoe3rEagR2hJOa+tqWoY8LTircnExOgfuPqEmL1/BjjS84WHyuKjoKibw7re9hwZdgIfffqsoksBL3x+iwJHVECCzgKLC/BL0jbl+LNHJThUpl/41+t1Oa7ETSzwtIwC7Cryr1mzA+59+j9vumqG13yVbXr4upiNQbNYg/wiaPlLuee8DT2LoXVPw0tx5mPrgLLTuehuuXouSGysYF+SmQ9nk5R3WoQSV2pKWlza05Wcn4+r2N0u0O1IF2c2RcEU8fblsOyWYOnGMSM2JorcuRVF+jt6Q6G0/oTA3S6/OsDDQqB2vRuCVXssb9q8p5bSo/WKpO05mIigwQORNiTy1nhqKTRqiY6qOwJsqPZBeuHRF2I+3aRlhypIt3ofmrV8vHEnJN0FeRCw+gQ0IFuSmSW/Fzktvx8r+/NmAlTKnyMuMQ+JZ2SuMYceMuMM4t+4BiAN+0iv3nW1IuyLlrKSziD7wOU6tuhs39tLDfFEJMm6+7Ha0BChcYTME7Crw6trt6uZttvpqMJF3WEexioy4o9IrrwKRNzU6e/4Sfl/7j173xKQUvPHeJ7h2veJfoGlRewRN95CO+HX1BpD2mLTIolIT1e35EuggANK0Xd/zP02t4yWZGm8I2apQxCamoXePLtrNTuZwmxUnv37XG1NYgOyEq3pVhoWB/XuJKr2Na8GtRF1mwkkUSa8JRaGGRWlRe8WKd5kp8JItuZOrLwpyUhHmrxI0qpLAu3vfIcFz5w5tobajKdjIOwYLPtZUQW8N13e9j9O/jUfUttmScHaPMBcQi3GgqCAnRRIev8DZNfcj7cZeqFQlf6qd3f2Rmx4DMh04t24GLv77NMjWl+5tWy2FlBYJp3/F+fUPyvOf/1N6iMiGT3hX+DceIrEhf8akDCCtITjS8idTgv8YARMRKPkpMnGgpbrl5Obi1NmLliJnYzr2n87J1RtutRqAXnllJZn3ivvMWeN2v0t/+R0tOg2EV2gk6jTvhk597sDto6fivodmCU3wR59/i2UrVuO/rbuEfSkJybpIpN3YI4pvLdwC0hqT9pi0yJOmPyXqKXJ280HDfq9J34EuuHl5k6TFWE3VDhcUc4b952Szm4qerOYR0qjk2tROcA+qX7Jep6Zp44Zic1VMXDxOnTkvWpzdaoEEt6KCXOSmXhN1NSmiH9nslEvIyVNh/7lsBAebruElnDyDIymBn3OySG9Ex4i0KkT7Dshvcjp3aGNXdhX3ZH+s039gthRTx0+exV0TZiKsSWdEdr4VL742T3imqCz9tBu7cPPqlmIy0gNj4pnfkJV0rrjOjrkCSfNMXmzOrL4PSefXgb7fQ9tNRfM7FiG41XhJkOwCMgtrNPA9RNy5BI1ueRcBTW8HbQ7OIg3rwYU4/fsEXNnyCm5e+Q/0hsoay0m9tg1Xtr4qNtDFHvlenF7o6hMO4rXFnYtRv88rCO/yGJoO/RzBbR9AaIcH0XzYV/Cp090a7DBNRsAkBNQm9bJSp517D2PkxCfw6rsLxAynz13Cky+9J/IcmY6AYsebEWu6ezL64Xzt7Y+MTlI3vDZI0CKXRyk3U3FaEoy3bN+DX1atE9ra2XPfxwOPPo87xt6PLv1GoH5kDyEcN+8wAH0Gj0XilV2C7vo9CSJVolWr/wJplZWyW62GqNvjWVGMOfSVcFkmCg4UZcYfF9ys3HAWbm6uGDVc1myJSjOi2n0nQuXsqjeidp8JULt66NUZKwy6pY+o1tPyKq/mNRpo0aGGROnRsjnDieuy9sgckwaCSDFryE+7iFq+PkKQIlMBanP0sHf/YcFity62O3BCTGgQ9ezWCUGB/qBNnCdPa4RFgz4VLRYWFmLKzKfx98atSEvPwNVrN/DJF99hwdeLK0pSOy4z4Yw2r5tJvrBet2jzfGF+FuJP/IQzq6ci4fQqSJoABLe8B82Hf4egFmPg7BmMkNYTJUHyVYR3fhSeQfJbHs/g1qjd6WFEjl6B+r1f1gqU6TEHcX33fJz6bYKUfgAqo5J/QqDWmCxc2/ke0qMPSIK2O/wb34bGt36AZrd/JXh1cvOD8ufmWw9+TYaiVqNBoA3WSj2njIA9ELCrwPvZN8vw9cevgY75pMW3aNYI8Qmy1oXKHExDQLHjTY89Uu6AmNh4TH/0BfS/fRxOn7sAJyf9W4A2Em5YsxRHdq1H9Pl9khB6CmcObsK2v1dg5dIv8cVHb+H1OU/j0ZlTQL5oB/TtgVaRzRAcFIAbUTHwyL0IF6ciHL6QhdTMwhL8GGqVfev2BGkuqOPVHe84nK/GTM3GMFrPyDsGgR4CiFdzg1e9Vmgw4hlAmLUVIbD9YNQf9oRJZBSzBtKoKwO0B1DUQDvetKh9AoZdp2X7y2AzbHhpoKd2098prXlKVHTVOHxi30H5obZrp/a0FLuGOzQHr1jarOHf/3aAHrINF/fPxm2GVeaXVfJDkuHA5It/49TKMYja97H0nSc/VBj2sVY58cwqSdC9D3HHfxIa2YBmdyBi+LcIaTNJEijLfyBW+PKp000Seucg8q7lklD8iBCKScN788pmofElzW/Moa/N0mbT25QSJgt5maA9GHW6PYUWI5civMsT8NB8phReOGUEHBEBfWnHuhyWoO7i7Aw6dU23oUiWCHSrOF8OAp7BbUUPsuksLCh2XSMqdaL3PvwSrbrehp9W/CFqJ4+/C+ePbMX6VT/g7Vefw/dffoDje/8FbUgRHTRR3Tq10bF9awy5tR9ozDOPTcd7r7+A7774AGtXfIu9m1fj8okd0g/FKXzx+jjQX0pRfUpKhIjmTUrUBbeaAO+wTijMS8flLa+CDnoo0ckOFYQnuQK6mgBk5BShsr7sJmMCAAAQAElEQVR381IlQipaiEr6YcujjEmBHiqoo64ddLHQZp4ZC9GpyqGosABpkmaJ1qC8QVAOkKA6U4K7fzOpmwrZyRdQLzxYygNVwY6X3o7cTE1DnfAwhIXKfAvm7RRZwj1ZfEIS1vy5AXPf+Qhk9hTcqCNGjZ9hlRXR5lMyE9A8dWrnUDm5wMm1lrA9Tb74Ly5vniO9qp+MmMPfiHtE29GCmaLCfCSd/1Mzz7fiu69Wg/5ofsci1O74IJzcalV4NrWLF/wlrSqZPZCGOLTtFLj51hd264ln/8DFf5/CuT9ngmx/aVMcpVQmgf/Sphek7/GjSL22HeRF58zqKVBMFsiMipQTzSVhvOGAd+DXcCBUTm4V5pMHMgK2RkBt6wl153NxcRY7fZW6g0dPabW9Sh2n5SPg5OIBcWxqUSGyEk6UGPDr73+C7OBef/dj8fq2V/fO2LlxldDWhgQHom+vrnji4fswdtSwCmswlUnzEmUt87CxT8LfT/9L+64RQ8TpUEpfJVWpVKjX60XxpZybdgM3HGQTW6bGHdnO4ykIDQ7CwH7yBjKFb3NT3Y1rOcmm240G+PuhfZuWyMjMxI7d+8W0pOFVqV2Qm3Zd/FiKyhoQZdJGvYIcuNZqhLikbPh4e5m9arWzG9w1B1C0beIjxtveF6+Y1qxI63+3Uzuzxlmr89Db+gs/0YeOnAC93SlvnqysbGzbuQ+0B+CeqY+iWfv+aNiqF8bd9xjmfbQQ9ECXmZklPVy3KvHdQbQHDZRNeyhvbki9vguXNr0kfVYy4e7XVBIIh8AjpIP0Cn40mg39Ei1G/YQG/V6HX6OBklbVHfnZSUg88zsu/POEJBw+KAuHGZZ5C5ByeaNEcwbIowHN4127C5oM/hR1u8+SXvuHGl0afe4Hj5yMkEad0L7nULz7vy+M9jOsJCE1KHKssKVtMugjBEaMgrN7gPS9cUN4dziz+j6R5krfu4X52ciMP47Lm1/CtZ3vIj16n/RsUIha9fuhYf830Xz4dyCzChfPEMNpuMwIVAkE1PbkctajU/H6+1/i/MWrePDpN/DuR9/g8RkT7MlSlZ3bK0TW8qbHyLu4aSEnT58TWpMpM5/B1Ws3QJraH7/+EP/88SPatZY37lA/S4XMhFOSFiFFElzromHzdpK2+B/MfvZRFBUBLSKaguYubS61sztoowNt0ki7sUt6vbe0tK42q8+IOybmOnQhGxXdrCYIaKKs2EuaHJCbYrrAS4NuMeKezN2/KTVBMbsQhWoeKeYMRd4txEqDgwJFam7kGdhcDIkIV4m0Kpg07D1wWPDaxQ4nrImJDaLs7ByxoZI+3226DwZtMqPNZkq3YyfP4Nsff8ETz81Fj1tGIahhBwwZNRm0B2Dt+o0gzOmBmzTFb74yC/+uXiJpF09h+z+/4q/fFmPwwL7w8HAX3x8+Pt54ZPpkhbRZKWlSr+14G/S2xrduLzS69QOQHWxYtxcQ2u4+rZDpHdYRdbpKr+lHLZMewGfDt15vqJxcJeHwuhAKz66dhosbnpU0s+tAm8vMYkJ6c5kqaU3Jm8GNPR8iLyNOKCka3TIPDfq+KgnhjUolRw+6E+5/HNt37RMPvecuXBaedEiRUeogIw3u0vdFWPtpiBjxvRBgSUOrVjsb6Qm4+tSFsA2+azlon4VXaHuj/biSEbAIAjYiorbRPEanIZvd/735LF57/mGMHXkbln3zPpo3aWC0L1eWjYB3mPyFREJaUnIKnnz+ddCGMtKa0I/Gqy8+KWxxSctaNqWKt6ZpXEX51OkhiPjV8sUjMyZDJckUUVHlC3iu3mGo1/NFMTb+xDKkXt8p8vaKSICnuQ9fyMKk8XdRtlIhK/aCdnxeepI2b0pGK/Bu3aXt7qXxNkCnhmkrq3kmXbNhLdOpoVhpsJkeGsQgKVI2rtXxz5VKqBImDfsPHBW82nvDmmBCimgT2YWLV8TnOycnV2wyI7OE20bci8AG7dF9wEg8NutVfPPDzzh6Qja96dCuFR6cNhHff/kBTuz9F5eOb8fy7z/DU49MQ89unSSq8v/WLZtj1U8LkXD5EJo2boC0tHRs3blXbjQjptfxpEmVVJWSdvMu0JsktZNLmRTozYlv3R6o1/MFtBi5FHW7PwMShmkQmUVEH/gC5NaMXvnfvLoVRdIbB2qTQ5EkIEch5+YVacpCUZUWtQ8X/n5CaE1zUq9LCoF6qN97Dhrf9j94BrcUfcqKTpw8i4TE5BJdKmzTrFKDBNg63Z6StLd9S9ClivDOj8jeH1y8qMiBEagWCNhV4CUE1Wo1enfvgIF9u8NJXTl26Evh0efexv2PvYKX3vgYWdnZNEWJcOT4GUx99GVMeuglfPPjSm17aeOTU1Ix6+UPMODOaZj3yXfa/o6U8QhqBUhfZJmJZ9Glz2B8/f0y0N+4McNxfM8/eO7JmVS0arh5ZYug76vjeqaWr4+wN0yVfrBMsZOkDXhhHWYIOtd3f4Bs+uEQJdtGWUnnQDunL8XkomHjSEQ0a1wpBrLjpR9AiYJ7UD24+deWckB2wjWRmhIN6NtDdKNd+rRznQrCjEXKKIK5lK2u/8W68jITkZN6FWoXT8RmeIu6wAB/kZobeQREiCH+znEiveHgm9bIHODI8VOCVzJvERk7R8YELnrY3rH7gDCdCgzww7Aht2Du7Kfw9++LkXjlsNDezn97Dsh8qmGDuiatYPpUeV/AwkVLTepPnchG9vqu90EbrqhM2sqw9vdT1qygdvZArQYDQOYOLSTNLwmCnsGtJRoq8cr/+q55OP37RFzfPR/JF//CuXUzhbnC+b8eEfXn/3wQV7fNRXbKRUmTHII63Z5G0yEL4KPzHSkRq9D/5JSbFRqnO8g7vItuUeSd3Hwl7bP89khUcMQIVBME1PZYR4/B9+LYyXOg1FioKE8fL1yK7p3b4dtPX4evJGgtXfFnCVJF0vu3V95ZgOcem4rvPnsDm7btxaGj8g9JWeNvH9QX0yeNLkHPUSo2b9+HU9cKhLalWWg+SAtErwYXLZgnBE5r85mbdgN5mXHCPozsS3Xna9mCNgkBih9Z3TZj+cDmI+DX6FZJc5IrfiwKclONdbNqXWbCSUH/0Pks3DtulMhXJlLsd8kfr6tfmCCVmxItUlOjgRob4i3bdoshinYoK/GMKFf3SDnQxKd2F8RrNF4hFTRpcPUJh5OrD5yKshHi5wTyXuLI+B04LJvXdGjbCu7ubo7MKt5/40Uc2/M3rp7ahV9+WIBZj89A7x5dKsz3vdLnz83NFX9t2CLcoJW3eHpQvbL1NZC/XTJJqN/7ZaGtLG9cee10v4jNYLe8K8wCwtpPkwTD5tKDcTZuXvkPUfs+Ra7OiWcFuWnSA9o1OLn5onbHmWh+x7fwa3gLSDEBM/5aSdruQCMPdv/+tw2rVv9lBqWSXWvV74uQNvfC1acO1M7uksa5Ner3mi3lTfcOUZIq11gXAaZeUQTUFR1YmXF0qlqbls1AqbFQUdo79hzGsEHyxoZht/XB9j3F9qwKzTPnL8PT0wMtI5rA2ckJgwb0xLbdB0VzaeP9/XxxS5+u8PBwvB+aS1eu4e4pj2D43dOw5UiSWMdLDw7CprXLQK8PRYUNotQbu8QsvnW7i1Q3aqHxzGCqwEtj63R9EuTqhmzdru14h6psFugHM+kKuUAqwoHz2cL9WmUnV+x3PUIbQ9HwmrNxjeYf0E/W8m7YvIOK4uGCNqUQv6T5FJXVOErXeGfwCe8sveKV7/UgM12S6cLjESjbAbdu4GbSpivdsbbO79UcONHFQTas0foHGdlERp/1h6bfi8YN61MXiwR/v1oYN3q4oLVo8XKRlhblZyfj0sbnkBF7GCSgNhrwjqRN7VZa9wrXO3sEIjBilDBLaDbsayE0QuVUkp5ajaaDP0NAM5n/kh3Kr/Hy9JQeukdC0tWA3og2adwAzaU3Tnl5+Zg0/SmQTXT5VErvEdxyHJrdvhCRo38VB1l4ak5yLH0EtzACVRMBuwi8ClQXLl1DRmaWUkR6RiYuXL6mLZuTIToqFeAvCac0rl6dUJDLG8rrhtj4JNQJC9ZWUb/YuETBhynjtQNtnLl85Tq+/fEXLPx2qfBRmZGZiTmvf4AOvYZh3V+bJGHcHS07DxNchXtX/lWXIGRGlHp9t+ht7FVdi2ZNRBttohMZE6P6veeAfljILjn64EITR1WuW9TBr3Fy5T3ITSKbQxUmDmqAAH+/yhGVRmdq7Hc9QhqiWMMbI7WY/l8xa9A9gEIR2nQ3rplOsWr1TJeEGOLYO6wT4uITKItA6bW5yFQgUux4Wzf0EBuo6O1PBcjYZIgi8Hbu2MYm85kyCW0ie/yh+1C/Xh2Qt4zBA/vih4X/E0KZKePN6TPjvgmi+3dLfgHZC4uCQUT2sRf/fRrZKZdAhxw0vm2+9NAsm64YdLVo0dW7NkhodK/VoARdtbOH9B0WUKLe3Irtu/aLt3dff/ouju76C4e2rxOmIiqVCuT14vbRU5Fy0/ZvwsxdB/dnBOyJgF0F3lff/RyuLsUbCFxcnPHqO59XGA96+lUGq1SlL02lliRjpSOK+5k6XjtUymRkpEM3ZGZmSE/iRXp1uu0Vyf/62zq07TFEbAB5+sU3QUf9Nm7dBx8uWIS8vDzcNWIwdm34FZOnPQmV2kV6jXYVqUk3LMpDWXynJl1HVuJpqJzcoPJpXmLehg3qSEgBJ06fLdFWFt2cAmeEdH4GtKakc2sQc/IPvfHZ2VnIysrSqyuLXnltCdcOIfncH1BB3mxCTLcMz8bV439Wfo7oC0QO8A0DPP1FPiPhmll0mzWuL9zGXbh0BWfPXRBjnX0bCVqpMUdFubw1VrQ9NzfHqvTL4yvh8g7Q5iA3v6bIzlcjJiZerNvHx7PCfKm96gkaHZt5ifTSlSsVplUe/6a2l3ZP79i1T/DYOrKZ3XlU1lJQkIc5zz6M/Vt+x4Wjm/Hj1/PRqEG4Vfhr1qQ+2rdtiaTkm/hpxW8l5ki8dgAXN8xCXmY83PyaIKzX68hT+Zbop/BOqaXvaY+wkm+3vMJ7lMkD8VFeOHr8BA4cOgYfHy8MuqWXlt5D0ybg1x8XiO+ELdv3oFv/O6V+R7Tt5dG1VXtp97Q15xcfFjnimBHQIlAs7WmrbJfJL8gHCbnKjG6ursjJzVWKZqVenh4oKChEriQA0sDE5BRx+hfldUNocACSU9K0VUlSv9CQQJg6XjtQk/Hy8oZu8PT0gkql0qvTba9I/rOvf5TWVqCZUU7S0jNA9nyb//xZ+qH5CM2aNpHnDJXdkxWlX5DLBvxVZP7yxhSknBRM+YR3MTpnx/ayVurM2YtG28ui7x/eFnW6PSnoJx77Gqqsa1oa7u4e8PDw0JbLolNemyrzCq7s/07MYxidObKl0nPkxF8SZP3rt4RvqKwJKkhLNJvu4Fv7CTo79x4SY/1qtxPlvJvnRbm8dVa03dXVzar0y+MrP/mEWGet2poHwAAAEABJREFUut0EHzdT5c9wnfBwUS5vvLF2/zrtBc2W9V1EejM1o8K0jNGvSJ2xezpZ+r5KkgQ9f+nVfrs2rezOY0XWZYkxDz0wSVynH3/+XQ+DwpRjiNn5KujgGp/wbmhy6/vw9S//vrD0PR3edjzIo0Ot+v1A7s9oo1y9ro/p8VoRHJYsXw36m3j3SAQEBOjRG3LbAOze9Dton8T1qBgMues+/PvfTr0+FZnTkmOM3dOWpG+MFuHFgREwREBtWGHLskqlwh6Nqx2ad9e+I3oaX6ozJ/Ts2h4bNu8SQ/6RPvS9u8k/aBmZWTh+6pyoj2jaEAmJybh2IwYFhYXYuGUPenfvKNpKGy8a7RgZHsdLrKhUKqz99Vt0MbDp8wqRBSCyYaN+tgip12XMdb0z6M5LP9RhIcFITUtHTJysmdNtLy9PPyBBLWS3YFe3vSG0OOWNKa89W3rtmXjmN1zZ8gpO/joalzY9D/fcC0aHXY/PMFpvamWOpG0vkh7uyJTByc2zwiYNNN8t/XpSgv807smUDYI5qdelH/xM0VYdo9Qbe8SyvGt3FmlCUrJIQ4IDRVqRiF43u2leQ7ds4IaYWPPvzYrMa+6YfQePiiFdOrYVaU2Nxtw5FPRdsmffYShuzpLOr8PV7W8JSAKa3o76fV6GyslVlG0eqdSo1WAA6vZ4FuT+jPhRleLn1hzefvrlD9H9/kn3iNQwalC/Drb+9QvII0+m9Fs3cdoTeOXN/xl24zIjUOMRsKvAO+eZGZi/4Ac8+MwbInz05Y+Y/cz0Cl+UJx+ciDV/bxVuya5ei8bEscMEreuScPvGBwtFXqVSYe4LD+Pltz/D1EfmoFOHlujYNlK0lTY+v6BAeJQgl2S/rdso8mfOXRJjbBFFaDZ96c5FJ3/51fLVrRJ5b42GNz32iChbOyrMz0ZG7CFA+rL3Du+K0v5aRDQRTadOnxepuVFI26kgYb4gNxVXtryKwvwcmPOXn5UAOjZUcSN04e/HEHN4EdJjDqKoMA8eAc2R7tEVaVn6mvTcvEK4BHQwZ6oSfbNi5XvFI1Q2P3ALCBd9siVBWGTMiG4b0Fv0Nm7He0q0VbcolzyAZMSCdrt7BDQTy4tPSBRpUIBsHiIKFYg8A2Ubz9aSwBsVFVsBCtYfotjvGj7cWn9mx5qBvFNMmTBaMEUuymKPfg/yiUsVoe2mgjSqlK9OYcVv66Q3kjfRsX1rtIqU731j6/PwcAd55Jn3xouief6nX2PE3Q+YbdcrBnPECFRTBNT2XFerFk1Bh03cPXIwKCz7ep7wnlBRnoIC/fHFB3OEW7K3X34CHu7uglREs0ZYvugDkaeoXesIfL/gTfz4xdt6rsZKG0/eHAy9SRBNomWLMOux6XByKt4BrFKp8PzTDxqd2s2vCdQuXsiTBITcDNnHqNGOFqpMjzkgCYz5kjDaBk4unqVSjajgxjWFoEoSqOv1egkuXqHCRpkE19zUq8hNi5a6FElB/z+93ky9vgNR+xfg3LrpOLN6KqL2fQxyFF+QcxNuvvVBO6fr934ZkXctR+Pb/ofOw+Zg3jpvLN6QjO0nMvDz5hS8tLQAI0YZ16zoz1h6KSv2omj0CGksUrWLO5w8pIeVwgKYewBF7bAQNG3cEEnJKTh09ISg5xnUQqSZiadFWt2iNM1hE+SOTFmbsiG1MhpeoqVs+mvT0B1RMbFU5XBhz37pgVLiqnMN1/BKEIhDK5ykX62mLtuRcOpXQOWEuj1fQFCLMaiOf98tWSGWNXWCaeujg37++eNHBPjXkt5e7kD3W0bh7Hn5gVsQ4ogRqMEISF8d9l29k1otXH6R2y+1lLcvN445Ox29STtzP/1gLv73zhzs37oGM++faJRZlUoFRcubEXvYaJ+KV5YcqXhnKM2cQRnRskVTkT191rjZgGgsJ3Jy9UKDvnOhUrsgLWo3rmx8Cpf/fUQSaGciO/mCpGk+jNgj3+PCP0/i1KrxIHdmyRfWIzc9Gi6ewfBrdBvqdp+FFiOXoOnQz1G740zhsohebdPUTtJDxc9Ll+LzdTfx1MIYdBr2Mv74Y63YFELtFQ1ZcRqBV6PhJTpu/mGUIDclRqTmRIZmDZ4a91pZ1VXgjdon4PEJl80ZcnNzQa9uPT094OrqKtoqGikPC60lgTc6xvoPiObySZtSDxw6LoZ171K5Nw2CSBWPwkP98ONLkRjU0Qv5Rc5o2P9N1KrXu4qvyjj7V6/dAG1Gc3V1EeYKxnuVrO3VvbOw66VNfteuR6HXbaOx/p/NJTtyDSNQwxCwi8BLJgwXLl8DpcZCDbsGJi2XTiW6f9LdQtAlX5dlDfIKlX8YM+KOltXNIm1p2uOEu5dJT+HZXNdkhkTdfOvC2Z1eY6u0TbnpUZKQ+zgub54jTlbKTj4P0nLLG0ceEj4mmw//DnW6PoFaDfrDyc1PO9Ywc/b8ZRQWFIB2w4+8Y7AkULkYdjG7nBV7WYzxDJFNGqjgpjl8wlxfvDR2oMaOVzFr8NQcT1odXZMVCpMZ+cHNO0y2tY+JlV2SBQdV3t0TafoLVa6oE+SCm4lRBK9DhaPHTyM/P19o9X19vB2KN1szQz52L296Hk1DchGTlIfnF2dBPvXM1pxo5rNyomh37x51B7y8PM2arU54GP5btwzjx4wQD4djJj2Eue98BEd2vWfWArkzI1ABBOwi8E67dxRCgwORnp4JyhuGCqyDh+gg4BXSVpQyrGzHmxl/HIV5GXD3ayw0qGLSUqKWmtPWjp04U0oP06rpkIW8LFng0R+hAglEZMvXZNBHiLzrZ83GkWFw9amj37WM0vGTMn+tW8q2nWV0NbkpU/HBW7uZdoyrRuDNrYCGV/HHu2P3fuGT1Nk9QBLia0nXIhPxp35BQU6Kdh5LZAroxKiU8yDsLUHPHBrKQxsJNvQQQ2MTEpMoQVAlDp0QBDSR2kt+EPFWG7uvNJ3slCgb1roabE61Ezs2nZaOB86W3tzkZcYhJ/U6FB+77n6N8NJPedh24Co2bd1pU55sNVlhYSF++GmlmG7qvaaZM4jOOhG9/fhmwXv4eN6rcHFxwbyPFuLOcdPF5mGdbpxlBGoMAnYReD/7ehm8pSdWb29PdOnQukSoJujbbRmyFjQApBGhHwprMaL1zlC3R7lT0OENpJHLyMys1G54tZMbKBhOSD+CDfq9Lmz53P1l8wnDPqaULS3w5t6MRWFuFlx8giSh1FPLgpt/bZHPqYDAS9qebl3aIzc3D9t370PM4W8lIfcmoFIh7uhinF07HVlJZ1Hpv6JCXN/1Pk7/NgFR22bj1Kp7hMlIpemaQSBNMWeoLZsz0NB4jcAbbCGB1yukJZFFiFe6SB0p2ntA1m537dzOkdiyOi+p17bj9O8TpTc3T+Dsmvtx/q+HkScJvt5hHdBo4DyMGTNO8PDVd8tEWt2ivzdsRWxcApo2boAeXeU3GxVd4wNTxuGfPxYjNCQIGzfvQM+Bd7Fdb0XB5HFVGgG1PbjPyc3FvkPHhYaXUsNgD56q25xeofIPpPCgYKXFpV7fKSgbO11NNBhEkRGyIGrOEcMGJACVGrUa9IPhX636fQ2rKlS2tMCbpXhoCGmox49rJTS8ROiWvj0pwdat25F49neRVyLSxMYe/QEZcccqFeJO/IybV7coZAFJAE44/Suyk88X11k5pxV4Nfa7NJ2lNbxBdWX3hU3DIMwHaA5HCXv3HxGsVP0Na2IZpkVFBWKzKb090g6Q7j03n7po0O8NkM09mXeRzf26vzZJgmG8tlt1yXy3dIVYyrTJ94i0slHXTu2x578/0KVjO1y6co3teisLKI+vkgjYReC9/ba+WLTkN8RIT7CUGoYqiaSDMe2tCLxWsuPNTrkkaVzi4eIVAnfpFaMpy2/RXBZ4K7Nxjeap3fFBkAsi7/Ae8KnbB3W7PyNpdmV3RdRemXBMY9LQxkImDVlxlwQ7HqGNRapEbppNaznJ0UqVWamyce30sV1CEDUcTOYsl/97EZUJ8cd/MiQrytkpl0Vq7Sjn5hWQOzlnj0C41Sp+YEhISBZTBwWSLbfIVipSfBmTL15yYVgpYhYcnJqWLoQTcsfVrnWkBSk7NqmctGgU5KaVYFLt4qWtCwzww+g7h4BsUr9ctFRbXx0yCYnJ+PPv/+Ds7IwJd4+02JLoDduGNUswfep4rV3vm/M+FRhabBImxAg4MAJ2EXg7t2+JL+e/LL2uqS9SyusGB8aryrCmaHit5Y837cZugYVvnR4iNSWKjGgiup08c06kFY1UameQU/fa3WahdtenJI3vAJDmF5X8S065Kcwt/Gr5gtx/VZKcGJ6luCQzFHg1Gt6KbFojwmTTSV4KNuw6C2NrJ7OWwIiRCGw+AuR+LaDp7fBvMgT+jQeBvFX4NRwocKtFp0LV6wPfur3gU0d6gKjTDT7hXeBduxPcfGWzCxj8ObkWCx4GTRYtat2RSfzoEk7QmDQEWWDTGtF1cvVGzE01PN2cEHvV+hs9aU5TAtloUz86UVGtVlO22ofkC3/hypbZRtfp7KH/gDPjvgmi3zc//OxwmnnBWAWj7yXtLgnyw4cOhKUe6hRWSIj+6L1X8PVn74oNue/M/xxtug9B2+6DEdKoEwaPnAzlvlPGcMoIVBcE7PItSgc4VBcAHXUd5IbLxSsMhXmZVnkFnao5Xc0nvKvJEERGyJu2Tp+5YPIYW3akHfE0X9vWLSixSMjSmDR4hjbSo+fsEwSonZCfkQw6hU2v0YQC/XD1690N2blFSFDJmxSVYWpnD9Tp9jTC2j+AsA4zQO7XSCMe3vlRhHd5HOStok63p4RmXJwK1fN50MlQ9XvPBvklrt/nVTToOxcN+r8lydLOCllNWgSVk7smb91Ea84gCd+6M2kFXgvZ8BLt+AxZiE+Pl30bU50dg5h63wHZnKG62+8W5mcj8cwqnPljMqL2fya9OUqE2tlNYKAb0cOZbplsWyMjmiIp+SZ+W/O3blOVzn/zw3LB/9R7x4rUGtGEsXeK09n8/Hxx6fJVXLh0FRmZmdi+ax8m3P840tIzrDEt02QE7IqAXQTevLx8fPHtcsTGJeKrH1aUCHZFpBpN7h0q2/Gmxx626KryspKQnXJR+lHyMMstUEuNp4bKmjRYdDE6xE6ckrSlUrmtBV8fZ0TJXh/cdVySSVNApVLBTavljaIqs4Ny6tovu1SggzNIwCVBtvkdX4uT48wmaDDAxTMETQZ9LDTEHiEdJI1vPdHj2s53kZN2Q+StFZEQlJlwElCpobjZg+bPEscKa0hpkwyEyPmMK3LqALHioaFb5/YOwI3lWSjMS0fc8aU4u2aq2HiZn50EMi+hB6+IO39EaLv7pLcN3eDXaCDq93kFteqXtNN/ePokwdjX3/8s0qoekcBJvnPr16uDW/v3supy2rRqgVv79S4xR0JiMg4dcZwHvxIMckUNQ8Byy1VbjpTplD5+94VKO/M3fbaa21Mxa8iItexr2mQ6Vi8AABAASURBVLTrOwSoPnW6S/KIk8ibEpHdHdmRJSWnQDkpy5Rxtupj6Q1rdIoaeWhw9qwFF++AEstQBN7cCnhqIGID+vakBBs274BHQHMERoyEX8OBcHLzE/WWiNxqNZA0xDMQ1u0FNBn8KTwCI6W3Bhm4svllFOSmW2IKozTS6XS1okJ4hbSRHqz0Ncpx8YliTLAFNbzwlG2EPREraDtCtHe//KDapWM7R2DHYjyQYBtz+Buc/mMK4k8sE/cRuRRsdMs7aHzrfPjU6SFdc09hl1+/z8vSG4mnUNqbpHGjh8PL01O8hj9xqnKmUnCAv+80J6tNHn+XTbhxc3M1Os/lq9eN1nMlI1CVEbCLwBsU4IeJY4fhvokjMWPK2BKhKgPqSLzTjwjxkxF3FEWFBZS1SEjV2u92M5uecsTwCY021WwCVhygmDS0jmxukVmytPa7+uYMCnFX7cY1809bIxrNmzYCPUBcvxGNcxesv5FMpXZGg76vwdU7XHrtHIcrW1+T7qt8YsXiQWu/q+OOTJkkQWPDGxgg23Qq9ZVJvQKaIDu3EL6uWSjIy6wMKYuMJU8m6RmZCJS+K8Nrh1qEpr2J5GXEIGrfp5JG934knvldunfyQFpbOvWwQb/X4RncxmwWPT09MGn8KDFu4XdVe/PazdQ0rFr9l1jLfVY0ZxATaKJBA/tocsUJ2Q8/8vTLeHbO2+yztxgWzlUDBOwi8Cq4DRnYC98u/R2vvvu5qLp4+QY2btkj8hxVHgHajEMauqLCfGRZ6NhZEgYy4o5Jml1neBsRRsrjOjLCMp4aypvH3PbCwkIcl4RwlUqFVpGyrbG5NAz7Z2nsdz1CGhs2ibKb1qShYp4aiMjggf0owaYtstZdFKwY0T3VoP8boB3zdE/d2POhVWZLU07wM9iwRpMlJGgOngiynMAbHh6GE1dyiDyyEk6J1J7RXo39bq/uXezJhkXmzkm9iuu75uHsuhlIvki2tir4NxmK5nd8g7o9ngOddleZiRSzhp9++UN4H6gMLXuOXbZitfCtPeiWPggLDbYJK2NG3o6Xn38czZo0FJry3j264NGZk+Hj7YXPv/4R7XoMwdJf9N0e2oQxnqSiCPC4MhBQl9Fm9aa5875ETGwCrl6PFnOF1w7G4uWrRZ4jyyCgPXUtTt4AU1mq6VHSAwm9ag5tD7Wz/qtmU2hHajw1kAbLlP626kMa0ry8PPHF7+pq/DWfubwUuyQrRcOrEXgratJA/CjuyTZt3UVFmwRXr1Ch6YXKSfjpTTj1i0XnzU4+j4KcVDh7BMDVp64e7dzcXKRLmk8XFxfxAw0L/ZFXjqOXsgW1TAs9HApiFYyqw4Y1eiC6um0uzq9/WLpPtorvi6DIMYgY8T3COz8CF0+N3XQFMVKGNWnUAH17dUVWVjYWL1uFqvr37eLlgvWpFTxZTQyuQPTC0w/h8M71iLt0AH//vhjz3ngJR3b9hfFjR4DMh2Y89iJuGTYeisvGCkzBQxgBh0DArgLv5Ss38NLTD0CxI3J3c0Vefr5DAFNdmNBuXIuxjMCbekMSeCVwfOt0l2Lz/yu+eB1N4LW0/S4hk6WYNIQYF3jd/GW3XxU5bY3oUxh8a19KJA3vTtCrSFEoK7JQm2dQJGiDHJGLPboYikaWypUNaZrT1XzryjbKuvTiNdrd0JAg3epK5+vUDsXxy7LAS4JapQlWksC+g/LntWsny9jvFuZnidP3jPm3rQyraZIm/sbeD3F12xtIOL0SNE96zEFc2vQCLm6YJd0X++Ds7ofQtlMlQfcHkTq51arMlEbHKi7KFny12Gi7o1fSJrETp88JE5bbBw2wO7tkKvXNZ+9h49qf0KJ5E+zZf1ic0PbUC28g5Waq3fljBhiBiiBgV4HX2dlJj+d8Fnb18LBEwTNE/sHMTDyFwoK8SpGk8WkaYcTHiDBiCnHFpOGk9OVuSn9b9bGKwFvKoRPKmhSThspoeP1q+aJNywjxKnev5lQuhb61U78G/RHcaryYhjw3ZCWdE/nKRmXZ71r6WGGFV09PD1yMk78OM+JPK9V2SUlTeeLUOeHJo2O71pXmIfbI9+JY6Iv/Po3Tv43H9V3vA9JbmsoSvnl1qyTovo6USxslwXYPYo98hzOrJ+PKlleQGX8crt61JU3uo2g+/HuQZlft7FHZKUsdf+ew2xASHISLl69i6469pfZz1AblZLVJ4+4Cvb1wFD67d+mAvZv/wNuvPgcPd3d89d1Pwszhh59WwpYP2NbCg+nWLATkb3g7rbltqwj8+MtapKdnYu/BY5j1ynwM6GO6X1c7sV2lpnVy8YBHQHNA+oHLSqicq5nM+GMoKsiBR2ALOLv5VgiHkOBA+PvVQnLKTfG6rEJErDBIeV1HwqMlyBfkZCIvLRFqVw+41goxSlLZtJadVDG3ZArRW/rLmtCNNrLjVealNKT1RNSq30+6L3Il4Wcu8jIrd8wraSCzEs9A5eRm1EY8ITGZprW4Q34i6uUbjOsJudJaspCTar9d6uSOjISJtq1awMPDnVircCDzkITTv4rPv0Lk5tUtiJGEUxJYUy5vQvLFf5B0/k8knl0taWlXgUxU4k/8BNLcxx75FjGHvkL0gc8Rte8T3NjzP0lgnodrO94W9QpNJS3My4J7rfrCNrfZsK/h32QIVGpDX85Kb8ularUaD0yRj+Fd+O1SyxG2AaWcnFyQ/S5NNfP+CZQ4VHBycsITD9+HI7vWY9TwwaDP4MNPzUG/offg8NGTDsUrM8MIlIWAXQXepx+eJL3CqSU90Trjwy+W4Ja+3TBtorzjtiymuc08BBT3ZOkxspsj80YX9069LtuJVtScQaHkiP54j5+UffC2lrSlCp9AxXNZ0efEYM/QJiI1Fqld3EEuyyTVO8iFmbE+ptTd0q+X6PafDe14xYSaqG6PZ8VDUH52itDu0WttTZPZCb0Op0GK7TnldUO84pIsKFC32iL58NqhOHZJs3HNjna8+6SHf1pQ505tKalwoOuQeG6d0fGJp38TgisJsCTIkkBLgi0JuCToxh3/SQi+CadXCUGYBGISjElAJkE59fpO5GfLDx+GE9DhJrWM+Mw17GfpMgm8KpUKf6z7F7FxlXvwsjRvZdFb8fuf4g1Nr+6dQf53y+przzayc1/yzUdY9+t3aNSgHg4cOobeg8bgsWdfBZs52PPK8NymImBXgVelUuH2W/vgu8/ewLKv38OIIf1BT+qmMs/9TEPAO1Q2a8iIO2ragFJ6pSn2u3V7lNLDtOoW2o1rslBo2ijr9crIyAQ5e6fX2vXrhVtkokytOYNx+11lEldl41pytFJldtqnRxc4Ozth156DWLT4F7tozhv0fQWu3mGSZvQaru2cZ/YalAFakxkj3hmoT4LGJZmljhUmmkqgH/TjGjtee25cO3BY/px27dReYc3ktCAnRdLY/i0ePE6tHIuUS/8YHevm1wC+dXsJ7Twd7ODfeDACmg5DYPM7EdRitDBVIe19aNspCGs/DXRaX3jnRxDe5QnU7f4M6vV83qhvXLWLJzwCmhmd09qVoSHBINMG0o7T58Da81mK/vca37u23qxmNv+aAf37dMfB7euEdwc3N1d8K33ntOk2GIt+WA7CXtONE0bA4RCwq8CbnJKKpSvWYfabn4jw08r10qvuVIcDqaoz5BHUClCp5U0r0itHVOAvS3rNnJ+dJHZWu/rUqQCF4iEtI+QfxFNnLhRX2jF3+NhJMXs7C56wpt2wFmrcJZmYUIossXFt7rsfIT+/AEXSv8clbUubboOE9kUib7P/Tq6+qN93LshOMz16H6IPLjR7bvqxTIvaK8b5hHcTqWGUYEWThvCwUBy/ki2mzLSja7Ldew8LHrp0NE3Dm5seLUwRLm18Fqd/n4SofZ9C0ZS7+dSTromboKdEKrUzGvR9FfV6vQjSztfp+pQkyD6G2p0eQliH6aATzkJaTxRCb1DkWARGjEJAs+HwbzIU/o1vQ60GA+Bbr4805nG4+zdVyELt4gUSiqHS35uh7WCDjLJ57evvfwa5GrTBlJWagrzD7Np7EL4+3hg9YmilaNlysKurC8i7w5Gd6zGwfy8kJafg8edeQ6/bRmP/QfmBzZb88FyMgCkI2FXgJf+7m3fsR8d2kSJs2roH5KrMFMa5j+kIqJ1c4BnUEvSXGSf/mFLenJCqOWyiVv3epQ0zuZ52/VLn02cdQ+C1yoY1xUNDaNkaXjdFw1vB09YyMjPx2UL9nenktuuTL78niG0a3KQHofp9XgEJPEnn1iD50r8w5y876TQK8zLh6lNXerAybrKQoGh4LXnKmoZJ0vCevZ6LwiIVcm5eRWF+jqbFdsmVq1FCeCA/qBHNSn9Yyk4+j7hjP+L8X4/g3LrpIFMEWUgvkjSszUGaWbKhbXr7l2g65HOhtSW/2SS4Nhn0sYSvcbtyc1bq7O6PJoM+QvPh30rpx2gxcilq1e8He/71690NjRvWl95yJAjTBnvyYsrc3y35RXS7Z/RwkLZUFKpQVLdObaxe/g1++WEB6tergyPHTgnbXrLxTUxKQUFBAU6dOY/zF6+w9rcKXdfqyqpdBd6YuHh8+b+XMXr4bSJ8OX8OrkfFVFes7bouxawhvYLHDKdpBF469rOyC1FseM+ccwyBl9wB0ZpokxCllghZcZcFGY9SXJKJRilSNq7lJFfsvqcfEvpRkUjp/T9jp4cJr5A2WndlsqbxkB5fZRXSovaLZp/wziI1FiUkJYvqECvY8NYJD0VBIRCV4irNUYQsO9jxHjxyTJob6NG1o0i1UVEhyCSJNOdn19yHC/88ifiTyyXB/Aogvb0h3MnsIGLED2h82/9AmllX79qgPxevUJDWlk7Joz50GA3VWyq4eIZImt4mEhvW35xmCs+PzJgsun3zw88itU9k2qx0WAb1vH/y3ZRU2TBsyC04tH0dnn/qQbEG8uLQotMtqBvRHT1vHYPOfUegXY+h7MtXoMORvRCwq8CrVpecXq1W2QuLaj2vsnEtI9Z8DW9uRqywzXRy9QF5aKgsUIqnhrj4RJAWoLL0Kjv+2IkzgkSbVhEirWxEHhpyJY2tyskZbgFlm38oGt6K+uJt2rgBaBe1Ic8RzZsYVtmsTO7KgiLHCM8AV7e/Ke4dUyYvyx2ZMl45ZS0wwE+pslhaO1TWep6OkqReiWpmonxfSFmr/79y4Th+/+Au1L80H3/NCsHw5tcQH30BaTd2Cc8Ip3+fgMv/vYQkSXOelxkvhEvS2IZ3eVxoVhsOeEeYHTh7GNeMW30BDjTBveNGCe8Wm7ftxplzFx2IM31W/lj3D8ivdId2rWDJh239WWxXcnd3wysvPAHy5jCgbw9kZGTqHU184dIVvPbWh7ZjiGdiBAwQKClxGnSwZrF9m0g8POtNfPXDChEemvUWunRoY80pHYa2rRnxCIgQP5I5qddK3V1dGk+p13aIJt+63YVvUFGoZKSYNZx0AH+8ikktYT1aAAAQAElEQVSDonmu5NKQrWxYCyu2byyNpnbTmiQgl9anrHovT088OlPWaOn2e2jaRN2izfMhbaaAfDUXFeTg8uY5yM+5WSYP+dk3kZ18ASonN3gGl/4dQAICEbLGprWw0GAijYNn00RqSw3vmZ+fQu24K1DHZcA1PgOtsuNx448ZuLr9LaRc3oSC3HSBjW/dXsLutsXIn0AaW//Gg0APooJhjgQC3l6eGD9mhMiT31iRccDoux9XCK6mTBgt0uoSNW3cEH/8/DWMKbQOHjleXZbJ66iCCKjtyfNzj03F8MH9cOVatAgjbx+AZx4p+eNtTx6ry9wqtRMUV0/0atScdVnSnEGZt2VkM5E9Y2ezhktXrgmXQHQ8qZf0QymYqmSUFXtJUPAsx5yBOrn5h1GCnEp4aSCn8FvWL8e7c59Hg/p1ha3c0ROnBV17RSqVCnW7Pyu96m6K/KxEXNnyKgrLOPgkPXov6M87rAPoXqW8sZComDQEBxlrrlRdvbqyh45/98oeMzITbINhQX4e/DLpgUDn7VYRkB+bAbWLN/wa3oL6vecgctQy0EYzspNVu3hWaq0ONtji7My8X37gI5OBzMwsi9OvLMEbUTH497/tIK0o2e9Wlp6jjXdycgLZoRvyVcvXx7CKy4yAzRCwq8BLT4B3SALvW3MeB4Vhg/oafSq0GRrVfCLvsPZihRmxR0RqSlSQk4rMhJNQO7vDJ9xyh4K01HhqOHn6vClsWK3PMY1g2CqyucXmyIq/LGh5hJVvVuDiIwtu+RkpKMqv+Capzh3b4rEHp+J/78wRWvj3P/5K8GDPiDZLNuw3Fy6ewZL29jyi9n5YKjtp0QdEW3n3GPn7pM09pMUTAywckbnNzYxCOLkHSlrVVOSmV8y22hy2CrLSUJQnm1HojivIKkDkXT+jTren4VNHervi5KrbzPkyEGjdsjnolLDUtHT8/OuaMnrap4lsXGnm0SOGCg8NlK9uYcyo20ssicxNSlRyBSNgIwTsKvBOe/xV0A+YstbE5BQ88MRrSrE45ZxFEFA0vOlmCLypGt+7XqEdLMKDQkTZgX7qjH198RYfOGE5gTcz5oJYpkdIQ5GWF7kF1hVdKrpxTQzWRENu7Ye2rSMRFR0r/GJqqu2WOLnVQoN+r0Pl5AY6sCDu2BIY/hUVFiAtap+o9g7rJFJjUXRMnKgODPAXqTWi2ho73jxX2fY6K/GUNabRo+nqE4Aip5JfxTnSQ6ZeRy6YhcD0qeNF/8+/+VGkjhKR+z1lQ92UidXLnEEX4/lvzcFH772CEbffijEjh2LRgnl4+tEHdLtwnhGwKQIlv2VtOH1mVjb8avlqZwz090Naerq2zBnLIuDm1wRqFy/kZcQiN0MWHsqbQTFnIPvd8vqa0x4ZIdu32ts1mfLqnzRC5vBfVt8sxYbXBJMGolPZjWtEQze89MzDojjv44XIz88XeXtGbr71xCt5qNSIP/kzUq5s1mOH3iAUFeTA3a+RpA0ufdNVvMYlWbAVXJIpDJFrMsrfzPOnBLbYuEafRfc69D1YJOakiHINbn+CsiUCV5iGwBhJyArwryXcYu3cI79BMG2kdXtt3LITsXEJoA2ndLqadWezH3Xy1UsPHT8s/ADffPYuxo0ZDrXariKH/cDgmR0CAbvefTk5ubgeFasF4npUjPQDXagtc8ayCKhUKniHthVEM2IPi7SsqDA/G+kx0g+FSi29Uu1RVlez28JCg0EbrshTQ5Kk2TebgIUGHNd4aGjdMsIiFAvz85CTeB0q8tCg0dyWR9i1kr54DenfMXQgaFPg9RvRWPrLH4bNdil7h3VAeJfHxNw39nyITJ2DHdKjNdrd2p1Fe2mR4qEhyAYC740Ud8GGte14Sdt3fdc8OAe6gYRcUFxUBL+InmjQc4zggaOKIeDs7Iz7J90jBn/13TKROkKknKx236Sq7YrMEbBkHmo8AmYBYFeBd/K44XjypfeEhwby1PDkS/MwdcIIsxZgq86//P437n3wRUx+aDa27jpoq2ktPo9XSDtBM8MEs4aM2EMoKsyHZ1BLOFlhk4ziBowckwumbBxlZGSCNq15enqANq1ZYnrFQ4N7cEOUtflKd67ijWuWsRdVqVR4adYjYoq3P1iAwkLHeIj0b3QbAiNGSjJdAa5sfQ250psGYtIU/7vUL0E5ZS1I1r5SnaVDeO1QQfJ8jISZygnZyRdQWAnbakGsjCjp3Grh77cgtRAq6V9yjhMgXb/MqLPgv8oj8MCUeyQ4VVi1+i+HcIFI9/Ca9RtBwvi994yq/AKZAiPACJiMgF0F3pG334L/vfkc0tKzRPjo7ecxfHB/k5m3VUfyIrH45zVY+L9XMO+1p/DW/K+QLWmnbTW/JefxCpU3rplix5uqOWzCt65ltbvKeiI1Zg32EnhPnJKFCku5I6N1ZcVdpASm2u9SZ8WkITclmooWCXeNGCJOnCIt788r11iEpiWIhLV/AD7hXVCYl4HLm15A/PGfxOEJKmd36cGqVZlTJGhMGszS8JZJsWQjvXmg2qiYBHj4N5GyRchOsc7Gytz0aMQe+V6aA4iLcxHpRdcIqN08kZeWgJzkKFHHUcURIM8bQ27rJ078WrR4ecUJWWjkT7/8Lr3FzMewwbcgKNB6D24WYpfJMALVCgG7CryEZP26YcIVGbkjqxseSlUOF7bvPoh+vTpLr+A9EBYahBbNGmHfQdv6E8xJuoG4Pb8hducvklAlu71CBf7cfOvC2T0ABTkp5R4IkHZDdhXlW00FXmXDWhsLmTPQ5dC6JAttTEWTgmLSYIlNa8qEKpUKs599VBTf+eBzh9HyEkP1er4AV69Q5GXGIe7ET5BUcCjKz0bSubUo688WAq+i4aVNf55BLQQ7WVY6gOL6rvelNyh5IA8MzimxYq6wToPg06iDyKddPCRSjiqHwIz7JggCX3yzxO6fA0Xonnovm6uIi8KRTRGo6ZPZXeCtCheANsuEhwVrWSXBPC4hUZQXL18N3bBq3SaE1o/Qr1u1CqvKCbo0DPPLvvsGf30zD5dWvoXLv8/D0fl34+/PXzJK03CssXJijqxZ2PnPD0ZpEK8/L1+KK9mNcbmwB5at2a23HoUm9SsvKH2NpenZ+ejVpy+2bt9VKh8KfWPjl61aj59WrtfypvQtK9Wlc/DEeTF/rYAgLQ1qL2u80kb9jIU95xIQG9QD265Lr1HLueZEi2is3XtJjDmTUUuPD2qjQP3KC9TPMOTkF2LI0CGoXa8h3pTeSpRHg9oNacjlNVj++z9a3qhfeUEet1o7Rrf8469/40waaU9V4jOkRNcOfl/iPtAdF5uULq5XenaeHt3yeKF2XTql5anfyRPHBDunz5zDsQupIn/u6H9avkobq1tPdMoLK3/+EucSPHClsDO2nw9HWmhXnPLsjsRcdxzObyzuh6P//a6dtzR6uvOWli9trG59aWN163X7l5bX7V9avrSxuvWljdWt1+1fWp76x8QnY9DgwWjWoiXe/WiR9t5R7unSxurWE53ygm5/Y/l33/8QoXUa4NbbbgPxVBo9Y2MN60obq1tvOMZYWbd/aXlj4wzrShtL9cs039OGY4yVqX95wdg4wzrxweWIETBAgAVeA0BKK6p0dpeqVMU/1GkZ2dANGVm5cPf00auLiYlBeUGXhmG+KD0Bua5+xawVFcHr2jajNA3HGivHpHkJWuqsS0ZpEK/5OWnIKvJFUl6Q3lp06VG/8oJuf8O8i6srAgICce16xfBJTSfss7T8lccLtevykJtfJOb38vLW0qB26ldeoH7GQl6hE3JcA5CS71Yqtrq0iUZKjkqMyVO76/FBbRR0+5eWp36GIT0zB60iI8QaL1+PRXR0dDk8xRidn+gSLUoplMaDbj31KyvkFbmIe1A3ckY2EmKv6vGoSwNqZ7EWZ2c3PT515y0tr0untDyNzcvJFiyRi8SrCfLn3DW/GLfSxurWE52yQlr8WTgV3hSfr+ichkhPThLXPwZByM4twM0iH1FWJ1/Ww8IYTd15S8sbG2dYV9pY3XrDMcbKuv1LyxsbZ1hX2ljdesMxxspK/xbNm4p751p0gvbeUe5pY+MM6xQ6ZaWGYwzLf23YJniIkHipDB2iW9Z4pY36lReUvmWl5dGg9rLGK9/T1K+8UBYdpa08GtQuPsQcMQIGCLDAawCIsWJwoCTApNBJSHJrUnIKQoICReGR+++Gbpg0ZgiunN6vV/fwww+jvKBLwzDfPP4v1I9aJ+ZTIpeCLMy8b1IJuoZjjZXvGPekIBPieRMPPfRQCRrEa1f/vWjmtA1jhw/UW4suPepXXtDtb5h/+sF7senfv6UfoExMnjLFKB8KfcOxVJ45eRRmTr5Ly5/St6yUxinht1UrseaP3/DE9HFaGtRW1niljfoZhoenjkajG7+jfvR6zJw2scz16NGZNg6Nb+4AXeMZY0virfQtKzXkRSm/8swDOLR/N5b//DPqNGhWLk/KOP10LKZNGK7FqCw+lDb98fqfEWprFxIj7kHdyNndDzMeelKPR+qrhDMnjorrNahfZy0v1KbMWVZK/coLNP65Z5+Bk5MTMjKzMeWBJ+Dk6gs3dTamTx0r+CqPBrUTndLCQw/ORM96l8Vnq3NjZ0ybOhXNY9eKa1+Ukyrdz6Nw35RxqB/zFzzykjHzfvM/F8SDbiiNF9163f6l5XX7l5YvbaxufWljdet1+5eW1+1fWl4Z++ITU/H3+rVYvHgxhgzoJu4f5Z4ubaxuvUKnrFS3v2F+ypSpOHLyvLh/n545XsxfGi3DscbKpY3VrTc2zrBOt39pecMxxsqljaV65Xva2DjDOupfXjAcY6ys+71S4TwPrHYIqO29ouycXBw5fgb7Dh3XBnvzZDh/7+4dsW33QeTk5iIp+SZOnrmIbp3bGHazWtnYBijSOGcnXq/QnK5eIXDxCkNhfjayk8+XoJFz84qwr3R294e7v+wvt0QnC1W0atlcUDp6/LRIbRVdvRaFzMws1K1TG15enhaZNjvhKlBUCPegelCpncyi6eYXJvrnppQUBEVDBSNnZ2c8/9SDYvQb730iUkeIgiPHQgIJxX8qBLccV1w0kkvQblqTTXKMdKl0lUqlQu2wEEHnRlQsPINbinyWhex4447/iNy066DPVu1ODyE7/jI8CtORnFWIVn2GirlUTs7wqS9/v6RdYjteAUolI18fb4wdOUxQ+coOLsqWr1yL3Nw83Nq/F8JCgwUfHDECjIBtEVDbdjr92b5d8htGTXoSCxb9jEVSXgn6vexfalCvNkYNGwg6Ge7Jl+bhqYcnw9Wl5CtZa3EaPmAqoCdAFUlyVQFOfHYfojcvloSsIrOn9g7VuCeLO1JibOqNXaLOt25PkVozaqnx1HD6jHw6mTXn0qV9/OQZUazEhjUxXjfKipHX4GHigRO6Y101Am9OcrRutUXyk8ffhdCQINAhH+v+2mQRmpUlQhu1mg/7CuGdOuFo7wAAEABJREFUH0Xtjg+i6dDPEdDsjjLJJihuyaQ3LmV2rGSjsnEtOjYOnoHyxrXMxMo/kGUlnUfCqZWCu7o9ngO5+os7Il+PXdcL0KdnV9FGkU9D+fOZdrl8f9nUn0P5CMy4b7zo9MPSX0E+4EXBRtF3S1eImabeKz3oiRxHjAAjYGsE7Crw7tp/FH8uX4CvPnwVX85/WRtsDYIp8909cjCWfPkOFn/xFvr17GTKEIv18W/VH+2fW4VGo2ej4cjn0PLRH+AX2VcSevNx9c9PcPKrB5GXJm+iM3VSL0XgjT1aYkjq9d2ijoQSkbFi1KJ5E0H95JlzIrVVdEwj8LbWaJgtMW9W3GVBxsMMDw1igBRpffFaWMMrkQZpeV94+iHK4s33PxOpI0T0lsG/yRAh6Lr51iuTJTqgIVljVuSnczpjmYMq2Fg7VNbwyp4aIgSVzAT5AUkUKhAVFuTi2s53pZFFoDV7hcga3Bv7/5LqgCiEwd+vlshT5NNIdh/IAi+hYZnQuWNbtGsTibT0DNjSVd+5C5dx8PBxBAb44Y4ht1hmMQ5HhRliBBwfAbsKvP5+PlCpVI6PkgNw6BZQByHdRiG0593S687WiLjvQ0kAfglqF3ekXTggPDeknJUFVVPY9Q7rKLplxB2VBOcCkacoLytJmDmonT3gFdKWqqwaIls0E/RJ+ygyNooUDW9ri7okuyi49whtJFJzIkXDa2mTBoWHqRPHCC3v0eOn8PfGrUp1lUkVryhhIcFW5zm8doiYIzomDu7+zaW8CllJZ6XPSb6Ur9j/2CPfIS8jBi6ewQhr/4AgkpeRAlXSReQVFCGwdT9Rp0Q+jeTPZ9qVYygqqPi8Cj1OZQQenHavyCz8dqlIbREpc028ZxRcXGz3ZtAWa+M5GIGqhIBdBV53NzfMeeszbN6+X2u/S7a8VQlAe/Ia0u0utHnqJ3iENUF+5k2c+eZRXP7jfRTl55bLlpOrN9xqNRA/4lk6r2vTNOYMPuFdYK4dalmTltYWqdHwnjpd0pa4tDGWqLemwOtZAZMGN//aYlmW9MUrCGoiV1dXPP2oLGi9O/9zTW3VSRISkgWzQUHWs98VE0iRYsNLGl61sxvc/aQHmKICZKfIDzRSF7P+Z8QdQ9I5+fAPMmVQO7uL8Sknt4Ie9/fdKECfXt1FnRI5uXvBg+6jwgJkXD+pVHNaSQTuuesOeHt54vCxk3jh1Xni4S8/33oPFHl5eVi6/HfB9f2T7hYpR4wAI2AfBOwq8MYlJCEhKRk//7beoW147XNpTJvVPag+2jyxFGF9JogBsTuW49jH90J5vS4qS4kUDW567GFtjzTN6Wq2MGegSeuEh8HL0xMxcfFIz8igKquH3Nxc0GtG0rY0byoJMxaaMSteNmlwD5XNNMwh66ax4bWWhpd4mTb5HvFade+BI9i0ZSdVVZkQr/F7HazxjmJNxsPDQgV5suGljHIARWbCaSqaFQrzs3F91zwxJjBiJDyDIkWeosTjmynBzusF6Nenm8jrRlo73kvFn0/dds6bjwBtPFarnaQHDRUWLf4Fd02YiYHDJ6KgoPgtl/lUSx/x25p/kJqWjh5dO6JZk4ZKR04ZAUbADgjYVeDVtdvVzdsBhyo9Je3qbjD8abSY/jmcvfyRFXsRxz6aiLjdK8tcl3eobCeYobHjLcjLRHrsEUiqXfiEd4Wt/lq3otfGwImTtrHjPXH6HMgmtHXL5lCrLfMRyE64Bnr1TKYnamfzX1sqJg05VrDhVa6jh4c7nn5suii+U8W0vEnJKYLv4KAAkVozUjS8ZNJA83hoNq7pvgmhelNC9MGFyM9OhqtPXYS0maIdUpifh5Qzu8R9eNO7qaR19NK2KZliO17pM6lUclopBFasWicJoGl6NPYfPIpNW+WNunoNFij88NOvgsp9k8aKlCNGgBGwHwKW+bWvIP/JKalYumIdZr/5iQg/rVwPqqsgueozrIIrqdWsK9rOWgHfpl1QlJ+DS6vewdkfnkF+ZqpRip4aG93MxFMoLMhDevR+oKgQJAgrr12NDrRwZYtmTQRFW21cO3ZC3oDUOlIWtMXklYyy4uTX3eI1dAVoOXtLgpykecrPSEFhXnYFKJg2ZMbU8Qjw98POPQewY7d0vU0bZvdeioY3MMDf6rzQWweaRBF4iz01yPcNtZkS0qMPIuXSv1JXFer1fB5qp+IHodRzu6EqzMPp+EJ07tFD6lPyv09D+YGUN66VxKaiNafPXTA69PslKxAvvXE02ljByktXrmHztt3w8fbCXcOHVJAKD2MEGAFLIWBXgffVdz/H5h370bFdpAibtu7B3HlfWmptNZKOi5cfImd8gQZ3zoLK2RXJJ7bg6PyxSDPyWtTJxQMeAZLQJwm5mfHHYGtzBuUCKZ4aTp2xjR3vca2HhgiFhUqnWbGXBA2PCmxYo4EqlQpuGjveXCtqeT09PfD4Q/fRlKhKWl5FGAm2gUlDmMZP6vWoGIGTq0841M4eyMuIRX5O8QE0orGUqCA3Hdf3fCBag1veI9sBi5IcJUufS8rtvJ6Pvr1KmjNQm1tgXTh71pIeWG+C/PVSXU0Mllyz8nBtSPO3NX+jYate6Df0Hsz/9GtYYhMtuT+jee4efQfo7QrlOTACjID9EFDbb2qA7Da//N/LGD38NhG+nD8Hyo+MPfmqDnOH9RonbHvdQxoKl2Unv5yOa399DkmVq7c8xT1ZesxhpEXtE22+dfU30IhKK0YtNL54bSXwHjsh22K2bmlBgTdOEXgbVxgpReC11sY1hbGHHpiIWr4++E96jbtnf9WwD1UE3iAbaHhJI0cCSlZWtvT6O13A5hncWqRZCadEWl50Y8+HKMhJhVuthghuJft/1R2TeGyTKO68VoDePTqLvLHIt4ncZuyB1Vh/risbgbF3DUOjBvX0OjWUyrcP6g93dzeQecMrb/4PnfrcgXY9hmL23Pexa+9BkAmU3qByCoWFhVi8bJXodd9ENmcQQHDECNgZAbsKvMbsJ9Vq2rdsDirctzQESNvY9qllCO0xBtI3NqI2fYsTn09DTlKUdohyAEXS+XUozM+SNL7N4OwuvV7X9rB+Rjl8wlYCr3KqG/nktNTqsmIvClKEuchUIHKzwcY1YsvbywuPzpTtSd/5YAFVOXxIUE5Zs4GXBgKjbngYJdCaNQS1EOVME05cS722TXp43CP6kymDobeT9KvHUZCVipj0QgQ0am3UflcMliLtxrXLbMcrwVHp/74+3ji4fR2WffcJXn3xcaz6aSGO7PwTvy75EtdO7RL1E8beKXwin794GR99/i1uHT4RjVr3xsNPzcGff/9n0qEVf/27BbFxCWjVohk6tGtVab6ZACPACFQeAbsKvO3bROLhWW/iqx9WiPDQrLfQpYPskL3yS2MKhIDKyQUNR72AiGmfiNej9GN79H/3IPEI2RaSHCw/YBQVkN1oEdQunjTMpkEc7+vpKYQLa3tqIAEm5WYqwkKCxY+apRaaGS1vuPMIqbiG11Uj8OZY0aRBWe/D0ycJ7xj//rcdR46dVKodNk2w0SlrCgDKxrWo6FhR5RkYIdIsHRd+osIgys++iRv7PhO1oW2nws23nsjrRsknt4ji9iv56FeKOYPoIEXFG9dM1MRLY/h/2Qi4urpgxO234dEZkzF4YF84OzuLAWTuQ/Vff/YurpzcgT9Xfo+HHrgX9P0Un5CEH35aibGTH0adiG64Z+qjWLL8dyRrDkMRBKSINMEkKH/85XeSjqEI06bcI9Xyf0aAEXAEBOwq8D732FQMH9wPV65FizDy9gF45pHJjoBLtePBL6Kn2NDm06gDCnOzcH7pizj/8xxc2/mOZq0k+KqQEXsEqde2a+psl0S2aComO2FlTw3WOGEtNzka5KHBtVYInNw8xToqErn5y1pFa9rwKnz51fLFIzMmieIb8z4VqSNHyqY1W9jwEg6KwKu4JvMIJHdiKpCGt6iokLoYDdf3fIDCvAy4+zdBYIu7jPZJPrFV1O+8XoA+vcr2huIZ3gIqZ1eQFxA6qEIM5MjqCDg5OaFf72744K3ZOHNwE3ZsWAk6rbBVZDOQqcva9Rsx8/EXUT+yJwbdOQmffPEdNm3eKcwgyBRi+859wvVZ3fDaVueVJ2AEGAHjCBjW2lXgJZOGOySB9605j4PCsEF9QXWGTHLZMgi4eAeg5YNfof6wJ6Byckbiwb+Qtv8iMk8lIP1QDDJPxCM3Og3psbbXJrWSXv3RKkvbRU1tlggnTp0VZNq0aiFSS0RZFrDfJT5cFQ1vcgwVrR4ee3Cq2Eyz/p/NOKqxa7b6pBWcwJZuyYhFRVCJiY2nIugACrda9aUHm1zk3Lwi6gyj5Iv/IiPmkPTZcoUwZVCV/Holc6Ks2AvIyC3C0dhC9O4u2+ga0lLKKrUaPg3aimL6pUMi5cj2CLRv0xIvP/849m5ejRN7/8U7rz2Hnt06gWx1ydvJi6/Nwx13348Ll3TuDUmH8OrbH9qeWZ6REWAEjCJQ8hvZaDfLVpIJQ0xcgjBjoLxhsOxsTE0PAZUKtftNQuvHl8DZNxBF+QUozMwHJKVVYXYBcqMykHntst4QWxQiNK7JLLE7uix+j2s8NFhS4M2MvSimrKhLMjFYitw0XhpsYdIgTQdyT/aQ5qjVdz74nKocNsRLr5SJOX+/WpRYKJRORtHw3tB4aqCenlp/vCXdk+VlxiPm0FfUDWHt7oerd7jIG0bJJzaLql3XCtClc3vQa3RRUUbko3FPlnrJ9g+iZbBVY5saNqgrPJ38u3oJrpzcic/mv46hg/pDUunC8O/MuYvajY+GbVxmBBgB2yJgF4HXtkvk2Ywh4Fm7KRqPel5qktQQUqz7vyA1V7dok3yLCI0v3lOyBtZakyoeGlpKryYtNUdWnPyA4BEmr6GidN2D6ouhOYnXRWqL6ImH7xe701f/+S9stWnQ3HUpwm5IcKC5QyvcX3FNFhUdp6XhoRF4M414ari28z3Qpk/P4DYIaHaHdoxhJvmkbM6w41o++vYs25xBGevTqL3Ipl85IlKOHAeBoEB/3HfvWPz64xdo3aJ5Cca8vTxBG+VKNHAFI+BoCNQAfuwi8M6YMhZhIUHo17MzKK8benXrWANgd4wlOrn7GmXE1Vu2JTXaaKXKyOZNBeWTVvTFm5ubi5Onz0OlUond02JCC0Rak4aQhpWmRmYnRCQvLZESqwf6wZ42Wd5Y46h+eRMUDw2BtvMeomh4FRteuhCeQfLGtUyDjWuJZ1cjS6pTObmhbo9nqavRUJCdjtQL+0Xb3hv5KM9+V3SUIq1Jw9Xj0huZHKmG/zsiAuRv15CvMaNuN6ziMiPACNgJAbsIvMpaP/xyiZLVpu98+I02zxnrIuBVNxLOXn4lJqET20pUWrmifr1w4TWAdsWnZ2RYZbbT0uvFoqIitGzRFJa0Fc+MkrXSnrVLanjMXYirX6gYkpMSLVJbRE8/+gBcXFywaglMdA0AABAASURBVPVf+jaI+pPbrZSg9dDgbzMewsPk60D3ozKpm299qJ09kJt2AwV5maI6Nz0asUe+E/nwTg/CxaN0oTz51DbRb78k7OYWOaN39y6iXF6kdvOEZ7h8b5GXlfL6c7t9EKDP0aIF83D3XcMw8o5B+Oi9VzD/rTn2YYZnZQQYgRII2EXgvR4Vi32HjiM9PVOklKewZecB5EhauBJccoVVEHBy80Lzye/Dp3FHqJzp2NMiuPqHIaDtrVaZrzyiEc0biy4nT8kuvkTBgpFiv2vJAyfyUhNAXi9IM+skCSaVZVex48210cY14pde39NrWXoYeNsB/fIm2EHDG147hKABbVojXERBijw1/nizEk6hqKgQ13a+i6LCPHiFdYBfo9ukHqX/T9Y5Xa1rp3Zwc3MtvbNBC9vxGgDigEV6iB43Zji+++IDLF30MaZPHQ9XV/pedUBmmaVKIsDDqyICanswffDoKSxa8hto4xqlSti8fR/mPDPDHizV2Dl9GnUQnhs6vbYJahdJeyUJWrST3B6AtIxoJqY9dfaCSC0dKQKvJTesZcVdFGx6hDQSaWUjracGG/ji1eX1+acehJOTE5avXItr16N0m+yet4fA6+zsjMAAPxQUFCBes2GOgFDseLOSziDx9K/ITr4gfW68ULfbLGouNRQVFiBFo+HddqVQuLwqtbORBp+G7URtGh9AIXDgiBFgBBgBcxGwi8A7Ykh/fDn/ZTw+c6JIKU/h1eceRLvWsp2cuQvh/pVDwMnVA4EdhoD+4navpMTmQdm4Zi1PDcdPyKYHltTwaj00hOoLvBUFz03jmsyWGl7ilbS8UyaMRlFREd56/zOqcpigCJzBQQE25SlcMWuIidXOm5dB+SLEn1iG2KM/AEVAnS6Pwdm9lraPsUzq+X0ozMvBjUwXJGYVoY+JG9YUWj6NOops2uXDKCosFHmOGAFGgBFgBExHwC4Cr8IeCb55efk4Lr3CJpMGJSjtnNoWgZCud4oJ4/b+bpcf1RbNZS8Hp06fE3xYOtJqeFta7qEqK+6yYNMjVDbHEIVKRPbS8BLLzz05U2h5f1qx2qG0vPYSeLUb12LiCB7cvLoVKZc3SXkV6MEAUEHl5Azv2p1Q3p9yutrGsxkC4x5dZQG2vHFKu2utYNC9UZiTiaxY67wBUebilBGwMAJMjhFwCATU9uRi++5DuGvyk3jypXl4/9Pv8PgL7+Kzr5fZk6UaPbd3/TYg11j5mTeRcnqbzbGwpklDcspNxMYngE4YI22mpRaXpfjgtZDA6+YfJljLsbFJA01ar244JowdIV7jz/toIVU5RLCHSQMtPLx2KCWI1rgmS48+IMq6UVFhPrKSzutWGc0nHf9P1O+8ng8Sds2x3xUDpUix401jswYJDf7PCDACjIB5CNhV4F2w6Gd8/fFraNq4Pn75dj6+++wNKd/AvBVwb4siENL9LkEvfu8fIrVJpJmkQf06wlvA9RvRsLSnhsNHT4pZ2rWJFKmlIq3AG1J5l2TEk5t/bUpga5MGMakUPStpeVUqFX74aaXYsCVV2f2/vQRerYY3VtbwVhSIzBunQZsbs+COs4lFZtvvKvP6NGovsml8AIXAgSNGgBFgBMxBwK4Cr7Ozk/DHS2YNxHSLZo2QmSW7+6EyB9sjENTpDqjUTiAXSnkZKTZnoHXL5mLO02cs+9pWMWdobUFzBsInX8JI7eoBF58gwXdlI2cvf0DCPz8zBYV52ZUlZ/b4Jo0aCLdKtFnrvQ+/NHu8NQYkJCYLsuQzWGRsFIWHyRreqGiy24VR0wUnN194BDQtkyPlsIkDsfLXrbn2uwrx4o1rh5UqTqshArwkRoARsA4C8jewdWiXS9XTw1308avljT/+3AQycUhOSRN1HNkHARcvP/i36gcUFSF+7+82Z8JaB1AcO3FGrMWSAm923CVBU/GRKgoWiNwD6ggquXYwa6CJZz/7KCX4bskKh9DyJtjBLRkBoNXwamx4a9Xvi5A298LVpw7Uzu7wDG6N+r1mS3kP6l5qSNKcrrbuWKJwU9Wja4dS+5bV4BHaBOSTl+6L3JvxZXXlNkaAEWAEGAEDBOwq8I69cxBSUtPw8LRx2LBlD5asWIuZU8YYsMhFfQSsXwruIm9ei7WDt4bIFrK27PTZ8xZdqKLhbWNBDa9izuBpIZdkyoJdNZ4acpJjlCqbpqTlvWvEEOTl5eF/n9n3IBjaHBYXL586Z2sNb1hYsMBd0fBSIbjlODS7fSEiR/+KRre8Kwm9rai61ECCKZk0FKldcCC6UNjvOjs7l9q/rAaVWg0frXuyQ2V15TZGgBFgBBgBAwTsKvDe2q87/Hx90KRhPXz63ovCRVmHtpa1sTRYLxdNQKBWRE/pFX0gcpOjkXbJtj+siobXkiYNhYWFoCOLVSoVWkXKvn5NgKHcLlmxl0QfDwu5JBPEpMjNP0yKgRw7aXhp8pdmPUIJFi1ejgSNSYGosHGUlHxTzEjCrkqlEnlbReG1ZZMG3eOFzZ07+cRmMeR6YRDyC4G+vbqJckUjn4btxVC24xUwAJwwAowAI2AiAnYVePMLCrDnwFF8u+Q3fPXDCm0wkXfuZiUEVCoVQrqOFNTjbLx5TfHFSwKqYMAC0ZlzF4W2slmThtIrZVcLUJRJZCoeGkIayxUWit387btxjZYRGdEUw2+/FdnZOfjws0VUZZeQYCdzBlpsSFCgcCGWIAn8+fn5VGV2SD65RYz571ymSPv1rpzA66tsXGNPDQJPjhgBRoARMBUBtakdrdHviRfexeKf1yArx2qbc6zBdo2gqZg1JB75BwW5WTZbc6MG9eDi4iL8wFrKU4NizmBJ+10CJEtjw+thYQ2vq2LSYEcNL63v1ReeAJkULPh6Md7/5Gv8vXErSFtObbYKCXYUeFUqFcJCg8VSozSuyUTBxKggNxs3z+0VvVcdiJIetlzQpWNbUa5o5FWvNWhTY2b0WRRkZ1SUDI9jBBgBRqDGIWBXgTcmLhEL3p+NR6aNx4wpY7WholchQdLEPPrc27j/sVfw0hsfIyvbuCB95PgZTH30ZUx66CV882PxqWKljU9OScWslz/AgDunYd4n31WUvSo1zi0gHL5NOqMoPxeJh9bblPdWLWSzgzNn5WN7Kzv58ZPyCWuWPFK4ICcTeanxULt6iAMBKsuj7ng3jcBLm5N0622drxMeBk9Pd0k7no95Hy7EXRNmYuDwicJPr614SdAKvP62mlJvntphIaIcrdm4JgomRjdPbweKCpHj0wCpOUDvHl1QUftdZUq1ixu860RKdIuQfvWYUm1iyt0YAUaAEai5CNhV4K0dGoTUtHSLof/xwqXo3rkdvv30dfj6+mDpij9L0CaN1SvvLMBzj00F+f3dtG0vDh09JfqVNf72QX0xfdJo0a+mRPYya1A2rp06axnXZIqG17Ib1mTePEIaWfx2cNUIvPa04aVFrVi1DllZkqRGBU3Yu/8wNm3dpSlZP0lIUFySBVh/MiMzhIfJdrxROscLG+lmtCr5hGzOcDJV9uJQWftdZRJv7cY1dk+mYMIpI8AIMALlIaAn8JbX2dLtD0y6C5Mfmo0Hn3lDL1R0nh17DmPYoD5i+LDb+mD7npIbrs6cvyxprTzQMqIJnJ2cMGhAT2zbfVCMKW28v58vbunTFR4ebqJfTYn8Ww+Ak7sXMq6dQFb8FZstOzJC9tRwxkIC77GTZwTvrTU+fkWhklGWYr9roRPWdNlRbHhzkqNBD2i6bbbMnz4nC/WGc1rquhjSNVZOSJIF3tCQIGPNVq8Lrx0i5oiJNc8NWFFhART/u78djBU0+vXqKtLKRr6NeONaZTHk8YwAI1DzELCrwPvZN8vQrEl9jB99O6bdO0obKnIZMjKzoFIB/pJwSuPr1QlFfEISZfVCbHwS6mjcDVED9YuNS4Sp42lMTQn0+jSo4zCx3Lhdv4rUFlFkc1ngPXn6XKWnS065iRtRMeIhh47OrTRBDYEsK3loIPIqJ2fhJQOS0JSflkhVdgktmjUxOm9Ec+P1RjtXsjI+QV5/gL9fJSmZPVwMCAsNESndQyJjYkTeTQpyMuDsG4Ltx6/Dy9MTHdu3NnF02d28G8l+fNOuHEVRYWHZnbmVEWAEGAFGQCBgV4H3Zmo63p/7DPr17IQuHVprg+DMSPTEi+9hxlNzS4SDGpMEtbp4OSpVcd6QlEotScbayuJ+po7XDpUymZkZ0A+ZIK2cfp1hn6pT9mk3RFolELdvNTLSbhqs1TrraFBf9lJw8sy5MufLyclGdnZ2mX32Hzwi+G/bqkWZ/cy9XunR5wVdJ79wi9JV+CBBiSa4GXPJKvSVecpKhw3pj/r1wokNbejcsS26d25rM55i42TNqo+3p83m1MUkKLCWWPv1qCiz5o8/ulGMi3drJNJundshNzenXBqm3NN5Khe4BdYV9vVJFw+VS1N3PZwv/s7Kzc1l7Er8fhXjY6l7xZR72lJzKXTEh44jCyJQPUgVS3t2WE/jBnVw7KTpWry35jyG+W/MKhE6to2UNCgeKCgoRG5enlhJYnIKgoNK2v2FBgcgWec0tySpX2hIoMnjBXGdyMPDE/rBAyqVyqDOsE/VKQc0bAPPOi1QKGmrsi/utcm6WraIEJ4arl6LgpOk7dTHtxg7V1c3uLm5lcnTuQtXxNVq2zqyzH6lzVFafW6CTLdW3RYWpaudL0AWNFVZKdahX+K+LcZV4SE0JAQHtq7FT99+BBdXF/Eg98sPC+Dt7WMznpI0fnjrhNe22ZzK+imtX7euuH/oLRCVTQ2ptGFNGrknRn647t+3h0n8m3JPEw++Gi1vbvQZk+jSGA769zh5g2FM9DGxBh6m3tOWnFv66PF/RqAEAnYVeMm8gDS2E2Y8D1073hJcaiq8vTzh4+1VImia0bNre2zYLG+o+ee/nejdTbZ1I3OF46dkwTqiaUPhSP/ajRgUSK8DN27Zg97dOwoSpY0XjaVEKpVKCLgqVXFKXVWq4rJKVbXzIZqT1+L3/VFirSqVddbWUmPHe/L0+UrNeeKUxkNDy4hK0VGpitdZVJAPsq8l0wP3oHoWo6tSFc+hbFzLvRlrFfoqVfFcKlXpeU9PD9w5bJD0Weok+Niz/5BIVSr9MSqVdcqKl4bgoECbzqtSyeupEy4fAhIdE2fy/NlxF8WhLc6etfDrdvn+69+7u8njVSp5bpWq9NRHs3Et/fIRi9JVqUqfU6XiNpWKMVCpHB8D+g3mwAgYImBXgfeRB8bhk3dfwFMPTdLa75ItryGTppaffHAi1vy9Vbglu3otGhPHyvan1yXh9o0PFgoyKpUKc194GC+//RmmPjIHnTq0BGmIqbG08fkFBegx+F7hkuy3dRtF/sy5SzSkRoTADkOhcnbFzbO7kZuaYJM1Fx9AIT+oVHTSY1bZsHZBsOMRatkDJwRRTeTmLwtauXY6XljDhjbp0qmtyO/ZZ1vPAFovDUH+Yn73vdQUAAAQAElEQVRbR4pbsutRph/znHxiq2DTvVEXXLx8TXp75Gkx+11BWIp8GskP86kX9ksl/s8IMAIOhACz4qAIqO3FFwmRi5b8prXbNcWGtzxegwL98cUHc4RbsrdffgIe7u5iSESzRli+6AORp6hd6wh8v+BN/PjF23quxkobT94cdv29BLqBaBKtmhCcPbwR0OYWsdT4vb+J1NpRZEQzMcXpM7JwKQoViI4ePy1GtYpsLlJLRFmKh4YQawq8tQWrpEkWGTtHnTq0ERzsPXBEpLaKYjQ2vHTqma3m1J2nli+Zb7gjKysbaekZuk2l5hV3ZOezZSG9T88uQgtb6oAKNLgHNwRpkPMzbyIn8XoFKPAQRoARYARqFgJ2E3hJiHR2di71cIiadRkcf7WKT97YXb8KW05rcxyp8QRw6sz5Ck91/uJl5OXloVGDevDy8qwwHcOBWoE3tKFhk2llE3q5OogvXoXVLhqB9+CR4zY7bS3lZqqY3t+vlsUFRkHYxCg8LFT0jIqOFWlZUV5GCtKvHQeZu/x7Kll0tZT/XUFMJ/JpKGt50y7bVuuuwwJnGQFGgBGoMgjYTeAlhEjoHTt1Ft77+Ft89cMKbaA2Do6FgG+TznD1r428tESknt9rdeaKD5+ouMCrnLDWulWERfnNUlySWVPDqxF4c+18vLACnI+PNyKaNUZ2dg6OHDulVFs1Vex36c2LVScqh7hi1kB2vOV0RfKJzaKLb9Ou2LRDNjfo27urqLN0pJg1pF22rdbd0utgejUbAV49I2ArBOwq8LaMaIQRQ/vB38/HVuvleSqBgKLljd/7RyWomDa0SaMGwlPD5SvXQe6DTBul3+vYCdmcgVyS6bdUrpQVJ9tve1rRhtfZyw8qZzfQK+vCvOzKMWyh0d06txeU9uy3jUYxIVHWkAYFlvS2IhixURSuOXzCHIHXuV4HXLl6A16enmjfpqVVOFU2rqVdss31sMoimCgjwAgwAjZCwK4C74wpY2Es2GjtPI2ZCASTtwaVCknHNiI/K93M0eZ3byFpFAHgRAUPoLDGhrXC/Dxkk82kSg23oHrmL8qMEY63ca2d4H7vAdsIWPHx8qET5KFBTGynSNHwRsWUbdJQkJstNnYSm3tjnChBvz7drGaO4VVXEqTVTqAHsILsDDEfR4wAI8AIMALGEbCrwJuckoqlK9Zh9pufiPDTyvWgOuOscq29EXD1DYJfRE/QsakJB9danR3FrKGiG9eOaz00WM6kIZv87xYVwiO4AVSSsGFNENz8NRvXHMSsoVtn+YQvW2l44xPlkxKD7OShQbm2ig1vdEycUmU0TT23G+SyzqtuJDbvk80++vXqZrSvJSrJTtingbyZMO3SQUuQZBqOjgDzxwgwAhVGwK4C76vvfo7NO/ajY7tIETZt3YO5876s8GJ4oPUREFpeaZq4Pb9LsXX/t2jeVExQkY1rGRmZ4pWyp6cHGjesL+hYItLa74Y2tgS5MmloN64lR5fZz1aNkRFNhA9sMjNRzA2sObcyR7CdTRq0Gt7osgXe5BNbBBz+Lfvh3/+2i3zf3tYTeGmC4o1rbMdLeHBgBBgBRqA0BOwq8JLLoS//9zJGD79NhC/nz4E5/i5LW1QNrrf60v1a9hXukLJiziPjuqzFstakLTWHT5w6a/7GNcWcwZLuyGidWYpLstBGVLRqcHOwjWtqtRqdOyr+eA9Zde1EPEHR8NpZ4A2vHUrsIDq2dIG3qKgIySdl/7uZfs0RF58Av1q+sLT9uGBEJ9IKvGzHq4MKZxkBRoARKImAXQVe+gE1ZEmtVhlWcdmBEFA7OSO483DBUdw+625ea6EIvKfNF3gVc4Y2LS1nzkCLJntJSj1soOFVBN4cBzFpoHV37STb8drCrMFRBN7aoSG0dJTllizjylHQBkMX3yDsOCMLxn16Wcc7g2BGE/lojhhOu3pMmFNoqjkRCHDECDACjEAxAnYVeNu3icTDs97UuiN7aNZbUPx9FrPIOUdDILjbKMFS4qH1KMzLEXlrRI0b1hOeGi5duWa2p4ZjJ84Illq3tNyBE0RQq+ENsb6G19U/jKaEo5y2Rsx01Xhq2GuDAyi0p6wFygc40Pz2CHXryNeBbHhJk2uMh6STsjlDQOtbsG2n7LbPmva7Cg9O7l7wCG0CFBYg49oJpZpTRoARYAQYAQME7CrwPvfYVAwf3A9XrkWLMPL2AXjmkckGLFqvyJQrhgBt2PJu0Ba0M5w8NlSMSvmjnJycoJxod+qseSeuKRre1hbU8NJmvay4y4BKDffghrD2nyNqeHt26ySWve/gEasfQKHV8AYFiDntFdEBOQH+figoKEB8gryRzpCX5BOyOYN/y77YtGWXaLbWgROCuE6kuCdLvWwb7xk6U3OWEWAEGIEqg4BdBN63//eNAGjtP1txhyTwvjXncVAYNqgvjJk5iM4cORQCIV3vFPxY2yevduOamWYNRzU+eC3pAzUn8RpQVAj3wDpQO7uI9Vsz0m5aS4lBaZpFa85vjLavjzeaNm4oDqBQMDbWzxJ1ipcGe29ao7XUDgumxKgdb05SFLLjL0Pt4oY4dbDWfrdVZDMxxtqRT6P2Yor0yh1AIWhw5JgI5Gck4/o/C3HmuydxaeXbYN/LjnmdmCvHRsAuAi9tKMqXtCV//rvNsdFh7kpFIKDdIOkH3h2pFw+AfvBL7VjJhkiNHe9pMzaukReBzMws1K1TG15enpXkoHh4lg1OWCueDVA5OcPFJwj0ujo/LQGO8qfY8e6zslmDok0NC5WFTXuuPzxM3rhmzI5XecvhF9kH23YeEGz279NdpLaIfBrKdtV84pot0LbDHIUFOPnFDNzY8DVSTm1H3J5VUvkBpF89ZgdmeEpGoOoiYLrAa8E1DrqlNwaPnokjx8+gx+B7SwQLTsWkrISAk6sHAjsMAf3F7f2NEquEyIgmgu7JM6ZvXFPMGSy/Ye2y4MXDBh4axERS5OYv24/mpJR96IHU1Wb/u3WRNYrW3LiWmpaOvLw81PL1sdrBDeYAprgmIztew3HJGu8MAa36Y6tiv2tld2S6PLgF1BEPRrRpjjTNum2cr/oIZMacF4eLGK4kft8awyouMwKMQBkI2EXgvW/Cndj4+zdo1zoCu/5eUiKUwS83ORACWrMGK37xRkbIr4XNOXyC3iAQTG1aWdhDg9YlWWMib5Pg6mCuyWjRXTSeGvbut57vV639rp1dktF6KWhdk2kOn6A6CvmZKdLrZdlFm19kb2zZvoeqYSv7XTGZFClmDfyqWwKjmv0vTXOffu14NVspL4cR+D975wFYRdG14ffe9Ep6oSa0BAi9Coq9on72BiriBwqCYENUUBBBUSwIiqAgithQrJ8KP6j03ltCCYFQ0gvp/d+ZW0jPTbK3JS9kZ2ennDnz7Cb33NmZM+YlYBWD19ClT96dZojybIcEPNt2h1tQOIqU1+0Z0TpH+2p3o0N4Wzmvuz6eGgwjvGouWBP9yk06JU5ws4BLMtmQErj4hiohUGAjm08IZcTIuaurC06eOg0xEivS1D5S9IvDrL3LmqFfNY3wilfMoox3h344EZ9knL8b2Vn3ZkLkWeIwGrxxXLhmCd6WaKPoYgrifnpLOeYozZUpR8Wf3HMxOLbsuWpHfyuW5BUJkIAgYFWDd9O2vRg9aQauuOXRCtMahGI87INAoH7xmrl2XhOeGsS0htLSUkQfjzUJyqEjx2Q5tQ1esdmGEOwm3ECJiAUOZx/d3NGCjAQLtGZaE2Jhaf8+unmjm7ftMq1SPUulpKbLGgGVRnhlohWCUL0v3guVRnjTjLurDcWGzbrR3WuvGmJxDb3CdNNMLp6iwWtx+Co3WJyTgTO/f4C9b/0HiVt/gMbBCcIrjsbR2diSi1g46+qB9CPrceDd+xG78nUUXUw25jNCAiRQlYBVDd4lX63C8+Mfxb+/f15hWkNVNZliqwQC+t4KjdYBGUc3okj5Q20OPQ2eGkyZ1lBYWIgTsXFwcnJCpw5hqqlTkHpWOvYXI66W8NBgUNzgmsyWfPEK3QYa/PHuMo+BlazfZc0WPDSI/rYMDRanCptPlBYXITNmi0z3FfN3N1vO/65stFzgHtoZwiASz6m5fg/LNceoGQiU5GUh/q+PsPfN23Bhw1coKy1GYP/b0WvKz+j21OfoN+NvRD29HH2m/YVeL/6CPi//jtChI+Tf3+SdvyoG8h2I/3MBSvKzzaAdRdogAapUTwJWNXiDg/wR0TEMDlqrqgH+azgBJw8f+HQdqvxxLkHKLvMsojC8Hj4ac7xORY0bTnTpLKdC1FnBxAJ5SXGypGtQuDxbKnDRz+EtyLhgqSZNasfgqcFcC9dS9AavzYzwhuh2W7uQmGTkc/HEdoiNV9yC28PFryX+Xq8zfodacMGaQRmN8jfUK0w3ypsVu8eQzLMdECgtyMW5tZ9JQ/f835/LZyqg7zD0mrwK7e99FYZ5/FonV3i07gLpuUXpl4ObN9reOgm9XvwJYuChrKQQ5/9Zpsi5XWcwlxQppfhDAiRgIGBVS9Pfzwerfl+L7Jxcgz482yEBw+K1pO3m8dbQNbKTpGLK5hOGBWtRZtphzV0xbqQyFgoMu60VpDdgSoMZdRzYv7eULgze0tJSGVczMLgkC7TyphOGPgUHBcio0Ku4uFjG08ttNnEk+jgyMi8iKDBA1TcLsiETg0vuycwz6m6iGixmIoHSonxc+PdLxUC9DWfXfIKSghz497oJPV/4ER3un6F8iWplkiRhEHe4fzp6PPc9xMLJkryLckrEvjl3ImX3/4CyMpPksBAJNHUCVjV4V/22Fu/MX4br7xrDObx2/KS16DxYGXXwR37KGWSbwfm9cYTXhM0nDuo3nIhScYc1cWvykmLFCW4WdEkmGnR091FeVbtAfIiJD0iRZgtHgL8vwtq1lhtQHFaMPbV1srURXo1Gg8oL19KP6ndX63YlNuinM1x1xUC1UZgs79LCNfN5zzBZGRaskUCZMvKasOlb7HvrPzjzx4cozs2EX4/r0PP5lej40BtwDWhTY93aMtyUt08Rj32AruM+g0ebbijMSMDJ717DwQ8eQmbM1tqqNos8dpIErGrwVueSTKTxttgXAfE6NbC/bue1pJ2/qK68mIsrFkrFxp1BYWFhrfLNtWAt17DpRHD7Wts3R6aLn+15ahD9NMzj3WkG92SXvDT4iaZs4jAYvOcvJCHn7BGIVfSO7i0U4yLKaPBa2h1ZeTBySoNimOeci5avxcvnMW59AmWlxUjavkoxdO/A6V/noigrFb5RV8uR2U4j3oJrYJgqSnqF9ULUhC/Q+dG5cA0KQ+6F44heMgFi84qc8zGqtEEhJGCPBKxq8NojMOpcPYGgAXfIjNR9a1BSmCfjagUODg6I6NQepcqr85gTp2oVa3BJ1rN7l1rLVc2sPSXP6IO3Q+0FzZBrmMdrawvXBvTVzRkV0xrU7naK0UuDr9qiGyzPAf6T9wAAEABJREFUsHDtQmIS0g3eGRSDRaPRYP2mbVLulVaYvysbVgKtkwvcW0ZA7MzHXbgUILbyU1aKlN2/Y//bd+PUj7NRmJkIny5XoPuz36LzI+8ob43M8yVaLKTs+ex3CL9nKpy8A5F1ag8OfTAcJ1a8jIL087ZCh3qQgMUIaC3WUrmGnnxuJk7GxUOcqzvKFWXUTgiIRTvCF6l47Z62b7XqWncxbDFcy45r584nyHmUIUGB8PVpoZoO4gOqVDHinbwD4ODirppcUwUZDF5bck0mdDeM8G7fpdt4QaSpdSTrF60F2ohbMtGvUL1rsuT4k0jduxplZWXw7ToUYt54hn7+bvuwtqKo1Q5vZXRPNJ4Vx3m8goMlDzE1IfaHN7DnjZuwe/p1OP7VFCRuWYn9c+/Dye+moyDtHFpEDEb3iV8h4rH34R7S0fzqaR0gBiN6T/kZbW4eDwdXT6TuX4P9c+5C3C/voDg3A8KrQ6ryN1t4hrh4chegPNcwv2ZsgQQsTsAqBu/jI+5EcKA/xLm6w+IU2KAqBMQfViEoaccv4qTqYTR4j52sUa4wPERmlOoL1nSjym5B7YV4ix+XFq7ZlqcGMYru6uqC4yfjoPYGFIlJKZKzrSxaE8q0CfbBO9e7oMepJchPOwtlYBf5qfHYoN9d7dqrBotiVj08w3T+kbPMMJfeqh2zg8bj//oYyTt+hpjqIgzJtANrEffzWxDbPbfoNBBRT3+JyMc/hHurSIv3RuPogpZXj0Tvl35F6JUPA1otEjd/h72zbsWemTfhxNevyIVuRxc9KQ11iyvIBknAAgSsYvD27x0FTw93iHN1hwX6zSYaR6Da2n7dr4aDmxfE69T8pLhqyzQ00bBw7UgtC9cOHdHNT+veTd0PlDx9X9xDrGPwuvi2lNgKM5Pk2VYCMa+6T88oqc7WHXvkWY0gJzcXRUVF8m+Es7OzGiJVkRHhcA59WzqWk6VB/B/zsWvrJplmzfm7UgEl8G6v856RHXdAueKPJQlkRG+upjkNuj65CJGjP4JH667V5Fs2SboyGzYRvV78GYH9boN4IyeO8lqkHVwn/apXTi9fhnESsEcCVjF47REUda6bgBhFCOh9syyo9uK1SyO8J6T86gJzLVi7NH/XWgavbtFaoQ1tL2zgb/DHu3O3ep4BUlLSpfgAK7okEwuKsk7tRdL2n+RK+pilExGYuFHqVT4oKylGQvQumXTlEOt5aJAKKIHw0eri1wrCxVVuQs2/K0pR/qhGoBZBGi289NNMaill8SznFkFof99r8O7Qv9q2Yz5/BjtfuRy7pl2JA3PvRfRn4xG7cibO/d9iJCmj2JnHtiEv8STEdIhqBSiJhRkJcrT44OxhODjndsT+8AaKczOVHP6QgHUI0OC1Dvcm22pQ/9tl35JV3oSic8dwiBHFE7GnUVJSItuoHBhGeKPUdklmWLAWFF65SYtcO/sEy3YKbNDgHdhf/YVrySmpsr+BAf7yXN+gOCcdZ9csQsznk3Dqx9nIOlXzfFaxgl28ej63bglOfjMNhz58BLtevUp5zXsjjiwcrdSfJX2lytG74oJqVTmfno82rVuiXdtW1eZbOtGrXQ/ZZG39lgUYqErAxb91FXktOitfgrQOVdJtJcGzbbdqVXHy1HlHEV+c8pJOQRi4yTt/wVnF4D2lGK7CABZbGovflZ3ThmL/3HsQ/elTiP1+BsTvnviiePzLyRC/W8W5GXKah5juIaZ9VNsgE0nAAgRo8FoAcnNqwr1VJNxCOqI4JwNpB/9WresODg4QRq/w1BB9LLaK3MLCQkQfOwmNRoOukeouBjG48nG1lsHrHST7W5CZCLFQSl7YSDB4YD+piZojvMn6BWsB/g3w0FBaohiqY3Bu7afKa9lNygjtKuX6v0jY/C0St3wPsVBHfFjvnX0rtk/uh4PvPyhHoc6uXoiUvX9Kd2Ni1Mq5RTBadB6EkMsfRPjdL6Pr2E/R6oE5sq/lgzwnX8Sml8IWRncNenmF676E0OA1EDH/OfvMIYgd7sqUphw9WsDR3QfCt277u19RUmz3J3jQ3VLX8hr6db8WfV5dg4FzdqLP1L90Ls4eeQftbn9ezv/173UjxDMmplppHBwhdooTU9gyj2+HGOgQv3vCKM6OP1xerIzLL44yxoAELE+gSRm8wpXR+MmzMWrCq3h55jzk5edXS3T/oRiMHD8ND499GZ8t/9FYpqb6ew8cxZTXP8B1d47GfydOx/otu411GKlKIPiye2Ri8s5f5VmtwDCP92g1WwwfiTkhjcFuXTrJkWC12hSjhcJDg6OHL8Q2ymrJrY8c8aHi5B0I4W6qOFs3+lmf+uYsG6AYpWJ0Mys7B2K3MTXaEr+HQk5gAzw0iNf4YkRK1C9/nP7lHcT9/LZcqCNGq8TrVpEvRuWEiyixoKfDfdPlh3v/mRvQ+5X/IfK/C5QP+ecQNPAu5QO+N1r3uQ6TVhfgt+gieHW+DK2uG42lZ9uhFBoMvXyAEGcTh1e4fh7vafWmmajYsSYnSixSO/bFc0BZKdoNm4i+r61D3+lrIXzrOvuE2HR/nX1D0WvKz+j40Cy0vXUSujzxidRbKq0MHjh5B0BsYuEbdbXy5e8BtFX6J8p2HfsZer30Kwa8uQ19pq1G1NPL0fnRuQi7Y7JcHBfQ+yZotI5SDAMSsBUCTcrgnbdoBQb164ml81+Ht7cXVqz8owpnMUL26psfYfKEkfh8wUz8vXEHhEErCtZU393NFc+PH4nVPy7Cow/cjlnvLhbFedRAIEAZAdA4OiMjepPyKiu5hlL1T+4a2UlWEiO5MlIuMPf8Xffg9uVas3zUxU+3cM0mpzX06yWBqOWPN8U4wqt7rSqFmxjkJcVVW9LB2R1ixK319WPQcfib6D7pawx8e5dcvCNcRAmXTQH9bpUf7tpaXM9luYTi/e2FcLzqWbRSZP21QeeS7bqrhlTbrjUS3YLby8Wj4lkpuqje7581+mIPbR774nmIOd/i+ZIeEOxB6XI6Cldl/srf7NChI+DdoR+g0aA+/5y8/OHRuguE39/gwfdJ92cdFAO6RcSgKmJ8Im3n96SKckxo8gRsz+BtBPLN2/dh2A1XSAnDrr8Cm7brPoxkgj6IOREHd3c3dI3oAEcHB9xw9WBs3KZbYV5T/YhO4Qjw84GDVovLB/WWK8hrGj3WN9OsT8JTg1/3ayQD8YpLRlQILo3wnqgizVzzd3P1O6y5BodXadOSCS7KK3bRXmFGojjZ1KH2wrWUlDTZv4AGjPCKD2yN1kHWLx8I41SMuImzf8/r4d6yc/lsk+MtQ4Nl2QsJSdi7/zCER4nwdm0QHKSMwMsc2wi82vWUilw8VfVvoMxgoAqB2O+nIzv+ENyCO6DD/dNVkdlUhITf9RLElwAxvUOMFAcOuANtbhrXVLrHftghgSZj8Obk5skvpr4+3vI2tGkVjGT9B6dM0AeJyWloFXLpw0mUS0xKVT64TKv/0+/r0LF9O7i5ukqJxcXFqHyIjMppze3av8+tAgMSt/1UhU9DWXRsHyZlHo05IWWKxWviEPIOHo6WeV0iOso8kabGkXPhuJTrEtBWVbn11c1RTGlQNMlLOWsVPcTc6Zp07te7u6IZIEZ4aypTn3TD762vr3e9+1qqdYLGSbgyE7MppVrwUkat/PreVm9Z1ekcEqz72xF/9jz+2bhVNnDF4P6qyBbtiedZHCIujoYeHm119yTz5G7VdGuoLg2pd/FsNKKXPA3hJWDfm7ch7tf3UJSfo2pfanumTdH5wqZvkbzrd2hdPNBhxByUahxV1c8UHWy5jNYzAOEPvIGuL/6Krs//hLZ3TAGcPSzCSP5iMiCBSgTsyuCd+NIcjHlmRpVjz4GjsltaZQRWRpRAo6m5axpt+Vc2l8rVVf/A4WNY8cMfePWFJ5QWdD/iw6nyIXIqpzW3a/ew3nBuEYLC9POI+3kOMk/slN4VGsOhU4d2EPfo+Mk4FBYWQnxglZSUSrl7D+gWSHTp3EFeN6ad8nXz9CO8LgFhqsot34YpcSf9CG9+RoJV9NCxLqm2bTFv2tHRUS4aTM/IrLaMKX00lEnWe2nw8/Wpt6yzfy1AaUEe3EI7o/OTS9Bt8i/oMHIe4ORWb1kGfcqfQ/VflsX2whs37xC/6hg8sK8qskU7Os66Z1pcN/RwaxMldcs+fVA13RqqS73rFRfh1DdTkRmzBcJLgJiakbjpa1zY+I2qfdGxrv6ZrkvnzBO7cObXuZJx+P0z4egTqqpudbVvT/k6zo1/puvTZ3ljGDQ1Ao3uj7bREiwoYNbUCXh35vNVjj49usDDXXyglaKwqEhqlJqegcBq/HgGB/ohPSNLlhFBmlIuOMi/zvpi1GnBZ99gwdsvoU2rSwsRXFxcUPkQciunNbdrTW4ainLSAY0GqTt+womlE3Bm5WtVWNWHi7u7uxxdF39A486cg5OTE5ydnZBxMQuZmVnwaeGNdm1bN6qNyvoUpJyG+OfdqpOqciu3U9e1e0AroQZKLiZZRQ9h0Nako6enJ/r2jpL67T8U3Wj9UtKU50aR1io0pF6yipNjkbJ9FaDRouODM+Hbvic8FW416d2Q9NYtQyH+JSalYMt23VSo66+9ol561tau4ZmurYwpeb7tewFaB+QlHIdjWbFq+pnSdmPLIC9d7k4mOJc/sk/uULUftT3TtfVBU5ClGOQvS9XEK/qAqKGq6lVb2/aYp9YzXZ++y5vDgAQqEbArg1fszubl6YHKh6FPgwf0wtp/da8Z1/yzBZcPVP7oK5liusOho8eVGBDRMQwpqemIP5eAktJSrFu/HZcP6iPzaqovyr8yaz5efmY0QvWvNGUFBjUSSNz2I8oq+S0VPhnFNps1VjIhw7BwLeb4Jddkh48ckzX79NIZXfJChaAkL0suRhGLOpz0UwpUENsgES763dYKbHAOr+jQwH46zwA7VdiAQnwJFTKr+8Iq0ms6Yle+LrNCLn8Q7iEdZVztwDCH9481/yAnNxedOoQhxMbm74o+a51c4Nm6K1BWBrHzoUiz96OstMTqXRC7j8UsmYCSvItykVbLa0ZZXScqQAIkYBoBuzJ46+rSpCeH47fVG6RbsjPxFzD83mGyylnFuJ05d5GMazQazJgyDtNmL8DIp6YqI1NdIUaIRWZN9Vf+sgYHjxzHg6Mn47IbR8gjQRnhEXV4VE/AMBWgcm5eDavoK5er6dqwcK28C6wD+vm7BmO4prr1TTe4t3IL6VDfqqqXd9G7NyrMSFBdthoCDQvXtu9s/CKppORUqVJQoL88mxJcWL8cYhMJ4T+3zU1jTanSoDIh+i+8p5U3DELAFYMHiJNNHl7tdV9CsuL22aR+NSkl3ABqNNoq2XkJsdWO/FYpaMaE2B/ekM+Za1CYfItgxqYomgQaRYCVqxKo+lelahm7SQnw98XCuVOlW7LZ0yYaF5YJLwvfLdHNtxKd6RkVgWUfvYHlC2dj9LbtlDUAABAASURBVMN3iyR51FR/7Kj7sXX1VxWOkKAAWYdB9QTcavBq4KZ8UFRfw7RUsShNlBQL18RZHIeOxIgT1N5hLTfhpJTrFqhbLCcvrBQ4uHlB4+git+YUo0xWUqPGZg0G77ZGGryFhYXIzc2TnlScnZ1rbK98hhj1jl/9iUwKv2cqtE6uMm6OIDQkqILYoUNs2OC1wx3X8hJjcWThGJSWlcLJwxcOLh5wVt6uOLi4oyT/Ig7NfxQXT+yqcA8sdXFhw1dI3fsXtM5uiHjsA3m2VNtshwRIoPEEmpTB23gclKAWAbGDj4ObzmOGQaazTzBcG2k8RnbWvaou74v30GGDwdvZ0JQqZ+MIbw3GuyqN1EOIq8EXb9r5etSqqai66a1ahkAYg2IDivLTTerbipgbK+rUxyXZqR9myukzft2vgU/EZaK62Q5vL08IX95lZXK2AK67+nKztdVYwZ5huildWacPoKy0tLHizF4/5+xRHP5olPxS59ftKvSe+if6zVwvzz2n/AqPNlGK0ZuDo5+OQ/Lu/5ldn/INZB7fgTP/myeThB9nV//WMs6ABEjAfgjQ4LWfe2VXmjr7hqL3lF8gduVpfdM4OLh6oDAjEY19vdq5Yxi0Wi2EUSVW7ZYqH+TRx2Oh0WjQLVK3MYVaoMRok5DlFhQuTlY/nH1DpA6FNjqtYWA/nYEl3JNJRRsQiPnyopp42yLOdR2p+9dA7JwmRt3a3TG5ruKNyj8Tfx69Bt8inzXlcVPOwNMvTG+UTHNWdvLwUb5gtlO+DCij5ueOmrOpRsvOOn1QGdkdrRi02XJubKeH50Dj4GiUK/rSdexn8Ot5g/JNoxSx372GM79/oMSVbx7GUuaJFCi/b8eXvyDbErvr+Xax3S855iHQDKSyi82CAA3eZnGbrdNJ8Rrev9eNaHXNKLS79RmpROzKmcpoU8MXn4jX3B3C20IYuidiTyP6WKzcCKRzx3CIPNmISkGe3iWZe3B7lSQ2ToyLT6gUUKB8AMuIjQUGg7cxC9eS9busBZqw6URxXhZO//KupND2lglw9gqQcXMFn33xLYTbtfLyV/36F46dOFU+yabiXmG6DSiy4vbblF7llbl4ai+OLnoSYqqOMGilsat1KF9ExrWOTug0fDZa3/CEvBZTDGI+fwYlhfny2hyB0ClmyUTFEM+BT+QQubueOdqhTBIgAfMToMFrfsZsQSEgdtlxD+2E/OTTSNzyvZLS8J+ukbqpC2KU17B4rUdUl4YLrKZmSUEuCjMT5SiTs29oNSUsn+SiH+EtSLfNhWuD+usWSTXG4E1N1bkkM2XBWvwf81GUnQr3VpEIuuxes9+Q6OO6Od2VG4o5Vn165XLWuPYyTGuw0YVrYqpA9OJxyih0AQL63CLfCFW3U155dmKUtdPDb0Pj6IyM6E04vGCk8ruaVL6IavETX7+CvMSTcPFrBTGVQaPRgP9IgATskwANXvu8b3apdfjdr0i941cvRFFOhow3JOgS0UFWE/N4DQvW1PbQkJ+kG7VzN5N7K9mBegbONu6poXfPbhC+TQ8dPYa8vIaNuhk8NPj7+dZKJ+v0ASRtXwVotHJLV43G/IZIZCfdc4dK/yI6V59eqZhVLr3Ce8l2L57cLc+2FGREb0bMkgkoKymC+ELc/v4Z0GhMu49ivna3cUvg6N4CeQkncHDeCOk9Qc3+nf97KdIPr4dWLFIbNQ9i4Zya8u1XFjUnAfskQIPXPu+bXWrt2TYKgf1vR6kyeirn3zWwFwbXZNHHYnFYMa6EmO5dI8RJtcMwncHNRqYziI656A1esfOUuLa1QziY79m9C8SiroZ6a0jRT2kIqGbTGEN/y0qKEfv9DHkZOnS42XzuygbKBf999AH4+rQolwLcdftNENNpKiTa0IVrQFtpFBbnZqIg9azNaCYMyZhlz6KstATBg+9D+3ummmzsGjrh0boLoiaugJhjX5ydJkd6049uNGQ36iyM8fi/PpYyxMiuW1CYjDMgARKwXwI0eO333tms5rUp1ubmCdC6uCNl9+/Ijj9cW9Ea87pE6BanxSivmA/qN52I6tq5xvINychNipXVbMrg9dXN4bXVRWsCmGEeb0MXrhkN3lrm8Aqfu2JqjHOLION8TtG2uY+2bVri0I41WPbJXMx+bTL+XPUFln/6vrmbbbR8r/DeUkZWnG344009sBbHvnwe0Bu7YY1YbCim+XSb8AVadB6E0qICHFOM6Av/fin729AgX/licPyrKbJ6y2seAxepSRQMSMDuCdDgtftbaF8dcPL0RZsbx0ml5QI24d9JXpkeGIzbI9EnkJCYjBbeXmjTuqXpAkwoeWmEN9yE0pYpYtjtrSAzCWIU1TKt1q8Vg8G7a8+B+lXUl05Nz5CxwBpGePPTzuHs/y2WZcLvmQZz+tyVjVQKxPbV9945DBPHPQZb9sFbXm2vcN20hqxT1jd4U/b8iRPCmFR+70OGjkBjjF1DH8VUg8jHP4TYYU/5xcCZPz7EyW9fVezpYkMRk89i7n7M0okQm194dxyA1vq/VSYLqFqQKSRAAjZCgAavjdyI5qRG8OB74aq8IhRz75K2/digrncIb2es162LuqO7QrDRB6+NuCQTOmkcHCFGNZVPchRdTBZJNncM6KszrjZt3dkg3QxzeANqmMMb+/3rEHM+/XteD3P73G1QB2ywkldYL5Qp/zOPb5c+bq2lYtLOXxRDdJpsvvX1Y9Du1kkyrkqg0aLd7c9BrhNQ4il7/sDRRU+gOC/bZPHiS6QY2RVvD8QiNbkwzsQ5xSY3woIkQAJWI0CD12ro9Q03w5NYhd3+7qmy5/F/LlA+lLJkvD5Bl8iOxuLdu0Ua442NpB/+F4c+fMQ43zHzpHV2daqpH5ZeuJa042ccfO9BHJ51I8QuV4JPTbqJdPHa39/PB2IDihOxcSKpXkdKSposX93GE2KXq6zY3XBw9URbxbiRBRnUSSD94DpoygAx93v39Gtx4uupcjpBnRVVLHBh49c4tXKmlNh22ESzufcKGngnuoz+WHlGPJAdtx+H5z8CMUVBNlxHcG7NImTGbFHeGrggYtQ8OLp51lGD2SRAAvZEgAavPd2tJqSreM3q3/MGlORnI155BVmfrsWfPY/jJ04pby+VcSvl1eiBQ0eRpn8VXh85lcsWpCtyv3oJOWePGLPifpyN7NMNez1vFKJixMVXN3WjICNRRanVixL9PvXDG8hNOIHSonzkxB/GcYVPXXOIBw/qJwU2ZB6vcQ5vpSkNJXlZiPv1XSlXGEzm9rkrG2oCQc65aJxfvxwoN1KZuu8vpB36B5b6J7wdnPntPdlcW2VUN/TKh2W8ukCNNO+O/RA14Qu4+LdGfsoZHJo3Almn9tYqWnyRO7fuM1mmw/0zwEVqEgUDEmhSBGjwNqnbaV+dER9+Yg5m0vafID6YTdV+wvOvyZ3WNBqN8jmuwdYde/D6Wx+aWr3GcsJ1k3hdXrlARszWyklWu3bxCZZtF6ZfkGdzBtX1W/DJUkbOamt3QF/dZgf1NXgLCwvlyLDw9uDp4V6hCbGta3FOOjzb9YAYxauQyYsaCeScOVRtXrIycl+UrRtNr7aASoniDY7B24GYrxs6dIRKkmsX4xoYhu5Pfwmv8N4QX6qPLByNlBq2I85LjNWNeisiQ696BH49rlNi/CEBEmhqBOzM4G1q+Jt3f8R81FbX/VdCiFv1ljzXFZSUlGDd+i1Viv270XaM0irKqZjgovfUUGDF3dZKCnJq7ZFh4drOXftrLVc5M1k/nSE4KKBCllhsJaZWiMT29+rmgIo4j7oJOHlXZGmoIb7M7Hn9Bhz++HGIHcvE2w1Dnlrn08qo7vl/lklx4Xe/It2PyQsLBQ5u3ug69lPpClE0efK71yAMcBE3HOLNQcyyZ+UbDLFIre0tTxuyeCYBEmhiBGjwNrEbam/daXn1SIgFItnxh5C88xerqu8a0Lra9m1pcZSz3hdvoQWmNFTb77IyiBE7sQCqWlhKYp+eUUoIHDgcjZzcXBk3JUhJS5fFKntoiP3hDZne8ppRyqvmcBlnAMAECN4d+sHRw6dCSTGH3itMNwqfrYzWC5/Y+968HQc/GI5z65ZAjHhWqNCAi1Or3kTCxq9lTTFFwJqj8u3vfRUGQ1YY4EcXj8Xpn+YgbsWLOPDBQyhIjYf4ver8sGlfumWnGJAACdgdARq8dnfLmp7C4XfqfF6e+WM+xIhLbT10cHDAtVcOrlLkqisuq5JWnwTxuvzkd7rNDMTuTWKqhdhlLfyeqfI1en1kmbOsi2F74QzzT2kQ0wfcQjsBipGrcXCCR6tIhUV3FOdkIPrTpyCmGaCaf25urujdo5vM2b23+lfqMrNSkKwf4S3voeHcus+QnxwnvxS1vu7xSjV4WRcBscAvSnm1H6q8qveJHIKQIQ+g+6QV6PrUUvSb8TfEiHmLCN3vTu75GJxdvRAH3r0P+9+5W46GinnbdbVROT925esweF/p+NAbCOg7rHIRi1+L/nce+R60js64eHwHErauRNbxbTBMDer40CyIEWGLK8YGSYAEVCFgihAavKZQYhmzEhAfuD5drpCGVLzygVtXY/PnzpA7XAlvACHBgRg5/B68OqXhryLFHL+ji8cpIz1nIXTpO30d+s/ahO7PfougAXfUpY5F88VIlGiwID1BnMx6FKSdQ96F43Bw90bUtLWImvgVuo1fBsMXFLEBxMF5I+TCoMqK9G/APF6jhwb9gjWxM9jZ1Z9I0e3veQUaRxcZZ1A/AmKhoxjhFJ4H2v3nebiF6DycCAMvsP9/EPn4fPR7/V9p/IrfQyE9P/k0xGio8Myx542bIaYniKklIq+2Q3iASN75qyzSacRb8O91k4zbQuDbdSiES0RoNJXU0Sh/e3RvFypl8JIESKAJEaDB24Rupj13JUz5IBb6J275Hrnnj4lojYfYZELscHVi/7+I3r0WH703E36+PjWWry2jrLgAMUsnIVcx7MSIZudH3qmtuNXzxIid2KmuJO8ixBbN5lQoYfN3UnyQYhTJiD4Iuuwe9HzhB7gro7+556Jx8P2HIBZB6bPlyTCPd/uu2lfHy8L6wOihQb/LWqx+KoN/75sg5lfqizXwxGq1ERDPlTB+Ix57H/1nbkBHZWTWN+pq+SVD+HwW0xOOLPwvds+4Dqd+nIXMmK0Qvzu66RC3Yde0KyHmBKfs+0s20/nRuTa5+KukIE/qVznIS4qrnMRrEiCBJkZA28T6w+7YKQExj7fVtboFbKd+nmOxXhxbPgVZcfvkqFfk4x9CTGWwWOMNbMhV75qsMDOpgRLqribckBlG6oIH31OlglwF/8w3cncrUVYYp8eXv2ickjKgX09ZZ8euffJsSnDJ4PWF2Djg4sldymtmL4Td/rwp1VlGJQLiC5UYmRVf/vrNWIdOD7+tjNTeKH83xHQW4VUleskE7Jx2lX7B2wWIhYzC64OmrAwRI9+Db7cvt78jAAAQAElEQVSrVNJGXTE+kVWnQ4kWWnQaIE48SKB5EGimvaTB20xvvC12u+U1I+VOYtlx+6XBY24dT34zDRlHN8r5oV1GfwQxymXuNtWQf2law3k1xFUrQ7hwElM9xCtu8WWk2kJKotjdSrwqd3T3QdrBdTjw3gPS52n7sLYQU05S0zIQG3dGKVn3T0qq7rVysI+bfIUuarS77dkqi65EOg/LEBBfAP26X6OM+M6S03w6j3wXAX1ugTCKy0oKqyqh0cAtVDdlomqm9VOEIS6MeaMmGi2EqzSP1l2NSYyQAAk0TQI0eJvmfbXLXokPV2HgCOVP//ouSvJzRNQsx6lVs5Gy90/FmPJFpGLsOnn5m6Udcwh11vviLTCfL14kbPpWqh4y+F55ri3wiRyCHs99B68OfVGYmYgjn4yBmHs7qG8PWW2Hie7JklJSZfl2qZsgRhI923ZHYL/bZBoD2yDg2/VKdHjgdfSb/jcMc4FtQzPTtRDTNcQ8/Y6jP0G/1/+B8Aduem2WJAESsFcCNHjt9c41Ub2F03fv9n1RnJuJs/+32Cy9PLf2MyRtWyVHdLs+sRCu/tW7IzNL4yoIdTH64k1UQVpVERdP7ERe0im4BrRBi4jqXwFXriW+MHR9YpHO/ZPyWlt4VxjdLh7BnhqYugFFSmoaugdp4XJhtxTf4f7X5JmB7RHQODgioPfNVRRzCwqHi951XpVMG0oQnljcWnWBg4uHDWlFVWyTALVqKgRo8DaVO9mE+hEm3JQprxoTNn2jGF5xqvYsceuPOLvmE2gcneXIrj2OUrnoDQqDSyVVASnCDKO7wYPvU67q9xN61SOIenq5nCbiXZSEpbe7ofBk1Y1CqpOaoRi8Uy7XeWIQG5KIecLVlWOabRAIveJBOR1AfAEThqMY6e844k1A+d0F/5EACZCAjRGgwWtjN4TqAG7B4QgZcj9QVorYlTNVQyLmmMb9pHwgax0gfHJ6tummimxLC3HWG7wFZthtTchMP7oBWicXBDRwOoFH6y5yioNvr5vg5qTBI+HJOLbilTq9SlwZkIpQLy2clP6JTSbAfzZNQOPoIqcD9HrpN/SbuR5iLrfwXW3TSlM5EiCBZkuABm+zvfW23fHWNzwJsUNU9un9SN2/ptHKZhzbhuMrXpZyOg2fDZ/Og2TcHgMX/eYThWYweBOFK7KyMgT0vRWOrp4NxiPmY3d+6A18fsIPeUVlSN+/Gvvfux85Z49WKzM3KQ73RpTJvI73z4DYIEBeMCABErAnAtSVBGyWAA1em701zVsxB1cPtB02UUKQC9gK82W8IUF2/GEcW/YsUFqCsDtfgl/3axsixmbqOLUIlroUZCahTDFO5YUKQWlxIcTcZiEqWIywi0gjD+eOgzHqlzxkOwXIXa0OLRiJ838vBZTR+/KiY1ZMhYNWgw3nHODdoW/5LMZJgARIgARIoNEEaPA2GiEF1ItAPQqLFfoebbqhKCsV59d+Wo+al4rmJpxE9KdPoUwx5sS80ODL7r6UaacxjUYDZ2H0KgZ80cUk1XohfN8Kf6reHfrBPbi9KnIH9O2FxJwyfHquPVpePVIauvF/fYzDC0cj6/RBCJ+uwj1cwYWjyMwvw59JIaq0SyEkQAIkQAIkUJ6AtvwF4yRgawTC73pJqnT+3y+q3cJWZtYQiK1xoxePRUl+NoIvuwdimkQNRe0u2cUvVOqs5uYTiQZXZJc/IGWrERh2XNuyfS/a3DweXZ/4BE7eAcg+tQ+HP3pM7tol3MNplMa2nS2Gp2+gEuMPCTQPAuwlCZCA5Qg0KYM3JTUd4yfPxqgJr+LlmfOQl1/9a/D9h2Iwcvw0PDz2ZXy2/Ecj7ZrqH44+ievvGoPLbhyBR8e9gj/XbjLWYcS8BDxaRSJo4J2ykbif35ZnUwIxKnx08TiI3Z+Eq7Mw4fnBlIp2Usa4cE0lX7xZsXuQm3BCGTkOUnWXrE4dwuDl6QGxAcXpM+fg1b4vej73PRzdvSCM3Eu4NejXygEBAb6XkhgjARIgARIgAZUINCmDd96iFRjUryeWzn8d3t5eWLHyjyqYxJzHV9/8CJMnjMTnC2bi7407sPeAbiFNTfXbtArGqi/fx6Y/v8Tz40di3qKvajSmqzTYqARWFgTa3PyU9JmbeWwb0g//K5JqPUrysnD006cgRnhbRFyGTiPeqrW8PWa66H3xFqYnqKJ+wpbvpZyGuCKTFWsJBg/sK3MN/ngd3LxR3dRjfzctQv0avlBONsKABEiABEiABKoh0KQM3s3b92HYDVfIbg67/gpsUl6jyotyQcyJOLi7u6FrRAc4OjjghqsHY+O2PbJETfW9vTzlKJWDVosWiiGt0WhRWlom6zAwPwGxbW2bm56SDcX9MhdlxQUyXl1QWpSP6KUTkaeMVnq2jULnR96prpjdp7mIObxKLwoyLihh437EtIi0A2ulkKCBd8izmkH/vj2luB2798mzCNyCwsSpwpGaV4oWAZzDWwEKLy4RYIwESIAEGkGgyRi8Obl50CjvSH19vCUOMSqbnJIm4+WDxOQ0tAq5NE9QlEtMSkVd9cUosJjS8ODoyZg1dQI8FKO5vFzGzUsgaNBdcA0Kg3DFdW7d59U2VlZSjGPLnkP26QNwC26PiMfnQ7jHqrawnSc6++gMwwIVpjQk6kd3A/oOg/hyoTaagf16SZGGEV5xIRewaR1EVB7i6+NX+4sQ4M8pDRIIAxIgARIgAVUJ2JXBO/GlORjzzIwqxx7dlARotZe6o9FcilcmptEqlrEx8VK52ur37tFFTmlY8uEMvPPhUqSlZ0oJubm5qHyIaROV03hdlVN9mOTlF6Dlrc9L5uf//QIZF+KQr6Tl5+dL/jk5OYj+cjIyj2+Hk3cgwh55H4VlDjKvPu3YS9lS1xaSRX7q+Ub1MftiBhK3/Shl+fS7s0ZZhYVFNebVxaxbZEcp/8ChaGRmZko5LuEDEDFhBVrd9gJa3jIJy1J64JeYYnh7esj8umQ21fz8cs90U+2jrfSrMc+0rfTBHvSwxjMt/+AwIIFKBC5Ze5UybPFSjKy+O/N5VD76KMaoGHEtKSlFYVGRVD01PQOBAX4yXj4IDvRDekaWMSlNKRcc5C9HbOuq76DVIrJTOIKDAiCmRgghrq6uqHxoNJoqaZXL8Loqt7qY+HceAL+eN6KspAiJf30AZ2cn5XCWrBP/moeLRzfA0cMXkU8shqd/qEyvS6a95nu37CAePwi3ZI3pQ27MBog5z55touAb3qNGZo6ODjXm1dV+YGAAukZ2QnFxMQ4dPW6U4x3aHi2H3ItWQx/CyZRC2Z/Q0GBjfl1ym2J++We6cf2r/+9Xc2uvMc90c2PVmP5a45mWf0wYkEAlAtpK1zZ96enhLufSilXf5Q+D0oMH9MLaf7fKyzX/bMHlA3WvUsV0BfFBKzIiOoZBeGOIP5eAktJSrFu/HZcP6iOyUFP9E7FnkJun8/hw9nwCYk+fQ6f2bWUdMSpc+RAZldN4rYUaDNrd9gzEtrcZRzfi/B/zkLb7N8T/9i6St6+C1sUdXZ74BO6BbVRpS6tVR2dzyHFU+urg6gnhcg0lhQ3ur9xZTXlgg4fc12AZpvRvgH4e7649B6ttJyVVN/0oSDGOTZHHMrb7bPLe8N5Y+xlQ/qTxhwQuEdDH7Mrg1etc42nSk8Px2+oN0i3ZmfgLGH7vMFn2rGLczpy7SMY1Gg1mTBmHabMXYORTU9G3d1eIEWKRWVP9cwnJ+M/wp6VbsofGTMEDd93MuYYCmBUOZ+8AtOh8GVAGJG/7AWd+noOEzd8CWkdEPv4h3EN0I59WUM3iTbroPTUUpJ1vUNtirnPu+RiIUfGAPrc0SIaplQb00335LD+Pt3xdw3z76t7KlC/HOAmQAAmQAAk0hIC2IZVstY5Y8LJw7lTplmz2tIlwc3WVqkZ0Csd3S+bKuAh6RkVg2UdvYPnC2Rj98N0iSR411b9ycF/836rF2Lr6K2z4fRkeuvtmWZ6BdQhknzkIKF9cYPyngVtAa3iF6YwqY3ITj8jd1pQ+NnThWsKmb5TaQPCgu+TZnIFhhHfT1h1VmhFz3tMzdHPifVp4V8m3QAKbIAESIAESaOIEmpTB28TvFbunEBDzTcWmEkq0wk/hxZQK183hwsVX56lBeK6ob3+LFF6p+/9PVhO70MmIGYMuER3ldCSxAcXZcxcqtJSUkiqvQ4IC5ZkBCZAACZCAtQg03XZp8Dbde9ske+bg5gUnL/8qfavOr2uVQk0soTGuyRK3/iBp+HW/Vnq1kBdmDgb01Y3AV57WkJKSLlsO4C5rkgMDEiABEiAB9QnQ4FWfKSWamUCrax+v0ILGwRHSr2uF1KZ/4aKfw1uYkVjvziZtXyXrhAy5X57rEzS07MD+OoN3x+79FUQYFqwF+Ff1qlKhIC9IgARIgARIoIEEaPA2EByrWY+A2P62x3PfofWtz6LtHS+i1+Sf4NvtKuspZKWWnX2CZcsF9dxtLWXPHyjKToNbUDi82us8lEhBZg4MO65VGeHVe2igwWvmG0DxJEACahOgPDsiQIPXjm4WVb1EwC24AwIH3Y2A/v+Bs36k81Ju84i5GHdbS6hXhy9sWCHLh1zxoDxbKhjUv7dsau/+wyjS+8sWCZdGeLnLmuDBgwRIgARIQH0CNHjVZ0qJJHCJgBljTi2UEV6tAwovJkN4OjClqez4QxCuyBxcPODf+xZTqqhWxtvLE507hssNKITRaxCcnKLzwRsYUHVutqEMzyRAAiRAAiTQGALaxlRmXRIgAesR0Gg0cPYOBEpLUJRp2jzexE3fSYUDB/wHDs46t30ywULBwGr88RoNXs7htdBdYDMkYB0CbJUErElAa83G2TYJkEDjCLjoXZMVZNQ9raE4NxMp+9fIBkOueEieLR0YPDWUX7hmnNJALw2Wvh1sjwRIgASaDQEavM3mVttDR6ljfQkYXJMVmmDwJm75Xo4G+0QOgWH+b33ba2z56nZcS0nVuyXjCG9j8bI+CZAACZBADQRo8NYAhskkYA8EDIZrQXrtI7xlJcVI2LJSdkl4uZARKwRdIzvC1dUF584nwGDoptBLgxXuBJu0eQJUkARIQFUCNHhVxUlhJGBZAi56DxV1jfCmHVyH4uw0uPi1QouIwZZVslxrWq0WBm8Nm7bulDk0eCUGBiRAAiRAAmYkQIPXjHDNLJriSQCGKQ11zeFN2KxbrCY2mtBoNFYlN6BvT9m+8McrvEuk6Kc0+Pm2kOkMSIAESIAESEBtAjR41SZKeSRgQQIuhkVrtUxpyDkXjezTB6B1ckFA/9stqF31TQ3U++PduXs/UtMyZKHAAD9oNNY1xKUiDOyUANUmARIggdoJ0OCtnQ9zScCmCYgpCkLB2qY0JG7+VhRBQJ9hcHT1lHFrBoMH9pXNb92xBxcSk2Q8KJA+eCUIBiRAAiRAAmYh0GwMXrPQo1ASsDIBrZMrHBQjtiQ/G6VF8HhvIAAAEABJREFU+VW0ka7I9q6W6cGXPyDP1g7EBhQd24dJNf5Zv0WeA+ihQXJgQAIkQAIkYB4CNHjNw5VSScBiBFz0C9cKUs9WaTNp248oKymCd/u+cA9uXyXfWgmGebz/W/2PVIEGr8RgqYDtkAAJkECzI0CDt9ndcna4qRGoaeFaWWkpLmzSTWcIHnKfTXV7YP9eUh+DpwYavBIHAxIgARIgATMRqN7gNVNjFEsCJKA+ARf9wrXCSgvX0g/9LV2ROXr6wbfb1eo33AiJ/fr0qFA7wN+3wjUvSIAESIAESEBNAjR41aRJWSRgBQI1jfBWcEWmta1f9R7dIuUGFAZctmzwGnTkmQRIgARIwH4J2NanoP1ypOYkYDUC1e22lpsYi6xTewGtA4Ivu8dqutXUsNiAol/vS6O8nNJQEymmkwAJkIDNELBrRWjw2vXto/IkALjoF62Vd02WsPFriSag141wdLe9DR3S0jOQmXkRYuMJcSz+/BvEnz0vdWZAAiRAAiRAAmoToMGrNlHKIwELE6g8paE4Pxspu/8ntbD4YjXZat3B9Dc/wMEjMXKzCY1Gg41bdmDC86/VXZElSIAESIAESKABBGjwNgAaq5CALRFw8g6UUxfECK8YLU3etkq6InNvGQHPNlG2pKpRlzXrNhrjhsi69VtQUlJiuOSZBEiABOyaAJW3LQI0eG3rflAbEqg3AY1GA5cWwbJeUWYiDIvVQocOl2kMSIAESIAESKC5E9A2dwDsPwlYj4B6LTvrXZMJY7dQMXod3LwR0OcW9RpQWdIN115RReK1Vw6Gg4NDlXQmkAAJkAAJkEBjCdDgbSxB1icBGyBgWLh2Yf1yqY0temaQiumD6S9Nwsjh9yAkOBD+fj646/abMH/uDH0uTyRAAs2OADtMAmYmQIPXzIApngTMTaCkIAeFGYlKM2X6AwgZcr8St90fP18ffPTeTJw8sAFnjm7F8k/fR5vWLW1XYWpGAiRAAiRg1wRo8Nr17WtWyrOzNRA4vvxFXDy5S8nV6A/or5VL/pAACZAACZAACaBJGbwpqekYP3k2Rk14FS/PnIe8/Pxqb/H+QzEYOX4aHh77Mj5b/qOxTF310zMu4pr//BcLl35nrMMICViTQEleFjKPbauiQuq+NVXSmEACJNBUCLAfJEAC9SXQpAzeeYtWYFC/nlg6/3V4e3thxco/qvAQbpteffMjTJ4wEp8vmIm/N+7A3gNHZbm66r/70Zfo0zMSEANp4D8SsD6BvOS4apWoKb3awkwkARIgARIggSZOoEkZvJu378OwG3Srv4ddfwU2bd9b5fbFnIiDu7sbukZ0gKODA264ejA2btsjy9VWX4wKu7m5oFtkJ0BMlZQ1bDegZs2DgEfrLnBw9azSWZ+Iy6qkMYEESIAESIAEmiuBJmPw5uTmQaOMvPr6eMt72aZVMJJT0mS8fJCYnIZWIYHGJFEuMSkVtdUvLi7G/E+/wYTRDxrrGSIlJcWofIi8ymm8rsqpsUxKS0sU9uJQX3ZjdbNU/VLly1e7O16oYPR6tIpA8NARChv1uOhYqyfPUnzsrR0d5+b9TJvhnlX7u6BjzWfa3Lx1nC37TIvPYB4kUJmAXRm8E1+agzHPzKhy7NFPSdBqL3VHo7kUr9xpjVaxjI2Jl8rVVF9Mjbjrtmvh7VV1JE0Yw5UPIbpyGq+LoTaDkhLxR7REdblq62lued7drkXUlN8QMXYJuj77Azo9uQQaNx9VuZSWlqoqz9xM7FU+n2n1/07U9CzwmbYMa2s80+IzmAcJVCZwydqrnGOD17OmTsC7M5+vcvTp0QUe7m7Kt/hSFBYVSc1T0zMQGOAn4+WD4EA/pGdkGZPSlHLBQf611hdTI2a+swiX3TgCi79YiS+/+w0ffKLzd+ri4gqXSocQXjmN11U5NZaJk5MznJ2d4VKJf3O8dnX3gk94T3iFhMHFDDwcHZ3gYga5lFnx94LPdEUe5nw++ExbhrU1nmnxGcyDBCoTsCuD19PDHV6eHlUOQ6cGD+iFtf9ulZdr/tmCywf2knExXeHQ0eMyHtExDMIbQ/y5BJQoo1br1m/H5YP6yLya6n/6wWvYuvoreYx59F48cv9tmPTkw7IOAxIgARJoSgTYFxIgARJoigTsyuCt6wZMenI4flu9QbolOxN/AcPvHSarnFWM25lzF8m4RqPBjCnjMG32Aox8air69u4KMUIsMmuqL/J4kAAJkAAJkAAJkAAJ2CcBbf3Vtt0aAf6+WDh3qnRLNnvaRLi5ukplIzqF47slc2VcBD2jIrDsozewfOFsjH74bpEkj5rqy0x98NhD/8HYUba9i5VeVZ5IgARIgARIgARIgAQUAk3K4FX6wx8SIAESsBwBtkQCJEACJGAXBGjw2sVtopIkQAIkQAIkQAIkYLsEbF0zGry2foeoHwmQAAmQAAmQAAmQQKMI0OBtFD5WJgESMJ0AS5IACZAACZCAdQjQ4LUOd7ZKAiRAAiRAAiTQXAmw3xYnQIPX4sjZIAmQAAmQAAmQAAmQgCUJ0OC1JG22RQKmE2BJEiABEiABEiABlQjQ4FUJJMWQAAmQAAmQAAmYgwBlkkDjCdDgbTxDSiABEiABEiABEiABErBhAjR4bfjmUDXTCbAkCZAACZAACZAACdREgAZvTWSYTgIkQAIkQAL2R4AakwAJVEOABm81UJhEAiRAAiRAAiRAAiTQdAjQ4G3kvSwqKkT5w9PTA19/vaJCWvl8m4hX0tleddJoNPLu2av+9qN3EZycnPhMW+D3RqPhM22p3ws+0xU/u8zFXaOx/DMtPxgYkEAlAjR4KwHhJQmQAAmQQPMhwJ6SAAk0DwI0eJvHfWYvSYAESIAESIAESKDZEqDBW+etN71ASmo6xk+ejVETXsXLM+chLz/f9MosWSuB/63ZgNGTZuC6O0fjuWnv4NTpc8by+w/FYOT4aXh47Mv4bPmPxnRGGkdg5FNTJXODlOKSEsx671OI9DHPzMDZ8wmGLJ4bSODXP//BPSOfxWU3jpB/Mwxi+EwbSKhz/vmPv/HouFcwfMwUTJ+zEJkXs6VgPtMSQ6OC/YdjIP4eDLn5Eaxdvw3l/33/82qMePIlPDL2FWzYuseYxc9KIwpGLEiABq+KsOctWoFB/Xpi6fzX4e3thRUr/1BRevMWFRzkjwVvv4TfvpmPTh3a4ZPPv5NAysrK8OqbH2HyhJH4fMFM/L1xB/YeOCrzGDScgDAQggL9oJ9+JwX99te/SEvPwLKP3sA9t1+Ptz5YKtMZNIyAMBQWfr4SL0x4DJv//BJjRt4nBdn0My01tK8gOycXi5b9gLdemySf3XxlIOL31etlJ/hMSwyNClxdXPDEo/fgqiH9Ksg5HX8BX377Gxa99yrenv4MZr27GPkFhbIMPyslBgYWJkCDV0Xgm7fvw7AbrpASh11/BTZt3yvjDBpPoF+vbnBxdoabqyuGDOiNxJR0KTTmRBzc3d3QNaIDHB0ccMPVg7Fx26WRBFmIQb0IXMzKxq9//ouH7r6lQr3N2/biFuW5FonXDB2IwzEnkZObJy55NIDAb3+tx/133oiBfbtDq9UirE2olMJnWmJQLRBfIKB8MdZoNNBoNVJuSFCAPPOZlhgaFUR0DENf5e+zeIbLC9qk/B2+UjGCPZS/zyHBAYjsFI6dew5B/ONnpaDAw9IEtCo32GzFiQ9+jfK31NfHWzJo0yoYySlpMs5AXQLf/PgHBvaJkkITk9PQKiRQxkUguCcmpYoojwYSmLfoa0x8cjjEB5hiJxilJKemo1VosLwWXy6E0ZCk8JcJDOpNICExBcdPnsbN947Fg6MnY+vO/VIGn2mJQbXAy9ND+aJ2Oe58eBKuuOVRFBUX45qhA6R8PtMSg1mC5NQ0tCz3t7l1y2AkpaTKL8n8rDQLcgqtgwAN3joA1SdbGAiG8hoN0RpYqHlesfJ/yLiYjVEj7jSK1ehHbXQJ5K7j0LDwcPRJWbFntwh5rhxoNMq3On2itlxcn8RTBQK1X5SUlsoC3y55B6++8KTyyvdTiNfvIpHPtKCgziHWUhw9HocVi+bgz5UL4e3lBTFlxyBdo+EzbWCh9lmjvLkwyNRoynGukM6/2QZGPJuXAJ80lfiK1zYlJaUoLCqSElPTMxAY4CfjDNQhsGPPQezefxgfzJ4spzcIqcGBfkjPyBJReYg5pmK+r7xgUG8CG7bswh//t0Euonri2ddx6OhxudhHCAr090VaeqaIyiMt4yLEPF95waDeBPx9fTBAeVPRwtsTXTq3h79fC5y7kAQ+0/VGWWuF3fuOws3VGe3DWsHH2wuD+nXH/kPHZB0+0xKDWYJAfz9kZJT7e6F8JgYF+IOflWbBbftCbUBDGrwq3oTBA3ph7b9bpcQ1/2zB5QN7yTiDxhMQC3w+//oXzJ42Cc5OTkaBYv6YWPEbfy4BYsRs3frtuHxQH2M+I/UjMHbU/di6+it5iMUmUV064YuPZ0khg5Xnea3CV1xs330Q7du1kh9e4ppH/QkMHdxH+QJ3FKXKSK+Y3pCSloFWoUHgM11/lrXVCPT3wbGTZ5CReVGy3rHnMDq1byur8JmWGMwSiL/DYj1FQWGh/KJ8JCYWA5UvG6IxflYKCjwsTYAGr4rEJz05HL+t3iDdkp2Jv4Dh9w5TUXrzFrXg02+x72A0rr59lBx9vGfksxKIRqPBjCnjMG32Aukuq2/vrujTo4vMY6AugdtvvhparUZyXvLVKrw48XE1G2h2sq6/6jL4+njjkXGv4KWZ8+S0Bk8Pd2g0fKbVfBgiOoVj6GV9cceISdI9lquLM+694wbZBJ9piaFRwbZd++Xf5LXrt8m/w8J1pBDYrk0o7hx2LR5/+jVMevltPDPuEeNgBT8rBSEeliagtXSDTbm9AOWV78K5U6VbstnTJiqv0Vybcnct2rdPP3hNjjoaRh9/WPaesf2eUREQrrKWL5yN0Q/fbUxnpHEEenTrDMHdIEUsVHvl2dGS9eL3X0Pb1iGGLJ4bQECj0eCZsQ/jq0/ehHCpJ7w1GMTwmTaQUOf8woSR+Pe3pfhq0ZsQccNbIj7TaPQ/4YrT8HdZnNf+9KlR5n133AjxfH+5cBauHNzXmM7PSiOKGiJMNgcBGrzmoEqZJEACJEACJEACJEACNkOABq/N3AoqQgKmE2BJEiABEiABEiAB0wnQ4DWdFUuSAAmQAAmQAAnYFgFqQwImEaDBaxImFiIBEiABEiABEiABErBXAjR47fXOUW/TCbAkCZAACZAACZBAsyZAg7dZ3352ngRIgARIoDkRYF9JoLkSoMHbXO88+00CJEACJEACJEACzYQADd5mcqNN7yZLkgAJkAAJkAAJkEDTIkCDt2ndT/aGBEiABEhALQKUQwIk0GQI0OBtMreSHSEBEiABEiABEiABEqiOAA3e6qiYnsaSJEACJEACJEACJEACNk6ABq+N3yCqRwIkQAL2QYBaklBd9lAAAAnWSURBVAAJkIDtEqDBa7v3hpqRAAmQAAmQAAmQAAmoQMCiBq8K+lIECZAACZAACZAACZAACdSLAA3eeuFiYRIgARJQhQCFkAAJkAAJWJAADV4LwmZTJEACJEACJEACJEAC5QlYJk6D1zKc2QoJkAAJkAAJkAAJkICVCNDgtRJ4NksCJGA6AZYkARIgARIggcYQoMHbGHqsSwIkQAIkQAIkQAKWI8CWGkiABm8DwbEaCZAACZAACZAACZCAfRCgwWsf94lakoDpBFiSBEiABEiABEigAgEavBVw8IIESIAESIAESKCpEGA/SMBAgAavgQTPJEACJEACJEACJEACTZIADd4meVvZKdMJsKQlCfy+ej3izyU0qMkDh49h1IRX66xrark6BVmhwM69h/DkczOt0DKbJAESIIGmTYAGb9O+v+wdCdgUgb/Wbca5C4kN0ql9WGu8MGFknXVNLVenIBYggeZGgP0lgSZMgAZvE7657BoJ2BKBNf9sQcyJOMxf/I0cxdx/OAaLv1iJl2Z+gPGTZ+O/E6ejuKQEU2ctwG0PjscD/30Bs977FHn5+bIbsXFn8c78ZTIuRkJHjp+Gl2fOwxPPvo5nXnkHSSlpMs/UcqWlpfhw8QrcN+o5PPXCLLyzYJnUQwqpFIhR6Skz3seIJ17Cw2Nfxp9rNxlLXHbjCKVPKzDmmRl4UNH5//7dasxbv3mX0q/XIHSd+NIcnDp9zpj342//h0fHvYJHxr6CG+95EmnpmTIvv6BQ9mvkU1Mx/sU3jf2SmQxIgARIgAQaRIAGb4OwNdtK7DgJNJjADVcPRkTHMEwY8yA+eXcaenaLkLLizpzHnOnP4LN50+Ho4IBHHrgNv32zAF8tektef7Xyf7Jc5eB0/HmMGXkfFr33Km6+bgiWrvi5chF5XVO5teu3YeuOfVg6fybmvfkiTsSekeWrC15762MMHdJP0elNzH9rCpZ987M03g1l27VpicXvv4YP33oJ7330JVLTM5CSmo7pby/Es+MewbIFM9GreyRef+cTWWWz0u6yr3/BrKlP48uFs7Dkw+nw9HSXeQZ9l330Bvr27Fpjv2RhBiRAAiRAAiYRoMFrEiYWIgESMBeBwf17wsPdzSj+YlY23vv4C0yc8hYOHjmOmOOnjHnlIx3D2yKsTahMCg0ORGxcvIxXDmoqt+9gDG654Up4erjD0dERd992XeWq8lroc/RYLH798185Mj3l9XnIycmHmCssCyjBNUMHKiEQGOCHyM7tcfDwCew/fBzdIjuia0QHmTf83lukkZyTm4dtOw/g9puvQuuWwTKvdcsQODs5yXj7dq2N/erbs0uN/ZKFGViRAJsmARKwJwI0eO3pblFXEmiCBFxcnI29Oh1/AW/MXYwbrxmCd994AaNG3In8/EJjfvmIg8OlP19arRbFxSXls43x2sqJEWVDQWH0GuLlzw7KqLPI+/idV+TItBid/v3bBbj3PzeUL1Y1XlamjFBf0tFJMaq1Go2xnKOjzsA1JugjTk6O+hgg2q6pX8ZCjJAACZAACdRJ4NJf4zqLskB9CbA8CZBARQIe7q64mJVTMbHcVfy5BLRuFSJHRl0VQ3jdhu3lctWN9uoegW27DhiFbt6+zxgvH/FQRp8jO4XL+b5i3q/IO3kqXk5ZEHFxfLvqL3GSo9EHjxxD924d0TOqMw5Hn0S0foT6mx//ROeOYXI0e1D/HhAeK86e1y3gKywqgjikEAYkQAIkQAKqE6DBqzpSCiQBEqiJwH133Ig1f2/BuBdmKa/8Y6oUG9A3Cg5arVzI9ezUt+HbwrtKGbUSrrtyEDqEt4ZYTPb8tLlyNLaFt2e14mdMGasYuJl4+MmXce9jz2HamwtQUlpqLJubl4eHxryI6XM+xosTR8Hf1wcB/r6Y+twYudDusfHTsH33QUx7/glZZ8iAXrj/zhvx8swPIRbBXX/nGGRn58q8JhqwWyRAAiRgVQI0eK2Kn42TQPMi0LdXN8yd+TzE9ACxaG3Mo/dCHAYKzk5OcgGZWMj13huT8fz4R7Hg7Zdldo9unbF0/usy3r93lJxeIC+UoFtkB2OeqeXENIhRw++U7b356iSUlpWhZ5RuIZ0issJPy5AgvPHKeKxY/BZWfv4uvl48B8GB/sYyT48ZLtO++ewdXH/VZcb0K4f0w5IPZ+DzBTNlO+HtWhnzhPEv+rl84Wys//1z+Pm2QG39MlZkhARIgARIoN4EbMfgrbfqrEACJEACjSMgXILdN+o5ZZT1Jbg4O+OOYdc0TiBrkwAJkAAJ2CQBGrw2eVuoFAmQgCUIrPryfXy/9F18q4zMitFkMcJc33a3rv6qvlXqLM8CJEACJEAC6hKgwasuT0ojARIgARIgARIgARJQh4BqUmjwqoaSgkiABEiABEiABEiABGyRAA1eW7wr1IkESMB0AixJAiRAAiRAAnUQoMFbByBmkwAJkAAJkAAJkIA9EKCONROgwVszG+aQAAmQAAmQAAmQAAk0AQI0eJvATWQXSMB0AixJAiRAAiRAAs2PAA3e5nfP2WMSIAESIAESIAESaFYEaPA2q9vNzpIACZAACZAACZBA8yNAg7f53XP22HQCLEkCJEACJEACJNAECNDgbQI3kV0gARIgARIgAfMSoHQSsG8CNHjt+/5RexIgARIgARIgARIggToI0OCtAxCzTSfAkiRAAiRAAiRAAiRgiwRo8NriXaFOJEACJEAC9kyAupMACdgYARq8NnZDqA4JkAAJkAAJkAAJkIC6BGjwqsvTdGksSQIkQAIkQAIkQAIkYBECNHgtgpmNkAAJkAAJ1ESA6SRAAiRgbgI0eM1NmPJJgARIgARIgARIgASsSsBODF6rMmLjJEACJEACJEACJEACdkyABq8d3zyqTgIk0AwJsMskQAIkQAL1JkCDt97IWIEESIAESIAESIAESMDaBOrTPg3e+tBiWRIgARIgARIgARIgAbsjQIPX7m4ZFSYBEjCdAEuSAAmQAAmQAECDl08BCZAACZAACZAACTR1As28fzR4m/kDwO6TAAmQAAmQAAmQQFMnQIO3qd9h9o8ETCfAkiRAAiRAAiTQJAnQ4G2St5WdIgESIAESIAESaDgB1mxqBGjwNrU7yv6QAAmQAAmQAAmQAAlUIECDtwIOXpCA6QRYkgRIgARIgARIwD4I0OC1j/tELUmABEiABEjAVglQLxKweQI0eG3+FlFBEiABEiABEiABEiCBxhCgwdsYeqxrOgGWJAESIAESIAESIAErEaDBayXwbJYESIAESKB5EmCvSYAELE+ABq/lmbNFEiABEiABEiABEiABCxKgwWtB2KY3xZIkQAIkQAIkQAIkQAJqEfh/AAAA//90bRVjAAAABklEQVQDAOD0cz4Xo8bEAAAAAElFTkSuQmCC"
+     },
+     "metadata": {
+      "image/png": {
+       "alt": "Validation information coefficient against training epoch, one line per label, with a dashed line at zero."
+      }
+     },
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "fig = go.Figure()\n",
     "for _label in catalog[\"label\"].unique().sort().to_list():\n",
@@ -416,8 +5459,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2c0ba9cb",
-   "metadata": {},
+   "id": "55e80977",
+   "metadata": {
+    "papermill": {
+     "duration": 0.031299,
+     "end_time": "2026-09-11T08:58:22.120839+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T08:58:22.089540+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "## Key takeaways\n",
     "\n",
@@ -450,6 +5501,39 @@
    "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.14.3"
+  },
+  "ml4t_provenance": {
+   "executed_at": "2026-09-11T08:58:37.067559+00:00",
+   "executor": "local-uv",
+   "library_digest": "73e24470870c6e8034aa20e44437900e3ef9ee6d62c806ecba805e9bbe7afe39",
+   "outputs_digest": "eff79cb73179b6d2947fbb241db72b8349c6d8bc7c8f1323e888eb6c44a89c36",
+   "parameters": {},
+   "production": true,
+   "source_py_blob": "84534a00e2b7f015a6c15d0c86a9556443ef0b61"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 15101.886888,
+   "end_time": "2026-09-11T08:58:25.118103+00:00",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "~/ml4t/public-nasdaq/case_studies/nasdaq100_microstructure/.09_dl_lstm.build.1986310.ipynb",
+   "output_path": "~/ml4t/public-nasdaq/case_studies/nasdaq100_microstructure/.09_dl_lstm.papermill.1986310.ipynb",
+   "parameters": {},
+   "start_time": "2026-09-11T04:46:43.231215+00:00",
+   "version": "2.7.0"
   }
  },
  "nbformat": 4,

--- a/case_studies/nasdaq100_microstructure/09_dl_lstm.py
+++ b/case_studies/nasdaq100_microstructure/09_dl_lstm.py
@@ -44,7 +44,7 @@
 # **Book Reference**: Chapter 13
 #
 # **Prerequisites**: [`05_evaluation`](05_evaluation.ipynb)
-
+#
 # **What it writes**: one training run per label and one complete validation prediction set per
 # label and checkpoint, in `run_log/registry.db` and under `run_log/training/` and
 # `run_log/predictions/`, grouped under a population this notebook alone publishes.

--- a/case_studies/nasdaq100_microstructure/09_dl_lstm.py
+++ b/case_studies/nasdaq100_microstructure/09_dl_lstm.py
@@ -313,8 +313,9 @@ show_plotly_with_alt(
 # ## Key takeaways
 #
 # 1. **A checkpoint is part of a configuration, not a detail of how it was fitted.** Scoring one
-#    fit at twenty points produces twenty candidates, and keeping the best of them after seeing
-#    the results is a selection decision. Selection happens in
+#    fit at twenty points produces twenty candidates, and keeping whichever of them scores
+#    highest on this page would be a selection decision taken on the wrong statistic: the
+#    curve below is an information coefficient, and selection is validation backtest Sharpe in
 #    [`14_backtest`](14_backtest.ipynb), over the population published here.
 #
 # 2. **How many windows are drawn is part of the model.** On a minute panel the cap decides what
@@ -326,5 +327,6 @@ show_plotly_with_alt(
 #
 # **Known limitations.** The window is fixed at sixty observations, so nothing earlier than the
 # trailing hour reaches the model whatever the architecture can represent. The declared sequence
-# cap is a compute budget rather than a derived quantity - `config/setup.yaml` says so, and
-# ml4t/agent-workspace#1015 is where that argument goes.
+# cap is a compute budget rather than a quantity derived from the data - `config/setup.yaml`
+# says so - so the same declared count covers a different share of the panel whenever the
+# panel's size changes.

--- a/case_studies/nasdaq100_microstructure/09_dl_lstm.py
+++ b/case_studies/nasdaq100_microstructure/09_dl_lstm.py
@@ -175,13 +175,18 @@ if (narrows or device != PUBLISHED_DEVICE) and not POPULATION_NAME:
 # - **`validation_start` and `validation_end` bracket the development sample.** The held-out tail
 #   must not appear; it is scored once, at the end of the case study.
 #
-# **How many windows are drawn is declared, not left to the tier.** Every row of this panel
-# starts a window, and the panel is minute bars, so an uncapped fold would build about four
-# million near-identical overlapping sequences - consecutive windows share 59 of their 60
-# observations. `modeling.dl.max_train_sequences` in `config/setup.yaml` declares the cap, which
-# makes it part of the training identity rather than a property of how the run was invoked. A
-# preview may lower it and cannot raise it above the declaration, because a preview that fits on
-# more windows than the canonical run is not rehearsing it.
+# **How far apart the training windows sit is declared, not left to the tier.** Every row of this
+# panel could start a window, and the panel is minute bars, so an unspaced fold would build about
+# four million near-identical overlapping sequences - neighbouring windows would share 59 of their
+# 60 observations. `modeling.dl.train_sequence_stride_horizons` in `config/setup.yaml` declares
+# the spacing instead: one window per label horizon, so consecutive windows of a symbol carry
+# labels that do not overlap - the window ending at t is scored on the return from t to t+H and
+# the next one starts at t+H. It is declared in horizons rather than in windows because the
+# horizon differs by label: `fwd_ret_5m` strides 5 observations, `fwd_ret_15m` 15 and
+# `fwd_ret_60m` 60, each spacing its own labels exactly, where a single window count could only
+# have been right for one of them. The spacing travels in the training identity; **how many
+# windows it yields is derived at run time** from the eligible rows of each fold rather than
+# declared, and is printed below.
 
 # %%
 requests = model_requests(
@@ -318,15 +323,16 @@ show_plotly_with_alt(
 #    curve below is an information coefficient, and selection is validation backtest Sharpe in
 #    [`14_backtest`](14_backtest.ipynb), over the population published here.
 #
-# 2. **How many windows are drawn is part of the model.** On a minute panel the cap decides what
-#    was fitted, so it is declared in `config/setup.yaml` and travels in the training identity
-#    rather than arriving with the invocation.
+# 2. **How far apart the training windows sit is part of the model.** On a minute panel the
+#    spacing decides what was fitted, so it is declared in `config/setup.yaml` as one window per
+#    label horizon and travels in the training identity rather than arriving with the invocation.
 #
 # 3. **A sequence family is measured on fewer rows than a tabular one.** A prediction needs a
 #    full window behind it, so the samples differ and the comparison has to say so.
 #
 # **Known limitations.** The window is fixed at sixty observations, so nothing earlier than the
-# trailing hour reaches the model whatever the architecture can represent. The declared sequence
-# cap is a compute budget rather than a quantity derived from the data - `config/setup.yaml`
-# says so - so the same declared count covers a different share of the panel whenever the
-# panel's size changes.
+# trailing hour reaches the model whatever the architecture can represent. The window spacing is a
+# modelling choice rather than a compute budget - one window per label horizon is what stops two
+# training examples carrying the same return twice - so the number of windows a fold yields
+# follows from how many eligible rows it holds, and a panel of a different size changes the count
+# without changing the declaration.

--- a/case_studies/nasdaq100_microstructure/09_dl_lstm.py
+++ b/case_studies/nasdaq100_microstructure/09_dl_lstm.py
@@ -180,8 +180,10 @@ if (narrows or device != PUBLISHED_DEVICE) and not POPULATION_NAME:
 # four million near-identical overlapping sequences - neighbouring windows would share 59 of their
 # 60 observations. `modeling.dl.train_sequence_stride_horizons` in `config/setup.yaml` declares
 # the spacing instead: one window per label horizon, so consecutive windows of a symbol carry
-# labels that do not overlap - the window ending at t is scored on the return from t to t+H and
-# the next one starts at t+H. It is declared in horizons rather than in windows because the
+# labels that do not overlap. [`02_labels`](02_labels.ipynb) takes the decision on the bar
+# closing at t, enters on the next bar's VWAP and holds for the horizon from that fill, so two
+# decisions H observations apart have return intervals that abut rather than share bars - the
+# exit of one is the entry of the next. It is declared in horizons rather than in windows because the
 # horizon differs by label: `fwd_ret_5m` strides 5 observations, `fwd_ret_15m` 15 and
 # `fwd_ret_60m` 60, each spacing its own labels exactly, where a single window count could only
 # have been right for one of them. The spacing travels in the training identity; **how many

--- a/case_studies/nasdaq100_microstructure/10_dl_tcn.ipynb
+++ b/case_studies/nasdaq100_microstructure/10_dl_tcn.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "cdcd55e7",
+   "id": "7d0339e9",
    "metadata": {},
    "source": [
     "# Temporal convolutional network - NASDAQ-100 Microstructure\n",
@@ -47,7 +47,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e2b89c15",
+   "id": "10ddbe26",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -70,7 +70,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0116820e",
+   "id": "3d7a583f",
    "metadata": {
     "tags": [
      "parameters"
@@ -91,7 +91,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d2f28560",
+   "id": "c3f1d5c1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -105,7 +105,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fc5aedd7",
+   "id": "5871a194",
    "metadata": {},
    "source": [
     "## 1. Which labels, and which model\n",
@@ -125,7 +125,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "77a74fd3",
+   "id": "de293873",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -134,7 +134,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9fda716d",
+   "id": "0d9e58fc",
    "metadata": {},
    "source": [
     "`tcn` is this notebook's slice of the declared family. The menu declares four\n",
@@ -153,7 +153,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3005362a",
+   "id": "35739635",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -170,7 +170,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d98853bf",
+   "id": "6d5c63b7",
    "metadata": {},
    "source": [
     "`LABELS` and `CONFIG_NAMES` narrow the run below this notebook's own slice, and a narrowed run\n",
@@ -188,7 +188,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e60c04df",
+   "id": "aac36819",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -209,7 +209,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3ff7ef14",
+   "id": "58991c5e",
    "metadata": {},
    "source": [
     "## 2. Binding the declarations to the data\n",
@@ -232,19 +232,24 @@
     "- **`validation_start` and `validation_end` bracket the development sample.** The held-out tail\n",
     "  must not appear; it is scored once, at the end of the case study.\n",
     "\n",
-    "**How many windows are drawn is declared, not left to the tier.** Every row of this panel\n",
-    "starts a window, and the panel is minute bars, so an uncapped fold would build about four\n",
-    "million near-identical overlapping sequences - consecutive windows share 59 of their 60\n",
-    "observations. `modeling.dl.max_train_sequences` in `config/setup.yaml` declares the cap, which\n",
-    "makes it part of the training identity rather than a property of how the run was invoked. A\n",
-    "preview may lower it and cannot raise it above the declaration, because a preview that fits on\n",
-    "more windows than the canonical run is not rehearsing it."
+    "**How far apart the training windows sit is declared, not left to the tier.** Every row of this\n",
+    "panel could start a window, and the panel is minute bars, so an unspaced fold would build about\n",
+    "four million near-identical overlapping sequences - neighbouring windows would share 59 of their\n",
+    "60 observations. `modeling.dl.train_sequence_stride_horizons` in `config/setup.yaml` declares\n",
+    "the spacing instead: one window per label horizon, so consecutive windows of a symbol carry\n",
+    "labels that do not overlap - the window ending at t is scored on the return from t to t+H and\n",
+    "the next one starts at t+H. It is declared in horizons rather than in windows because the\n",
+    "horizon differs by label: `fwd_ret_5m` strides 5 observations, `fwd_ret_15m` 15 and\n",
+    "`fwd_ret_60m` 60, each spacing its own labels exactly, where a single window count could only\n",
+    "have been right for one of them. The spacing travels in the training identity; **how many\n",
+    "windows it yields is derived at run time** from the eligible rows of each fold rather than\n",
+    "declared, and is printed below."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3b0479ea",
+   "id": "2fd81f45",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -272,7 +277,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "740b309c",
+   "id": "3af74696",
    "metadata": {},
    "source": [
     "## 3. Fitting the population\n",
@@ -313,7 +318,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "716ea36b",
+   "id": "e11db891",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -334,7 +339,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9458a6b4",
+   "id": "ba6fbe6e",
    "metadata": {},
    "source": [
     "`reused` is not zero on a second run. Every identity is re-derived from the inputs, the\n",
@@ -344,7 +349,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2d622a1c",
+   "id": "405c072d",
    "metadata": {},
    "source": [
     "## 4. What came out\n",
@@ -363,7 +368,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a516342e",
+   "id": "15371b3c",
    "metadata": {
     "tags": [
      "results"
@@ -388,7 +393,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "466aec57",
+   "id": "f56dac24",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -416,7 +421,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f53e1da6",
+   "id": "c56274f1",
    "metadata": {},
    "source": [
     "## Key takeaways\n",
@@ -427,18 +432,19 @@
     "   curve below is an information coefficient, and selection is validation backtest Sharpe in\n",
     "   [`14_backtest`](14_backtest.ipynb), over the population published here.\n",
     "\n",
-    "2. **How many windows are drawn is part of the model.** On a minute panel the cap decides what\n",
-    "   was fitted, so it is declared in `config/setup.yaml` and travels in the training identity\n",
-    "   rather than arriving with the invocation.\n",
+    "2. **How far apart the training windows sit is part of the model.** On a minute panel the\n",
+    "   spacing decides what was fitted, so it is declared in `config/setup.yaml` as one window per\n",
+    "   label horizon and travels in the training identity rather than arriving with the invocation.\n",
     "\n",
     "3. **A sequence family is measured on fewer rows than a tabular one.** A prediction needs a\n",
     "   full window behind it, so the samples differ and the comparison has to say so.\n",
     "\n",
     "**Known limitations.** The window is fixed at sixty observations, so nothing earlier than the\n",
-    "trailing hour reaches the model whatever the architecture can represent. The declared sequence\n",
-    "cap is a compute budget rather than a quantity derived from the data - `config/setup.yaml`\n",
-    "says so - so the same declared count covers a different share of the panel whenever the\n",
-    "panel's size changes."
+    "trailing hour reaches the model whatever the architecture can represent. The window spacing is a\n",
+    "modelling choice rather than a compute budget - one window per label horizon is what stops two\n",
+    "training examples carrying the same return twice - so the number of windows a fold yields\n",
+    "follows from how many eligible rows it holds, and a panel of a different size changes the count\n",
+    "without changing the declaration."
    ]
   }
  ],

--- a/case_studies/nasdaq100_microstructure/10_dl_tcn.ipynb
+++ b/case_studies/nasdaq100_microstructure/10_dl_tcn.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "37a465cf",
+   "id": "cdcd55e7",
    "metadata": {},
    "source": [
     "# Temporal convolutional network - NASDAQ-100 Microstructure\n",
@@ -47,7 +47,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f9970c5b",
+   "id": "e2b89c15",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -70,7 +70,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5d9bb6d9",
+   "id": "0116820e",
    "metadata": {
     "tags": [
      "parameters"
@@ -91,7 +91,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a9400b5a",
+   "id": "d2f28560",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -105,7 +105,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2cf8483a",
+   "id": "fc5aedd7",
    "metadata": {},
    "source": [
     "## 1. Which labels, and which model\n",
@@ -125,7 +125,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "551655f2",
+   "id": "77a74fd3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -134,7 +134,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "695d35c4",
+   "id": "9fda716d",
    "metadata": {},
    "source": [
     "`tcn` is this notebook's slice of the declared family. The menu declares four\n",
@@ -153,7 +153,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ea258df4",
+   "id": "3005362a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -170,7 +170,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "25554f7f",
+   "id": "d98853bf",
    "metadata": {},
    "source": [
     "`LABELS` and `CONFIG_NAMES` narrow the run below this notebook's own slice, and a narrowed run\n",
@@ -188,7 +188,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c9f49ec1",
+   "id": "e60c04df",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -209,7 +209,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1f7fb0fb",
+   "id": "3ff7ef14",
    "metadata": {},
    "source": [
     "## 2. Binding the declarations to the data\n",
@@ -244,7 +244,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "116c917a",
+   "id": "3b0479ea",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -272,7 +272,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a5099778",
+   "id": "740b309c",
    "metadata": {},
    "source": [
     "## 3. Fitting the population\n",
@@ -313,7 +313,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c29b2bcc",
+   "id": "716ea36b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -334,7 +334,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dccef131",
+   "id": "9458a6b4",
    "metadata": {},
    "source": [
     "`reused` is not zero on a second run. Every identity is re-derived from the inputs, the\n",
@@ -344,7 +344,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b6e8a4c1",
+   "id": "2d622a1c",
    "metadata": {},
    "source": [
     "## 4. What came out\n",
@@ -363,7 +363,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "275b8b5f",
+   "id": "a516342e",
    "metadata": {
     "tags": [
      "results"
@@ -388,7 +388,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "13b31b65",
+   "id": "466aec57",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -416,14 +416,15 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a51ae0f0",
+   "id": "f53e1da6",
    "metadata": {},
    "source": [
     "## Key takeaways\n",
     "\n",
     "1. **A checkpoint is part of a configuration, not a detail of how it was fitted.** Scoring one\n",
-    "   fit at twenty points produces twenty candidates, and keeping the best of them after seeing\n",
-    "   the results is a selection decision. Selection happens in\n",
+    "   fit at twenty points produces twenty candidates, and keeping whichever of them scores\n",
+    "   highest on this page would be a selection decision taken on the wrong statistic: the\n",
+    "   curve below is an information coefficient, and selection is validation backtest Sharpe in\n",
     "   [`14_backtest`](14_backtest.ipynb), over the population published here.\n",
     "\n",
     "2. **How many windows are drawn is part of the model.** On a minute panel the cap decides what\n",
@@ -435,8 +436,9 @@
     "\n",
     "**Known limitations.** The window is fixed at sixty observations, so nothing earlier than the\n",
     "trailing hour reaches the model whatever the architecture can represent. The declared sequence\n",
-    "cap is a compute budget rather than a derived quantity - `config/setup.yaml` says so, and\n",
-    "ml4t/agent-workspace#1015 is where that argument goes."
+    "cap is a compute budget rather than a quantity derived from the data - `config/setup.yaml`\n",
+    "says so - so the same declared count covers a different share of the panel whenever the\n",
+    "panel's size changes."
    ]
   }
  ],

--- a/case_studies/nasdaq100_microstructure/10_dl_tcn.ipynb
+++ b/case_studies/nasdaq100_microstructure/10_dl_tcn.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "7d0339e9",
+   "id": "1af44f98",
    "metadata": {},
    "source": [
     "# Temporal convolutional network - NASDAQ-100 Microstructure\n",
@@ -47,7 +47,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "10ddbe26",
+   "id": "04566a01",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -70,7 +70,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3d7a583f",
+   "id": "3eb40e84",
    "metadata": {
     "tags": [
      "parameters"
@@ -91,7 +91,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c3f1d5c1",
+   "id": "a4af0cda",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -105,7 +105,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5871a194",
+   "id": "abbf15e4",
    "metadata": {},
    "source": [
     "## 1. Which labels, and which model\n",
@@ -125,7 +125,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "de293873",
+   "id": "63f6aefa",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -134,7 +134,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0d9e58fc",
+   "id": "5b113cdf",
    "metadata": {},
    "source": [
     "`tcn` is this notebook's slice of the declared family. The menu declares four\n",
@@ -153,7 +153,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "35739635",
+   "id": "6e144c82",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -170,7 +170,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6d5c63b7",
+   "id": "68efe1a2",
    "metadata": {},
    "source": [
     "`LABELS` and `CONFIG_NAMES` narrow the run below this notebook's own slice, and a narrowed run\n",
@@ -188,7 +188,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "aac36819",
+   "id": "f29b4e72",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -209,7 +209,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "58991c5e",
+   "id": "13077f53",
    "metadata": {},
    "source": [
     "## 2. Binding the declarations to the data\n",
@@ -237,8 +237,10 @@
     "four million near-identical overlapping sequences - neighbouring windows would share 59 of their\n",
     "60 observations. `modeling.dl.train_sequence_stride_horizons` in `config/setup.yaml` declares\n",
     "the spacing instead: one window per label horizon, so consecutive windows of a symbol carry\n",
-    "labels that do not overlap - the window ending at t is scored on the return from t to t+H and\n",
-    "the next one starts at t+H. It is declared in horizons rather than in windows because the\n",
+    "labels that do not overlap. [`02_labels`](02_labels.ipynb) takes the decision on the bar\n",
+    "closing at t, enters on the next bar's VWAP and holds for the horizon from that fill, so two\n",
+    "decisions H observations apart have return intervals that abut rather than share bars - the\n",
+    "exit of one is the entry of the next. It is declared in horizons rather than in windows because the\n",
     "horizon differs by label: `fwd_ret_5m` strides 5 observations, `fwd_ret_15m` 15 and\n",
     "`fwd_ret_60m` 60, each spacing its own labels exactly, where a single window count could only\n",
     "have been right for one of them. The spacing travels in the training identity; **how many\n",
@@ -249,7 +251,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2fd81f45",
+   "id": "191025f5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -277,7 +279,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3af74696",
+   "id": "d9a9c739",
    "metadata": {},
    "source": [
     "## 3. Fitting the population\n",
@@ -318,7 +320,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e11db891",
+   "id": "b3e86632",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -339,7 +341,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ba6fbe6e",
+   "id": "4e9a33b0",
    "metadata": {},
    "source": [
     "`reused` is not zero on a second run. Every identity is re-derived from the inputs, the\n",
@@ -349,7 +351,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "405c072d",
+   "id": "66267fa1",
    "metadata": {},
    "source": [
     "## 4. What came out\n",
@@ -368,7 +370,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "15371b3c",
+   "id": "08211975",
    "metadata": {
     "tags": [
      "results"
@@ -393,7 +395,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f56dac24",
+   "id": "a8ef366a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -421,7 +423,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c56274f1",
+   "id": "92d30cd1",
    "metadata": {},
    "source": [
     "## Key takeaways\n",

--- a/case_studies/nasdaq100_microstructure/10_dl_tcn.py
+++ b/case_studies/nasdaq100_microstructure/10_dl_tcn.py
@@ -313,8 +313,9 @@ show_plotly_with_alt(
 # ## Key takeaways
 #
 # 1. **A checkpoint is part of a configuration, not a detail of how it was fitted.** Scoring one
-#    fit at twenty points produces twenty candidates, and keeping the best of them after seeing
-#    the results is a selection decision. Selection happens in
+#    fit at twenty points produces twenty candidates, and keeping whichever of them scores
+#    highest on this page would be a selection decision taken on the wrong statistic: the
+#    curve below is an information coefficient, and selection is validation backtest Sharpe in
 #    [`14_backtest`](14_backtest.ipynb), over the population published here.
 #
 # 2. **How many windows are drawn is part of the model.** On a minute panel the cap decides what
@@ -326,5 +327,6 @@ show_plotly_with_alt(
 #
 # **Known limitations.** The window is fixed at sixty observations, so nothing earlier than the
 # trailing hour reaches the model whatever the architecture can represent. The declared sequence
-# cap is a compute budget rather than a derived quantity - `config/setup.yaml` says so, and
-# ml4t/agent-workspace#1015 is where that argument goes.
+# cap is a compute budget rather than a quantity derived from the data - `config/setup.yaml`
+# says so - so the same declared count covers a different share of the panel whenever the
+# panel's size changes.

--- a/case_studies/nasdaq100_microstructure/10_dl_tcn.py
+++ b/case_studies/nasdaq100_microstructure/10_dl_tcn.py
@@ -175,13 +175,18 @@ if (narrows or device != PUBLISHED_DEVICE) and not POPULATION_NAME:
 # - **`validation_start` and `validation_end` bracket the development sample.** The held-out tail
 #   must not appear; it is scored once, at the end of the case study.
 #
-# **How many windows are drawn is declared, not left to the tier.** Every row of this panel
-# starts a window, and the panel is minute bars, so an uncapped fold would build about four
-# million near-identical overlapping sequences - consecutive windows share 59 of their 60
-# observations. `modeling.dl.max_train_sequences` in `config/setup.yaml` declares the cap, which
-# makes it part of the training identity rather than a property of how the run was invoked. A
-# preview may lower it and cannot raise it above the declaration, because a preview that fits on
-# more windows than the canonical run is not rehearsing it.
+# **How far apart the training windows sit is declared, not left to the tier.** Every row of this
+# panel could start a window, and the panel is minute bars, so an unspaced fold would build about
+# four million near-identical overlapping sequences - neighbouring windows would share 59 of their
+# 60 observations. `modeling.dl.train_sequence_stride_horizons` in `config/setup.yaml` declares
+# the spacing instead: one window per label horizon, so consecutive windows of a symbol carry
+# labels that do not overlap - the window ending at t is scored on the return from t to t+H and
+# the next one starts at t+H. It is declared in horizons rather than in windows because the
+# horizon differs by label: `fwd_ret_5m` strides 5 observations, `fwd_ret_15m` 15 and
+# `fwd_ret_60m` 60, each spacing its own labels exactly, where a single window count could only
+# have been right for one of them. The spacing travels in the training identity; **how many
+# windows it yields is derived at run time** from the eligible rows of each fold rather than
+# declared, and is printed below.
 
 # %%
 requests = model_requests(
@@ -318,15 +323,16 @@ show_plotly_with_alt(
 #    curve below is an information coefficient, and selection is validation backtest Sharpe in
 #    [`14_backtest`](14_backtest.ipynb), over the population published here.
 #
-# 2. **How many windows are drawn is part of the model.** On a minute panel the cap decides what
-#    was fitted, so it is declared in `config/setup.yaml` and travels in the training identity
-#    rather than arriving with the invocation.
+# 2. **How far apart the training windows sit is part of the model.** On a minute panel the
+#    spacing decides what was fitted, so it is declared in `config/setup.yaml` as one window per
+#    label horizon and travels in the training identity rather than arriving with the invocation.
 #
 # 3. **A sequence family is measured on fewer rows than a tabular one.** A prediction needs a
 #    full window behind it, so the samples differ and the comparison has to say so.
 #
 # **Known limitations.** The window is fixed at sixty observations, so nothing earlier than the
-# trailing hour reaches the model whatever the architecture can represent. The declared sequence
-# cap is a compute budget rather than a quantity derived from the data - `config/setup.yaml`
-# says so - so the same declared count covers a different share of the panel whenever the
-# panel's size changes.
+# trailing hour reaches the model whatever the architecture can represent. The window spacing is a
+# modelling choice rather than a compute budget - one window per label horizon is what stops two
+# training examples carrying the same return twice - so the number of windows a fold yields
+# follows from how many eligible rows it holds, and a panel of a different size changes the count
+# without changing the declaration.

--- a/case_studies/nasdaq100_microstructure/10_dl_tcn.py
+++ b/case_studies/nasdaq100_microstructure/10_dl_tcn.py
@@ -180,8 +180,10 @@ if (narrows or device != PUBLISHED_DEVICE) and not POPULATION_NAME:
 # four million near-identical overlapping sequences - neighbouring windows would share 59 of their
 # 60 observations. `modeling.dl.train_sequence_stride_horizons` in `config/setup.yaml` declares
 # the spacing instead: one window per label horizon, so consecutive windows of a symbol carry
-# labels that do not overlap - the window ending at t is scored on the return from t to t+H and
-# the next one starts at t+H. It is declared in horizons rather than in windows because the
+# labels that do not overlap. [`02_labels`](02_labels.ipynb) takes the decision on the bar
+# closing at t, enters on the next bar's VWAP and holds for the horizon from that fill, so two
+# decisions H observations apart have return intervals that abut rather than share bars - the
+# exit of one is the entry of the next. It is declared in horizons rather than in windows because the
 # horizon differs by label: `fwd_ret_5m` strides 5 observations, `fwd_ret_15m` 15 and
 # `fwd_ret_60m` 60, each spacing its own labels exactly, where a single window count could only
 # have been right for one of them. The spacing travels in the training identity; **how many

--- a/case_studies/nasdaq100_microstructure/11_dl_patchtst.ipynb
+++ b/case_studies/nasdaq100_microstructure/11_dl_patchtst.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "93d97638",
+   "id": "f08f99d9",
    "metadata": {},
    "source": [
     "# PatchTST - NASDAQ-100 Microstructure\n",
@@ -46,7 +46,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f87cd1d4",
+   "id": "7baf0af5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -69,7 +69,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1e34edec",
+   "id": "e2f20abe",
    "metadata": {
     "tags": [
      "parameters"
@@ -90,7 +90,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "df43b67e",
+   "id": "e2a88122",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -104,7 +104,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5a07c3f2",
+   "id": "b1063968",
    "metadata": {},
    "source": [
     "## 1. Which labels, and which model\n",
@@ -124,7 +124,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ab25a5aa",
+   "id": "e04c092e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -133,7 +133,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e2fd9886",
+   "id": "74c46218",
    "metadata": {},
    "source": [
     "`patchtst` is this notebook's slice of the declared family. The menu declares four\n",
@@ -152,7 +152,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8c918961",
+   "id": "00d6eb29",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -169,7 +169,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "862581d0",
+   "id": "daa58412",
    "metadata": {},
    "source": [
     "`LABELS` and `CONFIG_NAMES` narrow the run below this notebook's own slice, and a narrowed run\n",
@@ -187,7 +187,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f2bd2601",
+   "id": "b6ff69f4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -208,7 +208,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8363f7ae",
+   "id": "04fdc189",
    "metadata": {},
    "source": [
     "## 2. Binding the declarations to the data\n",
@@ -243,7 +243,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "100cef1c",
+   "id": "4b9abbde",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -271,7 +271,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "83ce0024",
+   "id": "c373880a",
    "metadata": {},
    "source": [
     "## 3. Fitting the population\n",
@@ -312,7 +312,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d5fc13a5",
+   "id": "d3a6c2ce",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -333,7 +333,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "12d7761e",
+   "id": "1b3ec32d",
    "metadata": {},
    "source": [
     "`reused` is not zero on a second run. Every identity is re-derived from the inputs, the\n",
@@ -343,7 +343,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "02b49f80",
+   "id": "33e0e83c",
    "metadata": {},
    "source": [
     "## 4. What came out\n",
@@ -362,7 +362,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cd5436ab",
+   "id": "bd8599c2",
    "metadata": {
     "tags": [
      "results"
@@ -387,7 +387,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "499a6a10",
+   "id": "71dc21b1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -415,14 +415,15 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0e4c7763",
+   "id": "25c58447",
    "metadata": {},
    "source": [
     "## Key takeaways\n",
     "\n",
     "1. **A checkpoint is part of a configuration, not a detail of how it was fitted.** Scoring one\n",
-    "   fit at twenty points produces twenty candidates, and keeping the best of them after seeing\n",
-    "   the results is a selection decision. Selection happens in\n",
+    "   fit at twenty points produces twenty candidates, and keeping whichever of them scores\n",
+    "   highest on this page would be a selection decision taken on the wrong statistic: the\n",
+    "   curve below is an information coefficient, and selection is validation backtest Sharpe in\n",
     "   [`14_backtest`](14_backtest.ipynb), over the population published here.\n",
     "\n",
     "2. **How many windows are drawn is part of the model.** On a minute panel the cap decides what\n",
@@ -434,8 +435,9 @@
     "\n",
     "**Known limitations.** The window is fixed at sixty observations, so nothing earlier than the\n",
     "trailing hour reaches the model whatever the architecture can represent. The declared sequence\n",
-    "cap is a compute budget rather than a derived quantity - `config/setup.yaml` says so, and\n",
-    "ml4t/agent-workspace#1015 is where that argument goes."
+    "cap is a compute budget rather than a quantity derived from the data - `config/setup.yaml`\n",
+    "says so - so the same declared count covers a different share of the panel whenever the\n",
+    "panel's size changes."
    ]
   }
  ],

--- a/case_studies/nasdaq100_microstructure/11_dl_patchtst.ipynb
+++ b/case_studies/nasdaq100_microstructure/11_dl_patchtst.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "5e876c47",
+   "id": "a85095c3",
    "metadata": {},
    "source": [
     "# PatchTST - NASDAQ-100 Microstructure\n",
@@ -46,7 +46,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "48439126",
+   "id": "7d378681",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -69,7 +69,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "564059c5",
+   "id": "b2d460db",
    "metadata": {
     "tags": [
      "parameters"
@@ -90,7 +90,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8517081d",
+   "id": "6bd6fa8a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -104,7 +104,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "53943b4b",
+   "id": "df3a6849",
    "metadata": {},
    "source": [
     "## 1. Which labels, and which model\n",
@@ -124,7 +124,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3dabda9f",
+   "id": "152f139f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -133,7 +133,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "97ac51ce",
+   "id": "d1827e6f",
    "metadata": {},
    "source": [
     "`patchtst` is this notebook's slice of the declared family. The menu declares four\n",
@@ -152,7 +152,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a85e780c",
+   "id": "b615b3c6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -169,7 +169,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bbf2fc9c",
+   "id": "3029e0cf",
    "metadata": {},
    "source": [
     "`LABELS` and `CONFIG_NAMES` narrow the run below this notebook's own slice, and a narrowed run\n",
@@ -187,7 +187,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d592ce35",
+   "id": "8bd11b48",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -208,7 +208,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "631c986c",
+   "id": "84f61d32",
    "metadata": {},
    "source": [
     "## 2. Binding the declarations to the data\n",
@@ -236,8 +236,10 @@
     "four million near-identical overlapping sequences - neighbouring windows would share 59 of their\n",
     "60 observations. `modeling.dl.train_sequence_stride_horizons` in `config/setup.yaml` declares\n",
     "the spacing instead: one window per label horizon, so consecutive windows of a symbol carry\n",
-    "labels that do not overlap - the window ending at t is scored on the return from t to t+H and\n",
-    "the next one starts at t+H. It is declared in horizons rather than in windows because the\n",
+    "labels that do not overlap. [`02_labels`](02_labels.ipynb) takes the decision on the bar\n",
+    "closing at t, enters on the next bar's VWAP and holds for the horizon from that fill, so two\n",
+    "decisions H observations apart have return intervals that abut rather than share bars - the\n",
+    "exit of one is the entry of the next. It is declared in horizons rather than in windows because the\n",
     "horizon differs by label: `fwd_ret_5m` strides 5 observations, `fwd_ret_15m` 15 and\n",
     "`fwd_ret_60m` 60, each spacing its own labels exactly, where a single window count could only\n",
     "have been right for one of them. The spacing travels in the training identity; **how many\n",
@@ -248,7 +250,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7350895f",
+   "id": "766b6f91",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -276,7 +278,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6a6f7c74",
+   "id": "0bad3f03",
    "metadata": {},
    "source": [
     "## 3. Fitting the population\n",
@@ -317,7 +319,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ca1b159b",
+   "id": "00e7795c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -338,7 +340,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7a1e614d",
+   "id": "117647cd",
    "metadata": {},
    "source": [
     "`reused` is not zero on a second run. Every identity is re-derived from the inputs, the\n",
@@ -348,7 +350,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "754d541a",
+   "id": "6d03e63f",
    "metadata": {},
    "source": [
     "## 4. What came out\n",
@@ -367,7 +369,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "dae251f8",
+   "id": "3ee1a0d4",
    "metadata": {
     "tags": [
      "results"
@@ -392,7 +394,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5026a69e",
+   "id": "cce8a4de",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -420,7 +422,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ddba5ed1",
+   "id": "e7776b34",
    "metadata": {},
    "source": [
     "## Key takeaways\n",

--- a/case_studies/nasdaq100_microstructure/11_dl_patchtst.ipynb
+++ b/case_studies/nasdaq100_microstructure/11_dl_patchtst.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "f08f99d9",
+   "id": "5e876c47",
    "metadata": {},
    "source": [
     "# PatchTST - NASDAQ-100 Microstructure\n",
@@ -46,7 +46,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7baf0af5",
+   "id": "48439126",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -69,7 +69,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e2f20abe",
+   "id": "564059c5",
    "metadata": {
     "tags": [
      "parameters"
@@ -90,7 +90,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e2a88122",
+   "id": "8517081d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -104,7 +104,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b1063968",
+   "id": "53943b4b",
    "metadata": {},
    "source": [
     "## 1. Which labels, and which model\n",
@@ -124,7 +124,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e04c092e",
+   "id": "3dabda9f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -133,7 +133,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "74c46218",
+   "id": "97ac51ce",
    "metadata": {},
    "source": [
     "`patchtst` is this notebook's slice of the declared family. The menu declares four\n",
@@ -152,7 +152,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "00d6eb29",
+   "id": "a85e780c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -169,7 +169,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "daa58412",
+   "id": "bbf2fc9c",
    "metadata": {},
    "source": [
     "`LABELS` and `CONFIG_NAMES` narrow the run below this notebook's own slice, and a narrowed run\n",
@@ -187,7 +187,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b6ff69f4",
+   "id": "d592ce35",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -208,7 +208,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "04fdc189",
+   "id": "631c986c",
    "metadata": {},
    "source": [
     "## 2. Binding the declarations to the data\n",
@@ -231,19 +231,24 @@
     "- **`validation_start` and `validation_end` bracket the development sample.** The held-out tail\n",
     "  must not appear; it is scored once, at the end of the case study.\n",
     "\n",
-    "**How many windows are drawn is declared, not left to the tier.** Every row of this panel\n",
-    "starts a window, and the panel is minute bars, so an uncapped fold would build about four\n",
-    "million near-identical overlapping sequences - consecutive windows share 59 of their 60\n",
-    "observations. `modeling.dl.max_train_sequences` in `config/setup.yaml` declares the cap, which\n",
-    "makes it part of the training identity rather than a property of how the run was invoked. A\n",
-    "preview may lower it and cannot raise it above the declaration, because a preview that fits on\n",
-    "more windows than the canonical run is not rehearsing it."
+    "**How far apart the training windows sit is declared, not left to the tier.** Every row of this\n",
+    "panel could start a window, and the panel is minute bars, so an unspaced fold would build about\n",
+    "four million near-identical overlapping sequences - neighbouring windows would share 59 of their\n",
+    "60 observations. `modeling.dl.train_sequence_stride_horizons` in `config/setup.yaml` declares\n",
+    "the spacing instead: one window per label horizon, so consecutive windows of a symbol carry\n",
+    "labels that do not overlap - the window ending at t is scored on the return from t to t+H and\n",
+    "the next one starts at t+H. It is declared in horizons rather than in windows because the\n",
+    "horizon differs by label: `fwd_ret_5m` strides 5 observations, `fwd_ret_15m` 15 and\n",
+    "`fwd_ret_60m` 60, each spacing its own labels exactly, where a single window count could only\n",
+    "have been right for one of them. The spacing travels in the training identity; **how many\n",
+    "windows it yields is derived at run time** from the eligible rows of each fold rather than\n",
+    "declared, and is printed below."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4b9abbde",
+   "id": "7350895f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -271,7 +276,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c373880a",
+   "id": "6a6f7c74",
    "metadata": {},
    "source": [
     "## 3. Fitting the population\n",
@@ -312,7 +317,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d3a6c2ce",
+   "id": "ca1b159b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -333,7 +338,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1b3ec32d",
+   "id": "7a1e614d",
    "metadata": {},
    "source": [
     "`reused` is not zero on a second run. Every identity is re-derived from the inputs, the\n",
@@ -343,7 +348,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "33e0e83c",
+   "id": "754d541a",
    "metadata": {},
    "source": [
     "## 4. What came out\n",
@@ -362,7 +367,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bd8599c2",
+   "id": "dae251f8",
    "metadata": {
     "tags": [
      "results"
@@ -387,7 +392,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "71dc21b1",
+   "id": "5026a69e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -415,7 +420,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "25c58447",
+   "id": "ddba5ed1",
    "metadata": {},
    "source": [
     "## Key takeaways\n",
@@ -426,18 +431,19 @@
     "   curve below is an information coefficient, and selection is validation backtest Sharpe in\n",
     "   [`14_backtest`](14_backtest.ipynb), over the population published here.\n",
     "\n",
-    "2. **How many windows are drawn is part of the model.** On a minute panel the cap decides what\n",
-    "   was fitted, so it is declared in `config/setup.yaml` and travels in the training identity\n",
-    "   rather than arriving with the invocation.\n",
+    "2. **How far apart the training windows sit is part of the model.** On a minute panel the\n",
+    "   spacing decides what was fitted, so it is declared in `config/setup.yaml` as one window per\n",
+    "   label horizon and travels in the training identity rather than arriving with the invocation.\n",
     "\n",
     "3. **A sequence family is measured on fewer rows than a tabular one.** A prediction needs a\n",
     "   full window behind it, so the samples differ and the comparison has to say so.\n",
     "\n",
     "**Known limitations.** The window is fixed at sixty observations, so nothing earlier than the\n",
-    "trailing hour reaches the model whatever the architecture can represent. The declared sequence\n",
-    "cap is a compute budget rather than a quantity derived from the data - `config/setup.yaml`\n",
-    "says so - so the same declared count covers a different share of the panel whenever the\n",
-    "panel's size changes."
+    "trailing hour reaches the model whatever the architecture can represent. The window spacing is a\n",
+    "modelling choice rather than a compute budget - one window per label horizon is what stops two\n",
+    "training examples carrying the same return twice - so the number of windows a fold yields\n",
+    "follows from how many eligible rows it holds, and a panel of a different size changes the count\n",
+    "without changing the declaration."
    ]
   }
  ],

--- a/case_studies/nasdaq100_microstructure/11_dl_patchtst.py
+++ b/case_studies/nasdaq100_microstructure/11_dl_patchtst.py
@@ -312,8 +312,9 @@ show_plotly_with_alt(
 # ## Key takeaways
 #
 # 1. **A checkpoint is part of a configuration, not a detail of how it was fitted.** Scoring one
-#    fit at twenty points produces twenty candidates, and keeping the best of them after seeing
-#    the results is a selection decision. Selection happens in
+#    fit at twenty points produces twenty candidates, and keeping whichever of them scores
+#    highest on this page would be a selection decision taken on the wrong statistic: the
+#    curve below is an information coefficient, and selection is validation backtest Sharpe in
 #    [`14_backtest`](14_backtest.ipynb), over the population published here.
 #
 # 2. **How many windows are drawn is part of the model.** On a minute panel the cap decides what
@@ -325,5 +326,6 @@ show_plotly_with_alt(
 #
 # **Known limitations.** The window is fixed at sixty observations, so nothing earlier than the
 # trailing hour reaches the model whatever the architecture can represent. The declared sequence
-# cap is a compute budget rather than a derived quantity - `config/setup.yaml` says so, and
-# ml4t/agent-workspace#1015 is where that argument goes.
+# cap is a compute budget rather than a quantity derived from the data - `config/setup.yaml`
+# says so - so the same declared count covers a different share of the panel whenever the
+# panel's size changes.

--- a/case_studies/nasdaq100_microstructure/11_dl_patchtst.py
+++ b/case_studies/nasdaq100_microstructure/11_dl_patchtst.py
@@ -179,8 +179,10 @@ if (narrows or device != PUBLISHED_DEVICE) and not POPULATION_NAME:
 # four million near-identical overlapping sequences - neighbouring windows would share 59 of their
 # 60 observations. `modeling.dl.train_sequence_stride_horizons` in `config/setup.yaml` declares
 # the spacing instead: one window per label horizon, so consecutive windows of a symbol carry
-# labels that do not overlap - the window ending at t is scored on the return from t to t+H and
-# the next one starts at t+H. It is declared in horizons rather than in windows because the
+# labels that do not overlap. [`02_labels`](02_labels.ipynb) takes the decision on the bar
+# closing at t, enters on the next bar's VWAP and holds for the horizon from that fill, so two
+# decisions H observations apart have return intervals that abut rather than share bars - the
+# exit of one is the entry of the next. It is declared in horizons rather than in windows because the
 # horizon differs by label: `fwd_ret_5m` strides 5 observations, `fwd_ret_15m` 15 and
 # `fwd_ret_60m` 60, each spacing its own labels exactly, where a single window count could only
 # have been right for one of them. The spacing travels in the training identity; **how many

--- a/case_studies/nasdaq100_microstructure/11_dl_patchtst.py
+++ b/case_studies/nasdaq100_microstructure/11_dl_patchtst.py
@@ -174,13 +174,18 @@ if (narrows or device != PUBLISHED_DEVICE) and not POPULATION_NAME:
 # - **`validation_start` and `validation_end` bracket the development sample.** The held-out tail
 #   must not appear; it is scored once, at the end of the case study.
 #
-# **How many windows are drawn is declared, not left to the tier.** Every row of this panel
-# starts a window, and the panel is minute bars, so an uncapped fold would build about four
-# million near-identical overlapping sequences - consecutive windows share 59 of their 60
-# observations. `modeling.dl.max_train_sequences` in `config/setup.yaml` declares the cap, which
-# makes it part of the training identity rather than a property of how the run was invoked. A
-# preview may lower it and cannot raise it above the declaration, because a preview that fits on
-# more windows than the canonical run is not rehearsing it.
+# **How far apart the training windows sit is declared, not left to the tier.** Every row of this
+# panel could start a window, and the panel is minute bars, so an unspaced fold would build about
+# four million near-identical overlapping sequences - neighbouring windows would share 59 of their
+# 60 observations. `modeling.dl.train_sequence_stride_horizons` in `config/setup.yaml` declares
+# the spacing instead: one window per label horizon, so consecutive windows of a symbol carry
+# labels that do not overlap - the window ending at t is scored on the return from t to t+H and
+# the next one starts at t+H. It is declared in horizons rather than in windows because the
+# horizon differs by label: `fwd_ret_5m` strides 5 observations, `fwd_ret_15m` 15 and
+# `fwd_ret_60m` 60, each spacing its own labels exactly, where a single window count could only
+# have been right for one of them. The spacing travels in the training identity; **how many
+# windows it yields is derived at run time** from the eligible rows of each fold rather than
+# declared, and is printed below.
 
 # %%
 requests = model_requests(
@@ -317,15 +322,16 @@ show_plotly_with_alt(
 #    curve below is an information coefficient, and selection is validation backtest Sharpe in
 #    [`14_backtest`](14_backtest.ipynb), over the population published here.
 #
-# 2. **How many windows are drawn is part of the model.** On a minute panel the cap decides what
-#    was fitted, so it is declared in `config/setup.yaml` and travels in the training identity
-#    rather than arriving with the invocation.
+# 2. **How far apart the training windows sit is part of the model.** On a minute panel the
+#    spacing decides what was fitted, so it is declared in `config/setup.yaml` as one window per
+#    label horizon and travels in the training identity rather than arriving with the invocation.
 #
 # 3. **A sequence family is measured on fewer rows than a tabular one.** A prediction needs a
 #    full window behind it, so the samples differ and the comparison has to say so.
 #
 # **Known limitations.** The window is fixed at sixty observations, so nothing earlier than the
-# trailing hour reaches the model whatever the architecture can represent. The declared sequence
-# cap is a compute budget rather than a quantity derived from the data - `config/setup.yaml`
-# says so - so the same declared count covers a different share of the panel whenever the
-# panel's size changes.
+# trailing hour reaches the model whatever the architecture can represent. The window spacing is a
+# modelling choice rather than a compute budget - one window per label horizon is what stops two
+# training examples carrying the same return twice - so the number of windows a fold yields
+# follows from how many eligible rows it holds, and a panel of a different size changes the count
+# without changing the declaration.


### PR DESCRIPTION
Stages 08-11 of `nasdaq100_microstructure` - the four deep-learning notebooks. One notebook at a time, per `REVIEW.md` Part 2 section H; this PR grows as each lands.

## Landed

| notebook | executed | wall | peak | configs | prediction sets |
|---|---|---|---|---|---|
| `08_dl_nlinear` | 2026-09-10T22:35:24Z | 13,773 s (3 h 49) | 36.5 GB | 3 | 60 / 60 complete |
| `09_dl_lstm` | 2026-09-11T08:58:37Z | 15,103 s (4 h 12) | 36.7 GB | 3 | 60 / 60 complete |

Both exit 0, unparameterized, 0 errors and 0 null `execution_count`. Each publishes its own population - `nasdaq100_microstructure-nlinear-validation-v1` and `-lstm_h64-validation-v1` - of `lstm_h64`/`nlinear` against `fwd_ret_15m`, `fwd_ret_5m` and `fwd_ret_60m`, two folds and 20 checkpoints each, all rows `identity_version=3`, `execution_tier=canonical`, `entry_point` set.

Validated against the canonical registry: no NULL `elapsed_s`, 20 checkpoints per label, the declared population holding exactly 60 members, and ten `ic_mean` values per notebook matching `prediction_metrics` to six decimals with `complete=true`. Sidecars 6/6, pair sync clean, conformance passing.

Two prose claims about sibling families were checked against the registry rather than left asserted, since a false one is a C-clause defect. Both hold: the sequence family fits on 19-22% fewer rows than linear and gbm on every label (6,453,961 / 6,711,664 / 5,325,226 against 8,006,995 / 8,266,239 / 6,846,288, with linear and gbm agreeing exactly), and the fold boundaries are byte-identical across families, so the families differ in sample density within identical windows rather than in the windows.

## Two corrections RoboRev caught, both prose-only

The four notebooks told the reader that `modeling.dl.max_train_sequences` caps how many training windows are drawn. That key is not declared here; `train_sequence_stride_horizons: 1` is, and the two are mutually exclusive. The executed render refutes the old claim outright - windows per fold are 210,028 for `fwd_ret_15m` (stride 15), 655,498 for `fwd_ret_5m` (stride 5) and 43,237 for `fwd_ret_60m` (stride 60), scaling with the horizon where a fixed cap would have given one number for all three.

The replacement then placed the label interval a bar early. `02_labels` measures `V(t+B+H) / V(t+B) - 1`: the decision is taken on the bar closing at `t`, the earliest actionable bar is the next one, and the position is held for `H` from that fill. Both are now stated in `02_labels`' own terms, which also gives the sharper reason for striding by the horizon - two decisions `H` apart have return intervals that abut, the exit of one being the entry of the next.

Both fixes went through `notebook_provenance.py sync-prose`, so the executed outputs and original stamps are unchanged and no number moved.

## Cost, and why the projections were wrong

| config | registered | vs `08` same label | condition |
|---|---|---|---|
| `fwd_ret_15m` | 3,226.4 s | 0.700 | ran alone |
| `fwd_ret_5m` | 7,710.2 s | 1.375 | ran beside a GBM |
| `fwd_ret_60m` | 2,961.0 s | 1.294 | ran beside a GBM |

`09` was scheduled at 19,400 s by scaling `08`'s measured 13,773 s by the ratio of the two notebooks' smoke previews (419.4 s against 297.5 s). The first config measured 0.700, so the smoke ratio was wrong by 1.87x in the direction that over-reserves the machine. `REVIEW.md` already records why: a preview cannot cost an estimator along an axis it collapsed, in either direction, and these collapsed folds and symbols. A same-label ratio against a landed sibling is a controlled comparison; a smoke ratio is not.

The run then took 15,103 s rather than the 9,636 s that 0.700 implied, because `us_equities_panel/07_gbm` was admitted beside it. Dividing each config by `08`'s own time for the same label normalises the label out, so 0.700 alone against 1.375 contended measures the concurrency cost directly at **1.96x**. `nb-run`'s gate checks slots and MemAvailable and does not model CPU; this notebook is CPU-bound on data feeding, with the 3090 at 18% while its kernel runs 76 threads.

The 36.7 GB peak is a publish-phase spike of about 100 seconds, not a sustained level - steady fitting sits at 13.7-16.7 GB.

## Not in this PR

`10_dl_tcn` and `11_dl_patchtst` did not run. `10` was cleared to start only if it could finish inside the window on the pessimistic basis of `08`'s 13,773 s, and the contention above pushed `09`'s exit past the point where that held.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RGzYYAT4kRAdDJZrXB7A3A