### PR TITLE
Check every supersedes declaration, and every live generation nothing declares

### DIFF
--- a/scripts/check_supersedes_literals.py
+++ b/scripts/check_supersedes_literals.py
@@ -25,11 +25,35 @@ meant missing 8 of 17 literals including 3 of the 6 stale ones. Looking the decl
 in ``official_populations`` and resolving the lineage of whatever name owns it reads all of
 them. Do not simplify this back to a name lookup.
 
+**Two lineages, and every declaration name.** A hash is looked up in ``official_populations``
+and in ``candidate_set_names``, which have the same shape and the same resolver rule -
+``candidate_set_supersedes`` offers a declared hash when it is the head or what the head
+replaced, exactly as ``population_supersedes`` does. And every ``SUPERSEDES_*`` constant is
+read, not a list of two: the corpus holds 24 distinct names, and the candidate-set ones hold a
+``dict`` keyed by set name rather than a string.
+
+**The declaration that is ABSENT is the one that costs a fit**, and no literal check can see
+it. ``us_equities_panel/06_linear`` ran with ``SUPERSEDES_SETS = {}`` - nothing to classify, so
+every literal passed - and was refused at registration after 78 minutes of cold fit and 19.2 h
+of registered fit over 64 configs: ``a changed candidate set named
+'us-equities-fwd-ret-1d-linear-v1' must explicitly supersedes 454f73021f33``. So the check runs
+per LIVE GENERATION as well as per literal: a candidate set with a head that no declaration in
+the case study names, by name or by hash, is reported with the hash to paste.
+
+The condition there is a head existing at check time, never a name appearing in source.
+Declaring nothing is correct until a generation exists to supersede - ``create`` refuses a
+first version that claims to replace one - so a rule keyed on the source would have failed
+``06_linear`` on the run where it was right. Reported by default and fatal only under
+``--require-declarations``, because the declaration is resolved in the worktree at launch
+rather than committed ahead of the run: a notebook on ``main`` is expected to name only what
+it has already replaced.
+
 Usage::
 
     python scripts/check_supersedes_literals.py                    # every case study
     python scripts/check_supersedes_literals.py --case-study etfs  # one
     python scripts/check_supersedes_literals.py --json             # machine-readable
+    python scripts/check_supersedes_literals.py --case-study etfs --require-declarations
 
 **What a stale literal does and does not cost, because the difference decides what this
 refuses.** ``OfficialPopulation.create`` reads the declared predecessor only when the member
@@ -71,15 +95,27 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 # which is the failure this script exists to prevent, arriving inside the script itself.
 _POPULATION_NAME = "SUPERSEDES_POPULATION"
 _CAUSAL_NAME = "SUPERSEDES_CAUSAL"
+_SUPERSEDES_PREFIX = "SUPERSEDES"
+
+# Every `SUPERSEDES_*` constant, not the two that were named here first. The committed corpus
+# uses 24 distinct names - `SUPERSEDES_SETS`, `SUPERSEDES_CANDIDATE_SETS`,
+# `SUPERSEDES_MODEL_POPULATION`, `SUPERSEDES_COST_BACKTESTS` and 20 more - and reading two of
+# them is how `us_equities_panel` reported "0 declared literal(s); 0 stale" on 2026-09-11 while
+# `06_linear.py:124` declared two live ones. Keying on the prefix rather than a list is what
+# keeps the 25th name from being invisible the day it is written.
+#
+# The value is a string for a single lineage and a `dict[name, hash]` where one notebook freezes
+# several - and a dict is not an `ast.Constant`, so the old reader skipped every dict-valued
+# declaration in the corpus whatever it was called.
 
 
-def _declared_literals(source: str) -> dict[str, str]:
-    """The string value assigned to each SUPERSEDES_* name, whatever the assignment shape."""
+def _declared_literals(source: str) -> dict[str, str | dict[str, str]]:
+    """The value assigned to each ``SUPERSEDES*`` name, whatever the assignment shape."""
     try:
         tree = ast.parse(source)
     except SyntaxError:
         return {}
-    found: dict[str, str] = {}
+    found: dict[str, str | dict[str, str]] = {}
     for node in ast.walk(tree):
         if isinstance(node, ast.AnnAssign):
             targets = [node.target]
@@ -87,13 +123,28 @@ def _declared_literals(source: str) -> dict[str, str]:
             targets = node.targets
         else:
             continue
-        value = node.value
-        if not isinstance(value, ast.Constant) or not isinstance(value.value, str):
-            continue
         for target in targets:
-            if isinstance(target, ast.Name) and target.id in (_POPULATION_NAME, _CAUSAL_NAME):
-                found[target.id] = value.value
+            if not isinstance(target, ast.Name) or not target.id.startswith(_SUPERSEDES_PREFIX):
+                continue
+            try:
+                value = ast.literal_eval(node.value)
+            except (ValueError, SyntaxError):
+                # Built at runtime. Unreadable here and reported as such by the caller rather
+                # than guessed at, which is the same answer `_population_name` gives.
+                continue
+            if isinstance(value, str) or (
+                isinstance(value, dict)
+                and all(isinstance(k, str) and isinstance(v, str) for k, v in value.items())
+            ):
+                found[target.id] = value
     return found
+
+
+def _declared_pairs(value: str | dict[str, str]) -> list[tuple[str | None, str]]:
+    """``(lineage name, hash)`` for a declaration, where a dict states its own names."""
+    if isinstance(value, dict):
+        return [(name, h) for name, h in value.items() if h]
+    return [(None, value)] if value else []
 
 
 @dataclass
@@ -139,14 +190,33 @@ def _registry_for(case_study: str, artifacts_root: Path) -> Path:
     return artifacts_root / case_study / "run_log" / "registry.db"
 
 
-def _current_generation(db: sqlite3.Connection, name: str) -> tuple[str, str | None] | None:
+# The two lineage tables a declared hash can live in. They have the same shape - a name, a
+# hash, and the hash it supersedes - and `candidate_set_supersedes` makes the same decision
+# about a candidate set that `population_supersedes` makes about a population: it offers the
+# declared hash when it is the head or what the head replaced, and withholds it otherwise
+# (`case_studies/research/comparison.py:112-123`). So one classifier serves both, and the
+# only thing that differs is which table to read.
+_LINEAGES: tuple[tuple[str, str], ...] = (
+    ("official_populations", "population_hash"),
+    ("candidate_set_names", "set_hash"),
+)
+
+
+def _current_generation(
+    db: sqlite3.Connection,
+    name: str,
+    *,
+    table: str = "official_populations",
+    hash_column: str = "population_hash",
+) -> tuple[str, str | None] | None:
     """The snapshot in force under *name*: the one nothing supersedes.
 
-    The same rule as ``OfficialPopulation.one``. A fork - two snapshots nothing supersedes -
-    has no defensible answer and is reported rather than picked between.
+    The same rule as ``OfficialPopulation.one`` and ``CandidateSet.one``. A fork - two
+    snapshots nothing supersedes - has no defensible answer and is reported rather than
+    picked between.
     """
     rows = db.execute(
-        "SELECT population_hash, supersedes_hash FROM official_populations WHERE name = ?",
+        f"SELECT {hash_column}, supersedes_hash FROM {table} WHERE name = ?",  # noqa: S608
         (name,),
     ).fetchall()
     if not rows:
@@ -156,6 +226,29 @@ def _current_generation(db: sqlite3.Connection, name: str) -> tuple[str, str | N
     if len(heads) != 1:
         raise ValueError(f"{len(heads)} current snapshots among {len(rows)} under {name!r}")
     return heads[0]
+
+
+def _owning_lineage(db: sqlite3.Connection, declared: str) -> tuple[str, str, str] | None:
+    """``(table, hash column, name)`` for whichever lineage holds *declared*.
+
+    Keyed on the hash rather than the name, which is the rule this whole script is built on:
+    the declaration's variable name does not say which lineage it belongs to, and on the
+    committed corpus the same file declares a population hash and a candidate-set hash under
+    two different ``SUPERSEDES_*`` names.
+    """
+    for table, hash_column in _LINEAGES:
+        try:
+            row = db.execute(
+                f"SELECT name FROM {table} WHERE {hash_column} = ?",  # noqa: S608
+                (declared,),
+            ).fetchone()
+        except sqlite3.OperationalError as exc:
+            if "no such table" not in str(exc):
+                raise
+            continue
+        if row is not None:
+            return table, hash_column, row[0]
+    return None
 
 
 def _declared_causal_hashes(literal: str) -> list[tuple[str, str | None]]:
@@ -301,18 +394,319 @@ def _check_causal(case_study: str, notebook: Path, registry: Path, literal: str)
     return findings
 
 
+def _check_lineage_literal(
+    case_study: str,
+    notebook: Path,
+    registry: Path,
+    parameter: str,
+    pairs: list[tuple[str | None, str]],
+) -> list[Finding]:
+    """Classify a declared hash against whichever lineage table holds it.
+
+    This is the population classifier applied to every other ``SUPERSEDES_*`` name, and the
+    verdicts are the same three because the resolver is the same: a hash that names the head
+    publishes over it, a hash that names what the head replaced resolves to the head, and
+    anything else is withheld and refused by ``create`` after the fit is paid for.
+
+    A dict-valued declaration states the lineage name itself, which is strictly more than the
+    population path can read: when the hash is in no lineage at all, the name still says
+    whether a generation exists to supersede, so a dead hash can be answered with the head to
+    paste instead of being reported as unresolved.
+    """
+    findings: list[Finding] = []
+    if not registry.exists():
+        return [
+            Finding(
+                case_study,
+                notebook.name,
+                declared,
+                "no-registry",
+                "no registry on disk; a clone publishes generation one and withholds this",
+                parameter,
+                label=name,
+            )
+            for name, declared in pairs
+        ]
+
+    db = sqlite3.connect(f"file:{registry}?mode=ro", uri=True)
+    try:
+        for name, declared in pairs:
+            owner = _owning_lineage(db, declared)
+            if owner is None:
+                # Absent is not evidence on its own - a reset or a reader's empty registry
+                # withholds the hash and `create` publishes generation one. It is wrong only
+                # when a generation already exists under the name this declaration states.
+                head = None
+                if name:
+                    for table, hash_column in _LINEAGES:
+                        try:
+                            head = _current_generation(
+                                db, name, table=table, hash_column=hash_column
+                            )
+                        except sqlite3.OperationalError:
+                            continue
+                        except ValueError as exc:
+                            findings.append(
+                                Finding(
+                                    case_study,
+                                    notebook.name,
+                                    declared,
+                                    "forked",
+                                    str(exc),
+                                    parameter,
+                                    label=name,
+                                )
+                            )
+                            head = None
+                            break
+                        if head is not None:
+                            break
+                if head is not None:
+                    tip, tip_supersedes = head
+                    findings.append(
+                        Finding(
+                            case_study,
+                            notebook.name,
+                            declared,
+                            "stale",
+                            f"{name!r} is at {tip} (superseding {tip_supersedes}) and this "
+                            "hash is in no lineage the registry holds",
+                            parameter,
+                            tip,
+                            name,
+                        )
+                    )
+                else:
+                    findings.append(
+                        Finding(
+                            case_study,
+                            notebook.name,
+                            declared,
+                            "unresolved",
+                            "this hash is in no lineage the registry holds, and no generation "
+                            f"was found under {name!r}"
+                            if name
+                            else "this hash is in no lineage the registry holds, and the "
+                            "declaration states no name to look one up under",
+                            parameter,
+                            label=name,
+                        )
+                    )
+                continue
+
+            table, hash_column, owner_name = owner
+            try:
+                head = _current_generation(db, owner_name, table=table, hash_column=hash_column)
+            except ValueError as exc:
+                findings.append(
+                    Finding(
+                        case_study,
+                        notebook.name,
+                        declared,
+                        "forked",
+                        str(exc),
+                        parameter,
+                        label=name,
+                    )
+                )
+                continue
+            assert head is not None  # a hash we just found has at least its own row
+            tip, tip_supersedes = head
+            remedy = None
+            if declared == tip:
+                status, detail = (
+                    "live",
+                    f"names the tip of {owner_name!r}; a refit publishes over it",
+                )
+            elif declared == tip_supersedes:
+                status, detail = (
+                    "live",
+                    f"names what the tip of {owner_name!r} replaced; a re-run resolves to it",
+                )
+            else:
+                status, detail = (
+                    "stale",
+                    f"{owner_name!r} is at {tip} (superseding {tip_supersedes}); this literal "
+                    "is neither",
+                )
+                remedy = tip
+            findings.append(
+                Finding(
+                    case_study, notebook.name, declared, status, detail, parameter, remedy, name
+                )
+            )
+    finally:
+        db.close()
+    return findings
+
+
+# A notebook that freezes a candidate set. Only these owe a declaration: a notebook that
+# reads one with `CandidateSet.one` is handed whatever generation is in force and supersedes
+# nothing.
+_FREEZES = re.compile(r"candidate_set_supersedes|CandidateSet\.create|\.freeze\(")
+
+# An f-string that could name a lineage, as a SQL LIKE pattern. `f"us-equities-{label}-linear-v1"`
+# becomes `us-equities-%-linear-v1`, which is what lets a static reader enumerate the sets a
+# notebook will freeze without executing it - the dict keys cannot do that, because the missing
+# declaration is exactly the entry that is not in the dict.
+_MIN_TEMPLATE_LITERAL = 8
+
+
+def _freeze_templates(source: str) -> set[str]:
+    """LIKE patterns for the lineage names *source* builds, where they can be read.
+
+    Degenerate templates are dropped rather than guessed at. `f"{a}-{b}"` becomes `%-%` and
+    matches every name in the table, which would attribute the whole registry to one notebook;
+    so a pattern needs real literal text and must not open with a wildcard.
+    """
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return set()
+    patterns: set[str] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.JoinedStr):
+            continue
+        pattern = ""
+        literal_chars = 0
+        for part in node.values:
+            if isinstance(part, ast.Constant) and isinstance(part.value, str):
+                pattern += part.value.replace("%", r"\%").replace("_", r"\_")
+                literal_chars += len(part.value)
+            else:
+                pattern += "%"
+        if (
+            literal_chars >= _MIN_TEMPLATE_LITERAL
+            and "%" in pattern
+            and not pattern.startswith("%")
+        ):
+            patterns.add(pattern)
+    return patterns
+
+
+def _undeclared_heads(case_study: str, registry: Path, notebooks: list[Path]) -> list[Finding]:
+    """Live candidate-set generations that no declaration in this case study covers.
+
+    This is the half that costs a fit, and it is not a stale-literal check. `us_equities_panel`
+    on 2026-09-10 declared `SUPERSEDES_SETS = {}` - nothing to classify, so every literal check
+    passes - and `06_linear` then ran 78 minutes of cold fit, 19.2 h of registered fit over 64
+    configs, and was refused at registration with `a changed candidate set named
+    'us-equities-fwd-ret-1d-linear-v1' must explicitly supersedes 454f73021f33`.
+
+    The condition is a live head existing NOW, not a name appearing in source. A first
+    generation must not be reported: before that run `fwd_ret_5d` and `fwd_ret_21d` had no
+    generation and declaring nothing for them was correct, and `create` refuses a first version
+    that claims to replace one. They have heads now, so the next run that moves their members
+    is refused unless they are declared.
+
+    Coverage is by name OR by hash, because a string-valued declaration names no set and only
+    its hash can place it - the same reason this script keys on hashes everywhere else.
+    """
+    if not registry.exists():
+        return []
+    db = sqlite3.connect(f"file:{registry}?mode=ro", uri=True)
+    try:
+        try:
+            rows = db.execute(
+                "SELECT name, set_hash, supersedes_hash FROM candidate_set_names"
+            ).fetchall()
+        except sqlite3.OperationalError as exc:
+            if "no such table" not in str(exc):
+                raise
+            return []
+
+        by_name: dict[str, list[tuple[str, str | None]]] = {}
+        for name, set_hash, supersedes in rows:
+            by_name.setdefault(name, []).append((set_hash, supersedes))
+        heads: dict[str, tuple[str, str | None]] = {}
+        for name, generations in by_name.items():
+            superseded = {s for _, s in generations if s}
+            live = [g for g in generations if g[0] not in superseded]
+            if len(live) == 1:
+                heads[name] = live[0]
+
+        declared_names: set[str] = set()
+        declared_hashes: set[str] = set()
+        owners: dict[str, list[str]] = {}
+        for notebook in notebooks:
+            source = notebook.read_text(encoding="utf-8", errors="ignore")
+            for value in _declared_literals(source).values():
+                for lineage_name, declared in _declared_pairs(value):
+                    if lineage_name:
+                        declared_names.add(lineage_name)
+                    declared_hashes.add(declared)
+            if not _FREEZES.search(source):
+                continue
+            for pattern in _freeze_templates(source):
+                for name in heads:
+                    if db.execute("SELECT ? LIKE ? ESCAPE '\\'", (name, pattern)).fetchone()[0]:
+                        owners.setdefault(name, []).append(notebook.name)
+
+        findings: list[Finding] = []
+        for name, (tip, tip_supersedes) in sorted(heads.items()):
+            if name in declared_names or tip in declared_hashes:
+                continue
+            if tip_supersedes and tip_supersedes in declared_hashes:
+                continue
+            attributed = sorted(set(owners.get(name, [])))
+            # Attribution is an annotation, never the key. A name whose template no notebook
+            # states - `cme_futures` builds all eleven of its names as plain literals - is
+            # still a live head nothing declares, and reporting it under the case study is
+            # more useful than dropping it because the owner could not be worked out.
+            if len(attributed) == 1:
+                notebook_name, where = attributed[0], f"{attributed[0]} freezes it"
+            else:
+                notebook_name = "-"
+                where = (
+                    f"frozen by one of {attributed}"
+                    if attributed
+                    else "no notebook states this name as a readable template"
+                )
+            findings.append(
+                Finding(
+                    case_study,
+                    notebook_name,
+                    tip,
+                    "undeclared",
+                    f"{name!r} is live at {tip} and no SUPERSEDES_* declaration in this case "
+                    f"study names it or its hash; {where}. The next run that moves its "
+                    "members is refused at the freeze, after the fit",
+                    "SUPERSEDES_SETS",
+                    tip,
+                    name,
+                )
+            )
+        return findings
+    finally:
+        db.close()
+
+
 def check_case_study(case_study: str, *, repo_root: Path, artifacts_root: Path) -> list[Finding]:
     findings: list[Finding] = []
     registry = _registry_for(case_study, artifacts_root)
+    notebooks = sorted((repo_root / "case_studies" / case_study).glob("[0-9]*.py"))
+    findings.extend(_undeclared_heads(case_study, registry, notebooks))
 
-    for notebook in sorted((repo_root / "case_studies" / case_study).glob("[0-9]*.py")):
+    for notebook in notebooks:
         declared_by_name = _declared_literals(notebook.read_text(encoding="utf-8", errors="ignore"))
         causal = declared_by_name.get(_CAUSAL_NAME, "")
-        if causal:
+        if causal and isinstance(causal, str):
             findings.extend(_check_causal(case_study, notebook, registry, causal))
 
+        # Every other `SUPERSEDES_*` name goes through the shared lineage classifier. The
+        # population one keeps its own branch below because it can fall back on
+        # `_population_name` to read the name out of the source when the hash is absent.
+        for parameter, value in sorted(declared_by_name.items()):
+            if parameter in (_CAUSAL_NAME, _POPULATION_NAME):
+                continue
+            pairs = _declared_pairs(value)
+            if pairs:
+                findings.extend(
+                    _check_lineage_literal(case_study, notebook, registry, parameter, pairs)
+                )
+
         declared = declared_by_name.get(_POPULATION_NAME, "")
-        if not declared:
+        if not declared or not isinstance(declared, str):
             continue
 
         if not registry.exists():
@@ -454,6 +848,16 @@ def main(argv: list[str] | None = None) -> int:
     )
     parser.add_argument("--json", action="store_true", help="emit findings as JSON")
     parser.add_argument(
+        "--require-declarations",
+        action="store_true",
+        help=(
+            "exit non-zero when a live candidate-set generation is declared nowhere. Off by "
+            "default and meant for the launch of the case study being queued: the declaration "
+            "is resolved in the worktree at launch, not committed ahead of the run, so a "
+            "notebook on main is expected to name only what it has already replaced."
+        ),
+    )
+    parser.add_argument(
         "--allow-stale-supersedes",
         action="store_true",
         help=(
@@ -475,12 +879,37 @@ def main(argv: list[str] | None = None) -> int:
             mark = "STALE" if finding.is_stale else finding.status.upper()
             print(f"{mark:<11} {finding.case_study}/{finding.notebook}  {finding.declared}")
             print(f"            {finding.detail}")
-        checked = len(findings)
+        undeclared_count = sum(f.status == "undeclared" for f in findings)
+        checked = len(findings) - undeclared_count
         stale = sum(f.is_stale for f in findings)
-        print(f"\n{checked} declared literal(s); {stale} stale")
+        print(
+            f"\n{checked} declared literal(s); {stale} stale; "
+            f"{undeclared_count} live generation(s) declared nowhere"
+        )
 
     stale = [f for f in findings if f.is_stale]
     unresolved = [f for f in findings if f.status == "unresolved"]
+    undeclared = [f for f in findings if f.status == "undeclared"]
+
+    if undeclared:
+        # The expensive one. A stale literal at least tells the reader a lineage exists; an
+        # absent declaration reads as "nothing to check" and every literal check passes, which
+        # is how `us_equities_panel/06_linear` reached registration having already paid for
+        # 19.2 h of registered fit.
+        print(
+            f"\n{len(undeclared)} live candidate-set generation(s) that no declaration names. "
+            "Each is refused at the freeze - after the fit - on the next run that moves its "
+            "members:\n",
+            file=sys.stderr,
+        )
+        for finding in undeclared:
+            print(
+                f"  {finding.case_study}: {finding.label}\n"
+                f"      {finding.detail}\n"
+                f'      fix: declare "{finding.label}": "{finding.remedy}" in the freezing '
+                "notebook's SUPERSEDES_* mapping, in the worktree you are about to launch",
+                file=sys.stderr,
+            )
 
     for finding in unresolved:
         # Warned, never blocked. Refusing on "I could not resolve this" would be the check
@@ -491,6 +920,13 @@ def main(argv: list[str] | None = None) -> int:
             f"      {finding.detail}",
             file=sys.stderr,
         )
+
+    if undeclared and args.require_declarations:
+        print(
+            "\nRefusing because --require-declarations was passed.",
+            file=sys.stderr,
+        )
+        return 1
 
     if stale and not args.allow_stale_supersedes:
         # Addressed to the person about to queue a chain, because that is the only person for

--- a/tests/test_supersedes_checker_reads_every_declaration.py
+++ b/tests/test_supersedes_checker_reads_every_declaration.py
@@ -1,0 +1,213 @@
+"""The pre-flight checker reads every ``SUPERSEDES_*`` declaration, and every live lineage.
+
+``scripts/check_supersedes_literals.py`` exists to catch, before a chain is queued, a
+declaration that the registry will refuse at write time - after the fit is paid for. It read
+two names, ``SUPERSEDES_POPULATION`` and ``SUPERSEDES_CAUSAL``, and only string-valued ones.
+
+Both halves of that were wrong against the committed corpus. There are 24 distinct
+``SUPERSEDES_*`` names in ``case_studies/``, the candidate-set ones hold a ``dict`` keyed by
+set name, and a dict is not an ``ast.Constant`` - so every candidate-set declaration was
+invisible whatever it was called. On 2026-09-11 the checker reported "0 declared literal(s);
+0 stale" for ``us_equities_panel`` while ``06_linear.py`` declared two live ones.
+
+The costlier half is the declaration that is ABSENT. ``us_equities_panel/06_linear`` ran with
+``SUPERSEDES_SETS = {}``, which gives a literal check nothing to classify, and was refused at
+registration after 78 minutes of cold fit and 19.2 h of registered fit across 64 configs:
+``a changed candidate set named 'us-equities-fwd-ret-1d-linear-v1' must explicitly supersedes
+454f73021f33``. So the check that pays for itself is per live generation, not per literal.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+
+_spec = importlib.util.spec_from_file_location(
+    "check_supersedes_literals", REPO / "scripts" / "check_supersedes_literals.py"
+)
+assert _spec and _spec.loader
+checker = importlib.util.module_from_spec(_spec)
+sys.modules["check_supersedes_literals"] = checker
+_spec.loader.exec_module(checker)
+
+
+def _registry(tmp_path: Path, rows: list[tuple[str, str, str | None]]) -> Path:
+    """A registry holding just the candidate-set lineage table the checker reads."""
+    path = tmp_path / "case_studies" / "demo" / "run_log" / "registry.db"
+    path.parent.mkdir(parents=True)
+    db = sqlite3.connect(path)
+    db.execute(
+        "CREATE TABLE candidate_set_names (name TEXT NOT NULL, set_hash TEXT NOT NULL, "
+        "supersedes_hash TEXT, created_at TEXT NOT NULL, git_commit TEXT, "
+        "PRIMARY KEY (name, set_hash))"
+    )
+    db.executemany(
+        "INSERT INTO candidate_set_names VALUES (?, ?, ?, '2026-01-01T00:00:00Z', NULL)", rows
+    )
+    db.commit()
+    db.close()
+    return path
+
+
+FREEZING_NOTEBOOK = """
+from case_studies.research.comparison import candidate_set_supersedes
+
+SUPERSEDES_SETS: dict = {}
+
+for label_name in LABELS:
+    full_set_name = f"demo-{label_name}-linear-v1"
+    candidate_set_supersedes(study, name=full_set_name, declared=SUPERSEDES_SETS.get(full_set_name, ""))
+"""
+
+
+# --- reading the declaration ----------------------------------------------------------
+
+
+def test_a_dict_valued_declaration_is_read_whatever_it_is_called() -> None:
+    """The shape the old reader dropped: not an ast.Constant, and not one of two names."""
+    declared = checker._declared_literals(
+        'SUPERSEDES_SETS: dict = {"a-v1": "1111"}\n'
+        'SUPERSEDES_CANDIDATE_SETS: dict[str, str] = {"b-v1": "2222"}\n'
+        'SUPERSEDES_COST_BACKTESTS: str = "3333"\n'
+    )
+    assert declared["SUPERSEDES_SETS"] == {"a-v1": "1111"}
+    assert declared["SUPERSEDES_CANDIDATE_SETS"] == {"b-v1": "2222"}
+    assert declared["SUPERSEDES_COST_BACKTESTS"] == "3333"
+
+
+def test_a_declaration_built_at_runtime_is_skipped_not_guessed() -> None:
+    """`literal_eval` fails and the name is reported absent rather than half-read."""
+    assert checker._declared_literals("SUPERSEDES_SETS = {NAME: resolve(NAME)}") == {}
+
+
+def test_a_dict_states_its_own_lineage_names() -> None:
+    assert checker._declared_pairs({"a-v1": "1111", "b-v1": ""}) == [("a-v1", "1111")]
+    assert checker._declared_pairs("3333") == [(None, "3333")]
+    assert checker._declared_pairs("") == []
+
+
+# --- classifying a declared hash ------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("declared", "status"),
+    [
+        # `candidate_set_supersedes` offers the hash when it is the head or what the head
+        # replaced, and withholds it otherwise (research/comparison.py:121).
+        ("55d6", "live"),
+        ("454f", "live"),
+        ("dead", "stale"),
+    ],
+)
+def test_a_candidate_set_literal_is_classified_by_the_resolvers_own_rule(
+    tmp_path: Path, declared: str, status: str
+) -> None:
+    registry = _registry(
+        tmp_path, [("demo-linear-v1", "454f", None), ("demo-linear-v1", "55d6", "454f")]
+    )
+    findings = checker._check_lineage_literal(
+        "demo", Path("06_linear.py"), registry, "SUPERSEDES_SETS", [("demo-linear-v1", declared)]
+    )
+    assert [f.status for f in findings] == [status]
+    if status == "stale":
+        assert findings[0].remedy == "55d6"
+
+
+def test_a_dead_hash_is_answered_with_the_head_because_the_dict_names_the_lineage(
+    tmp_path: Path,
+) -> None:
+    """More than the population path can do: the key says where to look when the hash is gone.
+
+    `fx_pairs/14_portfolio_management.py` declares three of these - hashes from before a
+    registry rebuild, in no lineage the table holds - and each names a set that does have a
+    live head, so the repair is printable instead of being reported as unresolvable.
+    """
+    registry = _registry(tmp_path, [("demo-linear-v1", "77ab", None)])
+    findings = checker._check_lineage_literal(
+        "demo", Path("06_linear.py"), registry, "SUPERSEDES_SETS", [("demo-linear-v1", "gone")]
+    )
+    assert findings[0].status == "stale"
+    assert findings[0].remedy == "77ab"
+
+
+# --- the missing declaration ----------------------------------------------------------
+
+
+def test_a_live_generation_that_nothing_declares_is_reported(tmp_path: Path) -> None:
+    """The half that costs a fit. An empty mapping gives a literal check nothing to read."""
+    registry = _registry(tmp_path, [("demo-fwd_ret_5d-linear-v1", "e7b7", None)])
+    notebook = tmp_path / "06_linear.py"
+    notebook.write_text(FREEZING_NOTEBOOK)
+
+    findings = checker._undeclared_heads("demo", registry, [notebook])
+
+    assert [f.status for f in findings] == ["undeclared"]
+    assert findings[0].label == "demo-fwd_ret_5d-linear-v1"
+    assert findings[0].remedy == "e7b7"
+    # Attributed through the f-string template, which is the only thing that can name a set
+    # the dict does not: the missing entry is by definition not a key.
+    assert findings[0].notebook == "06_linear.py"
+
+
+def test_a_name_with_no_generation_is_not_reported(tmp_path: Path) -> None:
+    """The boundary. Declaring nothing is CORRECT until a generation exists to supersede.
+
+    `create` refuses a first version that claims to replace one, so a rule keyed on the name
+    appearing in source would have failed 06_linear on the run where it was right.
+    """
+    registry = _registry(tmp_path, [("demo-fwd_ret_1d-linear-v1", "454f", None)])
+    notebook = tmp_path / "06_linear.py"
+    notebook.write_text(FREEZING_NOTEBOOK)
+
+    reported = {f.label for f in checker._undeclared_heads("demo", registry, [notebook])}
+    assert reported == {"demo-fwd_ret_1d-linear-v1"}
+    assert "demo-fwd_ret_5d-linear-v1" not in reported
+
+
+def test_a_declared_generation_is_not_reported(tmp_path: Path) -> None:
+    registry = _registry(tmp_path, [("demo-fwd_ret_5d-linear-v1", "e7b7", None)])
+    notebook = tmp_path / "06_linear.py"
+    notebook.write_text(
+        FREEZING_NOTEBOOK.replace(
+            "SUPERSEDES_SETS: dict = {}",
+            'SUPERSEDES_SETS: dict = {"demo-fwd_ret_5d-linear-v1": "e7b7"}',
+        )
+    )
+    assert checker._undeclared_heads("demo", registry, [notebook]) == []
+
+
+def test_a_string_declaration_covers_its_lineage_by_hash(tmp_path: Path) -> None:
+    """A string names no set, so only its hash can place it - the reason this keys on hashes."""
+    registry = _registry(tmp_path, [("demo-fwd_ret_5d-linear-v1", "e7b7", None)])
+    notebook = tmp_path / "06_linear.py"
+    notebook.write_text(FREEZING_NOTEBOOK + '\nSUPERSEDES_CANDIDATES: str = "e7b7"\n')
+    assert checker._undeclared_heads("demo", registry, [notebook]) == []
+
+
+def test_a_notebook_that_only_reads_a_set_is_not_named_as_its_owner(tmp_path: Path) -> None:
+    """A reader is handed whatever generation is in force and supersedes nothing."""
+    registry = _registry(tmp_path, [("demo-fwd_ret_5d-linear-v1", "e7b7", None)])
+    reader = tmp_path / "19_strategy_analysis.py"
+    reader.write_text('x = CandidateSet.one(study, name=f"demo-{label}-linear-v1")\n')
+
+    findings = checker._undeclared_heads("demo", registry, [reader])
+
+    assert [f.status for f in findings] == ["undeclared"]
+    assert findings[0].notebook == "-"
+    assert "no notebook states this name as a readable template" in findings[0].detail
+
+
+# --- the degenerate template ----------------------------------------------------------
+
+
+def test_a_template_with_no_literal_text_is_dropped() -> None:
+    """`f"{a}-{b}"` becomes `%-%` and would attribute the whole registry to one notebook."""
+    assert checker._freeze_templates('x = f"{a}-{b}"') == set()
+    assert checker._freeze_templates('x = f"{a}-linear-v1"') == set()
+    assert checker._freeze_templates('x = f"demo-{a}-linear-v1"') == {"demo-%-linear-v1"}


### PR DESCRIPTION
`scripts/check_supersedes_literals.py` exists to catch, before a chain is queued, a declaration the registry will refuse at write time - after the fit is paid for. It passed `us_equities_panel` with `0 declared literal(s); 0 stale` on the day `06_linear` lost 78 minutes of cold fit and 19.2 h of registered fit across 64 configs to exactly that refusal:

```
ValueError: a changed candidate set named 'us-equities-fwd-ret-1d-linear-v1'
must explicitly supersedes 454f73021f33
```

Two independent reasons it could not see it, and they need different fixes.

## It read 2 of 24 declaration names

`case_studies/` holds **24 distinct `SUPERSEDES_*` constants**. The script named two of them:

```
68 SUPERSEDES_POPULATION      12 SUPERSEDES_SETS       9 SUPERSEDES_CAUSAL
 4 SUPERSEDES_CANDIDATE_SETS   3 SUPERSEDES_MODEL_POPULATION   ... 24 total
```

It also required an `ast.Constant`, and every candidate-set declaration is a `dict` keyed by set name - so those were dropped whatever they were called. Reading the prefix and accepting both shapes:

| | before | after |
|---|---|---|
| declared literals seen | 22 | **42** |
| stale found | 7 | **11** |

The four new ones are real. `fx_pairs/14_portfolio_management.py` declares three hashes that appear nowhere in the registry - from before a rebuild its own comment describes - against names that each have a live head, so the next run that moves their members is refused. `sp500_equity_option_analytics/16_risk_management.py` has a fourth. Every previously reported finding keeps its classification; no regressions.

Hashes now resolve against `candidate_set_names` as well as `official_populations`. The two tables have the same shape and the same resolver rule, so one classifier serves both.

## The declaration that is absent

This is what cost the fit, and no literal check can reach it: `SUPERSEDES_SETS` was `{}`. An empty mapping gives a classifier nothing to classify and every literal passes.

So the check now also runs **per live generation**: a candidate set with a head that no declaration in the case study names, by name or by hash, is reported with the hash to paste. Against `us_equities_panel` today:

```
UNDECLARED  06_linear.py  e7b744f380d5
   'us-equities-fwd-ret-5d-linear-v1' is live at e7b744f380d5 and no SUPERSEDES_*
   declaration in this case study names it or its hash; 06_linear.py freezes it.
   The next run that moves its members is refused at the freeze, after the fit
```

Six of those: four for `06_linear`, two for `07_gbm`.

**The condition is a head existing at check time, never a name appearing in source.** Declaring nothing is correct until a generation exists to supersede - `create` refuses a first version claiming to replace one - so a source-keyed rule would have failed `06_linear` on the run where it was right. Before that run `fwd_ret_5d` and `fwd_ret_21d` had no generation; they have one now.

## What I chose, and what is open

**Reported by default, fatal only under `--require-declarations`.** The corpus has 32 live generations nothing declares, across four case studies, three of them finished. Failing by default would exit non-zero for all four today over latent faults nobody is about to trigger, and everyone would reach for the waiver - which would disable the stale check too. The declaration is also meant to be resolved in the worktree at launch rather than committed ahead, so a notebook on `main` naming only what it has already replaced is the expected state, not a defect.

If the lane wants it fatal by default once those 32 are resolved, it is a one-line change. I would not make it now.

**Attribution is an annotation, never the key.** A freezing notebook's f-string becomes a LIKE pattern (`f"us-equities-{label}-linear-v1"` → `us-equities-%-linear-v1`), which is the only thing that can name a set the dict does not - the missing entry is by definition not a key. Degenerate templates (`f"{a}-{b}"` → `%-%`) are dropped rather than guessed at; a notebook that only *reads* a set with `CandidateSet.one` is not named as its owner; and a name no template matches is still reported under its case study with no owner. `cme_futures` builds all eleven of its names as plain literals and its findings survive that way.

## Verification

13 new tests, **12 of which fail against the unpatched script** (the 13th is a control both versions pass). They cover each classification against a synthetic registry, the first-generation boundary, coverage by hash as well as by name, the read-only notebook, and the degenerate template.

```
tests/test_supersedes_checker_reads_every_declaration.py   13 passed
+ test_candidate_set_supersedes, test_population_supersedes,
  test_supersedes_declaration, test_causal_supersedes       111 passed in 87s
```

One correction worth recording: the two literals committed in `06_linear.py` are **live**, not stale. `candidate_set_supersedes` accepts `declared in (current.supersedes, current.hash)`, so naming what the head replaced still resolves. A stale-literal check pointed at those would have reported two false positives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
