### PR TITLE
Decide immutable=1 from the registry directory, and stop drawing a replayed line with a live weight

### DIFF
--- a/24_autonomous_agents/08_forecasting_pipeline.ipynb
+++ b/24_autonomous_agents/08_forecasting_pipeline.ipynb
@@ -2,13 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "5f747416",
+   "id": "18b4a7ba",
    "metadata": {
     "papermill": {
-     "duration": 0.002372,
-     "end_time": "2026-09-11T05:00:14.563716+00:00",
+     "duration": 0.002396,
+     "end_time": "2026-09-11T05:05:00.325391+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:00:14.561344+00:00",
+     "start_time": "2026-09-11T05:05:00.322995+00:00",
      "status": "completed"
     }
    },
@@ -50,19 +50,19 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "afeda7b5",
+   "id": "a8cf0542",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T05:00:14.569332Z",
-     "iopub.status.busy": "2026-09-11T05:00:14.569163Z",
-     "iopub.status.idle": "2026-09-11T05:00:17.746787Z",
-     "shell.execute_reply": "2026-09-11T05:00:17.746164Z"
+     "iopub.execute_input": "2026-09-11T05:05:00.330211Z",
+     "iopub.status.busy": "2026-09-11T05:05:00.330077Z",
+     "iopub.status.idle": "2026-09-11T05:05:03.320728Z",
+     "shell.execute_reply": "2026-09-11T05:05:03.320208Z"
     },
     "papermill": {
-     "duration": 3.181463,
-     "end_time": "2026-09-11T05:00:17.747542+00:00",
+     "duration": 2.99396,
+     "end_time": "2026-09-11T05:05:03.321406+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:00:14.566079+00:00",
+     "start_time": "2026-09-11T05:05:00.327446+00:00",
      "status": "completed"
     }
    },
@@ -109,13 +109,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9e17c210",
+   "id": "da5154f5",
    "metadata": {
     "papermill": {
-     "duration": 0.001885,
-     "end_time": "2026-09-11T05:00:17.752494+00:00",
+     "duration": 0.002201,
+     "end_time": "2026-09-11T05:05:03.326322+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:00:17.750609+00:00",
+     "start_time": "2026-09-11T05:05:03.324121+00:00",
      "status": "completed"
     }
    },
@@ -146,19 +146,19 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "1aac624d",
+   "id": "bb1b39d8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T05:00:17.757836Z",
-     "iopub.status.busy": "2026-09-11T05:00:17.757584Z",
-     "iopub.status.idle": "2026-09-11T05:00:17.760549Z",
-     "shell.execute_reply": "2026-09-11T05:00:17.760127Z"
+     "iopub.execute_input": "2026-09-11T05:05:03.331271Z",
+     "iopub.status.busy": "2026-09-11T05:05:03.331142Z",
+     "iopub.status.idle": "2026-09-11T05:05:03.334660Z",
+     "shell.execute_reply": "2026-09-11T05:05:03.333159Z"
     },
     "papermill": {
-     "duration": 0.006487,
-     "end_time": "2026-09-11T05:00:17.760960+00:00",
+     "duration": 0.007371,
+     "end_time": "2026-09-11T05:05:03.335835+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:00:17.754473+00:00",
+     "start_time": "2026-09-11T05:05:03.328464+00:00",
      "status": "completed"
     },
     "tags": [
@@ -187,13 +187,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7021f68f",
+   "id": "00add60a",
    "metadata": {
     "papermill": {
-     "duration": 0.003955,
-     "end_time": "2026-09-11T05:00:17.770389+00:00",
+     "duration": 0.002523,
+     "end_time": "2026-09-11T05:05:03.341369+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:00:17.766434+00:00",
+     "start_time": "2026-09-11T05:05:03.338846+00:00",
      "status": "completed"
     }
    },
@@ -210,19 +210,19 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "0a405d0f",
+   "id": "30a81fb6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T05:00:17.779025Z",
-     "iopub.status.busy": "2026-09-11T05:00:17.778847Z",
-     "iopub.status.idle": "2026-09-11T05:00:17.781080Z",
-     "shell.execute_reply": "2026-09-11T05:00:17.780626Z"
+     "iopub.execute_input": "2026-09-11T05:05:03.347125Z",
+     "iopub.status.busy": "2026-09-11T05:05:03.346951Z",
+     "iopub.status.idle": "2026-09-11T05:05:03.349415Z",
+     "shell.execute_reply": "2026-09-11T05:05:03.348960Z"
     },
     "papermill": {
-     "duration": 0.007333,
-     "end_time": "2026-09-11T05:00:17.781496+00:00",
+     "duration": 0.005911,
+     "end_time": "2026-09-11T05:05:03.349722+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:00:17.774163+00:00",
+     "start_time": "2026-09-11T05:05:03.343811+00:00",
      "status": "completed"
     }
    },
@@ -246,13 +246,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "279bee45",
+   "id": "c45b006d",
    "metadata": {
     "papermill": {
-     "duration": 0.001993,
-     "end_time": "2026-09-11T05:00:17.787635+00:00",
+     "duration": 0.001833,
+     "end_time": "2026-09-11T05:05:03.353479+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:00:17.785642+00:00",
+     "start_time": "2026-09-11T05:05:03.351646+00:00",
      "status": "completed"
     }
    },
@@ -264,20 +264,20 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "8887c904",
+   "id": "22eb2999",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T05:00:17.795592Z",
-     "iopub.status.busy": "2026-09-11T05:00:17.795234Z",
-     "iopub.status.idle": "2026-09-11T05:00:17.797828Z",
-     "shell.execute_reply": "2026-09-11T05:00:17.797304Z"
+     "iopub.execute_input": "2026-09-11T05:05:03.357854Z",
+     "iopub.status.busy": "2026-09-11T05:05:03.357723Z",
+     "iopub.status.idle": "2026-09-11T05:05:03.359678Z",
+     "shell.execute_reply": "2026-09-11T05:05:03.359371Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.008624,
-     "end_time": "2026-09-11T05:00:17.798273+00:00",
+     "duration": 0.004748,
+     "end_time": "2026-09-11T05:05:03.360089+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:00:17.789649+00:00",
+     "start_time": "2026-09-11T05:05:03.355341+00:00",
      "status": "completed"
     }
    },
@@ -311,14 +311,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9505bcba",
+   "id": "ff67071f",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.001953,
-     "end_time": "2026-09-11T05:00:17.803968+00:00",
+     "duration": 0.001966,
+     "end_time": "2026-09-11T05:05:03.363967+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:00:17.802015+00:00",
+     "start_time": "2026-09-11T05:05:03.362001+00:00",
      "status": "completed"
     }
    },
@@ -333,20 +333,20 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "0de50642",
+   "id": "238986d8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T05:00:17.808521Z",
-     "iopub.status.busy": "2026-09-11T05:00:17.808427Z",
-     "iopub.status.idle": "2026-09-11T05:00:17.811365Z",
-     "shell.execute_reply": "2026-09-11T05:00:17.810750Z"
+     "iopub.execute_input": "2026-09-11T05:05:03.368698Z",
+     "iopub.status.busy": "2026-09-11T05:05:03.368533Z",
+     "iopub.status.idle": "2026-09-11T05:05:03.371192Z",
+     "shell.execute_reply": "2026-09-11T05:05:03.370921Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.005789,
-     "end_time": "2026-09-11T05:00:17.811703+00:00",
+     "duration": 0.005632,
+     "end_time": "2026-09-11T05:05:03.371538+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:00:17.805914+00:00",
+     "start_time": "2026-09-11T05:05:03.365906+00:00",
      "status": "completed"
     }
    },
@@ -372,14 +372,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d8ece7f1",
+   "id": "5bf30847",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.002168,
-     "end_time": "2026-09-11T05:00:17.816276+00:00",
+     "duration": 0.004947,
+     "end_time": "2026-09-11T05:05:03.378924+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:00:17.814108+00:00",
+     "start_time": "2026-09-11T05:05:03.373977+00:00",
      "status": "completed"
     }
    },
@@ -391,20 +391,20 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "5753d7ad",
+   "id": "f0cbb359",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T05:00:17.821264Z",
-     "iopub.status.busy": "2026-09-11T05:00:17.821087Z",
-     "iopub.status.idle": "2026-09-11T05:00:17.826432Z",
-     "shell.execute_reply": "2026-09-11T05:00:17.825748Z"
+     "iopub.execute_input": "2026-09-11T05:05:03.384597Z",
+     "iopub.status.busy": "2026-09-11T05:05:03.384429Z",
+     "iopub.status.idle": "2026-09-11T05:05:03.387456Z",
+     "shell.execute_reply": "2026-09-11T05:05:03.387090Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.008492,
-     "end_time": "2026-09-11T05:00:17.826915+00:00",
+     "duration": 0.006255,
+     "end_time": "2026-09-11T05:05:03.387984+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:00:17.818423+00:00",
+     "start_time": "2026-09-11T05:05:03.381729+00:00",
      "status": "completed"
     }
    },
@@ -428,14 +428,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "381f15bc",
+   "id": "2aac475c",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.00375,
-     "end_time": "2026-09-11T05:00:17.835085+00:00",
+     "duration": 0.001871,
+     "end_time": "2026-09-11T05:05:03.391836+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:00:17.831335+00:00",
+     "start_time": "2026-09-11T05:05:03.389965+00:00",
      "status": "completed"
     }
    },
@@ -447,20 +447,20 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "c522e2b5",
+   "id": "013b6bee",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T05:00:17.841421Z",
-     "iopub.status.busy": "2026-09-11T05:00:17.841289Z",
-     "iopub.status.idle": "2026-09-11T05:00:17.844348Z",
-     "shell.execute_reply": "2026-09-11T05:00:17.843750Z"
+     "iopub.execute_input": "2026-09-11T05:05:03.396274Z",
+     "iopub.status.busy": "2026-09-11T05:05:03.396160Z",
+     "iopub.status.idle": "2026-09-11T05:05:03.399416Z",
+     "shell.execute_reply": "2026-09-11T05:05:03.398968Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.006322,
-     "end_time": "2026-09-11T05:00:17.844674+00:00",
+     "duration": 0.005945,
+     "end_time": "2026-09-11T05:05:03.399690+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:00:17.838352+00:00",
+     "start_time": "2026-09-11T05:05:03.393745+00:00",
      "status": "completed"
     }
    },
@@ -485,14 +485,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "14476643",
+   "id": "47925e08",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.002029,
-     "end_time": "2026-09-11T05:00:17.849170+00:00",
+     "duration": 0.001858,
+     "end_time": "2026-09-11T05:05:03.403503+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:00:17.847141+00:00",
+     "start_time": "2026-09-11T05:05:03.401645+00:00",
      "status": "completed"
     }
    },
@@ -504,20 +504,20 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "e2397de0",
+   "id": "8985c35e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T05:00:17.856233Z",
-     "iopub.status.busy": "2026-09-11T05:00:17.856023Z",
-     "iopub.status.idle": "2026-09-11T05:00:17.860086Z",
-     "shell.execute_reply": "2026-09-11T05:00:17.859639Z"
+     "iopub.execute_input": "2026-09-11T05:05:03.408996Z",
+     "iopub.status.busy": "2026-09-11T05:05:03.408771Z",
+     "iopub.status.idle": "2026-09-11T05:05:03.413354Z",
+     "shell.execute_reply": "2026-09-11T05:05:03.412740Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.009361,
-     "end_time": "2026-09-11T05:00:17.860609+00:00",
+     "duration": 0.008393,
+     "end_time": "2026-09-11T05:05:03.413872+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:00:17.851248+00:00",
+     "start_time": "2026-09-11T05:05:03.405479+00:00",
      "status": "completed"
     }
    },
@@ -558,14 +558,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "913c1248",
+   "id": "13c04338",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.002011,
-     "end_time": "2026-09-11T05:00:17.865288+00:00",
+     "duration": 0.002289,
+     "end_time": "2026-09-11T05:05:03.419755+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:00:17.863277+00:00",
+     "start_time": "2026-09-11T05:05:03.417466+00:00",
      "status": "completed"
     }
    },
@@ -577,20 +577,20 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "7e1c1578",
+   "id": "01561e75",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T05:00:17.870251Z",
-     "iopub.status.busy": "2026-09-11T05:00:17.870121Z",
-     "iopub.status.idle": "2026-09-11T05:00:17.873110Z",
-     "shell.execute_reply": "2026-09-11T05:00:17.872522Z"
+     "iopub.execute_input": "2026-09-11T05:05:03.424832Z",
+     "iopub.status.busy": "2026-09-11T05:05:03.424654Z",
+     "iopub.status.idle": "2026-09-11T05:05:03.428127Z",
+     "shell.execute_reply": "2026-09-11T05:05:03.427645Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.006366,
-     "end_time": "2026-09-11T05:00:17.873678+00:00",
+     "duration": 0.006602,
+     "end_time": "2026-09-11T05:05:03.428400+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:00:17.867312+00:00",
+     "start_time": "2026-09-11T05:05:03.421798+00:00",
      "status": "completed"
     }
    },
@@ -627,14 +627,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fc508897",
+   "id": "08c114ca",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.002533,
-     "end_time": "2026-09-11T05:00:17.878774+00:00",
+     "duration": 0.001852,
+     "end_time": "2026-09-11T05:05:03.432242+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:00:17.876241+00:00",
+     "start_time": "2026-09-11T05:05:03.430390+00:00",
      "status": "completed"
     }
    },
@@ -649,20 +649,20 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "129bbb48",
+   "id": "8e5c3a03",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T05:00:17.886675Z",
-     "iopub.status.busy": "2026-09-11T05:00:17.886358Z",
-     "iopub.status.idle": "2026-09-11T05:00:17.890234Z",
-     "shell.execute_reply": "2026-09-11T05:00:17.889749Z"
+     "iopub.execute_input": "2026-09-11T05:05:03.436642Z",
+     "iopub.status.busy": "2026-09-11T05:05:03.436519Z",
+     "iopub.status.idle": "2026-09-11T05:05:03.439629Z",
+     "shell.execute_reply": "2026-09-11T05:05:03.439015Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.009515,
-     "end_time": "2026-09-11T05:00:17.890567+00:00",
+     "duration": 0.005959,
+     "end_time": "2026-09-11T05:05:03.440094+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:00:17.881052+00:00",
+     "start_time": "2026-09-11T05:05:03.434135+00:00",
      "status": "completed"
     }
    },
@@ -697,14 +697,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c1682dba",
+   "id": "5796f4e2",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.002057,
-     "end_time": "2026-09-11T05:00:17.895130+00:00",
+     "duration": 0.001882,
+     "end_time": "2026-09-11T05:05:03.444003+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:00:17.893073+00:00",
+     "start_time": "2026-09-11T05:05:03.442121+00:00",
      "status": "completed"
     }
    },
@@ -720,20 +720,20 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "06a64cdc",
+   "id": "399b78d7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T05:00:17.900025Z",
-     "iopub.status.busy": "2026-09-11T05:00:17.899913Z",
-     "iopub.status.idle": "2026-09-11T05:00:17.902176Z",
-     "shell.execute_reply": "2026-09-11T05:00:17.901898Z"
+     "iopub.execute_input": "2026-09-11T05:05:03.448952Z",
+     "iopub.status.busy": "2026-09-11T05:05:03.448728Z",
+     "iopub.status.idle": "2026-09-11T05:05:03.451939Z",
+     "shell.execute_reply": "2026-09-11T05:05:03.451451Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.005428,
-     "end_time": "2026-09-11T05:00:17.902634+00:00",
+     "duration": 0.006447,
+     "end_time": "2026-09-11T05:05:03.452414+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:00:17.897206+00:00",
+     "start_time": "2026-09-11T05:05:03.445967+00:00",
      "status": "completed"
     }
    },
@@ -756,14 +756,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2fc7044f",
+   "id": "c08cb9a7",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.002137,
-     "end_time": "2026-09-11T05:00:17.907205+00:00",
+     "duration": 0.002812,
+     "end_time": "2026-09-11T05:05:03.457265+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:00:17.905068+00:00",
+     "start_time": "2026-09-11T05:05:03.454453+00:00",
      "status": "completed"
     }
    },
@@ -784,20 +784,20 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "8e83e425",
+   "id": "be0fffcb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T05:00:17.912419Z",
-     "iopub.status.busy": "2026-09-11T05:00:17.912039Z",
-     "iopub.status.idle": "2026-09-11T05:00:17.916562Z",
-     "shell.execute_reply": "2026-09-11T05:00:17.916182Z"
+     "iopub.execute_input": "2026-09-11T05:05:03.463074Z",
+     "iopub.status.busy": "2026-09-11T05:05:03.462883Z",
+     "iopub.status.idle": "2026-09-11T05:05:03.466372Z",
+     "shell.execute_reply": "2026-09-11T05:05:03.465867Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.007808,
-     "end_time": "2026-09-11T05:00:17.917111+00:00",
+     "duration": 0.006896,
+     "end_time": "2026-09-11T05:05:03.466715+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:00:17.909303+00:00",
+     "start_time": "2026-09-11T05:05:03.459819+00:00",
      "status": "completed"
     }
    },
@@ -826,14 +826,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3573da2a",
+   "id": "2e6b0a3e",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.003773,
-     "end_time": "2026-09-11T05:00:17.925194+00:00",
+     "duration": 0.001944,
+     "end_time": "2026-09-11T05:05:03.470776+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:00:17.921421+00:00",
+     "start_time": "2026-09-11T05:05:03.468832+00:00",
      "status": "completed"
     }
    },
@@ -846,20 +846,20 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "1198a5a5",
+   "id": "39cb1678",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T05:00:17.930862Z",
-     "iopub.status.busy": "2026-09-11T05:00:17.930748Z",
-     "iopub.status.idle": "2026-09-11T05:00:17.934521Z",
-     "shell.execute_reply": "2026-09-11T05:00:17.934111Z"
+     "iopub.execute_input": "2026-09-11T05:05:03.475474Z",
+     "iopub.status.busy": "2026-09-11T05:05:03.475337Z",
+     "iopub.status.idle": "2026-09-11T05:05:03.479515Z",
+     "shell.execute_reply": "2026-09-11T05:05:03.478954Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.007037,
-     "end_time": "2026-09-11T05:00:17.934911+00:00",
+     "duration": 0.007402,
+     "end_time": "2026-09-11T05:05:03.480132+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:00:17.927874+00:00",
+     "start_time": "2026-09-11T05:05:03.472730+00:00",
      "status": "completed"
     }
    },
@@ -897,7 +897,9 @@
     "        question.question, summaries, cutoff_date=cutoff\n",
     "    )\n",
     "    post_debate = (1 - DEBATE_WEIGHT) * aggregate_p + DEBATE_WEIGHT * midpoint\n",
-    "    final_p, confidence = _blend_final_probability(post_debate, supervisor)\n",
+    "    final_p, confidence = _blend_final_probability(\n",
+    "        post_debate, supervisor, medium_weight=SUPERVISOR_MEDIUM_WEIGHT\n",
+    "    )\n",
     "    tokens = sum((agent.token_usage for agent in agents), start=TokenUsage())\n",
     "    tokens = tokens + debate.token_usage + supervisor.token_usage\n",
     "    return ForecastResult(\n",
@@ -915,14 +917,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a918aaf7",
+   "id": "d6f15599",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.002052,
-     "end_time": "2026-09-11T05:00:17.939546+00:00",
+     "duration": 0.001917,
+     "end_time": "2026-09-11T05:05:03.484159+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:00:17.937494+00:00",
+     "start_time": "2026-09-11T05:05:03.482242+00:00",
      "status": "completed"
     }
    },
@@ -939,19 +941,19 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "id": "c66e942e",
+   "id": "74b60381",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T05:00:17.945715Z",
-     "iopub.status.busy": "2026-09-11T05:00:17.945535Z",
-     "iopub.status.idle": "2026-09-11T05:00:17.948881Z",
-     "shell.execute_reply": "2026-09-11T05:00:17.948516Z"
+     "iopub.execute_input": "2026-09-11T05:05:03.488871Z",
+     "iopub.status.busy": "2026-09-11T05:05:03.488770Z",
+     "iopub.status.idle": "2026-09-11T05:05:03.491563Z",
+     "shell.execute_reply": "2026-09-11T05:05:03.491160Z"
     },
     "papermill": {
-     "duration": 0.007235,
-     "end_time": "2026-09-11T05:00:17.949339+00:00",
+     "duration": 0.005734,
+     "end_time": "2026-09-11T05:05:03.491848+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:00:17.942104+00:00",
+     "start_time": "2026-09-11T05:05:03.486114+00:00",
      "status": "completed"
     }
    },
@@ -985,13 +987,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5186b5ee",
+   "id": "25a4d008",
    "metadata": {
     "papermill": {
-     "duration": 0.004053,
-     "end_time": "2026-09-11T05:00:17.957838+00:00",
+     "duration": 0.004377,
+     "end_time": "2026-09-11T05:05:03.498739+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:00:17.953785+00:00",
+     "start_time": "2026-09-11T05:05:03.494362+00:00",
      "status": "completed"
     }
    },
@@ -1014,19 +1016,19 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "id": "ea98724d",
+   "id": "4c88859c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T05:00:17.968049Z",
-     "iopub.status.busy": "2026-09-11T05:00:17.967919Z",
-     "iopub.status.idle": "2026-09-11T05:00:17.970592Z",
-     "shell.execute_reply": "2026-09-11T05:00:17.970114Z"
+     "iopub.execute_input": "2026-09-11T05:05:03.505158Z",
+     "iopub.status.busy": "2026-09-11T05:05:03.505043Z",
+     "iopub.status.idle": "2026-09-11T05:05:03.507905Z",
+     "shell.execute_reply": "2026-09-11T05:05:03.507524Z"
     },
     "papermill": {
-     "duration": 0.008613,
-     "end_time": "2026-09-11T05:00:17.971003+00:00",
+     "duration": 0.006195,
+     "end_time": "2026-09-11T05:05:03.508357+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:00:17.962390+00:00",
+     "start_time": "2026-09-11T05:05:03.502162+00:00",
      "status": "completed"
     }
    },
@@ -1058,13 +1060,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c808f175",
+   "id": "5c1d894b",
    "metadata": {
     "papermill": {
-     "duration": 0.003884,
-     "end_time": "2026-09-11T05:00:17.979932+00:00",
+     "duration": 0.001952,
+     "end_time": "2026-09-11T05:05:03.512535+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:00:17.976048+00:00",
+     "start_time": "2026-09-11T05:05:03.510583+00:00",
      "status": "completed"
     }
    },
@@ -1074,14 +1076,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4db49964",
+   "id": "c26f02bd",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.003239,
-     "end_time": "2026-09-11T05:00:17.987130+00:00",
+     "duration": 0.002035,
+     "end_time": "2026-09-11T05:05:03.516693+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:00:17.983891+00:00",
+     "start_time": "2026-09-11T05:05:03.514658+00:00",
      "status": "completed"
     }
    },
@@ -1093,20 +1095,20 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "id": "739c8740",
+   "id": "ebec92c2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T05:00:17.992722Z",
-     "iopub.status.busy": "2026-09-11T05:00:17.992510Z",
-     "iopub.status.idle": "2026-09-11T05:00:17.996569Z",
-     "shell.execute_reply": "2026-09-11T05:00:17.996160Z"
+     "iopub.execute_input": "2026-09-11T05:05:03.521662Z",
+     "iopub.status.busy": "2026-09-11T05:05:03.521587Z",
+     "iopub.status.idle": "2026-09-11T05:05:03.524621Z",
+     "shell.execute_reply": "2026-09-11T05:05:03.524224Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.007686,
-     "end_time": "2026-09-11T05:00:17.996895+00:00",
+     "duration": 0.006057,
+     "end_time": "2026-09-11T05:05:03.524907+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:00:17.989209+00:00",
+     "start_time": "2026-09-11T05:05:03.518850+00:00",
      "status": "completed"
     }
    },
@@ -1155,14 +1157,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "322db04d",
+   "id": "51eaf338",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.00282,
-     "end_time": "2026-09-11T05:00:18.002639+00:00",
+     "duration": 0.001999,
+     "end_time": "2026-09-11T05:05:03.529047+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:00:17.999819+00:00",
+     "start_time": "2026-09-11T05:05:03.527048+00:00",
      "status": "completed"
     }
    },
@@ -1174,19 +1176,19 @@
   {
    "cell_type": "code",
    "execution_count": 17,
-   "id": "eb85e802",
+   "id": "953b3003",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T05:00:18.008124Z",
-     "iopub.status.busy": "2026-09-11T05:00:18.007935Z",
-     "iopub.status.idle": "2026-09-11T05:00:18.011425Z",
-     "shell.execute_reply": "2026-09-11T05:00:18.010893Z"
+     "iopub.execute_input": "2026-09-11T05:05:03.535531Z",
+     "iopub.status.busy": "2026-09-11T05:05:03.535307Z",
+     "iopub.status.idle": "2026-09-11T05:05:03.538472Z",
+     "shell.execute_reply": "2026-09-11T05:05:03.537989Z"
     },
     "papermill": {
-     "duration": 0.006896,
-     "end_time": "2026-09-11T05:00:18.011779+00:00",
+     "duration": 0.007615,
+     "end_time": "2026-09-11T05:05:03.538717+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:00:18.004883+00:00",
+     "start_time": "2026-09-11T05:05:03.531102+00:00",
      "status": "completed"
     }
    },
@@ -1211,19 +1213,19 @@
   {
    "cell_type": "code",
    "execution_count": 18,
-   "id": "32f0017e",
+   "id": "bb5a1994",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T05:00:18.016768Z",
-     "iopub.status.busy": "2026-09-11T05:00:18.016642Z",
-     "iopub.status.idle": "2026-09-11T05:00:18.033863Z",
-     "shell.execute_reply": "2026-09-11T05:00:18.033162Z"
+     "iopub.execute_input": "2026-09-11T05:05:03.544114Z",
+     "iopub.status.busy": "2026-09-11T05:05:03.544030Z",
+     "iopub.status.idle": "2026-09-11T05:05:03.566405Z",
+     "shell.execute_reply": "2026-09-11T05:05:03.566015Z"
     },
     "papermill": {
-     "duration": 0.0206,
-     "end_time": "2026-09-11T05:00:18.034595+00:00",
+     "duration": 0.025596,
+     "end_time": "2026-09-11T05:05:03.566832+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:00:18.013995+00:00",
+     "start_time": "2026-09-11T05:05:03.541236+00:00",
      "status": "completed"
     }
    },
@@ -1246,13 +1248,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c93946bc",
+   "id": "13b0b208",
    "metadata": {
     "papermill": {
-     "duration": 0.002748,
-     "end_time": "2026-09-11T05:00:18.041700+00:00",
+     "duration": 0.002214,
+     "end_time": "2026-09-11T05:05:03.571800+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:00:18.038952+00:00",
+     "start_time": "2026-09-11T05:05:03.569586+00:00",
      "status": "completed"
     }
    },
@@ -1263,19 +1265,19 @@
   {
    "cell_type": "code",
    "execution_count": 19,
-   "id": "a8db838a",
+   "id": "82bd4f8e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T05:00:18.046982Z",
-     "iopub.status.busy": "2026-09-11T05:00:18.046851Z",
-     "iopub.status.idle": "2026-09-11T05:00:18.055397Z",
-     "shell.execute_reply": "2026-09-11T05:00:18.054743Z"
+     "iopub.execute_input": "2026-09-11T05:05:03.578561Z",
+     "iopub.status.busy": "2026-09-11T05:05:03.578453Z",
+     "iopub.status.idle": "2026-09-11T05:05:03.584536Z",
+     "shell.execute_reply": "2026-09-11T05:05:03.584064Z"
     },
     "papermill": {
-     "duration": 0.012593,
-     "end_time": "2026-09-11T05:00:18.056434+00:00",
+     "duration": 0.009643,
+     "end_time": "2026-09-11T05:05:03.584841+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:00:18.043841+00:00",
+     "start_time": "2026-09-11T05:05:03.575198+00:00",
      "status": "completed"
     }
    },
@@ -1346,13 +1348,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "90d9ce1e",
+   "id": "40638548",
    "metadata": {
     "papermill": {
-     "duration": 0.004181,
-     "end_time": "2026-09-11T05:00:18.066365+00:00",
+     "duration": 0.00237,
+     "end_time": "2026-09-11T05:05:03.589773+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:00:18.062184+00:00",
+     "start_time": "2026-09-11T05:05:03.587403+00:00",
      "status": "completed"
     }
    },
@@ -1370,19 +1372,19 @@
   {
    "cell_type": "code",
    "execution_count": 20,
-   "id": "8385a9be",
+   "id": "c2c88c4d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T05:00:18.073832Z",
-     "iopub.status.busy": "2026-09-11T05:00:18.073666Z",
-     "iopub.status.idle": "2026-09-11T05:00:18.080124Z",
-     "shell.execute_reply": "2026-09-11T05:00:18.079491Z"
+     "iopub.execute_input": "2026-09-11T05:05:03.595261Z",
+     "iopub.status.busy": "2026-09-11T05:05:03.595147Z",
+     "iopub.status.idle": "2026-09-11T05:05:03.599523Z",
+     "shell.execute_reply": "2026-09-11T05:05:03.599102Z"
     },
     "papermill": {
-     "duration": 0.009837,
-     "end_time": "2026-09-11T05:00:18.080484+00:00",
+     "duration": 0.007728,
+     "end_time": "2026-09-11T05:05:03.599871+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:00:18.070647+00:00",
+     "start_time": "2026-09-11T05:05:03.592143+00:00",
      "status": "completed"
     }
    },
@@ -1818,13 +1820,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a4400e35",
+   "id": "fb4adc99",
    "metadata": {
     "papermill": {
-     "duration": 0.003641,
-     "end_time": "2026-09-11T05:00:18.086772+00:00",
+     "duration": 0.002432,
+     "end_time": "2026-09-11T05:05:03.606103+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:00:18.083131+00:00",
+     "start_time": "2026-09-11T05:05:03.603671+00:00",
      "status": "completed"
     }
    },
@@ -1835,19 +1837,19 @@
   {
    "cell_type": "code",
    "execution_count": 21,
-   "id": "ad351974",
+   "id": "78887968",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T05:00:18.093385Z",
-     "iopub.status.busy": "2026-09-11T05:00:18.093200Z",
-     "iopub.status.idle": "2026-09-11T05:00:18.096375Z",
-     "shell.execute_reply": "2026-09-11T05:00:18.095870Z"
+     "iopub.execute_input": "2026-09-11T05:05:03.612708Z",
+     "iopub.status.busy": "2026-09-11T05:05:03.612495Z",
+     "iopub.status.idle": "2026-09-11T05:05:03.615740Z",
+     "shell.execute_reply": "2026-09-11T05:05:03.615393Z"
     },
     "papermill": {
-     "duration": 0.006879,
-     "end_time": "2026-09-11T05:00:18.096705+00:00",
+     "duration": 0.007459,
+     "end_time": "2026-09-11T05:05:03.616234+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:00:18.089826+00:00",
+     "start_time": "2026-09-11T05:05:03.608775+00:00",
      "status": "completed"
     }
    },
@@ -1875,13 +1877,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1cc9d9e4",
+   "id": "7bbe8869",
    "metadata": {
     "papermill": {
-     "duration": 0.002406,
-     "end_time": "2026-09-11T05:00:18.101685+00:00",
+     "duration": 0.002806,
+     "end_time": "2026-09-11T05:05:03.622310+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:00:18.099279+00:00",
+     "start_time": "2026-09-11T05:05:03.619504+00:00",
      "status": "completed"
     }
    },
@@ -1892,19 +1894,19 @@
   {
    "cell_type": "code",
    "execution_count": 22,
-   "id": "da9189ac",
+   "id": "135fc684",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T05:00:18.107723Z",
-     "iopub.status.busy": "2026-09-11T05:00:18.107516Z",
-     "iopub.status.idle": "2026-09-11T05:00:18.112445Z",
-     "shell.execute_reply": "2026-09-11T05:00:18.111887Z"
+     "iopub.execute_input": "2026-09-11T05:05:03.628413Z",
+     "iopub.status.busy": "2026-09-11T05:05:03.628306Z",
+     "iopub.status.idle": "2026-09-11T05:05:03.631981Z",
+     "shell.execute_reply": "2026-09-11T05:05:03.631417Z"
     },
     "papermill": {
-     "duration": 0.009112,
-     "end_time": "2026-09-11T05:00:18.113161+00:00",
+     "duration": 0.007307,
+     "end_time": "2026-09-11T05:05:03.632262+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:00:18.104049+00:00",
+     "start_time": "2026-09-11T05:05:03.624955+00:00",
      "status": "completed"
     }
    },
@@ -2110,13 +2112,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "72710f7f",
+   "id": "808b110c",
    "metadata": {
     "papermill": {
-     "duration": 0.003118,
-     "end_time": "2026-09-11T05:00:18.120415+00:00",
+     "duration": 0.002454,
+     "end_time": "2026-09-11T05:05:03.637436+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:00:18.117297+00:00",
+     "start_time": "2026-09-11T05:05:03.634982+00:00",
      "status": "completed"
     }
    },
@@ -2127,19 +2129,19 @@
   {
    "cell_type": "code",
    "execution_count": 23,
-   "id": "09bee5ee",
+   "id": "51e99102",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T05:00:18.126315Z",
-     "iopub.status.busy": "2026-09-11T05:00:18.126154Z",
-     "iopub.status.idle": "2026-09-11T05:00:18.129519Z",
-     "shell.execute_reply": "2026-09-11T05:00:18.129050Z"
+     "iopub.execute_input": "2026-09-11T05:05:03.643324Z",
+     "iopub.status.busy": "2026-09-11T05:05:03.643226Z",
+     "iopub.status.idle": "2026-09-11T05:05:03.645977Z",
+     "shell.execute_reply": "2026-09-11T05:05:03.645533Z"
     },
     "papermill": {
-     "duration": 0.006818,
-     "end_time": "2026-09-11T05:00:18.129847+00:00",
+     "duration": 0.006294,
+     "end_time": "2026-09-11T05:05:03.646316+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:00:18.123029+00:00",
+     "start_time": "2026-09-11T05:05:03.640022+00:00",
      "status": "completed"
     }
    },
@@ -2210,13 +2212,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "870c249d",
+   "id": "ed436e05",
    "metadata": {
     "papermill": {
-     "duration": 0.002441,
-     "end_time": "2026-09-11T05:00:18.134819+00:00",
+     "duration": 0.002493,
+     "end_time": "2026-09-11T05:05:03.651443+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:00:18.132378+00:00",
+     "start_time": "2026-09-11T05:05:03.648950+00:00",
      "status": "completed"
     }
    },
@@ -2238,14 +2240,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "22949d2f",
+   "id": "66956f86",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.002594,
-     "end_time": "2026-09-11T05:00:18.139897+00:00",
+     "duration": 0.002403,
+     "end_time": "2026-09-11T05:05:03.656522+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:00:18.137303+00:00",
+     "start_time": "2026-09-11T05:05:03.654119+00:00",
      "status": "completed"
     }
    },
@@ -2267,19 +2269,19 @@
   {
    "cell_type": "code",
    "execution_count": 24,
-   "id": "102a7cd4",
+   "id": "d5b07405",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T05:00:18.147216Z",
-     "iopub.status.busy": "2026-09-11T05:00:18.147012Z",
-     "iopub.status.idle": "2026-09-11T05:00:18.151166Z",
-     "shell.execute_reply": "2026-09-11T05:00:18.150700Z"
+     "iopub.execute_input": "2026-09-11T05:05:03.663887Z",
+     "iopub.status.busy": "2026-09-11T05:05:03.663767Z",
+     "iopub.status.idle": "2026-09-11T05:05:03.667271Z",
+     "shell.execute_reply": "2026-09-11T05:05:03.666838Z"
     },
     "papermill": {
-     "duration": 0.008135,
-     "end_time": "2026-09-11T05:00:18.151542+00:00",
+     "duration": 0.007798,
+     "end_time": "2026-09-11T05:05:03.667545+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:00:18.143407+00:00",
+     "start_time": "2026-09-11T05:05:03.659747+00:00",
      "status": "completed"
     }
    },
@@ -2323,19 +2325,19 @@
   {
    "cell_type": "code",
    "execution_count": 25,
-   "id": "e6847169",
+   "id": "ef4b159f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T05:00:18.157238Z",
-     "iopub.status.busy": "2026-09-11T05:00:18.157099Z",
-     "iopub.status.idle": "2026-09-11T05:00:18.265129Z",
-     "shell.execute_reply": "2026-09-11T05:00:18.264418Z"
+     "iopub.execute_input": "2026-09-11T05:05:03.673150Z",
+     "iopub.status.busy": "2026-09-11T05:05:03.673073Z",
+     "iopub.status.idle": "2026-09-11T05:05:03.771319Z",
+     "shell.execute_reply": "2026-09-11T05:05:03.770823Z"
     },
     "papermill": {
-     "duration": 0.111457,
-     "end_time": "2026-09-11T05:00:18.265535+00:00",
+     "duration": 0.101704,
+     "end_time": "2026-09-11T05:05:03.771772+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:00:18.154078+00:00",
+     "start_time": "2026-09-11T05:05:03.670068+00:00",
      "status": "completed"
     }
    },
@@ -2438,13 +2440,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fd26ac76",
+   "id": "25b64f8b",
    "metadata": {
     "papermill": {
-     "duration": 0.002715,
-     "end_time": "2026-09-11T05:00:18.271683+00:00",
+     "duration": 0.004205,
+     "end_time": "2026-09-11T05:05:03.782078+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:00:18.268968+00:00",
+     "start_time": "2026-09-11T05:05:03.777873+00:00",
      "status": "completed"
     }
    },
@@ -2456,19 +2458,19 @@
   {
    "cell_type": "code",
    "execution_count": 26,
-   "id": "4fff24e1",
+   "id": "86724d12",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T05:00:18.280678Z",
-     "iopub.status.busy": "2026-09-11T05:00:18.280461Z",
-     "iopub.status.idle": "2026-09-11T05:00:18.286863Z",
-     "shell.execute_reply": "2026-09-11T05:00:18.286415Z"
+     "iopub.execute_input": "2026-09-11T05:05:03.791709Z",
+     "iopub.status.busy": "2026-09-11T05:05:03.791598Z",
+     "iopub.status.idle": "2026-09-11T05:05:03.796671Z",
+     "shell.execute_reply": "2026-09-11T05:05:03.796235Z"
     },
     "papermill": {
-     "duration": 0.012201,
-     "end_time": "2026-09-11T05:00:18.287564+00:00",
+     "duration": 0.012234,
+     "end_time": "2026-09-11T05:05:03.797165+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:00:18.275363+00:00",
+     "start_time": "2026-09-11T05:05:03.784931+00:00",
      "status": "completed"
     }
    },
@@ -2524,13 +2526,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d3695f66",
+   "id": "ed7445a4",
    "metadata": {
     "papermill": {
-     "duration": 0.002763,
-     "end_time": "2026-09-11T05:00:18.293689+00:00",
+     "duration": 0.003101,
+     "end_time": "2026-09-11T05:05:03.803769+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:00:18.290926+00:00",
+     "start_time": "2026-09-11T05:05:03.800668+00:00",
      "status": "completed"
     }
    },
@@ -2551,13 +2553,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a6a63731",
+   "id": "90b69ea7",
    "metadata": {
     "papermill": {
-     "duration": 0.00271,
-     "end_time": "2026-09-11T05:00:18.299286+00:00",
+     "duration": 0.002782,
+     "end_time": "2026-09-11T05:05:03.809445+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:00:18.296576+00:00",
+     "start_time": "2026-09-11T05:05:03.806663+00:00",
      "status": "completed"
     }
    },
@@ -2568,19 +2570,19 @@
   {
    "cell_type": "code",
    "execution_count": 27,
-   "id": "0f516395",
+   "id": "91a10338",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T05:00:18.307730Z",
-     "iopub.status.busy": "2026-09-11T05:00:18.307613Z",
-     "iopub.status.idle": "2026-09-11T05:00:18.310141Z",
-     "shell.execute_reply": "2026-09-11T05:00:18.309752Z"
+     "iopub.execute_input": "2026-09-11T05:05:03.815747Z",
+     "iopub.status.busy": "2026-09-11T05:05:03.815634Z",
+     "iopub.status.idle": "2026-09-11T05:05:03.818039Z",
+     "shell.execute_reply": "2026-09-11T05:05:03.817709Z"
     },
     "papermill": {
-     "duration": 0.00872,
-     "end_time": "2026-09-11T05:00:18.310677+00:00",
+     "duration": 0.006433,
+     "end_time": "2026-09-11T05:05:03.818556+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:00:18.301957+00:00",
+     "start_time": "2026-09-11T05:05:03.812123+00:00",
      "status": "completed"
     }
    },
@@ -2605,13 +2607,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5b236254",
+   "id": "ab8f96ab",
    "metadata": {
     "papermill": {
-     "duration": 0.002819,
-     "end_time": "2026-09-11T05:00:18.316705+00:00",
+     "duration": 0.00281,
+     "end_time": "2026-09-11T05:05:03.824272+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:00:18.313886+00:00",
+     "start_time": "2026-09-11T05:05:03.821462+00:00",
      "status": "completed"
     }
    },
@@ -2631,19 +2633,19 @@
   {
    "cell_type": "code",
    "execution_count": 28,
-   "id": "4695fdfc",
+   "id": "5dedec24",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T05:00:18.322823Z",
-     "iopub.status.busy": "2026-09-11T05:00:18.322728Z",
-     "iopub.status.idle": "2026-09-11T05:00:18.325560Z",
-     "shell.execute_reply": "2026-09-11T05:00:18.325186Z"
+     "iopub.execute_input": "2026-09-11T05:05:03.833735Z",
+     "iopub.status.busy": "2026-09-11T05:05:03.833618Z",
+     "iopub.status.idle": "2026-09-11T05:05:03.836904Z",
+     "shell.execute_reply": "2026-09-11T05:05:03.836421Z"
     },
     "papermill": {
-     "duration": 0.006562,
-     "end_time": "2026-09-11T05:00:18.326008+00:00",
+     "duration": 0.010102,
+     "end_time": "2026-09-11T05:05:03.837210+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:00:18.319446+00:00",
+     "start_time": "2026-09-11T05:05:03.827108+00:00",
      "status": "completed"
     }
    },
@@ -2698,13 +2700,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bc340224",
+   "id": "b908927b",
    "metadata": {
     "papermill": {
-     "duration": 0.003513,
-     "end_time": "2026-09-11T05:00:18.332374+00:00",
+     "duration": 0.003219,
+     "end_time": "2026-09-11T05:05:03.844051+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:00:18.328861+00:00",
+     "start_time": "2026-09-11T05:05:03.840832+00:00",
      "status": "completed"
     }
    },
@@ -2721,20 +2723,20 @@
   {
    "cell_type": "code",
    "execution_count": 29,
-   "id": "67752843",
+   "id": "40c2b845",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T05:00:18.340217Z",
-     "iopub.status.busy": "2026-09-11T05:00:18.340073Z",
-     "iopub.status.idle": "2026-09-11T05:00:18.342871Z",
-     "shell.execute_reply": "2026-09-11T05:00:18.342561Z"
+     "iopub.execute_input": "2026-09-11T05:05:03.850126Z",
+     "iopub.status.busy": "2026-09-11T05:05:03.850031Z",
+     "iopub.status.idle": "2026-09-11T05:05:03.852640Z",
+     "shell.execute_reply": "2026-09-11T05:05:03.852277Z"
     },
     "lines_to_next_cell": 0,
     "papermill": {
-     "duration": 0.00679,
-     "end_time": "2026-09-11T05:00:18.343138+00:00",
+     "duration": 0.006173,
+     "end_time": "2026-09-11T05:05:03.852953+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:00:18.336348+00:00",
+     "start_time": "2026-09-11T05:05:03.846780+00:00",
      "status": "completed"
     }
    },
@@ -2770,13 +2772,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "22480219",
+   "id": "f8a685d5",
    "metadata": {
     "papermill": {
-     "duration": 0.002664,
-     "end_time": "2026-09-11T05:00:18.348606+00:00",
+     "duration": 0.002706,
+     "end_time": "2026-09-11T05:05:03.858438+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:00:18.345942+00:00",
+     "start_time": "2026-09-11T05:05:03.855732+00:00",
      "status": "completed"
     }
    },
@@ -2836,24 +2838,24 @@
    "version": "3.14.3"
   },
   "ml4t_provenance": {
-   "executed_at": "2026-09-11T05:00:29.079947+00:00",
+   "executed_at": "2026-09-11T05:05:13.929245+00:00",
    "executor": "local-uv",
    "library_digest": "45f6d8a6aa2f659af2d76e41192a6cae552e749fe04368b2f62766b9487259fe",
    "outputs_digest": "91454f308f680e62490d83b33a5233baef40091be622c9475aff0527daaec8bf",
    "parameters": {},
    "production": true,
-   "source_py_blob": "16aef3142ad7c6e4119304ddfa0d275f0e18521b"
+   "source_py_blob": "a3fbe9eecb17febabd2ed66016e855cb480324b0"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 5.805188,
-   "end_time": "2026-09-11T05:00:19.669017+00:00",
+   "duration": 5.451093,
+   "end_time": "2026-09-11T05:05:05.081178+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "~/ml4t/public-teach-g/24_autonomous_agents/.08_forecasting_pipeline.build.2096708.ipynb",
-   "output_path": "~/ml4t/public-teach-g/24_autonomous_agents/.08_forecasting_pipeline.papermill.2096708.ipynb",
+   "input_path": "~/ml4t/public-teach-g/24_autonomous_agents/.08_forecasting_pipeline.build.2142579.ipynb",
+   "output_path": "~/ml4t/public-teach-g/24_autonomous_agents/.08_forecasting_pipeline.papermill.2142579.ipynb",
    "parameters": {},
-   "start_time": "2026-09-11T05:00:13.863829+00:00",
+   "start_time": "2026-09-11T05:04:59.630085+00:00",
    "version": "2.7.0"
   }
  },

--- a/24_autonomous_agents/08_forecasting_pipeline.ipynb
+++ b/24_autonomous_agents/08_forecasting_pipeline.ipynb
@@ -2,13 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "6f21e7b0",
+   "id": "5f747416",
    "metadata": {
     "papermill": {
-     "duration": 0.003839,
-     "end_time": "2026-09-10T23:49:27.235849+00:00",
+     "duration": 0.002372,
+     "end_time": "2026-09-11T05:00:14.563716+00:00",
      "exception": false,
-     "start_time": "2026-09-10T23:49:27.232010+00:00",
+     "start_time": "2026-09-11T05:00:14.561344+00:00",
      "status": "completed"
     }
    },
@@ -50,19 +50,19 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "13211d9e",
+   "id": "afeda7b5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T23:49:27.240787Z",
-     "iopub.status.busy": "2026-09-10T23:49:27.240668Z",
-     "iopub.status.idle": "2026-09-10T23:49:30.352964Z",
-     "shell.execute_reply": "2026-09-10T23:49:30.352498Z"
+     "iopub.execute_input": "2026-09-11T05:00:14.569332Z",
+     "iopub.status.busy": "2026-09-11T05:00:14.569163Z",
+     "iopub.status.idle": "2026-09-11T05:00:17.746787Z",
+     "shell.execute_reply": "2026-09-11T05:00:17.746164Z"
     },
     "papermill": {
-     "duration": 3.115805,
-     "end_time": "2026-09-10T23:49:30.353881+00:00",
+     "duration": 3.181463,
+     "end_time": "2026-09-11T05:00:17.747542+00:00",
      "exception": false,
-     "start_time": "2026-09-10T23:49:27.238076+00:00",
+     "start_time": "2026-09-11T05:00:14.566079+00:00",
      "status": "completed"
     }
    },
@@ -109,13 +109,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cd6c35f4",
+   "id": "9e17c210",
    "metadata": {
     "papermill": {
-     "duration": 0.002161,
-     "end_time": "2026-09-10T23:49:30.359533+00:00",
+     "duration": 0.001885,
+     "end_time": "2026-09-11T05:00:17.752494+00:00",
      "exception": false,
-     "start_time": "2026-09-10T23:49:30.357372+00:00",
+     "start_time": "2026-09-11T05:00:17.750609+00:00",
      "status": "completed"
     }
    },
@@ -131,9 +131,11 @@
     "aggregated.\n",
     "\n",
     "Three weights decide how much each later stage can move the answer, and they are the numbers\n",
-    "to argue with. `DEBATE_WEIGHT` is the debate midpoint's share of the post-debate probability.\n",
-    "`SUPERVISOR_MEDIUM_WEIGHT` is the supervisor's share when it states medium confidence; at\n",
-    "high confidence it replaces the value outright and at low confidence it is ignored.\n",
+    "to argue with - on a live run. `DEBATE_WEIGHT` is the debate midpoint's share of the\n",
+    "post-debate probability. `SUPERVISOR_MEDIUM_WEIGHT` is the supervisor's share when it states\n",
+    "medium confidence; at high confidence it replaces the value outright and at low confidence it\n",
+    "is ignored. A replay reports the probabilities its capture recorded, so changing either weight\n",
+    "with `RUN_LIVE` left at `False` changes nothing: the run that produced the numbers is over.\n",
     "\n",
     "The three `CONFIDENCE_WHEN_*` values are what the pipeline reports as its own confidence in\n",
     "each of those three cases. They are an ordering, not an estimate: a forecast the supervisor\n",
@@ -144,19 +146,19 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "9da0f8a9",
+   "id": "1aac624d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T23:49:30.365215Z",
-     "iopub.status.busy": "2026-09-10T23:49:30.365033Z",
-     "iopub.status.idle": "2026-09-10T23:49:30.367744Z",
-     "shell.execute_reply": "2026-09-10T23:49:30.367308Z"
+     "iopub.execute_input": "2026-09-11T05:00:17.757836Z",
+     "iopub.status.busy": "2026-09-11T05:00:17.757584Z",
+     "iopub.status.idle": "2026-09-11T05:00:17.760549Z",
+     "shell.execute_reply": "2026-09-11T05:00:17.760127Z"
     },
     "papermill": {
-     "duration": 0.006309,
-     "end_time": "2026-09-10T23:49:30.368196+00:00",
+     "duration": 0.006487,
+     "end_time": "2026-09-11T05:00:17.760960+00:00",
      "exception": false,
-     "start_time": "2026-09-10T23:49:30.361887+00:00",
+     "start_time": "2026-09-11T05:00:17.754473+00:00",
      "status": "completed"
     },
     "tags": [
@@ -185,13 +187,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f360a78f",
+   "id": "7021f68f",
    "metadata": {
     "papermill": {
-     "duration": 0.002001,
-     "end_time": "2026-09-10T23:49:30.372546+00:00",
+     "duration": 0.003955,
+     "end_time": "2026-09-11T05:00:17.770389+00:00",
      "exception": false,
-     "start_time": "2026-09-10T23:49:30.370545+00:00",
+     "start_time": "2026-09-11T05:00:17.766434+00:00",
      "status": "completed"
     }
    },
@@ -208,19 +210,19 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "700b86ee",
+   "id": "0a405d0f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T23:49:30.377685Z",
-     "iopub.status.busy": "2026-09-10T23:49:30.377547Z",
-     "iopub.status.idle": "2026-09-10T23:49:30.379928Z",
-     "shell.execute_reply": "2026-09-10T23:49:30.379323Z"
+     "iopub.execute_input": "2026-09-11T05:00:17.779025Z",
+     "iopub.status.busy": "2026-09-11T05:00:17.778847Z",
+     "iopub.status.idle": "2026-09-11T05:00:17.781080Z",
+     "shell.execute_reply": "2026-09-11T05:00:17.780626Z"
     },
     "papermill": {
-     "duration": 0.005621,
-     "end_time": "2026-09-10T23:49:30.380246+00:00",
+     "duration": 0.007333,
+     "end_time": "2026-09-11T05:00:17.781496+00:00",
      "exception": false,
-     "start_time": "2026-09-10T23:49:30.374625+00:00",
+     "start_time": "2026-09-11T05:00:17.774163+00:00",
      "status": "completed"
     }
    },
@@ -244,13 +246,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "81e18656",
+   "id": "279bee45",
    "metadata": {
     "papermill": {
-     "duration": 0.001964,
-     "end_time": "2026-09-10T23:49:30.384372+00:00",
+     "duration": 0.001993,
+     "end_time": "2026-09-11T05:00:17.787635+00:00",
      "exception": false,
-     "start_time": "2026-09-10T23:49:30.382408+00:00",
+     "start_time": "2026-09-11T05:00:17.785642+00:00",
      "status": "completed"
     }
    },
@@ -262,20 +264,20 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "1767f463",
+   "id": "8887c904",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T23:49:30.389378Z",
-     "iopub.status.busy": "2026-09-10T23:49:30.389252Z",
-     "iopub.status.idle": "2026-09-10T23:49:30.391704Z",
-     "shell.execute_reply": "2026-09-10T23:49:30.391082Z"
+     "iopub.execute_input": "2026-09-11T05:00:17.795592Z",
+     "iopub.status.busy": "2026-09-11T05:00:17.795234Z",
+     "iopub.status.idle": "2026-09-11T05:00:17.797828Z",
+     "shell.execute_reply": "2026-09-11T05:00:17.797304Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.005587,
-     "end_time": "2026-09-10T23:49:30.392017+00:00",
+     "duration": 0.008624,
+     "end_time": "2026-09-11T05:00:17.798273+00:00",
      "exception": false,
-     "start_time": "2026-09-10T23:49:30.386430+00:00",
+     "start_time": "2026-09-11T05:00:17.789649+00:00",
      "status": "completed"
     }
    },
@@ -309,14 +311,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fe10714d",
+   "id": "9505bcba",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.001887,
-     "end_time": "2026-09-10T23:49:30.396000+00:00",
+     "duration": 0.001953,
+     "end_time": "2026-09-11T05:00:17.803968+00:00",
      "exception": false,
-     "start_time": "2026-09-10T23:49:30.394113+00:00",
+     "start_time": "2026-09-11T05:00:17.802015+00:00",
      "status": "completed"
     }
    },
@@ -331,20 +333,20 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "40b07897",
+   "id": "0de50642",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T23:49:30.400985Z",
-     "iopub.status.busy": "2026-09-10T23:49:30.400729Z",
-     "iopub.status.idle": "2026-09-10T23:49:30.404587Z",
-     "shell.execute_reply": "2026-09-10T23:49:30.403865Z"
+     "iopub.execute_input": "2026-09-11T05:00:17.808521Z",
+     "iopub.status.busy": "2026-09-11T05:00:17.808427Z",
+     "iopub.status.idle": "2026-09-11T05:00:17.811365Z",
+     "shell.execute_reply": "2026-09-11T05:00:17.810750Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.007095,
-     "end_time": "2026-09-10T23:49:30.405028+00:00",
+     "duration": 0.005789,
+     "end_time": "2026-09-11T05:00:17.811703+00:00",
      "exception": false,
-     "start_time": "2026-09-10T23:49:30.397933+00:00",
+     "start_time": "2026-09-11T05:00:17.805914+00:00",
      "status": "completed"
     }
    },
@@ -370,14 +372,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2004419e",
+   "id": "d8ece7f1",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.002258,
-     "end_time": "2026-09-10T23:49:30.410292+00:00",
+     "duration": 0.002168,
+     "end_time": "2026-09-11T05:00:17.816276+00:00",
      "exception": false,
-     "start_time": "2026-09-10T23:49:30.408034+00:00",
+     "start_time": "2026-09-11T05:00:17.814108+00:00",
      "status": "completed"
     }
    },
@@ -389,20 +391,20 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "1edb289e",
+   "id": "5753d7ad",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T23:49:30.415401Z",
-     "iopub.status.busy": "2026-09-10T23:49:30.415248Z",
-     "iopub.status.idle": "2026-09-10T23:49:30.418283Z",
-     "shell.execute_reply": "2026-09-10T23:49:30.417761Z"
+     "iopub.execute_input": "2026-09-11T05:00:17.821264Z",
+     "iopub.status.busy": "2026-09-11T05:00:17.821087Z",
+     "iopub.status.idle": "2026-09-11T05:00:17.826432Z",
+     "shell.execute_reply": "2026-09-11T05:00:17.825748Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.006189,
-     "end_time": "2026-09-10T23:49:30.418607+00:00",
+     "duration": 0.008492,
+     "end_time": "2026-09-11T05:00:17.826915+00:00",
      "exception": false,
-     "start_time": "2026-09-10T23:49:30.412418+00:00",
+     "start_time": "2026-09-11T05:00:17.818423+00:00",
      "status": "completed"
     }
    },
@@ -426,14 +428,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "02ddad9c",
+   "id": "381f15bc",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.001969,
-     "end_time": "2026-09-10T23:49:30.422838+00:00",
+     "duration": 0.00375,
+     "end_time": "2026-09-11T05:00:17.835085+00:00",
      "exception": false,
-     "start_time": "2026-09-10T23:49:30.420869+00:00",
+     "start_time": "2026-09-11T05:00:17.831335+00:00",
      "status": "completed"
     }
    },
@@ -445,20 +447,20 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "0178cbe4",
+   "id": "c522e2b5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T23:49:30.427886Z",
-     "iopub.status.busy": "2026-09-10T23:49:30.427687Z",
-     "iopub.status.idle": "2026-09-10T23:49:30.431207Z",
-     "shell.execute_reply": "2026-09-10T23:49:30.430727Z"
+     "iopub.execute_input": "2026-09-11T05:00:17.841421Z",
+     "iopub.status.busy": "2026-09-11T05:00:17.841289Z",
+     "iopub.status.idle": "2026-09-11T05:00:17.844348Z",
+     "shell.execute_reply": "2026-09-11T05:00:17.843750Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.00663,
-     "end_time": "2026-09-10T23:49:30.431513+00:00",
+     "duration": 0.006322,
+     "end_time": "2026-09-11T05:00:17.844674+00:00",
      "exception": false,
-     "start_time": "2026-09-10T23:49:30.424883+00:00",
+     "start_time": "2026-09-11T05:00:17.838352+00:00",
      "status": "completed"
     }
    },
@@ -483,14 +485,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d409042c",
+   "id": "14476643",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.001938,
-     "end_time": "2026-09-10T23:49:30.435552+00:00",
+     "duration": 0.002029,
+     "end_time": "2026-09-11T05:00:17.849170+00:00",
      "exception": false,
-     "start_time": "2026-09-10T23:49:30.433614+00:00",
+     "start_time": "2026-09-11T05:00:17.847141+00:00",
      "status": "completed"
     }
    },
@@ -502,20 +504,20 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "2cef06ef",
+   "id": "e2397de0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T23:49:30.440061Z",
-     "iopub.status.busy": "2026-09-10T23:49:30.439980Z",
-     "iopub.status.idle": "2026-09-10T23:49:30.443033Z",
-     "shell.execute_reply": "2026-09-10T23:49:30.442653Z"
+     "iopub.execute_input": "2026-09-11T05:00:17.856233Z",
+     "iopub.status.busy": "2026-09-11T05:00:17.856023Z",
+     "iopub.status.idle": "2026-09-11T05:00:17.860086Z",
+     "shell.execute_reply": "2026-09-11T05:00:17.859639Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.005881,
-     "end_time": "2026-09-10T23:49:30.443416+00:00",
+     "duration": 0.009361,
+     "end_time": "2026-09-11T05:00:17.860609+00:00",
      "exception": false,
-     "start_time": "2026-09-10T23:49:30.437535+00:00",
+     "start_time": "2026-09-11T05:00:17.851248+00:00",
      "status": "completed"
     }
    },
@@ -556,14 +558,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c0e225e6",
+   "id": "913c1248",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.001938,
-     "end_time": "2026-09-10T23:49:30.447509+00:00",
+     "duration": 0.002011,
+     "end_time": "2026-09-11T05:00:17.865288+00:00",
      "exception": false,
-     "start_time": "2026-09-10T23:49:30.445571+00:00",
+     "start_time": "2026-09-11T05:00:17.863277+00:00",
      "status": "completed"
     }
    },
@@ -575,20 +577,20 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "f1773834",
+   "id": "7e1c1578",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T23:49:30.452263Z",
-     "iopub.status.busy": "2026-09-10T23:49:30.452180Z",
-     "iopub.status.idle": "2026-09-10T23:49:30.454811Z",
-     "shell.execute_reply": "2026-09-10T23:49:30.454419Z"
+     "iopub.execute_input": "2026-09-11T05:00:17.870251Z",
+     "iopub.status.busy": "2026-09-11T05:00:17.870121Z",
+     "iopub.status.idle": "2026-09-11T05:00:17.873110Z",
+     "shell.execute_reply": "2026-09-11T05:00:17.872522Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.005552,
-     "end_time": "2026-09-10T23:49:30.455259+00:00",
+     "duration": 0.006366,
+     "end_time": "2026-09-11T05:00:17.873678+00:00",
      "exception": false,
-     "start_time": "2026-09-10T23:49:30.449707+00:00",
+     "start_time": "2026-09-11T05:00:17.867312+00:00",
      "status": "completed"
     }
    },
@@ -625,14 +627,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7edf09ef",
+   "id": "fc508897",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.00208,
-     "end_time": "2026-09-10T23:49:30.459499+00:00",
+     "duration": 0.002533,
+     "end_time": "2026-09-11T05:00:17.878774+00:00",
      "exception": false,
-     "start_time": "2026-09-10T23:49:30.457419+00:00",
+     "start_time": "2026-09-11T05:00:17.876241+00:00",
      "status": "completed"
     }
    },
@@ -647,20 +649,20 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "52ff4cd2",
+   "id": "129bbb48",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T23:49:30.464540Z",
-     "iopub.status.busy": "2026-09-10T23:49:30.464402Z",
-     "iopub.status.idle": "2026-09-10T23:49:30.467345Z",
-     "shell.execute_reply": "2026-09-10T23:49:30.466940Z"
+     "iopub.execute_input": "2026-09-11T05:00:17.886675Z",
+     "iopub.status.busy": "2026-09-11T05:00:17.886358Z",
+     "iopub.status.idle": "2026-09-11T05:00:17.890234Z",
+     "shell.execute_reply": "2026-09-11T05:00:17.889749Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.006299,
-     "end_time": "2026-09-10T23:49:30.467903+00:00",
+     "duration": 0.009515,
+     "end_time": "2026-09-11T05:00:17.890567+00:00",
      "exception": false,
-     "start_time": "2026-09-10T23:49:30.461604+00:00",
+     "start_time": "2026-09-11T05:00:17.881052+00:00",
      "status": "completed"
     }
    },
@@ -695,14 +697,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "34b6cb85",
+   "id": "c1682dba",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.003753,
-     "end_time": "2026-09-10T23:49:30.475648+00:00",
+     "duration": 0.002057,
+     "end_time": "2026-09-11T05:00:17.895130+00:00",
      "exception": false,
-     "start_time": "2026-09-10T23:49:30.471895+00:00",
+     "start_time": "2026-09-11T05:00:17.893073+00:00",
      "status": "completed"
     }
    },
@@ -718,20 +720,20 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "10439845",
+   "id": "06a64cdc",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T23:49:30.482977Z",
-     "iopub.status.busy": "2026-09-10T23:49:30.482824Z",
-     "iopub.status.idle": "2026-09-10T23:49:30.485623Z",
-     "shell.execute_reply": "2026-09-10T23:49:30.485191Z"
+     "iopub.execute_input": "2026-09-11T05:00:17.900025Z",
+     "iopub.status.busy": "2026-09-11T05:00:17.899913Z",
+     "iopub.status.idle": "2026-09-11T05:00:17.902176Z",
+     "shell.execute_reply": "2026-09-11T05:00:17.901898Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.006408,
-     "end_time": "2026-09-10T23:49:30.485901+00:00",
+     "duration": 0.005428,
+     "end_time": "2026-09-11T05:00:17.902634+00:00",
      "exception": false,
-     "start_time": "2026-09-10T23:49:30.479493+00:00",
+     "start_time": "2026-09-11T05:00:17.897206+00:00",
      "status": "completed"
     }
    },
@@ -754,14 +756,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bb413ffb",
+   "id": "2fc7044f",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.001955,
-     "end_time": "2026-09-10T23:49:30.490190+00:00",
+     "duration": 0.002137,
+     "end_time": "2026-09-11T05:00:17.907205+00:00",
      "exception": false,
-     "start_time": "2026-09-10T23:49:30.488235+00:00",
+     "start_time": "2026-09-11T05:00:17.905068+00:00",
      "status": "completed"
     }
    },
@@ -782,20 +784,20 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "2c06f173",
+   "id": "8e83e425",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T23:49:30.495542Z",
-     "iopub.status.busy": "2026-09-10T23:49:30.495422Z",
-     "iopub.status.idle": "2026-09-10T23:49:30.498124Z",
-     "shell.execute_reply": "2026-09-10T23:49:30.497748Z"
+     "iopub.execute_input": "2026-09-11T05:00:17.912419Z",
+     "iopub.status.busy": "2026-09-11T05:00:17.912039Z",
+     "iopub.status.idle": "2026-09-11T05:00:17.916562Z",
+     "shell.execute_reply": "2026-09-11T05:00:17.916182Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.005726,
-     "end_time": "2026-09-10T23:49:30.498467+00:00",
+     "duration": 0.007808,
+     "end_time": "2026-09-11T05:00:17.917111+00:00",
      "exception": false,
-     "start_time": "2026-09-10T23:49:30.492741+00:00",
+     "start_time": "2026-09-11T05:00:17.909303+00:00",
      "status": "completed"
     }
    },
@@ -804,6 +806,8 @@
     "def _blend_final_probability(\n",
     "    post_debate: float,\n",
     "    supervisor_artifact: SupervisorArtifact,\n",
+    "    *,\n",
+    "    medium_weight: float = SUPERVISOR_MEDIUM_WEIGHT,\n",
     ") -> tuple[float, float]:\n",
     "    \"\"\"Phase 4 to final: confidence-gated supervisor override. Returns (p_yes, confidence).\"\"\"\n",
     "    final_p = post_debate\n",
@@ -813,8 +817,8 @@
     "        final_confidence = CONFIDENCE_WHEN_OVERRIDDEN\n",
     "    elif supervisor_artifact.confidence == \"medium\":\n",
     "        if supervisor_artifact.p_yes is not None:\n",
-    "            final_p = (1 - SUPERVISOR_MEDIUM_WEIGHT) * post_debate + (\n",
-    "                SUPERVISOR_MEDIUM_WEIGHT * supervisor_artifact.p_yes\n",
+    "            final_p = (1 - medium_weight) * post_debate + (\n",
+    "                medium_weight * supervisor_artifact.p_yes\n",
     "            )\n",
     "            final_confidence = CONFIDENCE_WHEN_BLENDED\n",
     "    return max(0.01, min(0.99, final_p)), final_confidence"
@@ -822,14 +826,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1fcf888e",
+   "id": "3573da2a",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.001906,
-     "end_time": "2026-09-10T23:49:30.502438+00:00",
+     "duration": 0.003773,
+     "end_time": "2026-09-11T05:00:17.925194+00:00",
      "exception": false,
-     "start_time": "2026-09-10T23:49:30.500532+00:00",
+     "start_time": "2026-09-11T05:00:17.921421+00:00",
      "status": "completed"
     }
    },
@@ -842,20 +846,20 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "771be826",
+   "id": "1198a5a5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T23:49:30.506965Z",
-     "iopub.status.busy": "2026-09-10T23:49:30.506863Z",
-     "iopub.status.idle": "2026-09-10T23:49:30.510415Z",
-     "shell.execute_reply": "2026-09-10T23:49:30.510024Z"
+     "iopub.execute_input": "2026-09-11T05:00:17.930862Z",
+     "iopub.status.busy": "2026-09-11T05:00:17.930748Z",
+     "iopub.status.idle": "2026-09-11T05:00:17.934521Z",
+     "shell.execute_reply": "2026-09-11T05:00:17.934111Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.006402,
-     "end_time": "2026-09-10T23:49:30.510804+00:00",
+     "duration": 0.007037,
+     "end_time": "2026-09-11T05:00:17.934911+00:00",
      "exception": false,
-     "start_time": "2026-09-10T23:49:30.504402+00:00",
+     "start_time": "2026-09-11T05:00:17.927874+00:00",
      "status": "completed"
     }
    },
@@ -911,14 +915,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "41a756dc",
+   "id": "a918aaf7",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.0019,
-     "end_time": "2026-09-10T23:49:30.514825+00:00",
+     "duration": 0.002052,
+     "end_time": "2026-09-11T05:00:17.939546+00:00",
      "exception": false,
-     "start_time": "2026-09-10T23:49:30.512925+00:00",
+     "start_time": "2026-09-11T05:00:17.937494+00:00",
      "status": "completed"
     }
    },
@@ -935,19 +939,19 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "id": "48e36838",
+   "id": "c66e942e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T23:49:30.519445Z",
-     "iopub.status.busy": "2026-09-10T23:49:30.519335Z",
-     "iopub.status.idle": "2026-09-10T23:49:30.521816Z",
-     "shell.execute_reply": "2026-09-10T23:49:30.521541Z"
+     "iopub.execute_input": "2026-09-11T05:00:17.945715Z",
+     "iopub.status.busy": "2026-09-11T05:00:17.945535Z",
+     "iopub.status.idle": "2026-09-11T05:00:17.948881Z",
+     "shell.execute_reply": "2026-09-11T05:00:17.948516Z"
     },
     "papermill": {
-     "duration": 0.005519,
-     "end_time": "2026-09-10T23:49:30.522318+00:00",
+     "duration": 0.007235,
+     "end_time": "2026-09-11T05:00:17.949339+00:00",
      "exception": false,
-     "start_time": "2026-09-10T23:49:30.516799+00:00",
+     "start_time": "2026-09-11T05:00:17.942104+00:00",
      "status": "completed"
     }
    },
@@ -981,13 +985,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1f65373e",
+   "id": "5186b5ee",
    "metadata": {
     "papermill": {
-     "duration": 0.003068,
-     "end_time": "2026-09-10T23:49:30.529382+00:00",
+     "duration": 0.004053,
+     "end_time": "2026-09-11T05:00:17.957838+00:00",
      "exception": false,
-     "start_time": "2026-09-10T23:49:30.526314+00:00",
+     "start_time": "2026-09-11T05:00:17.953785+00:00",
      "status": "completed"
     }
    },
@@ -1010,19 +1014,19 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "id": "44278882",
+   "id": "ea98724d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T23:49:30.534225Z",
-     "iopub.status.busy": "2026-09-10T23:49:30.534100Z",
-     "iopub.status.idle": "2026-09-10T23:49:30.536656Z",
-     "shell.execute_reply": "2026-09-10T23:49:30.536350Z"
+     "iopub.execute_input": "2026-09-11T05:00:17.968049Z",
+     "iopub.status.busy": "2026-09-11T05:00:17.967919Z",
+     "iopub.status.idle": "2026-09-11T05:00:17.970592Z",
+     "shell.execute_reply": "2026-09-11T05:00:17.970114Z"
     },
     "papermill": {
-     "duration": 0.005672,
-     "end_time": "2026-09-10T23:49:30.537071+00:00",
+     "duration": 0.008613,
+     "end_time": "2026-09-11T05:00:17.971003+00:00",
      "exception": false,
-     "start_time": "2026-09-10T23:49:30.531399+00:00",
+     "start_time": "2026-09-11T05:00:17.962390+00:00",
      "status": "completed"
     }
    },
@@ -1054,13 +1058,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "822b8e7b",
+   "id": "c808f175",
    "metadata": {
     "papermill": {
-     "duration": 0.001988,
-     "end_time": "2026-09-10T23:49:30.541265+00:00",
+     "duration": 0.003884,
+     "end_time": "2026-09-11T05:00:17.979932+00:00",
      "exception": false,
-     "start_time": "2026-09-10T23:49:30.539277+00:00",
+     "start_time": "2026-09-11T05:00:17.976048+00:00",
      "status": "completed"
     }
    },
@@ -1070,14 +1074,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "34f430ef",
+   "id": "4db49964",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.001924,
-     "end_time": "2026-09-10T23:49:30.545226+00:00",
+     "duration": 0.003239,
+     "end_time": "2026-09-11T05:00:17.987130+00:00",
      "exception": false,
-     "start_time": "2026-09-10T23:49:30.543302+00:00",
+     "start_time": "2026-09-11T05:00:17.983891+00:00",
      "status": "completed"
     }
    },
@@ -1089,20 +1093,20 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "id": "1b694f88",
+   "id": "739c8740",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T23:49:30.550161Z",
-     "iopub.status.busy": "2026-09-10T23:49:30.550022Z",
-     "iopub.status.idle": "2026-09-10T23:49:30.553147Z",
-     "shell.execute_reply": "2026-09-10T23:49:30.552797Z"
+     "iopub.execute_input": "2026-09-11T05:00:17.992722Z",
+     "iopub.status.busy": "2026-09-11T05:00:17.992510Z",
+     "iopub.status.idle": "2026-09-11T05:00:17.996569Z",
+     "shell.execute_reply": "2026-09-11T05:00:17.996160Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.006457,
-     "end_time": "2026-09-10T23:49:30.553706+00:00",
+     "duration": 0.007686,
+     "end_time": "2026-09-11T05:00:17.996895+00:00",
      "exception": false,
-     "start_time": "2026-09-10T23:49:30.547249+00:00",
+     "start_time": "2026-09-11T05:00:17.989209+00:00",
      "status": "completed"
     }
    },
@@ -1133,6 +1137,8 @@
     "                \"max_steps\": MAX_STEPS,\n",
     "                \"debate_rounds\": DEBATE_ROUNDS,\n",
     "                \"correlation\": NEYMAN_CORRELATION,\n",
+    "                \"debate_weight\": DEBATE_WEIGHT,\n",
+    "                \"supervisor_medium_weight\": SUPERVISOR_MEDIUM_WEIGHT,\n",
     "            },\n",
     "            llm_calls=tracer.calls,\n",
     "            notes=\"Full AIA pipeline: research, aggregate, debate, supervisor.\",\n",
@@ -1149,14 +1155,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c660a0e2",
+   "id": "322db04d",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.002096,
-     "end_time": "2026-09-10T23:49:30.558199+00:00",
+     "duration": 0.00282,
+     "end_time": "2026-09-11T05:00:18.002639+00:00",
      "exception": false,
-     "start_time": "2026-09-10T23:49:30.556103+00:00",
+     "start_time": "2026-09-11T05:00:17.999819+00:00",
      "status": "completed"
     }
    },
@@ -1168,19 +1174,19 @@
   {
    "cell_type": "code",
    "execution_count": 17,
-   "id": "ce74e27f",
+   "id": "eb85e802",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T23:49:30.563309Z",
-     "iopub.status.busy": "2026-09-10T23:49:30.563160Z",
-     "iopub.status.idle": "2026-09-10T23:49:30.565747Z",
-     "shell.execute_reply": "2026-09-10T23:49:30.565451Z"
+     "iopub.execute_input": "2026-09-11T05:00:18.008124Z",
+     "iopub.status.busy": "2026-09-11T05:00:18.007935Z",
+     "iopub.status.idle": "2026-09-11T05:00:18.011425Z",
+     "shell.execute_reply": "2026-09-11T05:00:18.010893Z"
     },
     "papermill": {
-     "duration": 0.006174,
-     "end_time": "2026-09-10T23:49:30.566520+00:00",
+     "duration": 0.006896,
+     "end_time": "2026-09-11T05:00:18.011779+00:00",
      "exception": false,
-     "start_time": "2026-09-10T23:49:30.560346+00:00",
+     "start_time": "2026-09-11T05:00:18.004883+00:00",
      "status": "completed"
     }
    },
@@ -1205,19 +1211,19 @@
   {
    "cell_type": "code",
    "execution_count": 18,
-   "id": "08cabdc1",
+   "id": "32f0017e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T23:49:30.575565Z",
-     "iopub.status.busy": "2026-09-10T23:49:30.575441Z",
-     "iopub.status.idle": "2026-09-10T23:49:30.586729Z",
-     "shell.execute_reply": "2026-09-10T23:49:30.586367Z"
+     "iopub.execute_input": "2026-09-11T05:00:18.016768Z",
+     "iopub.status.busy": "2026-09-11T05:00:18.016642Z",
+     "iopub.status.idle": "2026-09-11T05:00:18.033863Z",
+     "shell.execute_reply": "2026-09-11T05:00:18.033162Z"
     },
     "papermill": {
-     "duration": 0.016442,
-     "end_time": "2026-09-10T23:49:30.587232+00:00",
+     "duration": 0.0206,
+     "end_time": "2026-09-11T05:00:18.034595+00:00",
      "exception": false,
-     "start_time": "2026-09-10T23:49:30.570790+00:00",
+     "start_time": "2026-09-11T05:00:18.013995+00:00",
      "status": "completed"
     }
    },
@@ -1240,13 +1246,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5ac29573",
+   "id": "c93946bc",
    "metadata": {
     "papermill": {
-     "duration": 0.00218,
-     "end_time": "2026-09-10T23:49:30.592153+00:00",
+     "duration": 0.002748,
+     "end_time": "2026-09-11T05:00:18.041700+00:00",
      "exception": false,
-     "start_time": "2026-09-10T23:49:30.589973+00:00",
+     "start_time": "2026-09-11T05:00:18.038952+00:00",
      "status": "completed"
     }
    },
@@ -1257,19 +1263,19 @@
   {
    "cell_type": "code",
    "execution_count": 19,
-   "id": "5aed1597",
+   "id": "a8db838a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T23:49:30.597513Z",
-     "iopub.status.busy": "2026-09-10T23:49:30.597385Z",
-     "iopub.status.idle": "2026-09-10T23:49:30.602764Z",
-     "shell.execute_reply": "2026-09-10T23:49:30.602314Z"
+     "iopub.execute_input": "2026-09-11T05:00:18.046982Z",
+     "iopub.status.busy": "2026-09-11T05:00:18.046851Z",
+     "iopub.status.idle": "2026-09-11T05:00:18.055397Z",
+     "shell.execute_reply": "2026-09-11T05:00:18.054743Z"
     },
     "papermill": {
-     "duration": 0.008747,
-     "end_time": "2026-09-10T23:49:30.603083+00:00",
+     "duration": 0.012593,
+     "end_time": "2026-09-11T05:00:18.056434+00:00",
      "exception": false,
-     "start_time": "2026-09-10T23:49:30.594336+00:00",
+     "start_time": "2026-09-11T05:00:18.043841+00:00",
      "status": "completed"
     }
    },
@@ -1340,13 +1346,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9169843b",
+   "id": "90d9ce1e",
    "metadata": {
     "papermill": {
-     "duration": 0.002222,
-     "end_time": "2026-09-10T23:49:30.607853+00:00",
+     "duration": 0.004181,
+     "end_time": "2026-09-11T05:00:18.066365+00:00",
      "exception": false,
-     "start_time": "2026-09-10T23:49:30.605631+00:00",
+     "start_time": "2026-09-11T05:00:18.062184+00:00",
      "status": "completed"
     }
    },
@@ -1364,19 +1370,19 @@
   {
    "cell_type": "code",
    "execution_count": 20,
-   "id": "a790f2fe",
+   "id": "8385a9be",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T23:49:30.613685Z",
-     "iopub.status.busy": "2026-09-10T23:49:30.613499Z",
-     "iopub.status.idle": "2026-09-10T23:49:30.620009Z",
-     "shell.execute_reply": "2026-09-10T23:49:30.619502Z"
+     "iopub.execute_input": "2026-09-11T05:00:18.073832Z",
+     "iopub.status.busy": "2026-09-11T05:00:18.073666Z",
+     "iopub.status.idle": "2026-09-11T05:00:18.080124Z",
+     "shell.execute_reply": "2026-09-11T05:00:18.079491Z"
     },
     "papermill": {
-     "duration": 0.010517,
-     "end_time": "2026-09-10T23:49:30.620681+00:00",
+     "duration": 0.009837,
+     "end_time": "2026-09-11T05:00:18.080484+00:00",
      "exception": false,
-     "start_time": "2026-09-10T23:49:30.610164+00:00",
+     "start_time": "2026-09-11T05:00:18.070647+00:00",
      "status": "completed"
     }
    },
@@ -1812,13 +1818,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "58b186b6",
+   "id": "a4400e35",
    "metadata": {
     "papermill": {
-     "duration": 0.00234,
-     "end_time": "2026-09-10T23:49:30.627395+00:00",
+     "duration": 0.003641,
+     "end_time": "2026-09-11T05:00:18.086772+00:00",
      "exception": false,
-     "start_time": "2026-09-10T23:49:30.625055+00:00",
+     "start_time": "2026-09-11T05:00:18.083131+00:00",
      "status": "completed"
     }
    },
@@ -1829,19 +1835,19 @@
   {
    "cell_type": "code",
    "execution_count": 21,
-   "id": "447298bd",
+   "id": "ad351974",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T23:49:30.633115Z",
-     "iopub.status.busy": "2026-09-10T23:49:30.632917Z",
-     "iopub.status.idle": "2026-09-10T23:49:30.636092Z",
-     "shell.execute_reply": "2026-09-10T23:49:30.635669Z"
+     "iopub.execute_input": "2026-09-11T05:00:18.093385Z",
+     "iopub.status.busy": "2026-09-11T05:00:18.093200Z",
+     "iopub.status.idle": "2026-09-11T05:00:18.096375Z",
+     "shell.execute_reply": "2026-09-11T05:00:18.095870Z"
     },
     "papermill": {
-     "duration": 0.006718,
-     "end_time": "2026-09-10T23:49:30.636443+00:00",
+     "duration": 0.006879,
+     "end_time": "2026-09-11T05:00:18.096705+00:00",
      "exception": false,
-     "start_time": "2026-09-10T23:49:30.629725+00:00",
+     "start_time": "2026-09-11T05:00:18.089826+00:00",
      "status": "completed"
     }
    },
@@ -1869,13 +1875,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "37b494e2",
+   "id": "1cc9d9e4",
    "metadata": {
     "papermill": {
-     "duration": 0.00227,
-     "end_time": "2026-09-10T23:49:30.641243+00:00",
+     "duration": 0.002406,
+     "end_time": "2026-09-11T05:00:18.101685+00:00",
      "exception": false,
-     "start_time": "2026-09-10T23:49:30.638973+00:00",
+     "start_time": "2026-09-11T05:00:18.099279+00:00",
      "status": "completed"
     }
    },
@@ -1886,19 +1892,19 @@
   {
    "cell_type": "code",
    "execution_count": 22,
-   "id": "90a8e25d",
+   "id": "da9189ac",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T23:49:30.646591Z",
-     "iopub.status.busy": "2026-09-10T23:49:30.646468Z",
-     "iopub.status.idle": "2026-09-10T23:49:30.649415Z",
-     "shell.execute_reply": "2026-09-10T23:49:30.649187Z"
+     "iopub.execute_input": "2026-09-11T05:00:18.107723Z",
+     "iopub.status.busy": "2026-09-11T05:00:18.107516Z",
+     "iopub.status.idle": "2026-09-11T05:00:18.112445Z",
+     "shell.execute_reply": "2026-09-11T05:00:18.111887Z"
     },
     "papermill": {
-     "duration": 0.006233,
-     "end_time": "2026-09-10T23:49:30.649824+00:00",
+     "duration": 0.009112,
+     "end_time": "2026-09-11T05:00:18.113161+00:00",
      "exception": false,
-     "start_time": "2026-09-10T23:49:30.643591+00:00",
+     "start_time": "2026-09-11T05:00:18.104049+00:00",
      "status": "completed"
     }
    },
@@ -2104,13 +2110,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1f45fda8",
+   "id": "72710f7f",
    "metadata": {
     "papermill": {
-     "duration": 0.002409,
-     "end_time": "2026-09-10T23:49:30.654763+00:00",
+     "duration": 0.003118,
+     "end_time": "2026-09-11T05:00:18.120415+00:00",
      "exception": false,
-     "start_time": "2026-09-10T23:49:30.652354+00:00",
+     "start_time": "2026-09-11T05:00:18.117297+00:00",
      "status": "completed"
     }
    },
@@ -2121,19 +2127,19 @@
   {
    "cell_type": "code",
    "execution_count": 23,
-   "id": "29e281c0",
+   "id": "09bee5ee",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T23:49:30.660179Z",
-     "iopub.status.busy": "2026-09-10T23:49:30.660063Z",
-     "iopub.status.idle": "2026-09-10T23:49:30.663079Z",
-     "shell.execute_reply": "2026-09-10T23:49:30.662725Z"
+     "iopub.execute_input": "2026-09-11T05:00:18.126315Z",
+     "iopub.status.busy": "2026-09-11T05:00:18.126154Z",
+     "iopub.status.idle": "2026-09-11T05:00:18.129519Z",
+     "shell.execute_reply": "2026-09-11T05:00:18.129050Z"
     },
     "papermill": {
-     "duration": 0.006243,
-     "end_time": "2026-09-10T23:49:30.663421+00:00",
+     "duration": 0.006818,
+     "end_time": "2026-09-11T05:00:18.129847+00:00",
      "exception": false,
-     "start_time": "2026-09-10T23:49:30.657178+00:00",
+     "start_time": "2026-09-11T05:00:18.123029+00:00",
      "status": "completed"
     }
    },
@@ -2204,13 +2210,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cb812903",
+   "id": "870c249d",
    "metadata": {
     "papermill": {
-     "duration": 0.002364,
-     "end_time": "2026-09-10T23:49:30.668303+00:00",
+     "duration": 0.002441,
+     "end_time": "2026-09-11T05:00:18.134819+00:00",
      "exception": false,
-     "start_time": "2026-09-10T23:49:30.665939+00:00",
+     "start_time": "2026-09-11T05:00:18.132378+00:00",
      "status": "completed"
     }
    },
@@ -2221,7 +2227,7 @@
     "pipeline: the aggregate over the research agents, the post-debate blend, and the final\n",
     "probability. Those are what the line below joins. Everything else a stage produced is an\n",
     "input to one of them - the market price the agents were shown, the agents' own answers, the\n",
-    "debate midpoint that enters the post-debate blend at weight `DEBATE_WEIGHT`, and the\n",
+    "debate midpoint that enters the post-debate blend at the run's own debate weight, and the\n",
     "supervisor's own probability - and is drawn as an open marker at the stage that read it.\n",
     "\n",
     "The distinction decides what a gap on this chart means. Between two carried values it is\n",
@@ -2231,21 +2237,105 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "22949d2f",
+   "metadata": {
+    "lines_to_next_cell": 2,
+    "papermill": {
+     "duration": 0.002594,
+     "end_time": "2026-09-11T05:00:18.139897+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T05:00:18.137303+00:00",
+     "status": "completed"
+    }
+   },
+   "source": [
+    "The post-debate value is the one number on the line that no stage stores: it is rebuilt from\n",
+    "the aggregate and the debate midpoint. On a replay it has to be rebuilt with the weights the\n",
+    "capture was recorded with rather than the ones set in this notebook now. Mixing the two\n",
+    "recomputes the middle point of the line and leaves the points either side of it at their\n",
+    "recorded values. Raising `DEBATE_WEIGHT` far enough would pull the post-debate point above\n",
+    "both of its neighbours and draw a large supervisor correction that never happened. So the\n",
+    "weights take effect on a live run, and are read back from the trace on a replay.\n",
+    "\n",
+    "Neither weight was recorded when the two committed captures were taken, so they fall back to\n",
+    "the values in use then. `carried_probabilities` re-derives each capture's final probability\n",
+    "from its own parts and raises if the fallback does not reproduce it, which is what keeps the\n",
+    "fallback from becoming an assumption nobody checks."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 24,
-   "id": "7ab3cbc3",
+   "id": "102a7cd4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T23:49:30.673945Z",
-     "iopub.status.busy": "2026-09-10T23:49:30.673796Z",
-     "iopub.status.idle": "2026-09-10T23:49:30.769622Z",
-     "shell.execute_reply": "2026-09-10T23:49:30.769116Z"
+     "iopub.execute_input": "2026-09-11T05:00:18.147216Z",
+     "iopub.status.busy": "2026-09-11T05:00:18.147012Z",
+     "iopub.status.idle": "2026-09-11T05:00:18.151166Z",
+     "shell.execute_reply": "2026-09-11T05:00:18.150700Z"
     },
     "papermill": {
-     "duration": 0.099374,
-     "end_time": "2026-09-10T23:49:30.770083+00:00",
+     "duration": 0.008135,
+     "end_time": "2026-09-11T05:00:18.151542+00:00",
      "exception": false,
-     "start_time": "2026-09-10T23:49:30.670709+00:00",
+     "start_time": "2026-09-11T05:00:18.143407+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "CAPTURED_DEBATE_WEIGHT = 0.3\n",
+    "CAPTURED_SUPERVISOR_MEDIUM_WEIGHT = 0.4\n",
+    "\n",
+    "\n",
+    "def carried_probabilities(result: ForecastResult, run: RunTrace) -> tuple[float, float, float]:\n",
+    "    \"\"\"Return (aggregate, debate midpoint, post-debate) under the run's own weights.\"\"\"\n",
+    "    debate_weight = float(run.params.get(\"debate_weight\", CAPTURED_DEBATE_WEIGHT))\n",
+    "    medium_weight = float(\n",
+    "        run.params.get(\"supervisor_medium_weight\", CAPTURED_SUPERVISOR_MEDIUM_WEIGHT)\n",
+    "    )\n",
+    "    aggregate_p = (\n",
+    "        result.aggregation.extremized_probability\n",
+    "        if result.aggregation.extremized_probability is not None\n",
+    "        else result.aggregation.raw_probability\n",
+    "    )\n",
+    "    midpoint = (\n",
+    "        (result.debate.bull_final_probability + result.debate.bear_final_probability) / 2\n",
+    "        if result.debate and result.debate.bull_final_probability is not None\n",
+    "        else aggregate_p\n",
+    "    )\n",
+    "    post_debate = (1 - debate_weight) * aggregate_p + debate_weight * midpoint\n",
+    "\n",
+    "    if result.supervisor is not None:\n",
+    "        rebuilt, _ = _blend_final_probability(\n",
+    "            post_debate, result.supervisor, medium_weight=medium_weight\n",
+    "        )\n",
+    "        if abs(round(rebuilt, 4) - result.final_probability) > 1e-4:\n",
+    "            raise RuntimeError(\n",
+    "                f\"Rebuilt final probability {rebuilt:.4f} does not match the recorded \"\n",
+    "                f\"{result.final_probability:.4f} for {result.question.question[:50]}: \"\n",
+    "                f\"the weights this line is drawn with are not the ones the run used.\"\n",
+    "            )\n",
+    "    return aggregate_p, midpoint, post_debate"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "id": "e6847169",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-11T05:00:18.157238Z",
+     "iopub.status.busy": "2026-09-11T05:00:18.157099Z",
+     "iopub.status.idle": "2026-09-11T05:00:18.265129Z",
+     "shell.execute_reply": "2026-09-11T05:00:18.264418Z"
+    },
+    "papermill": {
+     "duration": 0.111457,
+     "end_time": "2026-09-11T05:00:18.265535+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T05:00:18.154078+00:00",
      "status": "completed"
     }
    },
@@ -2276,20 +2366,9 @@
     "}\n",
     "\n",
     "carried_rows, input_rows = [], []\n",
-    "for r in results:\n",
+    "for r, run in zip(results, run_traces, strict=True):\n",
     "    q_short = textwrap.shorten(r.question.question, width=44, placeholder=\"...\")\n",
-    "\n",
-    "    aggregate_p = (\n",
-    "        r.aggregation.extremized_probability\n",
-    "        if r.aggregation.extremized_probability is not None\n",
-    "        else r.aggregation.raw_probability\n",
-    "    )\n",
-    "    midpoint = (\n",
-    "        (r.debate.bull_final_probability + r.debate.bear_final_probability) / 2\n",
-    "        if r.debate and r.debate.bull_final_probability is not None\n",
-    "        else aggregate_p\n",
-    "    )\n",
-    "    post_debate = (1 - DEBATE_WEIGHT) * aggregate_p + DEBATE_WEIGHT * midpoint\n",
+    "    aggregate_p, midpoint, post_debate = carried_probabilities(r, run)\n",
     "\n",
     "    carried_rows += [\n",
     "        {\"question\": q_short, \"stage\": \"Aggregate\", \"p_yes\": aggregate_p},\n",
@@ -2359,13 +2438,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "927e32d7",
+   "id": "fd26ac76",
    "metadata": {
     "papermill": {
-     "duration": 0.002876,
-     "end_time": "2026-09-10T23:49:30.776407+00:00",
+     "duration": 0.002715,
+     "end_time": "2026-09-11T05:00:18.271683+00:00",
      "exception": false,
-     "start_time": "2026-09-10T23:49:30.773531+00:00",
+     "start_time": "2026-09-11T05:00:18.268968+00:00",
      "status": "completed"
     }
    },
@@ -2376,20 +2455,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
-   "id": "f26ec71c",
+   "execution_count": 26,
+   "id": "4fff24e1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T23:49:30.782999Z",
-     "iopub.status.busy": "2026-09-10T23:49:30.782845Z",
-     "iopub.status.idle": "2026-09-10T23:49:30.788790Z",
-     "shell.execute_reply": "2026-09-10T23:49:30.788447Z"
+     "iopub.execute_input": "2026-09-11T05:00:18.280678Z",
+     "iopub.status.busy": "2026-09-11T05:00:18.280461Z",
+     "iopub.status.idle": "2026-09-11T05:00:18.286863Z",
+     "shell.execute_reply": "2026-09-11T05:00:18.286415Z"
     },
     "papermill": {
-     "duration": 0.010255,
-     "end_time": "2026-09-10T23:49:30.789476+00:00",
+     "duration": 0.012201,
+     "end_time": "2026-09-11T05:00:18.287564+00:00",
      "exception": false,
-     "start_time": "2026-09-10T23:49:30.779221+00:00",
+     "start_time": "2026-09-11T05:00:18.275363+00:00",
      "status": "completed"
     }
    },
@@ -2418,7 +2497,7 @@
        "└─────────────────────────────────┴──────────────────────────┴────────┘"
       ]
      },
-     "execution_count": 25,
+     "execution_count": 26,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2445,13 +2524,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cb90e764",
+   "id": "d3695f66",
    "metadata": {
     "papermill": {
-     "duration": 0.005,
-     "end_time": "2026-09-10T23:49:30.800286+00:00",
+     "duration": 0.002763,
+     "end_time": "2026-09-11T05:00:18.293689+00:00",
      "exception": false,
-     "start_time": "2026-09-10T23:49:30.795286+00:00",
+     "start_time": "2026-09-11T05:00:18.290926+00:00",
      "status": "completed"
     }
    },
@@ -2472,13 +2551,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1e15f735",
+   "id": "a6a63731",
    "metadata": {
     "papermill": {
-     "duration": 0.003136,
-     "end_time": "2026-09-10T23:49:30.808527+00:00",
+     "duration": 0.00271,
+     "end_time": "2026-09-11T05:00:18.299286+00:00",
      "exception": false,
-     "start_time": "2026-09-10T23:49:30.805391+00:00",
+     "start_time": "2026-09-11T05:00:18.296576+00:00",
      "status": "completed"
     }
    },
@@ -2488,20 +2567,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
-   "id": "a71797e0",
+   "execution_count": 27,
+   "id": "0f516395",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T23:49:30.815051Z",
-     "iopub.status.busy": "2026-09-10T23:49:30.814900Z",
-     "iopub.status.idle": "2026-09-10T23:49:30.817554Z",
-     "shell.execute_reply": "2026-09-10T23:49:30.817033Z"
+     "iopub.execute_input": "2026-09-11T05:00:18.307730Z",
+     "iopub.status.busy": "2026-09-11T05:00:18.307613Z",
+     "iopub.status.idle": "2026-09-11T05:00:18.310141Z",
+     "shell.execute_reply": "2026-09-11T05:00:18.309752Z"
     },
     "papermill": {
-     "duration": 0.006697,
-     "end_time": "2026-09-10T23:49:30.817960+00:00",
+     "duration": 0.00872,
+     "end_time": "2026-09-11T05:00:18.310677+00:00",
      "exception": false,
-     "start_time": "2026-09-10T23:49:30.811263+00:00",
+     "start_time": "2026-09-11T05:00:18.301957+00:00",
      "status": "completed"
     }
    },
@@ -2526,13 +2605,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4176d3e6",
+   "id": "5b236254",
    "metadata": {
     "papermill": {
-     "duration": 0.00263,
-     "end_time": "2026-09-10T23:49:30.823542+00:00",
+     "duration": 0.002819,
+     "end_time": "2026-09-11T05:00:18.316705+00:00",
      "exception": false,
-     "start_time": "2026-09-10T23:49:30.820912+00:00",
+     "start_time": "2026-09-11T05:00:18.313886+00:00",
      "status": "completed"
     }
    },
@@ -2551,20 +2630,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
-   "id": "61727043",
+   "execution_count": 28,
+   "id": "4695fdfc",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T23:49:30.830902Z",
-     "iopub.status.busy": "2026-09-10T23:49:30.830688Z",
-     "iopub.status.idle": "2026-09-10T23:49:30.834555Z",
-     "shell.execute_reply": "2026-09-10T23:49:30.833988Z"
+     "iopub.execute_input": "2026-09-11T05:00:18.322823Z",
+     "iopub.status.busy": "2026-09-11T05:00:18.322728Z",
+     "iopub.status.idle": "2026-09-11T05:00:18.325560Z",
+     "shell.execute_reply": "2026-09-11T05:00:18.325186Z"
     },
     "papermill": {
-     "duration": 0.008599,
-     "end_time": "2026-09-10T23:49:30.834942+00:00",
+     "duration": 0.006562,
+     "end_time": "2026-09-11T05:00:18.326008+00:00",
      "exception": false,
-     "start_time": "2026-09-10T23:49:30.826343+00:00",
+     "start_time": "2026-09-11T05:00:18.319446+00:00",
      "status": "completed"
     }
    },
@@ -2619,13 +2698,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8e25c46b",
+   "id": "bc340224",
    "metadata": {
     "papermill": {
-     "duration": 0.002935,
-     "end_time": "2026-09-10T23:49:30.841269+00:00",
+     "duration": 0.003513,
+     "end_time": "2026-09-11T05:00:18.332374+00:00",
      "exception": false,
-     "start_time": "2026-09-10T23:49:30.838334+00:00",
+     "start_time": "2026-09-11T05:00:18.328861+00:00",
      "status": "completed"
     }
    },
@@ -2641,21 +2720,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
-   "id": "432478ee",
+   "execution_count": 29,
+   "id": "67752843",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T23:49:30.848221Z",
-     "iopub.status.busy": "2026-09-10T23:49:30.848074Z",
-     "iopub.status.idle": "2026-09-10T23:49:30.852016Z",
-     "shell.execute_reply": "2026-09-10T23:49:30.851532Z"
+     "iopub.execute_input": "2026-09-11T05:00:18.340217Z",
+     "iopub.status.busy": "2026-09-11T05:00:18.340073Z",
+     "iopub.status.idle": "2026-09-11T05:00:18.342871Z",
+     "shell.execute_reply": "2026-09-11T05:00:18.342561Z"
     },
     "lines_to_next_cell": 0,
     "papermill": {
-     "duration": 0.008151,
-     "end_time": "2026-09-10T23:49:30.852382+00:00",
+     "duration": 0.00679,
+     "end_time": "2026-09-11T05:00:18.343138+00:00",
      "exception": false,
-     "start_time": "2026-09-10T23:49:30.844231+00:00",
+     "start_time": "2026-09-11T05:00:18.336348+00:00",
      "status": "completed"
     }
    },
@@ -2691,13 +2770,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "00130d16",
+   "id": "22480219",
    "metadata": {
     "papermill": {
-     "duration": 0.003023,
-     "end_time": "2026-09-10T23:49:30.858574+00:00",
+     "duration": 0.002664,
+     "end_time": "2026-09-11T05:00:18.348606+00:00",
      "exception": false,
-     "start_time": "2026-09-10T23:49:30.855551+00:00",
+     "start_time": "2026-09-11T05:00:18.345942+00:00",
      "status": "completed"
     }
    },
@@ -2757,24 +2836,24 @@
    "version": "3.14.3"
   },
   "ml4t_provenance": {
-   "executed_at": "2026-09-10T23:49:41.463129+00:00",
+   "executed_at": "2026-09-11T05:00:29.079947+00:00",
    "executor": "local-uv",
-   "library_digest": "1c423239ff154fba4f3b3ee29863ba8b333705bd81b6d236ece3df506ceefb87",
-   "outputs_digest": "1fe5720157501ae900bbe7d520c8dcdfc46a608df18dac52894f064eca47d2de",
+   "library_digest": "45f6d8a6aa2f659af2d76e41192a6cae552e749fe04368b2f62766b9487259fe",
+   "outputs_digest": "91454f308f680e62490d83b33a5233baef40091be622c9475aff0527daaec8bf",
    "parameters": {},
    "production": true,
-   "source_py_blob": "04107df0beb94e95284620ea2aa0e6da9ee0c89b"
+   "source_py_blob": "16aef3142ad7c6e4119304ddfa0d275f0e18521b"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 5.903959,
-   "end_time": "2026-09-10T23:49:32.479598+00:00",
+   "duration": 5.805188,
+   "end_time": "2026-09-11T05:00:19.669017+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "~/ml4t/public-teach-g/24_autonomous_agents/.08_forecasting_pipeline.build.275347.ipynb",
-   "output_path": "~/ml4t/public-teach-g/24_autonomous_agents/.08_forecasting_pipeline.papermill.275347.ipynb",
+   "input_path": "~/ml4t/public-teach-g/24_autonomous_agents/.08_forecasting_pipeline.build.2096708.ipynb",
+   "output_path": "~/ml4t/public-teach-g/24_autonomous_agents/.08_forecasting_pipeline.papermill.2096708.ipynb",
    "parameters": {},
-   "start_time": "2026-09-10T23:49:26.575639+00:00",
+   "start_time": "2026-09-11T05:00:13.863829+00:00",
    "version": "2.7.0"
   }
  },

--- a/24_autonomous_agents/08_forecasting_pipeline.py
+++ b/24_autonomous_agents/08_forecasting_pipeline.py
@@ -465,7 +465,9 @@ def _forecast_one(forecaster, question: ForecastQuestion) -> ForecastResult:
         question.question, summaries, cutoff_date=cutoff
     )
     post_debate = (1 - DEBATE_WEIGHT) * aggregate_p + DEBATE_WEIGHT * midpoint
-    final_p, confidence = _blend_final_probability(post_debate, supervisor)
+    final_p, confidence = _blend_final_probability(
+        post_debate, supervisor, medium_weight=SUPERVISOR_MEDIUM_WEIGHT
+    )
     tokens = sum((agent.token_usage for agent in agents), start=TokenUsage())
     tokens = tokens + debate.token_usage + supervisor.token_usage
     return ForecastResult(

--- a/24_autonomous_agents/08_forecasting_pipeline.py
+++ b/24_autonomous_agents/08_forecasting_pipeline.py
@@ -98,9 +98,11 @@ from utils.style import COLORS, add_message_title, show_with_alt
 # aggregated.
 #
 # Three weights decide how much each later stage can move the answer, and they are the numbers
-# to argue with. `DEBATE_WEIGHT` is the debate midpoint's share of the post-debate probability.
-# `SUPERVISOR_MEDIUM_WEIGHT` is the supervisor's share when it states medium confidence; at
-# high confidence it replaces the value outright and at low confidence it is ignored.
+# to argue with - on a live run. `DEBATE_WEIGHT` is the debate midpoint's share of the
+# post-debate probability. `SUPERVISOR_MEDIUM_WEIGHT` is the supervisor's share when it states
+# medium confidence; at high confidence it replaces the value outright and at low confidence it
+# is ignored. A replay reports the probabilities its capture recorded, so changing either weight
+# with `RUN_LIVE` left at `False` changes nothing: the run that produced the numbers is over.
 #
 # The three `CONFIDENCE_WHEN_*` values are what the pipeline reports as its own confidence in
 # each of those three cases. They are an ordering, not an estimate: a forecast the supervisor
@@ -406,6 +408,8 @@ def _run_research_agents(
 def _blend_final_probability(
     post_debate: float,
     supervisor_artifact: SupervisorArtifact,
+    *,
+    medium_weight: float = SUPERVISOR_MEDIUM_WEIGHT,
 ) -> tuple[float, float]:
     """Phase 4 to final: confidence-gated supervisor override. Returns (p_yes, confidence)."""
     final_p = post_debate
@@ -415,8 +419,8 @@ def _blend_final_probability(
         final_confidence = CONFIDENCE_WHEN_OVERRIDDEN
     elif supervisor_artifact.confidence == "medium":
         if supervisor_artifact.p_yes is not None:
-            final_p = (1 - SUPERVISOR_MEDIUM_WEIGHT) * post_debate + (
-                SUPERVISOR_MEDIUM_WEIGHT * supervisor_artifact.p_yes
+            final_p = (1 - medium_weight) * post_debate + (
+                medium_weight * supervisor_artifact.p_yes
             )
             final_confidence = CONFIDENCE_WHEN_BLENDED
     return max(0.01, min(0.99, final_p)), final_confidence
@@ -575,6 +579,8 @@ def _run_live_questions(questions_to_run: list[ForecastQuestion]) -> tuple[list,
                 "max_steps": MAX_STEPS,
                 "debate_rounds": DEBATE_ROUNDS,
                 "correlation": NEYMAN_CORRELATION,
+                "debate_weight": DEBATE_WEIGHT,
+                "supervisor_medium_weight": SUPERVISOR_MEDIUM_WEIGHT,
             },
             llm_calls=tracer.calls,
             notes="Full AIA pipeline: research, aggregate, debate, supervisor.",
@@ -700,13 +706,64 @@ else:
 # pipeline: the aggregate over the research agents, the post-debate blend, and the final
 # probability. Those are what the line below joins. Everything else a stage produced is an
 # input to one of them - the market price the agents were shown, the agents' own answers, the
-# debate midpoint that enters the post-debate blend at weight `DEBATE_WEIGHT`, and the
+# debate midpoint that enters the post-debate blend at the run's own debate weight, and the
 # supervisor's own probability - and is drawn as an open marker at the stage that read it.
 #
 # The distinction decides what a gap on this chart means. Between two carried values it is
 # movement, and a stage that never moves anything on any question is being paid for and not
 # used. Between two research agents it is disagreement: they answer in parallel and neither
 # saw the other.
+
+# %% [markdown]
+# The post-debate value is the one number on the line that no stage stores: it is rebuilt from
+# the aggregate and the debate midpoint. On a replay it has to be rebuilt with the weights the
+# capture was recorded with rather than the ones set in this notebook now. Mixing the two
+# recomputes the middle point of the line and leaves the points either side of it at their
+# recorded values. Raising `DEBATE_WEIGHT` far enough would pull the post-debate point above
+# both of its neighbours and draw a large supervisor correction that never happened. So the
+# weights take effect on a live run, and are read back from the trace on a replay.
+#
+# Neither weight was recorded when the two committed captures were taken, so they fall back to
+# the values in use then. `carried_probabilities` re-derives each capture's final probability
+# from its own parts and raises if the fallback does not reproduce it, which is what keeps the
+# fallback from becoming an assumption nobody checks.
+
+
+# %%
+CAPTURED_DEBATE_WEIGHT = 0.3
+CAPTURED_SUPERVISOR_MEDIUM_WEIGHT = 0.4
+
+
+def carried_probabilities(result: ForecastResult, run: RunTrace) -> tuple[float, float, float]:
+    """Return (aggregate, debate midpoint, post-debate) under the run's own weights."""
+    debate_weight = float(run.params.get("debate_weight", CAPTURED_DEBATE_WEIGHT))
+    medium_weight = float(
+        run.params.get("supervisor_medium_weight", CAPTURED_SUPERVISOR_MEDIUM_WEIGHT)
+    )
+    aggregate_p = (
+        result.aggregation.extremized_probability
+        if result.aggregation.extremized_probability is not None
+        else result.aggregation.raw_probability
+    )
+    midpoint = (
+        (result.debate.bull_final_probability + result.debate.bear_final_probability) / 2
+        if result.debate and result.debate.bull_final_probability is not None
+        else aggregate_p
+    )
+    post_debate = (1 - debate_weight) * aggregate_p + debate_weight * midpoint
+
+    if result.supervisor is not None:
+        rebuilt, _ = _blend_final_probability(
+            post_debate, result.supervisor, medium_weight=medium_weight
+        )
+        if abs(round(rebuilt, 4) - result.final_probability) > 1e-4:
+            raise RuntimeError(
+                f"Rebuilt final probability {rebuilt:.4f} does not match the recorded "
+                f"{result.final_probability:.4f} for {result.question.question[:50]}: "
+                f"the weights this line is drawn with are not the ones the run used."
+            )
+    return aggregate_p, midpoint, post_debate
+
 
 # %%
 STAGE_X = {
@@ -719,20 +776,9 @@ STAGE_X = {
 }
 
 carried_rows, input_rows = [], []
-for r in results:
+for r, run in zip(results, run_traces, strict=True):
     q_short = textwrap.shorten(r.question.question, width=44, placeholder="...")
-
-    aggregate_p = (
-        r.aggregation.extremized_probability
-        if r.aggregation.extremized_probability is not None
-        else r.aggregation.raw_probability
-    )
-    midpoint = (
-        (r.debate.bull_final_probability + r.debate.bear_final_probability) / 2
-        if r.debate and r.debate.bull_final_probability is not None
-        else aggregate_p
-    )
-    post_debate = (1 - DEBATE_WEIGHT) * aggregate_p + DEBATE_WEIGHT * midpoint
+    aggregate_p, midpoint, post_debate = carried_probabilities(r, run)
 
     carried_rows += [
         {"question": q_short, "stage": "Aggregate", "p_yes": aggregate_p},

--- a/25_live_trading/02_etfs_deployment_loop.ipynb
+++ b/25_live_trading/02_etfs_deployment_loop.ipynb
@@ -2,13 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "e81c3fdb",
+   "id": "013fb927",
    "metadata": {
     "papermill": {
-     "duration": 0.0021,
-     "end_time": "2026-09-11T05:00:32.133922+00:00",
+     "duration": 0.004279,
+     "end_time": "2026-09-11T05:05:17.440879+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:00:32.131822+00:00",
+     "start_time": "2026-09-11T05:05:17.436600+00:00",
      "status": "completed"
     }
    },
@@ -79,19 +79,19 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "0f09e15e",
+   "id": "1b359aba",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T05:00:32.138230Z",
-     "iopub.status.busy": "2026-09-11T05:00:32.138045Z",
-     "iopub.status.idle": "2026-09-11T05:00:35.472447Z",
-     "shell.execute_reply": "2026-09-11T05:00:35.471677Z"
+     "iopub.execute_input": "2026-09-11T05:05:17.449683Z",
+     "iopub.status.busy": "2026-09-11T05:05:17.448633Z",
+     "iopub.status.idle": "2026-09-11T05:05:20.889276Z",
+     "shell.execute_reply": "2026-09-11T05:05:20.888617Z"
     },
     "papermill": {
-     "duration": 3.337797,
-     "end_time": "2026-09-11T05:00:35.473527+00:00",
+     "duration": 3.445872,
+     "end_time": "2026-09-11T05:05:20.890073+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:00:32.135730+00:00",
+     "start_time": "2026-09-11T05:05:17.444201+00:00",
      "status": "completed"
     }
    },
@@ -147,19 +147,19 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "6e0f610b",
+   "id": "e293bab6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T05:00:35.480271Z",
-     "iopub.status.busy": "2026-09-11T05:00:35.480165Z",
-     "iopub.status.idle": "2026-09-11T05:00:35.482387Z",
-     "shell.execute_reply": "2026-09-11T05:00:35.481952Z"
+     "iopub.execute_input": "2026-09-11T05:05:20.896972Z",
+     "iopub.status.busy": "2026-09-11T05:05:20.896853Z",
+     "iopub.status.idle": "2026-09-11T05:05:20.899235Z",
+     "shell.execute_reply": "2026-09-11T05:05:20.898768Z"
     },
     "papermill": {
-     "duration": 0.005956,
-     "end_time": "2026-09-11T05:00:35.482792+00:00",
+     "duration": 0.006313,
+     "end_time": "2026-09-11T05:05:20.899741+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:00:35.476836+00:00",
+     "start_time": "2026-09-11T05:05:20.893428+00:00",
      "status": "completed"
     },
     "tags": [
@@ -184,13 +184,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9f00b105",
+   "id": "b51c0cb8",
    "metadata": {
     "papermill": {
-     "duration": 0.001399,
-     "end_time": "2026-09-11T05:00:35.486087+00:00",
+     "duration": 0.001694,
+     "end_time": "2026-09-11T05:05:20.903732+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:00:35.484688+00:00",
+     "start_time": "2026-09-11T05:05:20.902038+00:00",
      "status": "completed"
     }
    },
@@ -212,19 +212,19 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "0185884e",
+   "id": "434dc4a6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T05:00:35.489988Z",
-     "iopub.status.busy": "2026-09-11T05:00:35.489822Z",
-     "iopub.status.idle": "2026-09-11T05:00:35.493182Z",
-     "shell.execute_reply": "2026-09-11T05:00:35.492804Z"
+     "iopub.execute_input": "2026-09-11T05:05:20.908850Z",
+     "iopub.status.busy": "2026-09-11T05:05:20.908422Z",
+     "iopub.status.idle": "2026-09-11T05:05:20.913620Z",
+     "shell.execute_reply": "2026-09-11T05:05:20.913122Z"
     },
     "papermill": {
-     "duration": 0.00599,
-     "end_time": "2026-09-11T05:00:35.493548+00:00",
+     "duration": 0.008669,
+     "end_time": "2026-09-11T05:05:20.914110+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:00:35.487558+00:00",
+     "start_time": "2026-09-11T05:05:20.905441+00:00",
      "status": "completed"
     }
    },
@@ -259,13 +259,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b8dfcdad",
+   "id": "8bbf079a",
    "metadata": {
     "papermill": {
-     "duration": 0.002092,
-     "end_time": "2026-09-11T05:00:35.497455+00:00",
+     "duration": 0.001696,
+     "end_time": "2026-09-11T05:05:20.917767+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:00:35.495363+00:00",
+     "start_time": "2026-09-11T05:05:20.916071+00:00",
      "status": "completed"
     }
    },
@@ -285,19 +285,19 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "29c69fa6",
+   "id": "8ac77655",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T05:00:35.502001Z",
-     "iopub.status.busy": "2026-09-11T05:00:35.501792Z",
-     "iopub.status.idle": "2026-09-11T05:00:35.584167Z",
-     "shell.execute_reply": "2026-09-11T05:00:35.583786Z"
+     "iopub.execute_input": "2026-09-11T05:05:20.921725Z",
+     "iopub.status.busy": "2026-09-11T05:05:20.921636Z",
+     "iopub.status.idle": "2026-09-11T05:05:21.001432Z",
+     "shell.execute_reply": "2026-09-11T05:05:21.000771Z"
     },
     "papermill": {
-     "duration": 0.085064,
-     "end_time": "2026-09-11T05:00:35.584458+00:00",
+     "duration": 0.082354,
+     "end_time": "2026-09-11T05:05:21.001773+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:00:35.499394+00:00",
+     "start_time": "2026-09-11T05:05:20.919419+00:00",
      "status": "completed"
     }
    },
@@ -329,19 +329,19 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "6f771536",
+   "id": "74ba758c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T05:00:35.588805Z",
-     "iopub.status.busy": "2026-09-11T05:00:35.588686Z",
-     "iopub.status.idle": "2026-09-11T05:01:07.047540Z",
-     "shell.execute_reply": "2026-09-11T05:01:07.047202Z"
+     "iopub.execute_input": "2026-09-11T05:05:21.008684Z",
+     "iopub.status.busy": "2026-09-11T05:05:21.008293Z",
+     "iopub.status.idle": "2026-09-11T05:05:57.069642Z",
+     "shell.execute_reply": "2026-09-11T05:05:57.068800Z"
     },
     "papermill": {
-     "duration": 31.463154,
-     "end_time": "2026-09-11T05:01:07.049494+00:00",
+     "duration": 36.071745,
+     "end_time": "2026-09-11T05:05:57.075455+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:00:35.586340+00:00",
+     "start_time": "2026-09-11T05:05:21.003710+00:00",
      "status": "completed"
     }
    },
@@ -350,14 +350,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2026-09-11 01:00:35 | mlquant.features.adx | INFO | [ADX] Starting calculation with parameters: period=14 (shape: (4,))\n"
+      "2026-09-11 01:05:21 | mlquant.features.adx | INFO | [ADX] Starting calculation with parameters: period=14 (shape: (4,))\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2026-09-11 01:00:35 | mlquant.features.adx | INFO | [ADX] Completed calculation (shape: (4,)) (0.08ms)\n"
+      "2026-09-11 01:05:21 | mlquant.features.adx | INFO | [ADX] Completed calculation (shape: (4,)) (0.05ms)\n"
      ]
     },
     {
@@ -376,13 +376,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9d883b07",
+   "id": "d6fc8c88",
    "metadata": {
     "papermill": {
-     "duration": 0.001699,
-     "end_time": "2026-09-11T05:01:07.053208+00:00",
+     "duration": 0.00242,
+     "end_time": "2026-09-11T05:05:57.081242+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:01:07.051509+00:00",
+     "start_time": "2026-09-11T05:05:57.078822+00:00",
      "status": "completed"
     }
    },
@@ -425,19 +425,19 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "4ae09887",
+   "id": "ddfd7466",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T05:01:07.057364Z",
-     "iopub.status.busy": "2026-09-11T05:01:07.057264Z",
-     "iopub.status.idle": "2026-09-11T05:01:07.073208Z",
-     "shell.execute_reply": "2026-09-11T05:01:07.072834Z"
+     "iopub.execute_input": "2026-09-11T05:05:57.085399Z",
+     "iopub.status.busy": "2026-09-11T05:05:57.085282Z",
+     "iopub.status.idle": "2026-09-11T05:05:57.091686Z",
+     "shell.execute_reply": "2026-09-11T05:05:57.090870Z"
     },
     "papermill": {
-     "duration": 0.018892,
-     "end_time": "2026-09-11T05:01:07.073792+00:00",
+     "duration": 0.00927,
+     "end_time": "2026-09-11T05:05:57.092141+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:01:07.054900+00:00",
+     "start_time": "2026-09-11T05:05:57.082871+00:00",
      "status": "completed"
     }
    },
@@ -513,13 +513,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "27114be1",
+   "id": "e26bfbac",
    "metadata": {
     "papermill": {
-     "duration": 0.001844,
-     "end_time": "2026-09-11T05:01:07.079018+00:00",
+     "duration": 0.002459,
+     "end_time": "2026-09-11T05:05:57.096912+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:01:07.077174+00:00",
+     "start_time": "2026-09-11T05:05:57.094453+00:00",
      "status": "completed"
     }
    },
@@ -537,19 +537,19 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "1c2e1177",
+   "id": "a356071a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T05:01:07.082899Z",
-     "iopub.status.busy": "2026-09-11T05:01:07.082808Z",
-     "iopub.status.idle": "2026-09-11T05:01:07.194922Z",
-     "shell.execute_reply": "2026-09-11T05:01:07.194560Z"
+     "iopub.execute_input": "2026-09-11T05:05:57.102245Z",
+     "iopub.status.busy": "2026-09-11T05:05:57.102033Z",
+     "iopub.status.idle": "2026-09-11T05:05:57.205926Z",
+     "shell.execute_reply": "2026-09-11T05:05:57.205245Z"
     },
     "papermill": {
-     "duration": 0.114735,
-     "end_time": "2026-09-11T05:01:07.195367+00:00",
+     "duration": 0.107493,
+     "end_time": "2026-09-11T05:05:57.206558+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:01:07.080632+00:00",
+     "start_time": "2026-09-11T05:05:57.099065+00:00",
      "status": "completed"
     }
    },
@@ -570,13 +570,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dff9636c",
+   "id": "a6dcb9ce",
    "metadata": {
     "papermill": {
-     "duration": 0.001653,
-     "end_time": "2026-09-11T05:01:07.199119+00:00",
+     "duration": 0.003527,
+     "end_time": "2026-09-11T05:05:57.215481+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:01:07.197466+00:00",
+     "start_time": "2026-09-11T05:05:57.211954+00:00",
      "status": "completed"
     }
    },
@@ -593,19 +593,19 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "8e3fd3f2",
+   "id": "91cd6b4a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T05:01:07.203206Z",
-     "iopub.status.busy": "2026-09-11T05:01:07.203093Z",
-     "iopub.status.idle": "2026-09-11T05:01:07.212642Z",
-     "shell.execute_reply": "2026-09-11T05:01:07.211977Z"
+     "iopub.execute_input": "2026-09-11T05:05:57.222839Z",
+     "iopub.status.busy": "2026-09-11T05:05:57.222677Z",
+     "iopub.status.idle": "2026-09-11T05:05:57.231583Z",
+     "shell.execute_reply": "2026-09-11T05:05:57.231033Z"
     },
     "papermill": {
-     "duration": 0.012157,
-     "end_time": "2026-09-11T05:01:07.212974+00:00",
+     "duration": 0.012985,
+     "end_time": "2026-09-11T05:05:57.231954+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:01:07.200817+00:00",
+     "start_time": "2026-09-11T05:05:57.218969+00:00",
      "status": "completed"
     }
    },
@@ -640,19 +640,19 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "9599be8e",
+   "id": "af488ff4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T05:01:07.218048Z",
-     "iopub.status.busy": "2026-09-11T05:01:07.217845Z",
-     "iopub.status.idle": "2026-09-11T05:01:10.914894Z",
-     "shell.execute_reply": "2026-09-11T05:01:10.914344Z"
+     "iopub.execute_input": "2026-09-11T05:05:57.237384Z",
+     "iopub.status.busy": "2026-09-11T05:05:57.237222Z",
+     "iopub.status.idle": "2026-09-11T05:06:02.014262Z",
+     "shell.execute_reply": "2026-09-11T05:06:02.013676Z"
     },
     "papermill": {
-     "duration": 3.700275,
-     "end_time": "2026-09-11T05:01:10.915382+00:00",
+     "duration": 4.78067,
+     "end_time": "2026-09-11T05:06:02.015027+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:01:07.215107+00:00",
+     "start_time": "2026-09-11T05:05:57.234357+00:00",
      "status": "completed"
     }
    },
@@ -683,13 +683,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1481be1e",
+   "id": "4bdb8fd6",
    "metadata": {
     "papermill": {
-     "duration": 0.003762,
-     "end_time": "2026-09-11T05:01:10.924323+00:00",
+     "duration": 0.003194,
+     "end_time": "2026-09-11T05:06:02.021942+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:01:10.920561+00:00",
+     "start_time": "2026-09-11T05:06:02.018748+00:00",
      "status": "completed"
     }
    },
@@ -706,19 +706,19 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "b972cf4e",
+   "id": "363a9d14",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T05:01:10.931940Z",
-     "iopub.status.busy": "2026-09-11T05:01:10.931769Z",
-     "iopub.status.idle": "2026-09-11T05:01:10.938400Z",
-     "shell.execute_reply": "2026-09-11T05:01:10.937855Z"
+     "iopub.execute_input": "2026-09-11T05:06:02.029891Z",
+     "iopub.status.busy": "2026-09-11T05:06:02.029728Z",
+     "iopub.status.idle": "2026-09-11T05:06:02.035448Z",
+     "shell.execute_reply": "2026-09-11T05:06:02.034565Z"
     },
     "papermill": {
-     "duration": 0.011044,
-     "end_time": "2026-09-11T05:01:10.938829+00:00",
+     "duration": 0.011787,
+     "end_time": "2026-09-11T05:06:02.037084+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:01:10.927785+00:00",
+     "start_time": "2026-09-11T05:06:02.025297+00:00",
      "status": "completed"
     }
    },
@@ -776,13 +776,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "def8b2fb",
+   "id": "5a76e467",
    "metadata": {
     "papermill": {
-     "duration": 0.001993,
-     "end_time": "2026-09-11T05:01:10.944458+00:00",
+     "duration": 0.002156,
+     "end_time": "2026-09-11T05:06:02.042934+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:01:10.942465+00:00",
+     "start_time": "2026-09-11T05:06:02.040778+00:00",
      "status": "completed"
     }
    },
@@ -800,19 +800,19 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "c11d4fe1",
+   "id": "ec4e9a7f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T05:01:10.948766Z",
-     "iopub.status.busy": "2026-09-11T05:01:10.948606Z",
-     "iopub.status.idle": "2026-09-11T05:01:10.981643Z",
-     "shell.execute_reply": "2026-09-11T05:01:10.981025Z"
+     "iopub.execute_input": "2026-09-11T05:06:02.048197Z",
+     "iopub.status.busy": "2026-09-11T05:06:02.048076Z",
+     "iopub.status.idle": "2026-09-11T05:06:02.085499Z",
+     "shell.execute_reply": "2026-09-11T05:06:02.085006Z"
     },
     "papermill": {
-     "duration": 0.035829,
-     "end_time": "2026-09-11T05:01:10.982022+00:00",
+     "duration": 0.040717,
+     "end_time": "2026-09-11T05:06:02.085867+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:01:10.946193+00:00",
+     "start_time": "2026-09-11T05:06:02.045150+00:00",
      "status": "completed"
     }
    },
@@ -849,14 +849,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0847aa02",
+   "id": "f27fe827",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.001772,
-     "end_time": "2026-09-11T05:01:10.987294+00:00",
+     "duration": 0.002619,
+     "end_time": "2026-09-11T05:06:02.091275+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:01:10.985522+00:00",
+     "start_time": "2026-09-11T05:06:02.088656+00:00",
      "status": "completed"
     }
    },
@@ -882,19 +882,19 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "53c0e202",
+   "id": "b395ee16",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T05:01:10.991707Z",
-     "iopub.status.busy": "2026-09-11T05:01:10.991615Z",
-     "iopub.status.idle": "2026-09-11T05:01:10.995988Z",
-     "shell.execute_reply": "2026-09-11T05:01:10.995594Z"
+     "iopub.execute_input": "2026-09-11T05:06:02.097745Z",
+     "iopub.status.busy": "2026-09-11T05:06:02.097495Z",
+     "iopub.status.idle": "2026-09-11T05:06:02.105752Z",
+     "shell.execute_reply": "2026-09-11T05:06:02.105217Z"
     },
     "papermill": {
-     "duration": 0.007429,
-     "end_time": "2026-09-11T05:01:10.996686+00:00",
+     "duration": 0.012312,
+     "end_time": "2026-09-11T05:06:02.106282+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:01:10.989257+00:00",
+     "start_time": "2026-09-11T05:06:02.093970+00:00",
      "status": "completed"
     }
    },
@@ -984,13 +984,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bf7f0ed2",
+   "id": "e75732e7",
    "metadata": {
     "papermill": {
-     "duration": 0.00341,
-     "end_time": "2026-09-11T05:01:11.003816+00:00",
+     "duration": 0.003263,
+     "end_time": "2026-09-11T05:06:02.113287+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:01:11.000406+00:00",
+     "start_time": "2026-09-11T05:06:02.110024+00:00",
      "status": "completed"
     }
    },
@@ -1011,19 +1011,19 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "5860684a",
+   "id": "cb714f03",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T05:01:11.012981Z",
-     "iopub.status.busy": "2026-09-11T05:01:11.012837Z",
-     "iopub.status.idle": "2026-09-11T05:01:11.093896Z",
-     "shell.execute_reply": "2026-09-11T05:01:11.093479Z"
+     "iopub.execute_input": "2026-09-11T05:06:02.120809Z",
+     "iopub.status.busy": "2026-09-11T05:06:02.120680Z",
+     "iopub.status.idle": "2026-09-11T05:06:02.191494Z",
+     "shell.execute_reply": "2026-09-11T05:06:02.190844Z"
     },
     "papermill": {
-     "duration": 0.087176,
-     "end_time": "2026-09-11T05:01:11.094392+00:00",
+     "duration": 0.075301,
+     "end_time": "2026-09-11T05:06:02.191840+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:01:11.007216+00:00",
+     "start_time": "2026-09-11T05:06:02.116539+00:00",
      "status": "completed"
     }
    },
@@ -1069,13 +1069,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dfa82374",
+   "id": "88049cfa",
    "metadata": {
     "papermill": {
-     "duration": 0.001819,
-     "end_time": "2026-09-11T05:01:11.098639+00:00",
+     "duration": 0.001842,
+     "end_time": "2026-09-11T05:06:02.195869+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:01:11.096820+00:00",
+     "start_time": "2026-09-11T05:06:02.194027+00:00",
      "status": "completed"
     }
    },
@@ -1095,19 +1095,19 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "id": "ecff808e",
+   "id": "f1505128",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T05:01:11.103233Z",
-     "iopub.status.busy": "2026-09-11T05:01:11.103098Z",
-     "iopub.status.idle": "2026-09-11T05:01:11.106156Z",
-     "shell.execute_reply": "2026-09-11T05:01:11.105807Z"
+     "iopub.execute_input": "2026-09-11T05:06:02.201096Z",
+     "iopub.status.busy": "2026-09-11T05:06:02.200918Z",
+     "iopub.status.idle": "2026-09-11T05:06:02.205059Z",
+     "shell.execute_reply": "2026-09-11T05:06:02.204640Z"
     },
     "papermill": {
-     "duration": 0.005976,
-     "end_time": "2026-09-11T05:01:11.106433+00:00",
+     "duration": 0.007614,
+     "end_time": "2026-09-11T05:06:02.205367+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:01:11.100457+00:00",
+     "start_time": "2026-09-11T05:06:02.197753+00:00",
      "status": "completed"
     }
    },
@@ -1149,13 +1149,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8d234935",
+   "id": "dacc960d",
    "metadata": {
     "papermill": {
-     "duration": 0.002717,
-     "end_time": "2026-09-11T05:01:11.111556+00:00",
+     "duration": 0.001967,
+     "end_time": "2026-09-11T05:06:02.209432+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:01:11.108839+00:00",
+     "start_time": "2026-09-11T05:06:02.207465+00:00",
      "status": "completed"
     }
    },
@@ -1174,19 +1174,19 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "id": "6e464a98",
+   "id": "2db60ed7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T05:01:11.116653Z",
-     "iopub.status.busy": "2026-09-11T05:01:11.116509Z",
-     "iopub.status.idle": "2026-09-11T05:01:11.264652Z",
-     "shell.execute_reply": "2026-09-11T05:01:11.263840Z"
+     "iopub.execute_input": "2026-09-11T05:06:02.213833Z",
+     "iopub.status.busy": "2026-09-11T05:06:02.213748Z",
+     "iopub.status.idle": "2026-09-11T05:06:02.367926Z",
+     "shell.execute_reply": "2026-09-11T05:06:02.367275Z"
     },
     "papermill": {
-     "duration": 0.15213,
-     "end_time": "2026-09-11T05:01:11.265861+00:00",
+     "duration": 0.157254,
+     "end_time": "2026-09-11T05:06:02.368606+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:01:11.113731+00:00",
+     "start_time": "2026-09-11T05:06:02.211352+00:00",
      "status": "completed"
     }
    },
@@ -1236,13 +1236,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bec998e0",
+   "id": "796e00cf",
    "metadata": {
     "papermill": {
-     "duration": 0.002221,
-     "end_time": "2026-09-11T05:01:11.273148+00:00",
+     "duration": 0.005211,
+     "end_time": "2026-09-11T05:06:02.378146+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:01:11.270927+00:00",
+     "start_time": "2026-09-11T05:06:02.372935+00:00",
      "status": "completed"
     }
    },
@@ -1263,19 +1263,19 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "id": "d9c0418f",
+   "id": "b493018b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T05:01:11.278484Z",
-     "iopub.status.busy": "2026-09-11T05:01:11.278293Z",
-     "iopub.status.idle": "2026-09-11T05:01:11.284153Z",
-     "shell.execute_reply": "2026-09-11T05:01:11.283774Z"
+     "iopub.execute_input": "2026-09-11T05:06:02.387013Z",
+     "iopub.status.busy": "2026-09-11T05:06:02.386837Z",
+     "iopub.status.idle": "2026-09-11T05:06:02.392486Z",
+     "shell.execute_reply": "2026-09-11T05:06:02.392015Z"
     },
     "papermill": {
-     "duration": 0.009462,
-     "end_time": "2026-09-11T05:01:11.284642+00:00",
+     "duration": 0.010578,
+     "end_time": "2026-09-11T05:06:02.392902+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:01:11.275180+00:00",
+     "start_time": "2026-09-11T05:06:02.382324+00:00",
      "status": "completed"
     }
    },
@@ -1284,7 +1284,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Execution plane is an offline dry run; no broker connection will be opened.\n",
+      "Execution plane is an offline dry run; no broker connection will be opened.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "Latest scheduled cross-section: 2025-12-04\n",
       "Top-5 basket:\n"
      ]
@@ -1334,19 +1340,19 @@
   {
    "cell_type": "code",
    "execution_count": 17,
-   "id": "90c91e2e",
+   "id": "0caeb254",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T05:01:11.290662Z",
-     "iopub.status.busy": "2026-09-11T05:01:11.290533Z",
-     "iopub.status.idle": "2026-09-11T05:01:11.293523Z",
-     "shell.execute_reply": "2026-09-11T05:01:11.293205Z"
+     "iopub.execute_input": "2026-09-11T05:06:02.397710Z",
+     "iopub.status.busy": "2026-09-11T05:06:02.397621Z",
+     "iopub.status.idle": "2026-09-11T05:06:02.400578Z",
+     "shell.execute_reply": "2026-09-11T05:06:02.400199Z"
     },
     "papermill": {
-     "duration": 0.006835,
-     "end_time": "2026-09-11T05:01:11.294211+00:00",
+     "duration": 0.005811,
+     "end_time": "2026-09-11T05:06:02.400860+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:01:11.287376+00:00",
+     "start_time": "2026-09-11T05:06:02.395049+00:00",
      "status": "completed"
     }
    },
@@ -1389,14 +1395,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3415ff9b",
+   "id": "711ef4d9",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.004405,
-     "end_time": "2026-09-11T05:01:11.304823+00:00",
+     "duration": 0.002524,
+     "end_time": "2026-09-11T05:06:02.406451+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:01:11.300418+00:00",
+     "start_time": "2026-09-11T05:06:02.403927+00:00",
      "status": "completed"
     }
    },
@@ -1414,19 +1420,19 @@
   {
    "cell_type": "code",
    "execution_count": 18,
-   "id": "a81a52c0",
+   "id": "d35ebad7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T05:01:11.312387Z",
-     "iopub.status.busy": "2026-09-11T05:01:11.312276Z",
-     "iopub.status.idle": "2026-09-11T05:01:11.315936Z",
-     "shell.execute_reply": "2026-09-11T05:01:11.315618Z"
+     "iopub.execute_input": "2026-09-11T05:06:02.411753Z",
+     "iopub.status.busy": "2026-09-11T05:06:02.411570Z",
+     "iopub.status.idle": "2026-09-11T05:06:02.416642Z",
+     "shell.execute_reply": "2026-09-11T05:06:02.416196Z"
     },
     "papermill": {
-     "duration": 0.00763,
-     "end_time": "2026-09-11T05:01:11.316494+00:00",
+     "duration": 0.008334,
+     "end_time": "2026-09-11T05:06:02.416932+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:01:11.308864+00:00",
+     "start_time": "2026-09-11T05:06:02.408598+00:00",
      "status": "completed"
     }
    },
@@ -1483,13 +1489,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4059fb48",
+   "id": "1d35c0e9",
    "metadata": {
     "papermill": {
-     "duration": 0.002074,
-     "end_time": "2026-09-11T05:01:11.321711+00:00",
+     "duration": 0.002076,
+     "end_time": "2026-09-11T05:06:02.421128+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:01:11.319637+00:00",
+     "start_time": "2026-09-11T05:06:02.419052+00:00",
      "status": "completed"
     }
    },
@@ -1509,19 +1515,19 @@
   {
    "cell_type": "code",
    "execution_count": 19,
-   "id": "84e88620",
+   "id": "92ce6cd0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T05:01:11.326595Z",
-     "iopub.status.busy": "2026-09-11T05:01:11.326487Z",
-     "iopub.status.idle": "2026-09-11T05:01:11.329326Z",
-     "shell.execute_reply": "2026-09-11T05:01:11.329001Z"
+     "iopub.execute_input": "2026-09-11T05:06:02.426308Z",
+     "iopub.status.busy": "2026-09-11T05:06:02.426165Z",
+     "iopub.status.idle": "2026-09-11T05:06:02.431354Z",
+     "shell.execute_reply": "2026-09-11T05:06:02.430170Z"
     },
     "papermill": {
-     "duration": 0.006098,
-     "end_time": "2026-09-11T05:01:11.329885+00:00",
+     "duration": 0.009007,
+     "end_time": "2026-09-11T05:06:02.432297+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:01:11.323787+00:00",
+     "start_time": "2026-09-11T05:06:02.423290+00:00",
      "status": "completed"
     }
    },
@@ -1557,19 +1563,19 @@
   {
    "cell_type": "code",
    "execution_count": 20,
-   "id": "bdbc6311",
+   "id": "06b66f26",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T05:01:11.335921Z",
-     "iopub.status.busy": "2026-09-11T05:01:11.335747Z",
-     "iopub.status.idle": "2026-09-11T05:01:11.339468Z",
-     "shell.execute_reply": "2026-09-11T05:01:11.339082Z"
+     "iopub.execute_input": "2026-09-11T05:06:02.437658Z",
+     "iopub.status.busy": "2026-09-11T05:06:02.437543Z",
+     "iopub.status.idle": "2026-09-11T05:06:02.441039Z",
+     "shell.execute_reply": "2026-09-11T05:06:02.440748Z"
     },
     "papermill": {
-     "duration": 0.007465,
-     "end_time": "2026-09-11T05:01:11.339730+00:00",
+     "duration": 0.006871,
+     "end_time": "2026-09-11T05:06:02.441658+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:01:11.332265+00:00",
+     "start_time": "2026-09-11T05:06:02.434787+00:00",
      "status": "completed"
     }
    },
@@ -1625,13 +1631,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e1c45387",
+   "id": "f9cc95ae",
    "metadata": {
     "papermill": {
-     "duration": 0.002641,
-     "end_time": "2026-09-11T05:01:11.346053+00:00",
+     "duration": 0.002139,
+     "end_time": "2026-09-11T05:06:02.446307+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:01:11.343412+00:00",
+     "start_time": "2026-09-11T05:06:02.444168+00:00",
      "status": "completed"
     }
    },
@@ -1653,14 +1659,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "377be698",
+   "id": "6a269f44",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.002114,
-     "end_time": "2026-09-11T05:01:11.350424+00:00",
+     "duration": 0.001996,
+     "end_time": "2026-09-11T05:06:02.450350+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:01:11.348310+00:00",
+     "start_time": "2026-09-11T05:06:02.448354+00:00",
      "status": "completed"
     }
    },
@@ -1676,19 +1682,19 @@
   {
    "cell_type": "code",
    "execution_count": 21,
-   "id": "9ef32023",
+   "id": "d1f87cc8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T05:01:11.355714Z",
-     "iopub.status.busy": "2026-09-11T05:01:11.355534Z",
-     "iopub.status.idle": "2026-09-11T05:01:11.358295Z",
-     "shell.execute_reply": "2026-09-11T05:01:11.357835Z"
+     "iopub.execute_input": "2026-09-11T05:06:02.455022Z",
+     "iopub.status.busy": "2026-09-11T05:06:02.454937Z",
+     "iopub.status.idle": "2026-09-11T05:06:02.460512Z",
+     "shell.execute_reply": "2026-09-11T05:06:02.460167Z"
     },
     "papermill": {
-     "duration": 0.006107,
-     "end_time": "2026-09-11T05:01:11.358653+00:00",
+     "duration": 0.008473,
+     "end_time": "2026-09-11T05:06:02.460909+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:01:11.352546+00:00",
+     "start_time": "2026-09-11T05:06:02.452436+00:00",
      "status": "completed"
     }
    },
@@ -1706,19 +1712,19 @@
   {
    "cell_type": "code",
    "execution_count": 22,
-   "id": "e25bdffd",
+   "id": "88168acf",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T05:01:11.363620Z",
-     "iopub.status.busy": "2026-09-11T05:01:11.363548Z",
-     "iopub.status.idle": "2026-09-11T05:01:11.366314Z",
-     "shell.execute_reply": "2026-09-11T05:01:11.366025Z"
+     "iopub.execute_input": "2026-09-11T05:06:02.470071Z",
+     "iopub.status.busy": "2026-09-11T05:06:02.469981Z",
+     "iopub.status.idle": "2026-09-11T05:06:02.472851Z",
+     "shell.execute_reply": "2026-09-11T05:06:02.472554Z"
     },
     "papermill": {
-     "duration": 0.005546,
-     "end_time": "2026-09-11T05:01:11.366540+00:00",
+     "duration": 0.007716,
+     "end_time": "2026-09-11T05:06:02.473176+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:01:11.360994+00:00",
+     "start_time": "2026-09-11T05:06:02.465460+00:00",
      "status": "completed"
     }
    },
@@ -1762,13 +1768,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "680f7a0d",
+   "id": "ee129d9d",
    "metadata": {
     "papermill": {
-     "duration": 0.002033,
-     "end_time": "2026-09-11T05:01:11.370713+00:00",
+     "duration": 0.002294,
+     "end_time": "2026-09-11T05:06:02.477696+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:01:11.368680+00:00",
+     "start_time": "2026-09-11T05:06:02.475402+00:00",
      "status": "completed"
     }
    },
@@ -1785,19 +1791,19 @@
   {
    "cell_type": "code",
    "execution_count": 23,
-   "id": "e3e6d174",
+   "id": "dbfc6a7b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T05:01:11.375721Z",
-     "iopub.status.busy": "2026-09-11T05:01:11.375615Z",
-     "iopub.status.idle": "2026-09-11T05:01:11.379345Z",
-     "shell.execute_reply": "2026-09-11T05:01:11.379009Z"
+     "iopub.execute_input": "2026-09-11T05:06:02.483305Z",
+     "iopub.status.busy": "2026-09-11T05:06:02.483201Z",
+     "iopub.status.idle": "2026-09-11T05:06:02.490218Z",
+     "shell.execute_reply": "2026-09-11T05:06:02.489879Z"
     },
     "papermill": {
-     "duration": 0.006824,
-     "end_time": "2026-09-11T05:01:11.379615+00:00",
+     "duration": 0.010313,
+     "end_time": "2026-09-11T05:06:02.490597+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:01:11.372791+00:00",
+     "start_time": "2026-09-11T05:06:02.480284+00:00",
      "status": "completed"
     }
    },
@@ -1806,7 +1812,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Run metadata: 25_live_trading/output/etfs_deployment/runs/run_20260911T050111Z.json\n"
+      "Run metadata: 25_live_trading/output/etfs_deployment/runs/run_20260911T050602Z.json\n"
      ]
     }
    ],
@@ -1854,13 +1860,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "54679064",
+   "id": "46e334ce",
    "metadata": {
     "papermill": {
-     "duration": 0.003246,
-     "end_time": "2026-09-11T05:01:11.385094+00:00",
+     "duration": 0.002359,
+     "end_time": "2026-09-11T05:06:02.495697+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:01:11.381848+00:00",
+     "start_time": "2026-09-11T05:06:02.493338+00:00",
      "status": "completed"
     }
    },
@@ -1926,24 +1932,24 @@
    "version": "3.14.3"
   },
   "ml4t_provenance": {
-   "executed_at": "2026-09-11T05:01:21.971043+00:00",
+   "executed_at": "2026-09-11T05:06:14.200626+00:00",
    "executor": "local-uv",
-   "library_digest": "7a1735ed722656375de4706fc17ec2943ac1add5b7ca425c42c77812a6cfa8aa",
-   "outputs_digest": "082c86da03f6541d67f8e548daf5c0b4ff271c542c080db60dced6cc023f62d6",
+   "library_digest": "9578bd67a54c461226a1056c00cf1025d7b403d7adae488eda4c593fbee637d9",
+   "outputs_digest": "c2cd0632f37344172e67a5ec189096827fec3f819856ab3153c83404053a0a08",
    "parameters": {},
    "production": true,
    "source_py_blob": "fd7b7473602a4cbf19006ba9ce90c6fb8bfd6c2c"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 42.043202,
-   "end_time": "2026-09-11T05:01:13.507883+00:00",
+   "duration": 48.136654,
+   "end_time": "2026-09-11T05:06:04.719974+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "~/ml4t/public-teach-g/25_live_trading/.02_etfs_deployment_loop.build.2097994.ipynb",
-   "output_path": "~/ml4t/public-teach-g/25_live_trading/.02_etfs_deployment_loop.papermill.2097994.ipynb",
+   "input_path": "~/ml4t/public-teach-g/25_live_trading/.02_etfs_deployment_loop.build.2144480.ipynb",
+   "output_path": "~/ml4t/public-teach-g/25_live_trading/.02_etfs_deployment_loop.papermill.2144480.ipynb",
    "parameters": {},
-   "start_time": "2026-09-11T05:00:31.464681+00:00",
+   "start_time": "2026-09-11T05:05:16.583320+00:00",
    "version": "2.7.0"
   }
  },

--- a/25_live_trading/02_etfs_deployment_loop.ipynb
+++ b/25_live_trading/02_etfs_deployment_loop.ipynb
@@ -2,13 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "f0421a9f",
+   "id": "e81c3fdb",
    "metadata": {
     "papermill": {
-     "duration": 0.01007,
-     "end_time": "2026-09-11T00:48:19.126317+00:00",
+     "duration": 0.0021,
+     "end_time": "2026-09-11T05:00:32.133922+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:48:19.116247+00:00",
+     "start_time": "2026-09-11T05:00:32.131822+00:00",
      "status": "completed"
     }
    },
@@ -79,19 +79,19 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "ba2dd9af",
+   "id": "0f09e15e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:48:19.136812Z",
-     "iopub.status.busy": "2026-09-11T00:48:19.136667Z",
-     "iopub.status.idle": "2026-09-11T00:48:21.477275Z",
-     "shell.execute_reply": "2026-09-11T00:48:21.476864Z"
+     "iopub.execute_input": "2026-09-11T05:00:32.138230Z",
+     "iopub.status.busy": "2026-09-11T05:00:32.138045Z",
+     "iopub.status.idle": "2026-09-11T05:00:35.472447Z",
+     "shell.execute_reply": "2026-09-11T05:00:35.471677Z"
     },
     "papermill": {
-     "duration": 2.345052,
-     "end_time": "2026-09-11T00:48:21.477638+00:00",
+     "duration": 3.337797,
+     "end_time": "2026-09-11T05:00:35.473527+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:48:19.132586+00:00",
+     "start_time": "2026-09-11T05:00:32.135730+00:00",
      "status": "completed"
     }
    },
@@ -127,7 +127,7 @@
     "from sklearn.preprocessing import StandardScaler\n",
     "\n",
     "from data import load_etfs, load_macro\n",
-    "from utils.paths import display_path, get_case_study_dir, get_output_dir\n",
+    "from utils.paths import display_path, get_case_study_dir, get_output_dir, registry_readonly_uri\n",
     "from utils.style import COLORS, add_message_title, show_with_alt\n",
     "\n",
     "# basicConfig is a no-op once a handler exists, and importing the feature libraries installs one,\n",
@@ -147,19 +147,19 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "e28198ad",
+   "id": "6e0f610b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:48:21.481529Z",
-     "iopub.status.busy": "2026-09-11T00:48:21.481439Z",
-     "iopub.status.idle": "2026-09-11T00:48:21.483269Z",
-     "shell.execute_reply": "2026-09-11T00:48:21.483001Z"
+     "iopub.execute_input": "2026-09-11T05:00:35.480271Z",
+     "iopub.status.busy": "2026-09-11T05:00:35.480165Z",
+     "iopub.status.idle": "2026-09-11T05:00:35.482387Z",
+     "shell.execute_reply": "2026-09-11T05:00:35.481952Z"
     },
     "papermill": {
-     "duration": 0.004049,
-     "end_time": "2026-09-11T00:48:21.483469+00:00",
+     "duration": 0.005956,
+     "end_time": "2026-09-11T05:00:35.482792+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:48:21.479420+00:00",
+     "start_time": "2026-09-11T05:00:35.476836+00:00",
      "status": "completed"
     },
     "tags": [
@@ -184,13 +184,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "08146667",
+   "id": "9f00b105",
    "metadata": {
     "papermill": {
-     "duration": 0.001432,
-     "end_time": "2026-09-11T00:48:21.486448+00:00",
+     "duration": 0.001399,
+     "end_time": "2026-09-11T05:00:35.486087+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:48:21.485016+00:00",
+     "start_time": "2026-09-11T05:00:35.484688+00:00",
      "status": "completed"
     }
    },
@@ -212,19 +212,19 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "6b0346f3",
+   "id": "0185884e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:48:21.489881Z",
-     "iopub.status.busy": "2026-09-11T00:48:21.489806Z",
-     "iopub.status.idle": "2026-09-11T00:48:21.492138Z",
-     "shell.execute_reply": "2026-09-11T00:48:21.491895Z"
+     "iopub.execute_input": "2026-09-11T05:00:35.489988Z",
+     "iopub.status.busy": "2026-09-11T05:00:35.489822Z",
+     "iopub.status.idle": "2026-09-11T05:00:35.493182Z",
+     "shell.execute_reply": "2026-09-11T05:00:35.492804Z"
     },
     "papermill": {
-     "duration": 0.004508,
-     "end_time": "2026-09-11T00:48:21.492461+00:00",
+     "duration": 0.00599,
+     "end_time": "2026-09-11T05:00:35.493548+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:48:21.487953+00:00",
+     "start_time": "2026-09-11T05:00:35.487558+00:00",
      "status": "completed"
     }
    },
@@ -259,13 +259,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "41d4584d",
+   "id": "b8dfcdad",
    "metadata": {
     "papermill": {
-     "duration": 0.001508,
-     "end_time": "2026-09-11T00:48:21.495584+00:00",
+     "duration": 0.002092,
+     "end_time": "2026-09-11T05:00:35.497455+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:48:21.494076+00:00",
+     "start_time": "2026-09-11T05:00:35.495363+00:00",
      "status": "completed"
     }
    },
@@ -285,19 +285,19 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "b128b063",
+   "id": "29c69fa6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:48:21.499293Z",
-     "iopub.status.busy": "2026-09-11T00:48:21.499210Z",
-     "iopub.status.idle": "2026-09-11T00:48:21.560793Z",
-     "shell.execute_reply": "2026-09-11T00:48:21.560442Z"
+     "iopub.execute_input": "2026-09-11T05:00:35.502001Z",
+     "iopub.status.busy": "2026-09-11T05:00:35.501792Z",
+     "iopub.status.idle": "2026-09-11T05:00:35.584167Z",
+     "shell.execute_reply": "2026-09-11T05:00:35.583786Z"
     },
     "papermill": {
-     "duration": 0.064263,
-     "end_time": "2026-09-11T00:48:21.561413+00:00",
+     "duration": 0.085064,
+     "end_time": "2026-09-11T05:00:35.584458+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:48:21.497150+00:00",
+     "start_time": "2026-09-11T05:00:35.499394+00:00",
      "status": "completed"
     }
    },
@@ -329,19 +329,19 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "10cf02c4",
+   "id": "6f771536",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:48:21.565440Z",
-     "iopub.status.busy": "2026-09-11T00:48:21.565349Z",
-     "iopub.status.idle": "2026-09-11T00:48:48.448639Z",
-     "shell.execute_reply": "2026-09-11T00:48:48.448219Z"
+     "iopub.execute_input": "2026-09-11T05:00:35.588805Z",
+     "iopub.status.busy": "2026-09-11T05:00:35.588686Z",
+     "iopub.status.idle": "2026-09-11T05:01:07.047540Z",
+     "shell.execute_reply": "2026-09-11T05:01:07.047202Z"
     },
     "papermill": {
-     "duration": 26.88581,
-     "end_time": "2026-09-11T00:48:48.449086+00:00",
+     "duration": 31.463154,
+     "end_time": "2026-09-11T05:01:07.049494+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:48:21.563276+00:00",
+     "start_time": "2026-09-11T05:00:35.586340+00:00",
      "status": "completed"
     }
    },
@@ -350,14 +350,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2026-09-10 20:48:21 | mlquant.features.adx | INFO | [ADX] Starting calculation with parameters: period=14 (shape: (4,))\n"
+      "2026-09-11 01:00:35 | mlquant.features.adx | INFO | [ADX] Starting calculation with parameters: period=14 (shape: (4,))\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2026-09-10 20:48:21 | mlquant.features.adx | INFO | [ADX] Completed calculation (shape: (4,)) (0.05ms)\n"
+      "2026-09-11 01:00:35 | mlquant.features.adx | INFO | [ADX] Completed calculation (shape: (4,)) (0.08ms)\n"
      ]
     },
     {
@@ -376,13 +376,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "469fb649",
+   "id": "9d883b07",
    "metadata": {
     "papermill": {
-     "duration": 0.00302,
-     "end_time": "2026-09-11T00:48:48.455581+00:00",
+     "duration": 0.001699,
+     "end_time": "2026-09-11T05:01:07.053208+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:48:48.452561+00:00",
+     "start_time": "2026-09-11T05:01:07.051509+00:00",
      "status": "completed"
     }
    },
@@ -412,25 +412,32 @@
     "asserting it, which is what to do when the case study is deliberately re-swept.\n",
     "\n",
     "The pin names a **configuration**, not a training hash. A refit re-keys the hash while selecting\n",
-    "the same configuration, so a hash pin would fire on runs where nothing had changed."
+    "the same configuration, so a hash pin would fire on runs where nothing had changed.\n",
+    "\n",
+    "`registry_readonly_uri` opens the registry with `mode=ro` and adds `immutable=1` only where it\n",
+    "is true. A live registry is a WAL database that sweeps write to concurrently, and an immutable\n",
+    "connection ignores the -wal file and reads the pre-WAL main file, which would show up here as\n",
+    "a stale leader or as a table that appears not to exist. A downloaded artifact bundle is the\n",
+    "other case: its tree is left unwritable, and there the flag is what lets a WAL reader open the\n",
+    "file at all."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "584f91d4",
+   "id": "4ae09887",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:48:48.461466Z",
-     "iopub.status.busy": "2026-09-11T00:48:48.461360Z",
-     "iopub.status.idle": "2026-09-11T00:48:48.466007Z",
-     "shell.execute_reply": "2026-09-11T00:48:48.465712Z"
+     "iopub.execute_input": "2026-09-11T05:01:07.057364Z",
+     "iopub.status.busy": "2026-09-11T05:01:07.057264Z",
+     "iopub.status.idle": "2026-09-11T05:01:07.073208Z",
+     "shell.execute_reply": "2026-09-11T05:01:07.072834Z"
     },
     "papermill": {
-     "duration": 0.007714,
-     "end_time": "2026-09-11T00:48:48.466488+00:00",
+     "duration": 0.018892,
+     "end_time": "2026-09-11T05:01:07.073792+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:48:48.458774+00:00",
+     "start_time": "2026-09-11T05:01:07.054900+00:00",
      "status": "completed"
     }
    },
@@ -451,10 +458,7 @@
     "etfs_dir = get_case_study_dir(\"etfs\")\n",
     "labels_path = etfs_dir / \"labels\" / f\"{PRIMARY_LABEL}.parquet\"\n",
     "registry_path = etfs_dir / \"run_log\" / \"registry.db\"\n",
-    "# Read-only, but not `immutable=1`: the registry is a WAL database that sweeps write to\n",
-    "# concurrently, and an immutable connection ignores the -wal file and reads the pre-WAL main\n",
-    "# file, which shows up here as a stale leader or as a table that appears not to exist.\n",
-    "registry_uri = f\"{registry_path.resolve().as_uri()}?mode=ro\"\n",
+    "registry_uri = registry_readonly_uri(registry_path)\n",
     "with sqlite3.connect(registry_uri, uri=True) as conn:\n",
     "    winner = conn.execute(\n",
     "        \"\"\"SELECT tr.config_name, tr.spec_json, pm.ic_mean\n",
@@ -509,13 +513,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2c56688b",
+   "id": "27114be1",
    "metadata": {
     "papermill": {
-     "duration": 0.003002,
-     "end_time": "2026-09-11T00:48:48.473120+00:00",
+     "duration": 0.001844,
+     "end_time": "2026-09-11T05:01:07.079018+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:48:48.470118+00:00",
+     "start_time": "2026-09-11T05:01:07.077174+00:00",
      "status": "completed"
     }
    },
@@ -533,19 +537,19 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "c539d568",
+   "id": "1c2e1177",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:48:48.479905Z",
-     "iopub.status.busy": "2026-09-11T00:48:48.479815Z",
-     "iopub.status.idle": "2026-09-11T00:48:48.544760Z",
-     "shell.execute_reply": "2026-09-11T00:48:48.544195Z"
+     "iopub.execute_input": "2026-09-11T05:01:07.082899Z",
+     "iopub.status.busy": "2026-09-11T05:01:07.082808Z",
+     "iopub.status.idle": "2026-09-11T05:01:07.194922Z",
+     "shell.execute_reply": "2026-09-11T05:01:07.194560Z"
     },
     "papermill": {
-     "duration": 0.069095,
-     "end_time": "2026-09-11T00:48:48.545277+00:00",
+     "duration": 0.114735,
+     "end_time": "2026-09-11T05:01:07.195367+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:48:48.476182+00:00",
+     "start_time": "2026-09-11T05:01:07.080632+00:00",
      "status": "completed"
     }
    },
@@ -566,13 +570,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2fc6f1cf",
+   "id": "dff9636c",
    "metadata": {
     "papermill": {
-     "duration": 0.001767,
-     "end_time": "2026-09-11T00:48:48.548998+00:00",
+     "duration": 0.001653,
+     "end_time": "2026-09-11T05:01:07.199119+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:48:48.547231+00:00",
+     "start_time": "2026-09-11T05:01:07.197466+00:00",
      "status": "completed"
     }
    },
@@ -589,19 +593,19 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "fb37e0b1",
+   "id": "8e3fd3f2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:48:48.553497Z",
-     "iopub.status.busy": "2026-09-11T00:48:48.553391Z",
-     "iopub.status.idle": "2026-09-11T00:48:48.560443Z",
-     "shell.execute_reply": "2026-09-11T00:48:48.560040Z"
+     "iopub.execute_input": "2026-09-11T05:01:07.203206Z",
+     "iopub.status.busy": "2026-09-11T05:01:07.203093Z",
+     "iopub.status.idle": "2026-09-11T05:01:07.212642Z",
+     "shell.execute_reply": "2026-09-11T05:01:07.211977Z"
     },
     "papermill": {
-     "duration": 0.00997,
-     "end_time": "2026-09-11T00:48:48.560734+00:00",
+     "duration": 0.012157,
+     "end_time": "2026-09-11T05:01:07.212974+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:48:48.550764+00:00",
+     "start_time": "2026-09-11T05:01:07.200817+00:00",
      "status": "completed"
     }
    },
@@ -636,19 +640,19 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "ec33cddc",
+   "id": "9599be8e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:48:48.565581Z",
-     "iopub.status.busy": "2026-09-11T00:48:48.565497Z",
-     "iopub.status.idle": "2026-09-11T00:48:51.410975Z",
-     "shell.execute_reply": "2026-09-11T00:48:51.410587Z"
+     "iopub.execute_input": "2026-09-11T05:01:07.218048Z",
+     "iopub.status.busy": "2026-09-11T05:01:07.217845Z",
+     "iopub.status.idle": "2026-09-11T05:01:10.914894Z",
+     "shell.execute_reply": "2026-09-11T05:01:10.914344Z"
     },
     "papermill": {
-     "duration": 2.848757,
-     "end_time": "2026-09-11T00:48:51.411694+00:00",
+     "duration": 3.700275,
+     "end_time": "2026-09-11T05:01:10.915382+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:48:48.562937+00:00",
+     "start_time": "2026-09-11T05:01:07.215107+00:00",
      "status": "completed"
     }
    },
@@ -679,13 +683,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "be5b6e6d",
+   "id": "1481be1e",
    "metadata": {
     "papermill": {
-     "duration": 0.003282,
-     "end_time": "2026-09-11T00:48:51.418777+00:00",
+     "duration": 0.003762,
+     "end_time": "2026-09-11T05:01:10.924323+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:48:51.415495+00:00",
+     "start_time": "2026-09-11T05:01:10.920561+00:00",
      "status": "completed"
     }
    },
@@ -702,19 +706,19 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "a2fb6d20",
+   "id": "b972cf4e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:48:51.426611Z",
-     "iopub.status.busy": "2026-09-11T00:48:51.426385Z",
-     "iopub.status.idle": "2026-09-11T00:48:51.431492Z",
-     "shell.execute_reply": "2026-09-11T00:48:51.431203Z"
+     "iopub.execute_input": "2026-09-11T05:01:10.931940Z",
+     "iopub.status.busy": "2026-09-11T05:01:10.931769Z",
+     "iopub.status.idle": "2026-09-11T05:01:10.938400Z",
+     "shell.execute_reply": "2026-09-11T05:01:10.937855Z"
     },
     "papermill": {
-     "duration": 0.009705,
-     "end_time": "2026-09-11T00:48:51.431907+00:00",
+     "duration": 0.011044,
+     "end_time": "2026-09-11T05:01:10.938829+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:48:51.422202+00:00",
+     "start_time": "2026-09-11T05:01:10.927785+00:00",
      "status": "completed"
     }
    },
@@ -772,13 +776,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d14a60f1",
+   "id": "def8b2fb",
    "metadata": {
     "papermill": {
-     "duration": 0.001908,
-     "end_time": "2026-09-11T00:48:51.435922+00:00",
+     "duration": 0.001993,
+     "end_time": "2026-09-11T05:01:10.944458+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:48:51.434014+00:00",
+     "start_time": "2026-09-11T05:01:10.942465+00:00",
      "status": "completed"
     }
    },
@@ -796,19 +800,19 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "49fb8286",
+   "id": "c11d4fe1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:48:51.440128Z",
-     "iopub.status.busy": "2026-09-11T00:48:51.440035Z",
-     "iopub.status.idle": "2026-09-11T00:48:51.469341Z",
-     "shell.execute_reply": "2026-09-11T00:48:51.468799Z"
+     "iopub.execute_input": "2026-09-11T05:01:10.948766Z",
+     "iopub.status.busy": "2026-09-11T05:01:10.948606Z",
+     "iopub.status.idle": "2026-09-11T05:01:10.981643Z",
+     "shell.execute_reply": "2026-09-11T05:01:10.981025Z"
     },
     "papermill": {
-     "duration": 0.031975,
-     "end_time": "2026-09-11T00:48:51.469645+00:00",
+     "duration": 0.035829,
+     "end_time": "2026-09-11T05:01:10.982022+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:48:51.437670+00:00",
+     "start_time": "2026-09-11T05:01:10.946193+00:00",
      "status": "completed"
     }
    },
@@ -845,14 +849,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a4715d58",
+   "id": "0847aa02",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.001737,
-     "end_time": "2026-09-11T00:48:51.473446+00:00",
+     "duration": 0.001772,
+     "end_time": "2026-09-11T05:01:10.987294+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:48:51.471709+00:00",
+     "start_time": "2026-09-11T05:01:10.985522+00:00",
      "status": "completed"
     }
    },
@@ -878,19 +882,19 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "04e7a997",
+   "id": "53c0e202",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:48:51.477824Z",
-     "iopub.status.busy": "2026-09-11T00:48:51.477679Z",
-     "iopub.status.idle": "2026-09-11T00:48:51.483527Z",
-     "shell.execute_reply": "2026-09-11T00:48:51.483056Z"
+     "iopub.execute_input": "2026-09-11T05:01:10.991707Z",
+     "iopub.status.busy": "2026-09-11T05:01:10.991615Z",
+     "iopub.status.idle": "2026-09-11T05:01:10.995988Z",
+     "shell.execute_reply": "2026-09-11T05:01:10.995594Z"
     },
     "papermill": {
-     "duration": 0.008606,
-     "end_time": "2026-09-11T00:48:51.483842+00:00",
+     "duration": 0.007429,
+     "end_time": "2026-09-11T05:01:10.996686+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:48:51.475236+00:00",
+     "start_time": "2026-09-11T05:01:10.989257+00:00",
      "status": "completed"
     }
    },
@@ -980,13 +984,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b6866914",
+   "id": "bf7f0ed2",
    "metadata": {
     "papermill": {
-     "duration": 0.001779,
-     "end_time": "2026-09-11T00:48:51.487614+00:00",
+     "duration": 0.00341,
+     "end_time": "2026-09-11T05:01:11.003816+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:48:51.485835+00:00",
+     "start_time": "2026-09-11T05:01:11.000406+00:00",
      "status": "completed"
     }
    },
@@ -1007,19 +1011,19 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "ae2bcefa",
+   "id": "5860684a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:48:51.492131Z",
-     "iopub.status.busy": "2026-09-11T00:48:51.491977Z",
-     "iopub.status.idle": "2026-09-11T00:48:51.561818Z",
-     "shell.execute_reply": "2026-09-11T00:48:51.561349Z"
+     "iopub.execute_input": "2026-09-11T05:01:11.012981Z",
+     "iopub.status.busy": "2026-09-11T05:01:11.012837Z",
+     "iopub.status.idle": "2026-09-11T05:01:11.093896Z",
+     "shell.execute_reply": "2026-09-11T05:01:11.093479Z"
     },
     "papermill": {
-     "duration": 0.072704,
-     "end_time": "2026-09-11T00:48:51.562118+00:00",
+     "duration": 0.087176,
+     "end_time": "2026-09-11T05:01:11.094392+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:48:51.489414+00:00",
+     "start_time": "2026-09-11T05:01:11.007216+00:00",
      "status": "completed"
     }
    },
@@ -1065,13 +1069,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1ef74013",
+   "id": "dfa82374",
    "metadata": {
     "papermill": {
-     "duration": 0.001926,
-     "end_time": "2026-09-11T00:48:51.566327+00:00",
+     "duration": 0.001819,
+     "end_time": "2026-09-11T05:01:11.098639+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:48:51.564401+00:00",
+     "start_time": "2026-09-11T05:01:11.096820+00:00",
      "status": "completed"
     }
    },
@@ -1091,19 +1095,19 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "id": "84cb0b5e",
+   "id": "ecff808e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:48:51.571001Z",
-     "iopub.status.busy": "2026-09-11T00:48:51.570894Z",
-     "iopub.status.idle": "2026-09-11T00:48:51.574324Z",
-     "shell.execute_reply": "2026-09-11T00:48:51.573717Z"
+     "iopub.execute_input": "2026-09-11T05:01:11.103233Z",
+     "iopub.status.busy": "2026-09-11T05:01:11.103098Z",
+     "iopub.status.idle": "2026-09-11T05:01:11.106156Z",
+     "shell.execute_reply": "2026-09-11T05:01:11.105807Z"
     },
     "papermill": {
-     "duration": 0.00642,
-     "end_time": "2026-09-11T00:48:51.574637+00:00",
+     "duration": 0.005976,
+     "end_time": "2026-09-11T05:01:11.106433+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:48:51.568217+00:00",
+     "start_time": "2026-09-11T05:01:11.100457+00:00",
      "status": "completed"
     }
    },
@@ -1145,13 +1149,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b3139a57",
+   "id": "8d234935",
    "metadata": {
     "papermill": {
-     "duration": 0.001998,
-     "end_time": "2026-09-11T00:48:51.578666+00:00",
+     "duration": 0.002717,
+     "end_time": "2026-09-11T05:01:11.111556+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:48:51.576668+00:00",
+     "start_time": "2026-09-11T05:01:11.108839+00:00",
      "status": "completed"
     }
    },
@@ -1170,19 +1174,19 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "id": "4e2b6ab5",
+   "id": "6e464a98",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:48:51.583199Z",
-     "iopub.status.busy": "2026-09-11T00:48:51.583080Z",
-     "iopub.status.idle": "2026-09-11T00:48:51.708162Z",
-     "shell.execute_reply": "2026-09-11T00:48:51.707607Z"
+     "iopub.execute_input": "2026-09-11T05:01:11.116653Z",
+     "iopub.status.busy": "2026-09-11T05:01:11.116509Z",
+     "iopub.status.idle": "2026-09-11T05:01:11.264652Z",
+     "shell.execute_reply": "2026-09-11T05:01:11.263840Z"
     },
     "papermill": {
-     "duration": 0.127846,
-     "end_time": "2026-09-11T00:48:51.708430+00:00",
+     "duration": 0.15213,
+     "end_time": "2026-09-11T05:01:11.265861+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:48:51.580584+00:00",
+     "start_time": "2026-09-11T05:01:11.113731+00:00",
      "status": "completed"
     }
    },
@@ -1232,13 +1236,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1e6a56a2",
+   "id": "bec998e0",
    "metadata": {
     "papermill": {
-     "duration": 0.001992,
-     "end_time": "2026-09-11T00:48:51.712667+00:00",
+     "duration": 0.002221,
+     "end_time": "2026-09-11T05:01:11.273148+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:48:51.710675+00:00",
+     "start_time": "2026-09-11T05:01:11.270927+00:00",
      "status": "completed"
     }
    },
@@ -1259,19 +1263,19 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "id": "7659a182",
+   "id": "d9c0418f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:48:51.717339Z",
-     "iopub.status.busy": "2026-09-11T00:48:51.717255Z",
-     "iopub.status.idle": "2026-09-11T00:48:51.721444Z",
-     "shell.execute_reply": "2026-09-11T00:48:51.721184Z"
+     "iopub.execute_input": "2026-09-11T05:01:11.278484Z",
+     "iopub.status.busy": "2026-09-11T05:01:11.278293Z",
+     "iopub.status.idle": "2026-09-11T05:01:11.284153Z",
+     "shell.execute_reply": "2026-09-11T05:01:11.283774Z"
     },
     "papermill": {
-     "duration": 0.00719,
-     "end_time": "2026-09-11T00:48:51.721887+00:00",
+     "duration": 0.009462,
+     "end_time": "2026-09-11T05:01:11.284642+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:48:51.714697+00:00",
+     "start_time": "2026-09-11T05:01:11.275180+00:00",
      "status": "completed"
     }
    },
@@ -1330,19 +1334,19 @@
   {
    "cell_type": "code",
    "execution_count": 17,
-   "id": "a6852caf",
+   "id": "90c91e2e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:48:51.726488Z",
-     "iopub.status.busy": "2026-09-11T00:48:51.726421Z",
-     "iopub.status.idle": "2026-09-11T00:48:51.728479Z",
-     "shell.execute_reply": "2026-09-11T00:48:51.728277Z"
+     "iopub.execute_input": "2026-09-11T05:01:11.290662Z",
+     "iopub.status.busy": "2026-09-11T05:01:11.290533Z",
+     "iopub.status.idle": "2026-09-11T05:01:11.293523Z",
+     "shell.execute_reply": "2026-09-11T05:01:11.293205Z"
     },
     "papermill": {
-     "duration": 0.004835,
-     "end_time": "2026-09-11T00:48:51.728870+00:00",
+     "duration": 0.006835,
+     "end_time": "2026-09-11T05:01:11.294211+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:48:51.724035+00:00",
+     "start_time": "2026-09-11T05:01:11.287376+00:00",
      "status": "completed"
     }
    },
@@ -1385,14 +1389,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9d9338fc",
+   "id": "3415ff9b",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.001958,
-     "end_time": "2026-09-11T00:48:51.732888+00:00",
+     "duration": 0.004405,
+     "end_time": "2026-09-11T05:01:11.304823+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:48:51.730930+00:00",
+     "start_time": "2026-09-11T05:01:11.300418+00:00",
      "status": "completed"
     }
    },
@@ -1410,19 +1414,19 @@
   {
    "cell_type": "code",
    "execution_count": 18,
-   "id": "a24bc746",
+   "id": "a81a52c0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:48:51.737550Z",
-     "iopub.status.busy": "2026-09-11T00:48:51.737484Z",
-     "iopub.status.idle": "2026-09-11T00:48:51.740822Z",
-     "shell.execute_reply": "2026-09-11T00:48:51.740533Z"
+     "iopub.execute_input": "2026-09-11T05:01:11.312387Z",
+     "iopub.status.busy": "2026-09-11T05:01:11.312276Z",
+     "iopub.status.idle": "2026-09-11T05:01:11.315936Z",
+     "shell.execute_reply": "2026-09-11T05:01:11.315618Z"
     },
     "papermill": {
-     "duration": 0.006159,
-     "end_time": "2026-09-11T00:48:51.741083+00:00",
+     "duration": 0.00763,
+     "end_time": "2026-09-11T05:01:11.316494+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:48:51.734924+00:00",
+     "start_time": "2026-09-11T05:01:11.308864+00:00",
      "status": "completed"
     }
    },
@@ -1479,13 +1483,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a3136b28",
+   "id": "4059fb48",
    "metadata": {
     "papermill": {
-     "duration": 0.002138,
-     "end_time": "2026-09-11T00:48:51.745342+00:00",
+     "duration": 0.002074,
+     "end_time": "2026-09-11T05:01:11.321711+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:48:51.743204+00:00",
+     "start_time": "2026-09-11T05:01:11.319637+00:00",
      "status": "completed"
     }
    },
@@ -1505,19 +1509,19 @@
   {
    "cell_type": "code",
    "execution_count": 19,
-   "id": "3375e062",
+   "id": "84e88620",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:48:51.750316Z",
-     "iopub.status.busy": "2026-09-11T00:48:51.750228Z",
-     "iopub.status.idle": "2026-09-11T00:48:51.753241Z",
-     "shell.execute_reply": "2026-09-11T00:48:51.752758Z"
+     "iopub.execute_input": "2026-09-11T05:01:11.326595Z",
+     "iopub.status.busy": "2026-09-11T05:01:11.326487Z",
+     "iopub.status.idle": "2026-09-11T05:01:11.329326Z",
+     "shell.execute_reply": "2026-09-11T05:01:11.329001Z"
     },
     "papermill": {
-     "duration": 0.006218,
-     "end_time": "2026-09-11T00:48:51.753634+00:00",
+     "duration": 0.006098,
+     "end_time": "2026-09-11T05:01:11.329885+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:48:51.747416+00:00",
+     "start_time": "2026-09-11T05:01:11.323787+00:00",
      "status": "completed"
     }
    },
@@ -1553,19 +1557,19 @@
   {
    "cell_type": "code",
    "execution_count": 20,
-   "id": "d389d0ec",
+   "id": "bdbc6311",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:48:51.758523Z",
-     "iopub.status.busy": "2026-09-11T00:48:51.758453Z",
-     "iopub.status.idle": "2026-09-11T00:48:51.761119Z",
-     "shell.execute_reply": "2026-09-11T00:48:51.760785Z"
+     "iopub.execute_input": "2026-09-11T05:01:11.335921Z",
+     "iopub.status.busy": "2026-09-11T05:01:11.335747Z",
+     "iopub.status.idle": "2026-09-11T05:01:11.339468Z",
+     "shell.execute_reply": "2026-09-11T05:01:11.339082Z"
     },
     "papermill": {
-     "duration": 0.005535,
-     "end_time": "2026-09-11T00:48:51.761406+00:00",
+     "duration": 0.007465,
+     "end_time": "2026-09-11T05:01:11.339730+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:48:51.755871+00:00",
+     "start_time": "2026-09-11T05:01:11.332265+00:00",
      "status": "completed"
     }
    },
@@ -1621,13 +1625,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d62d4aed",
+   "id": "e1c45387",
    "metadata": {
     "papermill": {
-     "duration": 0.00211,
-     "end_time": "2026-09-11T00:48:51.765675+00:00",
+     "duration": 0.002641,
+     "end_time": "2026-09-11T05:01:11.346053+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:48:51.763565+00:00",
+     "start_time": "2026-09-11T05:01:11.343412+00:00",
      "status": "completed"
     }
    },
@@ -1649,14 +1653,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "46155789",
+   "id": "377be698",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.002111,
-     "end_time": "2026-09-11T00:48:51.769927+00:00",
+     "duration": 0.002114,
+     "end_time": "2026-09-11T05:01:11.350424+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:48:51.767816+00:00",
+     "start_time": "2026-09-11T05:01:11.348310+00:00",
      "status": "completed"
     }
    },
@@ -1672,19 +1676,19 @@
   {
    "cell_type": "code",
    "execution_count": 21,
-   "id": "9d6d3795",
+   "id": "9ef32023",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:48:51.775010Z",
-     "iopub.status.busy": "2026-09-11T00:48:51.774847Z",
-     "iopub.status.idle": "2026-09-11T00:48:51.776919Z",
-     "shell.execute_reply": "2026-09-11T00:48:51.776579Z"
+     "iopub.execute_input": "2026-09-11T05:01:11.355714Z",
+     "iopub.status.busy": "2026-09-11T05:01:11.355534Z",
+     "iopub.status.idle": "2026-09-11T05:01:11.358295Z",
+     "shell.execute_reply": "2026-09-11T05:01:11.357835Z"
     },
     "papermill": {
-     "duration": 0.005121,
-     "end_time": "2026-09-11T00:48:51.777358+00:00",
+     "duration": 0.006107,
+     "end_time": "2026-09-11T05:01:11.358653+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:48:51.772237+00:00",
+     "start_time": "2026-09-11T05:01:11.352546+00:00",
      "status": "completed"
     }
    },
@@ -1702,19 +1706,19 @@
   {
    "cell_type": "code",
    "execution_count": 22,
-   "id": "f75fff4f",
+   "id": "e25bdffd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:48:51.785698Z",
-     "iopub.status.busy": "2026-09-11T00:48:51.785622Z",
-     "iopub.status.idle": "2026-09-11T00:48:51.788353Z",
-     "shell.execute_reply": "2026-09-11T00:48:51.788095Z"
+     "iopub.execute_input": "2026-09-11T05:01:11.363620Z",
+     "iopub.status.busy": "2026-09-11T05:01:11.363548Z",
+     "iopub.status.idle": "2026-09-11T05:01:11.366314Z",
+     "shell.execute_reply": "2026-09-11T05:01:11.366025Z"
     },
     "papermill": {
-     "duration": 0.007951,
-     "end_time": "2026-09-11T00:48:51.788852+00:00",
+     "duration": 0.005546,
+     "end_time": "2026-09-11T05:01:11.366540+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:48:51.780901+00:00",
+     "start_time": "2026-09-11T05:01:11.360994+00:00",
      "status": "completed"
     }
    },
@@ -1758,13 +1762,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "71090057",
+   "id": "680f7a0d",
    "metadata": {
     "papermill": {
-     "duration": 0.002736,
-     "end_time": "2026-09-11T00:48:51.794213+00:00",
+     "duration": 0.002033,
+     "end_time": "2026-09-11T05:01:11.370713+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:48:51.791477+00:00",
+     "start_time": "2026-09-11T05:01:11.368680+00:00",
      "status": "completed"
     }
    },
@@ -1781,19 +1785,19 @@
   {
    "cell_type": "code",
    "execution_count": 23,
-   "id": "6d809547",
+   "id": "e3e6d174",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:48:51.800228Z",
-     "iopub.status.busy": "2026-09-11T00:48:51.800119Z",
-     "iopub.status.idle": "2026-09-11T00:48:51.803302Z",
-     "shell.execute_reply": "2026-09-11T00:48:51.803052Z"
+     "iopub.execute_input": "2026-09-11T05:01:11.375721Z",
+     "iopub.status.busy": "2026-09-11T05:01:11.375615Z",
+     "iopub.status.idle": "2026-09-11T05:01:11.379345Z",
+     "shell.execute_reply": "2026-09-11T05:01:11.379009Z"
     },
     "papermill": {
-     "duration": 0.006632,
-     "end_time": "2026-09-11T00:48:51.803825+00:00",
+     "duration": 0.006824,
+     "end_time": "2026-09-11T05:01:11.379615+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:48:51.797193+00:00",
+     "start_time": "2026-09-11T05:01:11.372791+00:00",
      "status": "completed"
     }
    },
@@ -1802,7 +1806,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Run metadata: 25_live_trading/output/etfs_deployment/runs/run_20260911T004851Z.json\n"
+      "Run metadata: 25_live_trading/output/etfs_deployment/runs/run_20260911T050111Z.json\n"
      ]
     }
    ],
@@ -1850,13 +1854,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "750d849c",
+   "id": "54679064",
    "metadata": {
     "papermill": {
-     "duration": 0.002466,
-     "end_time": "2026-09-11T00:48:51.809313+00:00",
+     "duration": 0.003246,
+     "end_time": "2026-09-11T05:01:11.385094+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:48:51.806847+00:00",
+     "start_time": "2026-09-11T05:01:11.381848+00:00",
      "status": "completed"
     }
    },
@@ -1922,24 +1926,24 @@
    "version": "3.14.3"
   },
   "ml4t_provenance": {
-   "executed_at": "2026-09-11T00:49:00.521796+00:00",
+   "executed_at": "2026-09-11T05:01:21.971043+00:00",
    "executor": "local-uv",
-   "library_digest": "0af5dc39c6c29f1e215740139cdb8886b6f5894060fe3cbd08b809a63ae853aa",
-   "outputs_digest": "4307a73ca3a0b44ced42cefe07ddbfc70be330784a50691dd356a02dc943de6f",
+   "library_digest": "7a1735ed722656375de4706fc17ec2943ac1add5b7ca425c42c77812a6cfa8aa",
+   "outputs_digest": "082c86da03f6541d67f8e548daf5c0b4ff271c542c080db60dced6cc023f62d6",
    "parameters": {},
    "production": true,
-   "source_py_blob": "964a2cb79c00cb06b3bd388fefa10e7cd36e76c0"
+   "source_py_blob": "fd7b7473602a4cbf19006ba9ce90c6fb8bfd6c2c"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 34.663913,
-   "end_time": "2026-09-11T00:48:53.129578+00:00",
+   "duration": 42.043202,
+   "end_time": "2026-09-11T05:01:13.507883+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "~/ml4t/public-teach-g/25_live_trading/.02_etfs_deployment_loop.build.694628.ipynb",
-   "output_path": "~/ml4t/public-teach-g/25_live_trading/.02_etfs_deployment_loop.papermill.694628.ipynb",
+   "input_path": "~/ml4t/public-teach-g/25_live_trading/.02_etfs_deployment_loop.build.2097994.ipynb",
+   "output_path": "~/ml4t/public-teach-g/25_live_trading/.02_etfs_deployment_loop.papermill.2097994.ipynb",
    "parameters": {},
-   "start_time": "2026-09-11T00:48:18.465665+00:00",
+   "start_time": "2026-09-11T05:00:31.464681+00:00",
    "version": "2.7.0"
   }
  },

--- a/25_live_trading/02_etfs_deployment_loop.py
+++ b/25_live_trading/02_etfs_deployment_loop.py
@@ -108,7 +108,7 @@ from sklearn.linear_model import Ridge
 from sklearn.preprocessing import StandardScaler
 
 from data import load_etfs, load_macro
-from utils.paths import display_path, get_case_study_dir, get_output_dir
+from utils.paths import display_path, get_case_study_dir, get_output_dir, registry_readonly_uri
 from utils.style import COLORS, add_message_title, show_with_alt
 
 # basicConfig is a no-op once a handler exists, and importing the feature libraries installs one,
@@ -229,15 +229,19 @@ print(f"Features: {features.shape}, {len(fc)} feature columns")
 #
 # The pin names a **configuration**, not a training hash. A refit re-keys the hash while selecting
 # the same configuration, so a hash pin would fire on runs where nothing had changed.
+#
+# `registry_readonly_uri` opens the registry with `mode=ro` and adds `immutable=1` only where it
+# is true. A live registry is a WAL database that sweeps write to concurrently, and an immutable
+# connection ignores the -wal file and reads the pre-WAL main file, which would show up here as
+# a stale leader or as a table that appears not to exist. A downloaded artifact bundle is the
+# other case: its tree is left unwritable, and there the flag is what lets a WAL reader open the
+# file at all.
 
 # %%
 etfs_dir = get_case_study_dir("etfs")
 labels_path = etfs_dir / "labels" / f"{PRIMARY_LABEL}.parquet"
 registry_path = etfs_dir / "run_log" / "registry.db"
-# Read-only, but not `immutable=1`: the registry is a WAL database that sweeps write to
-# concurrently, and an immutable connection ignores the -wal file and reads the pre-WAL main
-# file, which shows up here as a stale leader or as a table that appears not to exist.
-registry_uri = f"{registry_path.resolve().as_uri()}?mode=ro"
+registry_uri = registry_readonly_uri(registry_path)
 with sqlite3.connect(registry_uri, uri=True) as conn:
     winner = conn.execute(
         """SELECT tr.config_name, tr.spec_json, pm.ic_mean

--- a/25_live_trading/06_quantconnect_case_study.ipynb
+++ b/25_live_trading/06_quantconnect_case_study.ipynb
@@ -2,13 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "976282fd",
+   "id": "51d4955c",
    "metadata": {
     "papermill": {
-     "duration": 0.004579,
-     "end_time": "2026-09-11T05:01:25.113968+00:00",
+     "duration": 0.001873,
+     "end_time": "2026-09-11T05:06:17.934330+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:01:25.109389+00:00",
+     "start_time": "2026-09-11T05:06:17.932457+00:00",
      "status": "completed"
     }
    },
@@ -47,13 +47,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "114e0e15",
+   "id": "d25245fd",
    "metadata": {
     "papermill": {
-     "duration": 0.002006,
-     "end_time": "2026-09-11T05:01:25.119132+00:00",
+     "duration": 0.001099,
+     "end_time": "2026-09-11T05:06:17.936865+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:01:25.117126+00:00",
+     "start_time": "2026-09-11T05:06:17.935766+00:00",
      "status": "completed"
     }
    },
@@ -68,19 +68,19 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "a68ce0b3",
+   "id": "ef475fdf",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T05:01:25.123823Z",
-     "iopub.status.busy": "2026-09-11T05:01:25.123616Z",
-     "iopub.status.idle": "2026-09-11T05:01:27.418654Z",
-     "shell.execute_reply": "2026-09-11T05:01:27.418156Z"
+     "iopub.execute_input": "2026-09-11T05:06:17.940469Z",
+     "iopub.status.busy": "2026-09-11T05:06:17.940271Z",
+     "iopub.status.idle": "2026-09-11T05:06:19.886642Z",
+     "shell.execute_reply": "2026-09-11T05:06:19.886026Z"
     },
     "papermill": {
-     "duration": 2.298297,
-     "end_time": "2026-09-11T05:01:27.419599+00:00",
+     "duration": 1.949715,
+     "end_time": "2026-09-11T05:06:19.887753+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:01:25.121302+00:00",
+     "start_time": "2026-09-11T05:06:17.938038+00:00",
      "status": "completed"
     }
    },
@@ -103,13 +103,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "48466954",
+   "id": "7900ff89",
    "metadata": {
     "papermill": {
-     "duration": 0.002697,
-     "end_time": "2026-09-11T05:01:27.427295+00:00",
+     "duration": 0.002057,
+     "end_time": "2026-09-11T05:06:19.892465+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:01:27.424598+00:00",
+     "start_time": "2026-09-11T05:06:19.890408+00:00",
      "status": "completed"
     }
    },
@@ -136,20 +136,20 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "d771ff88",
+   "id": "99c53d83",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T05:01:27.433855Z",
-     "iopub.status.busy": "2026-09-11T05:01:27.433568Z",
-     "iopub.status.idle": "2026-09-11T05:01:27.436876Z",
-     "shell.execute_reply": "2026-09-11T05:01:27.436394Z"
+     "iopub.execute_input": "2026-09-11T05:06:19.897648Z",
+     "iopub.status.busy": "2026-09-11T05:06:19.897487Z",
+     "iopub.status.idle": "2026-09-11T05:06:19.899960Z",
+     "shell.execute_reply": "2026-09-11T05:06:19.899549Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.007257,
-     "end_time": "2026-09-11T05:01:27.437293+00:00",
+     "duration": 0.006012,
+     "end_time": "2026-09-11T05:06:19.900565+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:01:27.430036+00:00",
+     "start_time": "2026-09-11T05:06:19.894553+00:00",
      "status": "completed"
     },
     "tags": [
@@ -166,13 +166,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d6ffebe3",
+   "id": "3d1622ae",
    "metadata": {
     "papermill": {
-     "duration": 0.001532,
-     "end_time": "2026-09-11T05:01:27.440479+00:00",
+     "duration": 0.0011,
+     "end_time": "2026-09-11T05:06:19.903840+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:01:27.438947+00:00",
+     "start_time": "2026-09-11T05:06:19.902740+00:00",
      "status": "completed"
     }
    },
@@ -188,19 +188,19 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "920537d9",
+   "id": "7681d493",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T05:01:27.445885Z",
-     "iopub.status.busy": "2026-09-11T05:01:27.445619Z",
-     "iopub.status.idle": "2026-09-11T05:01:27.590628Z",
-     "shell.execute_reply": "2026-09-11T05:01:27.589887Z"
+     "iopub.execute_input": "2026-09-11T05:06:19.907468Z",
+     "iopub.status.busy": "2026-09-11T05:06:19.907297Z",
+     "iopub.status.idle": "2026-09-11T05:06:19.996796Z",
+     "shell.execute_reply": "2026-09-11T05:06:19.996009Z"
     },
     "papermill": {
-     "duration": 0.148753,
-     "end_time": "2026-09-11T05:01:27.591421+00:00",
+     "duration": 0.092243,
+     "end_time": "2026-09-11T05:06:19.997203+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:01:27.442668+00:00",
+     "start_time": "2026-09-11T05:06:19.904960+00:00",
      "status": "completed"
     }
    },
@@ -349,13 +349,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e677a0b5",
+   "id": "700517ef",
    "metadata": {
     "papermill": {
-     "duration": 0.001455,
-     "end_time": "2026-09-11T05:01:27.594875+00:00",
+     "duration": 0.001214,
+     "end_time": "2026-09-11T05:06:19.999881+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:01:27.593420+00:00",
+     "start_time": "2026-09-11T05:06:19.998667+00:00",
      "status": "completed"
     }
    },
@@ -373,13 +373,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1e99a21a",
+   "id": "dac68198",
    "metadata": {
     "papermill": {
-     "duration": 0.003098,
-     "end_time": "2026-09-11T05:01:27.599999+00:00",
+     "duration": 0.001123,
+     "end_time": "2026-09-11T05:06:20.002178+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:01:27.596901+00:00",
+     "start_time": "2026-09-11T05:06:20.001055+00:00",
      "status": "completed"
     }
    },
@@ -396,19 +396,19 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "6b4a1aac",
+   "id": "a9a97918",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T05:01:27.609216Z",
-     "iopub.status.busy": "2026-09-11T05:01:27.608840Z",
-     "iopub.status.idle": "2026-09-11T05:01:27.628519Z",
-     "shell.execute_reply": "2026-09-11T05:01:27.627862Z"
+     "iopub.execute_input": "2026-09-11T05:06:20.005608Z",
+     "iopub.status.busy": "2026-09-11T05:06:20.005429Z",
+     "iopub.status.idle": "2026-09-11T05:06:20.017692Z",
+     "shell.execute_reply": "2026-09-11T05:06:20.017068Z"
     },
     "papermill": {
-     "duration": 0.026424,
-     "end_time": "2026-09-11T05:01:27.629116+00:00",
+     "duration": 0.015,
+     "end_time": "2026-09-11T05:06:20.018354+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:01:27.602692+00:00",
+     "start_time": "2026-09-11T05:06:20.003354+00:00",
      "status": "completed"
     }
    },
@@ -460,19 +460,19 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "5ae8a69c",
+   "id": "6edb34b4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T05:01:27.633703Z",
-     "iopub.status.busy": "2026-09-11T05:01:27.633514Z",
-     "iopub.status.idle": "2026-09-11T05:01:27.637522Z",
-     "shell.execute_reply": "2026-09-11T05:01:27.636881Z"
+     "iopub.execute_input": "2026-09-11T05:06:20.022936Z",
+     "iopub.status.busy": "2026-09-11T05:06:20.022740Z",
+     "iopub.status.idle": "2026-09-11T05:06:20.026600Z",
+     "shell.execute_reply": "2026-09-11T05:06:20.026065Z"
     },
     "papermill": {
-     "duration": 0.007183,
-     "end_time": "2026-09-11T05:01:27.638043+00:00",
+     "duration": 0.009754,
+     "end_time": "2026-09-11T05:06:20.029971+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:01:27.630860+00:00",
+     "start_time": "2026-09-11T05:06:20.020217+00:00",
      "status": "completed"
     }
    },
@@ -503,13 +503,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c84f57ba",
+   "id": "9ae35e42",
    "metadata": {
     "papermill": {
-     "duration": 0.001733,
-     "end_time": "2026-09-11T05:01:27.641564+00:00",
+     "duration": 0.002577,
+     "end_time": "2026-09-11T05:06:20.036326+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:01:27.639831+00:00",
+     "start_time": "2026-09-11T05:06:20.033749+00:00",
      "status": "completed"
     }
    },
@@ -521,19 +521,19 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "0f4931f3",
+   "id": "3a7d1502",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T05:01:27.646327Z",
-     "iopub.status.busy": "2026-09-11T05:01:27.646054Z",
-     "iopub.status.idle": "2026-09-11T05:01:27.670850Z",
-     "shell.execute_reply": "2026-09-11T05:01:27.670214Z"
+     "iopub.execute_input": "2026-09-11T05:06:20.043118Z",
+     "iopub.status.busy": "2026-09-11T05:06:20.042977Z",
+     "iopub.status.idle": "2026-09-11T05:06:20.064848Z",
+     "shell.execute_reply": "2026-09-11T05:06:20.064076Z"
     },
     "papermill": {
-     "duration": 0.028747,
-     "end_time": "2026-09-11T05:01:27.671783+00:00",
+     "duration": 0.026103,
+     "end_time": "2026-09-11T05:06:20.065245+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:01:27.643036+00:00",
+     "start_time": "2026-09-11T05:06:20.039142+00:00",
      "status": "completed"
     }
    },
@@ -561,13 +561,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "47eeef13",
+   "id": "a9f404dc",
    "metadata": {
     "papermill": {
-     "duration": 0.001486,
-     "end_time": "2026-09-11T05:01:27.676456+00:00",
+     "duration": 0.001589,
+     "end_time": "2026-09-11T05:06:20.068619+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:01:27.674970+00:00",
+     "start_time": "2026-09-11T05:06:20.067030+00:00",
      "status": "completed"
     }
    },
@@ -583,13 +583,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "18634032",
+   "id": "b44184ae",
    "metadata": {
     "papermill": {
-     "duration": 0.001307,
-     "end_time": "2026-09-11T05:01:27.679312+00:00",
+     "duration": 0.00136,
+     "end_time": "2026-09-11T05:06:20.071528+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:01:27.678005+00:00",
+     "start_time": "2026-09-11T05:06:20.070168+00:00",
      "status": "completed"
     }
    },
@@ -606,13 +606,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3e50dfb7",
+   "id": "184af16e",
    "metadata": {
     "papermill": {
-     "duration": 0.001533,
-     "end_time": "2026-09-11T05:01:27.682249+00:00",
+     "duration": 0.001458,
+     "end_time": "2026-09-11T05:06:20.074430+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:01:27.680716+00:00",
+     "start_time": "2026-09-11T05:06:20.072972+00:00",
      "status": "completed"
     }
    },
@@ -654,13 +654,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0ed3fd74",
+   "id": "b3ec637e",
    "metadata": {
     "papermill": {
-     "duration": 0.001272,
-     "end_time": "2026-09-11T05:01:27.685033+00:00",
+     "duration": 0.001271,
+     "end_time": "2026-09-11T05:06:20.077121+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:01:27.683761+00:00",
+     "start_time": "2026-09-11T05:06:20.075850+00:00",
      "status": "completed"
     }
    },
@@ -683,19 +683,19 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "a7447b7a",
+   "id": "23c7cb4d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T05:01:27.689634Z",
-     "iopub.status.busy": "2026-09-11T05:01:27.689277Z",
-     "iopub.status.idle": "2026-09-11T05:01:27.693519Z",
-     "shell.execute_reply": "2026-09-11T05:01:27.692855Z"
+     "iopub.execute_input": "2026-09-11T05:06:20.080880Z",
+     "iopub.status.busy": "2026-09-11T05:06:20.080727Z",
+     "iopub.status.idle": "2026-09-11T05:06:20.084261Z",
+     "shell.execute_reply": "2026-09-11T05:06:20.083689Z"
     },
     "papermill": {
-     "duration": 0.007533,
-     "end_time": "2026-09-11T05:01:27.694010+00:00",
+     "duration": 0.009517,
+     "end_time": "2026-09-11T05:06:20.088050+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:01:27.686477+00:00",
+     "start_time": "2026-09-11T05:06:20.078533+00:00",
      "status": "completed"
     }
    },
@@ -796,13 +796,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f62d4712",
+   "id": "4f8607f9",
    "metadata": {
     "papermill": {
-     "duration": 0.003835,
-     "end_time": "2026-09-11T05:01:27.700885+00:00",
+     "duration": 0.001788,
+     "end_time": "2026-09-11T05:06:20.092427+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:01:27.697050+00:00",
+     "start_time": "2026-09-11T05:06:20.090639+00:00",
      "status": "completed"
     }
    },
@@ -820,13 +820,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "81a4bd04",
+   "id": "68b2fb99",
    "metadata": {
     "papermill": {
-     "duration": 0.00272,
-     "end_time": "2026-09-11T05:01:27.707026+00:00",
+     "duration": 0.001622,
+     "end_time": "2026-09-11T05:06:20.095870+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:01:27.704306+00:00",
+     "start_time": "2026-09-11T05:06:20.094248+00:00",
      "status": "completed"
     }
    },
@@ -862,13 +862,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2754fe26",
+   "id": "e597c7a5",
    "metadata": {
     "papermill": {
-     "duration": 0.002802,
-     "end_time": "2026-09-11T05:01:27.712814+00:00",
+     "duration": 0.001548,
+     "end_time": "2026-09-11T05:06:20.099178+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:01:27.710012+00:00",
+     "start_time": "2026-09-11T05:06:20.097630+00:00",
      "status": "completed"
     }
    },
@@ -881,19 +881,19 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "33e69fe0",
+   "id": "a3750467",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T05:01:27.717988Z",
-     "iopub.status.busy": "2026-09-11T05:01:27.717798Z",
-     "iopub.status.idle": "2026-09-11T05:01:27.725501Z",
-     "shell.execute_reply": "2026-09-11T05:01:27.724895Z"
+     "iopub.execute_input": "2026-09-11T05:06:20.103523Z",
+     "iopub.status.busy": "2026-09-11T05:06:20.103190Z",
+     "iopub.status.idle": "2026-09-11T05:06:20.110983Z",
+     "shell.execute_reply": "2026-09-11T05:06:20.110459Z"
     },
     "papermill": {
-     "duration": 0.010801,
-     "end_time": "2026-09-11T05:01:27.726299+00:00",
+     "duration": 0.010568,
+     "end_time": "2026-09-11T05:06:20.111421+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:01:27.715498+00:00",
+     "start_time": "2026-09-11T05:06:20.100853+00:00",
      "status": "completed"
     }
    },
@@ -944,19 +944,19 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "2f9dec14",
+   "id": "51055863",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T05:01:27.731274Z",
-     "iopub.status.busy": "2026-09-11T05:01:27.731066Z",
-     "iopub.status.idle": "2026-09-11T05:01:27.885475Z",
-     "shell.execute_reply": "2026-09-11T05:01:27.885169Z"
+     "iopub.execute_input": "2026-09-11T05:06:20.115308Z",
+     "iopub.status.busy": "2026-09-11T05:06:20.115187Z",
+     "iopub.status.idle": "2026-09-11T05:06:20.231816Z",
+     "shell.execute_reply": "2026-09-11T05:06:20.231046Z"
     },
     "papermill": {
-     "duration": 0.157635,
-     "end_time": "2026-09-11T05:01:27.886029+00:00",
+     "duration": 0.1192,
+     "end_time": "2026-09-11T05:06:20.232255+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:01:27.728394+00:00",
+     "start_time": "2026-09-11T05:06:20.113055+00:00",
      "status": "completed"
     }
    },
@@ -1005,19 +1005,19 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "0b5fed01",
+   "id": "51569bf3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T05:01:27.891027Z",
-     "iopub.status.busy": "2026-09-11T05:01:27.890868Z",
-     "iopub.status.idle": "2026-09-11T05:01:27.996218Z",
-     "shell.execute_reply": "2026-09-11T05:01:27.995539Z"
+     "iopub.execute_input": "2026-09-11T05:06:20.237290Z",
+     "iopub.status.busy": "2026-09-11T05:06:20.237085Z",
+     "iopub.status.idle": "2026-09-11T05:06:20.382169Z",
+     "shell.execute_reply": "2026-09-11T05:06:20.381606Z"
     },
     "papermill": {
-     "duration": 0.108419,
-     "end_time": "2026-09-11T05:01:27.996661+00:00",
+     "duration": 0.148806,
+     "end_time": "2026-09-11T05:06:20.382988+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:01:27.888242+00:00",
+     "start_time": "2026-09-11T05:06:20.234182+00:00",
      "status": "completed"
     }
    },
@@ -1076,13 +1076,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "487f92ba",
+   "id": "52eb714e",
    "metadata": {
     "papermill": {
-     "duration": 0.001931,
-     "end_time": "2026-09-11T05:01:28.000778+00:00",
+     "duration": 0.00207,
+     "end_time": "2026-09-11T05:06:20.387517+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:01:27.998847+00:00",
+     "start_time": "2026-09-11T05:06:20.385447+00:00",
      "status": "completed"
     }
    },
@@ -1100,13 +1100,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "31b244bc",
+   "id": "78b042d3",
    "metadata": {
     "papermill": {
-     "duration": 0.001941,
-     "end_time": "2026-09-11T05:01:28.004641+00:00",
+     "duration": 0.002031,
+     "end_time": "2026-09-11T05:06:20.391739+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:01:28.002700+00:00",
+     "start_time": "2026-09-11T05:06:20.389708+00:00",
      "status": "completed"
     }
    },
@@ -1135,13 +1135,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4cee5476",
+   "id": "b360ea16",
    "metadata": {
     "papermill": {
-     "duration": 0.00381,
-     "end_time": "2026-09-11T05:01:28.012201+00:00",
+     "duration": 0.002001,
+     "end_time": "2026-09-11T05:06:20.395800+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:01:28.008391+00:00",
+     "start_time": "2026-09-11T05:06:20.393799+00:00",
      "status": "completed"
     }
    },
@@ -1178,19 +1178,19 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "9294ae06",
+   "id": "83df8a88",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T05:01:28.019890Z",
-     "iopub.status.busy": "2026-09-11T05:01:28.019626Z",
-     "iopub.status.idle": "2026-09-11T05:01:28.043838Z",
-     "shell.execute_reply": "2026-09-11T05:01:28.043155Z"
+     "iopub.execute_input": "2026-09-11T05:06:20.403399Z",
+     "iopub.status.busy": "2026-09-11T05:06:20.403256Z",
+     "iopub.status.idle": "2026-09-11T05:06:20.429104Z",
+     "shell.execute_reply": "2026-09-11T05:06:20.428175Z"
     },
     "papermill": {
-     "duration": 0.028251,
-     "end_time": "2026-09-11T05:01:28.044314+00:00",
+     "duration": 0.031994,
+     "end_time": "2026-09-11T05:06:20.430120+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:01:28.016063+00:00",
+     "start_time": "2026-09-11T05:06:20.398126+00:00",
      "status": "completed"
     }
    },
@@ -1232,9 +1232,9 @@
    "version": "3.14.3"
   },
   "ml4t_provenance": {
-   "executed_at": "2026-09-11T05:01:39.823768+00:00",
+   "executed_at": "2026-09-11T05:06:30.796635+00:00",
    "executor": "local-uv",
-   "library_digest": "c3f5f8d5e39ee4defa3e44e5e450f1852fc5f8a8c51d9c71331279afc94daba9",
+   "library_digest": "a7b7873ac8564418e291dd8fb9685a20de7f03e0719cd43bc550c6b24b5d5a22",
    "outputs_digest": "918052e0eea528e4516722f36bf742d96869cd9a47dec819120efd66e064e7ed",
    "parameters": {},
    "production": true,
@@ -1242,14 +1242,14 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 6.165599,
-   "end_time": "2026-09-11T05:01:30.495403+00:00",
+   "duration": 4.862925,
+   "end_time": "2026-09-11T05:06:22.055844+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "~/ml4t/public-teach-g/25_live_trading/.06_quantconnect_case_study.build.2106376.ipynb",
-   "output_path": "~/ml4t/public-teach-g/25_live_trading/.06_quantconnect_case_study.papermill.2106376.ipynb",
+   "input_path": "~/ml4t/public-teach-g/25_live_trading/.06_quantconnect_case_study.build.2155068.ipynb",
+   "output_path": "~/ml4t/public-teach-g/25_live_trading/.06_quantconnect_case_study.papermill.2155068.ipynb",
    "parameters": {},
-   "start_time": "2026-09-11T05:01:24.329804+00:00",
+   "start_time": "2026-09-11T05:06:17.192919+00:00",
    "version": "2.7.0"
   }
  },

--- a/25_live_trading/06_quantconnect_case_study.ipynb
+++ b/25_live_trading/06_quantconnect_case_study.ipynb
@@ -2,13 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "a3db3c3e",
+   "id": "976282fd",
    "metadata": {
     "papermill": {
-     "duration": 0.001429,
-     "end_time": "2026-09-11T00:34:25.146187+00:00",
+     "duration": 0.004579,
+     "end_time": "2026-09-11T05:01:25.113968+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:34:25.144758+00:00",
+     "start_time": "2026-09-11T05:01:25.109389+00:00",
      "status": "completed"
     }
    },
@@ -47,13 +47,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "89b2e25f",
+   "id": "114e0e15",
    "metadata": {
     "papermill": {
-     "duration": 0.000968,
-     "end_time": "2026-09-11T00:34:25.148373+00:00",
+     "duration": 0.002006,
+     "end_time": "2026-09-11T05:01:25.119132+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:34:25.147405+00:00",
+     "start_time": "2026-09-11T05:01:25.117126+00:00",
      "status": "completed"
     }
    },
@@ -68,19 +68,19 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "ec12cf28",
+   "id": "a68ce0b3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:34:25.151568Z",
-     "iopub.status.busy": "2026-09-11T00:34:25.151452Z",
-     "iopub.status.idle": "2026-09-11T00:34:26.566836Z",
-     "shell.execute_reply": "2026-09-11T00:34:26.566307Z"
+     "iopub.execute_input": "2026-09-11T05:01:25.123823Z",
+     "iopub.status.busy": "2026-09-11T05:01:25.123616Z",
+     "iopub.status.idle": "2026-09-11T05:01:27.418654Z",
+     "shell.execute_reply": "2026-09-11T05:01:27.418156Z"
     },
     "papermill": {
-     "duration": 1.41776,
-     "end_time": "2026-09-11T00:34:26.567351+00:00",
+     "duration": 2.298297,
+     "end_time": "2026-09-11T05:01:27.419599+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:34:25.149591+00:00",
+     "start_time": "2026-09-11T05:01:25.121302+00:00",
      "status": "completed"
     }
    },
@@ -97,19 +97,19 @@
     "import polars as pl\n",
     "from demo_artifacts import normalize_demo_predictions\n",
     "\n",
-    "from utils.paths import display_path, get_case_study_dir, get_output_dir\n",
+    "from utils.paths import display_path, get_case_study_dir, get_output_dir, registry_readonly_uri\n",
     "from utils.style import COLORS, FIGSIZE, add_message_title, show_with_alt"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "cfbcafbe",
+   "id": "48466954",
    "metadata": {
     "papermill": {
-     "duration": 0.0016,
-     "end_time": "2026-09-11T00:34:26.570305+00:00",
+     "duration": 0.002697,
+     "end_time": "2026-09-11T05:01:27.427295+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:34:26.568705+00:00",
+     "start_time": "2026-09-11T05:01:27.424598+00:00",
      "status": "completed"
     }
    },
@@ -136,20 +136,20 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "cab2061b",
+   "id": "d771ff88",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:34:26.573002Z",
-     "iopub.status.busy": "2026-09-11T00:34:26.572904Z",
-     "iopub.status.idle": "2026-09-11T00:34:26.574940Z",
-     "shell.execute_reply": "2026-09-11T00:34:26.574552Z"
+     "iopub.execute_input": "2026-09-11T05:01:27.433855Z",
+     "iopub.status.busy": "2026-09-11T05:01:27.433568Z",
+     "iopub.status.idle": "2026-09-11T05:01:27.436876Z",
+     "shell.execute_reply": "2026-09-11T05:01:27.436394Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.003883,
-     "end_time": "2026-09-11T00:34:26.575247+00:00",
+     "duration": 0.007257,
+     "end_time": "2026-09-11T05:01:27.437293+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:34:26.571364+00:00",
+     "start_time": "2026-09-11T05:01:27.430036+00:00",
      "status": "completed"
     },
     "tags": [
@@ -166,40 +166,41 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6367ebd4",
+   "id": "d6ffebe3",
    "metadata": {
     "papermill": {
-     "duration": 0.000957,
-     "end_time": "2026-09-11T00:34:26.577345+00:00",
+     "duration": 0.001532,
+     "end_time": "2026-09-11T05:01:27.440479+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:34:26.576388+00:00",
+     "start_time": "2026-09-11T05:01:27.438947+00:00",
      "status": "completed"
     }
    },
    "source": [
-    "The registry is opened read-only, and deliberately not with `immutable=1`. That flag promises\n",
-    "SQLite the database cannot change while it is open, which lets it skip locking and WAL recovery.\n",
-    "That holds for a released case directory and not for a live one a sweep may be writing, and an\n",
-    "immutable read of a database with an uncheckpointed write-ahead log sees the pre-WAL main file:\n",
-    "a stale configuration selected silently, or a table that appears not to exist."
+    "The registry is opened read-only by `mode=ro`. `immutable=1` is a separate promise - that the\n",
+    "database cannot change while it is open, which lets SQLite skip locking and WAL recovery - and\n",
+    "an immutable read of a database with an uncheckpointed write-ahead log sees the pre-WAL main\n",
+    "file: a stale configuration selected silently, or a table that appears not to exist. The\n",
+    "promise holds for a downloaded artifact bundle, whose tree is left unwritable, and not for a\n",
+    "live case directory a sweep may be writing. `registry_readonly_uri` decides from the directory."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "e47af1be",
+   "id": "920537d9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:34:26.579996Z",
-     "iopub.status.busy": "2026-09-11T00:34:26.579935Z",
-     "iopub.status.idle": "2026-09-11T00:34:26.651256Z",
-     "shell.execute_reply": "2026-09-11T00:34:26.650361Z"
+     "iopub.execute_input": "2026-09-11T05:01:27.445885Z",
+     "iopub.status.busy": "2026-09-11T05:01:27.445619Z",
+     "iopub.status.idle": "2026-09-11T05:01:27.590628Z",
+     "shell.execute_reply": "2026-09-11T05:01:27.589887Z"
     },
     "papermill": {
-     "duration": 0.073525,
-     "end_time": "2026-09-11T00:34:26.652004+00:00",
+     "duration": 0.148753,
+     "end_time": "2026-09-11T05:01:27.591421+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:34:26.578479+00:00",
+     "start_time": "2026-09-11T05:01:27.442668+00:00",
      "status": "completed"
     }
    },
@@ -261,7 +262,7 @@
     "registry_path = case_study_dir / \"run_log\" / \"registry.db\"\n",
     "registry_hash_before = hashlib.sha256(registry_path.read_bytes()).hexdigest()\n",
     "\n",
-    "registry_uri = f\"{registry_path.resolve().as_uri()}?mode=ro\"\n",
+    "registry_uri = registry_readonly_uri(registry_path)\n",
     "with sqlite3.connect(registry_uri, uri=True) as conn:\n",
     "    winner = conn.execute(\n",
     "        \"\"\"SELECT ps.training_hash, br.backtest_hash, br.stage, bm.sharpe\n",
@@ -348,13 +349,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e67f9b9c",
+   "id": "e677a0b5",
    "metadata": {
     "papermill": {
-     "duration": 0.00266,
-     "end_time": "2026-09-11T00:34:26.657269+00:00",
+     "duration": 0.001455,
+     "end_time": "2026-09-11T05:01:27.594875+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:34:26.654609+00:00",
+     "start_time": "2026-09-11T05:01:27.593420+00:00",
      "status": "completed"
     }
    },
@@ -372,13 +373,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "850c3f95",
+   "id": "1e99a21a",
    "metadata": {
     "papermill": {
-     "duration": 0.002843,
-     "end_time": "2026-09-11T00:34:26.663324+00:00",
+     "duration": 0.003098,
+     "end_time": "2026-09-11T05:01:27.599999+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:34:26.660481+00:00",
+     "start_time": "2026-09-11T05:01:27.596901+00:00",
      "status": "completed"
     }
    },
@@ -395,19 +396,19 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "64b44d04",
+   "id": "6b4a1aac",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:34:26.668077Z",
-     "iopub.status.busy": "2026-09-11T00:34:26.667970Z",
-     "iopub.status.idle": "2026-09-11T00:34:26.684440Z",
-     "shell.execute_reply": "2026-09-11T00:34:26.683659Z"
+     "iopub.execute_input": "2026-09-11T05:01:27.609216Z",
+     "iopub.status.busy": "2026-09-11T05:01:27.608840Z",
+     "iopub.status.idle": "2026-09-11T05:01:27.628519Z",
+     "shell.execute_reply": "2026-09-11T05:01:27.627862Z"
     },
     "papermill": {
-     "duration": 0.019948,
-     "end_time": "2026-09-11T00:34:26.685494+00:00",
+     "duration": 0.026424,
+     "end_time": "2026-09-11T05:01:27.629116+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:34:26.665546+00:00",
+     "start_time": "2026-09-11T05:01:27.602692+00:00",
      "status": "completed"
     }
    },
@@ -459,19 +460,19 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "88ddee2d",
+   "id": "5ae8a69c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:34:26.692294Z",
-     "iopub.status.busy": "2026-09-11T00:34:26.692162Z",
-     "iopub.status.idle": "2026-09-11T00:34:26.696451Z",
-     "shell.execute_reply": "2026-09-11T00:34:26.695643Z"
+     "iopub.execute_input": "2026-09-11T05:01:27.633703Z",
+     "iopub.status.busy": "2026-09-11T05:01:27.633514Z",
+     "iopub.status.idle": "2026-09-11T05:01:27.637522Z",
+     "shell.execute_reply": "2026-09-11T05:01:27.636881Z"
     },
     "papermill": {
-     "duration": 0.008733,
-     "end_time": "2026-09-11T00:34:26.697300+00:00",
+     "duration": 0.007183,
+     "end_time": "2026-09-11T05:01:27.638043+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:34:26.688567+00:00",
+     "start_time": "2026-09-11T05:01:27.630860+00:00",
      "status": "completed"
     }
    },
@@ -502,13 +503,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9a1dfa47",
+   "id": "c84f57ba",
    "metadata": {
     "papermill": {
-     "duration": 0.00175,
-     "end_time": "2026-09-11T00:34:26.701425+00:00",
+     "duration": 0.001733,
+     "end_time": "2026-09-11T05:01:27.641564+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:34:26.699675+00:00",
+     "start_time": "2026-09-11T05:01:27.639831+00:00",
      "status": "completed"
     }
    },
@@ -520,19 +521,19 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "70ebe8c3",
+   "id": "0f4931f3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:34:26.704796Z",
-     "iopub.status.busy": "2026-09-11T00:34:26.704733Z",
-     "iopub.status.idle": "2026-09-11T00:34:26.721447Z",
-     "shell.execute_reply": "2026-09-11T00:34:26.721114Z"
+     "iopub.execute_input": "2026-09-11T05:01:27.646327Z",
+     "iopub.status.busy": "2026-09-11T05:01:27.646054Z",
+     "iopub.status.idle": "2026-09-11T05:01:27.670850Z",
+     "shell.execute_reply": "2026-09-11T05:01:27.670214Z"
     },
     "papermill": {
-     "duration": 0.018972,
-     "end_time": "2026-09-11T00:34:26.721896+00:00",
+     "duration": 0.028747,
+     "end_time": "2026-09-11T05:01:27.671783+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:34:26.702924+00:00",
+     "start_time": "2026-09-11T05:01:27.643036+00:00",
      "status": "completed"
     }
    },
@@ -560,13 +561,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "32b2eecc",
+   "id": "47eeef13",
    "metadata": {
     "papermill": {
-     "duration": 0.001161,
-     "end_time": "2026-09-11T00:34:26.724367+00:00",
+     "duration": 0.001486,
+     "end_time": "2026-09-11T05:01:27.676456+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:34:26.723206+00:00",
+     "start_time": "2026-09-11T05:01:27.674970+00:00",
      "status": "completed"
     }
    },
@@ -582,13 +583,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "04140a16",
+   "id": "18634032",
    "metadata": {
     "papermill": {
-     "duration": 0.001134,
-     "end_time": "2026-09-11T00:34:26.726699+00:00",
+     "duration": 0.001307,
+     "end_time": "2026-09-11T05:01:27.679312+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:34:26.725565+00:00",
+     "start_time": "2026-09-11T05:01:27.678005+00:00",
      "status": "completed"
     }
    },
@@ -605,13 +606,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2771a197",
+   "id": "3e50dfb7",
    "metadata": {
     "papermill": {
-     "duration": 0.001143,
-     "end_time": "2026-09-11T00:34:26.729053+00:00",
+     "duration": 0.001533,
+     "end_time": "2026-09-11T05:01:27.682249+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:34:26.727910+00:00",
+     "start_time": "2026-09-11T05:01:27.680716+00:00",
      "status": "completed"
     }
    },
@@ -653,13 +654,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d43fe978",
+   "id": "0ed3fd74",
    "metadata": {
     "papermill": {
-     "duration": 0.001086,
-     "end_time": "2026-09-11T00:34:26.731322+00:00",
+     "duration": 0.001272,
+     "end_time": "2026-09-11T05:01:27.685033+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:34:26.730236+00:00",
+     "start_time": "2026-09-11T05:01:27.683761+00:00",
      "status": "completed"
     }
    },
@@ -682,19 +683,19 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "c997560b",
+   "id": "a7447b7a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:34:26.734413Z",
-     "iopub.status.busy": "2026-09-11T00:34:26.734340Z",
-     "iopub.status.idle": "2026-09-11T00:34:26.736640Z",
-     "shell.execute_reply": "2026-09-11T00:34:26.736289Z"
+     "iopub.execute_input": "2026-09-11T05:01:27.689634Z",
+     "iopub.status.busy": "2026-09-11T05:01:27.689277Z",
+     "iopub.status.idle": "2026-09-11T05:01:27.693519Z",
+     "shell.execute_reply": "2026-09-11T05:01:27.692855Z"
     },
     "papermill": {
-     "duration": 0.004606,
-     "end_time": "2026-09-11T00:34:26.737211+00:00",
+     "duration": 0.007533,
+     "end_time": "2026-09-11T05:01:27.694010+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:34:26.732605+00:00",
+     "start_time": "2026-09-11T05:01:27.686477+00:00",
      "status": "completed"
     }
    },
@@ -795,13 +796,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "06d08ae0",
+   "id": "f62d4712",
    "metadata": {
     "papermill": {
-     "duration": 0.001157,
-     "end_time": "2026-09-11T00:34:26.739611+00:00",
+     "duration": 0.003835,
+     "end_time": "2026-09-11T05:01:27.700885+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:34:26.738454+00:00",
+     "start_time": "2026-09-11T05:01:27.697050+00:00",
      "status": "completed"
     }
    },
@@ -819,13 +820,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2ce0f36e",
+   "id": "81a4bd04",
    "metadata": {
     "papermill": {
-     "duration": 0.001108,
-     "end_time": "2026-09-11T00:34:26.741912+00:00",
+     "duration": 0.00272,
+     "end_time": "2026-09-11T05:01:27.707026+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:34:26.740804+00:00",
+     "start_time": "2026-09-11T05:01:27.704306+00:00",
      "status": "completed"
     }
    },
@@ -861,13 +862,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e9d475fc",
+   "id": "2754fe26",
    "metadata": {
     "papermill": {
-     "duration": 0.001213,
-     "end_time": "2026-09-11T00:34:26.744353+00:00",
+     "duration": 0.002802,
+     "end_time": "2026-09-11T05:01:27.712814+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:34:26.743140+00:00",
+     "start_time": "2026-09-11T05:01:27.710012+00:00",
      "status": "completed"
     }
    },
@@ -880,19 +881,19 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "e07ac357",
+   "id": "33e69fe0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:34:26.747370Z",
-     "iopub.status.busy": "2026-09-11T00:34:26.747298Z",
-     "iopub.status.idle": "2026-09-11T00:34:26.751527Z",
-     "shell.execute_reply": "2026-09-11T00:34:26.751239Z"
+     "iopub.execute_input": "2026-09-11T05:01:27.717988Z",
+     "iopub.status.busy": "2026-09-11T05:01:27.717798Z",
+     "iopub.status.idle": "2026-09-11T05:01:27.725501Z",
+     "shell.execute_reply": "2026-09-11T05:01:27.724895Z"
     },
     "papermill": {
-     "duration": 0.006299,
-     "end_time": "2026-09-11T00:34:26.751887+00:00",
+     "duration": 0.010801,
+     "end_time": "2026-09-11T05:01:27.726299+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:34:26.745588+00:00",
+     "start_time": "2026-09-11T05:01:27.715498+00:00",
      "status": "completed"
     }
    },
@@ -943,19 +944,19 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "26ea86c1",
+   "id": "2f9dec14",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:34:26.754969Z",
-     "iopub.status.busy": "2026-09-11T00:34:26.754903Z",
-     "iopub.status.idle": "2026-09-11T00:34:26.848001Z",
-     "shell.execute_reply": "2026-09-11T00:34:26.847568Z"
+     "iopub.execute_input": "2026-09-11T05:01:27.731274Z",
+     "iopub.status.busy": "2026-09-11T05:01:27.731066Z",
+     "iopub.status.idle": "2026-09-11T05:01:27.885475Z",
+     "shell.execute_reply": "2026-09-11T05:01:27.885169Z"
     },
     "papermill": {
-     "duration": 0.095181,
-     "end_time": "2026-09-11T00:34:26.848380+00:00",
+     "duration": 0.157635,
+     "end_time": "2026-09-11T05:01:27.886029+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:34:26.753199+00:00",
+     "start_time": "2026-09-11T05:01:27.728394+00:00",
      "status": "completed"
     }
    },
@@ -1004,19 +1005,19 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "5960a84f",
+   "id": "0b5fed01",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:34:26.851962Z",
-     "iopub.status.busy": "2026-09-11T00:34:26.851878Z",
-     "iopub.status.idle": "2026-09-11T00:34:26.918970Z",
-     "shell.execute_reply": "2026-09-11T00:34:26.918435Z"
+     "iopub.execute_input": "2026-09-11T05:01:27.891027Z",
+     "iopub.status.busy": "2026-09-11T05:01:27.890868Z",
+     "iopub.status.idle": "2026-09-11T05:01:27.996218Z",
+     "shell.execute_reply": "2026-09-11T05:01:27.995539Z"
     },
     "papermill": {
-     "duration": 0.069475,
-     "end_time": "2026-09-11T00:34:26.919439+00:00",
+     "duration": 0.108419,
+     "end_time": "2026-09-11T05:01:27.996661+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:34:26.849964+00:00",
+     "start_time": "2026-09-11T05:01:27.888242+00:00",
      "status": "completed"
     }
    },
@@ -1075,13 +1076,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "51d32895",
+   "id": "487f92ba",
    "metadata": {
     "papermill": {
-     "duration": 0.001561,
-     "end_time": "2026-09-11T00:34:26.922723+00:00",
+     "duration": 0.001931,
+     "end_time": "2026-09-11T05:01:28.000778+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:34:26.921162+00:00",
+     "start_time": "2026-09-11T05:01:27.998847+00:00",
      "status": "completed"
     }
    },
@@ -1099,13 +1100,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0f3debd4",
+   "id": "31b244bc",
    "metadata": {
     "papermill": {
-     "duration": 0.001457,
-     "end_time": "2026-09-11T00:34:26.925749+00:00",
+     "duration": 0.001941,
+     "end_time": "2026-09-11T05:01:28.004641+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:34:26.924292+00:00",
+     "start_time": "2026-09-11T05:01:28.002700+00:00",
      "status": "completed"
     }
    },
@@ -1134,13 +1135,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "59f8daf6",
+   "id": "4cee5476",
    "metadata": {
     "papermill": {
-     "duration": 0.001461,
-     "end_time": "2026-09-11T00:34:26.928746+00:00",
+     "duration": 0.00381,
+     "end_time": "2026-09-11T05:01:28.012201+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:34:26.927285+00:00",
+     "start_time": "2026-09-11T05:01:28.008391+00:00",
      "status": "completed"
     }
    },
@@ -1177,19 +1178,19 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "e0b69d66",
+   "id": "9294ae06",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:34:26.932371Z",
-     "iopub.status.busy": "2026-09-11T00:34:26.932290Z",
-     "iopub.status.idle": "2026-09-11T00:34:26.948528Z",
-     "shell.execute_reply": "2026-09-11T00:34:26.948152Z"
+     "iopub.execute_input": "2026-09-11T05:01:28.019890Z",
+     "iopub.status.busy": "2026-09-11T05:01:28.019626Z",
+     "iopub.status.idle": "2026-09-11T05:01:28.043838Z",
+     "shell.execute_reply": "2026-09-11T05:01:28.043155Z"
     },
     "papermill": {
-     "duration": 0.018758,
-     "end_time": "2026-09-11T00:34:26.949019+00:00",
+     "duration": 0.028251,
+     "end_time": "2026-09-11T05:01:28.044314+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:34:26.930261+00:00",
+     "start_time": "2026-09-11T05:01:28.016063+00:00",
      "status": "completed"
     }
    },
@@ -1231,25 +1232,24 @@
    "version": "3.14.3"
   },
   "ml4t_provenance": {
-   "executed_at": "2026-09-11T00:34:34.985693+00:00",
+   "executed_at": "2026-09-11T05:01:39.823768+00:00",
    "executor": "local-uv",
-   "library_digest": "7e58b187ca6aebc857aa811db8a932631d991f67d95d37bc9a77bc4f43baa193",
+   "library_digest": "c3f5f8d5e39ee4defa3e44e5e450f1852fc5f8a8c51d9c71331279afc94daba9",
    "outputs_digest": "918052e0eea528e4516722f36bf742d96869cd9a47dec819120efd66e064e7ed",
    "parameters": {},
    "production": true,
-   "source_py_blob": "d172ac58837f823f69ae0c670fe568697a1b0857",
-   "notes": "prose synced from the .py at 2026-09-11T00:48:09.896584+00:00 without re-executing; every code cell is identical to blob 01c130b28095"
+   "source_py_blob": "0fc5dbbadb27ae234418698de349ba87c1de9bf4"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 3.269026,
-   "end_time": "2026-09-11T00:34:27.768560+00:00",
+   "duration": 6.165599,
+   "end_time": "2026-09-11T05:01:30.495403+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "~/ml4t/public-teach-g/25_live_trading/.06_quantconnect_case_study.build.612553.ipynb",
-   "output_path": "~/ml4t/public-teach-g/25_live_trading/.06_quantconnect_case_study.papermill.612553.ipynb",
+   "input_path": "~/ml4t/public-teach-g/25_live_trading/.06_quantconnect_case_study.build.2106376.ipynb",
+   "output_path": "~/ml4t/public-teach-g/25_live_trading/.06_quantconnect_case_study.papermill.2106376.ipynb",
    "parameters": {},
-   "start_time": "2026-09-11T00:34:24.499534+00:00",
+   "start_time": "2026-09-11T05:01:24.329804+00:00",
    "version": "2.7.0"
   }
  },

--- a/25_live_trading/06_quantconnect_case_study.py
+++ b/25_live_trading/06_quantconnect_case_study.py
@@ -64,7 +64,7 @@ import matplotlib.pyplot as plt
 import polars as pl
 from demo_artifacts import normalize_demo_predictions
 
-from utils.paths import display_path, get_case_study_dir, get_output_dir
+from utils.paths import display_path, get_case_study_dir, get_output_dir, registry_readonly_uri
 from utils.style import COLORS, FIGSIZE, add_message_title, show_with_alt
 
 # %% [markdown]
@@ -94,18 +94,19 @@ EXPORT_PATH = get_output_dir(25, "quantconnect_export") / "ml4t_qc_predictions.j
 
 
 # %% [markdown]
-# The registry is opened read-only, and deliberately not with `immutable=1`. That flag promises
-# SQLite the database cannot change while it is open, which lets it skip locking and WAL recovery.
-# That holds for a released case directory and not for a live one a sweep may be writing, and an
-# immutable read of a database with an uncheckpointed write-ahead log sees the pre-WAL main file:
-# a stale configuration selected silently, or a table that appears not to exist.
+# The registry is opened read-only by `mode=ro`. `immutable=1` is a separate promise - that the
+# database cannot change while it is open, which lets SQLite skip locking and WAL recovery - and
+# an immutable read of a database with an uncheckpointed write-ahead log sees the pre-WAL main
+# file: a stale configuration selected silently, or a table that appears not to exist. The
+# promise holds for a downloaded artifact bundle, whose tree is left unwritable, and not for a
+# live case directory a sweep may be writing. `registry_readonly_uri` decides from the directory.
 
 # %%
 case_study_dir = get_case_study_dir("etfs")
 registry_path = case_study_dir / "run_log" / "registry.db"
 registry_hash_before = hashlib.sha256(registry_path.read_bytes()).hexdigest()
 
-registry_uri = f"{registry_path.resolve().as_uri()}?mode=ro"
+registry_uri = registry_readonly_uri(registry_path)
 with sqlite3.connect(registry_uri, uri=True) as conn:
     winner = conn.execute(
         """SELECT ps.training_hash, br.backtest_hash, br.stage, bm.sharpe

--- a/26_mlops_governance/03_safe_model_rollout.ipynb
+++ b/26_mlops_governance/03_safe_model_rollout.ipynb
@@ -2,13 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "01319d50",
+   "id": "5e94d32b",
    "metadata": {
     "papermill": {
-     "duration": 0.002279,
-     "end_time": "2026-09-11T01:29:48.875239+00:00",
+     "duration": 0.003346,
+     "end_time": "2026-09-11T05:01:43.057887+00:00",
      "exception": false,
-     "start_time": "2026-09-11T01:29:48.872960+00:00",
+     "start_time": "2026-09-11T05:01:43.054541+00:00",
      "status": "completed"
     }
    },
@@ -49,19 +49,19 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "22eab206",
+   "id": "e278aa4e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T01:29:48.879740Z",
-     "iopub.status.busy": "2026-09-11T01:29:48.879626Z",
-     "iopub.status.idle": "2026-09-11T01:29:48.883316Z",
-     "shell.execute_reply": "2026-09-11T01:29:48.882798Z"
+     "iopub.execute_input": "2026-09-11T05:01:43.063324Z",
+     "iopub.status.busy": "2026-09-11T05:01:43.063185Z",
+     "iopub.status.idle": "2026-09-11T05:01:43.067228Z",
+     "shell.execute_reply": "2026-09-11T05:01:43.066504Z"
     },
     "papermill": {
-     "duration": 0.006529,
-     "end_time": "2026-09-11T01:29:48.883609+00:00",
+     "duration": 0.007567,
+     "end_time": "2026-09-11T05:01:43.067681+00:00",
      "exception": false,
-     "start_time": "2026-09-11T01:29:48.877080+00:00",
+     "start_time": "2026-09-11T05:01:43.060114+00:00",
      "status": "completed"
     }
    },
@@ -83,13 +83,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "821a48a5",
+   "id": "993d0200",
    "metadata": {
     "papermill": {
-     "duration": 0.001749,
-     "end_time": "2026-09-11T01:29:48.887240+00:00",
+     "duration": 0.002012,
+     "end_time": "2026-09-11T05:01:43.072374+00:00",
      "exception": false,
-     "start_time": "2026-09-11T01:29:48.885491+00:00",
+     "start_time": "2026-09-11T05:01:43.070362+00:00",
      "status": "completed"
     }
    },
@@ -138,19 +138,19 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "d8af3930",
+   "id": "8d0a9670",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T01:29:48.891676Z",
-     "iopub.status.busy": "2026-09-11T01:29:48.891567Z",
-     "iopub.status.idle": "2026-09-11T01:29:48.894487Z",
-     "shell.execute_reply": "2026-09-11T01:29:48.894065Z"
+     "iopub.execute_input": "2026-09-11T05:01:43.077303Z",
+     "iopub.status.busy": "2026-09-11T05:01:43.076978Z",
+     "iopub.status.idle": "2026-09-11T05:01:43.080473Z",
+     "shell.execute_reply": "2026-09-11T05:01:43.079883Z"
     },
     "papermill": {
-     "duration": 0.006186,
-     "end_time": "2026-09-11T01:29:48.895256+00:00",
+     "duration": 0.00698,
+     "end_time": "2026-09-11T05:01:43.081299+00:00",
      "exception": false,
-     "start_time": "2026-09-11T01:29:48.889070+00:00",
+     "start_time": "2026-09-11T05:01:43.074319+00:00",
      "status": "completed"
     },
     "tags": [
@@ -182,20 +182,20 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "8896bcc5",
+   "id": "bdf6aeac",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T01:29:48.905067Z",
-     "iopub.status.busy": "2026-09-11T01:29:48.904830Z",
-     "iopub.status.idle": "2026-09-11T01:29:52.728664Z",
-     "shell.execute_reply": "2026-09-11T01:29:52.727909Z"
+     "iopub.execute_input": "2026-09-11T05:01:43.090844Z",
+     "iopub.status.busy": "2026-09-11T05:01:43.090477Z",
+     "iopub.status.idle": "2026-09-11T05:01:46.547279Z",
+     "shell.execute_reply": "2026-09-11T05:01:46.546467Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 3.830141,
-     "end_time": "2026-09-11T01:29:52.729533+00:00",
+     "duration": 3.462361,
+     "end_time": "2026-09-11T05:01:46.548232+00:00",
      "exception": false,
-     "start_time": "2026-09-11T01:29:48.899392+00:00",
+     "start_time": "2026-09-11T05:01:43.085871+00:00",
      "status": "completed"
     }
    },
@@ -214,7 +214,7 @@
     "import yaml\n",
     "from IPython.display import Markdown, display\n",
     "\n",
-    "from utils.paths import get_case_study_dir\n",
+    "from utils.paths import get_case_study_dir, registry_readonly_uri\n",
     "from utils.reproducibility import set_global_seeds\n",
     "from utils.style import COLORS, FIGSIZE, add_message_title, format_pct_axis, show_with_alt\n",
     "\n",
@@ -230,14 +230,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "adbcbf3c",
+   "id": "41742a23",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.002021,
-     "end_time": "2026-09-11T01:29:52.735077+00:00",
+     "duration": 0.001751,
+     "end_time": "2026-09-11T05:01:46.554065+00:00",
      "exception": false,
-     "start_time": "2026-09-11T01:29:52.733056+00:00",
+     "start_time": "2026-09-11T05:01:46.552314+00:00",
      "status": "completed"
     }
    },
@@ -253,20 +253,20 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "9e35376e",
+   "id": "0027032b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T01:29:52.740928Z",
-     "iopub.status.busy": "2026-09-11T01:29:52.740701Z",
-     "iopub.status.idle": "2026-09-11T01:29:52.744469Z",
-     "shell.execute_reply": "2026-09-11T01:29:52.743903Z"
+     "iopub.execute_input": "2026-09-11T05:01:46.560237Z",
+     "iopub.status.busy": "2026-09-11T05:01:46.560018Z",
+     "iopub.status.idle": "2026-09-11T05:01:46.563411Z",
+     "shell.execute_reply": "2026-09-11T05:01:46.562856Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.007556,
-     "end_time": "2026-09-11T01:29:52.744872+00:00",
+     "duration": 0.008005,
+     "end_time": "2026-09-11T05:01:46.563858+00:00",
      "exception": false,
-     "start_time": "2026-09-11T01:29:52.737316+00:00",
+     "start_time": "2026-09-11T05:01:46.555853+00:00",
      "status": "completed"
     }
    },
@@ -283,44 +283,50 @@
   },
   {
    "cell_type": "markdown",
-   "id": "311b8e25",
+   "id": "80632557",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.002005,
-     "end_time": "2026-09-11T01:29:52.749266+00:00",
+     "duration": 0.003137,
+     "end_time": "2026-09-11T05:01:46.570645+00:00",
      "exception": false,
-     "start_time": "2026-09-11T01:29:52.747261+00:00",
+     "start_time": "2026-09-11T05:01:46.567508+00:00",
      "status": "completed"
     }
    },
    "source": [
     "The connection is opened read-only, by `mode=ro` on the URI and `PRAGMA query_only` on the\n",
     "connection. Reviewing a candidate reads the case study's result record and must not be able\n",
-    "to write to it, and SQLite will enforce that if it is asked to. The URI deliberately leaves\n",
-    "out `immutable=1`, which promises something else: that the database cannot change while it\n",
-    "is open. The registry is what every sweep writes to, and an immutable connection skips\n",
-    "locking and ignores the write-ahead log, so it reads whatever the main file held before the\n",
-    "most recent writes - a superseded row, or a table that appears not to exist."
+    "to write to it, and SQLite will enforce that if it is asked to.\n",
+    "\n",
+    "What the URI must not add here is `immutable=1`, which promises something else: that the\n",
+    "database cannot change while it is open. The registry is what every sweep writes to, and an\n",
+    "immutable connection skips locking and ignores the write-ahead log, so it reads whatever the\n",
+    "main file held before the most recent writes - a superseded row, or a table that appears not\n",
+    "to exist. The one registry the promise does hold for is a downloaded artifact bundle, whose\n",
+    "tree `scripts/download_artifacts.py` verifies and then leaves unwritable, and there the flag\n",
+    "is also required: a WAL reader has to create the `-shm` sidecar unless it is told the file\n",
+    "cannot change. `registry_readonly_uri` decides between the two by asking whether anything can\n",
+    "still write to the directory."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "4d7b455f",
+   "id": "ee5674a5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T01:29:52.754778Z",
-     "iopub.status.busy": "2026-09-11T01:29:52.754584Z",
-     "iopub.status.idle": "2026-09-11T01:29:52.758340Z",
-     "shell.execute_reply": "2026-09-11T01:29:52.757447Z"
+     "iopub.execute_input": "2026-09-11T05:01:46.575757Z",
+     "iopub.status.busy": "2026-09-11T05:01:46.575569Z",
+     "iopub.status.idle": "2026-09-11T05:01:46.578666Z",
+     "shell.execute_reply": "2026-09-11T05:01:46.577991Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.007508,
-     "end_time": "2026-09-11T01:29:52.758885+00:00",
+     "duration": 0.006122,
+     "end_time": "2026-09-11T05:01:46.579016+00:00",
      "exception": false,
-     "start_time": "2026-09-11T01:29:52.751377+00:00",
+     "start_time": "2026-09-11T05:01:46.572894+00:00",
      "status": "completed"
     }
    },
@@ -328,22 +334,21 @@
    "source": [
     "def open_registry_readonly(path: Path) -> sqlite3.Connection:\n",
     "    \"\"\"Open a read-only, query-only SQLite connection.\"\"\"\n",
-    "    uri = f\"file:{path.resolve()}?mode=ro\"\n",
-    "    connection = sqlite3.connect(uri, uri=True)\n",
+    "    connection = sqlite3.connect(registry_readonly_uri(path), uri=True)\n",
     "    connection.execute(\"PRAGMA query_only=ON\")\n",
     "    return connection"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "5f12ef48",
+   "id": "fce8d3e0",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.002091,
-     "end_time": "2026-09-11T01:29:52.763414+00:00",
+     "duration": 0.001915,
+     "end_time": "2026-09-11T05:01:46.583478+00:00",
      "exception": false,
-     "start_time": "2026-09-11T01:29:52.761323+00:00",
+     "start_time": "2026-09-11T05:01:46.581563+00:00",
      "status": "completed"
     }
    },
@@ -356,19 +361,19 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "62cbbc17",
+   "id": "4b59840d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T01:29:52.768578Z",
-     "iopub.status.busy": "2026-09-11T01:29:52.768426Z",
-     "iopub.status.idle": "2026-09-11T01:29:52.772058Z",
-     "shell.execute_reply": "2026-09-11T01:29:52.771374Z"
+     "iopub.execute_input": "2026-09-11T05:01:46.589707Z",
+     "iopub.status.busy": "2026-09-11T05:01:46.589250Z",
+     "iopub.status.idle": "2026-09-11T05:01:46.593919Z",
+     "shell.execute_reply": "2026-09-11T05:01:46.593357Z"
     },
     "papermill": {
-     "duration": 0.006985,
-     "end_time": "2026-09-11T01:29:52.772506+00:00",
+     "duration": 0.009012,
+     "end_time": "2026-09-11T05:01:46.594364+00:00",
      "exception": false,
-     "start_time": "2026-09-11T01:29:52.765521+00:00",
+     "start_time": "2026-09-11T05:01:46.585352+00:00",
      "status": "completed"
     }
    },
@@ -400,14 +405,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "81cb776a",
+   "id": "0768e92c",
    "metadata": {
     "lines_to_next_cell": 0,
     "papermill": {
-     "duration": 0.002075,
-     "end_time": "2026-09-11T01:29:52.777006+00:00",
+     "duration": 0.001907,
+     "end_time": "2026-09-11T05:01:46.598609+00:00",
      "exception": false,
-     "start_time": "2026-09-11T01:29:52.774931+00:00",
+     "start_time": "2026-09-11T05:01:46.596702+00:00",
      "status": "completed"
     }
    },
@@ -416,20 +421,20 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "c4384eec",
+   "id": "7779c77b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T01:29:52.782310Z",
-     "iopub.status.busy": "2026-09-11T01:29:52.782156Z",
-     "iopub.status.idle": "2026-09-11T01:29:52.797319Z",
-     "shell.execute_reply": "2026-09-11T01:29:52.796617Z"
+     "iopub.execute_input": "2026-09-11T05:01:46.603163Z",
+     "iopub.status.busy": "2026-09-11T05:01:46.603038Z",
+     "iopub.status.idle": "2026-09-11T05:01:46.610938Z",
+     "shell.execute_reply": "2026-09-11T05:01:46.610527Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.018578,
-     "end_time": "2026-09-11T01:29:52.797748+00:00",
+     "duration": 0.010907,
+     "end_time": "2026-09-11T05:01:46.611405+00:00",
      "exception": false,
-     "start_time": "2026-09-11T01:29:52.779170+00:00",
+     "start_time": "2026-09-11T05:01:46.600498+00:00",
      "status": "completed"
     }
    },
@@ -516,14 +521,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ca8d66af",
+   "id": "757c5dba",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.002248,
-     "end_time": "2026-09-11T01:29:52.802344+00:00",
+     "duration": 0.003436,
+     "end_time": "2026-09-11T05:01:46.618873+00:00",
      "exception": false,
-     "start_time": "2026-09-11T01:29:52.800096+00:00",
+     "start_time": "2026-09-11T05:01:46.615437+00:00",
      "status": "completed"
     }
    },
@@ -537,20 +542,20 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "4bc65a5f",
+   "id": "86d5605d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T01:29:52.807963Z",
-     "iopub.status.busy": "2026-09-11T01:29:52.807800Z",
-     "iopub.status.idle": "2026-09-11T01:29:52.810499Z",
-     "shell.execute_reply": "2026-09-11T01:29:52.809913Z"
+     "iopub.execute_input": "2026-09-11T05:01:46.629806Z",
+     "iopub.status.busy": "2026-09-11T05:01:46.629643Z",
+     "iopub.status.idle": "2026-09-11T05:01:46.632361Z",
+     "shell.execute_reply": "2026-09-11T05:01:46.631716Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.0064,
-     "end_time": "2026-09-11T01:29:52.811030+00:00",
+     "duration": 0.008705,
+     "end_time": "2026-09-11T05:01:46.632914+00:00",
      "exception": false,
-     "start_time": "2026-09-11T01:29:52.804630+00:00",
+     "start_time": "2026-09-11T05:01:46.624209+00:00",
      "status": "completed"
     }
    },
@@ -565,14 +570,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dec0b54a",
+   "id": "f9c098ef",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.002167,
-     "end_time": "2026-09-11T01:29:52.815699+00:00",
+     "duration": 0.002557,
+     "end_time": "2026-09-11T05:01:46.639487+00:00",
      "exception": false,
-     "start_time": "2026-09-11T01:29:52.813532+00:00",
+     "start_time": "2026-09-11T05:01:46.636930+00:00",
      "status": "completed"
     }
    },
@@ -584,20 +589,20 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "93f07c61",
+   "id": "c21bab65",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T01:29:52.821491Z",
-     "iopub.status.busy": "2026-09-11T01:29:52.821324Z",
-     "iopub.status.idle": "2026-09-11T01:29:52.824951Z",
-     "shell.execute_reply": "2026-09-11T01:29:52.824324Z"
+     "iopub.execute_input": "2026-09-11T05:01:46.643911Z",
+     "iopub.status.busy": "2026-09-11T05:01:46.643763Z",
+     "iopub.status.idle": "2026-09-11T05:01:46.647521Z",
+     "shell.execute_reply": "2026-09-11T05:01:46.647036Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.0076,
-     "end_time": "2026-09-11T01:29:52.825550+00:00",
+     "duration": 0.00651,
+     "end_time": "2026-09-11T05:01:46.647863+00:00",
      "exception": false,
-     "start_time": "2026-09-11T01:29:52.817950+00:00",
+     "start_time": "2026-09-11T05:01:46.641353+00:00",
      "status": "completed"
     }
    },
@@ -621,14 +626,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e144ce59",
+   "id": "5c9912dd",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.002116,
-     "end_time": "2026-09-11T01:29:52.830246+00:00",
+     "duration": 0.001791,
+     "end_time": "2026-09-11T05:01:46.651823+00:00",
      "exception": false,
-     "start_time": "2026-09-11T01:29:52.828130+00:00",
+     "start_time": "2026-09-11T05:01:46.650032+00:00",
      "status": "completed"
     }
    },
@@ -639,20 +644,20 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "3b2b6988",
+   "id": "46ef4502",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T01:29:52.835942Z",
-     "iopub.status.busy": "2026-09-11T01:29:52.835719Z",
-     "iopub.status.idle": "2026-09-11T01:29:52.839708Z",
-     "shell.execute_reply": "2026-09-11T01:29:52.839050Z"
+     "iopub.execute_input": "2026-09-11T05:01:46.659180Z",
+     "iopub.status.busy": "2026-09-11T05:01:46.659007Z",
+     "iopub.status.idle": "2026-09-11T05:01:46.662697Z",
+     "shell.execute_reply": "2026-09-11T05:01:46.662143Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.007959,
-     "end_time": "2026-09-11T01:29:52.840416+00:00",
+     "duration": 0.008858,
+     "end_time": "2026-09-11T05:01:46.663013+00:00",
      "exception": false,
-     "start_time": "2026-09-11T01:29:52.832457+00:00",
+     "start_time": "2026-09-11T05:01:46.654155+00:00",
      "status": "completed"
     }
    },
@@ -674,14 +679,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "248c52c3",
+   "id": "4f77e6cb",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.002394,
-     "end_time": "2026-09-11T01:29:52.845711+00:00",
+     "duration": 0.001879,
+     "end_time": "2026-09-11T05:01:46.667184+00:00",
      "exception": false,
-     "start_time": "2026-09-11T01:29:52.843317+00:00",
+     "start_time": "2026-09-11T05:01:46.665305+00:00",
      "status": "completed"
     }
    },
@@ -693,20 +698,20 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "3b04f5ca",
+   "id": "11016911",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T01:29:52.851286Z",
-     "iopub.status.busy": "2026-09-11T01:29:52.851037Z",
-     "iopub.status.idle": "2026-09-11T01:29:52.854586Z",
-     "shell.execute_reply": "2026-09-11T01:29:52.853915Z"
+     "iopub.execute_input": "2026-09-11T05:01:46.672288Z",
+     "iopub.status.busy": "2026-09-11T05:01:46.672043Z",
+     "iopub.status.idle": "2026-09-11T05:01:46.675966Z",
+     "shell.execute_reply": "2026-09-11T05:01:46.675444Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.007018,
-     "end_time": "2026-09-11T01:29:52.854962+00:00",
+     "duration": 0.00716,
+     "end_time": "2026-09-11T05:01:46.676261+00:00",
      "exception": false,
-     "start_time": "2026-09-11T01:29:52.847944+00:00",
+     "start_time": "2026-09-11T05:01:46.669101+00:00",
      "status": "completed"
     }
    },
@@ -729,14 +734,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3ccecdad",
+   "id": "50614920",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.002139,
-     "end_time": "2026-09-11T01:29:52.859620+00:00",
+     "duration": 0.002419,
+     "end_time": "2026-09-11T05:01:46.680986+00:00",
      "exception": false,
-     "start_time": "2026-09-11T01:29:52.857481+00:00",
+     "start_time": "2026-09-11T05:01:46.678567+00:00",
      "status": "completed"
     }
    },
@@ -763,20 +768,20 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "3e5e1809",
+   "id": "86d90c81",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T01:29:52.864928Z",
-     "iopub.status.busy": "2026-09-11T01:29:52.864804Z",
-     "iopub.status.idle": "2026-09-11T01:29:52.869449Z",
-     "shell.execute_reply": "2026-09-11T01:29:52.868886Z"
+     "iopub.execute_input": "2026-09-11T05:01:46.685815Z",
+     "iopub.status.busy": "2026-09-11T05:01:46.685689Z",
+     "iopub.status.idle": "2026-09-11T05:01:46.690308Z",
+     "shell.execute_reply": "2026-09-11T05:01:46.689908Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.007943,
-     "end_time": "2026-09-11T01:29:52.869755+00:00",
+     "duration": 0.007655,
+     "end_time": "2026-09-11T05:01:46.690739+00:00",
      "exception": false,
-     "start_time": "2026-09-11T01:29:52.861812+00:00",
+     "start_time": "2026-09-11T05:01:46.683084+00:00",
      "status": "completed"
     }
    },
@@ -830,14 +835,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "21abb5f0",
+   "id": "19a2b6a5",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.002229,
-     "end_time": "2026-09-11T01:29:52.874548+00:00",
+     "duration": 0.00211,
+     "end_time": "2026-09-11T05:01:46.695190+00:00",
      "exception": false,
-     "start_time": "2026-09-11T01:29:52.872319+00:00",
+     "start_time": "2026-09-11T05:01:46.693080+00:00",
      "status": "completed"
     }
    },
@@ -858,20 +863,20 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "1b893bfd",
+   "id": "329c8bca",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T01:29:52.880270Z",
-     "iopub.status.busy": "2026-09-11T01:29:52.880122Z",
-     "iopub.status.idle": "2026-09-11T01:29:55.803785Z",
-     "shell.execute_reply": "2026-09-11T01:29:55.803036Z"
+     "iopub.execute_input": "2026-09-11T05:01:46.702027Z",
+     "iopub.status.busy": "2026-09-11T05:01:46.701885Z",
+     "iopub.status.idle": "2026-09-11T05:01:49.681877Z",
+     "shell.execute_reply": "2026-09-11T05:01:49.681432Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 2.927589,
-     "end_time": "2026-09-11T01:29:55.804533+00:00",
+     "duration": 2.98484,
+     "end_time": "2026-09-11T05:01:49.682589+00:00",
      "exception": false,
-     "start_time": "2026-09-11T01:29:52.876944+00:00",
+     "start_time": "2026-09-11T05:01:46.697749+00:00",
      "status": "completed"
     }
    },
@@ -956,14 +961,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "592464d8",
+   "id": "8c478871",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.002539,
-     "end_time": "2026-09-11T01:29:55.810185+00:00",
+     "duration": 0.003711,
+     "end_time": "2026-09-11T05:01:49.690568+00:00",
      "exception": false,
-     "start_time": "2026-09-11T01:29:55.807646+00:00",
+     "start_time": "2026-09-11T05:01:49.686857+00:00",
      "status": "completed"
     }
    },
@@ -992,20 +997,20 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "id": "d2bf3827",
+   "id": "f9285709",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T01:29:55.816708Z",
-     "iopub.status.busy": "2026-09-11T01:29:55.816503Z",
-     "iopub.status.idle": "2026-09-11T01:29:56.000692Z",
-     "shell.execute_reply": "2026-09-11T01:29:56.000111Z"
+     "iopub.execute_input": "2026-09-11T05:01:49.697835Z",
+     "iopub.status.busy": "2026-09-11T05:01:49.697622Z",
+     "iopub.status.idle": "2026-09-11T05:01:49.889096Z",
+     "shell.execute_reply": "2026-09-11T05:01:49.888373Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.188427,
-     "end_time": "2026-09-11T01:29:56.001301+00:00",
+     "duration": 0.196967,
+     "end_time": "2026-09-11T05:01:49.889538+00:00",
      "exception": false,
-     "start_time": "2026-09-11T01:29:55.812874+00:00",
+     "start_time": "2026-09-11T05:01:49.692571+00:00",
      "status": "completed"
     }
    },
@@ -1102,14 +1107,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7b1e8093",
+   "id": "cb1150e8",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.002465,
-     "end_time": "2026-09-11T01:29:56.006555+00:00",
+     "duration": 0.002223,
+     "end_time": "2026-09-11T05:01:49.894985+00:00",
      "exception": false,
-     "start_time": "2026-09-11T01:29:56.004090+00:00",
+     "start_time": "2026-09-11T05:01:49.892762+00:00",
      "status": "completed"
     }
    },
@@ -1122,20 +1127,20 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "id": "5b3507d3",
+   "id": "ab210664",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T01:29:56.012529Z",
-     "iopub.status.busy": "2026-09-11T01:29:56.012395Z",
-     "iopub.status.idle": "2026-09-11T01:29:56.015177Z",
-     "shell.execute_reply": "2026-09-11T01:29:56.014547Z"
+     "iopub.execute_input": "2026-09-11T05:01:49.900088Z",
+     "iopub.status.busy": "2026-09-11T05:01:49.899907Z",
+     "iopub.status.idle": "2026-09-11T05:01:49.902999Z",
+     "shell.execute_reply": "2026-09-11T05:01:49.902371Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.006804,
-     "end_time": "2026-09-11T01:29:56.015888+00:00",
+     "duration": 0.006408,
+     "end_time": "2026-09-11T05:01:49.903462+00:00",
      "exception": false,
-     "start_time": "2026-09-11T01:29:56.009084+00:00",
+     "start_time": "2026-09-11T05:01:49.897054+00:00",
      "status": "completed"
     }
    },
@@ -1151,14 +1156,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a39270bc",
+   "id": "17074593",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.004155,
-     "end_time": "2026-09-11T01:29:56.024711+00:00",
+     "duration": 0.002717,
+     "end_time": "2026-09-11T05:01:49.908724+00:00",
      "exception": false,
-     "start_time": "2026-09-11T01:29:56.020556+00:00",
+     "start_time": "2026-09-11T05:01:49.906007+00:00",
      "status": "completed"
     }
    },
@@ -1169,20 +1174,20 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "id": "6fccc3f3",
+   "id": "85bfcb80",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T01:29:56.031699Z",
-     "iopub.status.busy": "2026-09-11T01:29:56.031535Z",
-     "iopub.status.idle": "2026-09-11T01:29:56.034328Z",
-     "shell.execute_reply": "2026-09-11T01:29:56.033745Z"
+     "iopub.execute_input": "2026-09-11T05:01:49.915475Z",
+     "iopub.status.busy": "2026-09-11T05:01:49.915264Z",
+     "iopub.status.idle": "2026-09-11T05:01:49.918207Z",
+     "shell.execute_reply": "2026-09-11T05:01:49.917642Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.006699,
-     "end_time": "2026-09-11T01:29:56.034700+00:00",
+     "duration": 0.007837,
+     "end_time": "2026-09-11T05:01:49.918668+00:00",
      "exception": false,
-     "start_time": "2026-09-11T01:29:56.028001+00:00",
+     "start_time": "2026-09-11T05:01:49.910831+00:00",
      "status": "completed"
     }
    },
@@ -1196,14 +1201,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1ef0416d",
+   "id": "a51008cb",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.002549,
-     "end_time": "2026-09-11T01:29:56.040066+00:00",
+     "duration": 0.002074,
+     "end_time": "2026-09-11T05:01:49.923274+00:00",
      "exception": false,
-     "start_time": "2026-09-11T01:29:56.037517+00:00",
+     "start_time": "2026-09-11T05:01:49.921200+00:00",
      "status": "completed"
     }
    },
@@ -1230,20 +1235,20 @@
   {
    "cell_type": "code",
    "execution_count": 17,
-   "id": "e7eed628",
+   "id": "84cbe33e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T01:29:56.046633Z",
-     "iopub.status.busy": "2026-09-11T01:29:56.046477Z",
-     "iopub.status.idle": "2026-09-11T01:29:56.559071Z",
-     "shell.execute_reply": "2026-09-11T01:29:56.558595Z"
+     "iopub.execute_input": "2026-09-11T05:01:49.929478Z",
+     "iopub.status.busy": "2026-09-11T05:01:49.929308Z",
+     "iopub.status.idle": "2026-09-11T05:01:50.469401Z",
+     "shell.execute_reply": "2026-09-11T05:01:50.468651Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.516838,
-     "end_time": "2026-09-11T01:29:56.559762+00:00",
+     "duration": 0.543821,
+     "end_time": "2026-09-11T05:01:50.470028+00:00",
      "exception": false,
-     "start_time": "2026-09-11T01:29:56.042924+00:00",
+     "start_time": "2026-09-11T05:01:49.926207+00:00",
      "status": "completed"
     }
    },
@@ -1278,14 +1283,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6a9d841d",
+   "id": "43012150",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.002106,
-     "end_time": "2026-09-11T01:29:56.564366+00:00",
+     "duration": 0.004143,
+     "end_time": "2026-09-11T05:01:50.480493+00:00",
      "exception": false,
-     "start_time": "2026-09-11T01:29:56.562260+00:00",
+     "start_time": "2026-09-11T05:01:50.476350+00:00",
      "status": "completed"
     }
    },
@@ -1300,20 +1305,20 @@
   {
    "cell_type": "code",
    "execution_count": 18,
-   "id": "8846a0dc",
+   "id": "e8a3e950",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T01:29:56.569367Z",
-     "iopub.status.busy": "2026-09-11T01:29:56.569105Z",
-     "iopub.status.idle": "2026-09-11T01:29:56.575045Z",
-     "shell.execute_reply": "2026-09-11T01:29:56.574650Z"
+     "iopub.execute_input": "2026-09-11T05:01:50.489467Z",
+     "iopub.status.busy": "2026-09-11T05:01:50.489158Z",
+     "iopub.status.idle": "2026-09-11T05:01:50.495770Z",
+     "shell.execute_reply": "2026-09-11T05:01:50.495185Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.009034,
-     "end_time": "2026-09-11T01:29:56.575443+00:00",
+     "duration": 0.011953,
+     "end_time": "2026-09-11T05:01:50.496285+00:00",
      "exception": false,
-     "start_time": "2026-09-11T01:29:56.566409+00:00",
+     "start_time": "2026-09-11T05:01:50.484332+00:00",
      "status": "completed"
     }
    },
@@ -1396,14 +1401,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7e64c1dd",
+   "id": "96919ea3",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.002035,
-     "end_time": "2026-09-11T01:29:56.580011+00:00",
+     "duration": 0.002054,
+     "end_time": "2026-09-11T05:01:50.501871+00:00",
      "exception": false,
-     "start_time": "2026-09-11T01:29:56.577976+00:00",
+     "start_time": "2026-09-11T05:01:50.499817+00:00",
      "status": "completed"
     }
    },
@@ -1421,20 +1426,20 @@
   {
    "cell_type": "code",
    "execution_count": 19,
-   "id": "06a2d556",
+   "id": "ff03d922",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T01:29:56.584886Z",
-     "iopub.status.busy": "2026-09-11T01:29:56.584772Z",
-     "iopub.status.idle": "2026-09-11T01:29:56.587278Z",
-     "shell.execute_reply": "2026-09-11T01:29:56.586998Z"
+     "iopub.execute_input": "2026-09-11T05:01:50.511198Z",
+     "iopub.status.busy": "2026-09-11T05:01:50.511028Z",
+     "iopub.status.idle": "2026-09-11T05:01:50.514162Z",
+     "shell.execute_reply": "2026-09-11T05:01:50.513728Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.005473,
-     "end_time": "2026-09-11T01:29:56.587528+00:00",
+     "duration": 0.010686,
+     "end_time": "2026-09-11T05:01:50.514699+00:00",
      "exception": false,
-     "start_time": "2026-09-11T01:29:56.582055+00:00",
+     "start_time": "2026-09-11T05:01:50.504013+00:00",
      "status": "completed"
     }
    },
@@ -1453,14 +1458,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f05fc040",
+   "id": "ffba1e3a",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.001951,
-     "end_time": "2026-09-11T01:29:56.591489+00:00",
+     "duration": 0.003942,
+     "end_time": "2026-09-11T05:01:50.523044+00:00",
      "exception": false,
-     "start_time": "2026-09-11T01:29:56.589538+00:00",
+     "start_time": "2026-09-11T05:01:50.519102+00:00",
      "status": "completed"
     }
    },
@@ -1473,20 +1478,20 @@
   {
    "cell_type": "code",
    "execution_count": 20,
-   "id": "cb6c81f4",
+   "id": "d1a80027",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T01:29:56.596477Z",
-     "iopub.status.busy": "2026-09-11T01:29:56.596353Z",
-     "iopub.status.idle": "2026-09-11T01:29:56.599565Z",
-     "shell.execute_reply": "2026-09-11T01:29:56.599276Z"
+     "iopub.execute_input": "2026-09-11T05:01:50.531810Z",
+     "iopub.status.busy": "2026-09-11T05:01:50.531551Z",
+     "iopub.status.idle": "2026-09-11T05:01:50.536618Z",
+     "shell.execute_reply": "2026-09-11T05:01:50.535939Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.006435,
-     "end_time": "2026-09-11T01:29:56.600036+00:00",
+     "duration": 0.009934,
+     "end_time": "2026-09-11T05:01:50.537013+00:00",
      "exception": false,
-     "start_time": "2026-09-11T01:29:56.593601+00:00",
+     "start_time": "2026-09-11T05:01:50.527079+00:00",
      "status": "completed"
     }
    },
@@ -1504,14 +1509,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "32588f96",
+   "id": "aedeb3a0",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.001929,
-     "end_time": "2026-09-11T01:29:56.604731+00:00",
+     "duration": 0.002437,
+     "end_time": "2026-09-11T05:01:50.544026+00:00",
      "exception": false,
-     "start_time": "2026-09-11T01:29:56.602802+00:00",
+     "start_time": "2026-09-11T05:01:50.541589+00:00",
      "status": "completed"
     }
    },
@@ -1523,20 +1528,20 @@
   {
    "cell_type": "code",
    "execution_count": 21,
-   "id": "0f32327c",
+   "id": "2d100c3b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T01:29:56.609409Z",
-     "iopub.status.busy": "2026-09-11T01:29:56.609292Z",
-     "iopub.status.idle": "2026-09-11T01:29:56.615330Z",
-     "shell.execute_reply": "2026-09-11T01:29:56.614974Z"
+     "iopub.execute_input": "2026-09-11T05:01:50.549738Z",
+     "iopub.status.busy": "2026-09-11T05:01:50.549548Z",
+     "iopub.status.idle": "2026-09-11T05:01:50.556399Z",
+     "shell.execute_reply": "2026-09-11T05:01:50.555937Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.008905,
-     "end_time": "2026-09-11T01:29:56.615600+00:00",
+     "duration": 0.010402,
+     "end_time": "2026-09-11T05:01:50.556823+00:00",
      "exception": false,
-     "start_time": "2026-09-11T01:29:56.606695+00:00",
+     "start_time": "2026-09-11T05:01:50.546421+00:00",
      "status": "completed"
     }
    },
@@ -1663,14 +1668,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "159246ab",
+   "id": "27ace99b",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.002091,
-     "end_time": "2026-09-11T01:29:56.620047+00:00",
+     "duration": 0.00382,
+     "end_time": "2026-09-11T05:01:50.565039+00:00",
      "exception": false,
-     "start_time": "2026-09-11T01:29:56.617956+00:00",
+     "start_time": "2026-09-11T05:01:50.561219+00:00",
      "status": "completed"
     }
    },
@@ -1693,20 +1698,20 @@
   {
    "cell_type": "code",
    "execution_count": 22,
-   "id": "c1633381",
+   "id": "50504350",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T01:29:56.625296Z",
-     "iopub.status.busy": "2026-09-11T01:29:56.625142Z",
-     "iopub.status.idle": "2026-09-11T01:29:56.629397Z",
-     "shell.execute_reply": "2026-09-11T01:29:56.629066Z"
+     "iopub.execute_input": "2026-09-11T05:01:50.575170Z",
+     "iopub.status.busy": "2026-09-11T05:01:50.574968Z",
+     "iopub.status.idle": "2026-09-11T05:01:50.579165Z",
+     "shell.execute_reply": "2026-09-11T05:01:50.578770Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.007766,
-     "end_time": "2026-09-11T01:29:56.629904+00:00",
+     "duration": 0.009733,
+     "end_time": "2026-09-11T05:01:50.579665+00:00",
      "exception": false,
-     "start_time": "2026-09-11T01:29:56.622138+00:00",
+     "start_time": "2026-09-11T05:01:50.569932+00:00",
      "status": "completed"
     }
    },
@@ -1754,14 +1759,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ed46d604",
+   "id": "9540f571",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.002621,
-     "end_time": "2026-09-11T01:29:56.637081+00:00",
+     "duration": 0.004009,
+     "end_time": "2026-09-11T05:01:50.587819+00:00",
      "exception": false,
-     "start_time": "2026-09-11T01:29:56.634460+00:00",
+     "start_time": "2026-09-11T05:01:50.583810+00:00",
      "status": "completed"
     }
    },
@@ -1778,19 +1783,19 @@
   {
    "cell_type": "code",
    "execution_count": 23,
-   "id": "ffc3d4ed",
+   "id": "eb80002a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T01:29:56.643908Z",
-     "iopub.status.busy": "2026-09-11T01:29:56.643788Z",
-     "iopub.status.idle": "2026-09-11T01:29:56.646366Z",
-     "shell.execute_reply": "2026-09-11T01:29:56.646041Z"
+     "iopub.execute_input": "2026-09-11T05:01:50.592870Z",
+     "iopub.status.busy": "2026-09-11T05:01:50.592761Z",
+     "iopub.status.idle": "2026-09-11T05:01:50.597476Z",
+     "shell.execute_reply": "2026-09-11T05:01:50.595434Z"
     },
     "papermill": {
-     "duration": 0.006586,
-     "end_time": "2026-09-11T01:29:56.646596+00:00",
+     "duration": 0.008167,
+     "end_time": "2026-09-11T05:01:50.598233+00:00",
      "exception": false,
-     "start_time": "2026-09-11T01:29:56.640010+00:00",
+     "start_time": "2026-09-11T05:01:50.590066+00:00",
      "status": "completed"
     }
    },
@@ -1806,14 +1811,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "89041ae3",
+   "id": "dfa6186c",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.002068,
-     "end_time": "2026-09-11T01:29:56.651121+00:00",
+     "duration": 0.002275,
+     "end_time": "2026-09-11T05:01:50.603678+00:00",
      "exception": false,
-     "start_time": "2026-09-11T01:29:56.649053+00:00",
+     "start_time": "2026-09-11T05:01:50.601403+00:00",
      "status": "completed"
     }
    },
@@ -1824,20 +1829,20 @@
   {
    "cell_type": "code",
    "execution_count": 24,
-   "id": "a23a6491",
+   "id": "1bb9dfe4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T01:29:56.656065Z",
-     "iopub.status.busy": "2026-09-11T01:29:56.655964Z",
-     "iopub.status.idle": "2026-09-11T01:29:56.658512Z",
-     "shell.execute_reply": "2026-09-11T01:29:56.658193Z"
+     "iopub.execute_input": "2026-09-11T05:01:50.608915Z",
+     "iopub.status.busy": "2026-09-11T05:01:50.608795Z",
+     "iopub.status.idle": "2026-09-11T05:01:50.611701Z",
+     "shell.execute_reply": "2026-09-11T05:01:50.611204Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.005585,
-     "end_time": "2026-09-11T01:29:56.658936+00:00",
+     "duration": 0.006155,
+     "end_time": "2026-09-11T05:01:50.612105+00:00",
      "exception": false,
-     "start_time": "2026-09-11T01:29:56.653351+00:00",
+     "start_time": "2026-09-11T05:01:50.605950+00:00",
      "status": "completed"
     }
    },
@@ -1876,14 +1881,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c9f4a55a",
+   "id": "61aaa683",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.002055,
-     "end_time": "2026-09-11T01:29:56.663208+00:00",
+     "duration": 0.00207,
+     "end_time": "2026-09-11T05:01:50.616508+00:00",
      "exception": false,
-     "start_time": "2026-09-11T01:29:56.661153+00:00",
+     "start_time": "2026-09-11T05:01:50.614438+00:00",
      "status": "completed"
     }
    },
@@ -1894,20 +1899,20 @@
   {
    "cell_type": "code",
    "execution_count": 25,
-   "id": "a2ee8d69",
+   "id": "3d815854",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T01:29:56.668080Z",
-     "iopub.status.busy": "2026-09-11T01:29:56.667975Z",
-     "iopub.status.idle": "2026-09-11T01:29:56.670620Z",
-     "shell.execute_reply": "2026-09-11T01:29:56.670239Z"
+     "iopub.execute_input": "2026-09-11T05:01:50.621720Z",
+     "iopub.status.busy": "2026-09-11T05:01:50.621623Z",
+     "iopub.status.idle": "2026-09-11T05:01:50.624478Z",
+     "shell.execute_reply": "2026-09-11T05:01:50.624057Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.005749,
-     "end_time": "2026-09-11T01:29:56.671087+00:00",
+     "duration": 0.006059,
+     "end_time": "2026-09-11T05:01:50.624773+00:00",
      "exception": false,
-     "start_time": "2026-09-11T01:29:56.665338+00:00",
+     "start_time": "2026-09-11T05:01:50.618714+00:00",
      "status": "completed"
     }
    },
@@ -1952,14 +1957,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "335b44e8",
+   "id": "0866beb4",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.002987,
-     "end_time": "2026-09-11T01:29:56.676918+00:00",
+     "duration": 0.002229,
+     "end_time": "2026-09-11T05:01:50.630649+00:00",
      "exception": false,
-     "start_time": "2026-09-11T01:29:56.673931+00:00",
+     "start_time": "2026-09-11T05:01:50.628420+00:00",
      "status": "completed"
     }
    },
@@ -1971,20 +1976,20 @@
   {
    "cell_type": "code",
    "execution_count": 26,
-   "id": "6e4fd89c",
+   "id": "72cb6700",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T01:29:56.683492Z",
-     "iopub.status.busy": "2026-09-11T01:29:56.683344Z",
-     "iopub.status.idle": "2026-09-11T01:29:56.865468Z",
-     "shell.execute_reply": "2026-09-11T01:29:56.864758Z"
+     "iopub.execute_input": "2026-09-11T05:01:50.635961Z",
+     "iopub.status.busy": "2026-09-11T05:01:50.635830Z",
+     "iopub.status.idle": "2026-09-11T05:01:50.796128Z",
+     "shell.execute_reply": "2026-09-11T05:01:50.795686Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.186599,
-     "end_time": "2026-09-11T01:29:56.866443+00:00",
+     "duration": 0.164266,
+     "end_time": "2026-09-11T05:01:50.797061+00:00",
      "exception": false,
-     "start_time": "2026-09-11T01:29:56.679844+00:00",
+     "start_time": "2026-09-11T05:01:50.632795+00:00",
      "status": "completed"
     }
    },
@@ -2027,13 +2032,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cbb4f94f",
+   "id": "3239c276",
    "metadata": {
     "papermill": {
-     "duration": 0.003654,
-     "end_time": "2026-09-11T01:29:56.874035+00:00",
+     "duration": 0.002691,
+     "end_time": "2026-09-11T05:01:50.803610+00:00",
      "exception": false,
-     "start_time": "2026-09-11T01:29:56.870381+00:00",
+     "start_time": "2026-09-11T05:01:50.800919+00:00",
      "status": "completed"
     }
    },
@@ -2098,24 +2103,24 @@
    "version": "3.14.3"
   },
   "ml4t_provenance": {
-   "executed_at": "2026-09-11T01:30:09.204877+00:00",
+   "executed_at": "2026-09-11T05:02:02.977348+00:00",
    "executor": "local-uv",
-   "library_digest": "037c72d47b06deae928bf1e2c40e066cd6a7dc3fd10e055c49ea6ef2e5b19887",
+   "library_digest": "fde306bd00e3138b7660608085f941efb0e1a8ffbf32ea835c09ced420090080",
    "outputs_digest": "d913339fd4613473594087da5df49dbfed9afd51cdb26bffc4702c3e25d2bfd8",
    "parameters": {},
    "production": true,
-   "source_py_blob": "69eb2b3f0bf5fe9f76813349a33c77763b7bf0c3"
+   "source_py_blob": "dba8a492a48cfd3222dc8d811310e3ee9775a2d8"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 10.942134,
-   "end_time": "2026-09-11T01:29:59.003058+00:00",
+   "duration": 11.172706,
+   "end_time": "2026-09-11T05:01:53.528639+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "~/ml4t/public-teach-g/26_mlops_governance/.03_safe_model_rollout.build.1107745.ipynb",
-   "output_path": "~/ml4t/public-teach-g/26_mlops_governance/.03_safe_model_rollout.papermill.1107745.ipynb",
+   "input_path": "~/ml4t/public-teach-g/26_mlops_governance/.03_safe_model_rollout.build.2109688.ipynb",
+   "output_path": "~/ml4t/public-teach-g/26_mlops_governance/.03_safe_model_rollout.papermill.2109688.ipynb",
    "parameters": {},
-   "start_time": "2026-09-11T01:29:48.060924+00:00",
+   "start_time": "2026-09-11T05:01:42.355933+00:00",
    "version": "2.7.0"
   }
  },

--- a/26_mlops_governance/03_safe_model_rollout.ipynb
+++ b/26_mlops_governance/03_safe_model_rollout.ipynb
@@ -2,13 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "5e94d32b",
+   "id": "4aedb0cf",
    "metadata": {
     "papermill": {
-     "duration": 0.003346,
-     "end_time": "2026-09-11T05:01:43.057887+00:00",
+     "duration": 0.003572,
+     "end_time": "2026-09-11T05:06:33.817959+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:01:43.054541+00:00",
+     "start_time": "2026-09-11T05:06:33.814387+00:00",
      "status": "completed"
     }
    },
@@ -49,19 +49,19 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "e278aa4e",
+   "id": "8df13d02",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T05:01:43.063324Z",
-     "iopub.status.busy": "2026-09-11T05:01:43.063185Z",
-     "iopub.status.idle": "2026-09-11T05:01:43.067228Z",
-     "shell.execute_reply": "2026-09-11T05:01:43.066504Z"
+     "iopub.execute_input": "2026-09-11T05:06:33.823259Z",
+     "iopub.status.busy": "2026-09-11T05:06:33.823063Z",
+     "iopub.status.idle": "2026-09-11T05:06:33.826781Z",
+     "shell.execute_reply": "2026-09-11T05:06:33.826531Z"
     },
     "papermill": {
-     "duration": 0.007567,
-     "end_time": "2026-09-11T05:01:43.067681+00:00",
+     "duration": 0.007145,
+     "end_time": "2026-09-11T05:06:33.827383+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:01:43.060114+00:00",
+     "start_time": "2026-09-11T05:06:33.820238+00:00",
      "status": "completed"
     }
    },
@@ -83,13 +83,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "993d0200",
+   "id": "f0212b01",
    "metadata": {
     "papermill": {
-     "duration": 0.002012,
-     "end_time": "2026-09-11T05:01:43.072374+00:00",
+     "duration": 0.001734,
+     "end_time": "2026-09-11T05:06:33.831163+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:01:43.070362+00:00",
+     "start_time": "2026-09-11T05:06:33.829429+00:00",
      "status": "completed"
     }
    },
@@ -138,19 +138,19 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "8d0a9670",
+   "id": "16dbc130",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T05:01:43.077303Z",
-     "iopub.status.busy": "2026-09-11T05:01:43.076978Z",
-     "iopub.status.idle": "2026-09-11T05:01:43.080473Z",
-     "shell.execute_reply": "2026-09-11T05:01:43.079883Z"
+     "iopub.execute_input": "2026-09-11T05:06:33.835233Z",
+     "iopub.status.busy": "2026-09-11T05:06:33.835118Z",
+     "iopub.status.idle": "2026-09-11T05:06:33.837276Z",
+     "shell.execute_reply": "2026-09-11T05:06:33.836982Z"
     },
     "papermill": {
-     "duration": 0.00698,
-     "end_time": "2026-09-11T05:01:43.081299+00:00",
+     "duration": 0.00481,
+     "end_time": "2026-09-11T05:06:33.837667+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:01:43.074319+00:00",
+     "start_time": "2026-09-11T05:06:33.832857+00:00",
      "status": "completed"
     },
     "tags": [
@@ -182,20 +182,20 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "bdf6aeac",
+   "id": "ac4030da",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T05:01:43.090844Z",
-     "iopub.status.busy": "2026-09-11T05:01:43.090477Z",
-     "iopub.status.idle": "2026-09-11T05:01:46.547279Z",
-     "shell.execute_reply": "2026-09-11T05:01:46.546467Z"
+     "iopub.execute_input": "2026-09-11T05:06:33.841657Z",
+     "iopub.status.busy": "2026-09-11T05:06:33.841573Z",
+     "iopub.status.idle": "2026-09-11T05:06:37.008673Z",
+     "shell.execute_reply": "2026-09-11T05:06:37.007844Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 3.462361,
-     "end_time": "2026-09-11T05:01:46.548232+00:00",
+     "duration": 3.169558,
+     "end_time": "2026-09-11T05:06:37.009081+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:01:43.085871+00:00",
+     "start_time": "2026-09-11T05:06:33.839523+00:00",
      "status": "completed"
     }
    },
@@ -230,14 +230,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "41742a23",
+   "id": "f2237a8c",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.001751,
-     "end_time": "2026-09-11T05:01:46.554065+00:00",
+     "duration": 0.002096,
+     "end_time": "2026-09-11T05:06:37.013685+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:01:46.552314+00:00",
+     "start_time": "2026-09-11T05:06:37.011589+00:00",
      "status": "completed"
     }
    },
@@ -253,20 +253,20 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "0027032b",
+   "id": "c0e70bbd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T05:01:46.560237Z",
-     "iopub.status.busy": "2026-09-11T05:01:46.560018Z",
-     "iopub.status.idle": "2026-09-11T05:01:46.563411Z",
-     "shell.execute_reply": "2026-09-11T05:01:46.562856Z"
+     "iopub.execute_input": "2026-09-11T05:06:37.018651Z",
+     "iopub.status.busy": "2026-09-11T05:06:37.018505Z",
+     "iopub.status.idle": "2026-09-11T05:06:37.021526Z",
+     "shell.execute_reply": "2026-09-11T05:06:37.021073Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.008005,
-     "end_time": "2026-09-11T05:01:46.563858+00:00",
+     "duration": 0.006209,
+     "end_time": "2026-09-11T05:06:37.021988+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:01:46.555853+00:00",
+     "start_time": "2026-09-11T05:06:37.015779+00:00",
      "status": "completed"
     }
    },
@@ -283,14 +283,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "80632557",
+   "id": "a611fd50",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.003137,
-     "end_time": "2026-09-11T05:01:46.570645+00:00",
+     "duration": 0.00173,
+     "end_time": "2026-09-11T05:06:37.025604+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:01:46.567508+00:00",
+     "start_time": "2026-09-11T05:06:37.023874+00:00",
      "status": "completed"
     }
    },
@@ -313,20 +313,20 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "ee5674a5",
+   "id": "82b970f7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T05:01:46.575757Z",
-     "iopub.status.busy": "2026-09-11T05:01:46.575569Z",
-     "iopub.status.idle": "2026-09-11T05:01:46.578666Z",
-     "shell.execute_reply": "2026-09-11T05:01:46.577991Z"
+     "iopub.execute_input": "2026-09-11T05:06:37.030047Z",
+     "iopub.status.busy": "2026-09-11T05:06:37.029905Z",
+     "iopub.status.idle": "2026-09-11T05:06:37.033391Z",
+     "shell.execute_reply": "2026-09-11T05:06:37.032219Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.006122,
-     "end_time": "2026-09-11T05:01:46.579016+00:00",
+     "duration": 0.007822,
+     "end_time": "2026-09-11T05:06:37.035220+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:01:46.572894+00:00",
+     "start_time": "2026-09-11T05:06:37.027398+00:00",
      "status": "completed"
     }
    },
@@ -341,14 +341,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fce8d3e0",
+   "id": "96a7579a",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.001915,
-     "end_time": "2026-09-11T05:01:46.583478+00:00",
+     "duration": 0.001873,
+     "end_time": "2026-09-11T05:06:37.039569+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:01:46.581563+00:00",
+     "start_time": "2026-09-11T05:06:37.037696+00:00",
      "status": "completed"
     }
    },
@@ -361,19 +361,19 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "4b59840d",
+   "id": "fcfa9528",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T05:01:46.589707Z",
-     "iopub.status.busy": "2026-09-11T05:01:46.589250Z",
-     "iopub.status.idle": "2026-09-11T05:01:46.593919Z",
-     "shell.execute_reply": "2026-09-11T05:01:46.593357Z"
+     "iopub.execute_input": "2026-09-11T05:06:37.043836Z",
+     "iopub.status.busy": "2026-09-11T05:06:37.043716Z",
+     "iopub.status.idle": "2026-09-11T05:06:37.046098Z",
+     "shell.execute_reply": "2026-09-11T05:06:37.045811Z"
     },
     "papermill": {
-     "duration": 0.009012,
-     "end_time": "2026-09-11T05:01:46.594364+00:00",
+     "duration": 0.005054,
+     "end_time": "2026-09-11T05:06:37.046417+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:01:46.585352+00:00",
+     "start_time": "2026-09-11T05:06:37.041363+00:00",
      "status": "completed"
     }
    },
@@ -405,14 +405,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0768e92c",
+   "id": "af8f6bc0",
    "metadata": {
     "lines_to_next_cell": 0,
     "papermill": {
-     "duration": 0.001907,
-     "end_time": "2026-09-11T05:01:46.598609+00:00",
+     "duration": 0.001864,
+     "end_time": "2026-09-11T05:06:37.050394+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:01:46.596702+00:00",
+     "start_time": "2026-09-11T05:06:37.048530+00:00",
      "status": "completed"
     }
    },
@@ -421,20 +421,20 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "7779c77b",
+   "id": "ff14c43e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T05:01:46.603163Z",
-     "iopub.status.busy": "2026-09-11T05:01:46.603038Z",
-     "iopub.status.idle": "2026-09-11T05:01:46.610938Z",
-     "shell.execute_reply": "2026-09-11T05:01:46.610527Z"
+     "iopub.execute_input": "2026-09-11T05:06:37.055853Z",
+     "iopub.status.busy": "2026-09-11T05:06:37.055656Z",
+     "iopub.status.idle": "2026-09-11T05:06:37.065849Z",
+     "shell.execute_reply": "2026-09-11T05:06:37.064439Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.010907,
-     "end_time": "2026-09-11T05:01:46.611405+00:00",
+     "duration": 0.01516,
+     "end_time": "2026-09-11T05:06:37.067541+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:01:46.600498+00:00",
+     "start_time": "2026-09-11T05:06:37.052381+00:00",
      "status": "completed"
     }
    },
@@ -521,14 +521,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "757c5dba",
+   "id": "4fb03a05",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.003436,
-     "end_time": "2026-09-11T05:01:46.618873+00:00",
+     "duration": 0.00201,
+     "end_time": "2026-09-11T05:06:37.072320+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:01:46.615437+00:00",
+     "start_time": "2026-09-11T05:06:37.070310+00:00",
      "status": "completed"
     }
    },
@@ -542,20 +542,20 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "86d5605d",
+   "id": "ca948350",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T05:01:46.629806Z",
-     "iopub.status.busy": "2026-09-11T05:01:46.629643Z",
-     "iopub.status.idle": "2026-09-11T05:01:46.632361Z",
-     "shell.execute_reply": "2026-09-11T05:01:46.631716Z"
+     "iopub.execute_input": "2026-09-11T05:06:37.077575Z",
+     "iopub.status.busy": "2026-09-11T05:06:37.077394Z",
+     "iopub.status.idle": "2026-09-11T05:06:37.080040Z",
+     "shell.execute_reply": "2026-09-11T05:06:37.079655Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.008705,
-     "end_time": "2026-09-11T05:01:46.632914+00:00",
+     "duration": 0.006052,
+     "end_time": "2026-09-11T05:06:37.080482+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:01:46.624209+00:00",
+     "start_time": "2026-09-11T05:06:37.074430+00:00",
      "status": "completed"
     }
    },
@@ -570,14 +570,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f9c098ef",
+   "id": "c2522b14",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.002557,
-     "end_time": "2026-09-11T05:01:46.639487+00:00",
+     "duration": 0.001757,
+     "end_time": "2026-09-11T05:06:37.084207+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:01:46.636930+00:00",
+     "start_time": "2026-09-11T05:06:37.082450+00:00",
      "status": "completed"
     }
    },
@@ -589,20 +589,20 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "c21bab65",
+   "id": "bd7df158",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T05:01:46.643911Z",
-     "iopub.status.busy": "2026-09-11T05:01:46.643763Z",
-     "iopub.status.idle": "2026-09-11T05:01:46.647521Z",
-     "shell.execute_reply": "2026-09-11T05:01:46.647036Z"
+     "iopub.execute_input": "2026-09-11T05:06:37.089104Z",
+     "iopub.status.busy": "2026-09-11T05:06:37.088900Z",
+     "iopub.status.idle": "2026-09-11T05:06:37.092486Z",
+     "shell.execute_reply": "2026-09-11T05:06:37.092163Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.00651,
-     "end_time": "2026-09-11T05:01:46.647863+00:00",
+     "duration": 0.006855,
+     "end_time": "2026-09-11T05:06:37.092826+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:01:46.641353+00:00",
+     "start_time": "2026-09-11T05:06:37.085971+00:00",
      "status": "completed"
     }
    },
@@ -626,14 +626,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5c9912dd",
+   "id": "813108d8",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.001791,
-     "end_time": "2026-09-11T05:01:46.651823+00:00",
+     "duration": 0.003111,
+     "end_time": "2026-09-11T05:06:37.098228+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:01:46.650032+00:00",
+     "start_time": "2026-09-11T05:06:37.095117+00:00",
      "status": "completed"
     }
    },
@@ -644,20 +644,20 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "46ef4502",
+   "id": "cdfcd058",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T05:01:46.659180Z",
-     "iopub.status.busy": "2026-09-11T05:01:46.659007Z",
-     "iopub.status.idle": "2026-09-11T05:01:46.662697Z",
-     "shell.execute_reply": "2026-09-11T05:01:46.662143Z"
+     "iopub.execute_input": "2026-09-11T05:06:37.103487Z",
+     "iopub.status.busy": "2026-09-11T05:06:37.103279Z",
+     "iopub.status.idle": "2026-09-11T05:06:37.106558Z",
+     "shell.execute_reply": "2026-09-11T05:06:37.106126Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.008858,
-     "end_time": "2026-09-11T05:01:46.663013+00:00",
+     "duration": 0.00626,
+     "end_time": "2026-09-11T05:06:37.106831+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:01:46.654155+00:00",
+     "start_time": "2026-09-11T05:06:37.100571+00:00",
      "status": "completed"
     }
    },
@@ -679,14 +679,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4f77e6cb",
+   "id": "c506cc82",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.001879,
-     "end_time": "2026-09-11T05:01:46.667184+00:00",
+     "duration": 0.001824,
+     "end_time": "2026-09-11T05:06:37.110509+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:01:46.665305+00:00",
+     "start_time": "2026-09-11T05:06:37.108685+00:00",
      "status": "completed"
     }
    },
@@ -698,20 +698,20 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "11016911",
+   "id": "701ec373",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T05:01:46.672288Z",
-     "iopub.status.busy": "2026-09-11T05:01:46.672043Z",
-     "iopub.status.idle": "2026-09-11T05:01:46.675966Z",
-     "shell.execute_reply": "2026-09-11T05:01:46.675444Z"
+     "iopub.execute_input": "2026-09-11T05:06:37.114745Z",
+     "iopub.status.busy": "2026-09-11T05:06:37.114599Z",
+     "iopub.status.idle": "2026-09-11T05:06:37.118027Z",
+     "shell.execute_reply": "2026-09-11T05:06:37.117574Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.00716,
-     "end_time": "2026-09-11T05:01:46.676261+00:00",
+     "duration": 0.006122,
+     "end_time": "2026-09-11T05:06:37.118428+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:01:46.669101+00:00",
+     "start_time": "2026-09-11T05:06:37.112306+00:00",
      "status": "completed"
     }
    },
@@ -734,14 +734,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "50614920",
+   "id": "0b6015bc",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.002419,
-     "end_time": "2026-09-11T05:01:46.680986+00:00",
+     "duration": 0.002338,
+     "end_time": "2026-09-11T05:06:37.122724+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:01:46.678567+00:00",
+     "start_time": "2026-09-11T05:06:37.120386+00:00",
      "status": "completed"
     }
    },
@@ -768,20 +768,20 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "86d90c81",
+   "id": "077bfb4b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T05:01:46.685815Z",
-     "iopub.status.busy": "2026-09-11T05:01:46.685689Z",
-     "iopub.status.idle": "2026-09-11T05:01:46.690308Z",
-     "shell.execute_reply": "2026-09-11T05:01:46.689908Z"
+     "iopub.execute_input": "2026-09-11T05:06:37.129509Z",
+     "iopub.status.busy": "2026-09-11T05:06:37.129295Z",
+     "iopub.status.idle": "2026-09-11T05:06:37.134944Z",
+     "shell.execute_reply": "2026-09-11T05:06:37.134542Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.007655,
-     "end_time": "2026-09-11T05:01:46.690739+00:00",
+     "duration": 0.009255,
+     "end_time": "2026-09-11T05:06:37.135250+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:01:46.683084+00:00",
+     "start_time": "2026-09-11T05:06:37.125995+00:00",
      "status": "completed"
     }
    },
@@ -835,14 +835,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "19a2b6a5",
+   "id": "13e9cca0",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.00211,
-     "end_time": "2026-09-11T05:01:46.695190+00:00",
+     "duration": 0.003156,
+     "end_time": "2026-09-11T05:06:37.140882+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:01:46.693080+00:00",
+     "start_time": "2026-09-11T05:06:37.137726+00:00",
      "status": "completed"
     }
    },
@@ -863,20 +863,20 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "329c8bca",
+   "id": "036afb81",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T05:01:46.702027Z",
-     "iopub.status.busy": "2026-09-11T05:01:46.701885Z",
-     "iopub.status.idle": "2026-09-11T05:01:49.681877Z",
-     "shell.execute_reply": "2026-09-11T05:01:49.681432Z"
+     "iopub.execute_input": "2026-09-11T05:06:37.148874Z",
+     "iopub.status.busy": "2026-09-11T05:06:37.148688Z",
+     "iopub.status.idle": "2026-09-11T05:06:40.081097Z",
+     "shell.execute_reply": "2026-09-11T05:06:40.080651Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 2.98484,
-     "end_time": "2026-09-11T05:01:49.682589+00:00",
+     "duration": 2.937222,
+     "end_time": "2026-09-11T05:06:40.081692+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:01:46.697749+00:00",
+     "start_time": "2026-09-11T05:06:37.144470+00:00",
      "status": "completed"
     }
    },
@@ -961,14 +961,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8c478871",
+   "id": "0519ad19",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.003711,
-     "end_time": "2026-09-11T05:01:49.690568+00:00",
+     "duration": 0.004816,
+     "end_time": "2026-09-11T05:06:40.088872+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:01:49.686857+00:00",
+     "start_time": "2026-09-11T05:06:40.084056+00:00",
      "status": "completed"
     }
    },
@@ -997,20 +997,20 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "id": "f9285709",
+   "id": "357953ab",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T05:01:49.697835Z",
-     "iopub.status.busy": "2026-09-11T05:01:49.697622Z",
-     "iopub.status.idle": "2026-09-11T05:01:49.889096Z",
-     "shell.execute_reply": "2026-09-11T05:01:49.888373Z"
+     "iopub.execute_input": "2026-09-11T05:06:40.095809Z",
+     "iopub.status.busy": "2026-09-11T05:06:40.095637Z",
+     "iopub.status.idle": "2026-09-11T05:06:40.266679Z",
+     "shell.execute_reply": "2026-09-11T05:06:40.266196Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.196967,
-     "end_time": "2026-09-11T05:01:49.889538+00:00",
+     "duration": 0.174911,
+     "end_time": "2026-09-11T05:06:40.267025+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:01:49.692571+00:00",
+     "start_time": "2026-09-11T05:06:40.092114+00:00",
      "status": "completed"
     }
    },
@@ -1107,14 +1107,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cb1150e8",
+   "id": "a001c984",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.002223,
-     "end_time": "2026-09-11T05:01:49.894985+00:00",
+     "duration": 0.002421,
+     "end_time": "2026-09-11T05:06:40.272272+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:01:49.892762+00:00",
+     "start_time": "2026-09-11T05:06:40.269851+00:00",
      "status": "completed"
     }
    },
@@ -1127,20 +1127,20 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "id": "ab210664",
+   "id": "9a8390ee",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T05:01:49.900088Z",
-     "iopub.status.busy": "2026-09-11T05:01:49.899907Z",
-     "iopub.status.idle": "2026-09-11T05:01:49.902999Z",
-     "shell.execute_reply": "2026-09-11T05:01:49.902371Z"
+     "iopub.execute_input": "2026-09-11T05:06:40.278768Z",
+     "iopub.status.busy": "2026-09-11T05:06:40.278544Z",
+     "iopub.status.idle": "2026-09-11T05:06:40.280914Z",
+     "shell.execute_reply": "2026-09-11T05:06:40.280452Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.006408,
-     "end_time": "2026-09-11T05:01:49.903462+00:00",
+     "duration": 0.006352,
+     "end_time": "2026-09-11T05:06:40.281171+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:01:49.897054+00:00",
+     "start_time": "2026-09-11T05:06:40.274819+00:00",
      "status": "completed"
     }
    },
@@ -1156,14 +1156,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "17074593",
+   "id": "22ed2455",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.002717,
-     "end_time": "2026-09-11T05:01:49.908724+00:00",
+     "duration": 0.002736,
+     "end_time": "2026-09-11T05:06:40.287396+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:01:49.906007+00:00",
+     "start_time": "2026-09-11T05:06:40.284660+00:00",
      "status": "completed"
     }
    },
@@ -1174,20 +1174,20 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "id": "85bfcb80",
+   "id": "dd7cae27",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T05:01:49.915475Z",
-     "iopub.status.busy": "2026-09-11T05:01:49.915264Z",
-     "iopub.status.idle": "2026-09-11T05:01:49.918207Z",
-     "shell.execute_reply": "2026-09-11T05:01:49.917642Z"
+     "iopub.execute_input": "2026-09-11T05:06:40.292761Z",
+     "iopub.status.busy": "2026-09-11T05:06:40.292628Z",
+     "iopub.status.idle": "2026-09-11T05:06:40.295382Z",
+     "shell.execute_reply": "2026-09-11T05:06:40.294886Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.007837,
-     "end_time": "2026-09-11T05:01:49.918668+00:00",
+     "duration": 0.006069,
+     "end_time": "2026-09-11T05:06:40.295767+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:01:49.910831+00:00",
+     "start_time": "2026-09-11T05:06:40.289698+00:00",
      "status": "completed"
     }
    },
@@ -1201,14 +1201,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a51008cb",
+   "id": "0e1acb8b",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.002074,
-     "end_time": "2026-09-11T05:01:49.923274+00:00",
+     "duration": 0.001937,
+     "end_time": "2026-09-11T05:06:40.299776+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:01:49.921200+00:00",
+     "start_time": "2026-09-11T05:06:40.297839+00:00",
      "status": "completed"
     }
    },
@@ -1235,20 +1235,20 @@
   {
    "cell_type": "code",
    "execution_count": 17,
-   "id": "84cbe33e",
+   "id": "f0849666",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T05:01:49.929478Z",
-     "iopub.status.busy": "2026-09-11T05:01:49.929308Z",
-     "iopub.status.idle": "2026-09-11T05:01:50.469401Z",
-     "shell.execute_reply": "2026-09-11T05:01:50.468651Z"
+     "iopub.execute_input": "2026-09-11T05:06:40.305633Z",
+     "iopub.status.busy": "2026-09-11T05:06:40.305392Z",
+     "iopub.status.idle": "2026-09-11T05:06:40.785211Z",
+     "shell.execute_reply": "2026-09-11T05:06:40.784697Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.543821,
-     "end_time": "2026-09-11T05:01:50.470028+00:00",
+     "duration": 0.483683,
+     "end_time": "2026-09-11T05:06:40.785597+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:01:49.926207+00:00",
+     "start_time": "2026-09-11T05:06:40.301914+00:00",
      "status": "completed"
     }
    },
@@ -1283,14 +1283,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "43012150",
+   "id": "5f1db393",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.004143,
-     "end_time": "2026-09-11T05:01:50.480493+00:00",
+     "duration": 0.003845,
+     "end_time": "2026-09-11T05:06:40.794119+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:01:50.476350+00:00",
+     "start_time": "2026-09-11T05:06:40.790274+00:00",
      "status": "completed"
     }
    },
@@ -1305,20 +1305,20 @@
   {
    "cell_type": "code",
    "execution_count": 18,
-   "id": "e8a3e950",
+   "id": "e16606b4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T05:01:50.489467Z",
-     "iopub.status.busy": "2026-09-11T05:01:50.489158Z",
-     "iopub.status.idle": "2026-09-11T05:01:50.495770Z",
-     "shell.execute_reply": "2026-09-11T05:01:50.495185Z"
+     "iopub.execute_input": "2026-09-11T05:06:40.799893Z",
+     "iopub.status.busy": "2026-09-11T05:06:40.799676Z",
+     "iopub.status.idle": "2026-09-11T05:06:40.805164Z",
+     "shell.execute_reply": "2026-09-11T05:06:40.804789Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.011953,
-     "end_time": "2026-09-11T05:01:50.496285+00:00",
+     "duration": 0.008862,
+     "end_time": "2026-09-11T05:06:40.805572+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:01:50.484332+00:00",
+     "start_time": "2026-09-11T05:06:40.796710+00:00",
      "status": "completed"
     }
    },
@@ -1401,14 +1401,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "96919ea3",
+   "id": "726a2a1d",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.002054,
-     "end_time": "2026-09-11T05:01:50.501871+00:00",
+     "duration": 0.003125,
+     "end_time": "2026-09-11T05:06:40.811256+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:01:50.499817+00:00",
+     "start_time": "2026-09-11T05:06:40.808131+00:00",
      "status": "completed"
     }
    },
@@ -1426,20 +1426,20 @@
   {
    "cell_type": "code",
    "execution_count": 19,
-   "id": "ff03d922",
+   "id": "d7baa686",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T05:01:50.511198Z",
-     "iopub.status.busy": "2026-09-11T05:01:50.511028Z",
-     "iopub.status.idle": "2026-09-11T05:01:50.514162Z",
-     "shell.execute_reply": "2026-09-11T05:01:50.513728Z"
+     "iopub.execute_input": "2026-09-11T05:06:40.816200Z",
+     "iopub.status.busy": "2026-09-11T05:06:40.816079Z",
+     "iopub.status.idle": "2026-09-11T05:06:40.820021Z",
+     "shell.execute_reply": "2026-09-11T05:06:40.818395Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.010686,
-     "end_time": "2026-09-11T05:01:50.514699+00:00",
+     "duration": 0.008019,
+     "end_time": "2026-09-11T05:06:40.821452+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:01:50.504013+00:00",
+     "start_time": "2026-09-11T05:06:40.813433+00:00",
      "status": "completed"
     }
    },
@@ -1458,14 +1458,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ffba1e3a",
+   "id": "5541b99c",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.003942,
-     "end_time": "2026-09-11T05:01:50.523044+00:00",
+     "duration": 0.002268,
+     "end_time": "2026-09-11T05:06:40.826581+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:01:50.519102+00:00",
+     "start_time": "2026-09-11T05:06:40.824313+00:00",
      "status": "completed"
     }
    },
@@ -1478,20 +1478,20 @@
   {
    "cell_type": "code",
    "execution_count": 20,
-   "id": "d1a80027",
+   "id": "dcb4b5db",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T05:01:50.531810Z",
-     "iopub.status.busy": "2026-09-11T05:01:50.531551Z",
-     "iopub.status.idle": "2026-09-11T05:01:50.536618Z",
-     "shell.execute_reply": "2026-09-11T05:01:50.535939Z"
+     "iopub.execute_input": "2026-09-11T05:06:40.831845Z",
+     "iopub.status.busy": "2026-09-11T05:06:40.831734Z",
+     "iopub.status.idle": "2026-09-11T05:06:40.834755Z",
+     "shell.execute_reply": "2026-09-11T05:06:40.834304Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.009934,
-     "end_time": "2026-09-11T05:01:50.537013+00:00",
+     "duration": 0.006314,
+     "end_time": "2026-09-11T05:06:40.835028+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:01:50.527079+00:00",
+     "start_time": "2026-09-11T05:06:40.828714+00:00",
      "status": "completed"
     }
    },
@@ -1509,14 +1509,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "aedeb3a0",
+   "id": "ea2f5f76",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.002437,
-     "end_time": "2026-09-11T05:01:50.544026+00:00",
+     "duration": 0.00214,
+     "end_time": "2026-09-11T05:06:40.839305+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:01:50.541589+00:00",
+     "start_time": "2026-09-11T05:06:40.837165+00:00",
      "status": "completed"
     }
    },
@@ -1528,20 +1528,20 @@
   {
    "cell_type": "code",
    "execution_count": 21,
-   "id": "2d100c3b",
+   "id": "4069080e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T05:01:50.549738Z",
-     "iopub.status.busy": "2026-09-11T05:01:50.549548Z",
-     "iopub.status.idle": "2026-09-11T05:01:50.556399Z",
-     "shell.execute_reply": "2026-09-11T05:01:50.555937Z"
+     "iopub.execute_input": "2026-09-11T05:06:40.846211Z",
+     "iopub.status.busy": "2026-09-11T05:06:40.845958Z",
+     "iopub.status.idle": "2026-09-11T05:06:40.853183Z",
+     "shell.execute_reply": "2026-09-11T05:06:40.852537Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.010402,
-     "end_time": "2026-09-11T05:01:50.556823+00:00",
+     "duration": 0.011605,
+     "end_time": "2026-09-11T05:06:40.853582+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:01:50.546421+00:00",
+     "start_time": "2026-09-11T05:06:40.841977+00:00",
      "status": "completed"
     }
    },
@@ -1668,14 +1668,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "27ace99b",
+   "id": "6c6bdad6",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.00382,
-     "end_time": "2026-09-11T05:01:50.565039+00:00",
+     "duration": 0.002351,
+     "end_time": "2026-09-11T05:06:40.860078+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:01:50.561219+00:00",
+     "start_time": "2026-09-11T05:06:40.857727+00:00",
      "status": "completed"
     }
    },
@@ -1698,20 +1698,20 @@
   {
    "cell_type": "code",
    "execution_count": 22,
-   "id": "50504350",
+   "id": "dd703f6a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T05:01:50.575170Z",
-     "iopub.status.busy": "2026-09-11T05:01:50.574968Z",
-     "iopub.status.idle": "2026-09-11T05:01:50.579165Z",
-     "shell.execute_reply": "2026-09-11T05:01:50.578770Z"
+     "iopub.execute_input": "2026-09-11T05:06:40.865381Z",
+     "iopub.status.busy": "2026-09-11T05:06:40.865224Z",
+     "iopub.status.idle": "2026-09-11T05:06:40.869353Z",
+     "shell.execute_reply": "2026-09-11T05:06:40.868912Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.009733,
-     "end_time": "2026-09-11T05:01:50.579665+00:00",
+     "duration": 0.007245,
+     "end_time": "2026-09-11T05:06:40.869600+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:01:50.569932+00:00",
+     "start_time": "2026-09-11T05:06:40.862355+00:00",
      "status": "completed"
     }
    },
@@ -1759,14 +1759,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9540f571",
+   "id": "438c2234",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.004009,
-     "end_time": "2026-09-11T05:01:50.587819+00:00",
+     "duration": 0.002049,
+     "end_time": "2026-09-11T05:06:40.873799+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:01:50.583810+00:00",
+     "start_time": "2026-09-11T05:06:40.871750+00:00",
      "status": "completed"
     }
    },
@@ -1783,19 +1783,19 @@
   {
    "cell_type": "code",
    "execution_count": 23,
-   "id": "eb80002a",
+   "id": "dc2170ee",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T05:01:50.592870Z",
-     "iopub.status.busy": "2026-09-11T05:01:50.592761Z",
-     "iopub.status.idle": "2026-09-11T05:01:50.597476Z",
-     "shell.execute_reply": "2026-09-11T05:01:50.595434Z"
+     "iopub.execute_input": "2026-09-11T05:06:40.878906Z",
+     "iopub.status.busy": "2026-09-11T05:06:40.878758Z",
+     "iopub.status.idle": "2026-09-11T05:06:40.884450Z",
+     "shell.execute_reply": "2026-09-11T05:06:40.883551Z"
     },
     "papermill": {
-     "duration": 0.008167,
-     "end_time": "2026-09-11T05:01:50.598233+00:00",
+     "duration": 0.008972,
+     "end_time": "2026-09-11T05:06:40.884894+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:01:50.590066+00:00",
+     "start_time": "2026-09-11T05:06:40.875922+00:00",
      "status": "completed"
     }
    },
@@ -1811,14 +1811,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dfa6186c",
+   "id": "efc3097e",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.002275,
-     "end_time": "2026-09-11T05:01:50.603678+00:00",
+     "duration": 0.002245,
+     "end_time": "2026-09-11T05:06:40.889991+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:01:50.601403+00:00",
+     "start_time": "2026-09-11T05:06:40.887746+00:00",
      "status": "completed"
     }
    },
@@ -1829,20 +1829,20 @@
   {
    "cell_type": "code",
    "execution_count": 24,
-   "id": "1bb9dfe4",
+   "id": "5072430a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T05:01:50.608915Z",
-     "iopub.status.busy": "2026-09-11T05:01:50.608795Z",
-     "iopub.status.idle": "2026-09-11T05:01:50.611701Z",
-     "shell.execute_reply": "2026-09-11T05:01:50.611204Z"
+     "iopub.execute_input": "2026-09-11T05:06:40.895293Z",
+     "iopub.status.busy": "2026-09-11T05:06:40.895113Z",
+     "iopub.status.idle": "2026-09-11T05:06:40.898761Z",
+     "shell.execute_reply": "2026-09-11T05:06:40.898060Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.006155,
-     "end_time": "2026-09-11T05:01:50.612105+00:00",
+     "duration": 0.006958,
+     "end_time": "2026-09-11T05:06:40.899239+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:01:50.605950+00:00",
+     "start_time": "2026-09-11T05:06:40.892281+00:00",
      "status": "completed"
     }
    },
@@ -1881,14 +1881,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "61aaa683",
+   "id": "0cd12e92",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.00207,
-     "end_time": "2026-09-11T05:01:50.616508+00:00",
+     "duration": 0.002127,
+     "end_time": "2026-09-11T05:06:40.903656+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:01:50.614438+00:00",
+     "start_time": "2026-09-11T05:06:40.901529+00:00",
      "status": "completed"
     }
    },
@@ -1899,20 +1899,20 @@
   {
    "cell_type": "code",
    "execution_count": 25,
-   "id": "3d815854",
+   "id": "2a9215df",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T05:01:50.621720Z",
-     "iopub.status.busy": "2026-09-11T05:01:50.621623Z",
-     "iopub.status.idle": "2026-09-11T05:01:50.624478Z",
-     "shell.execute_reply": "2026-09-11T05:01:50.624057Z"
+     "iopub.execute_input": "2026-09-11T05:06:40.911582Z",
+     "iopub.status.busy": "2026-09-11T05:06:40.911115Z",
+     "iopub.status.idle": "2026-09-11T05:06:40.916052Z",
+     "shell.execute_reply": "2026-09-11T05:06:40.915315Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.006059,
-     "end_time": "2026-09-11T05:01:50.624773+00:00",
+     "duration": 0.010683,
+     "end_time": "2026-09-11T05:06:40.916488+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:01:50.618714+00:00",
+     "start_time": "2026-09-11T05:06:40.905805+00:00",
      "status": "completed"
     }
    },
@@ -1957,14 +1957,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0866beb4",
+   "id": "2def0d57",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.002229,
-     "end_time": "2026-09-11T05:01:50.630649+00:00",
+     "duration": 0.002127,
+     "end_time": "2026-09-11T05:06:40.921281+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:01:50.628420+00:00",
+     "start_time": "2026-09-11T05:06:40.919154+00:00",
      "status": "completed"
     }
    },
@@ -1976,20 +1976,20 @@
   {
    "cell_type": "code",
    "execution_count": 26,
-   "id": "72cb6700",
+   "id": "43acae25",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T05:01:50.635961Z",
-     "iopub.status.busy": "2026-09-11T05:01:50.635830Z",
-     "iopub.status.idle": "2026-09-11T05:01:50.796128Z",
-     "shell.execute_reply": "2026-09-11T05:01:50.795686Z"
+     "iopub.execute_input": "2026-09-11T05:06:40.926508Z",
+     "iopub.status.busy": "2026-09-11T05:06:40.926338Z",
+     "iopub.status.idle": "2026-09-11T05:06:41.134698Z",
+     "shell.execute_reply": "2026-09-11T05:06:41.134185Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.164266,
-     "end_time": "2026-09-11T05:01:50.797061+00:00",
+     "duration": 0.211829,
+     "end_time": "2026-09-11T05:06:41.135183+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:01:50.632795+00:00",
+     "start_time": "2026-09-11T05:06:40.923354+00:00",
      "status": "completed"
     }
    },
@@ -2032,13 +2032,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3239c276",
+   "id": "55ea4666",
    "metadata": {
     "papermill": {
-     "duration": 0.002691,
-     "end_time": "2026-09-11T05:01:50.803610+00:00",
+     "duration": 0.00603,
+     "end_time": "2026-09-11T05:06:41.143751+00:00",
      "exception": false,
-     "start_time": "2026-09-11T05:01:50.800919+00:00",
+     "start_time": "2026-09-11T05:06:41.137721+00:00",
      "status": "completed"
     }
    },
@@ -2103,9 +2103,9 @@
    "version": "3.14.3"
   },
   "ml4t_provenance": {
-   "executed_at": "2026-09-11T05:02:02.977348+00:00",
+   "executed_at": "2026-09-11T05:06:56.656990+00:00",
    "executor": "local-uv",
-   "library_digest": "fde306bd00e3138b7660608085f941efb0e1a8ffbf32ea835c09ced420090080",
+   "library_digest": "b30038750e21bd22a871949362c741c923602ae7868170c566756dafaae2f83a",
    "outputs_digest": "d913339fd4613473594087da5df49dbfed9afd51cdb26bffc4702c3e25d2bfd8",
    "parameters": {},
    "production": true,
@@ -2113,14 +2113,14 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 11.172706,
-   "end_time": "2026-09-11T05:01:53.528639+00:00",
+   "duration": 9.72738,
+   "end_time": "2026-09-11T05:06:42.864820+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "~/ml4t/public-teach-g/26_mlops_governance/.03_safe_model_rollout.build.2109688.ipynb",
-   "output_path": "~/ml4t/public-teach-g/26_mlops_governance/.03_safe_model_rollout.papermill.2109688.ipynb",
+   "input_path": "~/ml4t/public-teach-g/26_mlops_governance/.03_safe_model_rollout.build.2160031.ipynb",
+   "output_path": "~/ml4t/public-teach-g/26_mlops_governance/.03_safe_model_rollout.papermill.2160031.ipynb",
    "parameters": {},
-   "start_time": "2026-09-11T05:01:42.355933+00:00",
+   "start_time": "2026-09-11T05:06:33.137440+00:00",
    "version": "2.7.0"
   }
  },

--- a/26_mlops_governance/03_safe_model_rollout.py
+++ b/26_mlops_governance/03_safe_model_rollout.py
@@ -124,7 +124,7 @@ import polars as pl
 import yaml
 from IPython.display import Markdown, display
 
-from utils.paths import get_case_study_dir
+from utils.paths import get_case_study_dir, registry_readonly_uri
 from utils.reproducibility import set_global_seeds
 from utils.style import COLORS, FIGSIZE, add_message_title, format_pct_axis, show_with_alt
 
@@ -160,18 +160,23 @@ class PredictionIdentity:
 # %% [markdown]
 # The connection is opened read-only, by `mode=ro` on the URI and `PRAGMA query_only` on the
 # connection. Reviewing a candidate reads the case study's result record and must not be able
-# to write to it, and SQLite will enforce that if it is asked to. The URI deliberately leaves
-# out `immutable=1`, which promises something else: that the database cannot change while it
-# is open. The registry is what every sweep writes to, and an immutable connection skips
-# locking and ignores the write-ahead log, so it reads whatever the main file held before the
-# most recent writes - a superseded row, or a table that appears not to exist.
+# to write to it, and SQLite will enforce that if it is asked to.
+#
+# What the URI must not add here is `immutable=1`, which promises something else: that the
+# database cannot change while it is open. The registry is what every sweep writes to, and an
+# immutable connection skips locking and ignores the write-ahead log, so it reads whatever the
+# main file held before the most recent writes - a superseded row, or a table that appears not
+# to exist. The one registry the promise does hold for is a downloaded artifact bundle, whose
+# tree `scripts/download_artifacts.py` verifies and then leaves unwritable, and there the flag
+# is also required: a WAL reader has to create the `-shm` sidecar unless it is told the file
+# cannot change. `registry_readonly_uri` decides between the two by asking whether anything can
+# still write to the directory.
 
 
 # %%
 def open_registry_readonly(path: Path) -> sqlite3.Connection:
     """Open a read-only, query-only SQLite connection."""
-    uri = f"file:{path.resolve()}?mode=ro"
-    connection = sqlite3.connect(uri, uri=True)
+    connection = sqlite3.connect(registry_readonly_uri(path), uri=True)
     connection.execute("PRAGMA query_only=ON")
     return connection
 

--- a/scripts/download_artifacts.py
+++ b/scripts/download_artifacts.py
@@ -194,6 +194,17 @@ def _verify_run_log(run_log: Path) -> None:
             raise ValueError(f"artifact checksum mismatch: {relative}")
 
     registry = run_log / "registry.db"
+    # A bundle that ships an uncheckpointed write-ahead log cannot be read correctly once it is
+    # installed: the tree is left unwritable, so `mode=ro` cannot create the `-shm` sidecar it
+    # needs to replay the log, and `immutable=1` reads the pre-WAL main file instead - which can
+    # be missing the tables entirely. Neither the checksums nor the integrity check below would
+    # notice, because both describe the files as shipped. Refuse the bundle instead.
+    wal = registry.with_name(registry.name + "-wal")
+    if wal.is_file() and wal.stat().st_size > 0:
+        raise ValueError("Bundle ships an uncheckpointed registry write-ahead log")
+
+    # Nothing is writing this tree - it was just extracted and checksum-verified - so the
+    # integrity check reads the main file directly.
     uri = f"file:{registry.resolve()}?mode=ro&immutable=1"
     with sqlite3.connect(uri, uri=True) as connection:
         integrity = connection.execute("PRAGMA integrity_check").fetchone()

--- a/tests/test_download_artifacts.py
+++ b/tests/test_download_artifacts.py
@@ -7,9 +7,12 @@ import importlib.util
 import sqlite3
 import stat
 import tarfile
+from contextlib import closing
 from pathlib import Path
 
 import pytest
+
+from utils.paths import registry_readonly_uri
 
 SCRIPT_PATH = Path(__file__).resolve().parents[1] / "scripts" / "download_artifacts.py"
 SPEC = importlib.util.spec_from_file_location("download_artifacts", SCRIPT_PATH)
@@ -26,15 +29,29 @@ def _sha256(path: Path) -> str:
     return digest.hexdigest()
 
 
-def _build_bundle(tmp_path: Path, *, valid_manifest: bool = True) -> Path:
+def _build_bundle(
+    tmp_path: Path,
+    *,
+    valid_manifest: bool = True,
+    wal: bool = False,
+    ship_wal: bool = False,
+) -> Path:
+    """Build one bundle. `wal` writes the registry the way the case studies do."""
     run_log = tmp_path / "payload/case_studies/etfs/run_log"
     prediction = run_log / "predictions/abc/predictions.parquet"
     prediction.parent.mkdir(parents=True)
     prediction.write_bytes(b"stored predictions")
 
-    with sqlite3.connect(run_log / "registry.db") as connection:
-        connection.execute("CREATE TABLE release_probe (value TEXT NOT NULL)")
-        connection.execute("INSERT INTO release_probe VALUES ('accepted')")
+    connection = sqlite3.connect(run_log / "registry.db")
+    if wal:
+        connection.execute("PRAGMA journal_mode=WAL")
+    connection.execute("CREATE TABLE release_probe (value TEXT NOT NULL)")
+    connection.execute("INSERT INTO release_probe VALUES ('accepted')")
+    connection.commit()
+    if not ship_wal:
+        # Closing checkpoints the log and removes the sidecars, which is what a bundle must
+        # ship: the installed tree is unwritable, so nothing can replay a log afterwards.
+        connection.close()
 
     release_dir = run_log / ".release"
     release_dir.mkdir()
@@ -50,6 +67,8 @@ def _build_bundle(tmp_path: Path, *, valid_manifest: bool = True) -> Path:
     archive = tmp_path / "etfs.tar.gz"
     with tarfile.open(archive, "w:gz") as tar:
         tar.add(tmp_path / "payload/case_studies", arcname="case_studies")
+    if ship_wal:
+        connection.close()
     return archive
 
 
@@ -109,3 +128,40 @@ def test_verified_bundle_replaces_baseline_atomically(tmp_path: Path) -> None:
     assert not (existing / "registry.db").stat().st_mode & stat.S_IWUSR
     with sqlite3.connect(existing / "registry.db") as connection:
         assert connection.execute("SELECT value FROM release_probe").fetchone() == ("accepted",)
+
+
+def test_a_wal_mode_bundle_is_readable_once_it_is_installed(tmp_path: Path) -> None:
+    """The installed tree is unwritable, where a WAL read needs the -shm it cannot create."""
+    archive = _build_bundle(tmp_path, wal=True)
+
+    installed = download_artifacts.install_artifact_archive(
+        archive,
+        "etfs",
+        expected_sha256=_sha256(archive),
+        repo_root=tmp_path / "repo",
+        force=True,
+    )
+
+    registry = installed / "registry.db"
+    assert not registry.stat().st_mode & stat.S_IWUSR
+    with closing(sqlite3.connect(registry_readonly_uri(registry), uri=True)) as connection:
+        assert connection.execute("SELECT value FROM release_probe").fetchone() == ("accepted",)
+
+
+def test_a_bundle_shipping_an_uncheckpointed_log_is_refused(tmp_path: Path) -> None:
+    """Installed, it would read as a database with no tables - or not open at all."""
+    archive = _build_bundle(tmp_path, wal=True, ship_wal=True)
+    existing = tmp_path / "repo/case_studies/etfs/run_log"
+    existing.mkdir(parents=True)
+    (existing / "sentinel").write_text("keep")
+
+    with pytest.raises(ValueError, match="uncheckpointed"):
+        download_artifacts.install_artifact_archive(
+            archive,
+            "etfs",
+            expected_sha256=_sha256(archive),
+            repo_root=tmp_path / "repo",
+            force=True,
+        )
+
+    assert (existing / "sentinel").read_text() == "keep"

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -315,6 +315,17 @@ class TestRegistryReadonlyUri:
         ):
             reader.execute("INSERT INTO training_runs VALUES ('gbm')")
 
+    def test_a_question_mark_in_the_path_is_not_read_as_uri_syntax(self, tmp_path: Path) -> None:
+        """A raw f-string would end the path at the `?` and open a different file, or none."""
+        awkward = tmp_path / "run?log#1"
+        awkward.mkdir()
+        registry = _wal_registry(awkward)
+
+        with closing(sqlite3.connect(registry_readonly_uri(registry), uri=True)) as reader:
+            names = {row[0] for row in reader.execute("SELECT config_name FROM training_runs")}
+
+        assert names == {"ols"}
+
     def test_an_installed_bundle_is_readable_from_an_unwritable_tree(self, tmp_path: Path) -> None:
         """A WAL reader must create the -shm sidecar unless told the file cannot change."""
         run_log = tmp_path / "run_log"

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -8,6 +8,9 @@ to avoid overwriting production artifacts during tests.
 
 from __future__ import annotations
 
+import sqlite3
+import stat
+from contextlib import closing
 from pathlib import Path
 
 import pytest
@@ -20,6 +23,7 @@ from utils.paths import (
     get_case_study_dir,
     get_chapter_dir,
     get_output_dir,
+    registry_readonly_uri,
     require_chapter_inputs,
 )
 
@@ -264,3 +268,65 @@ class TestRequireChapterInputs:
         messages.mkdir()
 
         require_chapter_inputs({messages: "01_itch_parser"})
+
+
+# -----------------------------------------------------------------------------
+# registry_readonly_uri
+# -----------------------------------------------------------------------------
+
+
+def _wal_registry(directory: Path) -> Path:
+    """Write a WAL-mode registry with one committed row, as the case studies do."""
+    path = directory / "registry.db"
+    with closing(sqlite3.connect(path)) as db:
+        db.execute("PRAGMA journal_mode=WAL")
+        db.execute("CREATE TABLE training_runs (config_name TEXT)")
+        db.execute("INSERT INTO training_runs VALUES ('ols')")
+        db.commit()
+    return path
+
+
+def _unwritable(directory: Path) -> None:
+    """Strip the write bits the way scripts/download_artifacts.py installs a bundle."""
+    for path in [directory, *directory.rglob("*")]:
+        path.chmod(path.stat().st_mode & ~(stat.S_IWUSR | stat.S_IWGRP | stat.S_IWOTH))
+
+
+class TestRegistryReadonlyUri:
+    def test_a_live_registry_is_read_through_the_write_ahead_log(self, tmp_path: Path) -> None:
+        """A row committed after the reader connects is in the -wal file, not the main file."""
+        registry = _wal_registry(tmp_path)
+        with closing(sqlite3.connect(registry)) as writer:
+            reader = sqlite3.connect(registry_readonly_uri(registry), uri=True)
+            with closing(reader):
+                writer.execute("INSERT INTO training_runs VALUES ('ridge')")
+                writer.commit()
+
+                names = {row[0] for row in reader.execute("SELECT config_name FROM training_runs")}
+
+        assert names == {"ols", "ridge"}
+
+    def test_a_live_registry_connection_cannot_write(self, tmp_path: Path) -> None:
+        registry = _wal_registry(tmp_path)
+
+        with (
+            closing(sqlite3.connect(registry_readonly_uri(registry), uri=True)) as reader,
+            pytest.raises(sqlite3.OperationalError),
+        ):
+            reader.execute("INSERT INTO training_runs VALUES ('gbm')")
+
+    def test_an_installed_bundle_is_readable_from_an_unwritable_tree(self, tmp_path: Path) -> None:
+        """A WAL reader must create the -shm sidecar unless told the file cannot change."""
+        run_log = tmp_path / "run_log"
+        run_log.mkdir()
+        registry = _wal_registry(run_log)
+        _unwritable(run_log)
+
+        try:
+            with closing(sqlite3.connect(registry_readonly_uri(registry), uri=True)) as reader:
+                names = {row[0] for row in reader.execute("SELECT config_name FROM training_runs")}
+        finally:
+            for path in [run_log, *run_log.rglob("*")]:
+                path.chmod(path.stat().st_mode | stat.S_IWUSR)
+
+        assert names == {"ols"}

--- a/utils/paths.py
+++ b/utils/paths.py
@@ -362,6 +362,34 @@ def get_case_study_dir(strategy_id: str, *, create: bool = True) -> Path:
 
 
 # =============================================================================
+# Registry access
+# =============================================================================
+
+
+def registry_readonly_uri(registry: Path | str) -> str:
+    """Build a read-only SQLite URI for a case-study registry.
+
+    ``mode=ro`` is what makes the connection read-only. ``immutable=1`` promises SQLite
+    something else - that the file cannot change while it is open - and on that promise it
+    skips locking and never opens the ``-wal`` sidecar, so it reads whatever the main file
+    held before the most recent commits.
+
+    The promise is true of exactly one registry: one that ``scripts/download_artifacts.py``
+    installed, which verifies the bundle against its manifest and then leaves the whole
+    ``run_log`` tree unwritable. There the flag is also required, because the registries are
+    WAL-mode and a WAL reader has to create the ``-shm`` sidecar unless it is told the file
+    cannot change; without it the first query raises ``attempt to write a readonly database``.
+    So the flag is decided by whether anything can still write to the directory, which is the
+    same condition that makes the promise true.
+    """
+    path = Path(registry).resolve()
+    uri = f"file:{path}?mode=ro"
+    if not os.access(path.parent, os.W_OK):
+        uri += "&immutable=1"
+    return uri
+
+
+# =============================================================================
 # Dataset IDs (Tier 2 naming)
 # =============================================================================
 
@@ -424,6 +452,7 @@ __all__ = [
     "get_chapter_dir",
     "get_output_dir",
     "get_case_study_dir",
+    "registry_readonly_uri",
     # Constants
     "CH01",
     "CH02",

--- a/utils/paths.py
+++ b/utils/paths.py
@@ -383,7 +383,9 @@ def registry_readonly_uri(registry: Path | str) -> str:
     same condition that makes the promise true.
     """
     path = Path(registry).resolve()
-    uri = f"file:{path}?mode=ro"
+    # `as_uri()` percent-encodes the path. Interpolating it raw would let a checkout whose
+    # path contains `?` or `#` be read as URI syntax and open some other file, or none.
+    uri = f"{path.as_uri()}?mode=ro"
     if not os.access(path.parent, os.W_OK):
         uri += "&immutable=1"
     return uri


### PR DESCRIPTION
Codex came back on quota today, so I re-reviewed the three merged band-g PRs (#935, #936, #937) under it. It found two real defects in that merged work. Both are fixed here, and a third fell out of reproducing the first.

## `immutable=1` is a property of the directory, not of the notebook

#937 dropped `immutable=1` from the notebooks that read a case-study registry, for a real reason: the flag promises SQLite the file cannot change, so it skips locking, never opens the `-wal` sidecar, and reads whatever the main file held before the most recent commits. Against a registry a sweep is writing, that is a stale row or a table that appears not to exist.

It broke the one case where the flag is right. `scripts/download_artifacts.py` verifies a bundle against its manifest and then leaves the whole `run_log` tree unwritable. The registries are WAL-mode, and a WAL reader has to create the `-shm` sidecar unless it is told the file cannot change, so on a downloaded bundle `mode=ro` alone raises on the first query.

`utils.paths.registry_readonly_uri` decides the flag from whether anything can still write to the directory, which is the same condition that makes the promise true. `25_live_trading/02`, `25_live_trading/06` and `26_mlops_governance/03` call it.

Measured on SQLite 3.45.1, an unwritable tree:

| bundle contents | `mode=ro` | `mode=ro&immutable=1` |
|---|---|---|
| checkpointed db, no sidecars | `attempt to write a readonly database` | reads |
| db + non-empty `-wal` + `-shm` | reads | `no such table` |
| db + non-empty `-wal`, no `-shm` | `unable to open database file` | `no such table` |

## A bundle that ships an uncheckpointed log is broken either way

Rows two and three of that table have no good URI. Nothing catches it today: the manifest checksums describe the files as shipped, and `_verify_run_log`'s integrity check runs on an immutable connection, so it certifies the pre-WAL main file. `_verify_run_log` now refuses a bundle whose registry ships a non-empty `-wal`.

## ch24/08 drew one carried value with a live weight and its neighbours with a recorded one

The stage-contribution line joins three carried probabilities, and the middle one - post-debate - is the only one no stage stores. It was rebuilt from the aggregate and the debate midpoint using the current `DEBATE_WEIGHT`, while the points either side came from the pinned capture.

Replay is the default path, and the Settings prose names those weights as the numbers to argue with. Changing one recomputes a single point of the line: at `DEBATE_WEIGHT = 0.8` the recession question draws a post-debate value of 0.2633 against a recorded final of 0.175, reversing the supervisor adjustment the figure exists to show.

A live capture now records both blend weights in its params and a replay reads them back. The two committed captures predate that and fall back to the values in use when they were taken; `carried_probabilities` re-derives each capture's recorded final from its own parts and raises if the fallback does not reproduce it. Both reproduce exactly, and a wrong fallback fails the run with the mismatch named.

## Verification

- Five new tests, each checked against the implementations they are meant to reject: always-immutable misses a row committed after the reader connects; never-immutable cannot open an unwritable tree; no `-wal` guard lets the broken bundle install; a raw f-string URI breaks on a path containing `?` or `#`.
- The ch24 guard was checked by a real run with the fallback perturbed: exit 1, `Rebuilt final probability 0.2300 does not match the recorded 0.1750`.
- All four notebooks re-executed in the canonical environment. `26_mlops_governance/03`'s outputs are byte-identical; the two chapter 25 notebooks differ only in timestamps.
- `nbcheck` and `check_notebook_prose` clean on all four.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VEtXvNk14uZckwswthVihc
