### PR TITLE
ch15/10: the integrity check and the read shared a stale snapshot

### DIFF
--- a/15_causal_estimation/10_case_study_insights.ipynb
+++ b/15_causal_estimation/10_case_study_insights.ipynb
@@ -2,13 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "7010cbe6",
+   "id": "28177d0d",
    "metadata": {
     "papermill": {
-     "duration": 0.003646,
-     "end_time": "2026-09-11T00:09:03.968618+00:00",
+     "duration": 0.003748,
+     "end_time": "2026-09-11T05:11:10.805131+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:09:03.964972+00:00",
+     "start_time": "2026-09-11T05:11:10.801383+00:00",
      "status": "completed"
     }
    },
@@ -39,19 +39,19 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "f46cbc16",
+   "id": "265c8fe5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:09:03.974065Z",
-     "iopub.status.busy": "2026-09-11T00:09:03.973782Z",
-     "iopub.status.idle": "2026-09-11T00:09:08.275194Z",
-     "shell.execute_reply": "2026-09-11T00:09:08.274465Z"
+     "iopub.execute_input": "2026-09-11T05:11:10.812852Z",
+     "iopub.status.busy": "2026-09-11T05:11:10.812635Z",
+     "iopub.status.idle": "2026-09-11T05:11:15.229502Z",
+     "shell.execute_reply": "2026-09-11T05:11:15.228879Z"
     },
     "papermill": {
-     "duration": 4.305198,
-     "end_time": "2026-09-11T00:09:08.275921+00:00",
+     "duration": 4.421639,
+     "end_time": "2026-09-11T05:11:15.230145+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:09:03.970723+00:00",
+     "start_time": "2026-09-11T05:11:10.808506+00:00",
      "status": "completed"
     }
    },
@@ -76,25 +76,26 @@
     "    SHORT_NAMES,\n",
     "    registry_path,\n",
     ")\n",
+    "from utils.paths import registry_readonly_uri\n",
     "from utils.style import COLORS, add_message_title, show_with_alt"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "18624cf0",
+   "id": "a306cb6e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:09:08.280571Z",
-     "iopub.status.busy": "2026-09-11T00:09:08.280397Z",
-     "iopub.status.idle": "2026-09-11T00:09:08.282914Z",
-     "shell.execute_reply": "2026-09-11T00:09:08.282349Z"
+     "iopub.execute_input": "2026-09-11T05:11:15.234805Z",
+     "iopub.status.busy": "2026-09-11T05:11:15.234557Z",
+     "iopub.status.idle": "2026-09-11T05:11:15.236731Z",
+     "shell.execute_reply": "2026-09-11T05:11:15.236386Z"
     },
     "papermill": {
-     "duration": 0.005819,
-     "end_time": "2026-09-11T00:09:08.283661+00:00",
+     "duration": 0.005117,
+     "end_time": "2026-09-11T05:11:15.237279+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:09:08.277842+00:00",
+     "start_time": "2026-09-11T05:11:15.232162+00:00",
      "status": "completed"
     },
     "tags": [
@@ -108,13 +109,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c308b3e6",
+   "id": "60a07421",
    "metadata": {
     "papermill": {
-     "duration": 0.002372,
-     "end_time": "2026-09-11T00:09:08.288451+00:00",
+     "duration": 0.001276,
+     "end_time": "2026-09-11T05:11:15.240956+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:09:08.286079+00:00",
+     "start_time": "2026-09-11T05:11:15.239680+00:00",
      "status": "completed"
     }
    },
@@ -129,19 +130,19 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "8df72504",
+   "id": "f7e4226a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:09:08.292935Z",
-     "iopub.status.busy": "2026-09-11T00:09:08.292728Z",
-     "iopub.status.idle": "2026-09-11T00:09:08.295645Z",
-     "shell.execute_reply": "2026-09-11T00:09:08.295161Z"
+     "iopub.execute_input": "2026-09-11T05:11:15.244500Z",
+     "iopub.status.busy": "2026-09-11T05:11:15.244388Z",
+     "iopub.status.idle": "2026-09-11T05:11:15.246383Z",
+     "shell.execute_reply": "2026-09-11T05:11:15.246082Z"
     },
     "papermill": {
-     "duration": 0.005879,
-     "end_time": "2026-09-11T00:09:08.296103+00:00",
+     "duration": 0.004294,
+     "end_time": "2026-09-11T05:11:15.246605+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:09:08.290224+00:00",
+     "start_time": "2026-09-11T05:11:15.242311+00:00",
      "status": "completed"
     }
    },
@@ -164,14 +165,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "63894fec",
+   "id": "ec6812b8",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.001782,
-     "end_time": "2026-09-11T00:09:08.299911+00:00",
+     "duration": 0.001607,
+     "end_time": "2026-09-11T05:11:15.249557+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:09:08.298129+00:00",
+     "start_time": "2026-09-11T05:11:15.247950+00:00",
      "status": "completed"
     }
    },
@@ -191,39 +192,47 @@
     "condition alone, so it would admit a row written under an older identity version or at a\n",
     "preview tier. On the registries as they stand the two rules select the same rows.\n",
     "`current_causal_identities` in `case_studies/utils/registry/store.py` is the authority, and\n",
-    "a reader who needs the full rule should call it rather than copy the query below."
+    "a reader who needs the full rule should call it rather than copy the query below.\n",
+    "\n",
+    "The connection is read-only, and `registry_readonly_uri` decides whether it may also be\n",
+    "immutable. `immutable=1` promises SQLite the file cannot change while it is open, which lets\n",
+    "it skip locking and never open the write-ahead log. That is false of a case directory a sweep\n",
+    "is writing, and here it would be doubly wrong: the integrity check below runs on the same\n",
+    "connection, so it would certify the pre-WAL main file and the query would then read the same\n",
+    "stale snapshot the check had just approved. The promise does hold for a downloaded artifact\n",
+    "bundle, whose tree is left unwritable, and there the flag is what lets a WAL reader open the\n",
+    "file at all."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "9e98d080",
+   "id": "d5454c5d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:09:08.304981Z",
-     "iopub.status.busy": "2026-09-11T00:09:08.304800Z",
-     "iopub.status.idle": "2026-09-11T00:09:08.308826Z",
-     "shell.execute_reply": "2026-09-11T00:09:08.308315Z"
+     "iopub.execute_input": "2026-09-11T05:11:15.253572Z",
+     "iopub.status.busy": "2026-09-11T05:11:15.253459Z",
+     "iopub.status.idle": "2026-09-11T05:11:15.256704Z",
+     "shell.execute_reply": "2026-09-11T05:11:15.256164Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.007206,
-     "end_time": "2026-09-11T00:09:08.309368+00:00",
+     "duration": 0.005812,
+     "end_time": "2026-09-11T05:11:15.257157+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:09:08.302162+00:00",
+     "start_time": "2026-09-11T05:11:15.251345+00:00",
      "status": "completed"
     }
    },
    "outputs": [],
    "source": [
     "def _load_causal_runs(case_study: str) -> pl.DataFrame:\n",
-    "    \"\"\"Load one immutable causal row per label from a case-study registry.\"\"\"\n",
+    "    \"\"\"Load the current causal row per label from a case-study registry.\"\"\"\n",
     "    db_path = registry_path(case_study).resolve()\n",
     "    if not db_path.is_file():\n",
     "        raise FileNotFoundError(f\"Missing registry for {case_study}: {db_path}\")\n",
     "\n",
-    "    uri = f\"file:{db_path}?mode=ro&immutable=1\"\n",
-    "    with sqlite3.connect(uri, uri=True) as connection:\n",
+    "    with sqlite3.connect(registry_readonly_uri(db_path), uri=True) as connection:\n",
     "        connection.row_factory = sqlite3.Row\n",
     "        integrity = connection.execute(\"PRAGMA integrity_check\").fetchone()[0]\n",
     "        if integrity != \"ok\":\n",
@@ -251,14 +260,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "90130506",
+   "id": "c61997db",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.001676,
-     "end_time": "2026-09-11T00:09:08.312954+00:00",
+     "duration": 0.001329,
+     "end_time": "2026-09-11T05:11:15.261089+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:09:08.311278+00:00",
+     "start_time": "2026-09-11T05:11:15.259760+00:00",
      "status": "completed"
     }
    },
@@ -270,19 +279,19 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "7985badc",
+   "id": "a175b4a2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:09:08.317649Z",
-     "iopub.status.busy": "2026-09-11T00:09:08.317474Z",
-     "iopub.status.idle": "2026-09-11T00:09:08.322685Z",
-     "shell.execute_reply": "2026-09-11T00:09:08.321994Z"
+     "iopub.execute_input": "2026-09-11T05:11:15.264201Z",
+     "iopub.status.busy": "2026-09-11T05:11:15.264104Z",
+     "iopub.status.idle": "2026-09-11T05:11:15.266774Z",
+     "shell.execute_reply": "2026-09-11T05:11:15.266515Z"
     },
     "papermill": {
-     "duration": 0.00851,
-     "end_time": "2026-09-11T00:09:08.323198+00:00",
+     "duration": 0.00501,
+     "end_time": "2026-09-11T05:11:15.267364+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:09:08.314688+00:00",
+     "start_time": "2026-09-11T05:11:15.262354+00:00",
      "status": "completed"
     }
    },
@@ -314,13 +323,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1c4583fa",
+   "id": "17a84936",
    "metadata": {
     "papermill": {
-     "duration": 0.001657,
-     "end_time": "2026-09-11T00:09:08.326817+00:00",
+     "duration": 0.001301,
+     "end_time": "2026-09-11T05:11:15.270174+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:09:08.325160+00:00",
+     "start_time": "2026-09-11T05:11:15.268873+00:00",
      "status": "completed"
     }
    },
@@ -335,19 +344,19 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "d19734eb",
+   "id": "025d310e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:09:08.331261Z",
-     "iopub.status.busy": "2026-09-11T00:09:08.331083Z",
-     "iopub.status.idle": "2026-09-11T00:09:11.754764Z",
-     "shell.execute_reply": "2026-09-11T00:09:11.754026Z"
+     "iopub.execute_input": "2026-09-11T05:11:15.273835Z",
+     "iopub.status.busy": "2026-09-11T05:11:15.273690Z",
+     "iopub.status.idle": "2026-09-11T05:11:17.814700Z",
+     "shell.execute_reply": "2026-09-11T05:11:17.814364Z"
     },
     "papermill": {
-     "duration": 3.426999,
-     "end_time": "2026-09-11T00:09:11.755425+00:00",
+     "duration": 2.543773,
+     "end_time": "2026-09-11T05:11:17.815296+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:09:08.328426+00:00",
+     "start_time": "2026-09-11T05:11:15.271523+00:00",
      "status": "completed"
     }
    },
@@ -395,19 +404,19 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "fbcca94f",
+   "id": "a47d4a06",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:09:11.760621Z",
-     "iopub.status.busy": "2026-09-11T00:09:11.760488Z",
-     "iopub.status.idle": "2026-09-11T00:09:11.765361Z",
-     "shell.execute_reply": "2026-09-11T00:09:11.764864Z"
+     "iopub.execute_input": "2026-09-11T05:11:17.823329Z",
+     "iopub.status.busy": "2026-09-11T05:11:17.823183Z",
+     "iopub.status.idle": "2026-09-11T05:11:17.828927Z",
+     "shell.execute_reply": "2026-09-11T05:11:17.828306Z"
     },
     "papermill": {
-     "duration": 0.008194,
-     "end_time": "2026-09-11T00:09:11.765972+00:00",
+     "duration": 0.010068,
+     "end_time": "2026-09-11T05:11:17.829489+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:09:11.757778+00:00",
+     "start_time": "2026-09-11T05:11:17.819421+00:00",
      "status": "completed"
     }
    },
@@ -465,13 +474,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fcbb4fa6",
+   "id": "c33f97f0",
    "metadata": {
     "papermill": {
-     "duration": 0.001664,
-     "end_time": "2026-09-11T00:09:11.770370+00:00",
+     "duration": 0.001454,
+     "end_time": "2026-09-11T05:11:17.833909+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:09:11.768706+00:00",
+     "start_time": "2026-09-11T05:11:17.832455+00:00",
      "status": "completed"
     }
    },
@@ -482,13 +491,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3d3d273d",
+   "id": "eeed4a17",
    "metadata": {
     "papermill": {
-     "duration": 0.001543,
-     "end_time": "2026-09-11T00:09:11.773683+00:00",
+     "duration": 0.00137,
+     "end_time": "2026-09-11T05:11:17.836721+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:09:11.772140+00:00",
+     "start_time": "2026-09-11T05:11:17.835351+00:00",
      "status": "completed"
     }
    },
@@ -503,19 +512,19 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "8c82cd85",
+   "id": "644553be",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:09:11.777913Z",
-     "iopub.status.busy": "2026-09-11T00:09:11.777722Z",
-     "iopub.status.idle": "2026-09-11T00:09:11.780880Z",
-     "shell.execute_reply": "2026-09-11T00:09:11.780540Z"
+     "iopub.execute_input": "2026-09-11T05:11:17.841354Z",
+     "iopub.status.busy": "2026-09-11T05:11:17.841093Z",
+     "iopub.status.idle": "2026-09-11T05:11:17.845129Z",
+     "shell.execute_reply": "2026-09-11T05:11:17.844551Z"
     },
     "papermill": {
-     "duration": 0.006213,
-     "end_time": "2026-09-11T00:09:11.781509+00:00",
+     "duration": 0.007281,
+     "end_time": "2026-09-11T05:11:17.845580+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:09:11.775296+00:00",
+     "start_time": "2026-09-11T05:11:17.838299+00:00",
      "status": "completed"
     }
    },
@@ -534,19 +543,19 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "27bb5429",
+   "id": "7cfe0b6d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:09:11.786479Z",
-     "iopub.status.busy": "2026-09-11T00:09:11.786321Z",
-     "iopub.status.idle": "2026-09-11T00:09:11.790702Z",
-     "shell.execute_reply": "2026-09-11T00:09:11.790151Z"
+     "iopub.execute_input": "2026-09-11T05:11:17.853717Z",
+     "iopub.status.busy": "2026-09-11T05:11:17.853516Z",
+     "iopub.status.idle": "2026-09-11T05:11:17.857727Z",
+     "shell.execute_reply": "2026-09-11T05:11:17.857136Z"
     },
     "papermill": {
-     "duration": 0.007921,
-     "end_time": "2026-09-11T00:09:11.791448+00:00",
+     "duration": 0.007852,
+     "end_time": "2026-09-11T05:11:17.858174+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:09:11.783527+00:00",
+     "start_time": "2026-09-11T05:11:17.850322+00:00",
      "status": "completed"
     }
    },
@@ -606,19 +615,19 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "f7863193",
+   "id": "32d19879",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:09:11.796039Z",
-     "iopub.status.busy": "2026-09-11T00:09:11.795918Z",
-     "iopub.status.idle": "2026-09-11T00:09:11.951096Z",
-     "shell.execute_reply": "2026-09-11T00:09:11.950633Z"
+     "iopub.execute_input": "2026-09-11T05:11:17.864826Z",
+     "iopub.status.busy": "2026-09-11T05:11:17.864670Z",
+     "iopub.status.idle": "2026-09-11T05:11:17.982968Z",
+     "shell.execute_reply": "2026-09-11T05:11:17.982256Z"
     },
     "papermill": {
-     "duration": 0.157949,
-     "end_time": "2026-09-11T00:09:11.951454+00:00",
+     "duration": 0.12199,
+     "end_time": "2026-09-11T05:11:17.983453+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:09:11.793505+00:00",
+     "start_time": "2026-09-11T05:11:17.861463+00:00",
      "status": "completed"
     }
    },
@@ -684,19 +693,19 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "635a970a",
+   "id": "073d7e7f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:09:11.956512Z",
-     "iopub.status.busy": "2026-09-11T00:09:11.956387Z",
-     "iopub.status.idle": "2026-09-11T00:09:11.959745Z",
-     "shell.execute_reply": "2026-09-11T00:09:11.959280Z"
+     "iopub.execute_input": "2026-09-11T05:11:17.991085Z",
+     "iopub.status.busy": "2026-09-11T05:11:17.990916Z",
+     "iopub.status.idle": "2026-09-11T05:11:17.994818Z",
+     "shell.execute_reply": "2026-09-11T05:11:17.994262Z"
     },
     "papermill": {
-     "duration": 0.006377,
-     "end_time": "2026-09-11T00:09:11.960023+00:00",
+     "duration": 0.008288,
+     "end_time": "2026-09-11T05:11:17.995296+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:09:11.953646+00:00",
+     "start_time": "2026-09-11T05:11:17.987008+00:00",
      "status": "completed"
     }
    },
@@ -728,13 +737,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "21848ac2",
+   "id": "b0274c7a",
    "metadata": {
     "papermill": {
-     "duration": 0.001833,
-     "end_time": "2026-09-11T00:09:11.963959+00:00",
+     "duration": 0.001852,
+     "end_time": "2026-09-11T05:11:17.999456+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:09:11.962126+00:00",
+     "start_time": "2026-09-11T05:11:17.997604+00:00",
      "status": "completed"
     }
    },
@@ -756,19 +765,19 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "b29bea9f",
+   "id": "ba7fb37b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:09:11.968468Z",
-     "iopub.status.busy": "2026-09-11T00:09:11.968316Z",
-     "iopub.status.idle": "2026-09-11T00:09:11.973528Z",
-     "shell.execute_reply": "2026-09-11T00:09:11.972916Z"
+     "iopub.execute_input": "2026-09-11T05:11:18.004185Z",
+     "iopub.status.busy": "2026-09-11T05:11:18.003730Z",
+     "iopub.status.idle": "2026-09-11T05:11:18.010747Z",
+     "shell.execute_reply": "2026-09-11T05:11:18.010236Z"
     },
     "papermill": {
-     "duration": 0.008167,
-     "end_time": "2026-09-11T00:09:11.973904+00:00",
+     "duration": 0.010016,
+     "end_time": "2026-09-11T05:11:18.011217+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:09:11.965737+00:00",
+     "start_time": "2026-09-11T05:11:18.001201+00:00",
      "status": "completed"
     }
    },
@@ -792,19 +801,19 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "988012b1",
+   "id": "5d3d9494",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:09:11.979401Z",
-     "iopub.status.busy": "2026-09-11T00:09:11.979205Z",
-     "iopub.status.idle": "2026-09-11T00:09:12.136827Z",
-     "shell.execute_reply": "2026-09-11T00:09:12.136434Z"
+     "iopub.execute_input": "2026-09-11T05:11:18.018784Z",
+     "iopub.status.busy": "2026-09-11T05:11:18.018619Z",
+     "iopub.status.idle": "2026-09-11T05:11:18.102548Z",
+     "shell.execute_reply": "2026-09-11T05:11:18.102008Z"
     },
     "papermill": {
-     "duration": 0.16099,
-     "end_time": "2026-09-11T00:09:12.137265+00:00",
+     "duration": 0.088454,
+     "end_time": "2026-09-11T05:11:18.103112+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:09:11.976275+00:00",
+     "start_time": "2026-09-11T05:11:18.014658+00:00",
      "status": "completed"
     }
    },
@@ -859,19 +868,19 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "id": "db2ef706",
+   "id": "01530d0d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:09:12.143352Z",
-     "iopub.status.busy": "2026-09-11T00:09:12.143231Z",
-     "iopub.status.idle": "2026-09-11T00:09:12.146171Z",
-     "shell.execute_reply": "2026-09-11T00:09:12.145827Z"
+     "iopub.execute_input": "2026-09-11T05:11:18.107811Z",
+     "iopub.status.busy": "2026-09-11T05:11:18.107657Z",
+     "iopub.status.idle": "2026-09-11T05:11:18.111244Z",
+     "shell.execute_reply": "2026-09-11T05:11:18.110888Z"
     },
     "papermill": {
-     "duration": 0.00638,
-     "end_time": "2026-09-11T00:09:12.146532+00:00",
+     "duration": 0.006395,
+     "end_time": "2026-09-11T05:11:18.111650+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:09:12.140152+00:00",
+     "start_time": "2026-09-11T05:11:18.105255+00:00",
      "status": "completed"
     }
    },
@@ -920,19 +929,19 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "id": "b90ea62f",
+   "id": "eea68266",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:09:12.151913Z",
-     "iopub.status.busy": "2026-09-11T00:09:12.151788Z",
-     "iopub.status.idle": "2026-09-11T00:09:12.155549Z",
-     "shell.execute_reply": "2026-09-11T00:09:12.154808Z"
+     "iopub.execute_input": "2026-09-11T05:11:18.116493Z",
+     "iopub.status.busy": "2026-09-11T05:11:18.116340Z",
+     "iopub.status.idle": "2026-09-11T05:11:18.119963Z",
+     "shell.execute_reply": "2026-09-11T05:11:18.119586Z"
     },
     "papermill": {
-     "duration": 0.007087,
-     "end_time": "2026-09-11T00:09:12.155911+00:00",
+     "duration": 0.006631,
+     "end_time": "2026-09-11T05:11:18.120280+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:09:12.148824+00:00",
+     "start_time": "2026-09-11T05:11:18.113649+00:00",
      "status": "completed"
     }
    },
@@ -965,13 +974,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dc9cefd5",
+   "id": "4c571195",
    "metadata": {
     "papermill": {
-     "duration": 0.002163,
-     "end_time": "2026-09-11T00:09:12.160554+00:00",
+     "duration": 0.002906,
+     "end_time": "2026-09-11T05:11:18.125256+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:09:12.158391+00:00",
+     "start_time": "2026-09-11T05:11:18.122350+00:00",
      "status": "completed"
     }
    },
@@ -1017,19 +1026,19 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "id": "ec249759",
+   "id": "cf2b1e5d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:09:12.165761Z",
-     "iopub.status.busy": "2026-09-11T00:09:12.165624Z",
-     "iopub.status.idle": "2026-09-11T00:09:12.171156Z",
-     "shell.execute_reply": "2026-09-11T00:09:12.170571Z"
+     "iopub.execute_input": "2026-09-11T05:11:18.132122Z",
+     "iopub.status.busy": "2026-09-11T05:11:18.131921Z",
+     "iopub.status.idle": "2026-09-11T05:11:18.138050Z",
+     "shell.execute_reply": "2026-09-11T05:11:18.137582Z"
     },
     "papermill": {
-     "duration": 0.009408,
-     "end_time": "2026-09-11T00:09:12.172089+00:00",
+     "duration": 0.009784,
+     "end_time": "2026-09-11T05:11:18.138383+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:09:12.162681+00:00",
+     "start_time": "2026-09-11T05:11:18.128599+00:00",
      "status": "completed"
     }
    },
@@ -1086,19 +1095,19 @@
   {
    "cell_type": "code",
    "execution_count": 17,
-   "id": "79d20ec9",
+   "id": "5aa289df",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:09:12.180520Z",
-     "iopub.status.busy": "2026-09-11T00:09:12.180377Z",
-     "iopub.status.idle": "2026-09-11T00:09:12.186468Z",
-     "shell.execute_reply": "2026-09-11T00:09:12.185958Z"
+     "iopub.execute_input": "2026-09-11T05:11:18.144261Z",
+     "iopub.status.busy": "2026-09-11T05:11:18.144059Z",
+     "iopub.status.idle": "2026-09-11T05:11:18.150275Z",
+     "shell.execute_reply": "2026-09-11T05:11:18.149789Z"
     },
     "papermill": {
-     "duration": 0.011019,
-     "end_time": "2026-09-11T00:09:12.187419+00:00",
+     "duration": 0.00956,
+     "end_time": "2026-09-11T05:11:18.150814+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:09:12.176400+00:00",
+     "start_time": "2026-09-11T05:11:18.141254+00:00",
      "status": "completed"
     }
    },
@@ -1125,19 +1134,19 @@
   {
    "cell_type": "code",
    "execution_count": 18,
-   "id": "e95d5623",
+   "id": "0892d3bc",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:09:12.194273Z",
-     "iopub.status.busy": "2026-09-11T00:09:12.193990Z",
-     "iopub.status.idle": "2026-09-11T00:09:12.296344Z",
-     "shell.execute_reply": "2026-09-11T00:09:12.295800Z"
+     "iopub.execute_input": "2026-09-11T05:11:18.159170Z",
+     "iopub.status.busy": "2026-09-11T05:11:18.158859Z",
+     "iopub.status.idle": "2026-09-11T05:11:18.281574Z",
+     "shell.execute_reply": "2026-09-11T05:11:18.279955Z"
     },
     "papermill": {
-     "duration": 0.106188,
-     "end_time": "2026-09-11T00:09:12.296869+00:00",
+     "duration": 0.130723,
+     "end_time": "2026-09-11T05:11:18.283846+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:09:12.190681+00:00",
+     "start_time": "2026-09-11T05:11:18.153123+00:00",
      "status": "completed"
     }
    },
@@ -1185,19 +1194,19 @@
   {
    "cell_type": "code",
    "execution_count": 19,
-   "id": "065ea5df",
+   "id": "90dec60f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:09:12.305294Z",
-     "iopub.status.busy": "2026-09-11T00:09:12.305013Z",
-     "iopub.status.idle": "2026-09-11T00:09:12.309312Z",
-     "shell.execute_reply": "2026-09-11T00:09:12.308748Z"
+     "iopub.execute_input": "2026-09-11T05:11:18.300496Z",
+     "iopub.status.busy": "2026-09-11T05:11:18.300109Z",
+     "iopub.status.idle": "2026-09-11T05:11:18.306813Z",
+     "shell.execute_reply": "2026-09-11T05:11:18.306139Z"
     },
     "papermill": {
-     "duration": 0.010071,
-     "end_time": "2026-09-11T00:09:12.310106+00:00",
+     "duration": 0.017004,
+     "end_time": "2026-09-11T05:11:18.307515+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:09:12.300035+00:00",
+     "start_time": "2026-09-11T05:11:18.290511+00:00",
      "status": "completed"
     }
    },
@@ -1233,13 +1242,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "36e791a9",
+   "id": "2b1b5e87",
    "metadata": {
     "papermill": {
-     "duration": 0.004544,
-     "end_time": "2026-09-11T00:09:12.319793+00:00",
+     "duration": 0.004798,
+     "end_time": "2026-09-11T05:11:18.318540+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:09:12.315249+00:00",
+     "start_time": "2026-09-11T05:11:18.313742+00:00",
      "status": "completed"
     }
    },
@@ -1252,13 +1261,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "df0f4e0c",
+   "id": "e692436b",
    "metadata": {
     "papermill": {
-     "duration": 0.003517,
-     "end_time": "2026-09-11T00:09:12.328406+00:00",
+     "duration": 0.004538,
+     "end_time": "2026-09-11T05:11:18.327994+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:09:12.324889+00:00",
+     "start_time": "2026-09-11T05:11:18.323456+00:00",
      "status": "completed"
     }
    },
@@ -1273,19 +1282,19 @@
   {
    "cell_type": "code",
    "execution_count": 20,
-   "id": "51fce9c8",
+   "id": "508954a0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:09:12.334548Z",
-     "iopub.status.busy": "2026-09-11T00:09:12.334413Z",
-     "iopub.status.idle": "2026-09-11T00:09:12.337242Z",
-     "shell.execute_reply": "2026-09-11T00:09:12.336769Z"
+     "iopub.execute_input": "2026-09-11T05:11:18.341028Z",
+     "iopub.status.busy": "2026-09-11T05:11:18.340728Z",
+     "iopub.status.idle": "2026-09-11T05:11:18.344717Z",
+     "shell.execute_reply": "2026-09-11T05:11:18.344017Z"
     },
     "papermill": {
-     "duration": 0.007022,
-     "end_time": "2026-09-11T00:09:12.337955+00:00",
+     "duration": 0.012062,
+     "end_time": "2026-09-11T05:11:18.345222+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:09:12.330933+00:00",
+     "start_time": "2026-09-11T05:11:18.333160+00:00",
      "status": "completed"
     }
    },
@@ -1313,19 +1322,19 @@
   {
    "cell_type": "code",
    "execution_count": 21,
-   "id": "9fb27e68",
+   "id": "d1728527",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:09:12.348001Z",
-     "iopub.status.busy": "2026-09-11T00:09:12.347875Z",
-     "iopub.status.idle": "2026-09-11T00:09:12.353601Z",
-     "shell.execute_reply": "2026-09-11T00:09:12.353234Z"
+     "iopub.execute_input": "2026-09-11T05:11:18.360027Z",
+     "iopub.status.busy": "2026-09-11T05:11:18.359773Z",
+     "iopub.status.idle": "2026-09-11T05:11:18.369795Z",
+     "shell.execute_reply": "2026-09-11T05:11:18.369140Z"
     },
     "papermill": {
-     "duration": 0.010647,
-     "end_time": "2026-09-11T00:09:12.353973+00:00",
+     "duration": 0.017712,
+     "end_time": "2026-09-11T05:11:18.370470+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:09:12.343326+00:00",
+     "start_time": "2026-09-11T05:11:18.352758+00:00",
      "status": "completed"
     }
    },
@@ -1387,19 +1396,19 @@
   {
    "cell_type": "code",
    "execution_count": 22,
-   "id": "80ceaa58",
+   "id": "3fbeb4ed",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:09:12.360289Z",
-     "iopub.status.busy": "2026-09-11T00:09:12.360174Z",
-     "iopub.status.idle": "2026-09-11T00:09:12.598292Z",
-     "shell.execute_reply": "2026-09-11T00:09:12.597576Z"
+     "iopub.execute_input": "2026-09-11T05:11:18.378716Z",
+     "iopub.status.busy": "2026-09-11T05:11:18.378511Z",
+     "iopub.status.idle": "2026-09-11T05:11:18.661110Z",
+     "shell.execute_reply": "2026-09-11T05:11:18.660702Z"
     },
     "papermill": {
-     "duration": 0.242371,
-     "end_time": "2026-09-11T00:09:12.599209+00:00",
+     "duration": 0.28682,
+     "end_time": "2026-09-11T05:11:18.661702+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:09:12.356838+00:00",
+     "start_time": "2026-09-11T05:11:18.374882+00:00",
      "status": "completed"
     }
    },
@@ -1462,19 +1471,19 @@
   {
    "cell_type": "code",
    "execution_count": 23,
-   "id": "1b92238e",
+   "id": "d676ee2e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:09:12.610496Z",
-     "iopub.status.busy": "2026-09-11T00:09:12.610354Z",
-     "iopub.status.idle": "2026-09-11T00:09:12.614190Z",
-     "shell.execute_reply": "2026-09-11T00:09:12.613738Z"
+     "iopub.execute_input": "2026-09-11T05:11:18.668431Z",
+     "iopub.status.busy": "2026-09-11T05:11:18.668286Z",
+     "iopub.status.idle": "2026-09-11T05:11:18.672069Z",
+     "shell.execute_reply": "2026-09-11T05:11:18.671663Z"
     },
     "papermill": {
-     "duration": 0.010367,
-     "end_time": "2026-09-11T00:09:12.614862+00:00",
+     "duration": 0.007431,
+     "end_time": "2026-09-11T05:11:18.672508+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:09:12.604495+00:00",
+     "start_time": "2026-09-11T05:11:18.665077+00:00",
      "status": "completed"
     }
    },
@@ -1530,19 +1539,19 @@
   {
    "cell_type": "code",
    "execution_count": 24,
-   "id": "a0d8b736",
+   "id": "566897ae",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:09:12.626484Z",
-     "iopub.status.busy": "2026-09-11T00:09:12.626351Z",
-     "iopub.status.idle": "2026-09-11T00:09:12.628863Z",
-     "shell.execute_reply": "2026-09-11T00:09:12.628545Z"
+     "iopub.execute_input": "2026-09-11T05:11:18.682506Z",
+     "iopub.status.busy": "2026-09-11T05:11:18.682384Z",
+     "iopub.status.idle": "2026-09-11T05:11:18.685670Z",
+     "shell.execute_reply": "2026-09-11T05:11:18.685152Z"
     },
     "papermill": {
-     "duration": 0.008885,
-     "end_time": "2026-09-11T00:09:12.629292+00:00",
+     "duration": 0.01106,
+     "end_time": "2026-09-11T05:11:18.686238+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:09:12.620407+00:00",
+     "start_time": "2026-09-11T05:11:18.675178+00:00",
      "status": "completed"
     }
    },
@@ -1574,13 +1583,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2772c19f",
+   "id": "d49cd75d",
    "metadata": {
     "papermill": {
-     "duration": 0.002513,
-     "end_time": "2026-09-11T00:09:12.634457+00:00",
+     "duration": 0.00231,
+     "end_time": "2026-09-11T05:11:18.691719+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:09:12.631944+00:00",
+     "start_time": "2026-09-11T05:11:18.689409+00:00",
      "status": "completed"
     }
    },
@@ -1594,19 +1603,19 @@
   {
    "cell_type": "code",
    "execution_count": 25,
-   "id": "12f10dc8",
+   "id": "33c23252",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T00:09:12.640504Z",
-     "iopub.status.busy": "2026-09-11T00:09:12.640395Z",
-     "iopub.status.idle": "2026-09-11T00:09:12.643412Z",
-     "shell.execute_reply": "2026-09-11T00:09:12.643079Z"
+     "iopub.execute_input": "2026-09-11T05:11:18.697341Z",
+     "iopub.status.busy": "2026-09-11T05:11:18.697233Z",
+     "iopub.status.idle": "2026-09-11T05:11:18.700625Z",
+     "shell.execute_reply": "2026-09-11T05:11:18.700152Z"
     },
     "papermill": {
-     "duration": 0.006578,
-     "end_time": "2026-09-11T00:09:12.643754+00:00",
+     "duration": 0.006904,
+     "end_time": "2026-09-11T05:11:18.700967+00:00",
      "exception": false,
-     "start_time": "2026-09-11T00:09:12.637176+00:00",
+     "start_time": "2026-09-11T05:11:18.694063+00:00",
      "status": "completed"
     }
    },
@@ -1689,25 +1698,24 @@
    "version": "3.14.3"
   },
   "ml4t_provenance": {
-   "executed_at": "2026-09-11T00:09:25.322695+00:00",
+   "executed_at": "2026-09-11T05:11:33.414261+00:00",
    "executor": "local-uv",
-   "library_digest": "3628fbf62ad3bacb051a40336273fcbf88b8abf7aa53d14c99619bddf3847f28",
+   "library_digest": "0bf241c642be0ba5ec75fa51aa0fef6e29cff294ab7051c744ff9315af202b38",
    "outputs_digest": "6ada83884b9b52135a8e9bcda4e75ab33b99bae56722ced9c6dced9d68bcb233",
    "parameters": {},
    "production": true,
-   "source_py_blob": "5b6a8226d4a8b5c78d54b7221d8766f9633d11ac",
-   "notes": "prose synced from the .py at 2026-09-11T00:18:19.570614+00:00 without re-executing; every code cell is identical to blob 89ed9e794dd6"
+   "source_py_blob": "d45821c69a4190c0f19108585afc7d8904f95205"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 12.194718,
-   "end_time": "2026-09-11T00:09:15.325297+00:00",
+   "duration": 12.16787,
+   "end_time": "2026-09-11T05:11:22.174300+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "~/ml4t/public-teach-d/15_causal_estimation/.10_case_study_insights.build.415754.ipynb",
-   "output_path": "~/ml4t/public-teach-d/15_causal_estimation/.10_case_study_insights.papermill.415754.ipynb",
+   "input_path": "~/ml4t/public-teach-g/15_causal_estimation/.10_case_study_insights.build.2221430.ipynb",
+   "output_path": "~/ml4t/public-teach-g/15_causal_estimation/.10_case_study_insights.papermill.2221430.ipynb",
    "parameters": {},
-   "start_time": "2026-09-11T00:09:03.130579+00:00",
+   "start_time": "2026-09-11T05:11:10.006430+00:00",
    "version": "2.7.0"
   }
  },

--- a/15_causal_estimation/10_case_study_insights.py
+++ b/15_causal_estimation/10_case_study_insights.py
@@ -56,6 +56,7 @@ from case_studies.utils.analytics import (
     SHORT_NAMES,
     registry_path,
 )
+from utils.paths import registry_readonly_uri
 from utils.style import COLORS, add_message_title, show_with_alt
 
 # %% tags=["parameters"]
@@ -100,17 +101,25 @@ CASE_ORDER = {case_study: rank for rank, case_study in enumerate(CASE_STUDY_IDS)
 # preview tier. On the registries as they stand the two rules select the same rows.
 # `current_causal_identities` in `case_studies/utils/registry/store.py` is the authority, and
 # a reader who needs the full rule should call it rather than copy the query below.
+#
+# The connection is read-only, and `registry_readonly_uri` decides whether it may also be
+# immutable. `immutable=1` promises SQLite the file cannot change while it is open, which lets
+# it skip locking and never open the write-ahead log. That is false of a case directory a sweep
+# is writing, and here it would be doubly wrong: the integrity check below runs on the same
+# connection, so it would certify the pre-WAL main file and the query would then read the same
+# stale snapshot the check had just approved. The promise does hold for a downloaded artifact
+# bundle, whose tree is left unwritable, and there the flag is what lets a WAL reader open the
+# file at all.
 
 
 # %%
 def _load_causal_runs(case_study: str) -> pl.DataFrame:
-    """Load one immutable causal row per label from a case-study registry."""
+    """Load the current causal row per label from a case-study registry."""
     db_path = registry_path(case_study).resolve()
     if not db_path.is_file():
         raise FileNotFoundError(f"Missing registry for {case_study}: {db_path}")
 
-    uri = f"file:{db_path}?mode=ro&immutable=1"
-    with sqlite3.connect(uri, uri=True) as connection:
+    with sqlite3.connect(registry_readonly_uri(db_path), uri=True) as connection:
         connection.row_factory = sqlite3.Row
         integrity = connection.execute("PRAGMA integrity_check").fetchone()[0]
         if integrity != "ok":


### PR DESCRIPTION
The fourth of the five `immutable=1` sites, and the one where the flag defeated the notebook's own guard.

`_load_causal_runs` opened each of the nine case-study registries with `mode=ro&immutable=1`, ran `PRAGMA integrity_check` on that connection, and then read `causal_runs` from the same one.

`immutable=1` promises SQLite the file cannot change while it is open, which lets it skip locking and never open the write-ahead log. That is false of a case directory a sweep is writing. Here it was worse than a stale read: the integrity check inherited the same blind spot, so it certified the pre-WAL main file and the query then read the snapshot the check had just approved. A guard that shares the read's blind spot cannot catch the read's failure.

`registry_readonly_uri` (#945) adds the flag only where the directory is unwritable, which is the downloaded-artifact-bundle case it exists for. The markdown above the loader now says which registry each setting is for.

The docstring said "Load one immutable causal row per label". That "immutable" meant the registry's append-only row model, which the paragraph above it explains at length - two lines above an `immutable=1` that meant something else entirely. It now says "current", the word that paragraph uses.

## Verification

- Re-executed in the canonical environment: exit 0, 1.0 GB peak.
- Every text output is byte-identical to main. All nine registries were checkpointed at run time, so the flag was latent here rather than active - confirmed independently by the band working chapters 11 and 17, which measured identical table counts both ways on all nine. It would not have stayed latent: `03_econml_dml` and `04_dml_crypto_regime` write to these same registries.
- `nbcheck` clean, `check_notebook_prose` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VEtXvNk14uZckwswthVihc
