### PR TITLE
sync-alt could not see an alt passed by keyword, so chapter 7 had no cheap path

### DIFF
--- a/.github/scripts/notebook_provenance.py
+++ b/.github/scripts/notebook_provenance.py
@@ -732,6 +732,28 @@ def _alt_literal_spans(arg: ast.expr) -> list[ast.Constant] | None:
     return None
 
 
+def _alt_argument(node: ast.Call) -> ast.expr | None:
+    """The alt argument of an ``ALT_FUNCS`` call, whether positional or by keyword.
+
+    Reading ``node.args[1]`` alone made ``sync-alt`` unreachable for
+    ``show_plotly_with_alt(fig, alt=...)``: one positional argument, so the call was
+    skipped, its alt was never blanked, and a corrected wording compared as ordinary
+    source drift. What the author saw was "code cell N differs for something other
+    than an alt literal ... Re-run the notebook" - a plausible wrong answer rather
+    than a visible failure, which is the expensive kind, because the documented cheap
+    path for the correction is the one it closes.
+
+    Returns ``None`` when the call names no alt at all, which is left in the AST dump
+    the way an unknowable alt is.
+    """
+    if len(node.args) >= 2:
+        return node.args[1]
+    for keyword in node.keywords:
+        if keyword.arg == "alt":
+            return keyword.value
+    return None
+
+
 def _blank_alts(code: str) -> tuple[ast.Module, list[_AltText]] | None:
     """(*code* parsed with every alt's prose neutralised, the alts in source order).
 
@@ -771,13 +793,11 @@ def _blank_alts(code: str) -> tuple[ast.Module, list[_AltText]] | None:
 
     found: list[tuple[tuple[int, int], _AltText]] = []
     for node in ast.walk(tree):
-        if not (
-            isinstance(node, ast.Call)
-            and _alt_call_name(node.func) in ALT_FUNCS
-            and len(node.args) >= 2
-        ):
+        if not (isinstance(node, ast.Call) and _alt_call_name(node.func) in ALT_FUNCS):
             continue
-        arg = node.args[1]
+        arg = _alt_argument(node)
+        if arg is None:
+            continue
         position = (arg.lineno, arg.col_offset)
         parts = _alt_literal_spans(arg)
         if parts is None:

--- a/tests/test_notebook_alt_sync.py
+++ b/tests/test_notebook_alt_sync.py
@@ -289,7 +289,13 @@ def test_blank_alts_sees_an_alt_passed_by_keyword(repo):
 
 
 def test_blank_alts_reports_a_call_that_names_no_alt_as_unknowable(repo):
-    """The no-hit half: reading keywords must not invent an alt where there is none."""
+    """The no-hit half: reading keywords must not invent an alt where there is none.
+
+    Keep this even though it passes with and without the keyword fix. The other three
+    tests would all pass against a checker that reported an alt for every call, so this
+    is the case that makes them about keywords rather than about reporting more. A rule
+    you cannot write a must-still-fail case for is not a rule.
+    """
     tree_and_alts = provenance._blank_alts("show_plotly_with_alt(fig)")
     assert tree_and_alts is not None
     assert tree_and_alts[1] == []

--- a/tests/test_notebook_alt_sync.py
+++ b/tests/test_notebook_alt_sync.py
@@ -44,6 +44,16 @@ from utils.style import show_plotly_with_alt
 show_plotly_with_alt(fig, "Bars sorted from tallest at the left to shortest at the right.")
 """
 
+KEYWORD = """# %% [markdown]
+# # A notebook
+
+# %%
+from utils.style import show_plotly_with_alt
+
+show_plotly_with_alt(fig, alt="Bars sorted from tallest at the left to shortest at the right.")
+"""
+
+
 COMPUTED = """# %% [markdown]
 # # A notebook
 
@@ -262,3 +272,52 @@ def test_code_bodies_drops_the_preamble_so_cells_line_up(repo):
     src = "# ---\n# jupyter: meta\n# ---\n\n# %% [markdown]\n# Prose.\n\n# %%\nx = 1\n"
     assert len(provenance._code_bodies(src)) == 1
     assert provenance._code_bodies(src)[0].strip() == "x = 1"
+
+
+def test_blank_alts_sees_an_alt_passed_by_keyword(repo):
+    """The defect: one positional argument, so the call was skipped and never blanked.
+
+    Counted across main when this was fixed, 38 calls in 8 files pass the alt by
+    keyword and 1,033 pass it positionally. All 38 are chapter 7, which had merged
+    and so would have paid a re-execution for any wording fix.
+    """
+    positional = provenance._blank_alts('show_plotly_with_alt(fig, "A bar chart.")')
+    keyword = provenance._blank_alts('show_plotly_with_alt(fig, alt="A bar chart.")')
+    assert positional is not None and keyword is not None
+    assert positional[1] == ["A bar chart."]
+    assert keyword[1] == ["A bar chart."], "an alt= call reports no alt at all"
+
+
+def test_blank_alts_reports_a_call_that_names_no_alt_as_unknowable(repo):
+    """The no-hit half: reading keywords must not invent an alt where there is none."""
+    tree_and_alts = provenance._blank_alts("show_plotly_with_alt(fig)")
+    assert tree_and_alts is not None
+    assert tree_and_alts[1] == []
+
+
+def test_a_corrected_keyword_alt_is_alt_text_only_drift(repo):
+    """Same contract as the positional case, which is the whole point of the fix."""
+    py, nb_path = _write_pair(
+        repo, KEYWORD, "Bars sorted from tallest at the left to shortest at the right edge."
+    )
+    blob = _stamp(nb_path, py)
+    py.write_text(KEYWORD.replace("shortest at the right.", "shortest at the right edge."), "utf-8")
+    assert _drift(nb_path, py, blob) is True
+
+
+def test_sync_alt_writes_a_keyword_correction_into_the_outputs(repo):
+    """The cheap path end to end: before the fix this left the outputs saying the old thing."""
+    py, nb_path = _write_pair(
+        repo, KEYWORD, "Bars sorted from tallest at the left to shortest at the right."
+    )
+    _stamp(nb_path, py)
+    py.write_text(KEYWORD.replace("shortest at the right.", "shortest at the right edge."), "utf-8")
+    provenance.sync_alt(nb_path)
+    nb = json.loads(nb_path.read_text(encoding="utf-8"))
+    alts = [
+        o["metadata"]["image/png"]["alt"]
+        for c in nb["cells"]
+        for o in c.get("outputs", [])
+        if "image/png" in (o.get("data") or {})
+    ]
+    assert alts == ["Bars sorted from tallest at the left to shortest at the right edge."]


### PR DESCRIPTION
**All eight of chapter 7's notebooks had zero visible alt spans before this change, and all 38 after.** Not some alts missed: that whole chapter had no cheap path for correcting a figure description, silently, while being told to re-run instead.

`sync-alt` is the documented way to correct a figure description without paying a re-execution. `_blank_alts` found the alt span with

```python
and len(node.args) >= 2
...
arg = node.args[1]
```

so `show_plotly_with_alt(fig, alt=...)` has one positional argument, hit the `continue`, and its alt was never blanked. The corrected wording then compared as ordinary source drift.

The failure is a plausible wrong answer rather than a visible error. The author is told

> code cell N differs for something other than an alt literal, so the outputs on disk are not the ones this source produces. Re-run the notebook.

which reads as a real finding about the edit, so the natural response is to spend the re-run.

## Scale

Counted by AST across `main`: **1,033 calls pass the alt positionally, 38 pass it by keyword, and all 38 are chapter 7.**

| notebook | alt calls |
|---|---|
| `01_data_quality_diagnostics` | 1 |
| `02_preprocessing_pipeline` | 2 |
| `03_label_methods` | 16 |
| `04_maximum_favorable_adverse_excursion` | 3 |
| `05_signal_evaluation` | 7 |
| `06_ic_inference` | 2 |
| `07_multiple_testing` | 4 |
| `08_causal_sanity_checks` | 3 |

Every one of those eight reported **zero** visible alt spans before this change and reports all 38 after. Chapter 7 merged as #938, so they are `done` and any wording fix would have cost a full re-execution.

## The change

Read `node.keywords` for `alt` alongside the positional argument. A call that names no alt at all still reports nothing, so it stays in the AST dump the way an unknowable alt does.

## Verification

`tests/test_notebook_alt_sync.py` gains four tests; 18 pass. Three of the four fail against the unpatched module, one of them with the exact `SystemExit` quoted above. The fourth is the no-hit half - reading keywords must not invent an alt where the call names none - and passes both ways by design.

## Not in this PR

`sync-alt` compares against the blob the stamp records, so a `.py` that was uncommitted when `nb-run` executed it gives `stamped against blob ..., which is not in this repo` and the cheap path is closed for that run too. That is correct behaviour, not a defect, and touching its docstring is outside this change. Recorded here so it is findable: commit the `.py` before the run, not after.

Found by another session while working chapter 8. The script is shared infrastructure and outside a chapter branch, so it is fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
