### PR TITLE
An unknown flag ran the fixture generator, so --help destroyed four files

### DIFF
--- a/tests/generate_test_microstructure.py
+++ b/tests/generate_test_microstructure.py
@@ -7,9 +7,20 @@ Writes to ~/ml4t/test-data/data/ which serves as ML4T_DATA_PATH
 in CI.
 
 Usage:
-    uv run python tests/generate_test_microstructure.py
+    uv run python tests/generate_test_microstructure.py --check
+    uv run python tests/generate_test_microstructure.py --output-root DIR
+    uv run python tests/generate_test_microstructure.py            # writes the live fixture
+
+**Four of its twenty outputs no longer reproduce what is on disk**, so running it
+without checking first destroys real data. Measured 2026-09-11: it writes 345 rows
+to `futures/market/individual/ES/data.parquet` where the fixture carries 19,361 that
+are byte-identical to production, and 20, 3 and 3 rows to the ITCH `A`, `P` and `R`
+message files where the fixture carries 2,500, 2,500 and 5. Someone widened those
+four and did not update this script. `--check` reports the disagreement and writes
+nothing; run it before the bare form.
 """
 
+import argparse
 from datetime import date, datetime, time, timedelta
 from pathlib import Path
 
@@ -887,9 +898,51 @@ def generate_all(root: Path = TEST_DATA_ROOT, *, quiet: bool = False) -> list[Pa
     return written
 
 
-def main() -> None:
-    generate_all(TEST_DATA_ROOT)
+def main(argv: list[str] | None = None) -> int:
+    """Parse arguments before writing anything.
+
+    There was no parser here, so an unrecognized flag was ignored and the script ran:
+    `--help`, typed to find out what it did, silently overwrote four fixture files with
+    smaller synthetic ones. A parser makes an unknown flag an error instead of a write.
+    """
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--output-root",
+        type=Path,
+        default=TEST_DATA_ROOT,
+        help=f"where to write (default: {TEST_DATA_ROOT})",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="generate to a scratch directory and report which outputs disagree with "
+        "--output-root, writing nothing to it",
+    )
+    args = parser.parse_args(argv)
+
+    if not args.check:
+        generate_all(args.output_root)
+        return 0
+
+    import filecmp
+    import tempfile
+
+    with tempfile.TemporaryDirectory(prefix="generate-test-microstructure-") as scratch:
+        written = generate_all(Path(scratch), quiet=True)
+        disagree = []
+        for produced in written:
+            relative = produced.relative_to(scratch)
+            existing = args.output_root / relative
+            if not existing.exists():
+                disagree.append((relative, "absent"))
+            elif not filecmp.cmp(produced, existing, shallow=False):
+                disagree.append((relative, "differs"))
+
+    print(f"{len(written)} outputs, {len(written) - len(disagree)} reproduce {args.output_root}")
+    for relative, why in disagree:
+        print(f"  {why}: {relative}")
+    return 1 if disagree else 0
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/tests/generate_test_microstructure.py
+++ b/tests/generate_test_microstructure.py
@@ -19,8 +19,27 @@ import polars as pl
 # ── Output root ──────────────────────────────────────────────────────────────
 TEST_DATA_ROOT = Path.home() / "ml4t" / "test-data" / "data"
 
-# Seed for reproducibility
-RNG = np.random.default_rng(42)
+# Seed for reproducibility.
+#
+# One generator draws for all six functions, in the order `generate_all` calls them,
+# so they are NOT independent: calling one alone produces different bytes than calling
+# it in sequence. That is why `create_test_data.DATASETS` declares this file as one
+# unit rather than one entry per function - splitting it would either move every byte
+# of the current fixture or need a seed per function, which moves them the same way.
+SEED = 42
+RNG = np.random.default_rng(SEED)
+
+# Everything `generate_all` writes, as roots under the output directory. `Dataset.owns`
+# in create_test_data.py is built from this, so a generator that grows a new output adds
+# it here and the declaration follows.
+GENERATED_ROOTS: tuple[str, ...] = (
+    "equities/market/microstructure/nasdaq_itch/messages",
+    "equities/market/microstructure/market_by_order/NVDA",
+    "equities/market/microstructure/trade_and_quotes",
+    "equities/market/microstructure/iex/deep/parsed",
+    "futures/market/individual",
+    "prediction_markets",
+)
 
 
 # ═════════════════════════════════════════════════════════════════════════════
@@ -36,11 +55,9 @@ def _ns_timestamp(hour: int, minute: int, second: int = 0, micro: int = 0) -> da
     return datetime(2020, 1, 30, hour, minute, second, micro)
 
 
-def generate_itch_messages() -> None:
+def generate_itch_messages(root: Path = TEST_DATA_ROOT) -> None:
     """Generate all ITCH message type parquet files."""
-    itch_dir = (
-        TEST_DATA_ROOT / "equities" / "market" / "microstructure" / "nasdaq_itch" / "messages"
-    )
+    itch_dir = root / "equities" / "market" / "microstructure" / "nasdaq_itch" / "messages"
 
     # ── R (Stock Directory) ──────────────────────────────────────────────
     r_dir = itch_dir / "R"
@@ -389,7 +406,7 @@ def _generate_mbo_day(base_date: datetime, base_price_nano: int, start_order_id:
     return rows
 
 
-def generate_mbo_data() -> None:
+def generate_mbo_data(root: Path = TEST_DATA_ROOT) -> None:
     """Generate synthetic DataBento MBO tick data for NVDA.
 
     Key schema requirements from notebooks:
@@ -402,7 +419,7 @@ def generate_mbo_data() -> None:
     We include both ts_event and timestamp columns, and use DataBento file naming.
     We also generate enough data (spread across hours) for meaningful analysis.
     """
-    mbo_dir = TEST_DATA_ROOT / "equities" / "market" / "microstructure" / "market_by_order" / "NVDA"
+    mbo_dir = root / "equities" / "market" / "microstructure" / "market_by_order" / "NVDA"
     mbo_dir.mkdir(parents=True, exist_ok=True)
 
     # Remove old file if it exists (was named 20241104.parquet before)
@@ -459,7 +476,7 @@ def generate_mbo_data() -> None:
 # NB15 does spread analysis using NBBO quotes and trade size distribution
 
 
-def generate_taq_data() -> None:
+def generate_taq_data(root: Path = TEST_DATA_ROOT) -> None:
     """Generate synthetic AlgoSeek TAQ tick data for AAPL on 2020-03-16.
 
     Key schema requirements from notebooks:
@@ -469,14 +486,7 @@ def generate_taq_data() -> None:
 
     We generate ~600 events with realistic distributions.
     """
-    taq_dir = (
-        TEST_DATA_ROOT
-        / "equities"
-        / "market"
-        / "microstructure"
-        / "trade_and_quotes"
-        / "symbol=AAPL"
-    )
+    taq_dir = root / "equities" / "market" / "microstructure" / "trade_and_quotes" / "symbol=AAPL"
     taq_dir.mkdir(parents=True, exist_ok=True)
 
     # March 16, 2020: AAPL around $250, huge volatility day
@@ -552,11 +562,9 @@ def generate_taq_data() -> None:
 # Path: ML4T_DATA_PATH / "equities" / "market" / "microstructure" / "iex" / "deep" / "parsed" / {type}/
 
 
-def generate_iex_data() -> None:
+def generate_iex_data(root: Path = TEST_DATA_ROOT) -> None:
     """Generate synthetic IEX DEEP parsed data."""
-    parsed_dir = (
-        TEST_DATA_ROOT / "equities" / "market" / "microstructure" / "iex" / "deep" / "parsed"
-    )
+    parsed_dir = root / "equities" / "market" / "microstructure" / "iex" / "deep" / "parsed"
 
     base_date = datetime(2025, 1, 15, 14, 30, 0)  # 9:30 AM ET in UTC
     base_price = 240.0  # AAPL-ish
@@ -664,7 +672,7 @@ def generate_iex_data() -> None:
 # - Enough contracts for roll detection to produce adj_close
 
 
-def generate_individual_futures() -> None:
+def generate_individual_futures(root: Path = TEST_DATA_ROOT) -> None:
     """Generate synthetic CME individual contract data for ES, NQ, CL.
 
     Key requirements from NB06 (continuous construction):
@@ -673,7 +681,7 @@ def generate_individual_futures() -> None:
     - Need at least 3 contracts with clear roll transitions
     - Need enough data points for roll gaps to produce adj_close
     """
-    individual_dir = TEST_DATA_ROOT / "futures" / "market" / "individual"
+    individual_dir = root / "futures" / "market" / "individual"
 
     products = {
         "ES": {"base_price": 4500.0, "tick": 0.25},
@@ -771,9 +779,9 @@ def generate_individual_futures() -> None:
 # Schema: timestamp (Date), symbol (str), open/high/low/close (Float64), volume (Int64)
 
 
-def generate_kalshi_data() -> None:
+def generate_kalshi_data(root: Path = TEST_DATA_ROOT) -> None:
     """Generate synthetic Kalshi prediction market data."""
-    pm_dir = TEST_DATA_ROOT / "prediction_markets"
+    pm_dir = root / "prediction_markets"
     pm_dir.mkdir(parents=True, exist_ok=True)
 
     # 5 contracts, ~10 days each = ~50 rows
@@ -837,28 +845,50 @@ def generate_kalshi_data() -> None:
 # ═════════════════════════════════════════════════════════════════════════════
 
 
+def generate_all(root: Path = TEST_DATA_ROOT, *, quiet: bool = False) -> list[Path]:
+    """Write every synthetic fixture under ``root`` and return the files written.
+
+    Reseeds first, so a second call in the same process reproduces the first. Without
+    that the module-level generator carries its position across calls and the bytes
+    differ, which would make this unusable as a `Dataset.build`.
+
+    The call order is part of the output: see `SEED`.
+    """
+    global RNG
+    RNG = np.random.default_rng(SEED)
+
+    def say(message: str) -> None:
+        if not quiet:
+            print(message)
+
+    say(f"Generating test microstructure data in {root}\n")
+    for index, (label, generate) in enumerate(
+        (
+            ("ITCH Parsed Messages", generate_itch_messages),
+            ("DataBento MBO", generate_mbo_data),
+            ("AlgoSeek TAQ", generate_taq_data),
+            ("IEX Parsed Data", generate_iex_data),
+            ("CME Individual Futures", generate_individual_futures),
+            ("Kalshi Prediction Markets", generate_kalshi_data),
+        ),
+        start=1,
+    ):
+        say(f"{'' if index == 1 else chr(10)}{index}. {label}")
+        generate(root)
+    say("\nDone.")
+
+    written: list[Path] = []
+    for relative in GENERATED_ROOTS:
+        target = root / relative
+        if target.is_dir():
+            written.extend(sorted(p for p in target.rglob("*") if p.is_file()))
+        elif target.is_file():
+            written.append(target)
+    return written
+
+
 def main() -> None:
-    print(f"Generating test microstructure data in {TEST_DATA_ROOT}\n")
-
-    print("1. ITCH Parsed Messages")
-    generate_itch_messages()
-
-    print("\n2. DataBento MBO")
-    generate_mbo_data()
-
-    print("\n3. AlgoSeek TAQ")
-    generate_taq_data()
-
-    print("\n4. IEX Parsed Data")
-    generate_iex_data()
-
-    print("\n5. CME Individual Futures")
-    generate_individual_futures()
-
-    print("\n6. Kalshi Prediction Markets")
-    generate_kalshi_data()
-
-    print("\nDone.")
+    generate_all(TEST_DATA_ROOT)
 
 
 if __name__ == "__main__":

--- a/tests/test_synthetic_fixture_generator_writes_where_it_is_told.py
+++ b/tests/test_synthetic_fixture_generator_writes_where_it_is_told.py
@@ -1,0 +1,75 @@
+"""The synthetic generator must write where it is told, and must not surprise a reader.
+
+Both halves exist because of one incident on 2026-09-11. Every generator function took
+its output root from the module-level ``TEST_DATA_ROOT``, so the only thing the script
+could do was overwrite ``~/ml4t/test-data/data``; and there was no argument parser, so
+``--help`` - typed to find out what the script did - was ignored and ``main()`` ran. It
+replaced four fixture files with smaller synthetic ones, including a
+``futures/market/individual/ES/data.parquet`` that is byte-identical to production:
+19,361 rows became 345.
+
+The files were tracked and were restored from git. What could not be restored by git is
+the reason it was possible, which is what these tests hold in place.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO / "tests"))
+
+import generate_test_microstructure as generator  # noqa: E402
+
+
+def test_generate_all_writes_under_the_root_it_is_given(tmp_path):
+    """The contract that makes the script inspectable at all."""
+    written = generator.generate_all(tmp_path, quiet=True)
+
+    assert written, "generated nothing"
+    for path in written:
+        assert path.is_relative_to(tmp_path), f"{path} escaped the requested root"
+
+
+def test_generate_all_leaves_the_live_fixture_alone(tmp_path):
+    """The no-hit half: the test above passes even if the live root is written too."""
+    live = generator.TEST_DATA_ROOT
+    before = (
+        {p: p.stat().st_mtime_ns for p in live.rglob("*") if p.is_file()} if live.is_dir() else {}
+    )
+
+    generator.generate_all(tmp_path, quiet=True)
+
+    after = (
+        {p: p.stat().st_mtime_ns for p in live.rglob("*") if p.is_file()} if live.is_dir() else {}
+    )
+    assert after == before, "writing to a scratch root touched the live fixture"
+
+
+def test_generate_all_reseeds_so_two_calls_agree(tmp_path):
+    """Without the reseed one module-level generator carries its position across calls.
+
+    A `Dataset.build` that produced different bytes on its second call in a process
+    could not be checked against anything, which is the whole point of declaring it.
+    """
+    first = {
+        p.relative_to(tmp_path / "a"): p.read_bytes()
+        for p in generator.generate_all(tmp_path / "a", quiet=True)
+    }
+    second = {
+        p.relative_to(tmp_path / "b"): p.read_bytes()
+        for p in generator.generate_all(tmp_path / "b", quiet=True)
+    }
+
+    assert first.keys() == second.keys()
+    assert first == second, "a second call in the same process produced different bytes"
+
+
+def test_an_unrecognized_flag_is_an_error_rather_than_a_write():
+    """`--help` ran the script and destroyed four files. Argparse is what stops that."""
+    with pytest.raises(SystemExit) as excinfo:
+        generator.main(["--nonsense"])
+    assert excinfo.value.code != 0


### PR DESCRIPTION
`tests/generate_test_microstructure.py` had no argument parser, so an unrecognized flag was ignored and the script ran. `--help`, typed to find out what it did, overwrote four fixture files with smaller synthetic ones. All four were tracked and were restored from git at `8c773ef4`; `git status` in the fixture repo is clean and the row counts are verified back.

It could also only ever write one place: every generator function took its root from the module-level `TEST_DATA_ROOT`, so there was no way to see what it would produce without destroying what was there.

## Why that was worse than a papercut

Running the script is its own documented usage, and **4 of its 20 outputs no longer reproduce the fixture**:

| output | the script writes | the fixture holds |
|---|---|---|
| `futures/market/individual/ES/data.parquet` | 345 rows | **19,361** |
| `nasdaq_itch/messages/A/part-000000.parquet` | 20 rows | **2,500** |
| `nasdaq_itch/messages/P/part-000000.parquet` | 3 rows | **2,500** |
| `nasdaq_itch/messages/R/part-000000.parquet` | 3 rows | 5 |

ES is the sharp one: the fixture copy is byte-identical to production, and the script replaces real market data with 345 synthetic rows in the same shape it gives the fabricated `CL` and `NQ` beside it. Someone widened these four and did not update the script.

## What this PR changes

- **argparse**, so an unknown flag is an error rather than a write.
- **`--output-root`**, so the destination is a choice rather than a constant.
- **`--check`**, which generates to a scratch directory, reports which outputs disagree with `--output-root`, writes nothing to it, and exits non-zero when any do.

```
$ uv run python tests/generate_test_microstructure.py --check
20 outputs, 16 reproduce /home/stefan/ml4t/test-data/data
  differs: equities/market/microstructure/nasdaq_itch/messages/A/part-000000.parquet
  differs: equities/market/microstructure/nasdaq_itch/messages/P/part-000000.parquet
  differs: equities/market/microstructure/nasdaq_itch/messages/R/part-000000.parquet
  differs: futures/market/individual/ES/data.parquet
$ echo $?
1
```

Also: `generate_all` reseeds before running. One module-level `default_rng(42)` draws for all six generator functions in call order, so without a reseed a second call in the same process produces different bytes. `GENERATED_ROOTS` names the six output roots in one place.

## What this PR does not decide

**Which side is authoritative for those four files.** ES looks clear - production supplies it and the script should not write it at all - but the two ITCH files at 2,500 rows against 20 and 3 were a deliberate widening whose intent is not recorded anywhere I could find. The docstring now states the disagreement so nobody runs the bare form without knowing, and `--check` makes it a command rather than an archaeology exercise.

`main()`'s behaviour with no arguments is unchanged.

## Verification

Four tests, all passing, covering the contract rather than argparse: everything `generate_all` writes stays under the root it was given; the live fixture is untouched while a scratch root is written (the no-hit half - the first test passes even if both are written); two calls in one process agree, which is what the reseed buys; and an unrecognized flag exits non-zero.

Context: found while triaging #1117, whose premise is that these files have no builder. They have one - it is just not one `create_test_data.py` can see, and for four outputs it is wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
