### PR TITLE
08/05: remove an empty code cell left by a comment-to-markdown conversion

### DIFF
--- a/08_financial_features/05_feature_selection.ipynb
+++ b/08_financial_features/05_feature_selection.ipynb
@@ -2,13 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "f6a94acb",
+   "id": "5108f1b0",
    "metadata": {
     "papermill": {
-     "duration": 0.005859,
-     "end_time": "2026-09-11T07:25:40.743178+00:00",
+     "duration": 0.005742,
+     "end_time": "2026-09-11T08:16:50.196222+00:00",
      "exception": false,
-     "start_time": "2026-09-11T07:25:40.737319+00:00",
+     "start_time": "2026-09-11T08:16:50.190480+00:00",
      "status": "completed"
     },
     "tags": []
@@ -53,13 +53,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f4bcd839",
+   "id": "32689adc",
    "metadata": {
     "papermill": {
-     "duration": 0.004198,
-     "end_time": "2026-09-11T07:25:40.752936+00:00",
+     "duration": 0.005917,
+     "end_time": "2026-09-11T08:16:50.206224+00:00",
      "exception": false,
-     "start_time": "2026-09-11T07:25:40.748738+00:00",
+     "start_time": "2026-09-11T08:16:50.200307+00:00",
      "status": "completed"
     },
     "tags": []
@@ -71,19 +71,19 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "df152d8e",
+   "id": "5140734d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T07:25:40.762885Z",
-     "iopub.status.busy": "2026-09-11T07:25:40.762736Z",
-     "iopub.status.idle": "2026-09-11T07:25:47.264163Z",
-     "shell.execute_reply": "2026-09-11T07:25:47.262460Z"
+     "iopub.execute_input": "2026-09-11T08:16:50.216331Z",
+     "iopub.status.busy": "2026-09-11T08:16:50.216049Z",
+     "iopub.status.idle": "2026-09-11T08:16:57.635129Z",
+     "shell.execute_reply": "2026-09-11T08:16:57.634413Z"
     },
     "papermill": {
-     "duration": 6.508133,
-     "end_time": "2026-09-11T07:25:47.265804+00:00",
+     "duration": 7.42521,
+     "end_time": "2026-09-11T08:16:57.636166+00:00",
      "exception": false,
-     "start_time": "2026-09-11T07:25:40.757671+00:00",
+     "start_time": "2026-09-11T08:16:50.210956+00:00",
      "status": "completed"
     },
     "tags": []
@@ -125,19 +125,19 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "065c15a5",
+   "id": "0fc7bcd6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T07:25:47.278986Z",
-     "iopub.status.busy": "2026-09-11T07:25:47.278588Z",
-     "iopub.status.idle": "2026-09-11T07:25:47.287546Z",
-     "shell.execute_reply": "2026-09-11T07:25:47.285573Z"
+     "iopub.execute_input": "2026-09-11T08:16:57.645147Z",
+     "iopub.status.busy": "2026-09-11T08:16:57.644782Z",
+     "iopub.status.idle": "2026-09-11T08:16:57.648467Z",
+     "shell.execute_reply": "2026-09-11T08:16:57.647986Z"
     },
     "papermill": {
-     "duration": 0.017937,
-     "end_time": "2026-09-11T07:25:47.288621+00:00",
+     "duration": 0.009879,
+     "end_time": "2026-09-11T08:16:57.648918+00:00",
      "exception": false,
-     "start_time": "2026-09-11T07:25:47.270684+00:00",
+     "start_time": "2026-09-11T08:16:57.639039+00:00",
      "status": "completed"
     },
     "tags": [
@@ -162,19 +162,19 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "8bd60f58",
+   "id": "afe00578",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T07:25:47.298335Z",
-     "iopub.status.busy": "2026-09-11T07:25:47.298202Z",
-     "iopub.status.idle": "2026-09-11T07:25:47.344105Z",
-     "shell.execute_reply": "2026-09-11T07:25:47.343323Z"
+     "iopub.execute_input": "2026-09-11T08:16:57.654778Z",
+     "iopub.status.busy": "2026-09-11T08:16:57.654575Z",
+     "iopub.status.idle": "2026-09-11T08:16:57.700582Z",
+     "shell.execute_reply": "2026-09-11T08:16:57.700028Z"
     },
     "papermill": {
-     "duration": 0.051752,
-     "end_time": "2026-09-11T07:25:47.345417+00:00",
+     "duration": 0.050514,
+     "end_time": "2026-09-11T08:16:57.701895+00:00",
      "exception": false,
-     "start_time": "2026-09-11T07:25:47.293665+00:00",
+     "start_time": "2026-09-11T08:16:57.651381+00:00",
      "status": "completed"
     },
     "tags": []
@@ -186,13 +186,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cfc9a32e",
+   "id": "16a85ac0",
    "metadata": {
     "papermill": {
-     "duration": 0.003503,
-     "end_time": "2026-09-11T07:25:47.353246+00:00",
+     "duration": 0.004067,
+     "end_time": "2026-09-11T08:16:57.710578+00:00",
      "exception": false,
-     "start_time": "2026-09-11T07:25:47.349743+00:00",
+     "start_time": "2026-09-11T08:16:57.706511+00:00",
      "status": "completed"
     },
     "tags": []
@@ -206,19 +206,19 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "a433da02",
+   "id": "babfea01",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T07:25:47.359697Z",
-     "iopub.status.busy": "2026-09-11T07:25:47.359556Z",
-     "iopub.status.idle": "2026-09-11T07:25:47.528242Z",
-     "shell.execute_reply": "2026-09-11T07:25:47.527436Z"
+     "iopub.execute_input": "2026-09-11T08:16:57.720525Z",
+     "iopub.status.busy": "2026-09-11T08:16:57.719857Z",
+     "iopub.status.idle": "2026-09-11T08:16:57.910025Z",
+     "shell.execute_reply": "2026-09-11T08:16:57.908850Z"
     },
     "papermill": {
-     "duration": 0.172755,
-     "end_time": "2026-09-11T07:25:47.529441+00:00",
+     "duration": 0.197696,
+     "end_time": "2026-09-11T08:16:57.911967+00:00",
      "exception": false,
-     "start_time": "2026-09-11T07:25:47.356686+00:00",
+     "start_time": "2026-09-11T08:16:57.714271+00:00",
      "status": "completed"
     },
     "tags": []
@@ -240,13 +240,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5ecb018d",
+   "id": "4cc52355",
    "metadata": {
     "papermill": {
-     "duration": 0.002282,
-     "end_time": "2026-09-11T07:25:47.536203+00:00",
+     "duration": 0.003899,
+     "end_time": "2026-09-11T08:16:57.921282+00:00",
      "exception": false,
-     "start_time": "2026-09-11T07:25:47.533921+00:00",
+     "start_time": "2026-09-11T08:16:57.917383+00:00",
      "status": "completed"
     },
     "tags": []
@@ -264,19 +264,19 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "5ace6007",
+   "id": "d79cee7c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T07:25:47.541916Z",
-     "iopub.status.busy": "2026-09-11T07:25:47.541673Z",
-     "iopub.status.idle": "2026-09-11T07:25:47.645741Z",
-     "shell.execute_reply": "2026-09-11T07:25:47.645268Z"
+     "iopub.execute_input": "2026-09-11T08:16:57.932062Z",
+     "iopub.status.busy": "2026-09-11T08:16:57.931642Z",
+     "iopub.status.idle": "2026-09-11T08:16:58.034381Z",
+     "shell.execute_reply": "2026-09-11T08:16:58.033811Z"
     },
     "papermill": {
-     "duration": 0.107774,
-     "end_time": "2026-09-11T07:25:47.646241+00:00",
+     "duration": 0.109188,
+     "end_time": "2026-09-11T08:16:58.035077+00:00",
      "exception": false,
-     "start_time": "2026-09-11T07:25:47.538467+00:00",
+     "start_time": "2026-09-11T08:16:57.925889+00:00",
      "status": "completed"
     },
     "tags": []
@@ -334,19 +334,19 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "ae80df44",
+   "id": "dc5c3b69",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T07:25:47.650763Z",
-     "iopub.status.busy": "2026-09-11T07:25:47.650658Z",
-     "iopub.status.idle": "2026-09-11T07:25:47.653091Z",
-     "shell.execute_reply": "2026-09-11T07:25:47.652505Z"
+     "iopub.execute_input": "2026-09-11T08:16:58.046607Z",
+     "iopub.status.busy": "2026-09-11T08:16:58.046316Z",
+     "iopub.status.idle": "2026-09-11T08:16:58.050592Z",
+     "shell.execute_reply": "2026-09-11T08:16:58.049873Z"
     },
     "papermill": {
-     "duration": 0.005044,
-     "end_time": "2026-09-11T07:25:47.653348+00:00",
+     "duration": 0.011533,
+     "end_time": "2026-09-11T08:16:58.051509+00:00",
      "exception": false,
-     "start_time": "2026-09-11T07:25:47.648304+00:00",
+     "start_time": "2026-09-11T08:16:58.039976+00:00",
      "status": "completed"
     },
     "tags": []
@@ -358,13 +358,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4b826d5e",
+   "id": "8c1ffe5b",
    "metadata": {
     "papermill": {
-     "duration": 0.00207,
-     "end_time": "2026-09-11T07:25:47.657439+00:00",
+     "duration": 0.00355,
+     "end_time": "2026-09-11T08:16:58.060051+00:00",
      "exception": false,
-     "start_time": "2026-09-11T07:25:47.655369+00:00",
+     "start_time": "2026-09-11T08:16:58.056501+00:00",
      "status": "completed"
     },
     "tags": []
@@ -379,19 +379,19 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "97542d67",
+   "id": "9f37ca7d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T07:25:47.667019Z",
-     "iopub.status.busy": "2026-09-11T07:25:47.666791Z",
-     "iopub.status.idle": "2026-09-11T07:25:47.687212Z",
-     "shell.execute_reply": "2026-09-11T07:25:47.684651Z"
+     "iopub.execute_input": "2026-09-11T08:16:58.072604Z",
+     "iopub.status.busy": "2026-09-11T08:16:58.072414Z",
+     "iopub.status.idle": "2026-09-11T08:16:58.090050Z",
+     "shell.execute_reply": "2026-09-11T08:16:58.089513Z"
     },
     "papermill": {
-     "duration": 0.029137,
-     "end_time": "2026-09-11T07:25:47.689263+00:00",
+     "duration": 0.026373,
+     "end_time": "2026-09-11T08:16:58.090895+00:00",
      "exception": false,
-     "start_time": "2026-09-11T07:25:47.660126+00:00",
+     "start_time": "2026-09-11T08:16:58.064522+00:00",
      "status": "completed"
     },
     "tags": []
@@ -477,13 +477,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e54d5b1c",
+   "id": "b4f0c5f6",
    "metadata": {
     "papermill": {
-     "duration": 0.004059,
-     "end_time": "2026-09-11T07:25:47.697829+00:00",
+     "duration": 0.002326,
+     "end_time": "2026-09-11T08:16:58.097086+00:00",
      "exception": false,
-     "start_time": "2026-09-11T07:25:47.693770+00:00",
+     "start_time": "2026-09-11T08:16:58.094760+00:00",
      "status": "completed"
     },
     "tags": []
@@ -499,19 +499,19 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "524afd3f",
+   "id": "c326dab9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T07:25:47.710480Z",
-     "iopub.status.busy": "2026-09-11T07:25:47.710153Z",
-     "iopub.status.idle": "2026-09-11T07:25:47.876287Z",
-     "shell.execute_reply": "2026-09-11T07:25:47.875788Z"
+     "iopub.execute_input": "2026-09-11T08:16:58.104224Z",
+     "iopub.status.busy": "2026-09-11T08:16:58.103991Z",
+     "iopub.status.idle": "2026-09-11T08:16:58.224062Z",
+     "shell.execute_reply": "2026-09-11T08:16:58.223577Z"
     },
     "papermill": {
-     "duration": 0.173777,
-     "end_time": "2026-09-11T07:25:47.876872+00:00",
+     "duration": 0.125372,
+     "end_time": "2026-09-11T08:16:58.224898+00:00",
      "exception": false,
-     "start_time": "2026-09-11T07:25:47.703095+00:00",
+     "start_time": "2026-09-11T08:16:58.099526+00:00",
      "status": "completed"
     },
     "tags": []
@@ -537,32 +537,14 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "00a301b1",
-   "metadata": {
-    "lines_to_next_cell": 0,
-    "papermill": {
-     "duration": 0.003604,
-     "end_time": "2026-09-11T07:25:47.884496+00:00",
-     "exception": false,
-     "start_time": "2026-09-11T07:25:47.880892+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "outputs": [],
-   "source": []
-  },
-  {
    "cell_type": "markdown",
-   "id": "591e614e",
+   "id": "c0d3c295",
    "metadata": {
     "papermill": {
-     "duration": 0.003503,
-     "end_time": "2026-09-11T07:25:47.891576+00:00",
+     "duration": 0.003195,
+     "end_time": "2026-09-11T08:16:58.231820+00:00",
      "exception": false,
-     "start_time": "2026-09-11T07:25:47.888073+00:00",
+     "start_time": "2026-09-11T08:16:58.228625+00:00",
      "status": "completed"
     },
     "tags": []
@@ -577,19 +559,19 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "0835c0fe",
+   "id": "5f303e65",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T07:25:47.900420Z",
-     "iopub.status.busy": "2026-09-11T07:25:47.900121Z",
-     "iopub.status.idle": "2026-09-11T07:25:48.525435Z",
-     "shell.execute_reply": "2026-09-11T07:25:48.523992Z"
+     "iopub.execute_input": "2026-09-11T08:16:58.238393Z",
+     "iopub.status.busy": "2026-09-11T08:16:58.238205Z",
+     "iopub.status.idle": "2026-09-11T08:16:58.996191Z",
+     "shell.execute_reply": "2026-09-11T08:16:58.995175Z"
     },
     "papermill": {
-     "duration": 0.63243,
-     "end_time": "2026-09-11T07:25:48.527658+00:00",
+     "duration": 0.765128,
+     "end_time": "2026-09-11T08:16:58.999511+00:00",
      "exception": false,
-     "start_time": "2026-09-11T07:25:47.895228+00:00",
+     "start_time": "2026-09-11T08:16:58.234383+00:00",
      "status": "completed"
     },
     "tags": []
@@ -605,13 +587,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "851f3146",
+   "id": "d00f7212",
    "metadata": {
     "papermill": {
-     "duration": 0.006431,
-     "end_time": "2026-09-11T07:25:48.542777+00:00",
+     "duration": 0.004586,
+     "end_time": "2026-09-11T08:16:59.009870+00:00",
      "exception": false,
-     "start_time": "2026-09-11T07:25:48.536346+00:00",
+     "start_time": "2026-09-11T08:16:59.005284+00:00",
      "status": "completed"
     },
     "tags": []
@@ -632,19 +614,19 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "512301e3",
+   "id": "d8216382",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T07:25:48.556973Z",
-     "iopub.status.busy": "2026-09-11T07:25:48.556600Z",
-     "iopub.status.idle": "2026-09-11T07:25:48.583404Z",
-     "shell.execute_reply": "2026-09-11T07:25:48.582709Z"
+     "iopub.execute_input": "2026-09-11T08:16:59.021392Z",
+     "iopub.status.busy": "2026-09-11T08:16:59.021164Z",
+     "iopub.status.idle": "2026-09-11T08:16:59.070810Z",
+     "shell.execute_reply": "2026-09-11T08:16:59.069383Z"
     },
     "papermill": {
-     "duration": 0.034851,
-     "end_time": "2026-09-11T07:25:48.583991+00:00",
+     "duration": 0.057902,
+     "end_time": "2026-09-11T08:16:59.071771+00:00",
      "exception": false,
-     "start_time": "2026-09-11T07:25:48.549140+00:00",
+     "start_time": "2026-09-11T08:16:59.013869+00:00",
      "status": "completed"
     },
     "tags": []
@@ -766,19 +748,19 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "a5c49b87",
+   "id": "a42958ea",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T07:25:48.593988Z",
-     "iopub.status.busy": "2026-09-11T07:25:48.593775Z",
-     "iopub.status.idle": "2026-09-11T07:25:48.949835Z",
-     "shell.execute_reply": "2026-09-11T07:25:48.948898Z"
+     "iopub.execute_input": "2026-09-11T08:16:59.081282Z",
+     "iopub.status.busy": "2026-09-11T08:16:59.081082Z",
+     "iopub.status.idle": "2026-09-11T08:16:59.385246Z",
+     "shell.execute_reply": "2026-09-11T08:16:59.384478Z"
     },
     "papermill": {
-     "duration": 0.363388,
-     "end_time": "2026-09-11T07:25:48.951452+00:00",
+     "duration": 0.309569,
+     "end_time": "2026-09-11T08:16:59.386088+00:00",
      "exception": false,
-     "start_time": "2026-09-11T07:25:48.588064+00:00",
+     "start_time": "2026-09-11T08:16:59.076519+00:00",
      "status": "completed"
     },
     "tags": []
@@ -837,13 +819,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "462c4535",
+   "id": "3bf4d632",
    "metadata": {
     "papermill": {
-     "duration": 0.006872,
-     "end_time": "2026-09-11T07:25:48.965099+00:00",
+     "duration": 0.003317,
+     "end_time": "2026-09-11T08:16:59.394275+00:00",
      "exception": false,
-     "start_time": "2026-09-11T07:25:48.958227+00:00",
+     "start_time": "2026-09-11T08:16:59.390958+00:00",
      "status": "completed"
     },
     "tags": []
@@ -861,20 +843,20 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "1572e831",
+   "id": "e5131453",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T07:25:48.981355Z",
-     "iopub.status.busy": "2026-09-11T07:25:48.980998Z",
-     "iopub.status.idle": "2026-09-11T07:25:49.306536Z",
-     "shell.execute_reply": "2026-09-11T07:25:49.305756Z"
+     "iopub.execute_input": "2026-09-11T08:16:59.407535Z",
+     "iopub.status.busy": "2026-09-11T08:16:59.407273Z",
+     "iopub.status.idle": "2026-09-11T08:16:59.637722Z",
+     "shell.execute_reply": "2026-09-11T08:16:59.636981Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.334885,
-     "end_time": "2026-09-11T07:25:49.307328+00:00",
+     "duration": 0.237726,
+     "end_time": "2026-09-11T08:16:59.638537+00:00",
      "exception": false,
-     "start_time": "2026-09-11T07:25:48.972443+00:00",
+     "start_time": "2026-09-11T08:16:59.400811+00:00",
      "status": "completed"
     },
     "tags": []
@@ -897,14 +879,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "71155cd3",
+   "id": "a7a70a0c",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.005008,
-     "end_time": "2026-09-11T07:25:49.318013+00:00",
+     "duration": 0.004999,
+     "end_time": "2026-09-11T08:16:59.648970+00:00",
      "exception": false,
-     "start_time": "2026-09-11T07:25:49.313005+00:00",
+     "start_time": "2026-09-11T08:16:59.643971+00:00",
      "status": "completed"
     },
     "tags": []
@@ -917,19 +899,19 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "245e73f1",
+   "id": "d136c4e8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T07:25:49.332582Z",
-     "iopub.status.busy": "2026-09-11T07:25:49.332300Z",
-     "iopub.status.idle": "2026-09-11T07:25:49.337122Z",
-     "shell.execute_reply": "2026-09-11T07:25:49.336289Z"
+     "iopub.execute_input": "2026-09-11T08:16:59.660762Z",
+     "iopub.status.busy": "2026-09-11T08:16:59.660554Z",
+     "iopub.status.idle": "2026-09-11T08:16:59.666127Z",
+     "shell.execute_reply": "2026-09-11T08:16:59.665279Z"
     },
     "papermill": {
-     "duration": 0.014215,
-     "end_time": "2026-09-11T07:25:49.337677+00:00",
+     "duration": 0.013838,
+     "end_time": "2026-09-11T08:16:59.667593+00:00",
      "exception": false,
-     "start_time": "2026-09-11T07:25:49.323462+00:00",
+     "start_time": "2026-09-11T08:16:59.653755+00:00",
      "status": "completed"
     },
     "tags": []
@@ -968,19 +950,19 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "id": "8f603159",
+   "id": "61a6ee16",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T07:25:49.346622Z",
-     "iopub.status.busy": "2026-09-11T07:25:49.346368Z",
-     "iopub.status.idle": "2026-09-11T07:25:49.350323Z",
-     "shell.execute_reply": "2026-09-11T07:25:49.349626Z"
+     "iopub.execute_input": "2026-09-11T08:16:59.684212Z",
+     "iopub.status.busy": "2026-09-11T08:16:59.683969Z",
+     "iopub.status.idle": "2026-09-11T08:16:59.688499Z",
+     "shell.execute_reply": "2026-09-11T08:16:59.687982Z"
     },
     "papermill": {
-     "duration": 0.009402,
-     "end_time": "2026-09-11T07:25:49.351131+00:00",
+     "duration": 0.015478,
+     "end_time": "2026-09-11T08:16:59.688857+00:00",
      "exception": false,
-     "start_time": "2026-09-11T07:25:49.341729+00:00",
+     "start_time": "2026-09-11T08:16:59.673379+00:00",
      "status": "completed"
     },
     "tags": []
@@ -993,7 +975,7 @@
       "Correlation Filtering (threshold=0.9):\n",
       "  Before: 57 features\n",
       "  After:  45 features\n",
-      "  Removed: ['stoch_k', 'sma_ratio_50', 'vol_21d', 'vol_ratio_21d', 'vol_126d', 'ret_252d', 'ret_126d', 'vol_63d', 'rsi_7', 'cci_21', 'max_dd_126d', 'cci_14']\n"
+      "  Removed: ['vol_126d', 'vol_ratio_21d', 'stoch_k', 'ret_126d', 'rsi_7', 'vol_63d', 'sma_ratio_50', 'max_dd_126d', 'vol_21d', 'cci_14', 'cci_21', 'ret_252d']\n"
      ]
     }
    ],
@@ -1015,13 +997,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d8ace27e",
+   "id": "c2b7ceb6",
    "metadata": {
     "papermill": {
-     "duration": 0.0085,
-     "end_time": "2026-09-11T07:25:49.366642+00:00",
+     "duration": 0.00366,
+     "end_time": "2026-09-11T08:16:59.697822+00:00",
      "exception": false,
-     "start_time": "2026-09-11T07:25:49.358142+00:00",
+     "start_time": "2026-09-11T08:16:59.694162+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1043,13 +1025,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "77f9d5e3",
+   "id": "f93ae9a7",
    "metadata": {
     "papermill": {
-     "duration": 0.006055,
-     "end_time": "2026-09-11T07:25:49.379939+00:00",
+     "duration": 0.002787,
+     "end_time": "2026-09-11T08:16:59.703552+00:00",
      "exception": false,
-     "start_time": "2026-09-11T07:25:49.373884+00:00",
+     "start_time": "2026-09-11T08:16:59.700765+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1062,19 +1044,19 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "id": "53296d3b",
+   "id": "47bfbf81",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T07:25:49.398621Z",
-     "iopub.status.busy": "2026-09-11T07:25:49.398099Z",
-     "iopub.status.idle": "2026-09-11T07:25:49.405182Z",
-     "shell.execute_reply": "2026-09-11T07:25:49.404555Z"
+     "iopub.execute_input": "2026-09-11T08:16:59.713620Z",
+     "iopub.status.busy": "2026-09-11T08:16:59.713055Z",
+     "iopub.status.idle": "2026-09-11T08:16:59.718639Z",
+     "shell.execute_reply": "2026-09-11T08:16:59.717627Z"
     },
     "papermill": {
-     "duration": 0.019359,
-     "end_time": "2026-09-11T07:25:49.406251+00:00",
+     "duration": 0.012644,
+     "end_time": "2026-09-11T08:16:59.719246+00:00",
      "exception": false,
-     "start_time": "2026-09-11T07:25:49.386892+00:00",
+     "start_time": "2026-09-11T08:16:59.706602+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1100,19 +1082,19 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "id": "f09971c5",
+   "id": "cf6073b7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T07:25:49.421447Z",
-     "iopub.status.busy": "2026-09-11T07:25:49.421055Z",
-     "iopub.status.idle": "2026-09-11T07:25:49.919769Z",
-     "shell.execute_reply": "2026-09-11T07:25:49.918251Z"
+     "iopub.execute_input": "2026-09-11T08:16:59.728697Z",
+     "iopub.status.busy": "2026-09-11T08:16:59.728338Z",
+     "iopub.status.idle": "2026-09-11T08:17:00.427907Z",
+     "shell.execute_reply": "2026-09-11T08:17:00.427071Z"
     },
     "papermill": {
-     "duration": 0.508908,
-     "end_time": "2026-09-11T07:25:49.921612+00:00",
+     "duration": 0.708204,
+     "end_time": "2026-09-11T08:17:00.430948+00:00",
      "exception": false,
-     "start_time": "2026-09-11T07:25:49.412704+00:00",
+     "start_time": "2026-09-11T08:16:59.722744+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1178,13 +1160,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ba5ac0f5",
+   "id": "266833a0",
    "metadata": {
     "papermill": {
-     "duration": 0.003299,
-     "end_time": "2026-09-11T07:25:49.930464+00:00",
+     "duration": 0.003719,
+     "end_time": "2026-09-11T08:17:00.440839+00:00",
      "exception": false,
-     "start_time": "2026-09-11T07:25:49.927165+00:00",
+     "start_time": "2026-09-11T08:17:00.437120+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1199,19 +1181,19 @@
   {
    "cell_type": "code",
    "execution_count": 17,
-   "id": "28a6ccfd",
+   "id": "b46c12a9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T07:25:49.938516Z",
-     "iopub.status.busy": "2026-09-11T07:25:49.938329Z",
-     "iopub.status.idle": "2026-09-11T07:25:49.944032Z",
-     "shell.execute_reply": "2026-09-11T07:25:49.943393Z"
+     "iopub.execute_input": "2026-09-11T08:17:00.450625Z",
+     "iopub.status.busy": "2026-09-11T08:17:00.450417Z",
+     "iopub.status.idle": "2026-09-11T08:17:00.456847Z",
+     "shell.execute_reply": "2026-09-11T08:17:00.456245Z"
     },
     "papermill": {
-     "duration": 0.010693,
-     "end_time": "2026-09-11T07:25:49.944481+00:00",
+     "duration": 0.012266,
+     "end_time": "2026-09-11T08:17:00.457220+00:00",
      "exception": false,
-     "start_time": "2026-09-11T07:25:49.933788+00:00",
+     "start_time": "2026-09-11T08:17:00.444954+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1305,13 +1287,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1f37d873",
+   "id": "0261f971",
    "metadata": {
     "papermill": {
-     "duration": 0.004579,
-     "end_time": "2026-09-11T07:25:49.954491+00:00",
+     "duration": 0.003202,
+     "end_time": "2026-09-11T08:17:00.464451+00:00",
      "exception": false,
-     "start_time": "2026-09-11T07:25:49.949912+00:00",
+     "start_time": "2026-09-11T08:17:00.461249+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1332,19 +1314,19 @@
   {
    "cell_type": "code",
    "execution_count": 18,
-   "id": "11159f03",
+   "id": "e1e4f3fa",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T07:25:49.973592Z",
-     "iopub.status.busy": "2026-09-11T07:25:49.973261Z",
-     "iopub.status.idle": "2026-09-11T07:25:50.013801Z",
-     "shell.execute_reply": "2026-09-11T07:25:50.013303Z"
+     "iopub.execute_input": "2026-09-11T08:17:00.475093Z",
+     "iopub.status.busy": "2026-09-11T08:17:00.474847Z",
+     "iopub.status.idle": "2026-09-11T08:17:00.517233Z",
+     "shell.execute_reply": "2026-09-11T08:17:00.516284Z"
     },
     "papermill": {
-     "duration": 0.053064,
-     "end_time": "2026-09-11T07:25:50.014179+00:00",
+     "duration": 0.049521,
+     "end_time": "2026-09-11T08:17:00.518132+00:00",
      "exception": false,
-     "start_time": "2026-09-11T07:25:49.961115+00:00",
+     "start_time": "2026-09-11T08:17:00.468611+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1405,13 +1387,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cbe3b7bd",
+   "id": "48f1c42b",
    "metadata": {
     "papermill": {
-     "duration": 0.003045,
-     "end_time": "2026-09-11T07:25:50.020494+00:00",
+     "duration": 0.004269,
+     "end_time": "2026-09-11T08:17:00.526424+00:00",
      "exception": false,
-     "start_time": "2026-09-11T07:25:50.017449+00:00",
+     "start_time": "2026-09-11T08:17:00.522155+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1428,19 +1410,19 @@
   {
    "cell_type": "code",
    "execution_count": 19,
-   "id": "8f3bdff8",
+   "id": "0f621882",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T07:25:50.027289Z",
-     "iopub.status.busy": "2026-09-11T07:25:50.027121Z",
-     "iopub.status.idle": "2026-09-11T07:25:50.031179Z",
-     "shell.execute_reply": "2026-09-11T07:25:50.030319Z"
+     "iopub.execute_input": "2026-09-11T08:17:00.537358Z",
+     "iopub.status.busy": "2026-09-11T08:17:00.537098Z",
+     "iopub.status.idle": "2026-09-11T08:17:00.540924Z",
+     "shell.execute_reply": "2026-09-11T08:17:00.540237Z"
     },
     "papermill": {
-     "duration": 0.009782,
-     "end_time": "2026-09-11T07:25:50.033206+00:00",
+     "duration": 0.010507,
+     "end_time": "2026-09-11T08:17:00.541489+00:00",
      "exception": false,
-     "start_time": "2026-09-11T07:25:50.023424+00:00",
+     "start_time": "2026-09-11T08:17:00.530982+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1468,19 +1450,19 @@
   {
    "cell_type": "code",
    "execution_count": 20,
-   "id": "0f589df2",
+   "id": "2afe4b00",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T07:25:50.044201Z",
-     "iopub.status.busy": "2026-09-11T07:25:50.044028Z",
-     "iopub.status.idle": "2026-09-11T07:25:50.047207Z",
-     "shell.execute_reply": "2026-09-11T07:25:50.046803Z"
+     "iopub.execute_input": "2026-09-11T08:17:00.556782Z",
+     "iopub.status.busy": "2026-09-11T08:17:00.556434Z",
+     "iopub.status.idle": "2026-09-11T08:17:00.561361Z",
+     "shell.execute_reply": "2026-09-11T08:17:00.560614Z"
     },
     "papermill": {
-     "duration": 0.010285,
-     "end_time": "2026-09-11T07:25:50.047921+00:00",
+     "duration": 0.0155,
+     "end_time": "2026-09-11T08:17:00.561796+00:00",
      "exception": false,
-     "start_time": "2026-09-11T07:25:50.037636+00:00",
+     "start_time": "2026-09-11T08:17:00.546296+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1515,14 +1497,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6005dfc4",
+   "id": "2565c12c",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.006711,
-     "end_time": "2026-09-11T07:25:50.061417+00:00",
+     "duration": 0.003606,
+     "end_time": "2026-09-11T08:17:00.569768+00:00",
      "exception": false,
-     "start_time": "2026-09-11T07:25:50.054706+00:00",
+     "start_time": "2026-09-11T08:17:00.566162+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1565,19 +1547,19 @@
   {
    "cell_type": "code",
    "execution_count": 21,
-   "id": "794be6d5",
+   "id": "a98c876a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T07:25:50.078862Z",
-     "iopub.status.busy": "2026-09-11T07:25:50.078548Z",
-     "iopub.status.idle": "2026-09-11T07:25:50.085347Z",
-     "shell.execute_reply": "2026-09-11T07:25:50.084629Z"
+     "iopub.execute_input": "2026-09-11T08:17:00.579725Z",
+     "iopub.status.busy": "2026-09-11T08:17:00.579515Z",
+     "iopub.status.idle": "2026-09-11T08:17:00.585109Z",
+     "shell.execute_reply": "2026-09-11T08:17:00.584505Z"
     },
     "papermill": {
-     "duration": 0.017376,
-     "end_time": "2026-09-11T07:25:50.086045+00:00",
+     "duration": 0.0118,
+     "end_time": "2026-09-11T08:17:00.585668+00:00",
      "exception": false,
-     "start_time": "2026-09-11T07:25:50.068669+00:00",
+     "start_time": "2026-09-11T08:17:00.573868+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1654,19 +1636,19 @@
   {
    "cell_type": "code",
    "execution_count": 22,
-   "id": "17042c87",
+   "id": "ff158f75",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T07:25:50.108275Z",
-     "iopub.status.busy": "2026-09-11T07:25:50.107882Z",
-     "iopub.status.idle": "2026-09-11T07:26:45.660142Z",
-     "shell.execute_reply": "2026-09-11T07:26:45.659512Z"
+     "iopub.execute_input": "2026-09-11T08:17:00.596539Z",
+     "iopub.status.busy": "2026-09-11T08:17:00.596002Z",
+     "iopub.status.idle": "2026-09-11T08:17:51.335332Z",
+     "shell.execute_reply": "2026-09-11T08:17:51.334679Z"
     },
     "papermill": {
-     "duration": 55.571288,
-     "end_time": "2026-09-11T07:26:45.665650+00:00",
+     "duration": 50.757661,
+     "end_time": "2026-09-11T08:17:51.347550+00:00",
      "exception": false,
-     "start_time": "2026-09-11T07:25:50.094362+00:00",
+     "start_time": "2026-09-11T08:17:00.589889+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1751,19 +1733,19 @@
   {
    "cell_type": "code",
    "execution_count": 23,
-   "id": "a0cce48d",
+   "id": "b0779ba2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T07:26:45.675281Z",
-     "iopub.status.busy": "2026-09-11T07:26:45.675035Z",
-     "iopub.status.idle": "2026-09-11T07:26:45.777694Z",
-     "shell.execute_reply": "2026-09-11T07:26:45.777223Z"
+     "iopub.execute_input": "2026-09-11T08:17:51.363273Z",
+     "iopub.status.busy": "2026-09-11T08:17:51.363035Z",
+     "iopub.status.idle": "2026-09-11T08:17:51.476566Z",
+     "shell.execute_reply": "2026-09-11T08:17:51.475955Z"
     },
     "papermill": {
-     "duration": 0.109242,
-     "end_time": "2026-09-11T07:26:45.777956+00:00",
+     "duration": 0.123191,
+     "end_time": "2026-09-11T08:17:51.477709+00:00",
      "exception": false,
-     "start_time": "2026-09-11T07:26:45.668714+00:00",
+     "start_time": "2026-09-11T08:17:51.354518+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1818,13 +1800,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3d9dea7e",
+   "id": "992fbfd4",
    "metadata": {
     "papermill": {
-     "duration": 0.003092,
-     "end_time": "2026-09-11T07:26:45.784551+00:00",
+     "duration": 0.004091,
+     "end_time": "2026-09-11T08:17:51.490049+00:00",
      "exception": false,
-     "start_time": "2026-09-11T07:26:45.781459+00:00",
+     "start_time": "2026-09-11T08:17:51.485958+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1840,19 +1822,19 @@
   {
    "cell_type": "code",
    "execution_count": 24,
-   "id": "ccef0df5",
+   "id": "f590b49a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T07:26:45.792308Z",
-     "iopub.status.busy": "2026-09-11T07:26:45.792023Z",
-     "iopub.status.idle": "2026-09-11T07:26:58.618200Z",
-     "shell.execute_reply": "2026-09-11T07:26:58.617428Z"
+     "iopub.execute_input": "2026-09-11T08:17:51.499685Z",
+     "iopub.status.busy": "2026-09-11T08:17:51.499392Z",
+     "iopub.status.idle": "2026-09-11T08:18:05.892230Z",
+     "shell.execute_reply": "2026-09-11T08:18:05.890841Z"
     },
     "papermill": {
-     "duration": 12.83085,
-     "end_time": "2026-09-11T07:26:58.618735+00:00",
+     "duration": 14.399573,
+     "end_time": "2026-09-11T08:18:05.893493+00:00",
      "exception": false,
-     "start_time": "2026-09-11T07:26:45.787885+00:00",
+     "start_time": "2026-09-11T08:17:51.493920+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1911,13 +1893,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f72bd518",
+   "id": "e786df1c",
    "metadata": {
     "papermill": {
-     "duration": 0.006228,
-     "end_time": "2026-09-11T07:26:58.631167+00:00",
+     "duration": 0.006927,
+     "end_time": "2026-09-11T08:18:05.909975+00:00",
      "exception": false,
-     "start_time": "2026-09-11T07:26:58.624939+00:00",
+     "start_time": "2026-09-11T08:18:05.903048+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1932,13 +1914,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d3982e0c",
+   "id": "2fcf6e5d",
    "metadata": {
     "papermill": {
-     "duration": 0.006639,
-     "end_time": "2026-09-11T07:26:58.644412+00:00",
+     "duration": 0.004552,
+     "end_time": "2026-09-11T08:18:05.922286+00:00",
      "exception": false,
-     "start_time": "2026-09-11T07:26:58.637773+00:00",
+     "start_time": "2026-09-11T08:18:05.917734+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1949,13 +1931,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3dc13f1a",
+   "id": "522d0461",
    "metadata": {
     "papermill": {
-     "duration": 0.007403,
-     "end_time": "2026-09-11T07:26:58.660129+00:00",
+     "duration": 0.004945,
+     "end_time": "2026-09-11T08:18:05.931818+00:00",
      "exception": false,
-     "start_time": "2026-09-11T07:26:58.652726+00:00",
+     "start_time": "2026-09-11T08:18:05.926873+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1973,19 +1955,19 @@
   {
    "cell_type": "code",
    "execution_count": 25,
-   "id": "af20475c",
+   "id": "4d2d571e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T07:26:58.676417Z",
-     "iopub.status.busy": "2026-09-11T07:26:58.676292Z",
-     "iopub.status.idle": "2026-09-11T07:26:58.925987Z",
-     "shell.execute_reply": "2026-09-11T07:26:58.925154Z"
+     "iopub.execute_input": "2026-09-11T08:18:05.943614Z",
+     "iopub.status.busy": "2026-09-11T08:18:05.943480Z",
+     "iopub.status.idle": "2026-09-11T08:18:06.284988Z",
+     "shell.execute_reply": "2026-09-11T08:18:06.284395Z"
     },
     "papermill": {
-     "duration": 0.258767,
-     "end_time": "2026-09-11T07:26:58.926524+00:00",
+     "duration": 0.348313,
+     "end_time": "2026-09-11T08:18:06.285574+00:00",
      "exception": false,
-     "start_time": "2026-09-11T07:26:58.667757+00:00",
+     "start_time": "2026-09-11T08:18:05.937261+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2058,13 +2040,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fcf7e5e7",
+   "id": "1d4b5467",
    "metadata": {
     "papermill": {
-     "duration": 0.006482,
-     "end_time": "2026-09-11T07:26:58.939961+00:00",
+     "duration": 0.006263,
+     "end_time": "2026-09-11T08:18:06.296461+00:00",
      "exception": false,
-     "start_time": "2026-09-11T07:26:58.933479+00:00",
+     "start_time": "2026-09-11T08:18:06.290198+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2076,19 +2058,19 @@
   {
    "cell_type": "code",
    "execution_count": 26,
-   "id": "dad5c4b6",
+   "id": "4cd69966",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T07:26:58.954173Z",
-     "iopub.status.busy": "2026-09-11T07:26:58.953986Z",
-     "iopub.status.idle": "2026-09-11T07:26:58.959971Z",
-     "shell.execute_reply": "2026-09-11T07:26:58.959521Z"
+     "iopub.execute_input": "2026-09-11T08:18:06.313124Z",
+     "iopub.status.busy": "2026-09-11T08:18:06.312881Z",
+     "iopub.status.idle": "2026-09-11T08:18:06.323228Z",
+     "shell.execute_reply": "2026-09-11T08:18:06.321925Z"
     },
     "papermill": {
-     "duration": 0.01385,
-     "end_time": "2026-09-11T07:26:58.960453+00:00",
+     "duration": 0.018969,
+     "end_time": "2026-09-11T08:18:06.325849+00:00",
      "exception": false,
-     "start_time": "2026-09-11T07:26:58.946603+00:00",
+     "start_time": "2026-09-11T08:18:06.306880+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2150,19 +2132,19 @@
   {
    "cell_type": "code",
    "execution_count": 27,
-   "id": "6d7de1fc",
+   "id": "cc7f4779",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T07:26:58.974666Z",
-     "iopub.status.busy": "2026-09-11T07:26:58.974386Z",
-     "iopub.status.idle": "2026-09-11T07:26:59.026243Z",
-     "shell.execute_reply": "2026-09-11T07:26:59.025504Z"
+     "iopub.execute_input": "2026-09-11T08:18:06.342044Z",
+     "iopub.status.busy": "2026-09-11T08:18:06.341921Z",
+     "iopub.status.idle": "2026-09-11T08:18:06.409931Z",
+     "shell.execute_reply": "2026-09-11T08:18:06.409459Z"
     },
     "papermill": {
-     "duration": 0.059511,
-     "end_time": "2026-09-11T07:26:59.026778+00:00",
+     "duration": 0.077841,
+     "end_time": "2026-09-11T08:18:06.410958+00:00",
      "exception": false,
-     "start_time": "2026-09-11T07:26:58.967267+00:00",
+     "start_time": "2026-09-11T08:18:06.333117+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2198,13 +2180,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "242d17f0",
+   "id": "3b23551a",
    "metadata": {
     "papermill": {
-     "duration": 0.007389,
-     "end_time": "2026-09-11T07:26:59.041537+00:00",
+     "duration": 0.007285,
+     "end_time": "2026-09-11T08:18:06.425915+00:00",
      "exception": false,
-     "start_time": "2026-09-11T07:26:59.034148+00:00",
+     "start_time": "2026-09-11T08:18:06.418630+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2258,24 +2240,24 @@
    "version": "3.14.3"
   },
   "ml4t_provenance": {
-   "executed_at": "2026-09-11T07:27:16.229316+00:00",
+   "executed_at": "2026-09-11T08:18:20.313271+00:00",
    "executor": "local-uv",
    "library_digest": "415352dabd87a452f902172f98ece074587f5ba1bf9604e8530958f720919334",
-   "outputs_digest": "0652e0badc3e3127f240ed021d613f3fa30b74caaf17e2c8dce43d9f7a263e51",
+   "outputs_digest": "47ac0679d7491e62b40610a4518fe36d60f4f634a804a91179f080caa24fb38d",
    "parameters": {},
    "production": true,
-   "source_py_blob": "ba9c7d4bdc9731f35ee52ad43f99c378c201864c"
+   "source_py_blob": "fad905ac6e07ba945c7ab5821f0ff1010630d5f2"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 82.357964,
-   "end_time": "2026-09-11T07:27:02.007975+00:00",
+   "duration": 80.277541,
+   "end_time": "2026-09-11T08:18:09.404400+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "~/ml4t/public-teach-b6/08_financial_features/.05_feature_selection.build.2956993.ipynb",
-   "output_path": "~/ml4t/public-teach-b6/08_financial_features/.05_feature_selection.papermill.2956993.ipynb",
+   "input_path": "~/ml4t/public-teach-b6/08_financial_features/.05_feature_selection.build.3056495.ipynb",
+   "output_path": "~/ml4t/public-teach-b6/08_financial_features/.05_feature_selection.papermill.3056495.ipynb",
    "parameters": {},
-   "start_time": "2026-09-11T07:25:39.650011+00:00",
+   "start_time": "2026-09-11T08:16:49.126859+00:00",
    "version": "2.7.0"
   }
  },

--- a/08_financial_features/05_feature_selection.py
+++ b/08_financial_features/05_feature_selection.py
@@ -204,7 +204,6 @@ analysis = features_df.join(
 
 print(f"Analysis dataset: {analysis.shape}")
 
-# %% tags=[]
 # %% [markdown] tags=[]
 # Cross-sectional IC is computed per date, then sorted by timestamp. The sort matters:
 # `group_by` does not preserve order, and the Newey-West t-statistic below regresses each


### PR DESCRIPTION
Chapter 8's pass converted leading comment blocks into markdown cells. In
`05_feature_selection` that left the original `# %% tags=[]` marker stranded directly above
the new `# %% [markdown] tags=[]`, so the notebook shipped an empty code cell: no source, no
output, a blank input box for the reader and a null execution count in the file.

Nothing catches this. `nbcheck`'s null-execution-count rule passes it, because a cell with no
source has nothing to have executed, and in the `.py` it is two markers in a row rather than
anything that reads as wrong. I found it counting execution counts on `main` after #950
merged.

Swept the chapter's other seven notebooks with the same test; this was the only occurrence.
Notebook re-executed, `nbcheck` 0 findings, null execution counts 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)