### PR TITLE
Mark the three sp500 price-basis tests that assert production magnitudes

### DIFF
--- a/tests/test_sp500_eoa_backtest_price_basis.py
+++ b/tests/test_sp500_eoa_backtest_price_basis.py
@@ -5,6 +5,18 @@ price factor separately, so a panel built on the printed close books every split
 reverse split and cash dividend as P&L. `02_labels` builds every label from
 `close * adj_factor` inside a `sec_id`, which left the label and the backtest
 measuring returns on two different price series.
+
+Three of these tests assert an **absolute** property of the production extract - a shared
+window wider than 50,000 rows, 15 ticker reassignments, a 2019 panel wider than 100,000
+rows. `ml4t/third-edition-test-data` ships a reduced extract that is large enough for
+`load_sp500_daily_bars` to succeed and far too small to satisfy those counts, so the
+`DataNotFoundError` guard never fires and they fail locally on size. In CI they skip,
+because there are no licensed bars there at all: green where nobody looks and red where
+everybody does. They carry `@pytest.mark.production_extract`, which CI deselects, and are
+verified locally against the real data. The guard stays: it answers whether the data is
+present, the marker answers whether it is the production extract, and a checkout with no
+licensed bars still needs the first. The other tests in this file assert relations that
+hold on any extract, and those are the ones a CI job can gate.
 """
 
 from __future__ import annotations
@@ -235,6 +247,7 @@ def test_two_windows_of_one_series_agree_about_the_dates_they_share():
     assert max(abs(r) for r in _returns(seam, "GE")) < 0.20
 
 
+@pytest.mark.production_extract
 def test_two_real_loads_agree_about_the_dates_they_share():
     """The same guard through `load_backtest_prices`, on the windows holdout actually uses.
 
@@ -264,6 +277,7 @@ def test_two_real_loads_agree_about_the_dates_they_share():
     assert seam.filter(pl.col("r").abs() > 0.60).is_empty()
 
 
+@pytest.mark.production_extract
 def test_the_real_panel_carries_no_corporate_action_as_a_price_move():
     """The shipped 2017-2021 extract, through the loader the backtest calls."""
     try:
@@ -325,6 +339,7 @@ def test_the_real_panel_keeps_prices_at_the_level_positions_are_sized_against():
     assert drift == pytest.approx(0.0, abs=1e-9)
 
 
+@pytest.mark.production_extract
 def test_the_real_panel_matches_the_price_basis_the_labels_use():
     """`02_labels` builds every label from `close * adj_factor` within a `sec_id`."""
     try:


### PR DESCRIPTION
Three tests in `tests/test_sp500_eoa_backtest_price_basis.py` assert absolute counts of the production extract - a shared window over 50,000 rows, 15 ticker reassignments, a 2019 panel over 100,000 rows - and guard with `except DataNotFoundError: pytest.skip(...)`. That guard asks whether the data is present, not whether it is the production extract.

`ml4t/third-edition-test-data` ships a reduced extract that is large enough for `load_sp500_daily_bars` to succeed, so the guard never fires and the three fail on size: 4,058, 1 and 6,776 against 50,000, 15 and 100,000. In CI they skip instead, because no licensed bars are checked out there. The result is a test that is green where nobody looks and red where everybody does, which is how it stayed unnoticed.

They now carry `@pytest.mark.production_extract` - the marker `tests/test_eoa_universe_roster.py` one directory over already uses for exactly this shape, declared at `pyproject.toml:345` and deselected at `.github/workflows/test.yml:1040`. The `DataNotFoundError` guard stays: the marker and the guard answer different questions, and a checkout with no licensed data at all still needs the guard.

## Verification

A marker is the one change that can silently turn a gate off, so both halves were run against the reduced extract:

- `pytest tests/test_sp500_eoa_backtest_price_basis.py -m "not production_extract"` collects 15, deselects 3, passes 12.
- The bare run still fails exactly those three, on the same assertions.

An exemption with no case that must still fail would not be decidable from the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HduEssoPyjTKmdbP4KuujG

