### PR TITLE
Two producers wrote four fixture files, and the last one to run won

### DIFF
--- a/tests/create_test_data.py
+++ b/tests/create_test_data.py
@@ -1203,6 +1203,98 @@ def build_cme_futures(source: Path, output: Path) -> list[Path]:
     return written
 
 
+# --- NASDAQ ITCH messages and the ES individual contracts ---------------------
+#
+# Four fixture files under paths that `tests/generate_test_microstructure.py`
+# otherwise fills with synthetic data. They were widened from production on
+# 2026-05-06 (ES, for the `timestamp`/`tenor`/`product` schema) and 2026-05-17
+# (ITCH `A`, `P`, `R`, to unblock 08_financial_features/02_microstructure_features),
+# and the generator was not told, so for four months the two producers wrote
+# different content to the same paths and whichever ran last won. The generator now
+# names them in its `PRODUCTION_SOURCED` set and refuses them; they are declared here.
+
+ITCH_MESSAGES = Path("equities") / "market" / "microstructure" / "nasdaq_itch" / "messages"
+# The five the fixture carries. Widening beyond them costs little, but
+# 02_microstructure_features asserts >= 100 AAPL trade rows and reads three of these
+# by name, so narrowing is what would break.
+ITCH_SYMBOLS = ("AAPL", "GOOGL", "MSFT", "NVDA", "TSLA")
+ITCH_ROWS_PER_SYMBOL = 500
+# `R` is the stock directory: one row per symbol, so it is taken whole rather than
+# capped. `A` and `P` are the message types a notebook reads.
+ITCH_MESSAGE_TYPES = ("A", "P", "R")
+
+ES_INDIVIDUAL = Path("futures") / "market" / "individual" / "ES" / "data.parquet"
+
+
+def build_nasdaq_itch_messages(source: Path, output: Path) -> list[Path]:
+    """Take the first ``ITCH_ROWS_PER_SYMBOL`` messages per symbol from production.
+
+    Production stores each message type as 43 parquet parts in timestamp order. The
+    reduction reads them in that order, keeps the head per symbol, and re-sorts by
+    timestamp, which is what makes the result a contiguous early slice of the
+    trading day rather than a sample scattered across it: a limit-order-book reader
+    needs the adds that precede an event, and a random sample supplies neither side.
+
+    `R` has one row per symbol and is taken whole.
+    """
+    written: list[Path] = []
+    for message_type in ITCH_MESSAGE_TYPES:
+        source_dir = source / ITCH_MESSAGES / message_type
+        parts = sorted(source_dir.glob("part-*.parquet"))
+        if not parts:
+            raise FileNotFoundError(
+                f"No ITCH {message_type} messages at {source_dir}. Parse them with "
+                "data/equities/market/microstructure/nasdaq_itch_download.py."
+            )
+        frame = pl.scan_parquet(parts).filter(pl.col("stock").is_in(ITCH_SYMBOLS)).collect()
+        missing = sorted(set(ITCH_SYMBOLS) - set(frame["stock"].unique().to_list()))
+        if missing:
+            raise ValueError(
+                f"Production ITCH {message_type} carries no messages for {missing}. "
+                "The fixture's consumers read those symbols by name."
+            )
+        columns = frame.columns
+        if message_type != "R":
+            frame = (
+                frame.group_by("stock", maintain_order=True)
+                .head(ITCH_ROWS_PER_SYMBOL)
+                .select(columns)
+                .sort("timestamp")
+            )
+        destination = output / ITCH_MESSAGES / message_type / "part-000000.parquet"
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        frame.write_parquet(destination)
+        print(f"    {message_type}/: {frame.height:,} rows, {frame['stock'].n_unique()} symbols")
+        written.append(destination)
+    return written
+
+
+def build_individual_futures_es(source: Path, output: Path) -> list[Path]:
+    """Copy the production ES individual-contract bars verbatim.
+
+    290 KB for ten years across every listed contract month. A reduction would have
+    to choose which months to keep, and the notebook that reads this file rolls
+    between them, so dropping any is dropping the thing it demonstrates.
+
+    CL and NQ sit beside this file and are synthetic, from
+    `tests/generate_test_microstructure.py`; production carries neither.
+    """
+    src = source / ES_INDIVIDUAL
+    if not src.exists():
+        raise FileNotFoundError(
+            f"ES individual contracts not found at {src}. Fetch them with "
+            "data/futures/market/cme_download.py."
+        )
+    dst = output / ES_INDIVIDUAL
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copyfile(src, dst)
+    rows = pl.scan_parquet(dst).select(pl.len()).collect().item()
+    print(
+        f"    ES/data.parquet: {rows:,} rows ({dst.stat().st_size / 1e6:.1f} MB), copied verbatim"
+    )
+    return [dst]
+
+
 DATASETS: tuple[Dataset, ...] = (
     Dataset(
         name="etfs",
@@ -1368,6 +1460,45 @@ DATASETS: tuple[Dataset, ...] = (
         # Named individually, not as the 13f/ directory: bulk/ sits beside them and
         # is produced elsewhere, so --clean must not take it.
         owns=tuple(Path("equities") / "positioning" / "13f" / name for name in _13F_FILES),
+        budget={"subsample": "none"},
+    ),
+    Dataset(
+        name="nasdaq_itch_messages",
+        description=(
+            f"the first {ITCH_ROWS_PER_SYMBOL} production ITCH add-order and trade "
+            f"messages per symbol for {len(ITCH_SYMBOLS)} symbols, plus their stock "
+            "directory rows, as a contiguous slice of the open rather than a sample"
+        ),
+        build=build_nasdaq_itch_messages,
+        # Named individually, not as the messages/ directory: the other seven message
+        # types there are synthetic and come from tests/generate_test_microstructure.py,
+        # so --clean must not take them.
+        owns=tuple(
+            ITCH_MESSAGES / message_type / "part-000000.parquet"
+            for message_type in ITCH_MESSAGE_TYPES
+        ),
+        budget={
+            "symbols": list(ITCH_SYMBOLS),
+            "rows_per_symbol": ITCH_ROWS_PER_SYMBOL,
+            "message_types": list(ITCH_MESSAGE_TYPES),
+        },
+        entities={
+            (ITCH_MESSAGES / message_type / "part-000000.parquet").as_posix(): (
+                "stock",
+                len(ITCH_SYMBOLS),
+            )
+            for message_type in ITCH_MESSAGE_TYPES
+        },
+    ),
+    Dataset(
+        name="individual_futures_es",
+        description=(
+            "the whole production ES individual-contract panel, small enough to "
+            "ship intact and carrying every contract month the roll demonstrates"
+        ),
+        build=build_individual_futures_es,
+        # Named individually: CL and NQ sit in the same directory and are synthetic.
+        owns=(ES_INDIVIDUAL,),
         budget={"subsample": "none"},
     ),
 )

--- a/tests/generate_test_microstructure.py
+++ b/tests/generate_test_microstructure.py
@@ -11,13 +11,16 @@ Usage:
     uv run python tests/generate_test_microstructure.py --output-root DIR
     uv run python tests/generate_test_microstructure.py            # writes the live fixture
 
-**Four of its twenty outputs no longer reproduce what is on disk**, so running it
-without checking first destroys real data. Measured 2026-09-11: it writes 345 rows
-to `futures/market/individual/ES/data.parquet` where the fixture carries 19,361 that
-are byte-identical to production, and 20, 3 and 3 rows to the ITCH `A`, `P` and `R`
-message files where the fixture carries 2,500, 2,500 and 5. Someone widened those
-four and did not update this script. `--check` reports the disagreement and writes
-nothing; run it before the bare form.
+It owns sixteen files. Four more that it used to write are production-sourced and
+belong to `create_test_data.py` instead: the ITCH `A`, `P` and `R` message files and
+`futures/market/individual/ES/data.parquet`. Those were widened from production on
+2026-05-06 and 2026-05-17 and this script was not updated, so for four months, running
+it overwrote 19,361 real ES bars with 345 synthetic ones and 2,500 real ITCH adds and
+trades with 20 and 3. `PRODUCTION_SOURCED` now names them and `_write` refuses them,
+so the two producers no longer contend for the same path.
+
+`--check` regenerates to a scratch directory and reports any output that stopped
+reproducing the fixture, writing nothing. It exits non-zero when one disagrees.
 """
 
 import argparse
@@ -52,6 +55,33 @@ GENERATED_ROOTS: tuple[str, ...] = (
     "prediction_markets",
 )
 
+# Paths that live under `GENERATED_ROOTS` but that this module must not write: the
+# fixture takes them from production, and `build_nasdaq_itch_messages` and
+# `build_individual_futures_es` in create_test_data.py own them.
+#
+# The frames are still *built* here, for two reasons. The synthetic `D`, `E`, `X`, `C`
+# and `U` messages are keyed to the `A` block's order references, timestamps and share
+# counts, so deleting it would leave them referencing nothing. And the `A` and ES blocks
+# draw from the seeded module-level `RNG`, whose position every later output depends on,
+# so dropping the draws would move the bytes of all sixteen files this module does own.
+PRODUCTION_SOURCED: frozenset[str] = frozenset(
+    {
+        "equities/market/microstructure/nasdaq_itch/messages/A/part-000000.parquet",
+        "equities/market/microstructure/nasdaq_itch/messages/P/part-000000.parquet",
+        "equities/market/microstructure/nasdaq_itch/messages/R/part-000000.parquet",
+        "futures/market/individual/ES/data.parquet",
+    }
+)
+
+
+def _write(frame: pl.DataFrame, path: Path, root: Path) -> bool:
+    """Write ``frame`` to ``path`` unless production owns it. Returns whether it wrote."""
+    if path.relative_to(root).as_posix() in PRODUCTION_SOURCED:
+        return False
+    path.parent.mkdir(parents=True, exist_ok=True)
+    frame.write_parquet(path)
+    return True
+
 
 # ═════════════════════════════════════════════════════════════════════════════
 # 1. ITCH Parsed Messages (for NB 02-10)
@@ -72,7 +102,6 @@ def generate_itch_messages(root: Path = TEST_DATA_ROOT) -> None:
 
     # ── R (Stock Directory) ──────────────────────────────────────────────
     r_dir = itch_dir / "R"
-    r_dir.mkdir(parents=True, exist_ok=True)
     r_df = pl.DataFrame(
         {
             "stock_locate": pl.Series([1, 2, 3], dtype=pl.UInt16),
@@ -98,7 +127,7 @@ def generate_itch_messages(root: Path = TEST_DATA_ROOT) -> None:
             "inverse_indicator": ["N", "N", "N"],
         }
     ).cast({"timestamp": pl.Datetime("ns")})
-    r_df.write_parquet(r_dir / "part-000000.parquet")
+    _write(r_df, r_dir / "part-000000.parquet", root)
 
     # ── S (System Event) ─────────────────────────────────────────────────
     s_dir = itch_dir / "S"
@@ -121,7 +150,6 @@ def generate_itch_messages(root: Path = TEST_DATA_ROOT) -> None:
     # ── A (Add Order) ────────────────────────────────────────────────────
     # 20 orders for AAPL (stock_locate=1), spanning 10:00 to 15:00
     a_dir = itch_dir / "A"
-    a_dir.mkdir(parents=True, exist_ok=True)
 
     n_orders = 20
     base_price_aapl = 320.0  # AAPL price circa Jan 2020
@@ -155,7 +183,7 @@ def generate_itch_messages(root: Path = TEST_DATA_ROOT) -> None:
             "price": pl.Series([int(p * 10000) for p in prices], dtype=pl.UInt32),
         }
     ).cast({"timestamp": pl.Datetime("ns")})
-    a_df.write_parquet(a_dir / "part-000000.parquet")
+    _write(a_df, a_dir / "part-000000.parquet", root)
 
     # ── D (Order Delete) ─────────────────────────────────────────────────
     d_dir = itch_dir / "D"
@@ -235,7 +263,6 @@ def generate_itch_messages(root: Path = TEST_DATA_ROOT) -> None:
 
     # ── P (Non-Cross Trade) ──────────────────────────────────────────────
     p_dir = itch_dir / "P"
-    p_dir.mkdir(parents=True, exist_ok=True)
     p_df = pl.DataFrame(
         {
             "stock_locate": pl.Series([1, 1, 1], dtype=pl.UInt16),
@@ -253,7 +280,7 @@ def generate_itch_messages(root: Path = TEST_DATA_ROOT) -> None:
             "match_number": pl.Series([7001, 7002, 7003], dtype=pl.UInt64),
         }
     ).cast({"timestamp": pl.Datetime("ns")})
-    p_df.write_parquet(p_dir / "part-000000.parquet")
+    _write(p_df, p_dir / "part-000000.parquet", root)
 
     # ── U (Order Replace) ────────────────────────────────────────────────
     u_dir = itch_dir / "U"
@@ -279,9 +306,14 @@ def generate_itch_messages(root: Path = TEST_DATA_ROOT) -> None:
 
     print(f"  ITCH messages written to {itch_dir}")
     for sub in sorted(itch_dir.iterdir()):
-        if sub.is_dir() and sub.name != "enriched":
-            n = pl.scan_parquet(sub / "*.parquet").select(pl.len()).collect().item()
-            print(f"    {sub.name}/: {n} rows")
+        if not sub.is_dir() or sub.name == "enriched":
+            continue
+        target = sub / "part-000000.parquet"
+        if target.relative_to(root).as_posix() in PRODUCTION_SOURCED:
+            print(f"    {sub.name}/: production-sourced, left alone")
+            continue
+        n = pl.scan_parquet(sorted(sub.glob("*.parquet"))).select(pl.len()).collect().item()
+        print(f"    {sub.name}/: {n} rows")
 
 
 # ═════════════════════════════════════════════════════════════════════════════
@@ -779,8 +811,11 @@ def generate_individual_futures(root: Path = TEST_DATA_ROOT) -> None:
             .sort("timestamp")
         )
 
-        df.write_parquet(prod_dir / "data.parquet")
-        print(f"  Futures individual {product}: {len(df)} rows -> {prod_dir / 'data.parquet'}")
+        out_file = prod_dir / "data.parquet"
+        if _write(df, out_file, root):
+            print(f"  Futures individual {product}: {len(df)} rows -> {out_file}")
+        else:
+            print(f"  Futures individual {product}: production-sourced, left alone")
 
 
 # ═════════════════════════════════════════════════════════════════════════════
@@ -892,7 +927,13 @@ def generate_all(root: Path = TEST_DATA_ROOT, *, quiet: bool = False) -> list[Pa
     for relative in GENERATED_ROOTS:
         target = root / relative
         if target.is_dir():
-            written.extend(sorted(p for p in target.rglob("*") if p.is_file()))
+            written.extend(
+                sorted(
+                    p
+                    for p in target.rglob("*")
+                    if p.is_file() and p.relative_to(root).as_posix() not in PRODUCTION_SOURCED
+                )
+            )
         elif target.is_file():
             written.append(target)
     return written

--- a/tests/test_one_producer_per_fixture_file.py
+++ b/tests/test_one_producer_per_fixture_file.py
@@ -1,0 +1,113 @@
+"""Two producers wrote the same four fixture paths, and the last one to run won.
+
+``tests/generate_test_microstructure.py`` builds a small synthetic microstructure day.
+Four of the paths it wrote were later re-sourced from production - the ITCH ``A``, ``P``
+and ``R`` message files on 2026-05-17, to unblock
+``08_financial_features/02_microstructure_features``, and
+``futures/market/individual/ES/data.parquet`` on 2026-05-06, for the current futures
+schema. Nobody told the generator. From then on it wrote 20, 3 and 3 ITCH rows over
+2,500, 2,500 and 5, and 345 synthetic ES bars over 19,361 real ones, and the fixture
+held whichever producer had run last.
+
+Nothing caught it because no test compared the two producers. These do: the generator
+declares what production owns, ``create_test_data.py`` declares the same four paths, and
+the two declarations have to partition the fixture rather than overlap.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO / "tests"))
+sys.path.insert(0, str(REPO))
+
+import generate_test_microstructure as generator  # noqa: E402
+
+from tests.create_test_data import DATASETS  # noqa: E402
+
+
+def _declared_owners(relative: str) -> list[str]:
+    """Names of the datasets in create_test_data.py that claim ``relative``."""
+    return [
+        dataset.name
+        for dataset in DATASETS
+        if any(
+            relative == owned.as_posix() or relative.startswith(f"{owned.as_posix()}/")
+            for owned in dataset.owns
+        )
+    ]
+
+
+@pytest.fixture(scope="module")
+def generated(tmp_path_factory) -> set[str]:
+    """Everything the synthetic generator writes, relative to its root."""
+    root = tmp_path_factory.mktemp("generated")
+    return {path.relative_to(root).as_posix() for path in generator.generate_all(root, quiet=True)}
+
+
+def test_the_generator_writes_nothing_production_owns(generated: set[str]) -> None:
+    """The defect itself: a path both producers write is a path with no owner."""
+    contended = sorted(generated & generator.PRODUCTION_SOURCED)
+    assert not contended, (
+        f"{contended} are written by tests/generate_test_microstructure.py and also "
+        "declared as production-sourced. Whichever producer runs last wins, which is "
+        "how 19,361 real ES bars became 345 synthetic ones."
+    )
+
+
+@pytest.mark.parametrize("relative", sorted(generator.PRODUCTION_SOURCED))
+def test_every_production_sourced_path_has_exactly_one_builder(relative: str) -> None:
+    """Declaring a path out of the generator is only half of it.
+
+    Removing it there and declaring it nowhere else leaves a fixture file that no
+    builder reproduces, which is the same defect pointed the other way.
+    """
+    owners = _declared_owners(relative)
+    assert len(owners) == 1, (
+        f"{relative} is claimed by {owners or 'no dataset'} in create_test_data.py; "
+        "it needs exactly one."
+    )
+
+
+def test_no_generated_path_is_also_claimed_in_create_test_data(generated: set[str]) -> None:
+    """The other direction: the two producers must partition, not merely not collide."""
+    doubly_owned = {rel: owners for rel in sorted(generated) if (owners := _declared_owners(rel))}
+    assert not doubly_owned, (
+        f"tests/generate_test_microstructure.py writes {sorted(doubly_owned)}, which "
+        f"create_test_data.py also claims: {doubly_owned}."
+    )
+
+
+def test_the_guard_is_what_stops_the_write(tmp_path, monkeypatch) -> None:
+    """Negative selftest.
+
+    Without it the three tests above would pass just as well on a generator that had
+    stopped writing those paths for some unrelated reason - a renamed directory, a
+    deleted block - and the declaration would be decorative. Empty the declaration and
+    the writes have to come back.
+    """
+    monkeypatch.setattr(generator, "PRODUCTION_SOURCED", frozenset())
+    written = {
+        path.relative_to(tmp_path).as_posix()
+        for path in generator.generate_all(tmp_path, quiet=True)
+    }
+
+    missing = sorted(
+        path
+        for path in (
+            "equities/market/microstructure/nasdaq_itch/messages/A/part-000000.parquet",
+            "equities/market/microstructure/nasdaq_itch/messages/P/part-000000.parquet",
+            "equities/market/microstructure/nasdaq_itch/messages/R/part-000000.parquet",
+            "futures/market/individual/ES/data.parquet",
+        )
+        if path not in written
+    )
+    assert not missing, (
+        f"With the declaration emptied the generator still does not write {missing}, so "
+        "the declaration is not what is holding those paths back and these tests prove "
+        "nothing about it."
+    )


### PR DESCRIPTION
Four fixture paths had two producers and no owner. `tests/generate_test_microstructure.py` wrote synthetic versions of the ITCH `A`, `P` and `R` message files and `futures/market/individual/ES/data.parquet`; the fixture repo re-sourced all four from production (ES on 2026-05-06 for the `timestamp`/`tenor`/`product` schema, the three ITCH files on 2026-05-17 to unblock `08_financial_features/02_microstructure_features`) and nobody told the generator. From then on, running it replaced 2,500 real ITCH adds with 20, 2,500 real trades with 3, 5 stock-directory rows with 3, and 19,361 real ES bars with 345 synthetic ones. #949 stopped an unknown flag from triggering that; this says who owns what.

## The generator refuses them

`PRODUCTION_SOURCED` names the four and `_write` skips them. The frames are still built: the synthetic `D`, `E`, `X`, `C` and `U` messages are keyed to the `A` block's order references, timestamps and share counts, and the `A` and ES blocks draw from the seeded module-level `RNG` whose position every later output depends on, so deleting either block would move the bytes of all sixteen files the generator does own.

`--check` now reports `16 outputs, 16 reproduce`.

## They are declared in create_test_data.py instead

| dataset | what it takes |
|---|---|
| `nasdaq_itch_messages` | the first 500 production messages per symbol for AAPL, GOOGL, MSFT, NVDA, TSLA, read from the 43 production parts in timestamp order and re-sorted. That makes the result a contiguous slice of the open rather than a sample scattered across the day, which matters because a limit-order-book reader needs the adds that precede an event. `R` is one row per symbol and is taken whole. |
| `individual_futures_es` | the production ES panel copied verbatim, 290 KB for ten years of contract months. CL and NQ sit in the same directory, stay synthetic, and are named individually in `owns` so `--clean` does not take them. |

Both reproduce the committed fixture: `assert_frame_equal` on all four, and ES byte-identical. The fixture's `A`, `P` and `R` were rewritten by the new builder in `ml4t/third-edition-test-data` `ac5c6b0e` (same values, parquet encoding only), so the committed bytes are now what the builder produces.

## What holds it

`tests/test_one_producer_per_fixture_file.py`: no path is written by both producers, every production-sourced path has exactly one declared builder, and a negative selftest that empties `PRODUCTION_SOURCED` and requires the four writes to come back, so the declaration cannot pass by being decorative.

Checked against `origin/main`: the generator there writes all four contended paths and has no `PRODUCTION_SOURCED`; no dataset in `create_test_data.py` claims any of them.

## Verification

- `tests/generate_test_microstructure.py --check` -> `16 outputs, 16 reproduce`, exit 0, fixture untouched.
- The two CI-active consumers of these files pass: `08_financial_features/02_microstructure_features` and `data/equities/market/microstructure/dataset_card`.
- 91 tests pass across `test_one_producer_per_fixture_file`, `test_synthetic_fixture_generator_writes_where_it_is_told`, `test_fixture_manifest_matches_builders` and `test_create_test_data`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
