### PR TITLE
Measure the age of an as-of match where a null count cannot fail

### DIFF
--- a/16_strategy_simulation/01_backtest_first_principles.ipynb
+++ b/16_strategy_simulation/01_backtest_first_principles.ipynb
@@ -5,10 +5,10 @@
    "id": "c101e7c3",
    "metadata": {
     "papermill": {
-     "duration": 0.00596,
-     "end_time": "2026-09-11T11:59:49.667503+00:00",
+     "duration": 0.0034,
+     "end_time": "2026-09-11T14:19:07.448328+00:00",
      "exception": false,
-     "start_time": "2026-09-11T11:59:49.661543+00:00",
+     "start_time": "2026-09-11T14:19:07.444928+00:00",
      "status": "completed"
     }
    },
@@ -52,10 +52,10 @@
    "id": "3710f673",
    "metadata": {
     "papermill": {
-     "duration": 0.004601,
-     "end_time": "2026-09-11T11:59:49.677185+00:00",
+     "duration": 0.002704,
+     "end_time": "2026-09-11T14:19:07.454121+00:00",
      "exception": false,
-     "start_time": "2026-09-11T11:59:49.672584+00:00",
+     "start_time": "2026-09-11T14:19:07.451417+00:00",
      "status": "completed"
     }
    },
@@ -80,16 +80,16 @@
    "id": "22988f7a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T11:59:49.688446Z",
-     "iopub.status.busy": "2026-09-11T11:59:49.688116Z",
-     "iopub.status.idle": "2026-09-11T11:59:54.995386Z",
-     "shell.execute_reply": "2026-09-11T11:59:54.994031Z"
+     "iopub.execute_input": "2026-09-11T14:19:07.462050Z",
+     "iopub.status.busy": "2026-09-11T14:19:07.461496Z",
+     "iopub.status.idle": "2026-09-11T14:19:13.524912Z",
+     "shell.execute_reply": "2026-09-11T14:19:13.523610Z"
     },
     "papermill": {
-     "duration": 5.316173,
-     "end_time": "2026-09-11T11:59:54.998396+00:00",
+     "duration": 6.069159,
+     "end_time": "2026-09-11T14:19:13.525876+00:00",
      "exception": false,
-     "start_time": "2026-09-11T11:59:49.682223+00:00",
+     "start_time": "2026-09-11T14:19:07.456717+00:00",
      "status": "completed"
     }
    },
@@ -117,16 +117,16 @@
    "id": "9586da6a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T11:59:55.013091Z",
-     "iopub.status.busy": "2026-09-11T11:59:55.012553Z",
-     "iopub.status.idle": "2026-09-11T11:59:55.017115Z",
-     "shell.execute_reply": "2026-09-11T11:59:55.016210Z"
+     "iopub.execute_input": "2026-09-11T14:19:13.544179Z",
+     "iopub.status.busy": "2026-09-11T14:19:13.543965Z",
+     "iopub.status.idle": "2026-09-11T14:19:13.546831Z",
+     "shell.execute_reply": "2026-09-11T14:19:13.546361Z"
     },
     "papermill": {
-     "duration": 0.01271,
-     "end_time": "2026-09-11T11:59:55.017941+00:00",
+     "duration": 0.018191,
+     "end_time": "2026-09-11T14:19:13.547476+00:00",
      "exception": false,
-     "start_time": "2026-09-11T11:59:55.005231+00:00",
+     "start_time": "2026-09-11T14:19:13.529285+00:00",
      "status": "completed"
     },
     "tags": [
@@ -150,16 +150,16 @@
    "id": "744951d2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T11:59:55.032799Z",
-     "iopub.status.busy": "2026-09-11T11:59:55.032292Z",
-     "iopub.status.idle": "2026-09-11T11:59:55.036939Z",
-     "shell.execute_reply": "2026-09-11T11:59:55.036077Z"
+     "iopub.execute_input": "2026-09-11T14:19:13.560771Z",
+     "iopub.status.busy": "2026-09-11T14:19:13.560468Z",
+     "iopub.status.idle": "2026-09-11T14:19:13.564806Z",
+     "shell.execute_reply": "2026-09-11T14:19:13.564147Z"
     },
     "papermill": {
-     "duration": 0.013662,
-     "end_time": "2026-09-11T11:59:55.037496+00:00",
+     "duration": 0.012242,
+     "end_time": "2026-09-11T14:19:13.565470+00:00",
      "exception": false,
-     "start_time": "2026-09-11T11:59:55.023834+00:00",
+     "start_time": "2026-09-11T14:19:13.553228+00:00",
      "status": "completed"
     }
    },
@@ -187,10 +187,10 @@
    "id": "b3659e9f",
    "metadata": {
     "papermill": {
-     "duration": 0.003829,
-     "end_time": "2026-09-11T11:59:55.045749+00:00",
+     "duration": 0.005519,
+     "end_time": "2026-09-11T14:19:13.585168+00:00",
      "exception": false,
-     "start_time": "2026-09-11T11:59:55.041920+00:00",
+     "start_time": "2026-09-11T14:19:13.579649+00:00",
      "status": "completed"
     }
    },
@@ -226,16 +226,16 @@
    "id": "ba4be155",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T11:59:55.054805Z",
-     "iopub.status.busy": "2026-09-11T11:59:55.054625Z",
-     "iopub.status.idle": "2026-09-11T11:59:55.060222Z",
-     "shell.execute_reply": "2026-09-11T11:59:55.059552Z"
+     "iopub.execute_input": "2026-09-11T14:19:13.751019Z",
+     "iopub.status.busy": "2026-09-11T14:19:13.750792Z",
+     "iopub.status.idle": "2026-09-11T14:19:13.755722Z",
+     "shell.execute_reply": "2026-09-11T14:19:13.755029Z"
     },
     "papermill": {
-     "duration": 0.011127,
-     "end_time": "2026-09-11T11:59:55.060630+00:00",
+     "duration": 0.167387,
+     "end_time": "2026-09-11T14:19:13.756219+00:00",
      "exception": false,
-     "start_time": "2026-09-11T11:59:55.049503+00:00",
+     "start_time": "2026-09-11T14:19:13.588832+00:00",
      "status": "completed"
     }
    },
@@ -283,10 +283,10 @@
    "id": "4a55e705",
    "metadata": {
     "papermill": {
-     "duration": 0.002518,
-     "end_time": "2026-09-11T11:59:55.065860+00:00",
+     "duration": 0.046626,
+     "end_time": "2026-09-11T14:19:13.842247+00:00",
      "exception": false,
-     "start_time": "2026-09-11T11:59:55.063342+00:00",
+     "start_time": "2026-09-11T14:19:13.795621+00:00",
      "status": "completed"
     }
    },
@@ -302,10 +302,10 @@
    "id": "0bd5b11d",
    "metadata": {
     "papermill": {
-     "duration": 0.002047,
-     "end_time": "2026-09-11T11:59:55.070409+00:00",
+     "duration": 0.003517,
+     "end_time": "2026-09-11T14:19:13.850361+00:00",
      "exception": false,
-     "start_time": "2026-09-11T11:59:55.068362+00:00",
+     "start_time": "2026-09-11T14:19:13.846844+00:00",
      "status": "completed"
     }
    },
@@ -323,16 +323,16 @@
    "id": "edde7dce",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T11:59:55.077310Z",
-     "iopub.status.busy": "2026-09-11T11:59:55.077107Z",
-     "iopub.status.idle": "2026-09-11T11:59:55.119554Z",
-     "shell.execute_reply": "2026-09-11T11:59:55.118625Z"
+     "iopub.execute_input": "2026-09-11T14:19:13.859732Z",
+     "iopub.status.busy": "2026-09-11T14:19:13.859371Z",
+     "iopub.status.idle": "2026-09-11T14:19:13.918882Z",
+     "shell.execute_reply": "2026-09-11T14:19:13.917090Z"
     },
     "papermill": {
-     "duration": 0.047353,
-     "end_time": "2026-09-11T11:59:55.120507+00:00",
+     "duration": 0.066542,
+     "end_time": "2026-09-11T14:19:13.920418+00:00",
      "exception": false,
-     "start_time": "2026-09-11T11:59:55.073154+00:00",
+     "start_time": "2026-09-11T14:19:13.853876+00:00",
      "status": "completed"
     }
    },
@@ -354,16 +354,16 @@
    "id": "c4e0ad46",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T11:59:55.131507Z",
-     "iopub.status.busy": "2026-09-11T11:59:55.130968Z",
-     "iopub.status.idle": "2026-09-11T11:59:55.148682Z",
-     "shell.execute_reply": "2026-09-11T11:59:55.147431Z"
+     "iopub.execute_input": "2026-09-11T14:19:13.928739Z",
+     "iopub.status.busy": "2026-09-11T14:19:13.928466Z",
+     "iopub.status.idle": "2026-09-11T14:19:13.955517Z",
+     "shell.execute_reply": "2026-09-11T14:19:13.954686Z"
     },
     "papermill": {
-     "duration": 0.02522,
-     "end_time": "2026-09-11T11:59:55.149983+00:00",
+     "duration": 0.03222,
+     "end_time": "2026-09-11T14:19:13.956087+00:00",
      "exception": false,
-     "start_time": "2026-09-11T11:59:55.124763+00:00",
+     "start_time": "2026-09-11T14:19:13.923867+00:00",
      "status": "completed"
     }
    },
@@ -383,16 +383,16 @@
    "id": "d2b0865c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T11:59:55.160092Z",
-     "iopub.status.busy": "2026-09-11T11:59:55.159824Z",
-     "iopub.status.idle": "2026-09-11T11:59:55.170875Z",
-     "shell.execute_reply": "2026-09-11T11:59:55.169992Z"
+     "iopub.execute_input": "2026-09-11T14:19:13.964506Z",
+     "iopub.status.busy": "2026-09-11T14:19:13.963990Z",
+     "iopub.status.idle": "2026-09-11T14:19:13.982298Z",
+     "shell.execute_reply": "2026-09-11T14:19:13.981322Z"
     },
     "papermill": {
-     "duration": 0.016944,
-     "end_time": "2026-09-11T11:59:55.171684+00:00",
+     "duration": 0.024088,
+     "end_time": "2026-09-11T14:19:13.983512+00:00",
      "exception": false,
-     "start_time": "2026-09-11T11:59:55.154740+00:00",
+     "start_time": "2026-09-11T14:19:13.959424+00:00",
      "status": "completed"
     }
    },
@@ -441,10 +441,10 @@
    "id": "f1ad7c20",
    "metadata": {
     "papermill": {
-     "duration": 0.00389,
-     "end_time": "2026-09-11T11:59:55.180692+00:00",
+     "duration": 0.003529,
+     "end_time": "2026-09-11T14:19:13.992741+00:00",
      "exception": false,
-     "start_time": "2026-09-11T11:59:55.176802+00:00",
+     "start_time": "2026-09-11T14:19:13.989212+00:00",
      "status": "completed"
     }
    },
@@ -462,16 +462,16 @@
    "id": "b51a7e8f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T11:59:55.189834Z",
-     "iopub.status.busy": "2026-09-11T11:59:55.189616Z",
-     "iopub.status.idle": "2026-09-11T11:59:55.206626Z",
-     "shell.execute_reply": "2026-09-11T11:59:55.205410Z"
+     "iopub.execute_input": "2026-09-11T14:19:14.002260Z",
+     "iopub.status.busy": "2026-09-11T14:19:14.001965Z",
+     "iopub.status.idle": "2026-09-11T14:19:14.019073Z",
+     "shell.execute_reply": "2026-09-11T14:19:14.018085Z"
     },
     "papermill": {
-     "duration": 0.02318,
-     "end_time": "2026-09-11T11:59:55.207610+00:00",
+     "duration": 0.023503,
+     "end_time": "2026-09-11T14:19:14.020335+00:00",
      "exception": false,
-     "start_time": "2026-09-11T11:59:55.184430+00:00",
+     "start_time": "2026-09-11T14:19:13.996832+00:00",
      "status": "completed"
     }
    },
@@ -536,10 +536,10 @@
    "id": "290d1305",
    "metadata": {
     "papermill": {
-     "duration": 0.003328,
-     "end_time": "2026-09-11T11:59:55.216072+00:00",
+     "duration": 0.002972,
+     "end_time": "2026-09-11T14:19:14.027074+00:00",
      "exception": false,
-     "start_time": "2026-09-11T11:59:55.212744+00:00",
+     "start_time": "2026-09-11T14:19:14.024102+00:00",
      "status": "completed"
     }
    },
@@ -565,16 +565,16 @@
    "id": "ef4ca396",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T11:59:55.228101Z",
-     "iopub.status.busy": "2026-09-11T11:59:55.227769Z",
-     "iopub.status.idle": "2026-09-11T11:59:55.241560Z",
-     "shell.execute_reply": "2026-09-11T11:59:55.240984Z"
+     "iopub.execute_input": "2026-09-11T14:19:14.035482Z",
+     "iopub.status.busy": "2026-09-11T14:19:14.035170Z",
+     "iopub.status.idle": "2026-09-11T14:19:14.050295Z",
+     "shell.execute_reply": "2026-09-11T14:19:14.049831Z"
     },
     "papermill": {
-     "duration": 0.019508,
-     "end_time": "2026-09-11T11:59:55.242008+00:00",
+     "duration": 0.020308,
+     "end_time": "2026-09-11T14:19:14.050711+00:00",
      "exception": false,
-     "start_time": "2026-09-11T11:59:55.222500+00:00",
+     "start_time": "2026-09-11T14:19:14.030403+00:00",
      "status": "completed"
     }
    },
@@ -604,21 +604,46 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "8c012f06",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002257,
+     "end_time": "2026-09-11T14:19:14.055557+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T14:19:14.053300+00:00",
+     "status": "completed"
+    }
+   },
+   "source": [
+    "A backward as-of join has exactly one way to produce no match: no yield observation dated\n",
+    "on or before the ETF date. That happens only before the Treasury series begins. Once it has\n",
+    "begun the join always matches something, so a row count answers *did the series start in\n",
+    "time* and says nothing about whether it kept going - a month the Fed published nothing would\n",
+    "carry the last slope across it and still fill every row.\n",
+    "\n",
+    "What separates the two is the age of the observation each date matched. The series is\n",
+    "published every business day, so one day is a normal match and a long holiday weekend is the\n",
+    "most a healthy feed should ever be behind. The tolerance is declared here rather than read\n",
+    "off the result, so the print below is a check and not just a number."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 10,
    "id": "f3b0bdbb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T11:59:55.248860Z",
-     "iopub.status.busy": "2026-09-11T11:59:55.248693Z",
-     "iopub.status.idle": "2026-09-11T11:59:55.253513Z",
-     "shell.execute_reply": "2026-09-11T11:59:55.252989Z"
+     "iopub.execute_input": "2026-09-11T14:19:14.060921Z",
+     "iopub.status.busy": "2026-09-11T14:19:14.060603Z",
+     "iopub.status.idle": "2026-09-11T14:19:14.066836Z",
+     "shell.execute_reply": "2026-09-11T14:19:14.066406Z"
     },
     "papermill": {
-     "duration": 0.008803,
-     "end_time": "2026-09-11T11:59:55.253827+00:00",
+     "duration": 0.009502,
+     "end_time": "2026-09-11T14:19:14.067237+00:00",
      "exception": false,
-     "start_time": "2026-09-11T11:59:55.245024+00:00",
+     "start_time": "2026-09-11T14:19:14.057735+00:00",
      "status": "completed"
     }
    },
@@ -627,18 +652,38 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "Yield-curve observation age when read: median 0d, max 0d (tolerance 4d)\n",
       "Risk-on days: 2,495 (70.8%)\n",
       "Risk-off days: 1,027 (29.2%)\n"
      ]
     }
    ],
    "source": [
+    "MAX_SLOPE_AGE_DAYS = 4\n",
+    "\n",
     "regime_panel = (\n",
     "    price_panel.select(\"timestamp\")\n",
-    "    .join_asof(yield_curve.sort(\"timestamp\"), on=\"timestamp\", strategy=\"backward\")\n",
+    "    .join_asof(\n",
+    "        yield_curve.sort(\"timestamp\").with_columns(pl.col(\"timestamp\").alias(\"slope_asof\")),\n",
+    "        on=\"timestamp\",\n",
+    "        strategy=\"backward\",\n",
+    "    )\n",
     "    .drop_nulls()\n",
     ")\n",
-    "assert regime_panel.height == price_panel.height, \"Yield-curve history does not cover the panel\"\n",
+    "assert regime_panel.height == price_panel.height, (\n",
+    "    \"Yield-curve history begins after the ETF panel does\"\n",
+    ")\n",
+    "\n",
+    "slope_age_days = regime_panel.select(\n",
+    "    (pl.col(\"timestamp\") - pl.col(\"slope_asof\")).dt.total_days()\n",
+    ").to_series()\n",
+    "print(\n",
+    "    f\"Yield-curve observation age when read: median {slope_age_days.median():.0f}d, \"\n",
+    "    f\"max {slope_age_days.max()}d (tolerance {MAX_SLOPE_AGE_DAYS}d)\"\n",
+    ")\n",
+    "assert slope_age_days.max() <= MAX_SLOPE_AGE_DAYS, (\n",
+    "    f\"Yield curve went {slope_age_days.max()} days without a publication\"\n",
+    ")\n",
     "\n",
     "yield_curve_slope = regime_panel[\"slope\"].to_numpy()\n",
     "regime = yield_curve_slope > REGIME_THRESHOLD\n",
@@ -653,10 +698,10 @@
    "id": "8ca3d169",
    "metadata": {
     "papermill": {
-     "duration": 0.002545,
-     "end_time": "2026-09-11T11:59:55.258804+00:00",
+     "duration": 0.003088,
+     "end_time": "2026-09-11T14:19:14.073379+00:00",
      "exception": false,
-     "start_time": "2026-09-11T11:59:55.256259+00:00",
+     "start_time": "2026-09-11T14:19:14.070291+00:00",
      "status": "completed"
     }
    },
@@ -680,16 +725,16 @@
    "id": "3a23de18",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T11:59:55.267933Z",
-     "iopub.status.busy": "2026-09-11T11:59:55.267673Z",
-     "iopub.status.idle": "2026-09-11T11:59:55.273279Z",
-     "shell.execute_reply": "2026-09-11T11:59:55.272382Z"
+     "iopub.execute_input": "2026-09-11T14:19:14.081964Z",
+     "iopub.status.busy": "2026-09-11T14:19:14.081774Z",
+     "iopub.status.idle": "2026-09-11T14:19:14.086311Z",
+     "shell.execute_reply": "2026-09-11T14:19:14.085751Z"
     },
     "papermill": {
-     "duration": 0.011725,
-     "end_time": "2026-09-11T11:59:55.274186+00:00",
+     "duration": 0.010147,
+     "end_time": "2026-09-11T14:19:14.087118+00:00",
      "exception": false,
-     "start_time": "2026-09-11T11:59:55.262461+00:00",
+     "start_time": "2026-09-11T14:19:14.076971+00:00",
      "status": "completed"
     }
    },
@@ -712,16 +757,16 @@
    "id": "5cf23007",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T11:59:55.283161Z",
-     "iopub.status.busy": "2026-09-11T11:59:55.282916Z",
-     "iopub.status.idle": "2026-09-11T11:59:55.291551Z",
-     "shell.execute_reply": "2026-09-11T11:59:55.290776Z"
+     "iopub.execute_input": "2026-09-11T14:19:14.096903Z",
+     "iopub.status.busy": "2026-09-11T14:19:14.096729Z",
+     "iopub.status.idle": "2026-09-11T14:19:14.104938Z",
+     "shell.execute_reply": "2026-09-11T14:19:14.104460Z"
     },
     "papermill": {
-     "duration": 0.013801,
-     "end_time": "2026-09-11T11:59:55.292039+00:00",
+     "duration": 0.013795,
+     "end_time": "2026-09-11T14:19:14.105480+00:00",
      "exception": false,
-     "start_time": "2026-09-11T11:59:55.278238+00:00",
+     "start_time": "2026-09-11T14:19:14.091685+00:00",
      "status": "completed"
     }
    },
@@ -759,10 +804,10 @@
    "id": "848028c7",
    "metadata": {
     "papermill": {
-     "duration": 0.00291,
-     "end_time": "2026-09-11T11:59:55.297816+00:00",
+     "duration": 0.004036,
+     "end_time": "2026-09-11T14:19:14.114799+00:00",
      "exception": false,
-     "start_time": "2026-09-11T11:59:55.294906+00:00",
+     "start_time": "2026-09-11T14:19:14.110763+00:00",
      "status": "completed"
     }
    },
@@ -779,16 +824,16 @@
    "id": "6cfc781d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T11:59:55.304288Z",
-     "iopub.status.busy": "2026-09-11T11:59:55.303988Z",
-     "iopub.status.idle": "2026-09-11T11:59:57.758018Z",
-     "shell.execute_reply": "2026-09-11T11:59:57.757601Z"
+     "iopub.execute_input": "2026-09-11T14:19:14.226325Z",
+     "iopub.status.busy": "2026-09-11T14:19:14.226147Z",
+     "iopub.status.idle": "2026-09-11T14:19:18.284774Z",
+     "shell.execute_reply": "2026-09-11T14:19:18.283990Z"
     },
     "papermill": {
-     "duration": 2.458838,
-     "end_time": "2026-09-11T11:59:57.759059+00:00",
+     "duration": 4.063618,
+     "end_time": "2026-09-11T14:19:18.285438+00:00",
      "exception": false,
-     "start_time": "2026-09-11T11:59:55.300221+00:00",
+     "start_time": "2026-09-11T14:19:14.221820+00:00",
      "status": "completed"
     }
    },
@@ -994,10 +1039,10 @@
    "id": "c7de9237",
    "metadata": {
     "papermill": {
-     "duration": 0.003085,
-     "end_time": "2026-09-11T11:59:57.766737+00:00",
+     "duration": 0.002515,
+     "end_time": "2026-09-11T14:19:18.291434+00:00",
      "exception": false,
-     "start_time": "2026-09-11T11:59:57.763652+00:00",
+     "start_time": "2026-09-11T14:19:18.288919+00:00",
      "status": "completed"
     }
    },
@@ -1020,16 +1065,16 @@
    "id": "ab782178",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T11:59:57.772438Z",
-     "iopub.status.busy": "2026-09-11T11:59:57.772321Z",
-     "iopub.status.idle": "2026-09-11T11:59:57.775775Z",
-     "shell.execute_reply": "2026-09-11T11:59:57.775298Z"
+     "iopub.execute_input": "2026-09-11T14:19:18.297338Z",
+     "iopub.status.busy": "2026-09-11T14:19:18.297167Z",
+     "iopub.status.idle": "2026-09-11T14:19:18.301493Z",
+     "shell.execute_reply": "2026-09-11T14:19:18.301054Z"
     },
     "papermill": {
-     "duration": 0.007274,
-     "end_time": "2026-09-11T11:59:57.776452+00:00",
+     "duration": 0.008056,
+     "end_time": "2026-09-11T14:19:18.302008+00:00",
      "exception": false,
-     "start_time": "2026-09-11T11:59:57.769178+00:00",
+     "start_time": "2026-09-11T14:19:18.293952+00:00",
      "status": "completed"
     }
    },
@@ -1054,16 +1099,16 @@
    "id": "056e9467",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T11:59:57.786780Z",
-     "iopub.status.busy": "2026-09-11T11:59:57.786651Z",
-     "iopub.status.idle": "2026-09-11T11:59:57.790375Z",
-     "shell.execute_reply": "2026-09-11T11:59:57.790026Z"
+     "iopub.execute_input": "2026-09-11T14:19:18.307679Z",
+     "iopub.status.busy": "2026-09-11T14:19:18.307552Z",
+     "iopub.status.idle": "2026-09-11T14:19:18.313157Z",
+     "shell.execute_reply": "2026-09-11T14:19:18.312600Z"
     },
     "papermill": {
-     "duration": 0.009276,
-     "end_time": "2026-09-11T11:59:57.790836+00:00",
+     "duration": 0.009025,
+     "end_time": "2026-09-11T14:19:18.313586+00:00",
      "exception": false,
-     "start_time": "2026-09-11T11:59:57.781560+00:00",
+     "start_time": "2026-09-11T14:19:18.304561+00:00",
      "status": "completed"
     }
    },
@@ -1090,16 +1135,16 @@
    "id": "71d15f6f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T11:59:57.797043Z",
-     "iopub.status.busy": "2026-09-11T11:59:57.796947Z",
-     "iopub.status.idle": "2026-09-11T11:59:57.800549Z",
-     "shell.execute_reply": "2026-09-11T11:59:57.799976Z"
+     "iopub.execute_input": "2026-09-11T14:19:18.319542Z",
+     "iopub.status.busy": "2026-09-11T14:19:18.319405Z",
+     "iopub.status.idle": "2026-09-11T14:19:18.323687Z",
+     "shell.execute_reply": "2026-09-11T14:19:18.323080Z"
     },
     "papermill": {
-     "duration": 0.006863,
-     "end_time": "2026-09-11T11:59:57.800851+00:00",
+     "duration": 0.007775,
+     "end_time": "2026-09-11T14:19:18.324071+00:00",
      "exception": false,
-     "start_time": "2026-09-11T11:59:57.793988+00:00",
+     "start_time": "2026-09-11T14:19:18.316296+00:00",
      "status": "completed"
     }
    },
@@ -1129,10 +1174,10 @@
    "id": "2403554d",
    "metadata": {
     "papermill": {
-     "duration": 0.002435,
-     "end_time": "2026-09-11T11:59:57.805873+00:00",
+     "duration": 0.00247,
+     "end_time": "2026-09-11T14:19:18.329218+00:00",
      "exception": false,
-     "start_time": "2026-09-11T11:59:57.803438+00:00",
+     "start_time": "2026-09-11T14:19:18.326748+00:00",
      "status": "completed"
     }
    },
@@ -1155,16 +1200,16 @@
    "id": "ed493cab",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T11:59:57.811381Z",
-     "iopub.status.busy": "2026-09-11T11:59:57.811287Z",
-     "iopub.status.idle": "2026-09-11T11:59:59.276416Z",
-     "shell.execute_reply": "2026-09-11T11:59:59.275881Z"
+     "iopub.execute_input": "2026-09-11T14:19:18.335442Z",
+     "iopub.status.busy": "2026-09-11T14:19:18.335332Z",
+     "iopub.status.idle": "2026-09-11T14:19:21.071177Z",
+     "shell.execute_reply": "2026-09-11T14:19:21.070502Z"
     },
     "papermill": {
-     "duration": 1.471565,
-     "end_time": "2026-09-11T11:59:59.279869+00:00",
+     "duration": 2.743369,
+     "end_time": "2026-09-11T14:19:21.075059+00:00",
      "exception": false,
-     "start_time": "2026-09-11T11:59:57.808304+00:00",
+     "start_time": "2026-09-11T14:19:18.331690+00:00",
      "status": "completed"
     }
    },
@@ -8502,10 +8547,10 @@
    "id": "938513e0",
    "metadata": {
     "papermill": {
-     "duration": 0.009268,
-     "end_time": "2026-09-11T11:59:59.300234+00:00",
+     "duration": 0.010749,
+     "end_time": "2026-09-11T14:19:21.099485+00:00",
      "exception": false,
-     "start_time": "2026-09-11T11:59:59.290966+00:00",
+     "start_time": "2026-09-11T14:19:21.088736+00:00",
      "status": "completed"
     }
    },
@@ -8529,16 +8574,16 @@
    "id": "784dae4f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T11:59:59.319641Z",
-     "iopub.status.busy": "2026-09-11T11:59:59.319470Z",
-     "iopub.status.idle": "2026-09-11T11:59:59.322570Z",
-     "shell.execute_reply": "2026-09-11T11:59:59.322034Z"
+     "iopub.execute_input": "2026-09-11T14:19:21.126261Z",
+     "iopub.status.busy": "2026-09-11T14:19:21.126078Z",
+     "iopub.status.idle": "2026-09-11T14:19:21.129691Z",
+     "shell.execute_reply": "2026-09-11T14:19:21.128925Z"
     },
     "papermill": {
-     "duration": 0.013489,
-     "end_time": "2026-09-11T11:59:59.323018+00:00",
+     "duration": 0.018989,
+     "end_time": "2026-09-11T14:19:21.130512+00:00",
      "exception": false,
-     "start_time": "2026-09-11T11:59:59.309529+00:00",
+     "start_time": "2026-09-11T14:19:21.111523+00:00",
      "status": "completed"
     }
    },
@@ -8564,10 +8609,10 @@
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.009552,
-     "end_time": "2026-09-11T11:59:59.342572+00:00",
+     "duration": 0.013787,
+     "end_time": "2026-09-11T14:19:21.157941+00:00",
      "exception": false,
-     "start_time": "2026-09-11T11:59:59.333020+00:00",
+     "start_time": "2026-09-11T14:19:21.144154+00:00",
      "status": "completed"
     }
    },
@@ -8585,16 +8630,16 @@
    "id": "a1ecd0b8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T11:59:59.363819Z",
-     "iopub.status.busy": "2026-09-11T11:59:59.363658Z",
-     "iopub.status.idle": "2026-09-11T11:59:59.368028Z",
-     "shell.execute_reply": "2026-09-11T11:59:59.367521Z"
+     "iopub.execute_input": "2026-09-11T14:19:21.185738Z",
+     "iopub.status.busy": "2026-09-11T14:19:21.185565Z",
+     "iopub.status.idle": "2026-09-11T14:19:21.190634Z",
+     "shell.execute_reply": "2026-09-11T14:19:21.190106Z"
     },
     "papermill": {
-     "duration": 0.016102,
-     "end_time": "2026-09-11T11:59:59.368553+00:00",
+     "duration": 0.020083,
+     "end_time": "2026-09-11T14:19:21.191305+00:00",
      "exception": false,
-     "start_time": "2026-09-11T11:59:59.352451+00:00",
+     "start_time": "2026-09-11T14:19:21.171222+00:00",
      "status": "completed"
     }
    },
@@ -8643,10 +8688,10 @@
    "id": "8533af68",
    "metadata": {
     "papermill": {
-     "duration": 0.010236,
-     "end_time": "2026-09-11T11:59:59.389172+00:00",
+     "duration": 0.011432,
+     "end_time": "2026-09-11T14:19:21.215507+00:00",
      "exception": false,
-     "start_time": "2026-09-11T11:59:59.378936+00:00",
+     "start_time": "2026-09-11T14:19:21.204075+00:00",
      "status": "completed"
     }
    },
@@ -8661,16 +8706,16 @@
    "id": "9cf0113a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T11:59:59.410566Z",
-     "iopub.status.busy": "2026-09-11T11:59:59.410399Z",
-     "iopub.status.idle": "2026-09-11T11:59:59.438082Z",
-     "shell.execute_reply": "2026-09-11T11:59:59.437511Z"
+     "iopub.execute_input": "2026-09-11T14:19:21.239856Z",
+     "iopub.status.busy": "2026-09-11T14:19:21.239696Z",
+     "iopub.status.idle": "2026-09-11T14:19:21.260819Z",
+     "shell.execute_reply": "2026-09-11T14:19:21.259925Z"
     },
     "papermill": {
-     "duration": 0.038843,
-     "end_time": "2026-09-11T11:59:59.438580+00:00",
+     "duration": 0.034426,
+     "end_time": "2026-09-11T14:19:21.261595+00:00",
      "exception": false,
-     "start_time": "2026-09-11T11:59:59.399737+00:00",
+     "start_time": "2026-09-11T14:19:21.227169+00:00",
      "status": "completed"
     }
    },
@@ -8704,16 +8749,16 @@
    "id": "f28f2cbd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T11:59:59.457699Z",
-     "iopub.status.busy": "2026-09-11T11:59:59.457533Z",
-     "iopub.status.idle": "2026-09-11T11:59:59.461626Z",
-     "shell.execute_reply": "2026-09-11T11:59:59.461053Z"
+     "iopub.execute_input": "2026-09-11T14:19:21.287041Z",
+     "iopub.status.busy": "2026-09-11T14:19:21.286845Z",
+     "iopub.status.idle": "2026-09-11T14:19:21.291978Z",
+     "shell.execute_reply": "2026-09-11T14:19:21.291226Z"
     },
     "papermill": {
-     "duration": 0.014472,
-     "end_time": "2026-09-11T11:59:59.462152+00:00",
+     "duration": 0.018752,
+     "end_time": "2026-09-11T14:19:21.292817+00:00",
      "exception": false,
-     "start_time": "2026-09-11T11:59:59.447680+00:00",
+     "start_time": "2026-09-11T14:19:21.274065+00:00",
      "status": "completed"
     }
    },
@@ -8751,10 +8796,10 @@
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.009021,
-     "end_time": "2026-09-11T11:59:59.480387+00:00",
+     "duration": 0.007485,
+     "end_time": "2026-09-11T14:19:21.310735+00:00",
      "exception": false,
-     "start_time": "2026-09-11T11:59:59.471366+00:00",
+     "start_time": "2026-09-11T14:19:21.303250+00:00",
      "status": "completed"
     }
    },
@@ -8772,16 +8817,16 @@
    "id": "c2402b08",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T11:59:59.500648Z",
-     "iopub.status.busy": "2026-09-11T11:59:59.500476Z",
-     "iopub.status.idle": "2026-09-11T11:59:59.504437Z",
-     "shell.execute_reply": "2026-09-11T11:59:59.503749Z"
+     "iopub.execute_input": "2026-09-11T14:19:21.323263Z",
+     "iopub.status.busy": "2026-09-11T14:19:21.323044Z",
+     "iopub.status.idle": "2026-09-11T14:19:21.327577Z",
+     "shell.execute_reply": "2026-09-11T14:19:21.326793Z"
     },
     "papermill": {
-     "duration": 0.015094,
-     "end_time": "2026-09-11T11:59:59.504949+00:00",
+     "duration": 0.011699,
+     "end_time": "2026-09-11T14:19:21.328058+00:00",
      "exception": false,
-     "start_time": "2026-09-11T11:59:59.489855+00:00",
+     "start_time": "2026-09-11T14:19:21.316359+00:00",
      "status": "completed"
     }
    },
@@ -8813,16 +8858,16 @@
    "id": "24fae972",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T11:59:59.524259Z",
-     "iopub.status.busy": "2026-09-11T11:59:59.524101Z",
-     "iopub.status.idle": "2026-09-11T11:59:59.528013Z",
-     "shell.execute_reply": "2026-09-11T11:59:59.527568Z"
+     "iopub.execute_input": "2026-09-11T14:19:21.340490Z",
+     "iopub.status.busy": "2026-09-11T14:19:21.340373Z",
+     "iopub.status.idle": "2026-09-11T14:19:21.345367Z",
+     "shell.execute_reply": "2026-09-11T14:19:21.344630Z"
     },
     "papermill": {
-     "duration": 0.014461,
-     "end_time": "2026-09-11T11:59:59.528702+00:00",
+     "duration": 0.012117,
+     "end_time": "2026-09-11T14:19:21.345902+00:00",
      "exception": false,
-     "start_time": "2026-09-11T11:59:59.514241+00:00",
+     "start_time": "2026-09-11T14:19:21.333785+00:00",
      "status": "completed"
     }
    },
@@ -8877,10 +8922,10 @@
    "id": "074fa3b9",
    "metadata": {
     "papermill": {
-     "duration": 0.009189,
-     "end_time": "2026-09-11T11:59:59.547144+00:00",
+     "duration": 0.008617,
+     "end_time": "2026-09-11T14:19:21.366722+00:00",
      "exception": false,
-     "start_time": "2026-09-11T11:59:59.537955+00:00",
+     "start_time": "2026-09-11T14:19:21.358105+00:00",
      "status": "completed"
     }
    },
@@ -8900,16 +8945,16 @@
    "id": "e7fb1ea4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T11:59:59.561978Z",
-     "iopub.status.busy": "2026-09-11T11:59:59.561786Z",
-     "iopub.status.idle": "2026-09-11T11:59:59.566799Z",
-     "shell.execute_reply": "2026-09-11T11:59:59.566394Z"
+     "iopub.execute_input": "2026-09-11T14:19:21.379805Z",
+     "iopub.status.busy": "2026-09-11T14:19:21.379571Z",
+     "iopub.status.idle": "2026-09-11T14:19:21.384909Z",
+     "shell.execute_reply": "2026-09-11T14:19:21.384284Z"
     },
     "papermill": {
-     "duration": 0.011214,
-     "end_time": "2026-09-11T11:59:59.567206+00:00",
+     "duration": 0.01278,
+     "end_time": "2026-09-11T14:19:21.385305+00:00",
      "exception": false,
-     "start_time": "2026-09-11T11:59:59.555992+00:00",
+     "start_time": "2026-09-11T14:19:21.372525+00:00",
      "status": "completed"
     }
    },
@@ -8969,10 +9014,10 @@
    "id": "320cb286",
    "metadata": {
     "papermill": {
-     "duration": 0.004904,
-     "end_time": "2026-09-11T11:59:59.577272+00:00",
+     "duration": 0.006398,
+     "end_time": "2026-09-11T14:19:21.397546+00:00",
      "exception": false,
-     "start_time": "2026-09-11T11:59:59.572368+00:00",
+     "start_time": "2026-09-11T14:19:21.391148+00:00",
      "status": "completed"
     }
    },
@@ -8989,10 +9034,10 @@
    "id": "cee4a0d4",
    "metadata": {
     "papermill": {
-     "duration": 0.005814,
-     "end_time": "2026-09-11T11:59:59.588415+00:00",
+     "duration": 0.010898,
+     "end_time": "2026-09-11T14:19:21.419632+00:00",
      "exception": false,
-     "start_time": "2026-09-11T11:59:59.582601+00:00",
+     "start_time": "2026-09-11T14:19:21.408734+00:00",
      "status": "completed"
     }
    },
@@ -9009,16 +9054,16 @@
    "id": "3cce7d7b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T11:59:59.610397Z",
-     "iopub.status.busy": "2026-09-11T11:59:59.610214Z",
-     "iopub.status.idle": "2026-09-11T12:00:01.088233Z",
-     "shell.execute_reply": "2026-09-11T12:00:01.087550Z"
+     "iopub.execute_input": "2026-09-11T14:19:21.433760Z",
+     "iopub.status.busy": "2026-09-11T14:19:21.433574Z",
+     "iopub.status.idle": "2026-09-11T14:19:23.250694Z",
+     "shell.execute_reply": "2026-09-11T14:19:23.249837Z"
     },
     "papermill": {
-     "duration": 1.491309,
-     "end_time": "2026-09-11T12:00:01.089889+00:00",
+     "duration": 1.825016,
+     "end_time": "2026-09-11T14:19:23.252037+00:00",
      "exception": false,
-     "start_time": "2026-09-11T11:59:59.598580+00:00",
+     "start_time": "2026-09-11T14:19:21.427021+00:00",
      "status": "completed"
     }
    },
@@ -16262,10 +16307,10 @@
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.012527,
-     "end_time": "2026-09-11T12:00:01.116103+00:00",
+     "duration": 0.008166,
+     "end_time": "2026-09-11T14:19:23.268653+00:00",
      "exception": false,
-     "start_time": "2026-09-11T12:00:01.103576+00:00",
+     "start_time": "2026-09-11T14:19:23.260487+00:00",
      "status": "completed"
     }
    },
@@ -16279,16 +16324,16 @@
    "id": "f7b8f66a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T12:00:01.139401Z",
-     "iopub.status.busy": "2026-09-11T12:00:01.139217Z",
-     "iopub.status.idle": "2026-09-11T12:00:01.142208Z",
-     "shell.execute_reply": "2026-09-11T12:00:01.141629Z"
+     "iopub.execute_input": "2026-09-11T14:19:23.297794Z",
+     "iopub.status.busy": "2026-09-11T14:19:23.297587Z",
+     "iopub.status.idle": "2026-09-11T14:19:23.300792Z",
+     "shell.execute_reply": "2026-09-11T14:19:23.300154Z"
     },
     "papermill": {
-     "duration": 0.014026,
-     "end_time": "2026-09-11T12:00:01.142641+00:00",
+     "duration": 0.01901,
+     "end_time": "2026-09-11T14:19:23.301226+00:00",
      "exception": false,
-     "start_time": "2026-09-11T12:00:01.128615+00:00",
+     "start_time": "2026-09-11T14:19:23.282216+00:00",
      "status": "completed"
     }
    },
@@ -16306,16 +16351,16 @@
    "id": "c25556bb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T12:00:01.161625Z",
-     "iopub.status.busy": "2026-09-11T12:00:01.161416Z",
-     "iopub.status.idle": "2026-09-11T12:00:02.899065Z",
-     "shell.execute_reply": "2026-09-11T12:00:02.898507Z"
+     "iopub.execute_input": "2026-09-11T14:19:23.318034Z",
+     "iopub.status.busy": "2026-09-11T14:19:23.317816Z",
+     "iopub.status.idle": "2026-09-11T14:19:25.129608Z",
+     "shell.execute_reply": "2026-09-11T14:19:25.128924Z"
     },
     "papermill": {
-     "duration": 1.750746,
-     "end_time": "2026-09-11T12:00:02.899851+00:00",
+     "duration": 1.822544,
+     "end_time": "2026-09-11T14:19:25.131446+00:00",
      "exception": false,
-     "start_time": "2026-09-11T12:00:01.149105+00:00",
+     "start_time": "2026-09-11T14:19:23.308902+00:00",
      "status": "completed"
     }
    },
@@ -23547,10 +23592,10 @@
    "id": "d2b2f0e9",
    "metadata": {
     "papermill": {
-     "duration": 0.007526,
-     "end_time": "2026-09-11T12:00:02.915314+00:00",
+     "duration": 0.009021,
+     "end_time": "2026-09-11T14:19:25.156591+00:00",
      "exception": false,
-     "start_time": "2026-09-11T12:00:02.907788+00:00",
+     "start_time": "2026-09-11T14:19:25.147570+00:00",
      "status": "completed"
     }
    },
@@ -23567,16 +23612,16 @@
    "id": "a74c6b95",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T12:00:02.931185Z",
-     "iopub.status.busy": "2026-09-11T12:00:02.931026Z",
-     "iopub.status.idle": "2026-09-11T12:00:02.936237Z",
-     "shell.execute_reply": "2026-09-11T12:00:02.935540Z"
+     "iopub.execute_input": "2026-09-11T14:19:25.174184Z",
+     "iopub.status.busy": "2026-09-11T14:19:25.174054Z",
+     "iopub.status.idle": "2026-09-11T14:19:25.179836Z",
+     "shell.execute_reply": "2026-09-11T14:19:25.177782Z"
     },
     "papermill": {
-     "duration": 0.013852,
-     "end_time": "2026-09-11T12:00:02.936623+00:00",
+     "duration": 0.015623,
+     "end_time": "2026-09-11T14:19:25.180490+00:00",
      "exception": false,
-     "start_time": "2026-09-11T12:00:02.922771+00:00",
+     "start_time": "2026-09-11T14:19:25.164867+00:00",
      "status": "completed"
     }
    },
@@ -23636,16 +23681,16 @@
    "id": "0ac57c06",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T12:00:02.954328Z",
-     "iopub.status.busy": "2026-09-11T12:00:02.954157Z",
-     "iopub.status.idle": "2026-09-11T12:00:04.566025Z",
-     "shell.execute_reply": "2026-09-11T12:00:04.565327Z"
+     "iopub.execute_input": "2026-09-11T14:19:25.199361Z",
+     "iopub.status.busy": "2026-09-11T14:19:25.199149Z",
+     "iopub.status.idle": "2026-09-11T14:19:26.896972Z",
+     "shell.execute_reply": "2026-09-11T14:19:26.896059Z"
     },
     "papermill": {
-     "duration": 1.621435,
-     "end_time": "2026-09-11T12:00:04.566653+00:00",
+     "duration": 1.708227,
+     "end_time": "2026-09-11T14:19:26.897676+00:00",
      "exception": false,
-     "start_time": "2026-09-11T12:00:02.945218+00:00",
+     "start_time": "2026-09-11T14:19:25.189449+00:00",
      "status": "completed"
     }
    },
@@ -23906,10 +23951,10 @@
    "id": "9592a833",
    "metadata": {
     "papermill": {
-     "duration": 0.01872,
-     "end_time": "2026-09-11T12:00:04.605352+00:00",
+     "duration": 0.015898,
+     "end_time": "2026-09-11T14:19:26.928668+00:00",
      "exception": false,
-     "start_time": "2026-09-11T12:00:04.586632+00:00",
+     "start_time": "2026-09-11T14:19:26.912770+00:00",
      "status": "completed"
     }
    },
@@ -23926,16 +23971,16 @@
    "id": "e7e4505a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T12:00:04.645744Z",
-     "iopub.status.busy": "2026-09-11T12:00:04.645396Z",
-     "iopub.status.idle": "2026-09-11T12:00:04.655509Z",
-     "shell.execute_reply": "2026-09-11T12:00:04.654912Z"
+     "iopub.execute_input": "2026-09-11T14:19:26.956999Z",
+     "iopub.status.busy": "2026-09-11T14:19:26.956811Z",
+     "iopub.status.idle": "2026-09-11T14:19:26.967194Z",
+     "shell.execute_reply": "2026-09-11T14:19:26.966481Z"
     },
     "papermill": {
-     "duration": 0.031366,
-     "end_time": "2026-09-11T12:00:04.656053+00:00",
+     "duration": 0.023241,
+     "end_time": "2026-09-11T14:19:26.968249+00:00",
      "exception": false,
-     "start_time": "2026-09-11T12:00:04.624687+00:00",
+     "start_time": "2026-09-11T14:19:26.945008+00:00",
      "status": "completed"
     }
    },
@@ -24012,10 +24057,10 @@
    "id": "3ecbf2a5",
    "metadata": {
     "papermill": {
-     "duration": 0.018442,
-     "end_time": "2026-09-11T12:00:04.693720+00:00",
+     "duration": 0.010344,
+     "end_time": "2026-09-11T14:19:26.993279+00:00",
      "exception": false,
-     "start_time": "2026-09-11T12:00:04.675278+00:00",
+     "start_time": "2026-09-11T14:19:26.982935+00:00",
      "status": "completed"
     }
    },
@@ -24078,24 +24123,24 @@
    "version": "3.14.3"
   },
   "ml4t_provenance": {
-   "executed_at": "2026-09-11T12:00:15.449235+00:00",
-   "executor": "local-uv",
+   "source_py_blob": "bdb5803fa4d5d2fc16ebb9a6ccecb4c5aa949b25",
+   "outputs_digest": "1f3309dad44bfc4718cc59b26b9afd368cc4ae25978281ff396d18640d318dac",
    "library_digest": "5cd38db8077f7dca50a29be7cccbfb78348e4f57c225c1b91531fcbd1b7de68e",
-   "outputs_digest": "0dc49da7b12a8fa39af2101bb4e73a6b9dfc32b310c72c5c31a8b8ec404fce07",
-   "parameters": {},
+   "executed_at": "2026-09-11T14:20:57.426654+00:00",
+   "executor": "local-uv",
    "production": true,
-   "source_py_blob": "b99703438696afda59d773d0d529cffb61d31133"
+   "parameters": {}
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 17.915565,
-   "end_time": "2026-09-11T12:00:06.531476+00:00",
+   "duration": 23.368972,
+   "end_time": "2026-09-11T14:19:29.601607+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "~/ml4t/public-teach-d/16_strategy_simulation/.01_backtest_first_principles.build.3730275.ipynb",
-   "output_path": "~/ml4t/public-teach-d/16_strategy_simulation/.01_backtest_first_principles.papermill.3730275.ipynb",
+   "input_path": "16_strategy_simulation/01_backtest_first_principles.ipynb",
+   "output_path": "16_strategy_simulation/01_backtest_first_principles.ipynb",
    "parameters": {},
-   "start_time": "2026-09-11T11:59:48.615911+00:00",
+   "start_time": "2026-09-11T14:19:06.232635+00:00",
    "version": "2.7.0"
   }
  },

--- a/16_strategy_simulation/01_backtest_first_principles.py
+++ b/16_strategy_simulation/01_backtest_first_principles.py
@@ -258,13 +258,44 @@ yield_curve = macro_df.select(
     (pl.col("YIELD_CURVE_SLOPE") / 100).alias("slope"),
 ).drop_nulls()
 
+# %% [markdown]
+# A backward as-of join has exactly one way to produce no match: no yield observation dated
+# on or before the ETF date. That happens only before the Treasury series begins. Once it has
+# begun the join always matches something, so a row count answers *did the series start in
+# time* and says nothing about whether it kept going - a month the Fed published nothing would
+# carry the last slope across it and still fill every row.
+#
+# What separates the two is the age of the observation each date matched. The series is
+# published every business day, so one day is a normal match and a long holiday weekend is the
+# most a healthy feed should ever be behind. The tolerance is declared here rather than read
+# off the result, so the print below is a check and not just a number.
+
 # %%
+MAX_SLOPE_AGE_DAYS = 4
+
 regime_panel = (
     price_panel.select("timestamp")
-    .join_asof(yield_curve.sort("timestamp"), on="timestamp", strategy="backward")
+    .join_asof(
+        yield_curve.sort("timestamp").with_columns(pl.col("timestamp").alias("slope_asof")),
+        on="timestamp",
+        strategy="backward",
+    )
     .drop_nulls()
 )
-assert regime_panel.height == price_panel.height, "Yield-curve history does not cover the panel"
+assert regime_panel.height == price_panel.height, (
+    "Yield-curve history begins after the ETF panel does"
+)
+
+slope_age_days = regime_panel.select(
+    (pl.col("timestamp") - pl.col("slope_asof")).dt.total_days()
+).to_series()
+print(
+    f"Yield-curve observation age when read: median {slope_age_days.median():.0f}d, "
+    f"max {slope_age_days.max()}d (tolerance {MAX_SLOPE_AGE_DAYS}d)"
+)
+assert slope_age_days.max() <= MAX_SLOPE_AGE_DAYS, (
+    f"Yield curve went {slope_age_days.max()} days without a publication"
+)
 
 yield_curve_slope = regime_panel["slope"].to_numpy()
 regime = yield_curve_slope > REGIME_THRESHOLD

--- a/16_strategy_simulation/10_regime_backtest_analysis.ipynb
+++ b/16_strategy_simulation/10_regime_backtest_analysis.ipynb
@@ -5,10 +5,10 @@
    "id": "4db7d855",
    "metadata": {
     "papermill": {
-     "duration": 0.005652,
-     "end_time": "2026-09-11T12:20:06.352932+00:00",
+     "duration": 0.007098,
+     "end_time": "2026-09-11T14:20:27.638656+00:00",
      "exception": false,
-     "start_time": "2026-09-11T12:20:06.347280+00:00",
+     "start_time": "2026-09-11T14:20:27.631558+00:00",
      "status": "completed"
     }
    },
@@ -45,10 +45,10 @@
    "id": "04d79596",
    "metadata": {
     "papermill": {
-     "duration": 0.004798,
-     "end_time": "2026-09-11T12:20:06.362683+00:00",
+     "duration": 0.004291,
+     "end_time": "2026-09-11T14:20:27.649052+00:00",
      "exception": false,
-     "start_time": "2026-09-11T12:20:06.357885+00:00",
+     "start_time": "2026-09-11T14:20:27.644761+00:00",
      "status": "completed"
     }
    },
@@ -67,16 +67,16 @@
    "id": "000fe668",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T12:20:06.375993Z",
-     "iopub.status.busy": "2026-09-11T12:20:06.375703Z",
-     "iopub.status.idle": "2026-09-11T12:20:14.687109Z",
-     "shell.execute_reply": "2026-09-11T12:20:14.683181Z"
+     "iopub.execute_input": "2026-09-11T14:20:27.661804Z",
+     "iopub.status.busy": "2026-09-11T14:20:27.661269Z",
+     "iopub.status.idle": "2026-09-11T14:20:36.383710Z",
+     "shell.execute_reply": "2026-09-11T14:20:36.382799Z"
     },
     "papermill": {
-     "duration": 8.323804,
-     "end_time": "2026-09-11T12:20:14.691802+00:00",
+     "duration": 8.731697,
+     "end_time": "2026-09-11T14:20:36.386054+00:00",
      "exception": false,
-     "start_time": "2026-09-11T12:20:06.367998+00:00",
+     "start_time": "2026-09-11T14:20:27.654357+00:00",
      "status": "completed"
     }
    },
@@ -102,16 +102,16 @@
    "id": "86c4477f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T12:20:14.703303Z",
-     "iopub.status.busy": "2026-09-11T12:20:14.702981Z",
-     "iopub.status.idle": "2026-09-11T12:20:14.707714Z",
-     "shell.execute_reply": "2026-09-11T12:20:14.705845Z"
+     "iopub.execute_input": "2026-09-11T14:20:36.398710Z",
+     "iopub.status.busy": "2026-09-11T14:20:36.398018Z",
+     "iopub.status.idle": "2026-09-11T14:20:36.406441Z",
+     "shell.execute_reply": "2026-09-11T14:20:36.405207Z"
     },
     "papermill": {
-     "duration": 0.013123,
-     "end_time": "2026-09-11T12:20:14.710382+00:00",
+     "duration": 0.015797,
+     "end_time": "2026-09-11T14:20:36.407499+00:00",
      "exception": false,
-     "start_time": "2026-09-11T12:20:14.697259+00:00",
+     "start_time": "2026-09-11T14:20:36.391702+00:00",
      "status": "completed"
     },
     "tags": [
@@ -138,16 +138,16 @@
    "id": "e928f46b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T12:20:14.725012Z",
-     "iopub.status.busy": "2026-09-11T12:20:14.724802Z",
-     "iopub.status.idle": "2026-09-11T12:20:14.728233Z",
-     "shell.execute_reply": "2026-09-11T12:20:14.727194Z"
+     "iopub.execute_input": "2026-09-11T14:20:36.420565Z",
+     "iopub.status.busy": "2026-09-11T14:20:36.420089Z",
+     "iopub.status.idle": "2026-09-11T14:20:36.425445Z",
+     "shell.execute_reply": "2026-09-11T14:20:36.424184Z"
     },
     "papermill": {
-     "duration": 0.012032,
-     "end_time": "2026-09-11T12:20:14.729779+00:00",
+     "duration": 0.01425,
+     "end_time": "2026-09-11T14:20:36.426356+00:00",
      "exception": false,
-     "start_time": "2026-09-11T12:20:14.717747+00:00",
+     "start_time": "2026-09-11T14:20:36.412106+00:00",
      "status": "completed"
     }
    },
@@ -162,10 +162,10 @@
    "id": "971416a5",
    "metadata": {
     "papermill": {
-     "duration": 0.004498,
-     "end_time": "2026-09-11T12:20:14.741621+00:00",
+     "duration": 0.003942,
+     "end_time": "2026-09-11T14:20:36.434947+00:00",
      "exception": false,
-     "start_time": "2026-09-11T12:20:14.737123+00:00",
+     "start_time": "2026-09-11T14:20:36.431005+00:00",
      "status": "completed"
     }
    },
@@ -196,16 +196,16 @@
    "id": "54d16cec",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T12:20:14.752842Z",
-     "iopub.status.busy": "2026-09-11T12:20:14.752126Z",
-     "iopub.status.idle": "2026-09-11T12:20:14.762258Z",
-     "shell.execute_reply": "2026-09-11T12:20:14.760816Z"
+     "iopub.execute_input": "2026-09-11T14:20:36.444139Z",
+     "iopub.status.busy": "2026-09-11T14:20:36.443815Z",
+     "iopub.status.idle": "2026-09-11T14:20:36.450246Z",
+     "shell.execute_reply": "2026-09-11T14:20:36.449439Z"
     },
     "papermill": {
-     "duration": 0.019272,
-     "end_time": "2026-09-11T12:20:14.765788+00:00",
+     "duration": 0.01191,
+     "end_time": "2026-09-11T14:20:36.450892+00:00",
      "exception": false,
-     "start_time": "2026-09-11T12:20:14.746516+00:00",
+     "start_time": "2026-09-11T14:20:36.438982+00:00",
      "status": "completed"
     }
    },
@@ -239,10 +239,10 @@
    "id": "04b2aed4",
    "metadata": {
     "papermill": {
-     "duration": 0.006377,
-     "end_time": "2026-09-11T12:20:14.777627+00:00",
+     "duration": 0.002899,
+     "end_time": "2026-09-11T14:20:36.457401+00:00",
      "exception": false,
-     "start_time": "2026-09-11T12:20:14.771250+00:00",
+     "start_time": "2026-09-11T14:20:36.454502+00:00",
      "status": "completed"
     }
    },
@@ -258,10 +258,10 @@
    "id": "ee509cc6",
    "metadata": {
     "papermill": {
-     "duration": 0.004021,
-     "end_time": "2026-09-11T12:20:14.787249+00:00",
+     "duration": 0.004011,
+     "end_time": "2026-09-11T14:20:36.465549+00:00",
      "exception": false,
-     "start_time": "2026-09-11T12:20:14.783228+00:00",
+     "start_time": "2026-09-11T14:20:36.461538+00:00",
      "status": "completed"
     }
    },
@@ -279,16 +279,16 @@
    "id": "7e4a2b0d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T12:20:14.795386Z",
-     "iopub.status.busy": "2026-09-11T12:20:14.795179Z",
-     "iopub.status.idle": "2026-09-11T12:20:14.884087Z",
-     "shell.execute_reply": "2026-09-11T12:20:14.883672Z"
+     "iopub.execute_input": "2026-09-11T14:20:36.475185Z",
+     "iopub.status.busy": "2026-09-11T14:20:36.474686Z",
+     "iopub.status.idle": "2026-09-11T14:20:36.563437Z",
+     "shell.execute_reply": "2026-09-11T14:20:36.562435Z"
     },
     "papermill": {
-     "duration": 0.095757,
-     "end_time": "2026-09-11T12:20:14.885942+00:00",
+     "duration": 0.095743,
+     "end_time": "2026-09-11T14:20:36.564639+00:00",
      "exception": false,
-     "start_time": "2026-09-11T12:20:14.790185+00:00",
+     "start_time": "2026-09-11T14:20:36.468896+00:00",
      "status": "completed"
     }
    },
@@ -310,16 +310,16 @@
    "id": "2b5bec37",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T12:20:14.903228Z",
-     "iopub.status.busy": "2026-09-11T12:20:14.902878Z",
-     "iopub.status.idle": "2026-09-11T12:20:14.919689Z",
-     "shell.execute_reply": "2026-09-11T12:20:14.918544Z"
+     "iopub.execute_input": "2026-09-11T14:20:36.575451Z",
+     "iopub.status.busy": "2026-09-11T14:20:36.575055Z",
+     "iopub.status.idle": "2026-09-11T14:20:36.596152Z",
+     "shell.execute_reply": "2026-09-11T14:20:36.595179Z"
     },
     "papermill": {
-     "duration": 0.023395,
-     "end_time": "2026-09-11T12:20:14.921115+00:00",
+     "duration": 0.0282,
+     "end_time": "2026-09-11T14:20:36.596713+00:00",
      "exception": false,
-     "start_time": "2026-09-11T12:20:14.897720+00:00",
+     "start_time": "2026-09-11T14:20:36.568513+00:00",
      "status": "completed"
     }
    },
@@ -366,10 +366,10 @@
    "id": "d45884a8",
    "metadata": {
     "papermill": {
-     "duration": 0.006146,
-     "end_time": "2026-09-11T12:20:14.935233+00:00",
+     "duration": 0.003746,
+     "end_time": "2026-09-11T14:20:36.605223+00:00",
      "exception": false,
-     "start_time": "2026-09-11T12:20:14.929087+00:00",
+     "start_time": "2026-09-11T14:20:36.601477+00:00",
      "status": "completed"
     }
    },
@@ -387,16 +387,16 @@
    "id": "713dfd8e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T12:20:14.945829Z",
-     "iopub.status.busy": "2026-09-11T12:20:14.945638Z",
-     "iopub.status.idle": "2026-09-11T12:20:14.957322Z",
-     "shell.execute_reply": "2026-09-11T12:20:14.956587Z"
+     "iopub.execute_input": "2026-09-11T14:20:36.613933Z",
+     "iopub.status.busy": "2026-09-11T14:20:36.613604Z",
+     "iopub.status.idle": "2026-09-11T14:20:36.636471Z",
+     "shell.execute_reply": "2026-09-11T14:20:36.634046Z"
     },
     "papermill": {
-     "duration": 0.017965,
-     "end_time": "2026-09-11T12:20:14.957661+00:00",
+     "duration": 0.02904,
+     "end_time": "2026-09-11T14:20:36.637722+00:00",
      "exception": false,
-     "start_time": "2026-09-11T12:20:14.939696+00:00",
+     "start_time": "2026-09-11T14:20:36.608682+00:00",
      "status": "completed"
     }
    },
@@ -425,32 +425,80 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "5ee89046",
+   "metadata": {
+    "papermill": {
+     "duration": 0.006413,
+     "end_time": "2026-09-11T14:20:36.648889+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T14:20:36.642476+00:00",
+     "status": "completed"
+    }
+   },
+   "source": [
+    "The row count below only establishes that the Treasury series had started by the first ETF\n",
+    "date. A backward as-of join matches every later date to something, so a stretch where the\n",
+    "Fed published nothing would be carried across rather than reported. The measurement that\n",
+    "does see such a gap is the age of the observation each date matched, against a tolerance\n",
+    "declared before the result is printed."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 8,
    "id": "8045729b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T12:20:14.962799Z",
-     "iopub.status.busy": "2026-09-11T12:20:14.962644Z",
-     "iopub.status.idle": "2026-09-11T12:20:14.971428Z",
-     "shell.execute_reply": "2026-09-11T12:20:14.970487Z"
+     "iopub.execute_input": "2026-09-11T14:20:36.663308Z",
+     "iopub.status.busy": "2026-09-11T14:20:36.662809Z",
+     "iopub.status.idle": "2026-09-11T14:20:36.679385Z",
+     "shell.execute_reply": "2026-09-11T14:20:36.678121Z"
     },
     "papermill": {
-     "duration": 0.012657,
-     "end_time": "2026-09-11T12:20:14.972281+00:00",
+     "duration": 0.02502,
+     "end_time": "2026-09-11T14:20:36.680735+00:00",
      "exception": false,
-     "start_time": "2026-09-11T12:20:14.959624+00:00",
+     "start_time": "2026-09-11T14:20:36.655715+00:00",
      "status": "completed"
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Yield-curve observation age when read: median 0d, max 0d (tolerance 4d)\n"
+     ]
+    }
+   ],
    "source": [
+    "MAX_SLOPE_AGE_DAYS = 4\n",
+    "\n",
     "regime_panel = (\n",
     "    price_panel.select(\"timestamp\")\n",
-    "    .join_asof(yield_curve.sort(\"timestamp\"), on=\"timestamp\", strategy=\"backward\")\n",
+    "    .join_asof(\n",
+    "        yield_curve.sort(\"timestamp\").with_columns(pl.col(\"timestamp\").alias(\"slope_asof\")),\n",
+    "        on=\"timestamp\",\n",
+    "        strategy=\"backward\",\n",
+    "    )\n",
     "    .drop_nulls()\n",
     ")\n",
-    "assert regime_panel.height == price_panel.height\n",
+    "assert regime_panel.height == price_panel.height, (\n",
+    "    \"Yield-curve history begins after the ETF panel does\"\n",
+    ")\n",
+    "\n",
+    "slope_age_days = regime_panel.select(\n",
+    "    (pl.col(\"timestamp\") - pl.col(\"slope_asof\")).dt.total_days()\n",
+    ").to_series()\n",
+    "print(\n",
+    "    f\"Yield-curve observation age when read: median {slope_age_days.median():.0f}d, \"\n",
+    "    f\"max {slope_age_days.max()}d (tolerance {MAX_SLOPE_AGE_DAYS}d)\"\n",
+    ")\n",
+    "assert slope_age_days.max() <= MAX_SLOPE_AGE_DAYS, (\n",
+    "    f\"Yield curve went {slope_age_days.max()} days without a publication\"\n",
+    ")\n",
+    "\n",
     "yield_curve_slope = regime_panel[\"slope\"].to_numpy()\n",
     "allocation_risk_on = yield_curve_slope > YIELD_CURVE_THRESHOLD\n",
     "\n",
@@ -464,10 +512,10 @@
    "id": "89902096",
    "metadata": {
     "papermill": {
-     "duration": 0.004485,
-     "end_time": "2026-09-11T12:20:14.981790+00:00",
+     "duration": 0.003749,
+     "end_time": "2026-09-11T14:20:36.688983+00:00",
      "exception": false,
-     "start_time": "2026-09-11T12:20:14.977305+00:00",
+     "start_time": "2026-09-11T14:20:36.685234+00:00",
      "status": "completed"
     }
    },
@@ -482,16 +530,16 @@
    "id": "812677f7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T12:20:14.996690Z",
-     "iopub.status.busy": "2026-09-11T12:20:14.996327Z",
-     "iopub.status.idle": "2026-09-11T12:20:15.010320Z",
-     "shell.execute_reply": "2026-09-11T12:20:15.008571Z"
+     "iopub.execute_input": "2026-09-11T14:20:36.696505Z",
+     "iopub.status.busy": "2026-09-11T14:20:36.696055Z",
+     "iopub.status.idle": "2026-09-11T14:20:36.711618Z",
+     "shell.execute_reply": "2026-09-11T14:20:36.710725Z"
     },
     "papermill": {
-     "duration": 0.025413,
-     "end_time": "2026-09-11T12:20:15.011338+00:00",
+     "duration": 0.020372,
+     "end_time": "2026-09-11T14:20:36.712481+00:00",
      "exception": false,
-     "start_time": "2026-09-11T12:20:14.985925+00:00",
+     "start_time": "2026-09-11T14:20:36.692109+00:00",
      "status": "completed"
     }
    },
@@ -528,16 +576,16 @@
    "id": "e065fc2e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T12:20:15.020174Z",
-     "iopub.status.busy": "2026-09-11T12:20:15.019961Z",
-     "iopub.status.idle": "2026-09-11T12:20:15.028921Z",
-     "shell.execute_reply": "2026-09-11T12:20:15.027763Z"
+     "iopub.execute_input": "2026-09-11T14:20:36.720143Z",
+     "iopub.status.busy": "2026-09-11T14:20:36.719718Z",
+     "iopub.status.idle": "2026-09-11T14:20:36.729476Z",
+     "shell.execute_reply": "2026-09-11T14:20:36.728092Z"
     },
     "papermill": {
-     "duration": 0.015155,
-     "end_time": "2026-09-11T12:20:15.030588+00:00",
+     "duration": 0.016358,
+     "end_time": "2026-09-11T14:20:36.731849+00:00",
      "exception": false,
-     "start_time": "2026-09-11T12:20:15.015433+00:00",
+     "start_time": "2026-09-11T14:20:36.715491+00:00",
      "status": "completed"
     }
    },
@@ -570,10 +618,10 @@
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.004031,
-     "end_time": "2026-09-11T12:20:15.040100+00:00",
+     "duration": 0.005198,
+     "end_time": "2026-09-11T14:20:36.743366+00:00",
      "exception": false,
-     "start_time": "2026-09-11T12:20:15.036069+00:00",
+     "start_time": "2026-09-11T14:20:36.738168+00:00",
      "status": "completed"
     }
    },
@@ -588,16 +636,16 @@
    "id": "1215e4ad",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T12:20:15.059845Z",
-     "iopub.status.busy": "2026-09-11T12:20:15.059284Z",
-     "iopub.status.idle": "2026-09-11T12:20:15.066836Z",
-     "shell.execute_reply": "2026-09-11T12:20:15.065515Z"
+     "iopub.execute_input": "2026-09-11T14:20:36.756631Z",
+     "iopub.status.busy": "2026-09-11T14:20:36.756427Z",
+     "iopub.status.idle": "2026-09-11T14:20:36.762664Z",
+     "shell.execute_reply": "2026-09-11T14:20:36.761212Z"
     },
     "papermill": {
-     "duration": 0.021118,
-     "end_time": "2026-09-11T12:20:15.067397+00:00",
+     "duration": 0.01479,
+     "end_time": "2026-09-11T14:20:36.764908+00:00",
      "exception": false,
-     "start_time": "2026-09-11T12:20:15.046279+00:00",
+     "start_time": "2026-09-11T14:20:36.750118+00:00",
      "status": "completed"
     }
    },
@@ -643,16 +691,16 @@
    "id": "38f22dda",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T12:20:15.073595Z",
-     "iopub.status.busy": "2026-09-11T12:20:15.073429Z",
-     "iopub.status.idle": "2026-09-11T12:20:15.082312Z",
-     "shell.execute_reply": "2026-09-11T12:20:15.081750Z"
+     "iopub.execute_input": "2026-09-11T14:20:36.777700Z",
+     "iopub.status.busy": "2026-09-11T14:20:36.777523Z",
+     "iopub.status.idle": "2026-09-11T14:20:36.789565Z",
+     "shell.execute_reply": "2026-09-11T14:20:36.788560Z"
     },
     "papermill": {
-     "duration": 0.012731,
-     "end_time": "2026-09-11T12:20:15.082721+00:00",
+     "duration": 0.01926,
+     "end_time": "2026-09-11T14:20:36.790295+00:00",
      "exception": false,
-     "start_time": "2026-09-11T12:20:15.069990+00:00",
+     "start_time": "2026-09-11T14:20:36.771035+00:00",
      "status": "completed"
     }
    },
@@ -702,10 +750,10 @@
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.002387,
-     "end_time": "2026-09-11T12:20:15.087517+00:00",
+     "duration": 0.005314,
+     "end_time": "2026-09-11T14:20:36.800460+00:00",
      "exception": false,
-     "start_time": "2026-09-11T12:20:15.085130+00:00",
+     "start_time": "2026-09-11T14:20:36.795146+00:00",
      "status": "completed"
     }
    },
@@ -729,16 +777,16 @@
    "id": "c6a73e4a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T12:20:15.098308Z",
-     "iopub.status.busy": "2026-09-11T12:20:15.098017Z",
-     "iopub.status.idle": "2026-09-11T12:20:15.103796Z",
-     "shell.execute_reply": "2026-09-11T12:20:15.102914Z"
+     "iopub.execute_input": "2026-09-11T14:20:36.811339Z",
+     "iopub.status.busy": "2026-09-11T14:20:36.811132Z",
+     "iopub.status.idle": "2026-09-11T14:20:36.815018Z",
+     "shell.execute_reply": "2026-09-11T14:20:36.814192Z"
     },
     "papermill": {
-     "duration": 0.015066,
-     "end_time": "2026-09-11T12:20:15.106328+00:00",
+     "duration": 0.010374,
+     "end_time": "2026-09-11T14:20:36.815822+00:00",
      "exception": false,
-     "start_time": "2026-09-11T12:20:15.091262+00:00",
+     "start_time": "2026-09-11T14:20:36.805448+00:00",
      "status": "completed"
     }
    },
@@ -762,16 +810,16 @@
    "id": "e25c4843",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T12:20:15.120719Z",
-     "iopub.status.busy": "2026-09-11T12:20:15.120488Z",
-     "iopub.status.idle": "2026-09-11T12:20:15.778429Z",
-     "shell.execute_reply": "2026-09-11T12:20:15.777911Z"
+     "iopub.execute_input": "2026-09-11T14:20:36.826227Z",
+     "iopub.status.busy": "2026-09-11T14:20:36.825834Z",
+     "iopub.status.idle": "2026-09-11T14:20:37.688693Z",
+     "shell.execute_reply": "2026-09-11T14:20:37.687441Z"
     },
     "papermill": {
-     "duration": 0.667398,
-     "end_time": "2026-09-11T12:20:15.779585+00:00",
+     "duration": 0.872472,
+     "end_time": "2026-09-11T14:20:37.692944+00:00",
      "exception": false,
-     "start_time": "2026-09-11T12:20:15.112187+00:00",
+     "start_time": "2026-09-11T14:20:36.820472+00:00",
      "status": "completed"
     }
    },
@@ -800,10 +848,10 @@
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.005074,
-     "end_time": "2026-09-11T12:20:15.791121+00:00",
+     "duration": 0.004834,
+     "end_time": "2026-09-11T14:20:37.704174+00:00",
      "exception": false,
-     "start_time": "2026-09-11T12:20:15.786047+00:00",
+     "start_time": "2026-09-11T14:20:37.699340+00:00",
      "status": "completed"
     }
    },
@@ -817,16 +865,16 @@
    "id": "3ef95b45",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T12:20:15.802955Z",
-     "iopub.status.busy": "2026-09-11T12:20:15.802683Z",
-     "iopub.status.idle": "2026-09-11T12:20:15.807150Z",
-     "shell.execute_reply": "2026-09-11T12:20:15.806496Z"
+     "iopub.execute_input": "2026-09-11T14:20:37.718484Z",
+     "iopub.status.busy": "2026-09-11T14:20:37.717091Z",
+     "iopub.status.idle": "2026-09-11T14:20:37.722620Z",
+     "shell.execute_reply": "2026-09-11T14:20:37.721668Z"
     },
     "papermill": {
-     "duration": 0.011465,
-     "end_time": "2026-09-11T12:20:15.807955+00:00",
+     "duration": 0.012882,
+     "end_time": "2026-09-11T14:20:37.723215+00:00",
      "exception": false,
-     "start_time": "2026-09-11T12:20:15.796490+00:00",
+     "start_time": "2026-09-11T14:20:37.710333+00:00",
      "status": "completed"
     }
    },
@@ -848,16 +896,16 @@
    "id": "b6915f43",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T12:20:15.820600Z",
-     "iopub.status.busy": "2026-09-11T12:20:15.820269Z",
-     "iopub.status.idle": "2026-09-11T12:20:15.830161Z",
-     "shell.execute_reply": "2026-09-11T12:20:15.829047Z"
+     "iopub.execute_input": "2026-09-11T14:20:37.737209Z",
+     "iopub.status.busy": "2026-09-11T14:20:37.736863Z",
+     "iopub.status.idle": "2026-09-11T14:20:37.746322Z",
+     "shell.execute_reply": "2026-09-11T14:20:37.745002Z"
     },
     "papermill": {
-     "duration": 0.01812,
-     "end_time": "2026-09-11T12:20:15.830945+00:00",
+     "duration": 0.019827,
+     "end_time": "2026-09-11T14:20:37.747746+00:00",
      "exception": false,
-     "start_time": "2026-09-11T12:20:15.812825+00:00",
+     "start_time": "2026-09-11T14:20:37.727919+00:00",
      "status": "completed"
     }
    },
@@ -879,10 +927,10 @@
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.00354,
-     "end_time": "2026-09-11T12:20:15.839337+00:00",
+     "duration": 0.006633,
+     "end_time": "2026-09-11T14:20:37.760630+00:00",
      "exception": false,
-     "start_time": "2026-09-11T12:20:15.835797+00:00",
+     "start_time": "2026-09-11T14:20:37.753997+00:00",
      "status": "completed"
     }
    },
@@ -901,16 +949,16 @@
    "id": "b6332a5f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T12:20:15.853393Z",
-     "iopub.status.busy": "2026-09-11T12:20:15.853064Z",
-     "iopub.status.idle": "2026-09-11T12:20:15.860166Z",
-     "shell.execute_reply": "2026-09-11T12:20:15.859118Z"
+     "iopub.execute_input": "2026-09-11T14:20:37.773614Z",
+     "iopub.status.busy": "2026-09-11T14:20:37.773352Z",
+     "iopub.status.idle": "2026-09-11T14:20:37.779606Z",
+     "shell.execute_reply": "2026-09-11T14:20:37.778079Z"
     },
     "papermill": {
-     "duration": 0.016676,
-     "end_time": "2026-09-11T12:20:15.861024+00:00",
+     "duration": 0.013568,
+     "end_time": "2026-09-11T14:20:37.780485+00:00",
      "exception": false,
-     "start_time": "2026-09-11T12:20:15.844348+00:00",
+     "start_time": "2026-09-11T14:20:37.766917+00:00",
      "status": "completed"
     }
    },
@@ -938,16 +986,16 @@
    "id": "29b9dc6a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T12:20:15.875275Z",
-     "iopub.status.busy": "2026-09-11T12:20:15.875005Z",
-     "iopub.status.idle": "2026-09-11T12:20:15.894360Z",
-     "shell.execute_reply": "2026-09-11T12:20:15.892920Z"
+     "iopub.execute_input": "2026-09-11T14:20:37.796281Z",
+     "iopub.status.busy": "2026-09-11T14:20:37.795877Z",
+     "iopub.status.idle": "2026-09-11T14:20:37.812839Z",
+     "shell.execute_reply": "2026-09-11T14:20:37.811993Z"
     },
     "papermill": {
-     "duration": 0.02943,
-     "end_time": "2026-09-11T12:20:15.897090+00:00",
+     "duration": 0.027539,
+     "end_time": "2026-09-11T14:20:37.814467+00:00",
      "exception": false,
-     "start_time": "2026-09-11T12:20:15.867660+00:00",
+     "start_time": "2026-09-11T14:20:37.786928+00:00",
      "status": "completed"
     }
    },
@@ -1013,10 +1061,10 @@
    "id": "48c29460",
    "metadata": {
     "papermill": {
-     "duration": 0.004733,
-     "end_time": "2026-09-11T12:20:15.907097+00:00",
+     "duration": 0.005921,
+     "end_time": "2026-09-11T14:20:37.827448+00:00",
      "exception": false,
-     "start_time": "2026-09-11T12:20:15.902364+00:00",
+     "start_time": "2026-09-11T14:20:37.821527+00:00",
      "status": "completed"
     }
    },
@@ -1034,16 +1082,16 @@
    "id": "e1a63442",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T12:20:15.921317Z",
-     "iopub.status.busy": "2026-09-11T12:20:15.920414Z",
-     "iopub.status.idle": "2026-09-11T12:20:16.185555Z",
-     "shell.execute_reply": "2026-09-11T12:20:16.184817Z"
+     "iopub.execute_input": "2026-09-11T14:20:37.842634Z",
+     "iopub.status.busy": "2026-09-11T14:20:37.842149Z",
+     "iopub.status.idle": "2026-09-11T14:20:38.168209Z",
+     "shell.execute_reply": "2026-09-11T14:20:38.167666Z"
     },
     "papermill": {
-     "duration": 0.274554,
-     "end_time": "2026-09-11T12:20:16.186537+00:00",
+     "duration": 0.334691,
+     "end_time": "2026-09-11T14:20:38.169635+00:00",
      "exception": false,
-     "start_time": "2026-09-11T12:20:15.911983+00:00",
+     "start_time": "2026-09-11T14:20:37.834944+00:00",
      "status": "completed"
     }
    },
@@ -1105,10 +1153,10 @@
    "id": "2ecd41dd",
    "metadata": {
     "papermill": {
-     "duration": 0.005589,
-     "end_time": "2026-09-11T12:20:16.197275+00:00",
+     "duration": 0.00382,
+     "end_time": "2026-09-11T14:20:38.177336+00:00",
      "exception": false,
-     "start_time": "2026-09-11T12:20:16.191686+00:00",
+     "start_time": "2026-09-11T14:20:38.173516+00:00",
      "status": "completed"
     }
    },
@@ -1130,10 +1178,10 @@
    "id": "de9becff",
    "metadata": {
     "papermill": {
-     "duration": 0.006063,
-     "end_time": "2026-09-11T12:20:16.209808+00:00",
+     "duration": 0.002967,
+     "end_time": "2026-09-11T14:20:38.183797+00:00",
      "exception": false,
-     "start_time": "2026-09-11T12:20:16.203745+00:00",
+     "start_time": "2026-09-11T14:20:38.180830+00:00",
      "status": "completed"
     }
    },
@@ -1157,16 +1205,16 @@
    "id": "93801f1c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T12:20:16.224694Z",
-     "iopub.status.busy": "2026-09-11T12:20:16.224411Z",
-     "iopub.status.idle": "2026-09-11T12:20:16.233581Z",
-     "shell.execute_reply": "2026-09-11T12:20:16.232256Z"
+     "iopub.execute_input": "2026-09-11T14:20:38.195967Z",
+     "iopub.status.busy": "2026-09-11T14:20:38.195663Z",
+     "iopub.status.idle": "2026-09-11T14:20:38.203846Z",
+     "shell.execute_reply": "2026-09-11T14:20:38.202268Z"
     },
     "papermill": {
-     "duration": 0.019232,
-     "end_time": "2026-09-11T12:20:16.234792+00:00",
+     "duration": 0.017639,
+     "end_time": "2026-09-11T14:20:38.205689+00:00",
      "exception": false,
-     "start_time": "2026-09-11T12:20:16.215560+00:00",
+     "start_time": "2026-09-11T14:20:38.188050+00:00",
      "status": "completed"
     }
    },
@@ -1192,16 +1240,16 @@
    "id": "643bd2cc",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T12:20:16.258569Z",
-     "iopub.status.busy": "2026-09-11T12:20:16.258155Z",
-     "iopub.status.idle": "2026-09-11T12:20:16.524826Z",
-     "shell.execute_reply": "2026-09-11T12:20:16.523988Z"
+     "iopub.execute_input": "2026-09-11T14:20:38.220387Z",
+     "iopub.status.busy": "2026-09-11T14:20:38.220062Z",
+     "iopub.status.idle": "2026-09-11T14:20:38.395086Z",
+     "shell.execute_reply": "2026-09-11T14:20:38.393972Z"
     },
     "papermill": {
-     "duration": 0.281016,
-     "end_time": "2026-09-11T12:20:16.525844+00:00",
+     "duration": 0.183972,
+     "end_time": "2026-09-11T14:20:38.396128+00:00",
      "exception": false,
-     "start_time": "2026-09-11T12:20:16.244828+00:00",
+     "start_time": "2026-09-11T14:20:38.212156+00:00",
      "status": "completed"
     }
    },
@@ -1270,16 +1318,16 @@
    "id": "7d771307",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T12:20:16.541715Z",
-     "iopub.status.busy": "2026-09-11T12:20:16.541311Z",
-     "iopub.status.idle": "2026-09-11T12:20:16.554065Z",
-     "shell.execute_reply": "2026-09-11T12:20:16.550167Z"
+     "iopub.execute_input": "2026-09-11T14:20:38.413967Z",
+     "iopub.status.busy": "2026-09-11T14:20:38.413623Z",
+     "iopub.status.idle": "2026-09-11T14:20:38.420941Z",
+     "shell.execute_reply": "2026-09-11T14:20:38.419739Z"
     },
     "papermill": {
-     "duration": 0.023186,
-     "end_time": "2026-09-11T12:20:16.555640+00:00",
+     "duration": 0.019193,
+     "end_time": "2026-09-11T14:20:38.421944+00:00",
      "exception": false,
-     "start_time": "2026-09-11T12:20:16.532454+00:00",
+     "start_time": "2026-09-11T14:20:38.402751+00:00",
      "status": "completed"
     }
    },
@@ -1307,10 +1355,10 @@
    "id": "99735c01",
    "metadata": {
     "papermill": {
-     "duration": 0.008983,
-     "end_time": "2026-09-11T12:20:16.572874+00:00",
+     "duration": 0.007966,
+     "end_time": "2026-09-11T14:20:38.437568+00:00",
      "exception": false,
-     "start_time": "2026-09-11T12:20:16.563891+00:00",
+     "start_time": "2026-09-11T14:20:38.429602+00:00",
      "status": "completed"
     }
    },
@@ -1334,10 +1382,10 @@
    "id": "deefb7e3",
    "metadata": {
     "papermill": {
-     "duration": 0.008604,
-     "end_time": "2026-09-11T12:20:16.586453+00:00",
+     "duration": 0.005048,
+     "end_time": "2026-09-11T14:20:38.448534+00:00",
      "exception": false,
-     "start_time": "2026-09-11T12:20:16.577849+00:00",
+     "start_time": "2026-09-11T14:20:38.443486+00:00",
      "status": "completed"
     }
    },
@@ -1354,16 +1402,16 @@
    "id": "e47af34e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T12:20:16.605709Z",
-     "iopub.status.busy": "2026-09-11T12:20:16.605380Z",
-     "iopub.status.idle": "2026-09-11T12:20:16.618199Z",
-     "shell.execute_reply": "2026-09-11T12:20:16.612874Z"
+     "iopub.execute_input": "2026-09-11T14:20:38.463473Z",
+     "iopub.status.busy": "2026-09-11T14:20:38.463203Z",
+     "iopub.status.idle": "2026-09-11T14:20:38.471869Z",
+     "shell.execute_reply": "2026-09-11T14:20:38.470833Z"
     },
     "papermill": {
-     "duration": 0.025118,
-     "end_time": "2026-09-11T12:20:16.619883+00:00",
+     "duration": 0.018555,
+     "end_time": "2026-09-11T14:20:38.473269+00:00",
      "exception": false,
-     "start_time": "2026-09-11T12:20:16.594765+00:00",
+     "start_time": "2026-09-11T14:20:38.454714+00:00",
      "status": "completed"
     }
    },
@@ -1399,16 +1447,16 @@
    "id": "b916b102",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T12:20:16.633129Z",
-     "iopub.status.busy": "2026-09-11T12:20:16.632782Z",
-     "iopub.status.idle": "2026-09-11T12:20:16.769052Z",
-     "shell.execute_reply": "2026-09-11T12:20:16.768756Z"
+     "iopub.execute_input": "2026-09-11T14:20:38.483845Z",
+     "iopub.status.busy": "2026-09-11T14:20:38.483504Z",
+     "iopub.status.idle": "2026-09-11T14:20:38.621192Z",
+     "shell.execute_reply": "2026-09-11T14:20:38.620277Z"
     },
     "papermill": {
-     "duration": 0.142847,
-     "end_time": "2026-09-11T12:20:16.769888+00:00",
+     "duration": 0.14495,
+     "end_time": "2026-09-11T14:20:38.622022+00:00",
      "exception": false,
-     "start_time": "2026-09-11T12:20:16.627041+00:00",
+     "start_time": "2026-09-11T14:20:38.477072+00:00",
      "status": "completed"
     }
    },
@@ -1461,16 +1509,16 @@
    "id": "f638034d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T12:20:16.777298Z",
-     "iopub.status.busy": "2026-09-11T12:20:16.776850Z",
-     "iopub.status.idle": "2026-09-11T12:20:16.782041Z",
-     "shell.execute_reply": "2026-09-11T12:20:16.781131Z"
+     "iopub.execute_input": "2026-09-11T14:20:38.637777Z",
+     "iopub.status.busy": "2026-09-11T14:20:38.637183Z",
+     "iopub.status.idle": "2026-09-11T14:20:38.644004Z",
+     "shell.execute_reply": "2026-09-11T14:20:38.642913Z"
     },
     "papermill": {
-     "duration": 0.011553,
-     "end_time": "2026-09-11T12:20:16.784465+00:00",
+     "duration": 0.015802,
+     "end_time": "2026-09-11T14:20:38.645673+00:00",
      "exception": false,
-     "start_time": "2026-09-11T12:20:16.772912+00:00",
+     "start_time": "2026-09-11T14:20:38.629871+00:00",
      "status": "completed"
     }
    },
@@ -1494,10 +1542,10 @@
    "id": "9c2eb74c",
    "metadata": {
     "papermill": {
-     "duration": 0.006392,
-     "end_time": "2026-09-11T12:20:16.797441+00:00",
+     "duration": 0.00789,
+     "end_time": "2026-09-11T14:20:38.661058+00:00",
      "exception": false,
-     "start_time": "2026-09-11T12:20:16.791049+00:00",
+     "start_time": "2026-09-11T14:20:38.653168+00:00",
      "status": "completed"
     }
    },
@@ -1514,10 +1562,10 @@
    "id": "644a5825",
    "metadata": {
     "papermill": {
-     "duration": 0.004489,
-     "end_time": "2026-09-11T12:20:16.808427+00:00",
+     "duration": 0.006115,
+     "end_time": "2026-09-11T14:20:38.674180+00:00",
      "exception": false,
-     "start_time": "2026-09-11T12:20:16.803938+00:00",
+     "start_time": "2026-09-11T14:20:38.668065+00:00",
      "status": "completed"
     }
    },
@@ -1581,24 +1629,24 @@
    "version": "3.14.3"
   },
   "ml4t_provenance": {
-   "executed_at": "2026-09-11T12:20:37.390954+00:00",
-   "executor": "local-uv",
+   "source_py_blob": "ed347f71c311c519f295146cd039c593a71ceac1",
+   "outputs_digest": "a45d5f9878ed0a3dfcc4e67312e0c6793adfac4092f1043d4f754e8fb2d17960",
    "library_digest": "5cd38db8077f7dca50a29be7cccbfb78348e4f57c225c1b91531fcbd1b7de68e",
-   "outputs_digest": "917752246ad2aa79cd52a63ae9e18126c4586f3726e998c89883b9a8eb629c56",
-   "parameters": {},
+   "executed_at": "2026-09-11T14:20:43.463715+00:00",
+   "executor": "local-uv",
    "production": true,
-   "source_py_blob": "b453c50845569526d4c082e4e4040a67f1b26db5"
+   "parameters": {}
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 15.365306,
-   "end_time": "2026-09-11T12:20:20.330953+00:00",
+   "duration": 15.168151,
+   "end_time": "2026-09-11T14:20:41.405902+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "~/ml4t/public-teach-d/16_strategy_simulation/.10_regime_backtest_analysis.build.3954196.ipynb",
-   "output_path": "~/ml4t/public-teach-d/16_strategy_simulation/.10_regime_backtest_analysis.papermill.3954196.ipynb",
+   "input_path": "16_strategy_simulation/10_regime_backtest_analysis.ipynb",
+   "output_path": "16_strategy_simulation/10_regime_backtest_analysis.ipynb",
    "parameters": {},
-   "start_time": "2026-09-11T12:20:04.965647+00:00",
+   "start_time": "2026-09-11T14:20:26.237751+00:00",
    "version": "2.7.0"
   }
  },

--- a/16_strategy_simulation/10_regime_backtest_analysis.py
+++ b/16_strategy_simulation/10_regime_backtest_analysis.py
@@ -177,13 +177,40 @@ yield_curve = macro_frame.select(
     "timestamp", (pl.col("YIELD_CURVE_SLOPE") / 100).alias("slope")
 ).drop_nulls()
 
+# %% [markdown]
+# The row count below only establishes that the Treasury series had started by the first ETF
+# date. A backward as-of join matches every later date to something, so a stretch where the
+# Fed published nothing would be carried across rather than reported. The measurement that
+# does see such a gap is the age of the observation each date matched, against a tolerance
+# declared before the result is printed.
+
 # %%
+MAX_SLOPE_AGE_DAYS = 4
+
 regime_panel = (
     price_panel.select("timestamp")
-    .join_asof(yield_curve.sort("timestamp"), on="timestamp", strategy="backward")
+    .join_asof(
+        yield_curve.sort("timestamp").with_columns(pl.col("timestamp").alias("slope_asof")),
+        on="timestamp",
+        strategy="backward",
+    )
     .drop_nulls()
 )
-assert regime_panel.height == price_panel.height
+assert regime_panel.height == price_panel.height, (
+    "Yield-curve history begins after the ETF panel does"
+)
+
+slope_age_days = regime_panel.select(
+    (pl.col("timestamp") - pl.col("slope_asof")).dt.total_days()
+).to_series()
+print(
+    f"Yield-curve observation age when read: median {slope_age_days.median():.0f}d, "
+    f"max {slope_age_days.max()}d (tolerance {MAX_SLOPE_AGE_DAYS}d)"
+)
+assert slope_age_days.max() <= MAX_SLOPE_AGE_DAYS, (
+    f"Yield curve went {slope_age_days.max()} days without a publication"
+)
+
 yield_curve_slope = regime_panel["slope"].to_numpy()
 allocation_risk_on = yield_curve_slope > YIELD_CURVE_THRESHOLD
 

--- a/25_live_trading/09_crypto_funding_deployment_loop.ipynb
+++ b/25_live_trading/09_crypto_funding_deployment_loop.ipynb
@@ -3,7 +3,15 @@
   {
    "cell_type": "markdown",
    "id": "eb1f32e7",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.011516,
+     "end_time": "2026-09-11T14:39:00.424753+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T14:39:00.413237+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "# Crypto Funding Deployment Loop\n",
     "\n",
@@ -76,10 +84,17 @@
    "id": "5806b23a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T01:27:41.680874Z",
-     "iopub.status.busy": "2026-09-09T01:27:41.680701Z",
-     "iopub.status.idle": "2026-09-09T01:27:44.389115Z",
-     "shell.execute_reply": "2026-09-09T01:27:44.388546Z"
+     "iopub.execute_input": "2026-09-11T14:39:00.447650Z",
+     "iopub.status.busy": "2026-09-11T14:39:00.447270Z",
+     "iopub.status.idle": "2026-09-11T14:39:07.123697Z",
+     "shell.execute_reply": "2026-09-11T14:39:07.120330Z"
+    },
+    "papermill": {
+     "duration": 6.6904,
+     "end_time": "2026-09-11T14:39:07.125018+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T14:39:00.434618+00:00",
+     "status": "completed"
     }
    },
    "outputs": [],
@@ -134,10 +149,17 @@
    "id": "4611d15d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T01:27:44.395927Z",
-     "iopub.status.busy": "2026-09-09T01:27:44.395827Z",
-     "iopub.status.idle": "2026-09-09T01:27:44.398165Z",
-     "shell.execute_reply": "2026-09-09T01:27:44.397770Z"
+     "iopub.execute_input": "2026-09-11T14:39:07.143201Z",
+     "iopub.status.busy": "2026-09-11T14:39:07.142758Z",
+     "iopub.status.idle": "2026-09-11T14:39:07.150651Z",
+     "shell.execute_reply": "2026-09-11T14:39:07.149282Z"
+    },
+    "papermill": {
+     "duration": 0.019122,
+     "end_time": "2026-09-11T14:39:07.151797+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T14:39:07.132675+00:00",
+     "status": "completed"
     },
     "tags": [
      "parameters"
@@ -160,13 +182,22 @@
     ")\n",
     "NOTIONAL_PER_LEG_USD = 100.0  # paper notional per symbol\n",
     "SUBMIT_PAPER_ORDERS = False  # explicit opt-in only; publication execution is dry-run\n",
-    "MIN_OKX_LIVE_COVERAGE = 0.75"
+    "MIN_OKX_LIVE_COVERAGE = 0.75\n",
+    "MAX_FUNDING_AGE_HOURS = 8.0  # funding settles every 8h; one missed settlement is the limit"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "cff526f7",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.009779,
+     "end_time": "2026-09-11T14:39:07.169214+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T14:39:07.159435+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "## 1. Setup and Venue Connections\n",
     "\n",
@@ -181,12 +212,19 @@
    "id": "18e6648b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T01:27:44.409784Z",
-     "iopub.status.busy": "2026-09-09T01:27:44.409699Z",
-     "iopub.status.idle": "2026-09-09T01:27:44.412016Z",
-     "shell.execute_reply": "2026-09-09T01:27:44.411596Z"
+     "iopub.execute_input": "2026-09-11T14:39:07.186270Z",
+     "iopub.status.busy": "2026-09-11T14:39:07.185550Z",
+     "iopub.status.idle": "2026-09-11T14:39:07.199625Z",
+     "shell.execute_reply": "2026-09-11T14:39:07.196335Z"
     },
-    "lines_to_next_cell": 2
+    "lines_to_next_cell": 2,
+    "papermill": {
+     "duration": 0.022786,
+     "end_time": "2026-09-11T14:39:07.201437+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T14:39:07.178651+00:00",
+     "status": "completed"
+    }
    },
    "outputs": [],
    "source": [
@@ -202,7 +240,14 @@
    "cell_type": "markdown",
    "id": "31a403f2",
    "metadata": {
-    "lines_to_next_cell": 2
+    "lines_to_next_cell": 2,
+    "papermill": {
+     "duration": 0.009463,
+     "end_time": "2026-09-11T14:39:07.222399+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T14:39:07.212936+00:00",
+     "status": "completed"
+    }
    },
    "source": [
     "The requested deployment universe is fixed to the nineteen perpetuals used\n",
@@ -217,12 +262,19 @@
    "id": "ae5fbee6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T01:27:44.423465Z",
-     "iopub.status.busy": "2026-09-09T01:27:44.423380Z",
-     "iopub.status.idle": "2026-09-09T01:27:44.425680Z",
-     "shell.execute_reply": "2026-09-09T01:27:44.425238Z"
+     "iopub.execute_input": "2026-09-11T14:39:07.245204Z",
+     "iopub.status.busy": "2026-09-11T14:39:07.244862Z",
+     "iopub.status.idle": "2026-09-11T14:39:07.250301Z",
+     "shell.execute_reply": "2026-09-11T14:39:07.249197Z"
     },
-    "lines_to_next_cell": 2
+    "lines_to_next_cell": 2,
+    "papermill": {
+     "duration": 0.017924,
+     "end_time": "2026-09-11T14:39:07.251246+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T14:39:07.233322+00:00",
+     "status": "completed"
+    }
    },
    "outputs": [],
    "source": [
@@ -256,7 +308,14 @@
    "cell_type": "markdown",
    "id": "ab8c622a",
    "metadata": {
-    "lines_to_next_cell": 2
+    "lines_to_next_cell": 2,
+    "papermill": {
+     "duration": 0.009815,
+     "end_time": "2026-09-11T14:39:07.270001+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T14:39:07.260186+00:00",
+     "status": "completed"
+    }
    },
    "source": [
     "The demo carries an explicit eleven-pair mapping for its paper-execution rehearsal."
@@ -265,7 +324,15 @@
   {
    "cell_type": "markdown",
    "id": "f0f750d6",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.0077,
+     "end_time": "2026-09-11T14:39:07.291242+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T14:39:07.283542+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "The mapping is written out rather than queried, and both halves of that choice matter. USD\n",
     "pairs rather than USDT ones, because the paper account is funded in USD and a quote-currency\n",
@@ -284,12 +351,19 @@
    "id": "c1f85c41",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T01:27:44.442642Z",
-     "iopub.status.busy": "2026-09-09T01:27:44.442509Z",
-     "iopub.status.idle": "2026-09-09T01:27:44.444828Z",
-     "shell.execute_reply": "2026-09-09T01:27:44.444303Z"
+     "iopub.execute_input": "2026-09-11T14:39:07.305916Z",
+     "iopub.status.busy": "2026-09-11T14:39:07.305432Z",
+     "iopub.status.idle": "2026-09-11T14:39:07.311860Z",
+     "shell.execute_reply": "2026-09-11T14:39:07.309829Z"
     },
-    "lines_to_next_cell": 2
+    "lines_to_next_cell": 2,
+    "papermill": {
+     "duration": 0.017448,
+     "end_time": "2026-09-11T14:39:07.314113+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T14:39:07.296665+00:00",
+     "status": "completed"
+    }
    },
    "outputs": [],
    "source": [
@@ -312,7 +386,14 @@
    "cell_type": "markdown",
    "id": "81bde466",
    "metadata": {
-    "lines_to_next_cell": 2
+    "lines_to_next_cell": 2,
+    "papermill": {
+     "duration": 0.016306,
+     "end_time": "2026-09-11T14:39:07.347605+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T14:39:07.331299+00:00",
+     "status": "completed"
+    }
    },
    "source": [
     "The serialized feature order is also the model input contract."
@@ -324,12 +405,19 @@
    "id": "b6de71ed",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T01:27:44.457802Z",
-     "iopub.status.busy": "2026-09-09T01:27:44.457695Z",
-     "iopub.status.idle": "2026-09-09T01:27:44.459914Z",
-     "shell.execute_reply": "2026-09-09T01:27:44.459486Z"
+     "iopub.execute_input": "2026-09-11T14:39:07.373708Z",
+     "iopub.status.busy": "2026-09-11T14:39:07.373291Z",
+     "iopub.status.idle": "2026-09-11T14:39:07.382945Z",
+     "shell.execute_reply": "2026-09-11T14:39:07.377919Z"
     },
-    "lines_to_next_cell": 2
+    "lines_to_next_cell": 2,
+    "papermill": {
+     "duration": 0.023167,
+     "end_time": "2026-09-11T14:39:07.384434+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T14:39:07.361267+00:00",
+     "status": "completed"
+    }
    },
    "outputs": [],
    "source": [
@@ -354,7 +442,14 @@
    "cell_type": "markdown",
    "id": "f01d77d3",
    "metadata": {
-    "lines_to_next_cell": 2
+    "lines_to_next_cell": 2,
+    "papermill": {
+     "duration": 0.004889,
+     "end_time": "2026-09-11T14:39:07.396625+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T14:39:07.391736+00:00",
+     "status": "completed"
+    }
    },
    "source": [
     "The startup banner exposes the research, data, execution, artifact, and mutation boundaries."
@@ -366,10 +461,17 @@
    "id": "6b891860",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T01:27:44.472778Z",
-     "iopub.status.busy": "2026-09-09T01:27:44.472684Z",
-     "iopub.status.idle": "2026-09-09T01:27:44.531751Z",
-     "shell.execute_reply": "2026-09-09T01:27:44.531248Z"
+     "iopub.execute_input": "2026-09-11T14:39:07.415363Z",
+     "iopub.status.busy": "2026-09-11T14:39:07.415185Z",
+     "iopub.status.idle": "2026-09-11T14:39:07.463368Z",
+     "shell.execute_reply": "2026-09-11T14:39:07.461475Z"
+    },
+    "papermill": {
+     "duration": 0.060489,
+     "end_time": "2026-09-11T14:39:07.464601+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T14:39:07.404112+00:00",
+     "status": "completed"
     }
    },
    "outputs": [
@@ -415,7 +517,15 @@
   {
    "cell_type": "markdown",
    "id": "c8c67b68",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.004849,
+     "end_time": "2026-09-11T14:39:07.476308+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T14:39:07.471459+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "Eight of the nineteen case-study perps are absent from the\n",
     "demo's fixed Alpaca mapping. The strategy was researched on a universe chosen\n",
@@ -427,7 +537,15 @@
   {
    "cell_type": "markdown",
    "id": "dff9f810",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.004738,
+     "end_time": "2026-09-11T14:39:07.490186+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T14:39:07.485448+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "### 1a. OKX Data Plane\n",
     "\n",
@@ -444,10 +562,17 @@
    "id": "1da3d353",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T01:27:44.549260Z",
-     "iopub.status.busy": "2026-09-09T01:27:44.549124Z",
-     "iopub.status.idle": "2026-09-09T01:27:44.615555Z",
-     "shell.execute_reply": "2026-09-09T01:27:44.615064Z"
+     "iopub.execute_input": "2026-09-11T14:39:07.501874Z",
+     "iopub.status.busy": "2026-09-11T14:39:07.501669Z",
+     "iopub.status.idle": "2026-09-11T14:39:07.656373Z",
+     "shell.execute_reply": "2026-09-11T14:39:07.654355Z"
+    },
+    "papermill": {
+     "duration": 0.162842,
+     "end_time": "2026-09-11T14:39:07.658206+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T14:39:07.495364+00:00",
+     "status": "completed"
     }
    },
    "outputs": [],
@@ -470,7 +595,14 @@
    "cell_type": "markdown",
    "id": "0799f220",
    "metadata": {
-    "lines_to_next_cell": 2
+    "lines_to_next_cell": 2,
+    "papermill": {
+     "duration": 0.008622,
+     "end_time": "2026-09-11T14:39:07.676276+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T14:39:07.667654+00:00",
+     "status": "completed"
+    }
    },
    "source": [
     "#### Fetch 1H OHLCV bars\n",
@@ -486,12 +618,19 @@
    "id": "94b02c94",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T01:27:44.627959Z",
-     "iopub.status.busy": "2026-09-09T01:27:44.627853Z",
-     "iopub.status.idle": "2026-09-09T01:27:44.630674Z",
-     "shell.execute_reply": "2026-09-09T01:27:44.630296Z"
+     "iopub.execute_input": "2026-09-11T14:39:07.696094Z",
+     "iopub.status.busy": "2026-09-11T14:39:07.695872Z",
+     "iopub.status.idle": "2026-09-11T14:39:07.705142Z",
+     "shell.execute_reply": "2026-09-11T14:39:07.703541Z"
     },
-    "lines_to_next_cell": 2
+    "lines_to_next_cell": 2,
+    "papermill": {
+     "duration": 0.01902,
+     "end_time": "2026-09-11T14:39:07.706052+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T14:39:07.687032+00:00",
+     "status": "completed"
+    }
    },
    "outputs": [],
    "source": [
@@ -516,7 +655,14 @@
    "cell_type": "markdown",
    "id": "a2ffb7c0",
    "metadata": {
-    "lines_to_next_cell": 2
+    "lines_to_next_cell": 2,
+    "papermill": {
+     "duration": 0.00634,
+     "end_time": "2026-09-11T14:39:07.720261+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T14:39:07.713921+00:00",
+     "status": "completed"
+    }
    },
    "source": [
     "The parser records raw conservation counts and a payload hash before converting confirmed candles."
@@ -528,12 +674,19 @@
    "id": "313c49b1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T01:27:44.642762Z",
-     "iopub.status.busy": "2026-09-09T01:27:44.642666Z",
-     "iopub.status.idle": "2026-09-09T01:27:44.646303Z",
-     "shell.execute_reply": "2026-09-09T01:27:44.645887Z"
+     "iopub.execute_input": "2026-09-11T14:39:07.735381Z",
+     "iopub.status.busy": "2026-09-11T14:39:07.734940Z",
+     "iopub.status.idle": "2026-09-11T14:39:07.744830Z",
+     "shell.execute_reply": "2026-09-11T14:39:07.743363Z"
     },
-    "lines_to_next_cell": 2
+    "lines_to_next_cell": 2,
+    "papermill": {
+     "duration": 0.019932,
+     "end_time": "2026-09-11T14:39:07.745796+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T14:39:07.725864+00:00",
+     "status": "completed"
+    }
    },
    "outputs": [],
    "source": [
@@ -580,7 +733,14 @@
    "cell_type": "markdown",
    "id": "c0052bfd",
    "metadata": {
-    "lines_to_next_cell": 2
+    "lines_to_next_cell": 2,
+    "papermill": {
+     "duration": 0.006046,
+     "end_time": "2026-09-11T14:39:07.761614+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T14:39:07.755568+00:00",
+     "status": "completed"
+    }
    },
    "source": [
     "#### Aggregate 1H bars to 8H windows\n",
@@ -596,12 +756,19 @@
    "id": "521351f2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T01:27:44.658091Z",
-     "iopub.status.busy": "2026-09-09T01:27:44.658000Z",
-     "iopub.status.idle": "2026-09-09T01:27:44.660503Z",
-     "shell.execute_reply": "2026-09-09T01:27:44.660184Z"
+     "iopub.execute_input": "2026-09-11T14:39:07.800675Z",
+     "iopub.status.busy": "2026-09-11T14:39:07.800152Z",
+     "iopub.status.idle": "2026-09-11T14:39:07.811491Z",
+     "shell.execute_reply": "2026-09-11T14:39:07.809665Z"
     },
-    "lines_to_next_cell": 2
+    "lines_to_next_cell": 2,
+    "papermill": {
+     "duration": 0.039994,
+     "end_time": "2026-09-11T14:39:07.812750+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T14:39:07.772756+00:00",
+     "status": "completed"
+    }
    },
    "outputs": [],
    "source": [
@@ -631,7 +798,14 @@
    "cell_type": "markdown",
    "id": "d0c24fe0",
    "metadata": {
-    "lines_to_next_cell": 2
+    "lines_to_next_cell": 2,
+    "papermill": {
+     "duration": 0.006849,
+     "end_time": "2026-09-11T14:39:07.828781+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T14:39:07.821932+00:00",
+     "status": "completed"
+    }
    },
    "source": [
     "#### Fetch funding-rate history\n",
@@ -647,12 +821,19 @@
    "id": "a04d16d8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T01:27:44.672223Z",
-     "iopub.status.busy": "2026-09-09T01:27:44.672115Z",
-     "iopub.status.idle": "2026-09-09T01:27:44.674766Z",
-     "shell.execute_reply": "2026-09-09T01:27:44.674371Z"
+     "iopub.execute_input": "2026-09-11T14:39:07.843730Z",
+     "iopub.status.busy": "2026-09-11T14:39:07.843458Z",
+     "iopub.status.idle": "2026-09-11T14:39:07.847692Z",
+     "shell.execute_reply": "2026-09-11T14:39:07.846993Z"
     },
-    "lines_to_next_cell": 2
+    "lines_to_next_cell": 2,
+    "papermill": {
+     "duration": 0.011252,
+     "end_time": "2026-09-11T14:39:07.848493+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T14:39:07.837241+00:00",
+     "status": "completed"
+    }
    },
    "outputs": [],
    "source": [
@@ -679,7 +860,14 @@
    "cell_type": "markdown",
    "id": "73461337",
    "metadata": {
-    "lines_to_next_cell": 2
+    "lines_to_next_cell": 2,
+    "papermill": {
+     "duration": 0.009725,
+     "end_time": "2026-09-11T14:39:07.862757+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T14:39:07.853032+00:00",
+     "status": "completed"
+    }
    },
    "source": [
     "The funding parser applies the same raw-payload identity and conservation boundary as the candle parser."
@@ -691,12 +879,19 @@
    "id": "d7f9c482",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T01:27:44.686791Z",
-     "iopub.status.busy": "2026-09-09T01:27:44.686683Z",
-     "iopub.status.idle": "2026-09-09T01:27:44.689575Z",
-     "shell.execute_reply": "2026-09-09T01:27:44.689233Z"
+     "iopub.execute_input": "2026-09-11T14:39:07.877382Z",
+     "iopub.status.busy": "2026-09-11T14:39:07.877166Z",
+     "iopub.status.idle": "2026-09-11T14:39:07.881873Z",
+     "shell.execute_reply": "2026-09-11T14:39:07.881238Z"
     },
-    "lines_to_next_cell": 2
+    "lines_to_next_cell": 2,
+    "papermill": {
+     "duration": 0.010836,
+     "end_time": "2026-09-11T14:39:07.882529+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T14:39:07.871693+00:00",
+     "status": "completed"
+    }
    },
    "outputs": [],
    "source": [
@@ -735,7 +930,14 @@
    "cell_type": "markdown",
    "id": "80960b57",
    "metadata": {
-    "lines_to_next_cell": 2
+    "lines_to_next_cell": 2,
+    "papermill": {
+     "duration": 0.005919,
+     "end_time": "2026-09-11T14:39:07.894099+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T14:39:07.888180+00:00",
+     "status": "completed"
+    }
    },
    "source": [
     "A single-symbol connectivity probe fails early before the full cross-section begins."
@@ -747,10 +949,17 @@
    "id": "3f1a3d73",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T01:27:44.701555Z",
-     "iopub.status.busy": "2026-09-09T01:27:44.701462Z",
-     "iopub.status.idle": "2026-09-09T01:27:45.144627Z",
-     "shell.execute_reply": "2026-09-09T01:27:45.144027Z"
+     "iopub.execute_input": "2026-09-11T14:39:07.910150Z",
+     "iopub.status.busy": "2026-09-11T14:39:07.909872Z",
+     "iopub.status.idle": "2026-09-11T14:39:08.353250Z",
+     "shell.execute_reply": "2026-09-11T14:39:08.351327Z"
+    },
+    "papermill": {
+     "duration": 0.456091,
+     "end_time": "2026-09-11T14:39:08.355130+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T14:39:07.899039+00:00",
+     "status": "completed"
     }
    },
    "outputs": [
@@ -766,14 +975,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2026-09-08 21:27:44,914 INFO HTTP Request: GET https://www.okx.com/api/v5/market/candles?instId=BTC-USDT-SWAP&bar=1H&limit=24 \"HTTP/2 200 OK\"\n"
+      "2026-09-11 10:39:08,128 INFO HTTP Request: GET https://www.okx.com/api/v5/market/candles?instId=BTC-USDT-SWAP&bar=1H&limit=24 \"HTTP/2 200 OK\"\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2026-09-08 21:27:45,140 INFO HTTP Request: GET https://www.okx.com/api/v5/public/funding-rate-history?instId=BTC-USDT-SWAP&limit=5 \"HTTP/2 200 OK\"\n"
+      "2026-09-11 10:39:08,342 INFO HTTP Request: GET https://www.okx.com/api/v5/public/funding-rate-history?instId=BTC-USDT-SWAP&limit=5 \"HTTP/2 200 OK\"\n"
      ]
     },
     {
@@ -781,8 +990,8 @@
      "output_type": "stream",
      "text": [
       "  1H candles: 23 bars; aggregated to 2 8H bars\n",
-      "  latest 8H close = $78,420.70 at 2026-09-08 16:00:00+00:00\n",
-      "  funding:    5 entries; latest funding = 0.0048%\n"
+      "  latest 8H close = $77,184.10 at 2026-09-11 00:00:00+00:00\n",
+      "  funding:    5 entries; latest funding = 0.0040%\n"
      ]
     }
    ],
@@ -805,7 +1014,15 @@
   {
    "cell_type": "markdown",
    "id": "05ab8b2b",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.011528,
+     "end_time": "2026-09-11T14:39:08.379006+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T14:39:08.367478+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "### 1b. Alpaca Paper Execution Plane\n",
     "\n",
@@ -821,10 +1038,17 @@
    "id": "9e1567d4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T01:27:45.157907Z",
-     "iopub.status.busy": "2026-09-09T01:27:45.157746Z",
-     "iopub.status.idle": "2026-09-09T01:27:45.161251Z",
-     "shell.execute_reply": "2026-09-09T01:27:45.160773Z"
+     "iopub.execute_input": "2026-09-11T14:39:08.399245Z",
+     "iopub.status.busy": "2026-09-11T14:39:08.398906Z",
+     "iopub.status.idle": "2026-09-11T14:39:08.403965Z",
+     "shell.execute_reply": "2026-09-11T14:39:08.403259Z"
+    },
+    "papermill": {
+     "duration": 0.014041,
+     "end_time": "2026-09-11T14:39:08.404651+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T14:39:08.390610+00:00",
+     "status": "completed"
     }
    },
    "outputs": [
@@ -869,7 +1093,15 @@
   {
    "cell_type": "markdown",
    "id": "e972ff24",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.006777,
+     "end_time": "2026-09-11T14:39:08.418762+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T14:39:08.411985+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "## 2. Build Training Panel\n",
     "\n",
@@ -886,12 +1118,19 @@
    "id": "2559e33e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T01:27:45.173499Z",
-     "iopub.status.busy": "2026-09-09T01:27:45.173410Z",
-     "iopub.status.idle": "2026-09-09T01:27:45.319589Z",
-     "shell.execute_reply": "2026-09-09T01:27:45.319190Z"
+     "iopub.execute_input": "2026-09-11T14:39:08.432829Z",
+     "iopub.status.busy": "2026-09-11T14:39:08.432577Z",
+     "iopub.status.idle": "2026-09-11T14:39:08.768268Z",
+     "shell.execute_reply": "2026-09-11T14:39:08.766558Z"
     },
-    "lines_to_next_cell": 2
+    "lines_to_next_cell": 2,
+    "papermill": {
+     "duration": 0.343895,
+     "end_time": "2026-09-11T14:39:08.769932+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T14:39:08.426037+00:00",
+     "status": "completed"
+    }
    },
    "outputs": [
     {
@@ -901,7 +1140,13 @@
       "\n",
       "======================================================================\n",
       "STEP 2: BUILD TRAINING PANEL\n",
-      "======================================================================\n",
+      "======================================================================\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "Loaded prices : (108317, 7)\n",
       "Loaded premium: (107839, 3)\n",
       "Joined panel  : (108317, 9)\n"
@@ -939,7 +1184,14 @@
    "cell_type": "markdown",
    "id": "b4ffc060",
    "metadata": {
-    "lines_to_next_cell": 2
+    "lines_to_next_cell": 2,
+    "papermill": {
+     "duration": 0.008772,
+     "end_time": "2026-09-11T14:39:08.788398+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T14:39:08.779626+00:00",
+     "status": "completed"
+    }
    },
    "source": [
     "### Feature Computation\n",
@@ -954,12 +1206,19 @@
    "id": "25eeb836",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T01:27:45.332619Z",
-     "iopub.status.busy": "2026-09-09T01:27:45.332460Z",
-     "iopub.status.idle": "2026-09-09T01:27:45.335365Z",
-     "shell.execute_reply": "2026-09-09T01:27:45.334903Z"
+     "iopub.execute_input": "2026-09-11T14:39:08.806389Z",
+     "iopub.status.busy": "2026-09-11T14:39:08.806088Z",
+     "iopub.status.idle": "2026-09-11T14:39:08.811964Z",
+     "shell.execute_reply": "2026-09-11T14:39:08.810699Z"
     },
-    "lines_to_next_cell": 2
+    "lines_to_next_cell": 2,
+    "papermill": {
+     "duration": 0.015432,
+     "end_time": "2026-09-11T14:39:08.813068+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T14:39:08.797636+00:00",
+     "status": "completed"
+    }
    },
    "outputs": [],
    "source": [
@@ -975,7 +1234,14 @@
    "cell_type": "markdown",
    "id": "0972cf52",
    "metadata": {
-    "lines_to_next_cell": 2
+    "lines_to_next_cell": 2,
+    "papermill": {
+     "duration": 0.009836,
+     "end_time": "2026-09-11T14:39:08.832246+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T14:39:08.822410+00:00",
+     "status": "completed"
+    }
    },
    "source": [
     "RSI uses average gain divided by total average movement, which keeps the result in the 0-100 range."
@@ -987,12 +1253,19 @@
    "id": "f80db0fd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T01:27:45.348248Z",
-     "iopub.status.busy": "2026-09-09T01:27:45.348031Z",
-     "iopub.status.idle": "2026-09-09T01:27:45.350806Z",
-     "shell.execute_reply": "2026-09-09T01:27:45.350316Z"
+     "iopub.execute_input": "2026-09-11T14:39:08.860589Z",
+     "iopub.status.busy": "2026-09-11T14:39:08.860149Z",
+     "iopub.status.idle": "2026-09-11T14:39:08.867321Z",
+     "shell.execute_reply": "2026-09-11T14:39:08.865912Z"
     },
-    "lines_to_next_cell": 2
+    "lines_to_next_cell": 2,
+    "papermill": {
+     "duration": 0.027386,
+     "end_time": "2026-09-11T14:39:08.869015+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T14:39:08.841629+00:00",
+     "status": "completed"
+    }
    },
    "outputs": [],
    "source": [
@@ -1008,7 +1281,14 @@
    "cell_type": "markdown",
    "id": "9c11a89b",
    "metadata": {
-    "lines_to_next_cell": 2
+    "lines_to_next_cell": 2,
+    "papermill": {
+     "duration": 0.007431,
+     "end_time": "2026-09-11T14:39:08.888833+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T14:39:08.881402+00:00",
+     "status": "completed"
+    }
    },
    "source": [
     "A three-bar VWAP makes the price-distance feature use the same 24-hour window as short volatility."
@@ -1020,12 +1300,19 @@
    "id": "5f4b4f98",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T01:27:45.363941Z",
-     "iopub.status.busy": "2026-09-09T01:27:45.363770Z",
-     "iopub.status.idle": "2026-09-09T01:27:45.366653Z",
-     "shell.execute_reply": "2026-09-09T01:27:45.366210Z"
+     "iopub.execute_input": "2026-09-11T14:39:08.909075Z",
+     "iopub.status.busy": "2026-09-11T14:39:08.908766Z",
+     "iopub.status.idle": "2026-09-11T14:39:08.918185Z",
+     "shell.execute_reply": "2026-09-11T14:39:08.915949Z"
     },
-    "lines_to_next_cell": 2
+    "lines_to_next_cell": 2,
+    "papermill": {
+     "duration": 0.025465,
+     "end_time": "2026-09-11T14:39:08.921353+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T14:39:08.895888+00:00",
+     "status": "completed"
+    }
    },
    "outputs": [],
    "source": [
@@ -1040,7 +1327,14 @@
    "cell_type": "markdown",
    "id": "ff515eff",
    "metadata": {
-    "lines_to_next_cell": 2
+    "lines_to_next_cell": 2,
+    "papermill": {
+     "duration": 0.007924,
+     "end_time": "2026-09-11T14:39:08.940901+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T14:39:08.932977+00:00",
+     "status": "completed"
+    }
    },
    "source": [
     "Feature construction applies each expression in dependency order: returns before volatility."
@@ -1052,10 +1346,17 @@
    "id": "2c7b6c40",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T01:27:45.379599Z",
-     "iopub.status.busy": "2026-09-09T01:27:45.379442Z",
-     "iopub.status.idle": "2026-09-09T01:27:45.383730Z",
-     "shell.execute_reply": "2026-09-09T01:27:45.383202Z"
+     "iopub.execute_input": "2026-09-11T14:39:08.962218Z",
+     "iopub.status.busy": "2026-09-11T14:39:08.961584Z",
+     "iopub.status.idle": "2026-09-11T14:39:08.968205Z",
+     "shell.execute_reply": "2026-09-11T14:39:08.966776Z"
+    },
+    "papermill": {
+     "duration": 0.018484,
+     "end_time": "2026-09-11T14:39:08.968863+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T14:39:08.950379+00:00",
+     "status": "completed"
     }
    },
    "outputs": [],
@@ -1098,10 +1399,17 @@
    "id": "60d6eb82",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T01:27:45.391807Z",
-     "iopub.status.busy": "2026-09-09T01:27:45.391619Z",
-     "iopub.status.idle": "2026-09-09T01:27:45.422756Z",
-     "shell.execute_reply": "2026-09-09T01:27:45.422195Z"
+     "iopub.execute_input": "2026-09-11T14:39:08.991305Z",
+     "iopub.status.busy": "2026-09-11T14:39:08.991102Z",
+     "iopub.status.idle": "2026-09-11T14:39:09.104324Z",
+     "shell.execute_reply": "2026-09-11T14:39:09.102921Z"
+    },
+    "papermill": {
+     "duration": 0.124066,
+     "end_time": "2026-09-11T14:39:09.105653+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T14:39:08.981587+00:00",
+     "status": "completed"
     }
    },
    "outputs": [
@@ -1136,7 +1444,15 @@
   {
    "cell_type": "markdown",
    "id": "918db16a",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.010322,
+     "end_time": "2026-09-11T14:39:09.126264+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T14:39:09.115942+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "## 3. Train and Persist\n",
     "\n",
@@ -1153,12 +1469,19 @@
    "id": "cadbc2a7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T01:27:45.437094Z",
-     "iopub.status.busy": "2026-09-09T01:27:45.436972Z",
-     "iopub.status.idle": "2026-09-09T01:27:45.458357Z",
-     "shell.execute_reply": "2026-09-09T01:27:45.457896Z"
+     "iopub.execute_input": "2026-09-11T14:39:09.147698Z",
+     "iopub.status.busy": "2026-09-11T14:39:09.147490Z",
+     "iopub.status.idle": "2026-09-11T14:39:09.211624Z",
+     "shell.execute_reply": "2026-09-11T14:39:09.209698Z"
     },
-    "lines_to_next_cell": 2
+    "lines_to_next_cell": 2,
+    "papermill": {
+     "duration": 0.07771,
+     "end_time": "2026-09-11T14:39:09.213312+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T14:39:09.135602+00:00",
+     "status": "completed"
+    }
    },
    "outputs": [
     {
@@ -1193,7 +1516,14 @@
    "cell_type": "markdown",
    "id": "67a45a93",
    "metadata": {
-    "lines_to_next_cell": 2
+    "lines_to_next_cell": 2,
+    "papermill": {
+     "duration": 0.010154,
+     "end_time": "2026-09-11T14:39:09.231887+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T14:39:09.221733+00:00",
+     "status": "completed"
+    }
    },
    "source": [
     "LightGBM trains on the CPU with fixed seeds, and the feature scaler is fit on the training rows\n",
@@ -1206,12 +1536,19 @@
    "id": "a9ca5589",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T01:27:45.471779Z",
-     "iopub.status.busy": "2026-09-09T01:27:45.471676Z",
-     "iopub.status.idle": "2026-09-09T01:27:46.723454Z",
-     "shell.execute_reply": "2026-09-09T01:27:46.722788Z"
+     "iopub.execute_input": "2026-09-11T14:39:09.252505Z",
+     "iopub.status.busy": "2026-09-11T14:39:09.251993Z",
+     "iopub.status.idle": "2026-09-11T14:39:12.257044Z",
+     "shell.execute_reply": "2026-09-11T14:39:12.256329Z"
     },
-    "lines_to_next_cell": 2
+    "lines_to_next_cell": 2,
+    "papermill": {
+     "duration": 3.015128,
+     "end_time": "2026-09-11T14:39:12.257490+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T14:39:09.242362+00:00",
+     "status": "completed"
+    }
    },
    "outputs": [
     {
@@ -1251,7 +1588,15 @@
   {
    "cell_type": "markdown",
    "id": "2c275a8b",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.006649,
+     "end_time": "2026-09-11T14:39:12.268269+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T14:39:12.261620+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "`deterministic` and `force_col_wise` fix LightGBM's histogram construction order, so the same\n",
     "inputs in the same pinned environment produce the same booster on a re-run. A different platform\n",
@@ -1263,7 +1608,14 @@
    "cell_type": "markdown",
    "id": "5f4a34be",
    "metadata": {
-    "lines_to_next_cell": 2
+    "lines_to_next_cell": 2,
+    "papermill": {
+     "duration": 0.005613,
+     "end_time": "2026-09-11T14:39:12.278907+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T14:39:12.273294+00:00",
+     "status": "completed"
+    }
    },
    "source": [
     "The model, scaler, and feature order form one deployment artifact contract."
@@ -1275,12 +1627,19 @@
    "id": "a3bbd8b2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T01:27:46.748054Z",
-     "iopub.status.busy": "2026-09-09T01:27:46.747927Z",
-     "iopub.status.idle": "2026-09-09T01:27:46.759641Z",
-     "shell.execute_reply": "2026-09-09T01:27:46.759116Z"
+     "iopub.execute_input": "2026-09-11T14:39:12.290176Z",
+     "iopub.status.busy": "2026-09-11T14:39:12.289974Z",
+     "iopub.status.idle": "2026-09-11T14:39:12.312346Z",
+     "shell.execute_reply": "2026-09-11T14:39:12.311149Z"
     },
-    "lines_to_next_cell": 2
+    "lines_to_next_cell": 2,
+    "papermill": {
+     "duration": 0.029906,
+     "end_time": "2026-09-11T14:39:12.313858+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T14:39:12.283952+00:00",
+     "status": "completed"
+    }
    },
    "outputs": [],
    "source": [
@@ -1300,7 +1659,14 @@
    "cell_type": "markdown",
    "id": "53eb6511",
    "metadata": {
-    "lines_to_next_cell": 2
+    "lines_to_next_cell": 2,
+    "papermill": {
+     "duration": 0.010706,
+     "end_time": "2026-09-11T14:39:12.333505+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T14:39:12.322799+00:00",
+     "status": "completed"
+    }
    },
    "source": [
     "Metadata records the exact temporal boundary, device, seed, and research-to-live data-source change."
@@ -1312,10 +1678,17 @@
    "id": "4f91c882",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T01:27:46.785877Z",
-     "iopub.status.busy": "2026-09-09T01:27:46.785751Z",
-     "iopub.status.idle": "2026-09-09T01:27:46.789175Z",
-     "shell.execute_reply": "2026-09-09T01:27:46.788605Z"
+     "iopub.execute_input": "2026-09-11T14:39:12.354628Z",
+     "iopub.status.busy": "2026-09-11T14:39:12.354272Z",
+     "iopub.status.idle": "2026-09-11T14:39:12.361256Z",
+     "shell.execute_reply": "2026-09-11T14:39:12.360382Z"
+    },
+    "papermill": {
+     "duration": 0.019308,
+     "end_time": "2026-09-11T14:39:12.361874+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T14:39:12.342566+00:00",
+     "status": "completed"
     }
    },
    "outputs": [
@@ -1355,7 +1728,15 @@
   {
    "cell_type": "markdown",
    "id": "ffd5a26a",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.009472,
+     "end_time": "2026-09-11T14:39:12.380709+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T14:39:12.371237+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "The deployment artefact is a *separate fit* from the case\n",
     "study's research artefact. Same data, same labels, but a different feature\n",
@@ -1370,7 +1751,15 @@
   {
    "cell_type": "markdown",
    "id": "8e4fbf67",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.008404,
+     "end_time": "2026-09-11T14:39:12.400055+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T14:39:12.391651+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "## 4. Live Cross-Section from OKX\n",
     "\n",
@@ -1387,12 +1776,19 @@
    "id": "eff547a0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T01:27:46.815403Z",
-     "iopub.status.busy": "2026-09-09T01:27:46.815280Z",
-     "iopub.status.idle": "2026-09-09T01:27:54.225212Z",
-     "shell.execute_reply": "2026-09-09T01:27:54.224719Z"
+     "iopub.execute_input": "2026-09-11T14:39:12.417261Z",
+     "iopub.status.busy": "2026-09-11T14:39:12.416912Z",
+     "iopub.status.idle": "2026-09-11T14:39:19.485505Z",
+     "shell.execute_reply": "2026-09-11T14:39:19.484749Z"
     },
-    "lines_to_next_cell": 2
+    "lines_to_next_cell": 2,
+    "papermill": {
+     "duration": 7.077185,
+     "end_time": "2026-09-11T14:39:19.486258+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T14:39:12.409073+00:00",
+     "status": "completed"
+    }
    },
    "outputs": [
     {
@@ -1409,266 +1805,266 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2026-09-08 21:27:47,025 INFO HTTP Request: GET https://www.okx.com/api/v5/market/candles?instId=AAVE-USDT-SWAP&bar=1H&limit=250 \"HTTP/2 200 OK\"\n"
+      "2026-09-11 10:39:12,610 INFO HTTP Request: GET https://www.okx.com/api/v5/market/candles?instId=AAVE-USDT-SWAP&bar=1H&limit=250 \"HTTP/2 200 OK\"\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2026-09-08 21:27:47,222 INFO HTTP Request: GET https://www.okx.com/api/v5/public/funding-rate-history?instId=AAVE-USDT-SWAP&limit=50 \"HTTP/2 200 OK\"\n"
+      "2026-09-11 10:39:12,797 INFO HTTP Request: GET https://www.okx.com/api/v5/public/funding-rate-history?instId=AAVE-USDT-SWAP&limit=50 \"HTTP/2 200 OK\"\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2026-09-08 21:27:47,405 INFO HTTP Request: GET https://www.okx.com/api/v5/market/candles?instId=ADA-USDT-SWAP&bar=1H&limit=250 \"HTTP/2 200 OK\"\n"
+      "2026-09-11 10:39:12,985 INFO HTTP Request: GET https://www.okx.com/api/v5/market/candles?instId=ADA-USDT-SWAP&bar=1H&limit=250 \"HTTP/2 200 OK\"\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2026-09-08 21:27:47,626 INFO HTTP Request: GET https://www.okx.com/api/v5/public/funding-rate-history?instId=ADA-USDT-SWAP&limit=50 \"HTTP/2 200 OK\"\n"
+      "2026-09-11 10:39:13,178 INFO HTTP Request: GET https://www.okx.com/api/v5/public/funding-rate-history?instId=ADA-USDT-SWAP&limit=50 \"HTTP/2 200 OK\"\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2026-09-08 21:27:47,819 INFO HTTP Request: GET https://www.okx.com/api/v5/market/candles?instId=APT-USDT-SWAP&bar=1H&limit=250 \"HTTP/2 200 OK\"\n"
+      "2026-09-11 10:39:13,356 INFO HTTP Request: GET https://www.okx.com/api/v5/market/candles?instId=APT-USDT-SWAP&bar=1H&limit=250 \"HTTP/2 200 OK\"\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2026-09-08 21:27:48,004 INFO HTTP Request: GET https://www.okx.com/api/v5/public/funding-rate-history?instId=APT-USDT-SWAP&limit=50 \"HTTP/2 200 OK\"\n"
+      "2026-09-11 10:39:13,550 INFO HTTP Request: GET https://www.okx.com/api/v5/public/funding-rate-history?instId=APT-USDT-SWAP&limit=50 \"HTTP/2 200 OK\"\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2026-09-08 21:27:48,216 INFO HTTP Request: GET https://www.okx.com/api/v5/market/candles?instId=ATOM-USDT-SWAP&bar=1H&limit=250 \"HTTP/2 200 OK\"\n"
+      "2026-09-11 10:39:13,749 INFO HTTP Request: GET https://www.okx.com/api/v5/market/candles?instId=ATOM-USDT-SWAP&bar=1H&limit=250 \"HTTP/2 200 OK\"\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2026-09-08 21:27:48,420 INFO HTTP Request: GET https://www.okx.com/api/v5/public/funding-rate-history?instId=ATOM-USDT-SWAP&limit=50 \"HTTP/2 200 OK\"\n"
+      "2026-09-11 10:39:13,935 INFO HTTP Request: GET https://www.okx.com/api/v5/public/funding-rate-history?instId=ATOM-USDT-SWAP&limit=50 \"HTTP/2 200 OK\"\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2026-09-08 21:27:48,625 INFO HTTP Request: GET https://www.okx.com/api/v5/market/candles?instId=AVAX-USDT-SWAP&bar=1H&limit=250 \"HTTP/2 200 OK\"\n"
+      "2026-09-11 10:39:14,143 INFO HTTP Request: GET https://www.okx.com/api/v5/market/candles?instId=AVAX-USDT-SWAP&bar=1H&limit=250 \"HTTP/2 200 OK\"\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2026-09-08 21:27:48,821 INFO HTTP Request: GET https://www.okx.com/api/v5/public/funding-rate-history?instId=AVAX-USDT-SWAP&limit=50 \"HTTP/2 200 OK\"\n"
+      "2026-09-11 10:39:14,341 INFO HTTP Request: GET https://www.okx.com/api/v5/public/funding-rate-history?instId=AVAX-USDT-SWAP&limit=50 \"HTTP/2 200 OK\"\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2026-09-08 21:27:49,027 INFO HTTP Request: GET https://www.okx.com/api/v5/market/candles?instId=BNB-USDT-SWAP&bar=1H&limit=250 \"HTTP/2 200 OK\"\n"
+      "2026-09-11 10:39:14,535 INFO HTTP Request: GET https://www.okx.com/api/v5/market/candles?instId=BNB-USDT-SWAP&bar=1H&limit=250 \"HTTP/2 200 OK\"\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2026-09-08 21:27:49,207 INFO HTTP Request: GET https://www.okx.com/api/v5/public/funding-rate-history?instId=BNB-USDT-SWAP&limit=50 \"HTTP/2 200 OK\"\n"
+      "2026-09-11 10:39:14,737 INFO HTTP Request: GET https://www.okx.com/api/v5/public/funding-rate-history?instId=BNB-USDT-SWAP&limit=50 \"HTTP/2 200 OK\"\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2026-09-08 21:27:49,405 INFO HTTP Request: GET https://www.okx.com/api/v5/market/candles?instId=BTC-USDT-SWAP&bar=1H&limit=250 \"HTTP/2 200 OK\"\n"
+      "2026-09-11 10:39:14,923 INFO HTTP Request: GET https://www.okx.com/api/v5/market/candles?instId=BTC-USDT-SWAP&bar=1H&limit=250 \"HTTP/2 200 OK\"\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2026-09-08 21:27:49,589 INFO HTTP Request: GET https://www.okx.com/api/v5/public/funding-rate-history?instId=BTC-USDT-SWAP&limit=50 \"HTTP/2 200 OK\"\n"
+      "2026-09-11 10:39:15,108 INFO HTTP Request: GET https://www.okx.com/api/v5/public/funding-rate-history?instId=BTC-USDT-SWAP&limit=50 \"HTTP/2 200 OK\"\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2026-09-08 21:27:49,768 INFO HTTP Request: GET https://www.okx.com/api/v5/market/candles?instId=COMP-USDT-SWAP&bar=1H&limit=250 \"HTTP/2 200 OK\"\n"
+      "2026-09-11 10:39:15,293 INFO HTTP Request: GET https://www.okx.com/api/v5/market/candles?instId=COMP-USDT-SWAP&bar=1H&limit=250 \"HTTP/2 200 OK\"\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2026-09-08 21:27:49,963 INFO HTTP Request: GET https://www.okx.com/api/v5/public/funding-rate-history?instId=COMP-USDT-SWAP&limit=50 \"HTTP/2 200 OK\"\n"
+      "2026-09-11 10:39:15,480 INFO HTTP Request: GET https://www.okx.com/api/v5/public/funding-rate-history?instId=COMP-USDT-SWAP&limit=50 \"HTTP/2 200 OK\"\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2026-09-08 21:27:50,164 INFO HTTP Request: GET https://www.okx.com/api/v5/market/candles?instId=DOGE-USDT-SWAP&bar=1H&limit=250 \"HTTP/2 200 OK\"\n"
+      "2026-09-11 10:39:15,670 INFO HTTP Request: GET https://www.okx.com/api/v5/market/candles?instId=DOGE-USDT-SWAP&bar=1H&limit=250 \"HTTP/2 200 OK\"\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2026-09-08 21:27:50,376 INFO HTTP Request: GET https://www.okx.com/api/v5/public/funding-rate-history?instId=DOGE-USDT-SWAP&limit=50 \"HTTP/2 200 OK\"\n"
+      "2026-09-11 10:39:15,868 INFO HTTP Request: GET https://www.okx.com/api/v5/public/funding-rate-history?instId=DOGE-USDT-SWAP&limit=50 \"HTTP/2 200 OK\"\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2026-09-08 21:27:50,580 INFO HTTP Request: GET https://www.okx.com/api/v5/market/candles?instId=DOT-USDT-SWAP&bar=1H&limit=250 \"HTTP/2 200 OK\"\n"
+      "2026-09-11 10:39:16,066 INFO HTTP Request: GET https://www.okx.com/api/v5/market/candles?instId=DOT-USDT-SWAP&bar=1H&limit=250 \"HTTP/2 200 OK\"\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2026-09-08 21:27:50,772 INFO HTTP Request: GET https://www.okx.com/api/v5/public/funding-rate-history?instId=DOT-USDT-SWAP&limit=50 \"HTTP/2 200 OK\"\n"
+      "2026-09-11 10:39:16,269 INFO HTTP Request: GET https://www.okx.com/api/v5/public/funding-rate-history?instId=DOT-USDT-SWAP&limit=50 \"HTTP/2 200 OK\"\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2026-09-08 21:27:50,966 INFO HTTP Request: GET https://www.okx.com/api/v5/market/candles?instId=ETH-USDT-SWAP&bar=1H&limit=250 \"HTTP/2 200 OK\"\n"
+      "2026-09-11 10:39:16,458 INFO HTTP Request: GET https://www.okx.com/api/v5/market/candles?instId=ETH-USDT-SWAP&bar=1H&limit=250 \"HTTP/2 200 OK\"\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2026-09-08 21:27:51,187 INFO HTTP Request: GET https://www.okx.com/api/v5/public/funding-rate-history?instId=ETH-USDT-SWAP&limit=50 \"HTTP/2 200 OK\"\n"
+      "2026-09-11 10:39:16,641 INFO HTTP Request: GET https://www.okx.com/api/v5/public/funding-rate-history?instId=ETH-USDT-SWAP&limit=50 \"HTTP/2 200 OK\"\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2026-09-08 21:27:51,389 INFO HTTP Request: GET https://www.okx.com/api/v5/market/candles?instId=INJ-USDT-SWAP&bar=1H&limit=250 \"HTTP/2 200 OK\"\n"
+      "2026-09-11 10:39:16,830 INFO HTTP Request: GET https://www.okx.com/api/v5/market/candles?instId=INJ-USDT-SWAP&bar=1H&limit=250 \"HTTP/2 200 OK\"\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2026-09-08 21:27:51,564 INFO HTTP Request: GET https://www.okx.com/api/v5/public/funding-rate-history?instId=INJ-USDT-SWAP&limit=50 \"HTTP/2 200 OK\"\n"
+      "2026-09-11 10:39:17,009 INFO HTTP Request: GET https://www.okx.com/api/v5/public/funding-rate-history?instId=INJ-USDT-SWAP&limit=50 \"HTTP/2 200 OK\"\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2026-09-08 21:27:51,771 INFO HTTP Request: GET https://www.okx.com/api/v5/market/candles?instId=LINK-USDT-SWAP&bar=1H&limit=250 \"HTTP/2 200 OK\"\n"
+      "2026-09-11 10:39:17,203 INFO HTTP Request: GET https://www.okx.com/api/v5/market/candles?instId=LINK-USDT-SWAP&bar=1H&limit=250 \"HTTP/2 200 OK\"\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2026-09-08 21:27:51,947 INFO HTTP Request: GET https://www.okx.com/api/v5/public/funding-rate-history?instId=LINK-USDT-SWAP&limit=50 \"HTTP/2 200 OK\"\n"
+      "2026-09-11 10:39:17,399 INFO HTTP Request: GET https://www.okx.com/api/v5/public/funding-rate-history?instId=LINK-USDT-SWAP&limit=50 \"HTTP/2 200 OK\"\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2026-09-08 21:27:52,128 INFO HTTP Request: GET https://www.okx.com/api/v5/market/candles?instId=MKR-USDT-SWAP&bar=1H&limit=250 \"HTTP/2 200 OK\"\n"
+      "2026-09-11 10:39:17,590 INFO HTTP Request: GET https://www.okx.com/api/v5/market/candles?instId=MKR-USDT-SWAP&bar=1H&limit=250 \"HTTP/2 200 OK\"\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2026-09-08 21:27:52,129 INFO OKX venue coverage skip for MKRUSDT: OKX candles error for MKR-USDT-SWAP: {'code': '51001', 'data': [], 'msg': \"Instrument ID, Instrument ID code, or Spread ID doesn't exist.\"}\n"
+      "2026-09-11 10:39:17,591 INFO OKX venue coverage skip for MKRUSDT: OKX candles error for MKR-USDT-SWAP: {'code': '51001', 'data': [], 'msg': \"Instrument ID, Instrument ID code, or Spread ID doesn't exist.\"}\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2026-09-08 21:27:52,417 INFO HTTP Request: GET https://www.okx.com/api/v5/market/candles?instId=NEAR-USDT-SWAP&bar=1H&limit=250 \"HTTP/2 200 OK\"\n"
+      "2026-09-11 10:39:17,773 INFO HTTP Request: GET https://www.okx.com/api/v5/market/candles?instId=NEAR-USDT-SWAP&bar=1H&limit=250 \"HTTP/2 200 OK\"\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2026-09-08 21:27:52,611 INFO HTTP Request: GET https://www.okx.com/api/v5/public/funding-rate-history?instId=NEAR-USDT-SWAP&limit=50 \"HTTP/2 200 OK\"\n"
+      "2026-09-11 10:39:17,953 INFO HTTP Request: GET https://www.okx.com/api/v5/public/funding-rate-history?instId=NEAR-USDT-SWAP&limit=50 \"HTTP/2 200 OK\"\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2026-09-08 21:27:52,815 INFO HTTP Request: GET https://www.okx.com/api/v5/market/candles?instId=SOL-USDT-SWAP&bar=1H&limit=250 \"HTTP/2 200 OK\"\n"
+      "2026-09-11 10:39:18,141 INFO HTTP Request: GET https://www.okx.com/api/v5/market/candles?instId=SOL-USDT-SWAP&bar=1H&limit=250 \"HTTP/2 200 OK\"\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2026-09-08 21:27:53,025 INFO HTTP Request: GET https://www.okx.com/api/v5/public/funding-rate-history?instId=SOL-USDT-SWAP&limit=50 \"HTTP/2 200 OK\"\n"
+      "2026-09-11 10:39:18,348 INFO HTTP Request: GET https://www.okx.com/api/v5/public/funding-rate-history?instId=SOL-USDT-SWAP&limit=50 \"HTTP/2 200 OK\"\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2026-09-08 21:27:53,219 INFO HTTP Request: GET https://www.okx.com/api/v5/market/candles?instId=SUI-USDT-SWAP&bar=1H&limit=250 \"HTTP/2 200 OK\"\n"
+      "2026-09-11 10:39:18,544 INFO HTTP Request: GET https://www.okx.com/api/v5/market/candles?instId=SUI-USDT-SWAP&bar=1H&limit=250 \"HTTP/2 200 OK\"\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2026-09-08 21:27:53,407 INFO HTTP Request: GET https://www.okx.com/api/v5/public/funding-rate-history?instId=SUI-USDT-SWAP&limit=50 \"HTTP/2 200 OK\"\n"
+      "2026-09-11 10:39:18,730 INFO HTTP Request: GET https://www.okx.com/api/v5/public/funding-rate-history?instId=SUI-USDT-SWAP&limit=50 \"HTTP/2 200 OK\"\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2026-09-08 21:27:53,594 INFO HTTP Request: GET https://www.okx.com/api/v5/market/candles?instId=UNI-USDT-SWAP&bar=1H&limit=250 \"HTTP/2 200 OK\"\n"
+      "2026-09-11 10:39:18,916 INFO HTTP Request: GET https://www.okx.com/api/v5/market/candles?instId=UNI-USDT-SWAP&bar=1H&limit=250 \"HTTP/2 200 OK\"\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2026-09-08 21:27:53,848 INFO HTTP Request: GET https://www.okx.com/api/v5/public/funding-rate-history?instId=UNI-USDT-SWAP&limit=50 \"HTTP/2 200 OK\"\n"
+      "2026-09-11 10:39:19,108 INFO HTTP Request: GET https://www.okx.com/api/v5/public/funding-rate-history?instId=UNI-USDT-SWAP&limit=50 \"HTTP/2 200 OK\"\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2026-09-08 21:27:54,041 INFO HTTP Request: GET https://www.okx.com/api/v5/market/candles?instId=XRP-USDT-SWAP&bar=1H&limit=250 \"HTTP/2 200 OK\"\n"
+      "2026-09-11 10:39:19,297 INFO HTTP Request: GET https://www.okx.com/api/v5/market/candles?instId=XRP-USDT-SWAP&bar=1H&limit=250 \"HTTP/2 200 OK\"\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2026-09-08 21:27:54,221 INFO HTTP Request: GET https://www.okx.com/api/v5/public/funding-rate-history?instId=XRP-USDT-SWAP&limit=50 \"HTTP/2 200 OK\"\n"
+      "2026-09-11 10:39:19,479 INFO HTTP Request: GET https://www.okx.com/api/v5/public/funding-rate-history?instId=XRP-USDT-SWAP&limit=50 \"HTTP/2 200 OK\"\n"
      ]
     },
     {
@@ -1728,7 +2124,14 @@
    "cell_type": "markdown",
    "id": "b76ae071",
    "metadata": {
-    "lines_to_next_cell": 2
+    "lines_to_next_cell": 2,
+    "papermill": {
+     "duration": 0.004014,
+     "end_time": "2026-09-11T14:39:19.494908+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T14:39:19.490894+00:00",
+     "status": "completed"
+    }
    },
    "source": [
     "Raw, confirmed, parsed, and aggregated counts must reconcile before the live panel is accepted."
@@ -1740,10 +2143,17 @@
    "id": "d02d7f87",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T01:27:54.255336Z",
-     "iopub.status.busy": "2026-09-09T01:27:54.255184Z",
-     "iopub.status.idle": "2026-09-09T01:27:54.260085Z",
-     "shell.execute_reply": "2026-09-09T01:27:54.259612Z"
+     "iopub.execute_input": "2026-09-11T14:39:19.505405Z",
+     "iopub.status.busy": "2026-09-11T14:39:19.505143Z",
+     "iopub.status.idle": "2026-09-11T14:39:19.511060Z",
+     "shell.execute_reply": "2026-09-11T14:39:19.510530Z"
+    },
+    "papermill": {
+     "duration": 0.012141,
+     "end_time": "2026-09-11T14:39:19.511488+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T14:39:19.499347+00:00",
+     "status": "completed"
     }
    },
    "outputs": [
@@ -1757,17 +2167,17 @@
       "│ ---            ┆ ---                             ┆ ---      ┆ ---            ┆ ---             │\n",
       "│ str            ┆ str                             ┆ i64      ┆ i64            ┆ i64             │\n",
       "╞════════════════╪═════════════════════════════════╪══════════╪════════════════╪═════════════════╡\n",
-      "│ AAVE-USDT-SWAP ┆ 7785213eb5e1649530bef53c88d6de… ┆ 250      ┆ 249            ┆ 31              │\n",
-      "│ ADA-USDT-SWAP  ┆ 6adcbeba8687f7b00d007031ddd669… ┆ 250      ┆ 249            ┆ 31              │\n",
-      "│ APT-USDT-SWAP  ┆ b81f8d6fa76ddb90a0c733bd3b470e… ┆ 250      ┆ 249            ┆ 31              │\n",
-      "│ ATOM-USDT-SWAP ┆ 58a496158dfc0f7b988373081bac4e… ┆ 250      ┆ 249            ┆ 31              │\n",
-      "│ AVAX-USDT-SWAP ┆ 604d45cc94a8f03fead1c9cf41797d… ┆ 250      ┆ 249            ┆ 31              │\n",
+      "│ AAVE-USDT-SWAP ┆ d832345e7eafc0741e834935746eac… ┆ 250      ┆ 249            ┆ 30              │\n",
+      "│ ADA-USDT-SWAP  ┆ 77f649b1fc7fc48466d7a542d1bd0f… ┆ 250      ┆ 249            ┆ 30              │\n",
+      "│ APT-USDT-SWAP  ┆ 2e993aa358c1d6db1b43f029833ccc… ┆ 250      ┆ 249            ┆ 30              │\n",
+      "│ ATOM-USDT-SWAP ┆ 6d27eb5935b277f85a9e53cfbe62f7… ┆ 250      ┆ 249            ┆ 30              │\n",
+      "│ AVAX-USDT-SWAP ┆ 4f9b6e6262c91bf2a794ab93278a11… ┆ 250      ┆ 249            ┆ 30              │\n",
       "│ …              ┆ …                               ┆ …        ┆ …              ┆ …               │\n",
-      "│ NEAR-USDT-SWAP ┆ 6619552ca76f0afa9aafa996e3d75d… ┆ 250      ┆ 249            ┆ 31              │\n",
-      "│ SOL-USDT-SWAP  ┆ e6d83348785772c6574d6b744c388e… ┆ 250      ┆ 249            ┆ 31              │\n",
-      "│ SUI-USDT-SWAP  ┆ f57705aa5a64b62293decafffcca6a… ┆ 250      ┆ 249            ┆ 31              │\n",
-      "│ UNI-USDT-SWAP  ┆ c9e51d9d98a647c23b56cf4164f9fb… ┆ 250      ┆ 249            ┆ 31              │\n",
-      "│ XRP-USDT-SWAP  ┆ b4f4341d5479c3f0f436ff7563db8d… ┆ 250      ┆ 249            ┆ 31              │\n",
+      "│ NEAR-USDT-SWAP ┆ 0be700051f62de530f1363a4164e64… ┆ 250      ┆ 249            ┆ 30              │\n",
+      "│ SOL-USDT-SWAP  ┆ c4c4266034a26b9fb30bbd3453c001… ┆ 250      ┆ 249            ┆ 30              │\n",
+      "│ SUI-USDT-SWAP  ┆ fa41637acbc656200681448c0e3196… ┆ 250      ┆ 249            ┆ 30              │\n",
+      "│ UNI-USDT-SWAP  ┆ ef28fecfa6d8f6786ba7659db6049c… ┆ 250      ┆ 249            ┆ 30              │\n",
+      "│ XRP-USDT-SWAP  ┆ dc344e72f0488fb4acbdf673f3970a… ┆ 250      ┆ 249            ┆ 30              │\n",
       "└────────────────┴─────────────────────────────────┴──────────┴────────────────┴─────────────────┘\n"
      ]
     }
@@ -1807,7 +2217,15 @@
   {
    "cell_type": "markdown",
    "id": "0824f9ff",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.007831,
+     "end_time": "2026-09-11T14:39:19.528661+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T14:39:19.520830+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "Funding payloads must likewise conserve every raw row and contain unique publication timestamps."
    ]
@@ -1818,12 +2236,19 @@
    "id": "4981f2aa",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T01:27:54.281590Z",
-     "iopub.status.busy": "2026-09-09T01:27:54.281481Z",
-     "iopub.status.idle": "2026-09-09T01:27:54.286173Z",
-     "shell.execute_reply": "2026-09-09T01:27:54.285652Z"
+     "iopub.execute_input": "2026-09-11T14:39:19.681982Z",
+     "iopub.status.busy": "2026-09-11T14:39:19.681734Z",
+     "iopub.status.idle": "2026-09-11T14:39:19.693861Z",
+     "shell.execute_reply": "2026-09-11T14:39:19.692522Z"
     },
-    "lines_to_next_cell": 2
+    "lines_to_next_cell": 2,
+    "papermill": {
+     "duration": 0.031445,
+     "end_time": "2026-09-11T14:39:19.695031+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T14:39:19.663586+00:00",
+     "status": "completed"
+    }
    },
    "outputs": [
     {
@@ -1836,17 +2261,17 @@
       "│ ---            ┆ ---                             ┆ ---      ┆ ---         │\n",
       "│ str            ┆ str                             ┆ i64      ┆ i64         │\n",
       "╞════════════════╪═════════════════════════════════╪══════════╪═════════════╡\n",
-      "│ AAVE-USDT-SWAP ┆ 225675260815a5bdbff111527c4eb4… ┆ 50       ┆ 50          │\n",
-      "│ ADA-USDT-SWAP  ┆ 53ef6e1b955f66918d25b52306d6cc… ┆ 50       ┆ 50          │\n",
-      "│ APT-USDT-SWAP  ┆ 7cd431bf9d46afacbb6219c68bcc97… ┆ 50       ┆ 50          │\n",
-      "│ ATOM-USDT-SWAP ┆ 499cabfc87329746a998fd5a4188c8… ┆ 50       ┆ 50          │\n",
-      "│ AVAX-USDT-SWAP ┆ d0cbcd8fd18fdddfa40e689a13c966… ┆ 50       ┆ 50          │\n",
+      "│ AAVE-USDT-SWAP ┆ 3cd0481bec472b27744753d85685d2… ┆ 50       ┆ 50          │\n",
+      "│ ADA-USDT-SWAP  ┆ 2ef561e6b4bb6d46eb6a1acae925bb… ┆ 50       ┆ 50          │\n",
+      "│ APT-USDT-SWAP  ┆ cef9bca3b789ff4fd3bef48246a5fc… ┆ 50       ┆ 50          │\n",
+      "│ ATOM-USDT-SWAP ┆ bdab5e7dd676919e5eb0a2974daa7b… ┆ 50       ┆ 50          │\n",
+      "│ AVAX-USDT-SWAP ┆ 517aa3601123db267c9e39813c37ab… ┆ 50       ┆ 50          │\n",
       "│ …              ┆ …                               ┆ …        ┆ …           │\n",
-      "│ NEAR-USDT-SWAP ┆ 4393b9f420b5a04fecf70170b26d95… ┆ 50       ┆ 50          │\n",
-      "│ SOL-USDT-SWAP  ┆ 791f7d97a3d27e9d3963aacef2f390… ┆ 50       ┆ 50          │\n",
-      "│ SUI-USDT-SWAP  ┆ 4af38d56670a5f51d21c76858b3bb1… ┆ 50       ┆ 50          │\n",
-      "│ UNI-USDT-SWAP  ┆ 31dbd3f890565623636ae218e3bb08… ┆ 50       ┆ 50          │\n",
-      "│ XRP-USDT-SWAP  ┆ 74ad14cf242ee682902189fd393d7b… ┆ 50       ┆ 50          │\n",
+      "│ NEAR-USDT-SWAP ┆ cd499f4af0a52cea27fc9c44667e2b… ┆ 50       ┆ 50          │\n",
+      "│ SOL-USDT-SWAP  ┆ 40c46bc040ae88d0e0258b36d72b7d… ┆ 50       ┆ 50          │\n",
+      "│ SUI-USDT-SWAP  ┆ d582b59d46f232453a477e312a321d… ┆ 50       ┆ 50          │\n",
+      "│ UNI-USDT-SWAP  ┆ 01c7c10e4873215b1652e29bca08fe… ┆ 50       ┆ 50          │\n",
+      "│ XRP-USDT-SWAP  ┆ a6ad4528b52b0edb86196030ea3418… ┆ 50       ┆ 50          │\n",
       "└────────────────┴─────────────────────────────────┴──────────┴─────────────┘\n"
      ]
     }
@@ -1878,12 +2303,19 @@
    "id": "7f756f5e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T01:27:54.320609Z",
-     "iopub.status.busy": "2026-09-09T01:27:54.320490Z",
-     "iopub.status.idle": "2026-09-09T01:27:54.322751Z",
-     "shell.execute_reply": "2026-09-09T01:27:54.322253Z"
+     "iopub.execute_input": "2026-09-11T14:39:19.718968Z",
+     "iopub.status.busy": "2026-09-11T14:39:19.718647Z",
+     "iopub.status.idle": "2026-09-11T14:39:19.722937Z",
+     "shell.execute_reply": "2026-09-11T14:39:19.722049Z"
     },
-    "lines_to_next_cell": 2
+    "lines_to_next_cell": 2,
+    "papermill": {
+     "duration": 0.017582,
+     "end_time": "2026-09-11T14:39:19.723685+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T14:39:19.706103+00:00",
+     "status": "completed"
+    }
    },
    "outputs": [],
    "source": [
@@ -1898,7 +2330,14 @@
    "cell_type": "markdown",
    "id": "b8a435f9",
    "metadata": {
-    "lines_to_next_cell": 2
+    "lines_to_next_cell": 2,
+    "papermill": {
+     "duration": 0.004518,
+     "end_time": "2026-09-11T14:39:19.737100+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T14:39:19.732582+00:00",
+     "status": "completed"
+    }
    },
    "source": [
     "Concatenation preserves the symbol-level fetch boundary and reports coverage before feature computation."
@@ -1910,19 +2349,26 @@
    "id": "7c7e042f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T01:27:54.340338Z",
-     "iopub.status.busy": "2026-09-09T01:27:54.340221Z",
-     "iopub.status.idle": "2026-09-09T01:27:54.343609Z",
-     "shell.execute_reply": "2026-09-09T01:27:54.343181Z"
+     "iopub.execute_input": "2026-09-11T14:39:19.748942Z",
+     "iopub.status.busy": "2026-09-11T14:39:19.748763Z",
+     "iopub.status.idle": "2026-09-11T14:39:19.758460Z",
+     "shell.execute_reply": "2026-09-11T14:39:19.757440Z"
     },
-    "lines_to_next_cell": 2
+    "lines_to_next_cell": 2,
+    "papermill": {
+     "duration": 0.016957,
+     "end_time": "2026-09-11T14:39:19.759270+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T14:39:19.742313+00:00",
+     "status": "completed"
+    }
    },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Live bars: (558, 7) across 18 perps\n",
+      "Live bars: (540, 7) across 18 perps\n",
       "Live funding: (900, 3) across 18 perps\n"
      ]
     }
@@ -1941,7 +2387,14 @@
    "cell_type": "markdown",
    "id": "6e41f122",
    "metadata": {
-    "lines_to_next_cell": 2
+    "lines_to_next_cell": 2,
+    "papermill": {
+     "duration": 0.008377,
+     "end_time": "2026-09-11T14:39:19.776665+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T14:39:19.768288+00:00",
+     "status": "completed"
+    }
    },
    "source": [
     "Funding settles every eight hours and bars arrive far more often, so the two have to be aligned\n",
@@ -1957,12 +2410,19 @@
    "id": "098d5cad",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T01:27:54.362448Z",
-     "iopub.status.busy": "2026-09-09T01:27:54.362289Z",
-     "iopub.status.idle": "2026-09-09T01:27:54.374552Z",
-     "shell.execute_reply": "2026-09-09T01:27:54.373893Z"
+     "iopub.execute_input": "2026-09-11T14:39:19.796774Z",
+     "iopub.status.busy": "2026-09-11T14:39:19.796511Z",
+     "iopub.status.idle": "2026-09-11T14:39:19.824665Z",
+     "shell.execute_reply": "2026-09-11T14:39:19.823574Z"
     },
-    "lines_to_next_cell": 2
+    "lines_to_next_cell": 2,
+    "papermill": {
+     "duration": 0.039736,
+     "end_time": "2026-09-11T14:39:19.825879+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T14:39:19.786143+00:00",
+     "status": "completed"
+    }
    },
    "outputs": [],
    "source": [
@@ -1976,14 +2436,14 @@
     "                [\n",
     "                    pl.lit(None, dtype=pl.Float64).alias(\"funding_rate\"),\n",
     "                    pl.lit(None, dtype=pl.Float64).alias(\"premium\"),\n",
+    "                    pl.lit(None, dtype=pl.Datetime(\"ms\", \"UTC\")).alias(\"funding_asof\"),\n",
     "                ]\n",
     "            )\n",
     "        else:\n",
-    "            joined = sym_bars.join_asof(\n",
-    "                sym_fund.select([\"timestamp\", \"funding_rate\"]),\n",
-    "                on=\"timestamp\",\n",
-    "                strategy=\"backward\",\n",
+    "            sym_fund_asof = sym_fund.select([\"timestamp\", \"funding_rate\"]).with_columns(\n",
+    "                pl.col(\"timestamp\").alias(\"funding_asof\")\n",
     "            )\n",
+    "            joined = sym_bars.join_asof(sym_fund_asof, on=\"timestamp\", strategy=\"backward\")\n",
     "            sym_bars = joined.with_columns((pl.col(\"funding_rate\") * 3.0).alias(\"premium\"))\n",
     "        parts.append(sym_bars)\n",
     "    live_panel = pl.concat(parts).sort([\"symbol\", \"timestamp\"])\n",
@@ -1992,6 +2452,7 @@
     "        [\n",
     "            pl.lit(None, dtype=pl.Float64).alias(\"funding_rate\"),\n",
     "            pl.lit(None, dtype=pl.Float64).alias(\"premium\"),\n",
+    "            pl.lit(None, dtype=pl.Datetime(\"ms\", \"UTC\")).alias(\"funding_asof\"),\n",
     "        ]\n",
     "    )"
    ]
@@ -2000,10 +2461,24 @@
    "cell_type": "markdown",
    "id": "ae4fdf93",
    "metadata": {
-    "lines_to_next_cell": 2
+    "lines_to_next_cell": 2,
+    "papermill": {
+     "duration": 0.006014,
+     "end_time": "2026-09-11T14:39:19.841519+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T14:39:19.835505+00:00",
+     "status": "completed"
+    }
    },
    "source": [
-    "The latest fully populated row per symbol is the only live observation eligible for inference."
+    "The latest fully populated row per symbol is the only live observation eligible for inference,\n",
+    "and populated is not the same as current. The as-of join carries the last funding print forward\n",
+    "for as long as the feed stays silent, so `funding_rate` and the `premium` derived from it are\n",
+    "never null once a single rate has arrived: a symbol whose funding stopped publishing a week ago\n",
+    "still produces a complete feature row, and the null check cannot distinguish it from a live one.\n",
+    "A null count answers when the series began, never whether it kept going. The age of the matched\n",
+    "print against the eight-hour settlement grid answers the second question, and a symbol reading a\n",
+    "rate older than `MAX_FUNDING_AGE_HOURS` leaves the cross-section rather than being scored."
    ]
   },
   {
@@ -2012,10 +2487,17 @@
    "id": "a5d1454f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T01:27:54.405183Z",
-     "iopub.status.busy": "2026-09-09T01:27:54.405039Z",
-     "iopub.status.idle": "2026-09-09T01:27:54.410709Z",
-     "shell.execute_reply": "2026-09-09T01:27:54.410094Z"
+     "iopub.execute_input": "2026-09-11T14:39:19.859031Z",
+     "iopub.status.busy": "2026-09-11T14:39:19.858182Z",
+     "iopub.status.idle": "2026-09-11T14:39:19.910024Z",
+     "shell.execute_reply": "2026-09-11T14:39:19.908581Z"
+    },
+    "papermill": {
+     "duration": 0.064124,
+     "end_time": "2026-09-11T14:39:19.911541+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T14:39:19.847417+00:00",
+     "status": "completed"
     }
    },
    "outputs": [
@@ -2023,28 +2505,69 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Latest valid feature rows: 18 of 19 perps\n"
+      "Latest valid feature rows: 18 of 19 perps\n",
+      "Funding age at the inference row: median 0.0h, max 0.0h (tolerance 8h)\n",
+      "Inference cross-section: 18 of 19 requested perps (94.7%)\n"
      ]
     }
    ],
    "source": [
-    "live_features = compute_features_8h(live_panel)\n",
+    "live_features = compute_features_8h(live_panel).with_columns(\n",
+    "    ((pl.col(\"timestamp\") - pl.col(\"funding_asof\")).dt.total_minutes() / 60.0).alias(\n",
+    "        \"funding_age_hours\"\n",
+    "    )\n",
+    ")\n",
     "\n",
-    "# The latest valid feature row per symbol becomes the prediction input\n",
-    "latest_features = (\n",
+    "# The latest valid feature row per symbol is the prediction candidate\n",
+    "latest_candidates = (\n",
     "    live_features.filter(pl.all_horizontal([pl.col(c).is_not_null() for c in FEATURE_COLS]))\n",
     "    .group_by(\"symbol\")\n",
     "    .agg(pl.all().last())\n",
     "    .sort(\"symbol\")\n",
     ")\n",
-    "print(f\"Latest valid feature rows: {latest_features.shape[0]} of {len(CASE_STUDY_UNIVERSE)} perps\")\n",
-    "assert set(latest_features[\"symbol\"]) == set(available_symbols)"
+    "print(\n",
+    "    f\"Latest valid feature rows: {latest_candidates.shape[0]} of {len(CASE_STUDY_UNIVERSE)} perps\"\n",
+    ")\n",
+    "assert set(latest_candidates[\"symbol\"]) == set(available_symbols)\n",
+    "\n",
+    "funding_age = latest_candidates[\"funding_age_hours\"]\n",
+    "print(\n",
+    "    f\"Funding age at the inference row: median {funding_age.median():.1f}h, \"\n",
+    "    f\"max {funding_age.max():.1f}h (tolerance {MAX_FUNDING_AGE_HOURS:.0f}h)\"\n",
+    ")\n",
+    "is_fresh = pl.col(\"funding_age_hours\").is_not_null() & (\n",
+    "    pl.col(\"funding_age_hours\") <= MAX_FUNDING_AGE_HOURS\n",
+    ")\n",
+    "stale_funding = latest_candidates.filter(~is_fresh).select(\"symbol\", \"funding_age_hours\")\n",
+    "if len(stale_funding) > 0:\n",
+    "    print(\"Dropped for stale funding: \" + \", \".join(stale_funding[\"symbol\"]))\n",
+    "    print(stale_funding)\n",
+    "\n",
+    "latest_features = latest_candidates.filter(is_fresh)\n",
+    "fresh_coverage = len(latest_features) / len(CASE_STUDY_UNIVERSE)\n",
+    "print(\n",
+    "    f\"Inference cross-section: {len(latest_features)} of \"\n",
+    "    f\"{len(CASE_STUDY_UNIVERSE)} requested perps ({fresh_coverage:.1%})\"\n",
+    ")\n",
+    "if fresh_coverage < MIN_OKX_LIVE_COVERAGE:\n",
+    "    raise RuntimeError(\n",
+    "        f\"Coverage after the funding-freshness gate is {fresh_coverage:.1%}, below the \"\n",
+    "        f\"{MIN_OKX_LIVE_COVERAGE:.0%} deployment floor\"\n",
+    "    )"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "5f1249a6",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.01003,
+     "end_time": "2026-09-11T14:39:19.934262+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T14:39:19.924232+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "## 5. Predict Direction Probabilities\n",
     "\n",
@@ -2059,12 +2582,19 @@
    "id": "68899912",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T01:27:54.431173Z",
-     "iopub.status.busy": "2026-09-09T01:27:54.430967Z",
-     "iopub.status.idle": "2026-09-09T01:27:54.436469Z",
-     "shell.execute_reply": "2026-09-09T01:27:54.435848Z"
+     "iopub.execute_input": "2026-09-11T14:39:19.954425Z",
+     "iopub.status.busy": "2026-09-11T14:39:19.954120Z",
+     "iopub.status.idle": "2026-09-11T14:39:19.961896Z",
+     "shell.execute_reply": "2026-09-11T14:39:19.960986Z"
     },
-    "lines_to_next_cell": 2
+    "lines_to_next_cell": 2,
+    "papermill": {
+     "duration": 0.019112,
+     "end_time": "2026-09-11T14:39:19.962598+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T14:39:19.943486+00:00",
+     "status": "completed"
+    }
    },
    "outputs": [
     {
@@ -2099,7 +2629,14 @@
    "cell_type": "markdown",
    "id": "bc2ae33c",
    "metadata": {
-    "lines_to_next_cell": 2
+    "lines_to_next_cell": 2,
+    "papermill": {
+     "duration": 0.008106,
+     "end_time": "2026-09-11T14:39:19.979594+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T14:39:19.971488+00:00",
+     "status": "completed"
+    }
    },
    "source": [
     "The probability frame keeps symbol and timestamp identity beside all three class probabilities."
@@ -2111,10 +2648,17 @@
    "id": "8fa24aa8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T01:27:54.461730Z",
-     "iopub.status.busy": "2026-09-09T01:27:54.461558Z",
-     "iopub.status.idle": "2026-09-09T01:27:54.474162Z",
-     "shell.execute_reply": "2026-09-09T01:27:54.473735Z"
+     "iopub.execute_input": "2026-09-11T14:39:19.995787Z",
+     "iopub.status.busy": "2026-09-11T14:39:19.995592Z",
+     "iopub.status.idle": "2026-09-11T14:39:20.004592Z",
+     "shell.execute_reply": "2026-09-11T14:39:20.003325Z"
+    },
+    "papermill": {
+     "duration": 0.017484,
+     "end_time": "2026-09-11T14:39:20.006312+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T14:39:19.988828+00:00",
+     "status": "completed"
     }
    },
    "outputs": [],
@@ -2133,7 +2677,14 @@
    "cell_type": "markdown",
    "id": "920a4332",
    "metadata": {
-    "lines_to_next_cell": 2
+    "lines_to_next_cell": 2,
+    "papermill": {
+     "duration": 0.005566,
+     "end_time": "2026-09-11T14:39:20.017657+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T14:39:20.012091+00:00",
+     "status": "completed"
+    }
    },
    "source": [
     "Both directional thresholds can fire at once, which happens whenever the flat probability is\n",
@@ -2148,10 +2699,17 @@
    "id": "0740cbb1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T01:27:54.532890Z",
-     "iopub.status.busy": "2026-09-09T01:27:54.532699Z",
-     "iopub.status.idle": "2026-09-09T01:27:54.537042Z",
-     "shell.execute_reply": "2026-09-09T01:27:54.536517Z"
+     "iopub.execute_input": "2026-09-11T14:39:20.037993Z",
+     "iopub.status.busy": "2026-09-11T14:39:20.037765Z",
+     "iopub.status.idle": "2026-09-11T14:39:20.043786Z",
+     "shell.execute_reply": "2026-09-11T14:39:20.042893Z"
+    },
+    "papermill": {
+     "duration": 0.018627,
+     "end_time": "2026-09-11T14:39:20.044503+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T14:39:20.025876+00:00",
+     "status": "completed"
     }
    },
    "outputs": [
@@ -2165,16 +2723,16 @@
       "│ ---      ┆ ---                     ┆ ---     ┆ ---      ┆ ---      ┆ ---      ┆ ---    │\n",
       "│ str      ┆ datetime[ms, UTC]       ┆ f64     ┆ f64      ┆ f64      ┆ f64      ┆ str    │\n",
       "╞══════════╪═════════════════════════╪═════════╪══════════╪══════════╪══════════╪════════╡\n",
-      "│ ATOMUSDT ┆ 2026-09-08 16:00:00 UTC ┆ 1.857   ┆ 0.000002 ┆ 0.000005 ┆ 0.999993 ┆ long   │\n",
-      "│ DOTUSDT  ┆ 2026-09-08 16:00:00 UTC ┆ 1.2455  ┆ 0.000002 ┆ 0.000007 ┆ 0.999991 ┆ long   │\n",
-      "│ INJUSDT  ┆ 2026-09-08 16:00:00 UTC ┆ 6.401   ┆ 0.000015 ┆ 0.99997  ┆ 0.000015 ┆ flat   │\n",
-      "│ BTCUSDT  ┆ 2026-09-08 16:00:00 UTC ┆ 78420.7 ┆ 0.000015 ┆ 0.99997  ┆ 0.000015 ┆ flat   │\n",
-      "│ BNBUSDT  ┆ 2026-09-08 16:00:00 UTC ┆ 751.8   ┆ 0.000015 ┆ 0.99997  ┆ 0.000015 ┆ flat   │\n",
-      "│ DOGEUSDT ┆ 2026-09-08 16:00:00 UTC ┆ 0.09    ┆ 0.000014 ┆ 0.999972 ┆ 0.000014 ┆ flat   │\n",
-      "│ ETHUSDT  ┆ 2026-09-08 16:00:00 UTC ┆ 2484.11 ┆ 0.000013 ┆ 0.999973 ┆ 0.000013 ┆ flat   │\n",
-      "│ AVAXUSDT ┆ 2026-09-08 16:00:00 UTC ┆ 8.004   ┆ 0.000011 ┆ 0.999978 ┆ 0.000011 ┆ flat   │\n",
-      "│ APTUSDT  ┆ 2026-09-08 16:00:00 UTC ┆ 0.6469  ┆ 0.999993 ┆ 0.000006 ┆ 0.000002 ┆ short  │\n",
-      "│ ADAUSDT  ┆ 2026-09-08 16:00:00 UTC ┆ 0.2192  ┆ 0.999993 ┆ 0.000005 ┆ 0.000002 ┆ short  │\n",
+      "│ DOGEUSDT ┆ 2026-09-11 00:00:00 UTC ┆ 0.08377 ┆ 0.000002 ┆ 0.000005 ┆ 0.999994 ┆ long   │\n",
+      "│ UNIUSDT  ┆ 2026-09-11 00:00:00 UTC ┆ 6.087   ┆ 0.000002 ┆ 0.000005 ┆ 0.999993 ┆ long   │\n",
+      "│ SUIUSDT  ┆ 2026-09-11 00:00:00 UTC ┆ 0.7368  ┆ 0.000002 ┆ 0.000005 ┆ 0.999993 ┆ long   │\n",
+      "│ DOTUSDT  ┆ 2026-09-11 00:00:00 UTC ┆ 1.1237  ┆ 0.000002 ┆ 0.000005 ┆ 0.999993 ┆ long   │\n",
+      "│ AAVEUSDT ┆ 2026-09-11 00:00:00 UTC ┆ 122.81  ┆ 0.000002 ┆ 0.000005 ┆ 0.999993 ┆ long   │\n",
+      "│ XRPUSDT  ┆ 2026-09-11 00:00:00 UTC ┆ 1.3508  ┆ 0.000002 ┆ 0.000006 ┆ 0.999993 ┆ long   │\n",
+      "│ SOLUSDT  ┆ 2026-09-11 00:00:00 UTC ┆ 99.69   ┆ 0.000002 ┆ 0.000006 ┆ 0.999993 ┆ long   │\n",
+      "│ ADAUSDT  ┆ 2026-09-11 00:00:00 UTC ┆ 0.2077  ┆ 0.000002 ┆ 0.000006 ┆ 0.999992 ┆ long   │\n",
+      "│ ETHUSDT  ┆ 2026-09-11 00:00:00 UTC ┆ 2466.27 ┆ 0.000002 ┆ 0.000008 ┆ 0.99999  ┆ long   │\n",
+      "│ INJUSDT  ┆ 2026-09-11 00:00:00 UTC ┆ 5.988   ┆ 0.000294 ┆ 0.747449 ┆ 0.252256 ┆ flat   │\n",
       "└──────────┴─────────────────────────┴─────────┴──────────┴──────────┴──────────┴────────┘\n"
      ]
     }
@@ -2195,7 +2753,15 @@
   {
    "cell_type": "markdown",
    "id": "caa79e01",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.009667,
+     "end_time": "2026-09-11T14:39:20.063069+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T14:39:20.053402+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "The probability edge shows direction and strength in one view. Positive\n",
     "values favour an upward move; negative values favour a downward move."
@@ -2207,10 +2773,17 @@
    "id": "ad19bbb8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T01:27:54.561146Z",
-     "iopub.status.busy": "2026-09-09T01:27:54.560792Z",
-     "iopub.status.idle": "2026-09-09T01:27:56.063125Z",
-     "shell.execute_reply": "2026-09-09T01:27:56.062437Z"
+     "iopub.execute_input": "2026-09-11T14:39:20.085532Z",
+     "iopub.status.busy": "2026-09-11T14:39:20.085273Z",
+     "iopub.status.idle": "2026-09-11T14:39:22.691069Z",
+     "shell.execute_reply": "2026-09-11T14:39:22.690516Z"
+    },
+    "papermill": {
+     "duration": 2.618335,
+     "end_time": "2026-09-11T14:39:22.691595+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T14:39:20.073260+00:00",
+     "status": "completed"
     }
    },
    "outputs": [
@@ -2218,175 +2791,77 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2026-09-08 21:27:54,570 INFO Chromium init'ed with kwargs {}\n"
+      "2026-09-11 10:39:20,641 INFO Conforming 1 to file://~/scratch/tmpf6077_qk/index.html\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2026-09-08 21:27:54,571 INFO Found chromium path: /usr/bin/google-chrome\n"
+      "2026-09-11 10:39:22,073 INFO Getting tab from queue (has 1)\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2026-09-08 21:27:54,572 INFO Temp directory created: ~/scratch/tmpvrwe74dx.\n"
+      "2026-09-11 10:39:22,074 INFO Got 90A3\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2026-09-08 21:27:54,573 INFO Opening browser.\n"
+      "2026-09-11 10:39:22,235 INFO Reloading tab 90A3 before return.\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2026-09-08 21:27:54,573 INFO Temp directory created: ~/scratch/tmpe70l5xpg.\n"
+      "2026-09-11 10:39:22,409 INFO Putting tab 90A3 back (queue size: 0).\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2026-09-08 21:27:54,574 INFO Temporary directory at: ~/scratch/tmpe70l5xpg\n"
+      "2026-09-11 10:39:22,409 INFO Waiting for all cleanups to finish.\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2026-09-08 21:27:54,806 INFO Conforming 1 to file://~/scratch/tmpvrwe74dx/index.html\n"
+      "2026-09-11 10:39:22,410 INFO Exiting Kaleido.\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2026-09-08 21:27:55,711 INFO Getting tab from queue (has 1)\n"
+      "2026-09-11 10:39:22,411 INFO Cancelling tasks.\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2026-09-08 21:27:55,712 INFO Got 06D2\n"
+      "2026-09-11 10:39:22,412 INFO Exiting Kaleido/Choreo.\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2026-09-08 21:27:55,770 INFO Reloading tab 06D2 before return.\n"
+      "2026-09-11 10:39:22,685 INFO Cancelling tasks.\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2026-09-08 21:27:55,837 INFO Putting tab 06D2 back (queue size: 0).\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "2026-09-08 21:27:55,837 INFO Waiting for all cleanups to finish.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "2026-09-08 21:27:55,838 INFO Exiting Kaleido.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "2026-09-08 21:27:55,839 INFO TemporaryDirectory.cleanup() worked.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "2026-09-08 21:27:55,839 INFO shutil.rmtree worked.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "2026-09-08 21:27:55,840 INFO Closing browser.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "2026-09-08 21:27:55,841 INFO TemporaryDirectory.cleanup() worked.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "2026-09-08 21:27:55,842 INFO shutil.rmtree worked.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "2026-09-08 21:27:55,842 INFO Closing browser.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "2026-09-08 21:27:55,842 INFO Cancelling tasks.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "2026-09-08 21:27:55,842 INFO Exiting Kaleido/Choreo.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "2026-09-08 21:27:56,058 INFO TemporaryDirectory.cleanup() worked.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "2026-09-08 21:27:56,059 INFO shutil.rmtree worked.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "2026-09-08 21:27:56,059 INFO Cancelling tasks.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "2026-09-08 21:27:56,059 INFO Exiting Kaleido/Choreo.\n"
+      "2026-09-11 10:39:22,687 INFO Exiting Kaleido/Choreo.\n"
      ]
     },
     {
@@ -2405,27 +2880,11 @@
          "type": "bar",
          "x": [
           -0.9999936379461257,
-          -0.9999933108865522,
-          -0.9999932693505061,
-          -0.9999932566856761,
-          -0.9999932357165678,
-          -0.9999931249406488,
-          -0.9999927974879632,
-          -0.9999925119125964,
-          -0.9999918570823214,
-          -0.9999913488594694
+          -0.9999897381895844
          ],
          "y": [
-          "XRPUSDT",
-          "AAVEUSDT",
-          "NEARUSDT",
-          "COMPUSDT",
-          "SUIUSDT",
-          "SOLUSDT",
-          "LINKUSDT",
-          "UNIUSDT",
-          "ADAUSDT",
-          "APTUSDT"
+          "APTUSDT",
+          "ATOMUSDT"
          ]
         },
         {
@@ -2436,20 +2895,22 @@
          "orientation": "h",
          "type": "bar",
          "x": [
-          -1.7954298466512394e-08,
           -1.794357863869733e-08,
+          -1.793780812535601e-08,
           -1.7807844308363337e-08,
-          -1.678157082635629e-08,
-          -1.5758667656421747e-08,
-          -1.3305711971071192e-08
+          -1.7807844308363337e-08,
+          -1.7545761939225413e-08,
+          0.15938393295559292,
+          0.25196156754621535
          ],
          "y": [
-          "INJUSDT",
-          "BTCUSDT",
+          "AVAXUSDT",
           "BNBUSDT",
-          "DOGEUSDT",
-          "ETHUSDT",
-          "AVAXUSDT"
+          "COMPUSDT",
+          "NEARUSDT",
+          "LINKUSDT",
+          "BTCUSDT",
+          "INJUSDT"
          ]
         },
         {
@@ -2460,12 +2921,26 @@
          "orientation": "h",
          "type": "bar",
          "x": [
-          0.9999894035534184,
-          0.9999912638063014
+          0.999987933950845,
+          0.9999906301264344,
+          0.9999906461502817,
+          0.9999907524373166,
+          0.9999909809280895,
+          0.9999913146515117,
+          0.9999914388194565,
+          0.9999916001360537,
+          0.9999917119544142
          ],
          "y": [
+          "ETHUSDT",
+          "ADAUSDT",
+          "SOLUSDT",
+          "XRPUSDT",
+          "AAVEUSDT",
           "DOTUSDT",
-          "ATOMUSDT"
+          "SUIUSDT",
+          "UNIUSDT",
+          "DOGEUSDT"
          ]
         }
        ],
@@ -2561,11 +3036,11 @@
         }
        }
       },
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAArwAAAH0CAYAAADfWf7fAAAQAElEQVR4AezdCWAM1x8H8G9ut7hK1VWtlrrqaOuq+ygt/lqkVSJCSOIKQVtExH1TV9xStLQp6qgiqo46Squl1buIWxWJI4iE//ye7NrNZcXe+Wrf7Jv33rx585nd2V9mZ2ddExNv32OiAZ8DfA7wOcDnAJ8DfA7wOcDngLM+B1zBfxSgAAUoAIAIFKAABSjgrAIMeJ11z3K7KEABClCAAhSgQFYEnHAZBrxOuFO5SRSgAAUoQAEKUIACDwQY8D6wYI4CFDBdgC0pQAEKUIACDiPAgNdhdhUHSgEKUIACFKCA/QlwRI4gwIDXEfYSx0gBClCAAhSgAAUokGUBBrxZpuOCFDBdgC0pQAEKUIACFLCdAANe29lzzRSgAAUoQIHsJsDtpYBNBBjw2oSdK6UABShAAQpQgAIUsJYAA15rSXM9pguwJQUoQAEKUIACFDCjAANeM2KyKwpQgAIUoIA5BdgXBShgHgEGvOZxZC8UoAAFKEABClCAAnYqwIDXTneM6cNiSwpQgAIUoAAFKECBzAQY8GamwzoKUIACFHAcAY6UAhSgQAYCDHgzgGExBShAAQpQgAIUoIBzCGS3gNc59hq3ggIUoAAFKEABClDAZAEGvCZTsSEFKEABZxLgtlCAAhTIPgIMeLPPvuaWUoACFKAABShAgWwpkGnAmy1FuNEUoAAFKEABClCAAk4lwIDXqXYnN4YCFLCQALulAAUoQAEHFmDA68A7j0OnAAUoQAEKUIAC1hVwzLUx4HXM/cZRU4ACFKAABShAAQqYKMCA10QoNqMABUwXYEsKUIACFKCAPQkw4LWnvcGxUIACFKAABSjgTALcFjsRYMBrJzuCw6AABShAAQpQgAIUsIwAA17LuLJXCpguwJYUoAAFKEABClhUgAGvRXnZOQUoQAEKUIACpgqwHQUsJcCA11Ky7JcCFKAABShAAQpQwC4EGPDaxW7gIEwXYEsKUIACFKAABSjwaAIMeB/Ni60pQAEKUIAC9iHAUVCAAiYLMOA1mYoNKUABClCAAhSgAAUcUYABryPuNdPHzJYUoAAFKEABClAg2wsw4M32TwECUIACFMgOAtxGClAgOwsw4M3Oe5/bTgEKUIACFKAABbKBAANeg53MLAUoQAEKUIACFKCA8wkw4HW+fcotogAFKPC4AlyeAhSggFMJMOB1qt3JjaEABShAAQpQgAIUSC2Q9YA3dU+cpwAFKEABClCAAhSggB0KMOC1w52SnYe0bccetO7YA8WefRnv9ggxiaJrr0H4YOQkfdvU8/oKO8zMW/wJGrz2th2O7PGHVLhMDcj+fJye2ncOxuiJMzPtomuvULwfPlHfJvX+f6ZKA6z7cpu+3hIZe+lz6qzFaPlmN6sO58jR3+Fdoir+u3TFqutNvbK5C1eo15KMZfb8ZamrM5y3pllQSBhC3h+tH0vq566+wgoZOfbUb+FjhTUZryL169O4NutzQalss94Tl3RWAQa8TrhnT546q96Avt33vclb9+Pho2qZuPirJi9jasNH6Xvk2BmoWa0yTvyyGx8vmmHqKtguGwuUf+4ZPF26ZIYCtV6uhkIFvfX1pSrUxZebv9HP21vG1PGZ2s7S25c7V040fLUWPDzcLb2qDPv/9+IlDI2YjMH9e+LyyR/Rp5dvum3txUw3uIc9d3XtHvcxve1+stgTeLHKC4/bNZenQGoBu51nwGu3uyZ7Duzk6bN4pWY15MjhlT0BuNWPLPBBaDB6+XfKcDn5w6le7ZoZ1rPi8QSeebo0vlg5H/nz5X28jh5j6TNnz6ulG7z6ClxdHedt7WHPXbVRFpq0fb0pZk4Ot1Dv7JYC9ifgOEcG+7NzqBEV1j5eXr5qLTp0CYb8tV+vWQd8unqj2obYk2fQ6PX7AUOZiq9CPhLs2W+oqktOTsasecsg7Z96rrZqt37TNlWnm2S1b93y8vjr73+r9V69dh1vd+ur8p+t+VKq8MOPP+N/7/RC6RfqoXq9NzB89FTcvHlL1ZkyuXDxP8j2VKjZDOVebIRuQUNw+sw5tej1Gwko8nRNHPzhsJqXScWXW6BO07ckq9LOb7+DbHtSUpKan/zhQjT/ny+KPvOSGqf0pyoymBw7cRLyMd4LLzVH+epN0XvgCPz2xz/pthaHIWHj8Uqjdmo/tX27Jw7/8ptR28zWL/vmzU5Bykr2Y8NW7+DsuQtGyxvOyL6bOH0+Xm/fHSXL11H7WeeuaydtPvpkNaRfeX5I+8TEOxgzaRZeatBGLfdGhx7Y+90PukX0j+fO/6v2nVHfKbViL32IpdTLWNes35xS++Dhzp0kBA8YofZd5VotMWrCTOj2hbR62MfChpc01Hi1NeQ5JpfLiI/sE/lEpEDJFyEfzUt/uhS14nO1v+7cuaMryvRR99H4gqUrlUvZyg3Qo8/7OP/vRaPlVn6+HrKt8pxq2PIdLF0era9Pb3z6SoPMw9ot+mhVhmNINuE1bbAqlf3ltz/1z2Fxk9fIjt37VZ24SZnukobC2rFG5lMn1VibXImLx6Bh49VrWfa7PK+kf60qw/8zew3LtuqOX9KfrFcXABt2aG0zeX7L5QvPVWsMed7KGWjD8Ug+9XNXLuEZNmqKOkaIsRz3pN3W7bvxWjs/9bquWb8NJkybB9mPUifp7t27kEsUGr/xrjpWNWvrC3keSl1G2y3tDS9peNhret+BQxDb7bv2qvcBsZbLz+T4LOuRJNtsymta2maWfv/zGDoHDFCvPzlmB4WEwfDTR1nPw2yvXb+B/kNGwdBf+pHldOvOynNRtywfHU+AAa/j7bMsj3jh0lUI7NEZh/dtQqeObREYMhwnYk+jdKmn8M2Xn6h+TxzdjbjTh7Fg5jg1P2nGfKz/ahsihg/Ar99vxXshgRg5bgY2b9ul6nWTrPStW1YeXyj/rFpvzpw5sCpqlsp3fPN1yBtXG5+eKPZEEfywewNmT43Ayuj12hvmOFnsoenevXvw8e2L37UAc83H8xCzbrkKAN98NxASyOTJnUtdQrHnu0Oqr+Oxp3D16jX8+fcJfaCy78CPqK19LO7u7g452C+MWonRwwfi+M+7sGvLp3i5RlW1bHoT+ai1ufbmkztXLqxeEYm9X3+OutrZxqvXrqXXHPFXr6JyxfL47KPZ2BMTjcYN6miBZqB+LJmtXw7w3Xu/j7fbv6H28U97voRfp7fg4uKS7rp0hRJwBWvPi18ObIG/bwf1x4EE+bp6eZQgt1uX9vj9h20I6vEuwsdNx8KoTzFx9PtqXfLRbNu3e+Gvf2KluT7Nnv8Revj6QPru7ttR9b1rzwFVn5iYCC+vHJg+Pkz10Tugi/ax9JQ01/1+uvpLPP9cWRzcuQ4zJoZh5ecbMGXmItXHo07kOZQvbx51uYw8z389uBWlShZHs0Z1sUrr17A/WY9Yenh4GBZnmv/p51/V8yt62Vx8sWo+jp04hQlT5+mXkT9I5E33nfatcfTgFnTv2hEDPhiDFZ9+odqkNz5VkWqSWbtjx09i4+ZvENK7O4aE9MKe/T8YjcHU17ThKt8Lm4gSTxXDlrVROP7LLowJC4W8Vg3b6PL/nfhBvX7F98I/B/GS9vp4tc5Lump0CQjFtevXsXDWePy0dxPeaNlIPcflta5vZJB52Gu4R9e3tdf1/Wt2T/+xT637qeLFDHq4n7W22bCIKdignRyImjcZX29YgQv/XsL2nXvvDyaT6RLtD6BnypbGbu3YsmzBVMhrsd+gCPh1fksdAyOnj8aB7w8jYvyH+l4mTp+HDyOXol+gH377IQaTRr2Hm7duq/rMtls1SJmEm/iaXvbJWkwdOxQHdnyBkk8VR2DIMMg+km5MfU1L24ySHDPb+gSgaqUXsCF6MbauW4b8+fOgY9c+kMBeljPF9v0RE3Hw0GGsWDhdvb/Jmf/U/o/6XJR1mzuxP+sJMOC1nrXN1+SvBTNNtACqgHd+BAd0xhOFC+HQ4V8yHNft24mYMXepFtwNgCwnH1m+1qw+ur7bHh998rnRco/at9HCmcwsW7kGEpROnzAchQsVQJ1XaiDsvb74+LN1uPjf5UyWvF8lbxYShMycEo4Kzz+DMqVLaB/jjVQB7aatO1WjOq9Uw76Us5MSHNR5pbq2nurYk3IN9F6trra2Xml87vxFFCzgrYLcXLlyoooWnEoAKHXppaXaWUJxmzl5hFq/LNupQxu8UvPF9JprgXV1dHm7nfojpGSJ4ugf5IdKLzyPTVu+Ue0zW/+lS1dUEF9PC6i98+dT2+rXuT3kWj21cAaTd33a4PXXGkHG6d+lo8rLpwGGzTt1aI3WLZuoS008tMB/0UefYVC/nmhcv47ymBAxGMWffAKLl60yXAxvvNYYb7RsrPru1qWD6lv2qTQSi8H9A1CxQjnVR4d2reCnPbdSB55lny6lHGSb5HkogXHUx8bPP+nvcdK7Pu3UJx7yR5D0I3/wfPf9T5BymTc1yWtr5NAQZS/PjXc7tsGBH37SL74wahVatWioLsGQ7ZF9LX/YLViyUt/mcTN3tE8iVi75EO/KH7XdO6l1ybZIv4/ympb2unTu/AW8WPkFyHOygHb8aNe6eYbPYd0y8tg7dAT+016nS+ZOklnIHztyTf8c7Q/XGtUqq2ur5TlX/cWKWL1+i2qTemLKazj1Mo86b24zOQMpz/MPQoO0Y0kNPFGkEOSPtRsJCQ8dWrUqFTGwT3f1mpA/zqbPWYKAbu/g7bdaq2Og/AExdFAQJDCWzpK0/S3H6aGDgvG/N5pBlqlWtaJ6zUi9KUk+MTP1NT10UG9Uf7GSOq70DfRVf+TKGXhZj6mvaWmbUZLtqlLpecixodwzpSHX548fOQRHf/0L8twxxfaadnb3E+3EyHsDgvByzarKbdSwAZBjtm69WXku6pblo2MKMOB1zP2WpVEXf7Ko0XJFnyicadB4XDv7K2+Q8lGafJSlS+Fjp+P4idNGfT1q30YLZzLzj3a26tW6LxmdTWrWqJ5a4tiJk+oxs4m0KVa0COTNWtfu+XJPQ9I/x++fjZRgdtfeg+pj8n3fHYLM19EC3D37D+GWdpZEzvBKUCzLy7ov/ncJjVp1Uh/pr1q9AfIRudSll/4+dgI1tDd2OTucXn3qsoSEm+rjyobaR91Fnq4J7xJV1RmeU6fPqaaZrV+C+bq1aqJZW1/tTOlk7QzsSsjlKmrBTCaVXihvVFulYgV1ZtKw8MXKFfWzJ06eUYF100Z19WWyfY3q14acXdQXapmH9b1S+3hfLqeQy2zk+TVhWiR026otrv6vXPE59aibVK1cAecvXIRY6coe97FV8wbwcPeAnBmVvpavWg2xlDdcmTc1lXzqSaOmhQsVgpyx0hX+9c8JNG34wE3KZf63P//RnyWTssdJcnbQ8OxrmVIltNf5JdXlo7ym1QIpk/b/a4mQ90ZDLsf5MDIKh37K+A/llEUggdrmmJ34RAu+ixQuqIr/ORYLCfoKp7rsYXPMuY5/oAAAEABJREFULsinTapRqokpr+FUizzyrLnN5DIZOevZoF5t/Vjy5skN+WNUX5BB5sUqFYxq/vjrGEZPnKkuJ5DXiKSmbbpAAr9z5//F38dOQo7TL9dI/49oo84ymHmU13SJ4g/eR4poJ02kS8OTD6a8pmWZjJIcl2O+2WO0vXLJkTxv5Plriq2ujQTOuvXIGd5KLzw4lvyTheeiri8+OqYAA17H3G9ZGrW84FMvqH3in7pIP+/icv+j8H1fr4Z8PGmY9m9fo28nmUftW5YxNbm5uRk1dXM3njeqTGcmvY+kDfus9VI1LdhN1t7Ej2LHt9+hXq0a2lmZ6th34BDkzJin9pH2S9WrqJ7lTM3uLZ+hk3bm7oYWnI6fGomGLd82CmpUwyxOhmofg/7081HMmjoSf/74tXKXs5qJKdeRPmz9q1fMRdh7fZDDy0v76H8jXmncDo9ytw7dsOXNWpeXxxw5veTBKEmQa1jg7uZuOJthXtf3p6s3YuL0+Rjxfl/18ag8v4YP6QvdtmbYQUqFqe1Smmf6IM+Rzm+3xadrNqhgPnrNV5DLGTJdKJ3K9F8H94xaGj73pMJdez6LiYvL/deblD1Ock/1enFxcdEH0y4u99dhymvacAxyVm9J5CSUKvkU9u7/Hk1ad1bX9hu2Mcx/rX10L9daL5w1QX2yoatzcXFRZztlX6dO08YP0zVL8yj7J3VhasfU9Y8ybwkzWb+7u/FbrCnHrpypvrDr4uKCqeOGqmNBajPDT29cXO7vW1lvVpMpr+nMnuOP+5qWcbu4uOCtti3T3d722h9e0kZSVmxlOV1yccnac1G3PB8dT8DV8YbMEVtCwEsLkKRf3TVSkn/m6ZLqzOrXO/bKbJZTen2b2tkz2sfZR3753aj5jz/9qubLlimlHjObSBv5gpqcCdG1ky/XyJnjZ54urYrkkgkJaD/RzjZe1z4KkzOycsnB38di1f1b5eyu4RuBnM3uqX3EOF77mG3fttU4qZ19/f7Qz6qv1JNny5bRAulftIA6KXVVuvMSZL/xWhNUfuF5FNA+OpYzN0d//8uobWbrz6G9WcpHnyPe74ftGz9GjRcrY/O2+5duGHViMPPLr8a+R47+BvkY0aCJUbZMqacgwcaRX+7vB12lXB5TVttfunl5zKzv/d//hLramXSxLqadhZf2Px81Hsv9sj/lQZ8O//wbihYpDLkkQF/4CJmcOXLg7r27aZbwfectxGzfA/koOuHmTbzZpkWaNo9bUO6ZMjjyyx9G3fx45CheeP5ZfVlG49M3SMmY2i6luXp45jFe0y2avIr3BvTCpx/NxqB+PbB24xbVZ+rJX//Ewj9oCN4fGISW2plzw3q5FlvOeMtH04blmeVNeQ1ntrxhnbXMSpUsrq6dN9zX8iWzHw8bv2YMx5ZR/gXtubF9176MqvFs2VLw8vI0unQmdeOHbfejvKZT9204b+pr2nCZ1Pnnyz2DPdofVXKZReo6mTfFNr028t72y68PjiVZeS7K+pkcV4ABr+PuO7OOvGSJJ9VB0/CAIEGeXKc5bfZiyPVQl6/EQQ5Cn3/xlf5LNqYMIr2+TVlO2sg1jvLxlJwtkkBVvqwxetJMdX1ikZSPSaVdSkrzUL/uy6iqfQTef0gE/vjruPrYdOAHY1Bae0Nq2ayBvn3tl19UX4arV6emeqOSN5C62pnejz/7ArVerqFvJz9gINe3yseJUrhrz0EVzD5dpoTMpkndOreHfLu43+BR6s4MYiiWcuY4TWOtoHLF59V1jnJdnmxv0IAwxF998AW3zNb/2x9/Y+qsxfo7UMhHxPKx3dOl0x+btjr1/8rPN6r70sp6liz/TOX93n1L1aU3kY/Le3Z7G3J2W96YZJsmzViAn4/+gQC/t40WyazvytrHiz9oH43L8nLtrDzPtm7fbbS8zMg12PIxujh+rZ05nLNwOeR6YKnLSpKPr4/+ZvxHhPQjb5KN69fC8NHT8Gbb15A7Vy4p1if51nt649M3MCEjPnKN8mdrvlTPi7UbtkC+BNTT/x390hmNT98gJWNqu5Tm6iGrr2m5M8ohbV9JJ3J95EHtD7yn07n38Y2EBLzTrS+aNKwLCY6R6l/tl6ur7wPItb3bd+1VlwzJXSzkhyL2H/wxVev7s6a+hu+3znxqLTP5I9r3nTcxbsoc9bqXS6PCxkzDlbj4zAeYTm2o9seF3Dd6/NS56vglgZtc1yyfjkhz2achwd0wdvIcfLExRl1iJX9QyGtG6iU9bLsf5TUt/WWUTH1NZ7S8lPt3aS8PCOj3AY5ofwDL9sqxTd4D5Bhliq1cPiLflRB/ec+QY+mIsdMhzzXVuTbJynNRW4z/O7AAA14H3nnmHLocIAb09kcbnwDINWJyGy/pf2Aff/WR85Ll0aj8Sku82qKjCnblZvNSb0rKqG9Tli3x1JPYGL0I3//4s7qNUWDIMO3NtA6mjB1qyuLqnpyrls5Enjx58L93eqJZ2y4qoP18eSQ8PT30fch1u3I2tfZL1R+UaW/OUlbnlWr6sjx5cmHOguUo8Xxt5STjmTzmfe1j22f1bQwzcgnCxugl6lvp7Tr1gtyqavrsRUZfnjBsPy58MOQAL7dFq/+aD54vVxaNGzy4DjCz9efKmRM7v92PSq+8psZWo34btGhaH/JFMMN1pM4PCemJKbMWqlseLVkWDblDhwQZqdsZzkcMHQD5gkzIe6NQtXYrFaSvWzUfurPmuraZ9S3jer1FQzR5ozNebtgO8sfWgN7ddYvqH/27dNCC6d9RpuKrCHlvNN5+6w2E9k3bTr/AQzJ9e3XV9uEyyPNcbktm2Pzt9q3VH3VyFwXDcskvjFqp+X4n2SynNq2aQr6AOXfRClR8qQU+nBuFUcMHoLPP//R9ZjY+fSMtY2o7ranR/1l5TV/49z+0au+vzOR2VPIcHTUsxKhfmZFrq+WTkTXrN6u2YqxLUi/powVT0bzxqxg6cgqeqdJQC5D7a8+f77TXaG6k908+QjflNZzesqnLrGk2NnwQamvHkHbv9EKtJm+q24jJ/k89pofNSx8bPlukncE9gsZvvIsKNZppf9guQmLibf2iQ0J6oXdAF0z5cIG6fZ9c43vh34v6elO229TXtL7TdDKmvqbTWVRfJJ9sbVn7EeR41iVgIOR1P/CDsZBP5Tzc3VU7U2wnjHpP3YHn3R4hKF+jqbpUSZ53+fPmUX3I5FGfi7IMk+MKMOB13H2X4cjlTJVc62X4BYn/TvyQ5ssyu7Z8isDunfT9yEeQspwkCXqkwsXFRQVM29Yvx5k/9+H7XeshN5lv17qFVKuU1b7Vwqkm5/76Dq9pQZphsXzjeP2nC3Hytz049O1GjB4eqi610LX5aP4UjB85RDeL1PPFtI/Ll8ydiN++j8FfP32j6sVIv4CWadqwrrpmzPAXmuQMlVjIG47WRP3fpEEdyPXLUi7pxNHd2lnNd1RdRpPyz5XF8oXT1C29ZJmDO9erSxakvfjv3LxKsipJgLxo9gQc2LEOcsssGYP8cMLYEYNUfWbrl9vLiZOsQ9Kl2EP4cNIIdfmBWjiDifxRIbelk2W+jYmG3DXAsGl6+1f+WJDrbWVbTv2+V/1RIl/0S72cvAFm1LcEMmHv9cOPezaqJPtoiBZ8S3tdP5+vmAvZdjGR8f28/yuEf9Afhtd0fjR/KiZEvKdbRO1fw+fDP0d2Qm6yr2sgH7PLmKU/MdaVy+OJk2dR/rlnIJdZyLwuyRn9v4+dTGOjq5fHUC0I/2rNUsnqk6xX1q8v0DLiu2PTSvV62vHVSnTt9JZW+uD/zMb3oBXU5QKpt8OUMbi4PPw1bbgeycstxM7/fUC9RsRNnmdPpdz6q0rF8qpc7qIif/BIfXpJ+pEkZ+jkThbyOpJjiuzvz5bNQaUKz0l1uulhr2G5c4GsU/pOt4OUwvRsLWUmY5E7M/x+aBvkFoETR72P+R+OxYwJYSmjgfZcnWr03JXnu7wm9A1SMnJbt7WfzMOxn3fijx+/hvgbtpNLjOTYJa9fuRWcvPblj+eUxdN9rsixZ5f2HqBr87DXtBwHxVgum9ItI/tcyuQ5IGWmvKY/SnW8luVSJzmWyXvQ4b2b1HFfXleyXK5cOVVTU2zlRMucaaPUMV+OYXKM+OOvY0aXa0k/j/pcVAPgxCEFGPA65G4zz6DZCwUo8EDg0uU4LFy6Et19OzwoTMnJF/9aNH0VVSsZf4M+pZoPFKCAnQkc+ukX/e0r5bryfoMjcOnyFbSzwLX5drbpHE4GAgx4M4BhMQUokH0EgkLC8FKDtnizbQt065w24JVPHVYtnZV9QLLflnKLnUwgZ86cmDXvI3WJx2vtfHHm7AWs0c6Sy/3GnWxTuTkmCjDgNRGKzSjgjALyUV/ThnWdcdMeaZsiZ4xWHxfLx8DyJaBHWpiNKUABuxOo8Pwz+svP5LKiNZ9E6i8ls7vBckBWEWDAayoz21GAAhSgAAUoQAEKOKQAA16H3G0cNAUoQAHbCXDNFKAABRxNgAGvo+0xjpcCFKAABShAAQpQ4JEELBTwPtIY2JgCFKAABShAAQpQgAIWE2DAazFadkwBClAAABEoQAEKUMDmAgx4bb4LOAAKUIACFKAABSjg/AK23EIGvLbU57opQAEKUIACFKAABSwuwIDX4sRcAQUoYLoAW1KAAhSgAAXML8CA1/ym7JECFKAABShAAQo8ngCXNqsAA16zcrIzClCAAhSgAAUoQAF7E2DAa297hOOhgOkCbEkBClCAAhSggAkCDHhNQGITClCAAhSgAAXsWYBjo0DmAgx4M/dhLQUoQAEKUIACFKCAgwsw4HXwHcjhmy7AlhSgAAUoQAEKZE8BBrzZc79zqylAAQpQIPsKcMspkO0EGPBmu13ODaYABShAAQpQgALZS4ABb/ba36ZvLVtSgAIUoAAFKEABJxFgwOskO5KbQQEKUIAClhFgrxSggOMLMOB1/H3ILaAABShAAQpQgAIUyESAAW8mOKZXsSUFKEABClCAAhSggL0KMOC11z3DcVGAAhRwRAGOmQIUoIAdCjDgtcOdwiFRgAIUoAAFKEABCphPwBYBr/lGz54oQAEKUIACFKAABSjwEAEGvA8BYjUFKEABywmwZwpQgAIUsIYAA15rKHMdFKAABShAAQpQgAIZC1i4hgGvhYHZPQUoQAEKUIACFKCAbQUY8NrWn2unAAVMF2BLClCAAhSgQJYEGPBmiY0LUYACFKAABShAAVsJcL2PKsCA91HF2J4CFKAABShAAQpQwKEEGPA61O7iYClgugBbUoACFKAABShwX4AB730HTilAAQpQgAIUcE4BbhUFwICXTwIKUIACFKAABShAAacWYMDr1LuXG2eyABtSgAIUoAAFKOC0Agx4nXbXcsMoQAEKUIACjy7AJSjgjAIMeJ1xr3KbKEABClCAAhSgAAX0Agx49RTMmC7AlhSgAAUoQAEKUMBxBBjwOs6+4ipyA9AAABAASURBVEgpQAEKUMDeBDgeClDAIQQY8DrEbuIgKUABClCAAhSgAAWyKsCAN6typi/HlhSgAAUoQAEKUIACNhRgwGtDfK6aAhSgQPYS4NZSgAIUsI0AA17buHOtFKAABShAAQpQgAJWErC7gNdK283VUIACFKAABShAAQpkEwEGvNlkR3MzKUABhxPggClAAQpQwEwCDHjNBMluKEABClCAAhSgAAUsIfD4fTLgfXxD9kABClCAAhSgAAUoYMcCDHjteOdwaBSggOkCbEkBClCAAhTISIABb0YyJpZ7eHjC0snNzQ3JyckWX4+lt4P9Gz9X3N09kJSUxP1qhdeQtZ97rVq9zv3qhPv1zp07cHNz5751sn0r76+urm5W2a8mhhaq2eXLl5DFlG2WU1AmThjwmgjFZhSgAAUoQAEKUMCaAk88UQxM6Rs86n5gwPuoYmxPAWcQ4DZYXKDA1lFgci6Dp76dikLbxnC/Otlz+8ldky1+POAKbC/AgNf2+4AjoAAFKEABClDARgJcbfYQsErAO3XOMrTyCca9e/dwOzERtVt0TjfFnjqH/y7H4f1RM+DXezi6BA3F+OmLcP1GgtobScnJarmISfPUvEzkGsjGbXtg2JiZMouREyOxKWaXysvkRsJNNGrbXbKQfPiEuejoH4oO3ULh33eEvu+AkAi1vqBBY+DXJwzzo6LVWB82XtUxJxSgAAUoQAEKUIACditg8YBXgtwd3x5AoYLe+P6no/Dy9MS+LStU6hvQCT7tWqi8lJUu+SQGhU3BM0+XRNScMVg2dywS7yRh3LSFCtDFxQW5c+XEL7/9pb7sI4U79x5CsaKFJPvQtHrDNly9dgPLIscjeulUDAzuYrTM4D5+iJwyHPOnheF47GmM0gLrh43XqAPOOKkAN4sCFKAABShAAUcWsHjAe/DHX1C2TEl0aNMMW7/Zl6nVj0d+Q1z8Nfi/2061c3FxUUHp3gOH8d+lK/qyOi+/iD1amRR8vXMfmtSvJdmHpitx8ahS8Tnk8PJUbStVKIc8uXOpvOFEgtxhoT2x9+BhnD3/r2EV8xSgAAUoQIHsK8Atp4CDClg84JUgt3mj2mjSoBb2aUGqXIKQkdWpsxdQvlwZuLk+GFbePLkhZ35jT53VLyb9bd/1HW7dTsQJrbxsmRL6uswybVs2xobNOyCXLSxavgYnT5/PsLmst1zZUjh24kyGbVhBAQpQgAIUoAAFKGD/Ag8iSwuMVYLb/QePoGnDWupShCoVy+nPzGa4Ou2sboZ1KRUVyz+LP/8+ju279qPxqy+ra4NTqjJ9KFOqOFYtngRfn9ZaIHsKvkFDcTw244DW1SDwzqjj27dvwfLpNuT+j5Zfzy1zbAv7eITnRFLSHXo9gpejvAYyOl6wnAIUsE+BxMTbVjkWZ3Xrt36zF+269DNpcTlB+Orrvia1NaXRsDEfImrlF6Y0tes2Fg1493z3Ey5diUPD1v7qy2bffHsQMZlc1lCyeFH88fcJ3L17V4927foNxJ46p53lLa4CW7kmWCrr1a6O2YtWoXmjujKrT/nz5UFc/HX9/OUr8fDOn1c/7+nhgdovVcW4sP7qrPP23Qf0dYYZ+YKcrFeCZMPy1HlXVzdYPrnCxcXFCutx4zqssj8fOAOuNLeyueVfr27gPwrcF+DUUQRcXFzBY4Oj7K2sjdM1a4uZttTWHfswbGCA/ktpMWsWYO+Bn9TdD9LroVqVCsifNw+WfLxWVUtwK3d4qPvKiyhcqIAq003avNYInd56HaVKFNMVqcdqlStgU8xuJNy8peaj121BtcrlVf7I0T9xJe6qysudH47HnkbhgvnVvOFEzkzPXbwK1auURwktCDesS5330AJoayR3d3dYYz1ch4dVnd3d3ay6Pu5f6+zf1McJzlOAAvYtYK1jo7kUmr8VgDmLVqLngJF407c/Jn64GMkpJwv9+4bh1q3beKmJj0p//RMLOYk3a+HHeN0nCI3adMOkmUv07Y+dOI0m/+uOD+evUP3JmeTVG2LUUFeu3gQ5uyzrkv4Gj5iiyh1xYrGAV27ntf/gYTSs95LeRb4gVuPFCti553t9WerMlNGD8PfxU5Bbg/kGD4OXpwc+GNAjdTOUfKoYOnd8PU15w3o10aBuDW2nRUBubXbpcjyC/X0g/85duIiuvYerulY+wShSyBuvN68vVSpNnh2lru/tERIBT229I4YEqnJLTtg3BShAAQpQgAIUeFSBo7//jTmThuPTxVNxTDuBt3PPQdXFklmjkSOHFw5+/alK5Z4pjSjtROLhX/7ApIhQLJ83AefOX8TCj6JVe5lcvXZdO/nijgXTR2LRzFFYoNXJJ+TvvNVK+yS9Dnr3eEf1NXnUIGnukMliAa+Xpye+/mJRmrsgTNawmzeqo7A6tW+FkEDjW4MVLuiNCSNCEDV7NJZHjlPBrgTKsoC7mxu2rb1/izKZ1yW5jnfs8AfXtgT4tseKeeMhtzaTct3Z4RaN62L9xzO1HRqOXRujMHHkQMiZU+ln4Yxwtb7IKcMh6w7066gF255SpU/pjVdfyQwFKEABCjyOAJelAAUeQcD37TYqSPXwcEfVSs/j19//yXDpT9duRv9enSHfgZJProO6++BLg98scHV1RY8ub6nlCxXwVicVf//ruJp3lonFAl5nAeJ2UIACFKAABShAAXsTkMBUNyY5IRh/9Zpu1uhRfnQrTquTSx3ksgRJ7/Z8D+cv/KdvJycW5TtOugIPd3dk1J+ujaM9OlbA62i6HC8FKEABClCAAhSwooCLi4vR2uQHu+Qs8JplH6rLEnSXOsijUcMMZlxcjPvLoJndFzPgtftdxAFSgAIUSCvAEgpQgALpCRQskB+JiXdw8b/L+up327+BSTMXQ+58JYXqe1bfH5HsQ1Ohgt44c87xf4SLAe9DdzUbUIACFHh0gSvNR4DJuQzO1AvFpabDuV+d7Ll9rv7gR3+B2/EScnlC+zbN0conSH+XhiB/H1StVB5dAt+H3KM3cGAEjhz9w6St+F+rxtjx7UHVl53epcGk7WDAaxITG1GAAhSgAAUoQAHbCMiX/dcun6lf+dbVCyF3X9AV9OzaAcNCe+lmMbhvN/3lC9JO96W0L1bMwu4vl2Hp7LGQZWSBsmVK4OsvFktWnyKnjkDLpq+q+adLl0DMmoWqP96lQZFwQgEKUMBOBTgsClCAAhTI1gI8w5utdz83ngIUoAAFKECB7CSQXbeVAW923fPcbgpQwKICBbaOApNzGTz17VQU2jaG+9XJnttP7pps0WMBO7cPAQa89rEfOAoK2JEAh0IBClCAAhRwLgGbBbz7vz+MZm/2RGDoaPToPxL9P5gI+Zk8Q94vt+6Cf98R6N4vXGsTju9+uH8LjVkLP0HtFp3TpLBxszFyYiQ2Gfx6iNxwuVHb7qpbyYdPmIuO/qHo0C1U9X39RoKqCwiJQJegoQgaNAZ+fcIwPyoactsOSemtS8piT51Ty3JCAQpQgAIUoIATCnCTnEbAZgGvCL7w/DOYNzUMiz4ciS4+b6Df+xPw97GTUoVd+w5h/kefY1xYPyyeGYEh/fwxfOxsVd83oBP2bVmhktxQedvahSo/emgftWxGk9UbtuHqtRtYFjke0UunYmBwF6Omg/v4IXLKcMyfFobjsacxatI8eHl6qr5lfbJen3Yt9POlSz5ptDxnKEABClCAAhSgAAXsT8CmAa8hR80XK6LD/5pjRfSXqviztZvRrVNbFHuisJp/7pnSePONJohet1XNZ2VyJS4eVSo+hxxenmrxShXKQe5Xp2YMJhLkDgvtib0HD+Psece/2bLBpjFrfgH2SAEKUIACFKCAnQvYTcArTtUql0fsqbOSVb/qUVkLSNVMyuSF8s/i1NkLKXOP/tC2ZWNs2LxDXbawaPkanDx9PsNO8ubJjXJlS+HYiTMZtmEFBShAAQpQgAI6AT7ag8DEY7tQMGa0yUna28O4LT0Guwp45cbIhhvs4uJiOPvY+TKlimPV4knw9WmtBbKn4Bs0FMdjMw5oU48nvQEkJCTA0unmzZu4fTvR4uux9Haw/7TPlcRE7ldnfF6kd6xgGQUoYL8C8j5rjWOR/Qo4/8jsKuCVs6mlSjyp1J968gn88ttfKq+b/Pr73yhZvKhuNt3H/PnyIC7+ur7u8pV4eOfPq5/39PBA7ZeqYlxYfzRpUAvbdx/Q1xlmkpKTtbPN5yBBsmF56nyOHDlg6eTl5QUPD3eLr8fS2yH9Mxk/X9zduV+d8TkB/qMABRxKQN5nrXEscigUEwY7ZfZSfLVttwktbd/EbgLeY7Gn8enazejS8Q2l0rHda1j6yTpc/O+ymv/j7xOQL511bNdCzWc0qVa5AjbF7EbCzVuqSfS6LahWubzKHzn6J67EXVV5uTvDcW2dhQvmV/OGk6SkJMxdvArVq5RHiYcE2HIWmMkVNKABnwMPngOGxxPmKZCBAIvtSMBaxy872uRsNxSbBry//vGP/rZkMyJXYNQHwXi2bCm1E+rXro4A37fwXsQMdUuyybOWQu7C8EyZksjsX8N6NdGgbg30HBABv97DcelyPIL9fSD/zl24iK5amdS18glGkULeeL15falSafLsKHV9b4+QCHh6emDEkEBVzgkFKEABClCAAhSgQMYChw7/Cv++Yejc6z0MG/Mhrl2/oRqPnTofY6bMR+DACFUn7aTi1u1EhI2bhXcCBiNk6AS17O9/HpMqiySbBby1alZFzJoF+tuSzZzwPuSuCYZbKcHoklmjsOjDCJXkUgTDesnLLcnk1mSS16UA3/ZYMW88ouaMwdjh/VC4UAFV1aJxXaz/eCYWTA/Hro1RmDhyIOQjZalcOCMcyyPHqduSRc0ejUC/juqWZFKnS53at0JIoPGtzHR1FnlkpxSgAAUoQAEKUMDOBeQyUAlye/d4ByvmT4Sbmxs+WrlOP+rk5GTMmRKG+dNHYtrcj1T56vVbIZ+2f7Jgkoq5fv71T1VuqYnNAl5LbRD7pQAFKEAB5xPgFlGAAvYrcObsBeTLlwc1qr6gBunT7jUc/uUPlZdJ7ZdfhJurK+QEpe7SUvmUv22rxnBxcUH558qiYvlnpanFEgNei9GyYwpQgAIUoAAFKJA9BDzc3fUbKp+e38M9/byb24Nw8+69++Xy4K6dCdY1cnd302Ut8vhgBBbp3pqdcl0UoAAFKEABClCAAtYWeKp4UcRfvY6ffvldrfqzLzajWpUKKp/RpGL5Z/D9T0dV9dVr1/H7n8dV3lITBryWkmW/FKBAtha40nwEbJa4bovYn6kXiktNh1ukbz5XbPd6OVd/cLY+Vplj4+VMbcT7vTFz/sfqi2m3bt1G17fbZtr1W22aQ24d22fIWEz8cDHKlimBPHlyZ7rM41Qy4H0cPS5LAQpQgAIUoAAFsqnAoD7d0LLpq2rrq1d9AUtmjVZfWhs7vD/y5M6lyoeF9kKT+rVUXiZffTZPHuDUtcp5AAAQAElEQVTp4Y6hA3ti9qRhkC+73bx5C08WK6LqzDnR9cWAVyfBRwpQgAIUoAAFKEABqwgkJ99Fs3bd8Xb3QXhv5DQM7uevvthmqZUz4LWULPulAAUcRIDDpAAFKOA8Au+VrY/LzcJMTtLeFlvvoZ3h3b1pOVYtnoLl8ybg5eqVLToMBrwW5WXnFKAABShAAQpQwEEEnHiYDHideOdy0yhAAQpQgAIUoAAFAKsHvJ17fYBhY2Yqe7kdRfd+4SqvmyTfvYvmb/XCf5fjVNHUOcsgPwN8T27YpkqAr3d+h+DBY1PmoG5u3DV4GGTZkRMjsSlml77uRsJNNGrbXc1LPnzCXHT0D0WHbqHw7ztC/cqHVAaERKBL0FD108J+fcIwPyoatxMTVardojPSS7GnzsmiTBTITgLcVgpQgAIUoIDDCVg14D0eewaJdxJx6PBvSLh5S/0ix7kLF3H+wn96uP3fH8GzZUuhcEFvSJC749sDKKTlJTjWNWrS4BWV3frNXhXkTp4dhff6+z/0YufVG7bh6rUbWBY5HtFLp2JgcBfVj24yuI8fIqcMx/xpYTgeexqjJs2Dl6cn9m1ZoVLfgE7waddC5aWsdMkndYvykQIUoAAFKECBbCXAjXUkAasGvBKgtmxaHy/XqIyde75XPyfXrGFtbN6+R2+2bcd+NE0JaA/++AvKlimJDm2aYes3+/RtJPNBSHdELvkMH32yDtWrlMcLzz8jxZmmK3HxqFLxOeTw8lTtKlUop79thipImUiQOyy0J/YePIyz5/9NKeUDBShAAQpQgAIUoIAjClg14N22cz9aNq2L15rURcyOvcqreaM6+HrXdyqflJSEPd/9qL9fmwS5zRvVRpMGtbDvwGFIvWqoTUo+VUwrfwWr1m5GL7+OWsnD/2/bsjE2bN6hLltYtHwNTp4+n+FCefPkRjntTPOxE2cybMMKCjxMgPUUoAAFKEABCthewGoB79Hf/0GhAt4o9kRh1KpZBX8dO6V+hk5+Wk5uNizXw367/ydUqvAM8ufLo4Lb/QePoGnDWsidK6d2ZrYc9mhBr45MLnf4/sejyJc3N/4+flJXnOljmVLFsWrxJPj6tMaxE6fgGzQUx2MzDmhdXR/Ok5BwA5ZON28mIDHxtsXXY+ntYP9pnyuJiYncr1Z4DVn7uScHImuvk+tL+/oyt8mdO4mQ47G5+80m/dntsU7eX621X+XYYOm04KNovNTEx+Qk7S09Jnvo/+ERnZlGufWbvTh89A/15a86r3XBf5euaGd296ve5bIGOeMbs3MfmjWso8r2fPcTLl2JQ8PW/mqZb749iBiDyxqi121VlzEMGxiAyTOj1PW+sqAEy3Hx1yWrkvxsnXf+vCovE08PD9R+qSrGhfXXzhDXwvbdB6Q4TUpKToYE4RIkp6k0KMiVKzcsnXLmzAVPTy+Lr8fS28H+0z5XPD09uV+t8Bqy9nNPDhHWXifXl/b1ZW4TDw9PyPHY3P2yP8vvu8yMPbX3V2vtVzk2MNlGwNUaq5WzsTE79mHNsun6L3xNGzMY23Z+p1YvlzVIQHzop1/RoG5NVbZVay/BrHw5TFLMmgXYe+AnddeEK3FX8cnnm9DLrwOqVamA0tqZ27Ubv1bLVatcAZtidkO+FCcF0eu2oFrl8pLFkaN/QpaVmes3ErSzu6dRuGB+mTVKcunE3MWr1LXBJYoXNarjjAUF2DUFKEABClCAAg4jEH/1OoaO/hABIeHo3i8M/+vcN9Ox37x1C6vWfJVpG0tVWiXg/eHwr3iiSCE8WbSIfjvki2v/HD+lbj/2dOmn4OnhiepVKyBXzhwqqN1/8DAa1ntJ3z5P7lyo8WIF9WU3uVVZF5831KUP0iCk17tYunKdusVYw3o1taC5BnoOiIBf7+G4dDkewf4+kH9yR4iuWpnUya3OihTyxuvN60uVSnK3h6BBY9AjJEI7o+qBEUMCVTknFKAABShAAWsKcF0UcASBHXsOoOgThbBwRgRmThj60CHfupWI1RtiHtrOEg2sEvDWfLEiomaPNhq/m6srtnw+TzvD6q3KV8wfj7HD+6m83CXh6y8WpbmDwuSIUMjZ4DHD+uCt1s1UW5kUKVwQGz6ZpW8f4NseK+aNR9ScMarPwoUKSDO0aFwX6z+eiQXTw7FrYxQmjhwId3d3VbdwRjiWR45TtyWTsQb6dVS3JFOVKZNO7VshJND4VmYpVXygAAUoQAEKUIAC2Ubg6O9/I+qTddimfSIfPMg4xos9dRbtuvTH290HIaB/OI6dOK1cFiyLxvkLF9UZ4TmLVqoya02sEvBaa2Oy13q4tRSgAAUoQAEKUMA2AhXLP4t33mqpPimfOyXMaBAFvPNpZ31HYtXiKQjo2h4TZy5W9T19O6CY9mm/nBHu3eMdVWatCQNea0lzPRSgAAUoYBkB9koBCtiVQI4cXpDvZoWGTcbCZZ/jxMkzNh8fA16b7wIOgAIUoAAFKEABCjiPwKrVX+HU2fMY3Kcb5k8Lx82bt22+cdkl4LU5NAdAAQpQgAIUoAAFsoPAydPnUKPKCyhWtLC6w1ZScpLa7Fy5cuDatRsqb+0JA15ri3N9FKAABWwqwJVTgAIUsKxAh/+1wOxFn6DXwAj8cPhX5M+XV61QbkrQ+rWG6DNkLPilNUXCCQUoQAEKUIACFKCAPQt0/N9rCOx2/9avuXPlxBcrZqnhPv9sGZWXyxn69+qMrz6bp8plIl9Wmz1pGORR5q2V0j3Da62Vcz0UoAAFKEABClCAAhSwtAADXksLs38KUMCRBTh2ClCAAg4l0LNrBxz8+lOTk7R3qA3M4mAZ8GYRjotRgAIUoAAFKECB7CPg2Ftq84A3csmnqN2is1E6c+6C0bxh/T8nTqP+G35G6ss+3YBZCz9RZSMnRmJTzC6Vl8mNhJto1La7ZCH58Alz0dE/FB26hcK/7whcv5Gg6gJCItAlaCiCBo2BX58wzI+Kxu3ERJUM12+Yjz11Ti3LCQUoQAEKUIACFKCA/QrYPOAVGjmdvm/LCujSU08W1ef7BnSCT7sW+vnSJZ+URbKUVm/YhqvXbmBZ5HhEL52KgcHGPxM8uI+f+mnh+dPCcDz2NEZNmqd+Xlg3LnOOJUsbwIUoYOcCHB4FKEABClDAHgXsIuC1FsyVuHhUqfgccnh5qlVWqlAOeXLnUnnDidw2Y1hoT+w9eBhnz/9rWMU8BShAAQpQgAIUeJgA6+1MwC4C3gUfResvYWjaLuChRHfuJOnbyyUGclnEQxfSGrRt2RgbNu9Qly0sWr4GJ0+f10rT/z9vntwoV7YUjp3I/OfwkpOTYY109+5dq6zHGtvCdTx4znC/PrBwpueFHFWcaXu4Lfefp3y93ndwtueDNferHBuYbCNgFwGv4SUN29YufKiEh4e7/hIHudwgyP/+PeAetmCZUsWxavEk+Pq01gLZU/ANGorjsRkHtK6uD+e5c+cOLJ2SkpJUsGvp9bB/y+9LI2PtuSNvHKnLOG/9/WBuczkWmbtP9mf750Vy8l3I8Zj7wvb7wpz7QI7D1tqvcmxgso3AwyM624wry2vNny8P4uKv65e/fCUe3vnv/8KHFHp6eKD2S1UxLqw/mjSohe27D0hxmpSknbmVL6VJkJym0qAgR44csHTy8vKChzZuS6+H/Vt+X6Y25n61vnnqfWCJeTlEWKJf9mnb54uHdrJFjsfcD+bfD7Y09dDeX621X+XYYOl0e/lyxDdvbnKS9pYekz3073QBb7XKFbApZjcSbt5SvtHrtqBa5fIqf+Ton7gSd1Xl5e4Mx2NPo3DB/GrecCJ/6c1dvArVq5RHieJFDauYpwAFKEABClCAAhRwMAG7CHgNr+GVa3L/PnYyy4wN69VEg7o10HNABPx6D8ely/EITrnk4dyFi+iqlUldK59gFCnkjdeb14fu3+TZUer63h4hEfD09MCIIYG6Kj7aXIADoAAFKEABClDA3gW+2rYbk2ctfaxhrlrzFW7eun/i8rE6MljY5gGvXH8r1+EapmfLltIPsVP7VggJfHD7MHc3N+zaGKWvl4xckyu3DJO8pADf9lgxbzyi5ozB2OH9ULhQASlGi8Z1sf7jmVgwPRzSx8SRA+Hu7q7qFs4Ix/LIceq2ZFGzRyPQr6O6JZmqTJmkHktKMR8oQAEKUIAC1hPgmijg5AKrN8Tg1q1Es26lzQNes24NO6MABShAAQpQgAIUsIrA9t3foc+QseoHvXy6h+rXefbcv+g9eAze6hqCVWs26cs/X7cVXYI+wDsBgzE/6jN9+Zu+/TF1TpT2KftoTJq5BOe1T+QHDp+Efu+P17d53AwD3scVtM/lOSoKUIACFKAABShgUYEP563A5FGh+GzJVMyeOEy/LrmEVD5FXz5vAqK1IDfu6jUcO3EaC5d/jg/HvY8ls0Zj28792HvgJ/0yJZ8qpn3KHoYh/fxRrGgRTBszBDMnfKCvf9wMA97HFeTyFKAABShgxwIcGgUoYCmBqpWex6QPl2Dpx2tx9949/WqqaOXyw165cuZA2TIlcfLUOfz4829oXP8VFCyQHzlz5MAbLRrg8C9/6JdpXL+WPm+JDANeS6iyTwpQgAIUoAAFKODkAqM+6IO332qFe9p/gQNH4dbt+9fdeqR8P0o2383VVd2/WvKG5fKdLFlOyiV5etz/TpXkLZEY8AKwBCz7pAAFKEABClCAAs4scO36DTz/bBn4v/sm3N1ccf7f/zLc3GqVK+Cbbw9Afh9B7sDwZcwuVK9SId32cmY4/uq1dOuyWsiAN6tyXI4CFKCA8wlwiyhAAQqYLNDRPxSt3+mN9yOmqzthlSlZPMNly5Ypga4+bdF/6AT49w1Dgzo1Uatm1XTbv9vhDcyYt5xfWktXh4UUoAAFKEABClCAAlYT+Oqzediwcg4mhA9AD9/2ar0tm76KwX27qbxMpK561Rcki/Ztm2N55HisXDgZvfw6qjKZrFn2IfLlzSNZlZo3qoMZ49638ZfW1FA4oQAFKEABClCAAhSggGMI8JIGx9hPHCUFKGCHAhwSBShAAXsT8OrSBfm3bjU5SXt72wZLjMdiAW9ScjJqt+iMwNDR6DVwFHr0D8fmr7812oYvt+6Cf98R6N4vXNV/98MRo/od336Pbn3CtLqReCdgCCbPjkL81euqTUBIhOpf1iFJriORipETI7EpZpdkVbqRcBON2nbX58MnzFU3SO7QLVSt+/qNBFUn/XUJGoqgQWPgp61zflQ0bicmqiT9p5diT51Ty3JCAQpQgAIUoAAFsrGA3W+6xQJe2XIPD3fMmxqG+dNGYMzQvljy8VrIz8VJ3a59hzD/o88xLqwfFs+MUDcaHj52Nv4+dlKqsf/7w5g0awnCBgVi0YcjsWB6OIoWKYSTpx8EmdLvvi0rIElueqwWzGSyesM2XL12A8sixyN66VQMDO5i1HpwHz9EThmujTcMx2NPY9SkefDy9FT9yzr6ocA4MwAAEABJREFUBnSCT7sW+vnSJZ80Wp4zFKAABShAAQpQgAL2J2DRgNdwc4sVLYzQ3n5Y8dmXqviztZvRrVNbFHuisJp/7pnSePONJuoXOaRg5erN6N65HcqWeUpmkTdPbvj6tEblF8qp+axMrsTFo0rF55DDy1MtXqlCOciNkdWMwUSC3GGhPbH34GGcPf+vQQ2zFKBAlgW4IAUoQAEKUMBGAlYLeGX7alarqO7RlnjnDs6c+xeVtYBTynXphfLP4tTZC2r21JnzqFrxeZXPaNJr4Cj9ZQ2DRkzJqJm+vG3LxtiweYe6bGHR8jU4efq8vi51RgLscmVL4diJM6mrjObv3EmENVJycpJV1mONbeE6HjxnuF8fWDjT80IOEs60PdyW+89Tvl7vOzjb88Ga+1WODZKYrC9g1YD33r17cHN9sEoXF5dMt9jV7X5bCTp119B+unaLfhnDSxqmjBqkL88oU6ZUcaxaPEmdKT524hR8g4bieGzGAa2rwVgz6pPlFKAABShAAQpQgAL2LXA/orTSGE9owWXhQgXg6eGBp558Ar/89pfRmn/9/W+ULF5UlZV8qph2dvW0ystlDXINrVw/qwoymeTPlwdx8df1LeQXPbzz59XPy7prv1QV48L6o0mDWti++4C+zjAjX7qTL6VJkGxYnjrv4eEJayQ3N3errMca28J1PHjOZLxfH7Shl+NZyHGC+83x9tvD9hlfr863T2WfW3O/yrGByTYCVgt44+KvYuaCT9C54+tqSzu2ew1LP1mHi/9dVvN//H0C8qWyju1aqPl33noN0+Yuw9c7v4OcGZbCm7cS5SHTJD9dtylmNxJu3lLtotdtQbXK5VX+yNE/cSXuqsrL3RmOx55G4YL51bzhJCkpCXMXr0L1KuVRIiUAN6xnngIUoAAFKEABKwlwNRQwg4BFA947d5L0tyUbNGIqXmtaF+3bNFfDrl+7OgJ838J7ETMgtyybPGspRg/tg2fKlIT8q1WzKob09ceyT9fj7R6D0bpTXyQm3kGLJnWkWiXDa3hbtA9UZQ3r1USDujXQc0AE/HoPx6XL8Qj294H8O3fhIrpqZVLXyicYRQp54/Xm9aVKJbntmdyWrEdIBDw9PTBiyP0+VSUnFKAABShAAQpQgAIOKWCxgNfdzU3dvkt3W7JFH0agVdNXjZAk2FwyaxSkTpJcamDYQILXj+aOxaeLp2DDJ7MQrgWg3vnuX56wcEa46l8udZC05fN5+kUDfNtjxbzxiJozBmOH94NcRiGVLRrXxfqPZ6pbnO3aGIWJIwfC3d1dqiD9LY8cp25LFjV7NAL9OqpbkqnKlEmn9q0QEmh8K7OUKj7YVoBrpwAFKEABCjidwL//ngdT+gaPurMtFvA+6kDYngIUoAAFKECBxxXg8s4iULBgITBlbvAo+5oB76NosS0FKEABClCAAhSggMMJMOB1uF32+ANmDxSgAAUoQAEKUCA7CTDgzU57m9tKAQpQgAKGAsxTgALZRIABbzbZ0dxMClCAAhSgAAUokF0FGPA+bM+zngIUoAAFKEABClDAoQUY8Dr07uPgKUABClhPgGuiAAUo4KgCDHgddc9x3BSgAAUoQAEKUIACJgmYOeA1aZ36RgEhEegSNFT9Kpp/3xFY/9U3RnW+QcP080d//0f9apsU7P/+MJq92VPNdw78AOET5uK/S1ekCiMnRmJTzC6Vl8mNhJto1La7ZCF5advRPxQduoVC1nn9RoKq041FfmnNr08Y5kdF43Ziokq1W3RGein21Dm1LCcUoAAFKEABClCAAvYrYNOAV1gG9/FTv3w2PLQXps9boQJMKZckAeqeAz9JNk164flnIL/iJr+m5uHhjs++2JKmTeqC1Ru24eq1G1gWOR7RS6diYLDxr6bJWCKnDMf8aWE4HnsaoybNU7+2Jr/kJqlvQCf4tGuh/4W30iWfTL0KzlOAAhS4L8ApBShAAQrYjYDNA16dhKubK/LkygkPd3dV5OICdH27NT5auU7NZzRx1Rq6uLigYAHvjJroy6/ExaNKxeeQw8tTlVWqUA55cudSecOJl6cnhoX2xN6Dh3H2/L+GVcxTgAIUoAAFKEABCjyCgD00tXnA22vgKHW5wDs9BiPA9y24uj4Y0vPlnlYB8OFf/khjdeDQz2q5ui198fOvf+KNFvXTtEld0LZlY2zYvANy2cKi5Wtw8vT51E3083nz5Ea5sqVw7MQZfRkzFKAABShAAQpQgAKOJ/AgurTR2OdPG6EuEVgxfzxWRG/EhYuXjEbi16ktln7yBVL/e7l6ZbXc118sQrOGdRC55LPUTdLMlylVHKsWT4KvT2stkD0F36ChOB6bcUBrGHyn6Syl4Natm7B8uoXExEQrrMca28J1PHi+3MKdO3estl9v3rwJ+02OObYH+9L4eS2Hh4zqWG5s9Sgetn7+6l6vth6HOdf/KP7O2lb26+3bt6xyLJZjA5NtBGwe8Oo2+5kyJVG2dAkcOvybKrp3T3vQJi9Vq4TLV65qgelpuLi4aIXG/+fKmQMN6tTAAe2Mr9Tkz5cHcfHXJavS5Svx8M6fV+Vl4unhgdovVcW4sP5o0qAWtu8+IMVpUlJyMuRLaRIkp6k0KPDw8ISlk6enJ9zd3S2+HktvB/v3TLUPPeDm5paqzNNi815enmAyr0FGz2k5RGRUx/KsP8dt/fyV47Cnp5dTvY74fPRUx2F3dw+LHXsNjeXY8NDEBhYRsJuAN/7qdRz94xgKFcyfZkPlUoeoletwTwuA01RqBfu//xmFUq7hrVa5AjbF7EbCzVtaDRC9bguqVS6v8keO/okrcVdVXu7OcDz2NAqns76kpCTMXbwK1auUR4niRVX7jCYSsFg6yZlmSZZeD/t3Uwc+azpYc7+6urqBybwGbtofLOklOV6kV84yt8d6jdn6+evi4qK9hly15OY0ic9J2Zeuj/W8fBRD8J/NBFxttuaUFU+eHYXAgaPRplNf1KpZBXKpQkqV/uHV2tW1v7zc9fOS+fWP+7cp8+k+CJ+s/hJ9e74jxWhYryYa1K2hbnXm13s4Ll2OR7C/D+TfuQsX0VUr6zkgAq18glGkkDdeb/7g2l8Zi1zf2yMkAp6eHhgxJFAWY6KAvQlwPBSgAAUoQAEKPIKATQPehTPCsTxyHOZNC8POjUsxbGCAfuhSJ19a0xWsXDhJ3YZM5mvVrIqYNQvU/KeLp2DTp3NRsfyzUqVSgG97rJg3HnLLsrHD+6FwoQKqvEXjulj/8UwsmB6OXRujMHHkQHWpgFTK+mQscluyqNmjEejXEV6enlKlT53at0JIoPGtzPSVzFCAAhSgAAUoYGUBro4CpgnYNOA1bYhsRQEKUIACFKAABShAgawLMODNuh2XdBABDpMCFKAABShAgewtwIA3e+9/bj0FKEABCmQfAW4pBbKtAAPebLvrueEUoAAFKEABClAgewgw4M0e+9n0rWRLClCAAhSgAAUo4GQCDHidbIdycyhAAQpQwDwC7IUCFHAeAQa8zrMvuSUUoAAFKEABClCAAukIMOBNB8X0IrakAAUoQAEKUIACFLB3AQa89r6HOD4KUIACjiDAMVKAAhSwYwG7CHgDQiLQJWgoeg6IgH/fEVj/1Te4nZiI2i06p5tiT53D1zu/Q7c+YejRfySCBo3BJ59vUswjJ0ZiU8wulZfJjYSbaNS2u2Qh+fAJc9HRPxQduoWqdV2/kaDqdGOQvvy0fudHRasxPGwcamFOKEABClCAAhSgAAXsVsCaAW+mCIP7+GHB9HAMD+2F6fNWqLb7tqyApL4BneDTroXKy/y5C/9i6tyPEP5eMBZ9OBKRU4bjiSIF1TKZTVZv2Iar125gWeR4RC+dioHBXYyayxikr/nTwnA89jRGTZoHL09P/XpTj6N0ySeNlucMBShAAQpQgAIUoID9CdhNwKujcXVzRZ5cOeHh7q4rSvO4cvVmdO/cDmUMAs6mDWqlaZe64EpcPKpUfA45vDxVVaUK5ZAndy6VN5xIkDsstCf2HjyMs+f/NaxingIUoIAZBNgFBShAAQpYU8BuAt5eA0epyxfe6TEYAb5vwdU146GdOnMeVSs+/8hObVs2xobNO9QlEIuWr8HJ0+cz7CNvntwoV7YUjp04k2EbVlCAAhSgAAUoQAEKPIaAlRbNOKq00gB0q5k/bYS6dGDF/PFYEb0RFy5e0lWl++ji4pJueWaFZUoVx6rFk+Dr01oLZE/BN2gojsdmHNBmFnTr1nPjxnVYOiUk3MDt27csvh5Lbwf7N36uyH5NTLzN/WqF15C1n3tyfLD2Ork+49eXJTzk9SqvW0v0zT4tv/8yMr59+zZu3kywyrFYjg1MthGwm4BXt/nPlCmJsqVL4NDh33RFaR5LPlUMR379M025FOTPlwdx8dclq9LlK/Hwzp9X5WXi6eGB2i9Vxbiw/mjSoBa27z4gxWlSUnIy5MtxEiSnqTQoyJ07DyydcuXKDS+vHBZfj6W349H6z61tr3OnXLlywdPTy4rbmUdbl0Mmhxu3HCIe7fnO/eIIXvJ6zaUdjx1hrKaP0bmPs7lzP3z7vLy8kDNnLu048/C2pvSXmb0cG5hsI+Bqm9VmvNb4q9dx9I9jKFQwf4aN3nnrNSz4aDW++fagvs22nftVvlrlCtgUsxsJN2+p+eh1W1CtcnmVP3L0T1yJu6ry128kaGd3T6NwOutJSkrC3MWrUL1KeZQoXlS158TaAnIGPzskcbXWdsq6mChAAQoYCljr+GPP69F5mGuMuv4s8cg+sypg1oD3j79P4PP1W1X661jsI41p8uwoBA4cjTad+qJWzSp4uXrlDJevVbMqBvXuiqUff4F3At5DnyHj8O/Fy6p9w3o10aBuDXWLM7/ew3HpcjyC/X0g/85duIiuWpnc/qyVTzCKFPLG683rS5VKMga5LVmPkAjtzJsHRgwJVOWcUIACFKAABShAAQo4roDZAt6pc5Zh+tzlOHXmAv46dgqjJy/A9MjlJsksnBGO5ZHjMG9aGHZuXIphAwOMluvUvhVCAo1vIdakwStYFjkWKxdOxOxJQyFtdAsF+LbHinnjETVnDMYO74fChQqoqhaN62L9xzPV7c92bYzCxJED4Z5yNwjdGCKnDEfU7NEI9OsIuVuDWjBlIutIPY6UKj5QwG4EOBAKUIACFKAABYwFzBbwnjx9TgWsA4K64IOQ7lgyKwJ7D/xkvDbOUYACFKAABShAAesIcC0U0AuYLeB1d0/blXxBTL8mZihAAQpQgAIUoAAFKGADgbRRahYHkSNHDgwKm4Kvtn2Lz77YgsDQMepHHg7++AskZbFbLkYBywqwdwpQgAIUoAAFnF7AbAHvpctxuJ5wE+u++kbd6svd3Q3HT57B4hVrVXJ6SW4gBShAAQpQwIEFOHQKOLOA2QLeeVPDkFlyZkRuGwUoQAEKUIACFKCA/QqYLeCVTbxzJwm//PaXuoRBLmOQJFAR+JYAABAASURBVOVMziLA7aAABShAAQpQgAKOJ2C2gPfb/T/iTd8QhAydhMmzlqLf+xMwe+FKxxPhiClAAQpQgAIPE2A9BSjgUAJmC3jnLF6FhR+OxLNlS+GzJVOxdPZoLV/aoTA4WApQgAIUoAAFKEAB5xMwW8ArX1Ir9kRhyGUNwlS+3NNIuJkg2eyauN0UoAAFKEABClCAAnYgYLaAN1fOHGpzvPPnwbpN2yGXOFyJu6bKsjqRnwA+cvRPJCUno3aLzka/3Lbs0w1Y8FG06jpyyadY+sk6lR85MRKbYnapvExuJNxEo7bdJQvJh0+Yi47+oejQLRT+fUfg+o37QXlASAS6BA2F/LSwX58wzI+Kxu3ERJVk3eml2FPnVL+cUIACFKBAZgKsowAFKGBbAbMFvB3aNkfc1WsI7v42tu38DiuiN6JX1/Zm27ocXp7Yve8Q4uKvZrnP1Ru24eq1G1gWOR7RS6diYHAXo74G9/FD5JThmD8tDMdjT2PUpHnw8vTEvi0rVOob0Ak+7VqovJSVLvmk0fKcoQAFKEABClCAAhSwPwGzBbxNG9SCd768eKZMScya+IG6RVm1KhVM3uLMGrq4uMDd3R1tWzbCqrWbM2uaad2VuHj1YxgSPEvDShXKIU/uXJI1ShLkDgvtib0HD+Ps+X+N6jhDAQpQgAIUoAAFKOBYAmYLeNt1CYFcTrB+8w78+99liyi0b9sMW7bvVZcmZGUFbVs2xgZtfHLZwqLla3Dy9PkMu8mbJzfKlS2FYyfOZNhGKu7evQtrpHv37lllPdbYFq7j/nPm3r27uMf96pTP68c8NjiliTO87vl6veuUz03Zr5Ks8RyVYwOTbQTMFvDKWd0Xni+LvQd+QudeH+B/nftj7LSFZt2q3LlyomWTuvh8XUyW+i1TqjhWLZ4EX5/WWiB7Cr5BQ3E8NuOA1tX14Ty3b9+CpVNi4m3cuXPH4uux9Haw/1tG+/DWrVvcr1Z4/djieScHKFusl+s0fo2Z2yMpKQlyPDZ3v+zPsvvtYb537iQaHZsf1v5x6uXYwPQoAuZr+/CIzsR1lSheFB3/1wIBXd5C17fb4K525ur7H4+auHTmzeQvL0nS6u03W2LNxm1ISkqGi4uLFBml/PnyIC7+ur7s8pV4eOfPq5/39PBA7ZeqYlxYfzRpUAvbdx/Q1xlm5Ity8qU0CZINy1Pnc+bMBUunHDlywtPT0+LrsfR2sP+0zxXu17QmzvA8keOEM2wHt8H4+emhvX/I8Zguxi6O7uHp6QVr7Vc5NjDZRsDVXKsdNXmeusvBkk++QO7cOTFn0lCsXT7DXN3r+8mXN48WqL6i7sSgC4L1lVqmWuUKWt1uJNy8pc0B0eu2oFrl8iovd3y4Enf/S29yd4bjsadRuGB+VWc4SdL+ip+7eBWqVykPCeQN65inAAXsS4CjoQAFKEABCjxMwGwB792799T1iK7pnHV92CAetb5Lx9a4cPGyfrE7WoDq5emh5hvWq4kGdWtAbmnm13s4Ll2OR7C/D+TfuQsX0VUrk7pWPsEoUsgbrzevL1UqTZ4dpW5L1iMkQjuj6oERQwJVOScUoAAFKEABClDAzgU4vEwEzBbwjnwvCCvmjUcXn9bq1l/Bg8dCvsiWybofWrVgeri6q4K7mxu2rX1wPXAB73zY/WUUenbtgLt37+LX34+hVIkn9f0F+LZXY4maMwZjh/dD4UIFVF2LxnWx/uOZkH53bYzCxJED1d0fpHLhjHAsjxynbksWNXs0Av06qluSSZ0udWrfCiGBXXSzfKQABShAAQpQgAIUcAABswW8cvb08/VbseTjtVjx2Ubc0874Vq/6gkUJ5DrbJu0C8HTpp1D3lRctui52TgGnEOBGUIACFKAABbKhgNkC3uBBY/HLb/+gzssvYsmsUdi4ajbCBvW0KKmc+f1m3WK8198/3S+wWXTl7JwCFKAABShAAYcV4MCzl4DZAl75gppc1tDmtYb8olf2eg5xaylAAQpQgAIUoIBdC5gt4JUfnJA7H8hlBqMnz0frd/pgz4Gf7HrjOTgKZC7AWgpQgAIUoAAFnEHAbAHvZ2u3qJ/p/e77n3H9xg1MHhWKyCWfOoMRt4ECFKAABSiQvQW49RRwcAGzBbxeXp6K4tCRX1G/Tk2UL/c0r6tVIpxQgAIUoAAFKEABCthSwGwBr4eHO9Zs2IZde39A9aoVIJc2yA842HLjnGndt1q3QVyzZvacOLZH3D/xzZvjdpu2dHtEN0d4HUQ708GH20IBClDACQTMFvC+3787/rt8Rd2/9smiRRB76ixerVXdCYi4CRSgAAUoQIFHEWBbClDA3gTMFvCWKVVc/RBEkwavqG18pkxJBHd/W+U5oQAFKEABClCAAhSggK0EzBbwmmMDOvf6AMPGzDTqKiAkAl2ChkJ+Jjhk6EScPf8vZi38BLVbdE6TwsbNxsiJkdgUs0vfx42Em2jUtrual3z4hLno6B+KDt1C4d93BOTOElKpW0/QoDHw6xOG+VHRuJ2YqFJ665Ky2FPnZNEsJS5EAQpQgAIUoAAFKGAdAbsJeI/HnkHinUQcOvwbEm7eMtr6wX38ID8T/Grt6pg0cyn6BnTCvi0rVMqdK6f62WGZHz20j9FyqWdWb9imfvZ4WeR4RC+dioHBxj8TLOuJnDIc86eF4XjsaYyaNE/9vLD0LUnW69OuhVqvzJcu+eDnjFOvi/MUoAAFKGCSABtRgAIUsLiA3QS8W7/Zi5ZN6+PlGpWxc8/36W74KzWq4J/jp9KtM6XwSlw8qlR8DjlS7ihRqUI5dSu11Mt6eXpiWGhP7D14WJ1RTl3PeQpQgAIUoAAFKEABxxF47IBXflwis2Qqxbad+7WAty5ea1IXMTv2Gi+WMvf9T0dRtkzJlLlHf2jbsjE2bN4BuWxh0fI1OHn6fIad5M2TG+XKlsKxE2cybCMVd+7cgaUT73Yh0kwUcCyBpKQ7YDKvgaWPtQ/rPzk5We3Th7VzpHp5f8nuSfZrcnKStm/NkzLb/451FHOu0T52wCs/OJFZMoXr6O//oFABbxR7ojBq1ayCv46dQvzV6/pFew0chVdf98OObw9icF8/ZPWffLFu1eJJ8PVprQWyp+AbNBTHYzMOaF1dH85z9+5dWCNldZu5HAUoYBuB5OS7sETKzn3eu3cXtkzAPe14f8+mYzD39kugl92TvIcna3/MJGtBrzmS9JdRss3RiGsVgYdHdNIqk/Th+PeQWcpkUX2VXM5w+Ogf6ktodV7rgv8uXcHXu/br6+dPG4HdX0Zhxrj3UKJ4UX15epn8+fIgLv5BsHz5Sjy88+fVN/X08EDtl6piXFh/NGlQC9t3H9DXGWaStCe/fClNgmTD8tR5Ly8vWDp5et7/UY/U6+Y8BShgvwKWPi5kx/49Pb1gy+Tm5q6t31NLth2HOQ28vHLAK5snDy0uEFPzOXgho9en/R6xHHJkjzToxw54Ddd2504SfvntLxz88Rd9MqxPL3/v3j3E7NiHNcum678MNm3MYGzb+V16zR9aVq1yBWyK2a3/4lv0ui2oVrm8Wu7I0T9xJe6qysvdGY7HnkbhgvnVvOFEPt6Zu3gVqlcp/9AA23A55ilAAQpQgAIUoAAF7E/AbAHvt/t/xJu+IQgZOgmTZy1Fv/cnYPbClQ/d4h8O/4onihSC/FiFrvHLNSqrL6f9dzlOV2TyY8N6NdGgbg30HBChbmV26XI8gv19IP/OXbiIrr2Hq7pWPsEoUsgbrzevL1UqTZ4dpa7v7RESof0F74ERQwJVOScUoICDCnDYFKAABShAAU3AbAHvHO2M6MIPR+LZsqXw2ZKpWDp7tJYvra0i8/9rvlgRUVpbw1Zurq7Y8vk87eyrNxbOCFd3VjCsN8xvW7sQcmsyw7IA3/ZYMW885FZmY4f3Q+FCBVR1i8Z1sf7jmVgwPRy7NkZh4siBcHd3V3WynuWR4yC3JZPxBPp1hNytQVWmTDq1b4WQwC4pc3ygAAUoQAEKUIACjiGQ3UdptoDX3d1NfelMLmsQ1PLlnkbCzQTJMlGAAhSgAAUoQAEKUMBmAmYLeHPlzKE2wjt/HqzbtB1yicOVuGuqjBMKUMARBDhGClCAAhSggHMKmC3g7dC2OeKuXkNw97fVF85WRG9Er67tnVPNBluVY8N6eMfEMDmRQf6tW+G1fh33qRPtU91rtIMNjhFcJQUoYEYBduV0AmYLeJs2qAXvfHnxTJmSmDXxA8ybGoZqVSo4HRg3iAIUoAAFKEABClDAsQTMFvAu+Cga6SXH4uBoKWCyABtSgAIUoAAFKOAgAmYLeA2390bCLWzcuhsnT18wLGaeAhSgAAUoQAGnE+AGUcD+BcwW8Pbs2gG6NCCoCz6PmoobCTftX8BBRnirdRvENWvG5EQG8c2b43abttynTrRPda/RaAc5rnCYFKAABbKLgNkC3tRg8hO+d+7cSV3M+WwqwM2mAAUoQAEKUIACthIwW8Cb+vrdcdMWIfnu3YduV/zV66jb0hefr99q1DYgJAJdgoaqXz7z6xOG+VHRuJ2YaNRm6pxlkF9Mk58n1lWMnBiJTTG7dLPqLHOjtt3VvJxxDp8wFx39Q9GhWyj8+46A/MSwVGa0Plln7RadkV6KPXVOFmWiAAUoQAEKmCrAdhSggA0EzBbwph57yRLFMHX0oNTFaeZjduzFs0+XVLcyS105uI+f+uWz+dPCcDz2NEZNmqdvIkHujm8PoFBBb3z/01F9eWaZ1Ru24eq1G1gWOR7RS6diYHAXo+bprU9+bW3flhWQ1DegE3zatVB5mS9d8kmj5TlDAQpQgAIUoAAFKGB/AmYLeHXX7+oeu3R8A7ofo8hss7ft+A6hvbvi3PmL+O9yXLpNJegcFtoTew8extnz/6o2B3/8BWXLlESHNs2w9Zt9quxhkytx8epninN4eaqmlSqUQ57cuVTecJLe+gzrLZ7nCihAAQpQgAIUoAAFzCZgtoA3MHR0mkF17vVBmjLDgvMX/tOC3CsqCG3RuA6+2vatYbVRPm+e3ChXthSOnTijyiXIbd6oNpo0qIV9Bw4jKSlJlWc2aduyMTZs3qEuk1i0fA1Onj6fYfPU68uwISsoQAEKUMBiAuyYAhSggDkEzBbwph6MXC8r17+mLjec37pjH5o1rK2KWr/WEDEPOVPr6np/uBLc7j94BE0b1kLuXDm1gLkc9mhBr+ook0mZUsWxavEk+Pq01gLnU/ANGorjsWcyXEK3vgwbaBW3b9+C5dNtbU38nwIUcCQByx8XrHHs4ToM92NS0h0rHO9pbmhujbx8wT4x8bZV9q0jHcOcbaz3I8jH2Cr5spp8oevwL38YfbGrc+AHePONppn2vG3HfkStXKeW6+g/CH8di83wrGtScjLkS2IStO757idcuhKHhq39UbtFZ3zz7UF9sJw/Xx7ExV/Xr/fylXh458+rn5e7R9R+qSrGhfVXZ4e37z6gZB7dAAAQAElEQVSgrzPMGK7PsDx13tXVDZZPrqlXy3kKUMDOBSx/XHCzwrGH6zDcjy4urjCcZ945nh8uLi5wcbHOvrXzw5ZTD8/1cbdOrtmVL3C1b9Nc/2UumV+7bAbeeatlht3L5QRXr103Wkau+93yzZ40y8gZ3bmLV6F6lfIoUbwo5MzwsIEB+mVj1izA3gM/qbs4VKtcAZtidiPh5i3VT/S6LahWubzKHzn6J67EXVV5uTvD8djTKFwwv5o3nKRen2Fd6ryHhweskVKvl/MUoIB9C1jjuJBmHVY6HmXX9bq5uVnleJ9dfW213e7u7lbbr/Z91HLu0T12wKvjCe3tCwkoP/tiiyr679IVnDh5VuXTm2zZ/i0a13/ZqEqux93y9YOAd/LsKHW9bY+QCHh6emDEkEAV1O4/eBgN672kX1a+eFbjxQrYued7rbwmGtStgZ4DIuDXezguXY5HsL8P5N+5CxfRVSuTOrmdWZFC3ni9eX2pUim99akKTihAAQpQgAIUoAAFHEYg9UDNFvB+tHI9xs9YjHWbvlHrkNuGjZ22UOXTmwT4tke/nu8aVT3/bBl8HjVNlS2cEY7lkePUbcmiZo9GoF9HeHl6qvT1F4vS3F1hckQomjeqo5aVvlfMG4+oOWMwdng/FC5UQJW3aFwX6z+eiQXTw7FrYxQmjhwI+ctOKjNan9TpUqf2rRASaHwrM10dHylAAQpQgAIUoAAF7FPAbAHv5q93Y9ncscibN7fa0iKFC+JGQoLKc0IBClDA/gQ4IgpQgAIUyC4CZgt4vXLkgIeHu5GbC1yM5jlDAQpQgAIUoAAFKGBnAtlgOGYLeAvkz4df//hHkcnlDItXrMWzZUupeU4oQAEKUIACFKAABShgKwGzBbzh7wVizcavcfT3f1D/dT+cOnMeA4I622q7nG69OTash3dMDJMTGeTfuhVe69c5yj7lOB/hudfB6Y5A3CAKUIACji1gtoDXO19eDA/tiU2fzsHaFR9i5HtB8NbO+jo2D0dPAQpQgAIUoAAFDAWYd0QBswW8svF//H0CW7bvwY5vD6gfkZAyJgpQgAIUoAAFKEABCthSwGwB79Q5yzB97nKcOnNBC3ZPYfTkBZgeudyW28Z1U8BmAlwxBShAAQpQgAL2I2C2gPfk6XOYNy0MA4K64IOQ7lgyK0L9+pn9bKpjj+RW6zaIa9aMyYkM4ps3x+02bblPnWif6l6j0Y59uOHoKWBOAfZFAbsQMFvA6+6etitPDw+72EgOggIUoAAFKEABClAg+wqkjVKzaJEjRw4MCpuCr7Z9i8++2ILA0DGoUvE5HPzxF5Ue1u36zTswesoCo2Zdg4epuz4kJSejdovORpdILPt0AxZ8dP88SuTST7H0k3Vq2ZETI7EpZpfKy+RGwk00attdspB8+IS56Ogfig7dQuHfdwSu30hQdQEhEegSNFT9lLFfnzDMj4pWP2N8OzFRrVvWnzrFnjqnluXkMQW4OAUoQAEKUIACFLCggNkC3kuX43BdCy7XffUNtu8+AHd3Nxw/eQZyP15Jj7sNObw8sXvfIcTFX81yV6s3bMPVazewLHI8opdOxcDgLkZ9De7jp37KeP60MByPPY1Rk+apnzLet2UFJPUN6ASfdi1UXuZLl3zSaHnOUIACFKAABR5HgMtSgAKWETBLwCtnYHt3fxvzpoZlmB5n+C4uLloA7Y62LRth1drNWe7qSly8OusswbN0UqlCOeTJnUuyRsnL0xPDQnti78HDOHv+X6M6zlCAAhSgAAUoQAEKOJaAWQJedzc3LFy22uJb3r5tM2zZvlddmpCVlbVt2RgbNu9Qly0sWr4GJ0+fz7CbvHlyo1zZUjh24kyGbWxTwbVSgAIUoAAFKEABCjyKgFkCXlmhl5cH/vjruGQtlnLnyomWTeri83UxWVpHmVLFsWrxJPj6tNYC2VPwDRqK47EZB7Surg/nSUhIgKXTzZs3s7S9XIgCFLCdgKWPC+w/AQlWOP4aOicm3oEcjw3LmLf8e6CljW/fTrTafrXdEYlrfnhEZ6LRmXP/Qr7s9U6PwQgMHa1PJi6O/HnzIP6q8fW5V+KvoYB3Xty7d08l6evtN1tizcZtSEpKhouLixQZpfz58iAu/rq+7PKVeHjnz6uflztH1H6pKsaF9UeTBrXU9cb6SoOMXKYhX0qTINmgOE1Wvqxn6eTl5ZVmvSygAAXsW8DSxwX2nwPWNpDvpsjx2Nrr5fosu689PNxhrf1q30ct5x6d2QLeAUFdMHPC+xjYuyu6d26nT6byVXrhWRz+5U/9Gdcd334PuVSi2BOFjbrIpwXGTRq8ou7EIIGwUaU2U61yBa1uNxJu3tLmgOh1W1CtcnmVP3L0T1yJux9Uy90ZjseeRuGC+VWd4SQpKQlzF69C9SrlUaJ4UcOqNHk5C2yNlGbFLKAABexawBrHBa7DFTSggSM9B+z6oOXkgzNbwPtStUrqC2HyJTDJ65KpfoUKeGPYwJ4YPWU+evQPx2daoDrqg2B1MEvdR5eOrXHh4uXUxWq+Yb2aaFC3BnoOiIBf7+G4dDkewf4+kH/nLlxEV61M6lr5BKNIIW+83ry+VKk0eXaUur63R0gEPD09MGJIoCrnhAIUoIDjC3ALKEABCmRfAbMFvHsP/IT/vdsf4RPmKM3f/zqOkKETVd7UiQSrS2aNwqIPIzB38jDIXRRkWTnTu23tQsmqVMA7H3Z/GYWeXTuo+aBuPujWqa3KyyTAtz1WzBuPqDljMHZ4PxQuVECK0aJxXaz/eCYWTA/Hro1RmDhyoLr7g1QunBGO5ZHj1G3JomaPRqBfR3h5ekqVPnVq3wohgca3MtNXMkMBClCAAhSgAAUoYJcCRgHv44xw9qKVWPjhSBQs4K26KV/uaVz874rKc0IBClCAAhSgAAUoQAFbCZgt4PVwd09zves93LPVdnG9FKAABR5HgMtSgAIUoIATCZgv4PVwh9wRQWdz6Mhv+rO9ujI+UoACFKAABShAAQo4koBzjNVsAe+gPn4YNXke/j52EoEDR2PCjEXo17OTcyjZwVbk2LAe3jExTE5kkH/rVnitX8d96kT7VPca7WAHxwwOgQIUoAAFHgiYLeCVa3anjRmMke8Fo8P/mmHlosl47pnSD9bEHAUo4LQC3DAKUIACFKCAPQs8dsB77MQZBA8ei0Ztu2Pg8MkoW+YpNKlfC26uj921PbtxbBSgAAUoQAEKUCC1AOftVOCxo9IxU+ej8gvPIuL93ihVohgmzYyy00117GHdat0Gcc2aMTmRQXzz5rjdpi33qRPtU91rNNqxDzccPQUoQAGnE3jsgPfqteuQ++DWr10dA4J8Ib9e5nRK3CAKmFOAfVGAAhSgAAUoYFWBxw54DUfr4uKS7i+jgf8oQAEKUIACFKBAKgHOUsBaAo8d8J459y9qt+isT+f//U+fl/KMNiQgJAJHjv5pVL3/+8Po/8FEVSZ5WX7nnu/VvEwGDJuMgz/+IlkYLv/vf5fxpu8A7N53CCMnRmJTzC7VRiY3Em6q64t1+fAJc9HRPxQduoXCv+8IXL+RIFWqvy5BQxE0aAz8+oRhflQ0bicmqiTjSC/FnjqnluWEAhSgAAUoQAEKUMB+BR474J054X1klh5n04sXewIfrVqfaRdx8VfR7/3x6BPwDl6tXT3Ttqs3bMPVazewLHI8opdOxcDgLkbtB/fxUz8tPH9amLo0Y9SkeernhfdtWQFJfQM6waddC5WX+dIlnzRanjOWEGCfFKAABShAAQpQ4PEEHjvgfalaJWSWsjo8FxcXdceHfHlz47sffk7TjVaNhJs30ff9CfB/tx0av/pymjapC67ExaNKxeeQw8tTVVWqUA55cudSecOJl6cnhoX2xN6Dh3H2/L+GVcxTgAIUoAAFbCPAtVKAAlkWeOyAN8trNnHBbp3+l+5Z3nv3gAkzlqBl01fRvFEdmPKvbcvG2LB5h7psYdHyNTh5+nyGi+XNkxvlypaC3HYtw0asoAAFKEABClCAAhSwewG7D3irVnoeycnJ+O3PY2kwSxQvim079qnrbNNUplNQplRxrFo8Cb4+rbVA9hR8g4bieOyZdFreL3I14V7CCQk3YOl08+b964zvjyrTKSspQAE7EbD0cYH9W/7Ym9r4zp1EyPE4dTnnrb8vzGmemHjbavvVTg5P2XIYdhvw3tNO4UqSveL3Tlss1s7ISl6X5JKGXn4dULpkcQwJn44kLSiWuvz58iAu/rpkVbp8JR7e+fOqvEw8PTxQ+6WqGBfWH00a1ML23QekOE2S/uRLaRIkp6k0KMiVKzcsnXLmTHvZhcEQmKUABexQwNLHBfb/sGOv+es9PDwhx2Pam9/Wlqaenl5W2692eKjKNkNydYQtlQD1Py1wPXk67V0Rwgb1RM4cnggbNwsSIFerXAGbYnYj4eYttWnR67agWuXyKi93hbgSd1Xl5e4Mx2NPo3DB/GrecJKUlIS5i1ehepXykLPIhnXMU4ACFKAABShAAQo4loBNA95eA0fpb2EmtxnLjK5Lx9Yw/AKZdgJYBbhy2cGY4f3UWd3Js6LQsF5NNKhbAz0HRMCv93BcuhyPYH8fyL9zFy6iq1Ymda18glGkkDdeb15fqlSaPDtKXd/bIyQCnp4eGDEkUJVzQgEKUIACFKAABSjguAI2C3gXzgjX395LbvEl87VqVsWH499TmpKfMmqQysukSf2XVXu5I4TMS3u544Lk3d3c1O3EhvTrJrMI8G2PFfPGI2rOGIzVguHChQqo8haN62L9xzOxYHo4dm2MwsSRA+Hu7q7qpL/lkeNUP1GzRyPQr6O6JZmqTJl0at8KIYHGtzJLqeIDBShAAUcW4NgpQAEKOLWAzQJep1blxlGAAhSgAAUoQAEK2I2A6QGv3QyZA6EABShAAQpQgAIUoIDpAgx4TbdiSwpQgAJKgBMKUIACFHAsAQa8DrK/cmxYD++YGCYnMsi/dSu81q/jPnWifap7jXZwkOMKh0kBClDgMQUcZnEGvA6zqzhQClCAAhSgAAUoQIGsCDDgzYoal6EABUwXYEsKUIACFKCAjQUY8Np4B5i6+lut2yCuWTMmJzKIb94ct9u05T51on2qe41Gm/rCZjsKUCBbCXBjbSfAgNd29lwzBShAAQpQgAIUoIAVBBjwWgGZq6CA6QJsSQEKUIACFKCAuQXsIuDdvvsAAkIi0CVoKF7rEIgvNm3Xb+eXW3fBv+8IdO8Xjh79w/HdD0f0dZFLPsXST9bp5yUzcmIkNsXskqxKNxJuolHb7vp8+IS56Ogfig7dQlW/128kqDrd+oMGjYFfnzDMj4rG7cRElWq36Iz0Uuypc2pZTihAAQpQgAIUMLMAu6OAGQVsHvDevXsXo6fMRy+/9lgeOQ5rls1A2dIl1Cbu2ncI8z/6HOPC+mHxzAgM6eeP4WNn4+9jJ1X9o05Wb9iGq9duYFnkeEQvnYqBU6VAeQAAEABJREFUwV2Muhjcxw+RU4Zj/rQwHI89jVGT5sHL0xP7tqxQqW9AJ/i0a6HyUla65JNGy3OGAhSgAAUoQAEKUMD+BGwe8N66nahUXqz0vHrMlTMHqlR8TuU/W7sZ3Tq1RbEnCqv5554pjTffaILodVvV/KNOrsTFq75zeHmqRStVKIc8uXOpvOFEgtxhoT2x9+BhnD3/r2EV8/YlwNFQgAIUoAAFKECBhwrYPOCVAPfN1xujU8/3MGzsLGzbuR9y1ldGfubcv6isBaWS16UXyj+LU2cv6GYf6bFty8bYsHkH5LKFRcvX4OTp8xkunzdPbpQrWwrHTpzJsI1UJCcnwxpJ1sVEAQo4joA1jgtch3WOvzpneW/S5e3v0boWzrT91tyvjnMEc76R2jzgFdK+Pd/FjHHv4flny2DO4lUYO3WhFKvk4uKiHs0xKVOqOFYtngRfn9ZaIHsKvkFDcTw244DW1fXhPHfu3IGlU1JSkjk2n31QgAJWFLD0cYH9W/7Ym9o4Ofku5Hicupzz1t8X5jSX4N1a+9WKhyCuKpXAwyO6VAtYarZ4sSdUIDp/2ghs3bEP9+7dw1NPPoFffvvLaJW//v43ShYvalRmOJM/Xx7ExV/XF12+Eg/v/Hn1854eHqj9UlWMC+uPJg1qQb4wp680yCRpZ27lS2kSJBsUp8nmyJEDlk5eXl5p1puVAi5DAQpYT8DSxwX2b/ljb2pjDw93yPE4dTnnrb8vzGnuocUF1tqv1jsCcU2pBWwe8MqdEAzvvHDo8K8o6J0PLi4u6NjuNXUXhov/XVbj/uPvE5AvnnVs10LNpzepVrkCNsXsRsLNW6o6et0WVKtcXuWPHP0TV+KuqrzcneF47GkULphfzRtO5C+9udqZ5upVyqNEJsG14TLMU4ACFKCAwwhwoBSgQDYTsHnAK97LP/tS3SpMbhc2Y94KvNffX4pRv3Z1BPi+hfciZkBuSTZ51lKMHtoHz5QpCd2/BR9FG90yrF7tamhQtwZ6DoiAX+/huHQ5HsH+PpB/5y5cRFetTOpa+QSjSCFvvN68vlSpNHl2lLq+t0dIBDw9PTBiSKAq54QCFKAABShAAQpQwHEFbB7wenl6YvbED/DZkqkqbY6ehzovv6gXlYB0yaxRWPRhhEpyOYKuMkgLZOX2YIbJ3c1NC5LbY8W88YiaMwZjh/dD4UIF1CItGtfF+o9nYsH0cOzaGIWJIwfC3d1d1S2cEa5uixY5ZTiiZo9GoF9HyNhUZcqkU/tWCAk0vpVZShUfKEABClCAAhSgAAXsVMDmAa+dunBYFKAABSiQIsAHClCAAo4uwIDX0fcgx08BClCAAhSgAAUokKmAmQLeTNfBSjMI5NiwHt4xMUxOZJB/61Z4rV/HfepE+1T3Gu1ghtc8u6AABShAAfMJMOA1nyV7ogAFKADQgAIUoAAF7E6AAa/d7RIOiAIUoAAFKEABCji+gD1tAQNee9obHAsFKEABClCAAhSggNkFGPCandQyHd5q3QZxzZoxOZFBfPPmuN2mbTbfp875nI62zGGAvVKAAhSgQBYFGPBmEY6LUYACFKAABShAAbMJsCOLCjDgtSgvO6cABShAAQpQgAIUsLWA3QW8i1esRedeH6jUzjcER3//Rxm16xKC8//+p/Iy2bn3BwwYNlmyiFz6KZZ+sk7lR06MxKaYXSovkxsJN9GobXfJQvLhE+aqnzHu0C0U/n1H4PqNBFUXEBKBLkFD1U8L+/UJw/yoaNxOTFSpdovORj9frJuPPXVOLcsJBawkwNVQgAIUoAAFKJAFAbsKeCW4/eLLrzFt7GCsmD8ekZOHI2eOHFnYrPQXWb1hG65eu4FlkeMRvXQqBgZ3MWo4uI8fIqcMx/xpYTgeexqjJs1TPy+8b8sKSOob0Ak+7VqovMyXLvmk0fKcoQAFKEABClDAGgJcBwUeTcCuAt5LV+JRtkxJPFG4oNqKYkULa/NPqbw5Jlfi4lGl4nPI4eWpuqtUoRzy5M6l8oYTL09PDAvtib0HD+Ps+X8Nq5inAAUoQAEKUIACFHAwAbsKeF+uXgm3bt9WlxpMnhWFn37+3aycbVs2xobNO9RlC4uWr8HJ0+cz7D9vntwoV7YUjp04k2EbqbhzJxHWSLIupkcTYGsK2FLAGscFrsM6x1+dc3JyklWO97r18dE6+9ea+9WWx6Tsvm67CnjlzOu8qWEY0q8b3NxcMHD4FKPrcR93Z5UpVRyrFk+Cr09rLZA9Bd+goTgem3FA6+pqVzyPu/lcngIUoAAFsqcAt5oC2V7A7iI6FxcXlC/3NAYGd8WgPr7YtG2P2klyxjU+/prKyyQuLh7e+fNK1ijlz5cHcfHX9WWXrxi38/TwQO2XqmJcWH80aVAL23cf0Lc1zCQlJ0O+lCZBsmF56ryHhyeskVKvl/MUoIB9C1jjuMB1WOf4q3N2c3O3yvFetz4+Wmf/WnO/2vdRy7lHZ1cBr1xioLuEIPnuXfzy2z8oVCC/2gPVqjyPz9bFqLzcPWHDlp2oUbWCmjecVKtcQTsrvBsJN2+p4uh1W1CtcnmVP3L0T1yJu6rycneG47GnUbjg/f5VYcokKSkJcxevQvUq5VGieNGUUid/4OZRgAIUoAAFKEABJxWwq4D3duJtDB0zA936hKH1O33w48+/o5dfe0XfvfObSNbOunYNHobu/cJRtdLzaNnsVVVnOGlYryYa1K2BngMi4Nd7OC5djkewvw/k37kLF9FVK5O6Vj7BKFLIG683ry9VKk2eHaWu7+0REgFPTw+MGBKoyjmhAAUoQIHsI8AtpQAFnE/ArgLecmVLY9WiyVg6ezQ2fToXKxdORPFiTyj1fHnzYOR7Qfho7lismDcecoswN9f7ww/q5oNundqqdjIJ8G2v2kTNGYOxw/uhcKECUowWjeti/cczsWB6OHZtjMLEkQPh7u6u6hbOCMfyyHHqtmRR2voD/TqqW5KpypRJp/atEBJofCuzlCo+UIACFKAABShAAQrYqcD9iNFOB2e/w+LIKEABClCAAhSgAAUcRYABr6PsKY6TAhSggD0KcEwUoAAFHECAAa8D7CQZYo4N6+EdE8PkRAb5t26F1/p13KdOtE91r9EO8qJlogAFKEABuxGwRsBrNxvLgVCAAhSgAAUoQAEKZD8BBrzZb59ziylAAZsJcMUUoAAFKGALAQa8tlDnOilAAQpQgAIUoEB2FrDytjPgtTJ4Vld3q3UbxDVrxuREBvHNm+N2m7bcp060T3Wv0eisvtC5HAUoQAEKWESAAa9FWNkpBShgBgF2QQEKUIACFDCLgEUD3rj4qxg5MRKde32A3oPHYtiYmTgee0YN/L/LcXh/1AzIr6F1CRqK8dMX4fqNBFW3//vDqN2iMzZs2aHmZfLTz7+rss/Xb5VZRC75FG/6DkCvgaMgv7524NDPqlzWtylml8rL5EbCTTRq212ykHz4hLno6B+KDt1C4d93hH6dASERkHEEDRoDvz5hmB8VjduJiSrJWNJLsafOqX45oQAFKEABClCAApYTYM+PK2DRgHfQiGnIny8PVswfjzmTh2Fgb19cib+qxjwobAqeebok5NfQls0di8Q7SRg3baGqc3FxQZlST+Hrnd+peZls0/JPl34KLi4uMqtS69caYv60ERgxOBDh4+eq4FRVZDBZvWEbrl67gWWR4xG9dCoGBncxajm4j5/6pbX508JwPPY0Rk2ap35tbd+WFZAkv+7m066Fyst86ZJPGi3PGQpQgAIUoAAFKEAB+xOwWMB75OifuHDxEvoGvKPf6kIFvFG9SgX8eOQ3xMVfg/+77VSdi4uLCj73HjiM/y5dUWUlij+h2shZ33v37uHgjz+jmrasqkw1kcA5Rw4vnLtwKVWN8eyVuHhUqfgccnh5qopKFcohT+5cKm848fL0xLDQnth78DDOnv/XsIp5CtitAAdGAQpQgAIUoED6AhYLeE+ePoeKz5eFu7t7mjWfOnsB5cuVgZvrg9XnzZMbcsY09tRZffvGr76ineXdrwW7v2iB8gtwdXGFBL/6BimZYyfO4OatW3iyaKGUkvQf2rZsjA2bd0AuW1i0fA1Onj6ffkOtVMZTrmwpSN/aLP+nAAUoQAEKUMAxBDhKCqQReBBxpqkyQ4F25jbDXjKrS1moeaPakEsZ5NKGpg1eSSl98LDgo2h1XW/4xDmIeL+3uvzgQW3aXJlSxbFq8ST4+rTWAtlT8A0aiuMp1xSnbQ24GgTk6dVL2a1bN2H5dEtWxUQBCjiQgOWPC9Y49tjXOm7evAlbpjt37qjjvS3HYO5183l6E7Jfb9++pfatpT0c6BDmdEO1WMBbqsST+PWPY0hKTk6DVrJ4Ufzx9wncvXtXX3ft+g3EnjqnneUtrs7iypncYkULI1E7wPzy29+oXvUFfVtdpmfXDup62uWR4/BKjcqqWK4Zjou/rvIyuXwlHt7580pWJU8PD9R+qSrGhfVHkwa1sH33AVWeeiLjlvFIkJy6znDew8MTlk6envcvwTBcL/OPKcDFKWBhAUsfF7Jj/15enrBlkk8sPT29bDoGc29/dnwepd5mNzc37dNoD4u/l8t6LXzYYfeZCFgs4JVrZZ8oXBAjJ0Ti0pU4NQR5PHTkN3Utbv68ebDk47WqXILbqXOWoe4rL6JwoQKqTDeR63wlubi46IoyfaxWuQI2xexGws37Z0Wj121Btcrl1TJyXfGVuKsqL9cGH489jcIF86t5w0lSUhLmLl6F6lXKo4QWnBvWpc7LC8XSyZQzzanHxXkKUMC2ApY+LmTH/l1d3bRP3myXXFxctPW7asl2YzC3gZubG7J7ctU+zbWWAfjPZgKullzzlFEDtb+a3NCj30h13ew0LagtkD+fWuWU0YPw9/FTkFuA+QYPg5enBz4Y0EPVGU7kzG2TdC5nMGxjmG9YryYa1K2BngMi1C3PLl2OR7C/D+TfuQsX0bX3cFXXyicYRQp54/Xm9aVKpcmzo9Q4e4REwFMbz4ghgaqcEwpQgAIUoAAFKEABxxWwaMDrrQW3I98LwtrlM9TtvsYO7we5tZhwFS7ojQkjQhA1ezTkkgQJdnV3TKhVsyqmjBokzYxSaG9ftG/TXJUFaUFst05tVT71JMC3PVbMGw+55ZmsU3fWuEXjulj/8UwsmB6OXRujMHGkBOTuavGFM8LVOCKnDIeMKdCvoxaEe6o63aRT+1YICTS+lZmuzrkfuXUUoAAFKEABClDAcQUsGvA6LgtHTgEKUIACFEhHgEUUoIBDCjDgdcjdxkFTgAIUoAAFKEABCpgqwIDXVCnT27ElBShAAQpQgAIUoIAdCTDgtaOdkdlQcmxYD++YGCYnMsi/dSu81q/jPnWifap7jXbI7MWcreq4sRSgAAXsQ4ABr33sB46CAhSgAAUoQAEKUMBCAjYPeC20XeyWAhSgAAUoQAEKUIACSoABr2Kw/8mt1m0Q16wZkxMZxH/trboAABAASURBVDdvjttt2nKfOtE+1b1Go7N2SOFSFKAABShgIQEGvBaCZbcUoAAFKEABClCAAlkRMP8yDHjNb8oeKUABClCAAhSgAAXsSMDiAW9ScjJqt+iM6ZHL9Zu97NMNWPDR/Q/9Ipd8quqljS79d+mKvu3UOcsgPwN87949fZks86bvAPQaOApdgoZizYZt+rqREyOxKWaXfv5Gwk00attdzUs+fMJcdPQPRYduofDvOwLXbySouoCQCNVX0KAxkJ87nh8VjduJiSrpxpX6MfbUObUsJxSggPUFuEYKUIACFKCAqQIWD3hlIDm8PLF73yHExV+V2TSpZ9cO2LdlhT4VLlRAtZEgd8e3B1CooDe+/+moKtNNWr/WEPOnjUDE+8GYMX8Frl67rqvK8HG1FhhfvXYDyyLHI3rpVAwM7mLUdnAfP0ROGa71G4bjsacxatI8eHl66sfVN6ATfNq10M+XLvmk0fKcoQAFKEABClCAAlYW4OpMELB4wOvi4gJ3d3e0bdkIq9ZuNmFID5oc/PEXlC1TEh3aNMPWb/Y9qDDIlS1dAoUKeONy3DWD0vSzV+LiUaXic5AAXFpUqlAOeXLnkqxRkiB3WGhP7D14GGfP/2tUxxkKUIACFKAABShAAccSsHjAq+No37YZtmzfC7msQFeme5TLG3SXCzRtF6ArVkFu80a10aRBLew7cBhJSUn6Ol3mxKlzyJ8/L0o9VVRXlOFj25aNsWHzDshlC4uWr8HJ0+czbJs3T26UK1sKx06cybANKyjgMAIcKAUoQAEKUCAbC7haa9tz58qJlk3q4vN1MWlWaXhJw7a1C1W9BLf7Dx5B04a1IMtWqVgOe7SgV1VqE12Q/E6PwejSsTVcXR++KWVKFceqxZPg69NaC2RPwTdoKI7HZhzQmtLnjRvXYemUkHBD22L+TwEKOJKApY8L7N/yx97UxomJtyHH49TlnLf+vngc89TL3r59GzdvJlj8vVzW60jHMGcb68OjxMfcYrkOV5J08/abLbFm4zbtTG0yXFxcpCjDtOe7n3DpShwatvZXX2r75tuDiDG4rEGC5F0boxA+JBCTZi5B3NX7lzTkz5cHcfHX9f1evhIPb+0MsK7A08MDtV+qinFh/dWZ4+27D+iqjB7ly3bypTQJko0qUs3kzp0Hlk65cuVOtVbOUoAC9i5g6eMC+7f8sTe1saenF+R4nLrcsedza+9h2Tt5eXkhZ85cZnTI+Llp78ctZx6fqzU3Ll/ePFqQ+Yq6i4IuCM5o/Vt37MOwgQH6L4jFrFmAvQd+UndN0C3j4eGO15rUQ+UXnsXq9dtUcbXKFbT+dyPh5i01H71uC6pVLq/yR47+iStx9784d/1GgnZ29zQKF8yv6gwncnZ57uJVqF6lPEoUf/ilEobLMu8MAtwGClCAAtlFQE4+Zfek29fmctD1x0d7ErBqwCsb3qVja1y4eFmy+qS7PEF3He+vf/yD/QcPo2G9l/Rt5MtlNV6sgJ17vteX6TK9u7+Dz9fHQM7KNqxXEw3q1kDPARHw6z0cly7HI9jfB/Lv3IWL6KqVSZ3c6qxIIW+83ry+VKk0eXaUur63R0gEPD09MEI7e6wqOKEABShAAQpkRwFuMwWcRMDiAa+7mxt01+WKWQHvfNj9ZRTkkgSZD9KCUcNbkkn+heefwddfLEpzB4XJEaFo3qgOZJlundrK4io9XfopfPXZXMi6pCDAtz1WzBuPqDljMHZ4P+huc9aicV2s/3gmFkwPh1wOMXHkQHUHCVlm4YxwLI8cp25LFjV7NAL9OqpbkkmdLnVq3wohgV10s3ykAAUoQAEKUIACFHAAAYsHvA5gwCE+ngCXpgAFKEABClCAAnYtwIDXrncPB0cBClCAAo4jwJFSgAL2KsCA1173DMdFAQpQgAIUoAAFKGAWAQa8ZmE0vZOstsyxYT28Y2KYnMgg/9at8Fq/jvvUifap7jXaIasvdC5HAQpQgAIWEWDAaxFWdkoBClCAAg8RYDUFKEABqwkw4LUaNVdEAQpQgAIUoAAFKGALAfsOeG0hYqfrvNW6DeKaNWNyIoP45s1xu01b7lMn2qe612i0nR5HOCwKUIAC2VWAAW923fPcbgpQwKEEOFgKUIACFMi6AAPerNtxSQpQgAIUoAAFKEAB6wpkaW1WDXi37z6A2i064+Tp82kGG3/1Ouq29MXn67equoXLPsfsRStVXjf54+8TaO83UM0GhESovqQ/SR39Q1X5yImR2BSzS+VlciPhJhq17S5ZSD58wlxI2w7dQuHfdwSu30hQddJfl6ChCBo0Bn59wjA/Khq3ExNVkv7TS7GnzqllOaEABShAAQpQgAIUsF8Bqwa8X+/cj+eeKY3NX+9OIxKzYy+efboktu38TtW1aFwPMd/sU3ndJGbHPrRoUlc3i/nTRkB+iljSZ0um6sszyqzesA1Xr93AssjxiF46FQODuxg1HdzHT/208PxpYTgeexqjJs1TPy8s/UvqG9AJPu1a6NdZuuSTRstzhgIUsBMBDoMCFKAABShgIGC1gFfOlv5w+FeMHd4XW1MFsjKebTu+Q2jvrjh3/iL+uxyHUiWKIX++vPj517+kWiUJgFs0ehDwqsJHmFyJi0eVis8hh5enWqpShXLIkzuXyhtOvDw9MSy0J/YePIyz5/81rGKeAhSgAAUoQAEKOIwAB3pfwGoB79e7vkPdl6uhRPFi8M6fD7/+8c/9EWjT8xf+04LcKyoYbdG4Dr7a9q1WCjRtWEs743v/LO8vv/2lLZdXBcKqUpv0GjhKf1nDoBFTtJLM/2/bsjE2bN6hLltYtHwN0ru0QtdD3jy5Ua5sKRw7cUZXlO7j3bt3YY2U7spZSAEK2K2ANY4LXId1jr8653v37lnleK9bHx+ts39lv0qyhrfdHrCywcBcrbWNMd/sR4smddTqJKjd+s1elZfJ1h370Kxhbcmi9WsN9ZcyNNfK5BIHeSLGaG2aavOqUcrE8JKGKaMGpZRm/FCmVHGsWjwJvj6ttUD2FHyDhuJ47JkMF3B1fTjP7du3YOmUmHg7wzGyggKPL8AeLCFg6eMC+7f8sTe1cVJSEuR4nLqc89bfF+Y0v3Mn0eLv47rxWuJYwz5NE3h4RGdaP5m2ki+kHTj0M/p/MFGdkZ02d5m6rEECWVlw2479iFq5TtV19B+Ev47FqrOvxYoWRkntjPChw79qZ3q/Q8um9aR5pil/vjyIi7+ub3P5Srw6M6wr8PTwQO2XqmJcWH80aVAL8kU6XZ3hY1JyMuRLaRIkG5anzufMmQuWTjly5Ey9Ws5TgAJ2LmDp4wL7t/yxN7Wxh/b+Icfj1OWct/6+MKe5p6cX9PvVwu/pdn7YcurhWSXglS+ryVld+eKXLhUv9gQkkJXLCq5eu67/IpjUd+n4BrZ8s0fBN234CmYu+AQlnyqGwgW9VVlmk2qVK2BTzG4k3LylmkWv24Jqlcur/JGjf+JK3FWVl7szHI89rfWZX80bTuSv+LmLV6F6lfIoUbyoYRXzFKAABShAAQpQgAIOJmCVgDdm5340qveyEU3j+q9gq3Zmd8v2b9G4vnGdnHnd8vX9gLdZwzr4+/gpNG3witHyMmN4DW+L9oFShIb1aqJB3RroOSACfr2H49LleAT7+0D+nbtwEV21Mqlr5ROMIoW88Xrz+lKl0uTZUer63h4hEfD09MCIIff7VJWcUOC+AKcUoAAFKEABCjiYgFUC3sgpw/Fq7epGNJ3eaokPQrojwLc9+vV816ju+WfL4POoaapMLlHY89UytG/TXM3rJgtnhBudFd7y+TxdlepzxbzxiJozBmOH90PhQgVUXYvGdbH+45lYMD0cuzZGYeLIgXB3d1d10t/yyHHqtmRRs0cj0K+juiWZqkyZdGrfCiGBxrcyS6niAwUoQAEKUCCbCXBzKeA4AlYJeB2HgyOlAAUoQAEKUIACFHA2AQa8zrZH7Wx7OBwKUIACFKAABShgawEGvLbeAyauP8eG9fCOiWFyIoP8W7fCa/067lMn2qe612gHE1/XbJatBLixFKCADQUY8NoQn6umAAUoQAEKUIACFLC8AANeyxubvga2pAAFKEABClCAAhQwuwADXrOTskMKUIACFHhcAS5PAQpQwJwCDHjNqWnBvm61boO4Zs2YnMggvnlz3G7TlvvUifap7jUabcFjAbumAAUoQIFHF3DggPfRN5ZLUIACFKAABShAAQpkPwEGvNlvn3OLKUABZxPg9lCAAhSgQKYCNg94v975HYIHj9UP8vAvf6Br8DAk372LyCWf4k3fAeg1cBS6BA3Fmg3b9O0M66T9gUM/q7qREyOxKWaXysvkRsJNNGrbXbKQfPiEuejoH4oO3ULh33cErt9IUHUBIRFqHUGDxsCvTxjmR0XjdmKiSrVbdEZ6KfbUObUsJxSgAAUoQAEKUIACthfIaAQ2D3ibNHhFjW3rN3tVkDt5dhTe6+8PN9f7Q2v9WkPMnzYCEe8HY8b8Fbh67bpqLxNd3YjBgQgfP1cFp1KeUVqtBcxXr93AssjxiF46FQODuxg1HdzHD5FThmvrC8Px2NMYNWkevDw9sW/LCpX6BnSCT7sWKi9lpUs+abQ8ZyhAAQpQgAIUoAAF7E/gflRp43F9ENJdO5v7GT76ZB2qVymPF55/Js2IypYugUIFvHE57lqaumeeLokcObxw7sKlNHWGBVfi4lGl4nPI4eWpiitVKIc8uXOpvOFEgtxhoT2x9+BhnD3/r2EV8xSggMMLcAMoQAEKUCC7CdhFwFvyqWKQM72r1m5GL7+O6e6DE6fOIX/+vCj1VNE09cdOnMHNW7fwZNFCaeoMC9q2bIwNm3dALltYtHwNTp4+b1htlM+bJzfKlS0F6duoItXMnTt3YOmUlJSUaq2cpQAF7F0gKekOmMxrYOlj7cP6T05OVvv0Ye0cqV7eX7J7kv2anJyk7VvzpMz2v90dt7LRgFztYVvv3buH7388inx5c+Pv4yeNhrTgo2h1/ew7PQajS8fWcE251EEa6erCJ85BxPu91eUHUp5RKlOqOFYtngRfn9ZaIHsKvkFDcTz2TEbNjdaVUaO7d+/CGimj9bOcAhSwT4Hk5LtgMq/BvXt3YcsE3NOO9/dsOgZzb78Eetk9yXt4svbHTLIW9JojSX8ZJfs8WmWPUdlFwBu9bqu6jGHYwABMnhmlHUzu6fV7du2AXRujED4kEJNmLkHc1QeXNEidXEu7PHIcXqlRWS2TP18exMVfV3mZXL4SD2/tzLDkJXl6eKD2S1UxLqy/dla5FrbvPiDFaVKS9uSXL6VJkJym0qDAy8sLlk6envcvwTBYLbMUsJYA15NFAUsfF7Jj/56eXrBlcnNz19bvqSXbjsOcBl5eOeCVzZOHFheIqfkcvJDR6zOLhxMuZgYBmwe8V+Ku4pPPN6GXXwdUq1IBpbWzsGs3fm20aR4e7nitST1UfuFZrF49AKqFAAAQAElEQVT/4E4NRo1SZqpVroBNMbuRcPOWKoletwXVKpdX+SNH/4SsT2bk7gzHY0+jcMH8MmuU5OOduYtXqeuJSxRPewmFUWPOUIACFKAABSiQDQS4iY4sYPOAd+qcZeji8wbkzKxAhvR6F0tXrtPfLkzKdKl393fw+foYyNlXXVnqx4b1aqJB3RroOSACfr2H49LleAT7+0D+nbtwEV21Mqlr5ROMIoW88Xrz+lKlktwhQq7v7RESof0F74ER2lllVcEJBShAAQpQgAIUoIDDCtg84B0zrA/eat1MD1ikcEFs+GSWuntCkBaoduvUVl/3dOmn8NVnc+Hu5obUdfpGWibAtz1WzBuPqDljMHZ4PxQuVEArBVo0rov1H8/EgunhkMskJo4cCHd3d1W3cEY45NIIuS1Z1OzRCPTrCLlbg6pMmXRq3wohgca3Mkup4gMFlAAnFKAABShAAQrYn4DNA177I+GIKEABClCAAhR4TAEuTgG7EmDAa1e7g4OhAAUoQAEKUIACFDC3AANec4taqL8cG9bDOybGuVI23578W7fCa/067lMnfB50sNBxgN1SgAIUoEDWBBjwZs2NS1GAAhSgAAXMJsCOKEABywow4H1M3zt3EmHplJycDDc3N4uvx9Lbwf6NnyvyK1zypUm6GLs4g8emTV/y9WqFY6O1nyseHh5ITk7ivnWyfSvvr3fvJltlvz5myMHFH0OAAe9j4Fl3Ua6NAhSgAAUoQAEKUCArAgx4s6LGZShAAQpQwHYCXDMFKECBRxRgwPuIYLZu/sWm7Xinx2DUbtFZ/6txth4T1/9oAvLDKWOnLYT8MIr8CMrps+fT7eD9iOlqP8u+lnT093/SbcdC+xH479IV9BkyDv59R2Do6A9x89b9X3y0nxFyJKYIfPbFFnQO/AC+QcOwa9+hdBfh6zNdFocqPHz0D/UjVXVb+mLbzv3gP+cWcNaA12n3WtEihTBqaB/9j2k47YY68YZt2LwDl6/EqR9Gad+mGSbMWJLh1s6dPAz7tqxQqWL5ZzJsxwr7EPhw/seoVbMqlswahXz58uLj6E32MTCOwmSB2FPnsGzVBsyfNgKTRg7A2KkLcOt2YrrL8/WZLovDFObw8kKvru3RsG5NhxkzB5p1AQa8WbezyZK1X6qKcmVL22TdXKl5BPbs/xGtmr2qOmtc/xUc/eMf3Ei4qeY5cWyBPd/9hNeb39+3r2v7+NvvfrSDDeIQHkXg2/2H0EALgHLnyoliRQujfLmncfDQL+A/5xN4/tkyqPFiRbi6MhRyvr2bdou4l9OasIQCFhW4qH3s/dSTRdU63N3cUOyJwvj34mU1n3oSGjYVLTsEYcrsj3DnTlLqas7bkYD80eLiAhTwzqdGVfKporj4X/r7VTXgxC4FLl66jOLFiujHVqJ4Ufz73yX9vGGGr09DDeYpYN8CKuC17yFmr9H1/2CiuqZIru00TIeO/Ja9IBx4a+csXpnuPly1ZrN+q1xctMgoZc7VIJ9SpB4G9u6K7esWYaL2servfx3H8s82gv/sW8DwTJGLCw+v9r23Mh6di8EZPxeXB69VwyX4+jTUYJ4C9i/AI7Kd7aOxw/ti6uhBaVL1KhXsbKQcTkYC/u+2S7P/ZJ+2e6OxWqRIoQK4fCVe5WVyOe4qnihSULJG6YnC98uqVHwOXTq+gd/+5JfWjIAsM5PlXuUj8OTku0i8c0f1celKHIqk7ENVwIlDCBQpVBBxcQavT20/PlG4UJqxP5Gyb/n6TEPDAgrYpQADXjvbLXly50LePLnTJDsbJoeTiUDOHDnS7D/Zp16enmqpOq+8iG07v1P57374GWVLPwUJlqTgR+1Mvu7Shes3EqQISUlJ2L3/ECo8xy+tKRA7ntR5Wdu3O/apEW79Zi/qaftazXDiMAL1alVXr7fbiYnqD9Nf/ziGV2pWVuPn61MxcJJtBJxrQxnwOtj+jFzyqbpVldz+qJVPMAaNmOJgW8DhtmnZCK6uLuq2ZItXrMF7/bvrUYaMnI74q9fU/FtdB6p9LY/58+WB79utVTkn9isQEvguNmzZpW5LdvLUObzb4XX7HSxHlq5A6ZJPot3rTdC9XzhChk7CgGBfeHp4qLZD+PpUDs4y2f/9YXWM3bZzP8LGzUbTdgHOsmncjnQEXNMpY5EdCwT5+6hbVOluVTVl1CA7Hi2Hlp6AfFFt2MAAdVuyBdPDUapEMX2zmDUL9Lec2/L5PLWv1308E30DOkGW0ze0kwyHYSxQuFABRE4Zrm5LNi6sP+Rsv3ELzjmCQMf/tcCKeeOxLHIsGtSpoR8yX596CqfIyC0Ede+l8rht7UKn2C5uRPoCDHjTd2EpBShAAQpQgAIUMFWA7excgAGvne8gDo8CFKAABShAAQpQ4PEEGPA+nh+XpoDpAmxJAQpQgAIUoIBNBBjw2oSdK6UABShAAQpkXwFuOQWsLcCA19riXB8FKEABClCAAhSggFUFGPBalZsrM12ALSlAAQpQgAIUoIB5BBjwmseRvVCAAhSgAAUsI8BeKUCBxxZgwPvYhOyAAhSgAAUoQAEKUMCeBRjw2vPeMX1sbEkBClCAAhSgAAUokIEAA94MYFhMAQpQgAKOKMAxU4ACFEgrwIA3rQlLKEABClCAAhSgAAWcSCBbBrxOtP+4KRSgAAUoQAEKUIACDxFgwPsQIFZTgAIUcGIBbhoFKECBbCHAgDdb7GZuJAUoQAEKUIACFMi+Ag8PeLOvDbecAhSgAAUoQAEKUMAJBBjwOsFO5CZQgALWEeBaKEABClDAMQUY8DrmfuOoKUABClCAAhSggK0EHG69DHgdbpdxwBSgAAUoQAEKUIACjyLAgPdRtNiWAhQwXYAtKUABClCAAnYiwIDXTnYEh0EBClCAAhSggHMKcKtsL8CA1/b7gCOgAAUoQAEKUIACFLCgAANeC+KyawqYLsCWFKAABShAAQpYSoABr6Vk2S8FKEABClCAAo8uwCUoYAEBBrwWQGWXFKBA5gLvR0xHh26hCBw4Gp0DP8Dn67fqF7h+IwGde32AO3eS9GWPmklKTkannu8h7uq1R100Tfuln6zDrIWfpCk3d8Hfx06iXktfBIbeNxk0YgpOn72gX83Pv/6FYWNm6ucNMwd//AV9howzLLJIfv3mHYhc+qlF+manFKAABSwpwIDXkrrs21IC7NcJBNq3aY5508Lw4fj3sPzTjZCgTTZrRfRGvNakHjw83GU2S8ndzQ3/a9UYKz7bmKXlDRd6rUkd1ZdhmaXyuXPnwrypYVgxbzxeeP5ZjJ4yX7+q2YtWonPHN/Tztsi0avYqYr7Zj/ir122xeq6TAhSgQJYFGPBmmY4LUoAC5hAoVMAbFZ57Gr/9eVx1tynmWzRt+IrKy0TO9srZT8lLCgiJwJGjf0pWnQ2d+OES9H1vPNr7DcTcxatUuUyaNqiFL7fulmy6qXaLzohc8il6DohAO98QHDryG6bM/gh+fcLQa+Ao/PvfZbXc5q/34otN21VegnKpHzr6Q9VmwLDJ+nbbdx+AnLlWDbXJ/u8Po/8HE7UcVDAfGjYZ/n1HoGm7AOzc+4Mqz2xSv3Z1/PlPrGpy6sx5/HcpTnMqq+ZlIgGwnCUPHjwWO/Z8L0X6tHjFWnXm3DdomBY0L4CcNZfKVj7B+mA1ZOgkSJJyCWClTvILPoqGbF8fzbRH/3CMn7EYcsZc6uQPiVo1q2DL9j0yy2QXAhwEBShgigADXlOU2IYCFLCYwJW4q/hVC3aff7YMJLBzdXFBsScKm7y+W7cT1VniTxZO1ALhv/DNtwfVsgUL5EfePDnxz4lTaj69SblnSmPB9HAE+L6F0LApaNawFqJmj0adl17Eko+/SG8RxJ46i55+HTF/2gi0bFo3w3aGC89euBKB3TpiyaxR2LhqDqpWLGdYnW5+z3c/4TltfFJ56PCvqFThWcmq9PWu/di193ss1cY6Y9wQGP5BIIH3ppjdmD3xAyyZPQqXLl/B0o/XquVqVH0B3/1wRAWwFy5egiQJZqVM6lQjbXL+30uYMKI/Fn0YARcXF2zf9Z1Wev//KtrYf/z5t/sznFKAAhRwEAEGvA6yox5nmFyWAvYoMGPecshZ1uBBo+Hr8wZeqVEZZ85dQOFCBR5puA3q1ISrqys8PTxQ55UX8ZNBMFa0SGGcOv3gOtjUHdevU0MVvVjpeXh5eqCq9igFVSs9h2MZBMrPPl0KZUo+Kc3wZNEiGbZTDVIm1atWUGeTFy5fjZ9//RPe+fOl1Bg/XL12XZk0atsdP//2J8IG9VINzp6/iKJFCqq8TH488gdav9YIeXLnUtv9VuumUqzSocO/QS49kHXIGdl33mqFH7QyqXypeiV8/+OvOPr736hY/hmVJH/wx6N4qVpFaaKS5KVvmSn2RCGjPxpkm0+f/VeqmChAAQo4jAADXofZVRwoBZxLICSwC/ZtWYGViyZDrueVrfP09ERSUpJk9cnNzRXJd+/q51PX6yvSySTeuQMPT/d0au4XSZAsOVctYPbQAmbJS5L5pKRkyaZJMh5doWE7Nze3VON8MOb+vTpjYLAvSjxZFNPmfAT58peuD8PHfHnzKJNv1i3GlFGDUKJ4UVXt4eGOOwYu93APEsyqSm3i7v5gG1PXeWrL3rt3T2sFFdT+oJ0tPnjoKGq++IJKEgBLkCzBsGqkTdzcHrw1uGo2hhZyRt3TwEpr7kj/c6wUoEA2FXhwVMumANxsClDAfgTKlS2lneU1PntY4qliOHn6nBqk3LXgeOwZlddN1n75tQqS5ezoV9t2o1rlF3RVOHnqHF547sF1r/oKC2RKlywOuSRD1/Xu/Yd0WXXdbInixdCyaT281uRVHP7l/jXI+gYPyTz7dGmjOzZUr1Ieew78BF0gK5c/6LqoUfUFfPX1boiHXK6wcs1XqJly9lbOzrq4ADE79mpllVTa+s0eSJnU6frI7PH02fPQXWqRWTvWUYACFLAnAQa8qfcG5ylAAZsJ5M2TG5VfeFb/ZS0ZyNvtXsPcJZ+qL6h9HP0lSqdcTiB1kooXKwLf4GHqC2Gv1qqOhvVqSjFOnDyLZ7QAuoB3+pcPqEZmnMhlDmVLl4B8UWxQ2BR1qYGu+14DI9DszZ6Q8j+PxcLvnTa6KpMe677yotoe3ZnuJvVr4flnS6svxQ0cPgkXU75gJ501fvVlNG1QG8GDxsK/zwjkzZMH3Tr9T6pUql7lBch10oULekOS5KVMVZowOXTkd7RoXMeElmxCAQpQwH4EGPDaz77gSCiQbQQmhA+AT7sW6W6vXHO6YfNOfV3lF8ph7bIZ6nZd7/X3x0dzx6JKxef09Y3rv4xPFkzE51HTENz9bX35hi07IMGyviBVRi6n0BXJl+Q2fDJLN6v6ly+YSUG3Tm3RN6CTZPFStUpqHGpGm8h1sLp22izGhfXHssixmDJ6EEJ7+0JuuSblqxZNRsyaBap87LC+KKmdtZZyVbSfkQAAA8dJREFUw/SsFpxv+XyeYZE+L5c0NGnwCnYZ3N1BxjRzwvuYNmYI5HH2pKH69j26vIkV88ersYQN6qmu9UXKv6EDe6jLSFJmVV7KdPM9u3aAJJmX5OvTWr/98gXDS5fi8GLl8lLFRAEKUMBhBBjwOsyu4kApkD0EJKgsVaKY0fWwj7rlcia0cMECqFer2qMuarftfX3a4Nr1GzYd34mTZzAguItNx8CVU4ACFMiKwGMGvFlZJZehAAUokLlAh7bN4eb68MOT/EiDBMipe3NzdcU7b7VMXezQ87ly5kCb1xradBuqVakAuX2cTQfBlVOAAhTIgsDD31Gy0CkXoQAFKJDtBLjBFKAABShgtwIMeO1213BgFKAABShAAQpQwPEE7HHEDHjtca9wTBSgAAUoQAEKUIACZhNgwGs2SnZEAQqYLsCWFKAABShAAesJMOC1njXXRAEKUIACFKAABYwFOGcVAQa8VmHmSihAAQpQgAIUoAAFbCXAgNdW8lwvBUwXYEsKUIACFKAABR5DgAHvY+BxUQpQgAIUoAAFrCnAdVEgawIMeLPmxqUoQAEKUIACFKAABRxEgAGvg+woDtN0AbakAAUoQAEKUIAChgIMeA01mKcABShAAQo4jwC3hAIUSBFgwJsCwQcKUIACFKAABShAAecUYMDrnPvV9K1iSwpQgAIUoAAFKODkAgx4nXwHc/MoQAEKUMA0AbaiAAWcV4ABr/PuW24ZBShAAQpQgAIUoIAmwIBXQzD9f7akAAUoQAEKUIACFHA0AQa8jrbHOF4KUIAC9iDAMVCAAhRwIAEGvA60szhUClCAAhSgAAUoQIFHF7BkwPvoo+ESFKAABShAAQpQgAIUMLMAA14zg7I7ClCAAmkFWEIBClCAArYUYMBrS32umwIUoAAFKEABCmQnARttKwNeG8FztRSgAAUoQAEKUIAC1hFgwGsdZ66FAhQwXYAtKUABClCAAmYVYMBrVk52RgEKUIACFKAABcwlwH7MJcCA11yS7IcCFKAABShAAQpQwC4FGPDa5W7hoChgugBbUoACFKAABSiQuQAD3sx9WEsBClCAAhSggGMIcJQUyFCAAW+GNKygAAUoQAEKUIACFHAGAQa8zrAXuQ2mC7AlBShAAQpQgALZToABb7bb5dxgClCAAhSgAEADCmQnAQa82Wlvc1spQAEKUIACFKBANhRgwJsNd7rpm8yWFKAABShAAQpQwPEFGPA6/j7kFlCAAhSggKUF2D8FKODQAgx4HXr3cfAUoAAFKEABClCAAg8T+D8AAAD//xV8lA8AAAAGSURBVAMAxoUiHl8HeJwAAAAASUVORK5CYII="
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAArwAAAH0CAYAAADfWf7fAAAQAElEQVR4AezdCWAM1x8H8G9uR9zUfZRqqauOtq66S2nVX4u0SkQISVwhaEsi4r6pK24pWtoUdVRdVUcdpdXS6l3EfZQkjiAS/vN77NrNZRO7m93NV/tm37z3Zt6bz8xOfpnMzjonJNy5z0QDHgM8BngM8BjgMcBjgMcAjwFHPQacwX8UoAAFKACACBSgAAUo4KgCDHgddc9yuyhAAQpQgAIUoEBmBBxwGQa8DrhTuUkUoAAFKEABClCAAo8EGPA+smCOAhQwXYAtKUABClCAAnYjwIDXbnYVB0oBClCAAhSggO0JcET2IMCA1x72EsdIAQpQgAIUoAAFKJBpAQa8mabjghQwXYAtKUABClCAAhTIOgEGvFlnz54pQAEKUIAC2U2A20uBLBFgwJsl7OyUAhSgAAUoQAEKUMBaAgx4rSXNfkwXYEsKUIACFKAABShgRgEGvGbE5KooQAEKUIAC5hTguihAAfMIMOA1jyPXQgEKUIACFKAABShgowIMeG10x5g+LLakAAUoQAEKUIACFEhPgAFvejqsowAFKEAB+xHgSClAAQqkIcCANw0YFlOAAhSgAAUoQAEKOIZAdgt4HWOvcSsoQAEKUIACFKAABUwWYMBrMhUbUoACFHAkAW4LBShAgewjwIA3++xrbikFKEABClCAAhTIlgLpBrzZUoQbTQEKUIACFKAABSjgUAIMeB1qd3JjKEABCwlwtRSgAAUoYMcCDHjteOdx6BSgAAUoQAEKUMC6AvbZGwNe+9xvHDUFKEABClCAAhSggIkCDHhNhGIzClDAdAG2pAAFKEABCtiSAANeW9obHAsFKEABClCAAo4kwG2xEQEGvDayIzgMClCAAhSgAAUoQAHLCDDgtYwr10oB0wXYkgIUoAAFKEABiwow4LUoL1dOAQpQgAIUoICpAmxHAUsJMOC1lCzXSwEKUIACFKAABShgEwIMeG1iN3AQpguwJQUoQAEKUIACFMiYAAPejHmxNQUoQAEKUMA2BDgKClDAZAEGvCZTsSEFKEABClCAAhSggD0KMOC1x71m+pjZkgIUoAAFKEABCmR7AQa82f4QIAAFKECB7CDAbaQABbKzAAPe7Lz3ue0UoAAFKEABClAgGwgw4DXYycxSgAIUoAAFKEABCjieAANex9un3CIKUIACTyrA5SlAAQo4lAADXofandwYClCAAhSgAAUoQIHkApkPeJOvifMUoAAFKEABClCAAhSwQQEGvDa4U7LzkLbv3Iu2nXqi2DMv4b2eQSZRdOs9GB+OnKRvm3xeX2GDmXmLP0Xj196xwZE9+ZAKl6sN2Z9PsqYOXQIxeuLMdFfRrXcwPgibqG+TfP9XqN4Y677arq+3RMZW1jl11mK0fqu7VYdz9NgfyF+qBv67EmPVfpN3NnfhCvVekrHMnr8seXWa89Y0CwgKRdAHo/VjSX7s6iuskJFzT6NWXlboybiL5O9P49rMzwUks838mrikowow4HXAPXvq9Dn1A+i7/T+YvHU/HTmmlomNu2byMqY2zMi6R46dgTo1q+Hkr3vwyaIZpnbBdtlYoNKzFfB02dJpCtR9qSYKFcyvry9TuQG+2vytft7WMqaOz9R2lt6+3LlyoskrdeHm5mrprtJc/6XLVzAsfDKGDOiFq6d+Qt/e3qm2tRUz3eAed+zq2j3pa2rbXbzYU3ih+vNPumouT4HkAjY7z4DXZndN9hzYqTPn8HKdmsiRwyN7AnCrMyzwYXAgevt2TnM5+cWpYb06adaz4skEKjxdFl+unI98efM82YqeYOmz5y6opRu/8jKcne3nx9rjjl21URaatHu9BWZODrPQ2rlaCtiegP2cGWzPzq5GVFj78/LyVWvRsWsg5Lf9hq92xGerN6ptiD51Fk1ffxAwlKvyCuRPgr36D1N1SUlJmDVvGaR9yWfrqXbrN21XdbpJZtetW15ef/vjH9Xvtes38E73fir/+ZqvpAo//vQL/vdub5R9viFqNXwDIaOn4tat26rOlMnFy/9BtqdynVdR8YWm6B4wFGfOnleL3rgZjyJP18GhH4+oeZlUeakV6rd4W7Iq7frue8i2JyYmqvnJHy1Ey/95o2iFF9U4ZX2qIo3J8ZOnIH/Ge/7FlqhUqwX6DBqB3//8N9XW4jA0dDxebtpe7ad27/TCkV9/N2qbXv+yb97qHKCsZD82afMuzp2/aLS84Yzsu4nT5+P1Dj1QulJ9tZ917rp20ubjT1dD1ivHh7RPSLiLMZNm4cXGb6rl3ujYE/u+/1G3iP71/IVLat8ZrfthrdjLOsRS6mWsa9Zvflj76OXu3UQEDhyh9l21uq0xasJM6PaFtHrcn4UNb2mo/UpbyDEmt8uIj+wT+YtIgdIvQP40L+vTpcgVX6j9dffuXV1Ruq+6P40vWLpSuZSv1hg9+36AC5cuGy238ov1kG2VY6pJ63exdHmUvj618ekrDTKPa7fo41VpjiHJhPe0QVcq++vvf+mPYXGT98jOPQdUnbhJme6WhsLauUbmkyfVWJvExMZh8PDx6r0s+12OK1m/VpXm/+m9h2VbdecvWZ/0qwuADVdobTM5vuX2hWdrNoMct3IF2nA8kk9+7MotPMNHTVHnCDGW856027pjD15r76Pe13UavYkJ0+ZB9qPUSbp37x7kFoVmb7ynzlWvtvOGHIdSl9Z2S3vDWxoe957ef/AwxHbH7n3q54BYy+1ncn6WfiTJNpvynpa26aU//jqOLn4D1ftPztkBQaEw/Ouj9PM42+s3bmLA0FEw9Jf1yHK6vjNzLOqW5av9CTDgtb99lukRL1y6Cv49u+DI/k3o3Kkd/INCcDL6DMqWKYlvv/pUrffksT2IPXMEC2aOU/OTZszH+q+3IzxkIH77YSveD/LHyHEzsHn7blWvm2Rm3bpl5fX5Ss+ofnPmzIFVkbNUvtNbr0N+cL3p1QvFniqCH/dswOyp4VgZtV77gTlOFntsun//Pry8++EPLcBc88k8bFu3XAWAb73nDwlkPHPnUrdQ7P3+sFrXiejTuHbtOv7656Q+UNl/8CfU0/4s7urqCjnZL4xcidEhg3Dil93YveUzvFS7hlo2tYn8qbWl9sMnd65cWL0iAvu++QINtKuN165fT6054q5dQ7UqlfD5x7Oxd1sUmjWurwWa/vqxpNe/nOB79PkA73R4Q+3jn/d+BZ/Ob8PJySnVvnSFEnAFasfFrwe3wNe7o/rlQIJ8Xb28SpDbvWsH/PHjdgT0fA9h46ZjYeRnmDj6A9WX/Gm23Tu98fe/0dJcn2bP/xg9vb0g6+7h3Umte/feg6o+ISEBHh45MH18qFpHH7+u2p+lp6S47/ez1V/huWfL49CudZgxMRQrv9iAKTMXqXVkdCLHUN48nup2GTnOfzu0FWVKl8CrTRtglbZew/VJP2Lp5uZmWJxu/udfflPHV9Syufhy1XwcP3kaE6bO0y8jv5DID913O7TFsUNb0KNbJwz8cAxWfPalapPa+FRFskl67Y6fOIWNm79FUJ8eGBrUG3sP/Gg0BlPf04Zdvh86EaVKFsOWtZE48etujAkNhrxXDdvo8v+d/FG9f8X34r+H8KL2/nil/ou6anT1C8b1GzewcNZ4/LxvE95o3VQd4/Je1zcyyDzuPdyz2zva+/rBPbtn/tyv+i5ZopjBGh5krW02PHwKNmgXByLnTcY3G1bg4qUr2LFr34PBpDNdov0CVKF8WezRzi3LFkyFvBf7Dw6HT5e31TkwYvpoHPzhCMLHf6Rfy8Tp8/BRxFL09/fB7z9uw6RR7+PW7TuqPr3tVg0eTsJMfE8v+3Qtpo4dhoM7v0TpkiXgHzQcso9kNaa+p6VtWknOme28/FCj6vPYELUYW9ctQ758nujUrS8ksJflTLH9YMREHDp8BCsWTlc/3+TKf3L/jB6L0re5E9dnPQEGvNazzvKefLVgprkWQBXInw+Bfl3wVOFCOHzk1zTHdedOAmbMXaoFdwMhy8mfLF97tRG6vdcBH3/6hdFyGV230cLpzCxbuQYSlE6fEILChQqg/su1Efp+P3zy+Tpc/u9qOks+qJIfFhKEzJwShsrPVUC5sqW0P+ONVAHtpq27VKP6L9fE/odXJyU4qP9yLa2fWtj78B7ofVpdPa1faXz+wmUULJBfBbm5cuVEdS04lQBQ6lJLS7WrhOI2c/II1b8s27njm3i5zgupNdcC61ro+k579UtI6VIlMCDAB1Wffw6btnyr2qfX/5UrMSqIb6gF1Pnz5VXb6tOlA+RePbVwGpP3vN7E6681hYzTt2snlZe/Bhg279yxLdq2bq5uNXHTAv9FH3+Owf17oVmj+spjQvgQlCj+FBYvW2W4GN54rRneaN1Mrbt7145q3bJPpZFYDBnghyqVK6p1dGzfBj7asZU88Cz/dBnlINskx6EExpGfGB9/sr4nSe95tVd/8ZBfgmQ98gvP9z/8DCmXeVOTvLdGDgtS9nJsvNfpTRz88Wf94gsjV6FNqybqFgzZHtnX8ovdgiUr9W2eNHNX+0vEyiUf4T35pbZHZ9WXbIusNyPvaWmvS+cvXMQL1Z6HHJMFtPNH+7Yt0zyGdcvIa5/gEfhPe58umTtJZiG/7Mg9/XO0X1xr16ym7q2WY67WC1Wwev0W1Sb5xJT3cPJlMjpvbjO5AinH+YfBAdq5pDaeKlII8svazfj4xw6tZvUqGNS3h3pPyC9n0+csgV/3d/HO223VOVB+gRg2OAASGMvKErX9LefpYYMD8b83XoUsU7NGFfWekXpTkvzFzNT39LDBfVDrharqvNLP31v9kitX4KUfU9/T0jatJNtVvepzkHNDxQplIffnjx85FMd++xty7Jhie127uvupdmHk/YEBeKlODeU2avhAyDlb129mjkXdsny1TwEGvPa53zI16hLFixotV/SpwukGjSe0q7/yA1L+lCZ/ytKlsLHTceLkGaN1ZXTdRgunM/OvdrXqlQYvGl1NerVpQ7XE8ZOn1Gt6E2lTrGgRyA9rXbvnKj4NSf+eeHA1UoLZ3fsOqT+T7//+MGS+vhbg7j1wGLe1qyRyhVeCYlle+r783xU0bdNZ/Ul/1eoNkD+RS11q6Z/jJ1Fb+8EuV4dTq09eFh9/S/25son2p+4iT9dB/lI11BWe02fOq6bp9S/BfIO6dfBqO2/tSulk7QrsSsjtKmrBdCZVn69kVFu9SmV1ZdKw8IVqVfSzJ0+dVYF1i6YN9GWyfU0b1YNcXdQXapnHrXul9ud9uZ1CbrOR42vCtAjotlVbXP1frcqz6lU3qVGtMi5cvAyx0pU96Wublo3h5uoGuTIq61q+ajXEUn7gyrypqXTJ4kZNCxcqBLlipSv8+9+TaNHkkZuUy/zvf/2rv0omZU+S5Oqg4dXXcmVKae/zK2qVGXlPqwUeTjr8rzWC3h8NuR3no4hIHP457V+UHy4CCdQ2b9uFT7Xgu0jhgqr43+PRkKCvcLLbn2OaOAAAEABJREFUHjZv2w35a5NqlGxiyns42SIZnjW3mdwmI1c9Gzespx9LHs/ckF9G9QVpZF6oXtmo5s+/j2P0xJnqdgJ5j0hq8WZXSOB3/sIl/HP8FOQ8/VLt1H+JNlpZGjMZeU+XKvHo50gR7aKJrNLw4oMp72lZJq0k5+Vt3+412l655UiOGzl+TbHVtZHAWdePXOGt+vyjc8m/mTgWdeviq30KMOC1z/2WqVHLGz75gtpf/JMX6eednB78KXz/N6shf540TAd2rNG3k0xG1y3LmJpcXFyMmrq4Gs8bVaYyk9qfpA3XWffFmlqwm6T9ED+Gnd99j4Z1a2tXZWph/8HDkCtj7tqftF+sVV2tWa7U7NnyOTprV+5uasHp+KkRaNL6HaOgRjXM5GSY9mfQn385hllTR+Kvn75R7nJVM+HhfaSP63/1irkIfb8vcnh4aH/634iXm7VHRp7WoRu2/LDW5eU1R04PeTFKEuQaFri6uBrOppnXrfuz1Rsxcfp8jPign/rzqBxfIUP7Qbetaa7gYYWp7R42T/dFjpEu77TDZ2s2qGA+as3XkNsZ0l0olcrU3wf3jVoaHntS4aodz2Li5PTg/SZlT5Jck71fnJyc9MG0k9ODPkx5TxuOQa7qLYmYhDKlS2LfgR/QvG0XdW+/YRvD/Dfan+7lXuuFsyaov2zo6pycnNTVTtnXydO08cN1zVK8yv5JXpjcMXl9RuYtYSb9u7oa/4g15dyVM9kHdp2cnDB13DB1LkhuZvjXGyenB/tW+s1sMuU9nd4x/qTvaRm3k5MT3m7XOtXt7aD94iVtJGXGVpbTJSenzB2LuuX5an8CzvY3ZI7YEgIeWoAk69XdIyX5Ck+XVldWv9m5T2YznVJbt6krq6D9Ofvor38YNf/p59/UfPlyZdRrehNpIx9Qkyshunby4Rq5clzh6bKqSG6ZkID2U+1q4w3tT2FyRVZuOfjneLR6fqtc3TX8QSBXs3tpf2Icr/2Zbf/21TilXX394fAval3JJ8+UL6cF0r9qAXVi8qpU5yXIfuO15qj2/HMooP3pWK7cHPvjb6O26fWfQ/thKX/6HPFBf+zY+Alqv1ANm7c/uHXDaCUGM7/+Zux79NjvkD8jGjQxypYrUxISbBz99cF+0FXK7THltf2lm5fX9NZ94Ief0UC7ki7WxbSr8NL+l2PGY3lQ9pe86NORX35H0SKFIbcE6AszkMmZIwfu3b+XYgnvd9/Gth17IX+Kjr91C2+92SpFmyctqFihHI7++qfRan46egzPP/eMviyt8ekbPMyY2u5hc/VS4Qne062av4L3B/bGZx/PxuD+PbF24xa1zuSTv/+Nhm/AUHwwKACttSvnhvVyL7Zc8ZY/TRuWp5c35T2c3vKGddYyK1O6hLp33nBfy4fMfjpi/J4xHFta+ee1Y2PH7v1pVeOZ8mXg4eFudOtM8saP2+6MvKeTr9tw3tT3tOEyyfPPVayAvdovVXKbRfI6mTfFNrU28rPt198enUsycyxK/0z2K8CA1373nVlHXrpUcXXSNDwhSJAn92lOm70Ycj/U1ZhYyEnoiy+/1n/IxpRBpLZuU5aTNnKPo/x5Sq4WSaAqH9YYPWmmuj+xyMM/k0q7hynFS6MGL6GG9ifwAUPD8effJ9SfTQd9OAZltR9IrV9trG9f76UX1IfhGtavo35QyQ+QBtqV3k8+/xJ1X6qtbydfYCD3t8qfE6Vw995DKph9ulwpmU2RunfpAPl0cf8ho9STGcRQLOXKcYrGWkG1Ks+p+xzlvjzZ3oCBoYi79ugDbun1//uf/2DqrMX6J1DIn4jlz3ZPl019bFp36v+VX2xUz6WVfpYs/1zlfd57W9WlNpE/l/fq/g7k6rb8YJJtmjRjAX459if8fN4xWiS9dVfT/rz4o/ancVle7p2V42zrjj1Gy8uM3IMtf0YXx2+0K4dzFi6H3A8sdZlJ8ufrY78b/xIh65Efks0a1UXI6Gl4q91ryJ0rlxTrk3zqPbXx6RuYkBEfuUf58zVfqeNi7YYtkA8B9fJ9V790WuPTN3iYMbXdw+bqJbPvaXkyymFtX8lK5P7IQ9oveE+n8uzjm/HxeLd7PzRv0gASHCPZv3ov1VKfB5B7e3fs3qduGZKnWMgXRRw49FOy1g9mTX0PP2id/tRaZvJLtPe7b2HclDnqfS+3RoWOmYaY2Lj0B5hKbbD2y4U8N3r81Lnq/CWBm9zXLH8dkeayT4MCu2Ps5Dn4cuM2dYuV/EIh7xmpl/S47c7Ie1rWl1Yy9T2d1vJS7tu1g7zAr/+HOKr9AizbK+c2+Rkg5yhTbOX2EfmshPjLzww5l44YOx1yrKmVa5PMHIvaYvzfjgUY8NrxzjPn0OUEMbCPL9708oPcIyaP8ZL1D+rrq/7kvGR5FKq93BqvtOqkgl152LzUm5LSWrcpy5YqWRwboxbhh59+UY8x8g8arv0wrY8pY4eZsrh6JueqpTPh6emJ/73bC6+266oC2i+WR8Dd3U2/DrlvV66m1nux1qMy7YezlNV/uaa+zNMzF+YsWI5Sz9VTTjKeyWM+0P5s+4y+jWFGbkHYGLVEfSq9fefekEdVTZ+9yOjDE4btx4UNgZzg5bFojV7zwnMVy6NZ40f3AabXf66cObHruwOo+vJramy1G72JVi0aQT4IZthH8vzQoF6YMmuheuTRkmVRkCd0SJCRvJ3hfPiwgZAPyAS9Pwo16rVRQfq6VfOhu2qua5veumVcr7dqguZvdMFLTdpDftka2KeHblH9q2/Xjlow/QfKVXkFQe+Pxjtvv4Hgfinb6Rd4TKZf727aPlwGOc7lsWSGzd/p0Fb9UidPUTAsl/zCyJWa7/eSzXR6s00LyAcw5y5agSovtsJHcyMxKmQgunj9T7/O9Manb6RlTG2nNTX6PzPv6YuX/kObDr7KTB5HJcfoqOFBRuuVGbm3Wv4ysmb9ZtVWjHVJ6iV9vGAqWjZ7BcNGTkGF6k20AHmAdvx8r71HcyO1f/IndFPew6ktm7zMmmZjwwajnnYOaf9ub9Rt/pZ6jJjs/+Rjety8rGPD54u0K7hH0eyN91C59qvaL7aLkJBwR7/o0KDe6OPXFVM+WqAe3yf3+F68dFlfb8p2m/qe1q80lYyp7+lUFtUXyV+2tqz9GHI+6+o3CPK+H/ThWMhf5dxcXVU7U2wnjHpfPYHnvZ5BqFS7hbpVSY67fHk81TpkktFjUZZhsl8BBrz2u+/SHLlcqZJ7vQw/IPHfyR9TfFhm95bP4N+js3498idIWU6SBD1S4eTkpAKm7euX4+xf+/HD7vWQh8y3b9tKqlXK7LrVwskm5//+Hq9pQZphsXzieP1nC3Hq9704/N1GjA4JVrda6Np8PH8Kxo8cqptF8vli2p/Ll8ydiN9/2Ia/f/5W1YuRfgEt06JJA3XPmOE3NMkVKrGQHzhaE/V/88b1IfcvS7mkk8f2aFc131V1aU0qPVseyxdOU4/0kmUO7VqvblmQ9uK/a/MqyaokAfKi2RNwcOc6yCOzZAzyxQljRwxW9en1L4+XEyfpQ9KV6MP4aNIIdfuBWjiNifxSIY+lk2W+2xYFeWqAYdPU9q/8siD328q2nP5jn/qlRD7ol3w5+QGY1rolkAl9vz9+2rtRJdlHQ7XgW9rr1vPFirmQbRcTGd8vB75G2IcDYHhP58fzp2JC+Pu6RdT+NTwe/j26C/KQfV0D+TO7jFnWJ8a6cnk9eeocKj1bAXKbhczrklzR/+f4qRQ2unp5DdaC8K/XLJWsPkm/0r++QMuI785NK9X7aefXK9Gt89ta6aP/0xvfo1ZQtwsk3w5TxuDk9Pj3tGE/kpdHiF3456B6j4ibHGclHz76q3qVSqpcnqIiv/BIfWpJ1iNJrtDJkyzkfSTnFNnfny+bg6qVn5XqVNPj3sPy5ALpU9ad6goeFqZmaykzGYs8meGPw9shjwicOOoDzP9oLGZMCH04GmjH6lSjY1eOd3lP6Bs8zMhj3dZ+Og/Hf9mFP3/6BuJv2E5uMZJzl7x/5VFw8t6XX54fLp7qsSLnnt3azwBdm8e9p+U8KMZy25RuGdnnUibHgJSZ8p7+ONn5WpZLnuRcJj+DjuzbpM778r6S5XLlyqmammIrF1rmTBulzvlyDpNzxJ9/Hze6XUvWk9FjUQ2AE7sUYMBrl7vNPIPmWihAgUcCV67GYuHSlejh3fFR4cOcfPCvVYtXUKOq8SfoH1bzhQIUsDGBwz//qn98pdxX3n9IOK5cjUF7C9ybb2ObzuGkIcCANw0YFlOAAtlHICAoFC82boe32rVC9y4pA175q8OqpbOyD0j221JusYMJ5MyZE7Pmfaxu8XitvTfOnruINdpVcnneuINtKjfHRAEGvCZCsRkFHFFA/tTXokkDR9y0DG1TxIzR6s/F8mdg+RBQhhZmYwpQwOYEKj9XQX/7mdxWtObTCP2tZDY3WA7IKgIMeE1lZjsKUIACFKAABShAAbsUYMBrl7uNg6YABSiQdQLsmQIUoIC9CTDgtbc9xvFSgAIUoAAFKEABCmRIwEIBb4bGwMYUoAAFKEABClCAAhSwmAADXovRcsUUoAAFABCBAhSgAAWyXIABb5bvAg6AAhSgAAUoQAEKOL5AVm4hA96s1GffFKAABShAAQpQgAIWF2DAa3FidkABCpguwJYUoAAFKEAB8wsw4DW/KddIAQpQgAIUoAAFnkyAS5tVgAGvWTm5MgpQgAIUoAAFKEABWxNgwGtre4TjoYDpAmxJAQpQgAIUoIAJAgx4TUBiEwpQgAIUoAAFbFmAY6NA+gIMeNP3YS0FKEABClCAAhSggJ0LMOC18x3I4ZsuwJYUoAAFKEABCmRPAQa82XO/c6spQAEKUCD7CnDLKZDtBBjwZrtdzg2mAAUoQAEKUIAC2UuAAW/22t+mby1bUoACFKAABShAAQcRYMDrIDuSm0EBClCAApYR4FopQAH7F2DAa//7kFtAAQpQgAIUoAAFKJCOAAPedHBMr2JLClCAAhSgAAUoQAFbFWDAa6t7huOiAAUoYI8CHDMFKEABGxRgwGuDO4VDogAFKEABClCAAhQwn0BWBLzmGz3XRAEKUIACFKAABShAgccIMOB9DBCrKUABClhOgGumAAUoQAFrCDDgtYYy+6AABShAAQpQgAIUSFvAwjUMeC0MzNVTgAIUoAAFKEABCmStAAPerPVn7xSggOkCbEkBClCAAhTIlAAD3kyxcSEKUIACFKAABSiQVQLsN6MCDHgzKsb2FKAABShAAQpQgAJ2JcCA1652FwdLAdMF2JICFKAABShAgQcCDHgfOHBKAQpQgAIUoIBjCnCrKAAGvDwIKEABClCAAhSgAAUcWoABr0PvXm6cyQJsSAEKUIACFKCAwwow4HXYXcsNowAFKEABCmRcgEtQwBEFGPA64l7lNlGAAhSgAAUoQAEK6AUY8OopmDFdgC0pQAEKUIACFFXTjr4AABAASURBVKCA/Qgw4LWffcWRUoACFKCArQlwPBSggF0IMOC1i93EQVKAAhSgAAUoQAEKZFaAAW9m5Uxfji0pQAEKUIACFKAABbJQgAFvFuKzawpQgALZS4BbSwEKUCBrBBjwZo07e6UABShAAQpQgAIUsJKAzQW8VtpudkMBClCAAhSgAAUokE0EGPBmkx3NzaQABexOgAOmAAUoQAEzCTDgNRMkV0MBClCAAhSgAAUoYAmBJ18nA94nN+QaKEABClCAAhSgAAVsWIABrw3vHA6NAhQwXYAtKUABClCAAmkJMOBNS8bEcjc3d1g6ubi4ICkpyeL9WHo7uH7jY8XV1Q2JiYncr1Z4D1n72GvT5nXuVwfcr3fv3oWLiyv3rYPtW/n56uzsYpX9amJooZpdvXoFmUzZZjkFZeKEAa+JUGxGAQpQgAIUoAAFrCnw1FPFwJS6QUb3AwPejIqxPQUcQYDbYHGBAltHgcmxDEp+NxWFto/hfnWwY7v47skWPx+wg6wXYMCb9fuAI6AABShAAQpQIIsE2G32ELBYwJuYlIR6rbrAP3g0eg8ahZ4DwrD5m++MVL/auhu+/UagR/8wVf/9j0eN6nd+9wO69w3V6kbiXb+hmDw7EnHXbqg2fkHhav3Sh6ROvsGqfOTECGzatlvlZXIz/haatushWUg+bMJcSNuO3YNV3zduxqs6WV/XgGEIGDwGPlqf8yOjcCchQSVZf2op+vR5tSwnFKAABShAAQpQgAK2K2CxgFc22c3NFfOmhmL+tBEYM6wflnyyFqs3bJMq7N5/GPM//gLjQvtj8cxwDO3vi5Cxs/HP8VOq/sAPRzBp1hKEDvbHoo9GYsH0MBQtUginzjwKMmW9+7esgKTPl0xVy6U3Wb1hO65dv4llEeMRtXQqBgV2NWo+pK8PIqaEaOMNxYnoMxg1aR483N3V+qWPfn6d4dW+lX6+bOniRstzxlEFuF0UoAAFKEABCtizgEUDXkOYYkULI7iPD1Z8/pUq/nztZnTv3A7Fniqs5p+tUBZvvdEcUeu2qvmVqzejR5f2KF+upJrP45kb3l5tUe35imo+M5OY2DhUr/Iscni4q8WrVq4Iz9y5VN5wIkHu8OBe2HfoCM5duGRYxTwFKEABClAg+wpwyylgpwJWC3jFp07NKrhw6T8k3L2Ls+cvoZoWcEq5Lj1f6RmcPndRzZ4+ewE1qjyn8mlNeg8apb+tYfCIKWk105e3a90MGzbvVLctLFq+BqfOXNDXJc9IgF2xfBkcP3k2eRXnKUABClCAAhSgAAXsSMCqAe/9+/fh4vyoSycnp3SpnF0etJWgU3cP7Wdrt+iXMbylYcqowfrytDLlypTAqsWT1JXi4ydPwztgGE5Epx3QOhuMNa113rlzG5ZPdyDPf7R8P7fNsS1cRwaOicTEu/TKgJe9vAfSOl+wnAIUsE2BhIQ7VjkXZ3brt367D+279jdp8ejT5/DK694mtTWl0fAxHyFy5ZemNLXpNg8iSisN8aQWXBYuVADubm4oWfwp/Pr730Y9//bHPyhdoqgqK12ymHZ19YzKy20Ncg+t3D+rCtKZ5Mvridi4G/oWV2PikD9fHv289F3vxRoYFzoAzRvXxY49B/V1hhn50F306fOQINmwPHne2dkFlk/OcHJyskI/LuzDKvvzkTPgTHMrm1v+/eoC/qPAAwFO7UXAyckZPDfYy97K3DidM7dYxpeKjbuGmQs+RZdOr6uFO7V/DUs/XYfL/11V83/+cxLyobJO7Vup+Xfffg3T5i7DN7u+h1wZlsJbtxPkJd1Us1plbNq2B/G3bqt2Ueu2oGa1Sip/9NhfiIm9pvLydIYT0WdQuGA+NW84kW+/mrt4FWpVr4RSDwNww3rDvJsWvFsjubq6whr9sA83qzq7urpYtT/uX+vsX8NzBPMUoIDtC1jr3GguiZZv+2HOopXoNXAk3vIegIkfLUbSvXtq9b79QnH79h282NxLpb//jYZcxJu18BO87hWApm92x6SZS/Ttj588g+b/64GP5q9Q65MryboHDKxcvQlydVn6kvUNGfH420fVIGxwYtGA9+7dRP1jyQaPmIrXWjRAhzdbKoZG9WrBz/ttvB8+A/LIssmzlmL0sL6oUK405F/dOjUwtJ8vln22Hu/0HIK2nfshIeEuWjWvL9UqGd7D26qDvypr0rAOGjeore20cPj0CcGVq3EI9PWC/Dt/8TK6aWW9BoajjVcgihTKj9dbNpIqleSxZ/JYsp5B4XB3d8OIoQ/WqSotNOFqKUABClCAAhSgQEYFjml/FZ8zKQSfLZ6K49oFvF17D6lVLJk1GjlyeODQN5+pVLFCWUR+shZHfv0Tk8KDsXzeBJy/cBkLP45S7WVy7foN7eKLKxZMH4lFM0dhgVYnfyF/9+02aNm0Pvr0fFeta7IJt4/K+mwxWSzgdXVxUY/v0j2WbNFHWpDZ4hUjAwk2l8waBamTJLcaGDaQ4PXjuWO1nTkFGz6dhTAtAM2f98HtCQtnhKn1y60OkrZ8MU+/qJ93B6yYNx6Rc8ZgbEh/yG0UUtmqWQOs/2SmtkPDsHtjJCaOHAS5cip1sr7lEePUY8kiZ4+Gv08n9UgyqdOlzh3aIMjf+FFmujq+UoACFKDAEwlwYQpQIAMC3u+8qYJUNzdX1Kj6HH774980l/5s7WYM6N0FVSo9o/5yHdDDC18ZfGeBs7MzenZ9Wy1fqEB+yG2lf/x9Qs07ysRiAa+jAHE7KEABClCAAhSggK0JSGCqG5NcZIy7dl03a/QqX7oVq9XJrQ5yW4Kk93q9jwsX/9O3k0e0ymecdAVurq5Ia326Nvb2al8Br73pcrwUoAAFKEABClDAigJOTk5GveXOlVNdCV6z7CN1W4LuVgd5NWqYxoyTk/H60mhm88UMeG1+F3GAFKAABVIKsIQCFKBAagIFC+RTn3nSPRRA2rzX4Q1MmrkY12/clFncSUjAgR+OqvzjJoUK5lffnfC4drZez4DX1vcQx0cBCtilQEzLEWByLIOzDYNxpUUI96uDHdvnGw2xy3NMWoOW2xPkAQFtvAL0T2kI8PVCjaqV0NX/A8gzev0HhePosT/TWoVR+f/aNMPO7w6pddnoUxqMxpvWDAPetGRYTgEKUIACFKAABWxAQJ6UsHb5TP1Itq5eCHn6gq6gV7eOGB7cWzeLIf26629fkHa6D6V9uWIW9ny1DEtnj4UsIwuUL1cK33y5WLL6FDF1BFo/fNDA02VLYduahWp9fEqDnogZClCAAjYowCFRgAIUoEC2FuAV3my9+7nxFKAABShAAQpkJ4Hsuq0MeLPrnud2U4ACFhUosHUUmBzLoOR3U1Fo+xjuVwc7tovvnmzRcwFXbhsCDHhtYz9wFBSwIQEOhQIUoAAFKOBYAjYT8K7fvBOjpyww0u0WOBzH/vgXiUlJqNeqC6ZHLNfXL/tsA+Sr76QgYulnWPrpOsli5MQIbDL49hB54HLTdj1UneTDJsxFJ99gdOweDN9+I3DjZryq8wsKR9eAYQgYPAY+fUMxPzJKPbZDHt0hfaeWok+fV8tyQgEKUIACFKCAAwpwkxxGwGYC3seJ5vBwx579hxEbd+1xTdOsX71hO65dv4llEeMRtXQqBgV2NWo7pK8PIqaEYP60UJyIPoNRk+bBw90d+7esUKmfX2d4tW+l8lJWtnRxo+U5QwEKUIACFKAABShgewJ2EfA6OTnB1dUV7Vo3xaq1mzOtGBMbh+pVnoUEz7KSqpUrQp5XJ3nDJEHu8OBe2HfoCM5duGRYxTwFkgtwngIUoAAFKEABGxewi4BXZ9ih3avYsmMf5NYEXVlGXtu1boYNm3eq2xYWLV+DU2cupLl4Hs/cqFi+DI6fPJtmG1ZQgAIUoAAFKKAT4KstCEw8vhsFt402OUl7Wxi3pcdgVwFv7lw50bp5A3yxblumXMqVKYFViyfB26utFsiehnfAMJyITjuglQc1P66j+Ph4WDrdunULd+4kWLwfS28H15/yWElI4H51xOPicecN1lOAArYlID9nrXEusq2tzl6jsZmAN18eT8RdM74/NybuOgrkz4P79++rJLvmnbdaY83G7UhMTIKTk5MUGaV8eT0RG3dDX3Y1Jg758+XRz7u7uaHeizUwLnQAmjeuix17DurrDDPyQTn5UJoEyYblyfM5cuSApZOHhwfc3Fwt3o+lt0PWz2R8vMitOjQxNnEED/AfBShgVwLyc9Ya5x67QjFhsFNmL8XX2/eY0DLrm9hMwFv1+Wdw5Ne/9Fdcd373A1xdXFDsqcJGSnm1wLh545fVkxgkEDaq1GZqVqus1e1B/K3b2hwQtW4LalarpPJHj/2FmNgHQbU8neFE9BkULphP1RlOEhMTMXfxKtSqXgmlShQ1rEqRl6vATM6gAQ14DDw6BlKcKFhAgZQCLLEhAWudv2xok7PdUGwm4C1UID+GD+qF0VPmo+eAMHyuBaqjPgxUgVTyvdK1U1tcvHw1ebGab9KwDho3qI1eA8Ph0ycEV67GIdDXC/Lv/MXL6KaVSV0br0AUKZQfr7dsJFUqTZ4dqe7v7RkUDnd3N4wY6q/KOaEABShAAQpQgAIUSFvg8JHf4NsvFF16v4/hYz7C9Rs3VeOxU+djjBbb+Q8KV3XSTipu30lA6LhZeNdvCIKGTVDL/vHXcamySLKZgFe2ToLVJbNGYdFH4Zg7eTjkKQpSLld6t69dKFmVCuTPiz1fRaJXt45qPqC7F7p3bqfyMvHz7oAV88Yjcs4YjA3pj8KFCkgxWjVrgPWfzMSC6WHYvTESE0cOUk9/kMqFM8KwPGKceixZ5OzR8PfppB5JJnW61LlDGwT5Gz/KTFdnkVeulAIUoAAFKEABCti4gNwGKkFun57vYsX8iXDR/kL/8cp1+lEnJSVhzpRQzJ8+EtPmfqzKV6/fqr4L4dMFk1TM9ctvf6lyS01sKuC11EZyvRSgAAUoYN8CHD0FKGC7AmfPXUTevJ6oXeN5NUiv9q/hyK9/qrxM6r30AlycnSEPH9DdWvrbn/+iXZtm6vNYlZ4tjyqVnpGmFksMeC1GyxVTgAIUoAAFKECB7CHg5uqq31D5QPZ93NfPu7g8Cjfv3X9QLi/yF3xdI1dXF13WIq+PRmCR1VtzpeyLAhSgAAUoQAEKUMDaAiVLFEXctRv4+dc/VNeff7kZNatXVvm0JlUqVcAPPx9T1deu38Aff51QeUtNGPBaSpbrpQAFsrVATMsRyLLEvi1if7ZhMK60CLHIunmsZN375XyjIdn6XGWOjZcrteEf9MHM+Z+oD6bdvn0H3d559Nmq1Pp4+82WkEfH9h06FhM/Wozy5UrB0zN3ak3NUsaA1yyMXAkFKEABClCAAhTIXgKD+3ZH6xavqI2uVeN5LJk1Wn1obWzIAHjmzqXKhwf3RvNGdVVeJl9/Pk9e4O7mimGDemH2pOGQD7vdunUbxYsVUXXmnOg9Bo0OAAAQAElEQVTWxYBXJ8FXClCAAhSgAAUoQAGrCCQl3cOr7XvgnR6D8f7IaRjS31d9sM1SnTPgtZQs10sBCtiJgGWGWWDrKDA5lkHJ76ai0PYx3K8OdmwX3z3ZMieBLFrr++Ub4eqroSYnaZ8VQ3XTrvDu2bQcqxZPwfJ5E/BSrWoWHQYDXovycuUUoAAFKEABClDATgQceJgMeB1453LTKEABClCAAhSgAAUAmwt4F69Yiy69P1SpvXcQjv3xr9pP7bsG4cKl/1ReJrv2/YiBwx/8GSJi6WdY+umDb/QYOTECm7btliYq3Yy/habteujzYRPmopNvMDp2D4ZvvxHqWz6k0i8oHF0DhqmvFvbpG4r5kVG4k5CgUr1WXZBaij59XhZlokB2EuC2UoACFKAABexOwKYCXgluv/zqG0wbOwQr5o9HxOQQ5MyRw2yoqzdsx7XrN7EsYjyilk7FoMCuRuse0tcHEVNCMH9aKE5En8GoSfPg4e6O/VtWqNTPrzO82rdSeSkrW7q40fKcoQAFKEABClAguwhwO+1JwKYC3isxcShfrjSeKlxQGRYrWlibL6ny5pjExMahepVnkcPDXa2uauWK+sdmqIKHEwlyhwf3wr5DR3DuwqWHpXyhAAUoQAEKUIACFLBHAZsKeF+qVRW379xRtxpMnhWJn3958I0d5oJt17oZNmzeqW5bWLR8DU6duZDmqvN45kbF8mVw/OTZNNuwggKPE2A9BShAAQpQgAJZL2BTAa9ceZ03NRRD+3eHi4sTBoVMMbof90m5ypUpgVWLJ8Hbq60WyJ6Gd8AwnIhOO6B1dn48T3z8TVg63boVj4SEOxbvx9LbwfWnPFYSEhK4X63wHrL2sfek5youTwEHFLDpTZKfs9Y4T1gDYcHHUXixuZfJSdpbY1xZ3cfjIzorj9DJyQmVKj6NQYHdMLivNzZt36tGIFdc4+Kuq7xMYmPjkD9fHskapXx5PREbd0NfJl9bZ9jO3c0N9V6sgXGhA9C8cV3s2HNQ39Ywk5iUBPlQmgTJhuXJ87ly5YalU86cueDu7mHxfiy9HVx/ymPF3d2d+9UK7yFrH3vJzxOcpwAFbFtAfs5a4zxh2wqOPTpnW9o8ucVAdwtB0r17+PX3f1GoQD41xJrVn8Pn67apvDw9YcOWXahdo7KaN5zUrFZZuyq8B/G3bqviqHVbULNaJZU/euwvxMReU/kbN+O1q7tnULjgg/WrwoeTxMREzF28CrWqV0KpEkUflvLF4gLsgAIUoAAFKEABuxGIu3YDw0Z/BL+gMPToH4r/demX7thv3b6NVWu+TreNpSptKuC9o/3ZftiYGejeNxRt3+2Ln375A719Oqht79HlLSRpV127BQ7XUMNQo+pzaP3qK6rOcNKkYR00blAbvQaGw6dPCK5cjUOgrxfk3/mLl9FNK5O6Nl6BKFIoP15v2UiqVJo8O1Ld39szKFy7ouqGEUP9VTknFKAABShAAWsKsC8K2IPAzr0HUfSpQlg4IxwzJwx77JBv307A6g0PLl4+trGZG9hUwFuxfFmsWjQZS2ePxqbP5mLlwokoUewptcl583hi5PsB+HjuWKyYNx7yiDAX5wfDD+juhe6d26l2MvHz7qDaRM4Zg7Eh/VG4UAEpRqtmDbD+k5lYMD0MuzdGYuLIQXB1dVV1C2eEYXnEOPVYskitf3+fTuqRZKry4aRzhzYI8jd+lNnDKr5QgAIUoAAFKECBbCNw7I9/EPnpOmzfuR+Bg0cbbXf06XNo33UA3ukxGH4DwnD85BlVv2BZFC5oFx/livCcRStVmbUmDyJGa/XGfswowFVRgAIUoAAFKECBrBGoUukZvPt2a/WX8rlTQo0GUSB/Xu2q70isWjwFft06YOLMxaq+l3dHFCtaRKsLR5+e76oya00Y8FpLmv1QgAIUoIBlBLhWClDApgRy5PDA1m/3ITh0MhYu+wInT6X9RCxrDZwBr7Wk2Q8FKEABClCAAhTIBgKrVn+N0+cuYEjf7pg/LQy3bt3J8q3OLgFvlkNzABSgQPYSiGk5AkyOZXC2YTCutAjhfnWwY/t8oyHZ6+Rkha09deY8ald/HsWKFsa+gz8jMSlR9ZorVw5cv35T5a09YcBrbXH2RwEKUCBLBdg5BShAAcsKdPxfK8xe9Cl6DwrHj0d+Q768eVSHHu7uaPtaE/QdOhb80Joi4YQCFKAABShAAQpQwJYFOv3vNfh3f/Do19y5cuLLFbPUcJ97ppzKy+0MA3p3wdefz1PlMpEPq82eNNw2PrQmA2KiAAUoQIHMCxTYOgpMjmVQ8rupKLR9DPergx3bxXdPzvwbnUvajQBvabCbXcWBUoACWSDALilAAQrYlUCvbh1x6JvPTE7S3q42MJODZcCbSTguRgEKUIACFKAABbKPgH1vaZYFvAd+OIJX3+oF/+DR6DlgJAZ8OBHyrR2GnF9t3Q3ffiPQo3+Y1iYM3/94VFXPWvgp6rXqkiKFjpuNkRMjsGnbbtVOJjfjb6Fpux6SheTDJsxFJ99gdOwerNZ942a8qvMLCkfXgGEIGDwGPn1DMT8yCncSElRKrS8piz59Xi3LCQUoQAEKUIACFKCA7QpkWcArJM8/VwHzpoZi0Ucj0dXrDfT/YAL+OX5KqrB7/2HM//gLjAvtj8UzwzG0vy9Cxs5W9fK1wvu3rIAkuUl6+9qFKj96WF+1bFqT1Ru249r1m1gWMR5RS6diUKDx1wQP6eujvlp4/rRQnIg+g1GT5qmvF5Z+JEm/Xu1bqb5kvmzp4ml1xXIKZEsBbjQFKEABClDAFgWyNOA1BKnzQhV0/F9LrIj6ShV/vnYzunduh2JPFVbzz1Yoi7feaI6odVvVfGYmMbFxqF7lWeTwcFeLV61cEZ65c6m84UQemzE8uBf2HTqCcxcuGVYxTwEKUIACFKAABR4nwHobE7CZgFdcalarhOjT5ySLs+cvoZoWkKqZh5PnKz2D0+cuPpzL+Eu71s2wYfNOddvCouVrcOrMhTRXksczNyqWL4PjJ9P/OrykpCRYI927d88q/VhjW9jHo2OG+/WRhSMdF2meWFhBAQrYpIC1zj82ufHZZFA2FfA6OxsPx8nJyay7oVyZEli1eBK8vdpqgexpeAcMw4notAPa5ONJbTB3796FpVNiYqIKdi3dD9dv+X1pZKwdO3KSTV7GeevvB3Obp3auYBkFKGC7AvJz1tzngdTWZ7sCjj8y4wgzi7dXrqaWKVVcjaJk8afw6+9/q7xu8tsf/6B0iaK62VRf8+X1RGzcDX3d1Zg45M/34Bs+pNDdzQ31XqyBcaED0LxxXezYc1CKU6RE7cpt9OnzkCA5RaVBQY4cOWDp5OHhATdt3Jbuh+u3/L5Mbsz9an3z5PvAEvMGpwhmKUABEwSyuon8nLXEuSD5Oq2xnXeWL0dcy5YmJ2lvjXFldR82E/Aejz6Dz9ZuRtdObyiTTu1fw9JP1+Hyf1fV/J//nIR86KxT+1ZqPq1JzWqVsWnbHsTfuq2aRK3bgprVKqn80WN/ISb2msrL0xlOaH0WLphPzRtO5De9uYtXoVb1Sij1mADbcDnmKUABClCAAhSgAAVsTyBLA97f/vxX/1iyGRErMOrDQDxTvoxSalSvFvy838b74TPUI8kmz1oKeQpDhXKlkd6/Jg3roHGD2ug1MBw+fUJw5WocAn0ffO3d+YuX0U0rk7o2XoEoUig/Xm/ZCLp/k2dHqvt7ewaFw93dDSOG+uuq+JrlAhwABShAAQpQgAK2LvD19j2QmO1Jxrlqzde4dfvBhcsnWY/hslkW8NatUwPb1izQP5Zs5oQPIE9NMBycBKNLZo3Coo/CVZJbEQzrJS+PJJNHk0lel/y8O2DFvPGInDMGY0P6o3ChAqqqVbMGWP/JTCyYHobdGyMxceQguLq6qrqFM8KwPGKceixZ5OzR8PfppB5JpiofTjp3aIMgf+NHmT2s4gsFKEABClDAOgLshQIOLrB6wzbcvp1g1q3MsoDXrFvBlVGAAhSgAAUoQAEKWFVgx57v0XfoWPWFXl49gvV9nzt/CX2GjMHb3YKwas0mffkX67aia8CHeNdvCOZHfq4vf8t7AKbOidT+yj4ak2YuwQXtL/KDQiah/wfj9W2eNMOA90kFbXN5jooCFKAABShAAQpYVOCjeSsweVQwPl8yFbMnDtf3JbeQyl/Rl8+boL4/IfbadRw/eQYLl3+Bj8Z9gCWzRmP7rgPYd/Bn/TKlSxbT/soeqr5orFjRIpg2ZihmTvhQX/+kGQa8TyrI5SlAAQqkIhDTcgSYbMHAfGM42zAYV1qEcL862LF9vtGQVN7BLDJFoEbV5zDpoyVY+sla3Lt/X79Ida1cvtgrV84cKF+uNE6dPo+ffvkdzRq9jIIF8iFnjhx4o1VjHPn1T/0yzRrV1ectkWHAawlVrpMCFKAABShAAQo4uMCoD/vinbfb4L72n/+gUbh958F9t24PPx8lm+/i7Ax5+pXkDctdXVy0pR4Fye5uDz5TJe0skRjwArAELNdJAQpQgAIUoAAFHFng+o2beO6ZcvB97y24ujjjwqX/0tzcmtUq49vvDkK+H0GewPDVtt2oVb1yqu3lynDcteup1mW2kAFvZuW4HAUoQAHHE+AWUYACFDBZoJNvMNq+2wcfhE9Hq2YNUK50iTSXLV+uFLp5tcOAYRPg2y8UjevXgTyxK7UF3uv4BmbMW84PraWGwzIKUIACtiRQYOsoMDmWQcnvpqLQ9jHcrw52bBffPdmWTh12NZavP5+HDSvnYELYQPT07qDG3rrFKxjSr7vKy0TqatV4XrLo0K4llkeMx8qFk9Hbp5Mqk8maZR8hbx5PyarUsml9zBj3QRZ/aE0NhRMKUIACFKAABShAAQrYhwBvabCP/cRRUoACNijAIVGAAhSwNQGPrl2Rb+tWk5O0t7VtsMR4rBrw7thzEPVadcGpMxdSbEvctRto0NobX6zfquoWLvsCsxetVHnd5M9/TqKDzyA16xcUrtYl65Mk95FIxciJEdi0bbdkVboZfwtN2/XQ58MmzFUPSO7YPRi+/Ubgxs14VSfr6xowDAGDx8CnbyjmR0bhTkKCSrL+1FL06fNqWU4oQAEKUIACFKBANhaw+U23asD7za4DeLZCWWz+Zk8KmG079+GZp0tj+67vVV2rZg2x7dv9Kq+bbNu5H62aN9DNYv60Edi/ZYVK8tBjfUUamdUbtuPa9ZtYFjEeUUunYlBgV6OWQ/r6IGJKiLbeUJyIPoNRk+bBw91drV/66efXGV7tW+nny5YubrQ8ZyhAAQpQgAIUoAAFbE/AagGvXC398chvGBvSD1uTBbLCsn3n9wju0w3nL1zGf1djUaZUMeTLmwe//Pa3VKskAXCrpo8CXlWYgUlMbByqV3kWOTzc1VJVK1eEPBhZzRhMJMgdHtwL+w4dwbkLlwxqmKUABTItwAUpQAEKUIACWSRgMDyasQAAEABJREFUtYD3m93fo8FLNVGqRDHkz5cXv/35r36TL1z8TwtyY1Qw2qpZfXy9/TtV16JJXe2K736V//X3v7Xl8qhAWBVok96DRulvaxg8YopWkv7/7Vo3w4bNO9VtC4uWr0Fqt1bo1pDHMzcqli+D4yfP6opSfb17NwHWSElJiVbpxxrbwj4eHTPcr48sHOm4SPVkwUIKUMBmBax1/tEB8NX6As7W6nLbtwfQqnl91Z0EtVu/3afyMtm6cz9ebVJPsmj7WhP9rQwttTK5xeH+/fvYprVpoc2rRg8nhrc0TBk1+GFp2i/lypTAqsWT4O3VVgtkT8M7YBhORJ9NcwFnZ6vxpDkGVlCAAhSgAAUoQAEKPJmAVSI6+UDawcO/YMCHE9UV2Wlzl6nbGiSQleFv33kAkSvXqbpOvoPx9/FodfW1WNHCKK1dET585DftSu/3aN2ioTRPN+XL64nYuBv6NvKNHvnz5dHPu7u5od6LNTAudACaN64L+SCdvtIgk5iUBPlQmgTJBsUpsm5u7rBGcnFxtUo/1tgW9vHomEl7vz5qQy/7s0hxomABBShg0wLWOs/aNIKDD84qAa98WE2u6soHv3SpRLGnIIGs3FZw7foN/QfBpL5rpzew5du9ir5Fk5cxc8GnKF2yGAoXzK/K0pvIV9dt2rYH8bduq2ZR67agZrVKKn/02F+Iib2m8vJ0hhPRZ7R15lPzhpPExETMXbwKtapXQqkSRQ2rmKcABShAAQpQwJoC7IsCZhCwSsC7bdcBNG34ktFwmzV6GVu1K7tbdnyHZo2M6+TK65ZvHgS8rzapj39OnEaLxi8bLS8zhvfwturgL0Vo0rAOGjeojV4Dw+HTJwRXrsYh0NcL8u/8xcvoppVJXRuvQBQplB+vt2wkVSpNnh2p7u/tGRQOd3c3jBj6YJ2qkhMKUIACFKAABShAAbsUsErAK4/6eqVeLSOgzm+3xodBPeDn3QH9e71nVPfcM+XwReQ0VSa3KOz9ehk6vNlSzesmC2eEGV0V3vLFPF2VWueKeeMROWcMxob0R+FCBVRdq2YNsP6TmVgwPQy7N0Zi4shBcHV1VXWyvuUR49RjySJnj4a/Tyf1SDJV+XDSuUMbBPkbP8rsYRVfslaAvVOAAhSgAAUcTuDSpQtgSt0gozvbKgFvRgfF9hSgAAUoQAEKZEaAyziKQMGChcCUvkFG9jUD3oxosS0FKEABClCAAhSggN0JMOC1u1325APmGihAAcsLxLQcASbHMjjbMBhXWoRwvzrYsX2+0RDLnxDYQ5YLMODN8l3AAVCAAhSgQBYJsFsKUCCbCDDgzSY7mptJAQpQgAIUoAAFsqsAA97H7XnWU4ACFKAABShAAQrYtQADXrvefRw8BShgqwIFto6Co6Xsvj0lv5uKQtvHcL862LFdfPdkWz2NcFxmFGDAa0ZMrooCFKAABShAAQpQwPYEzBzwZnwDv9n1PQKHjNUveOTXP9EtcDiS7t1DxJLP8Jb3QMg3qnUNGIY1G7br2xnWSfuDh39RdSMnRmDTtt0qL5Ob8bfQtF0PyULyYRPmopNvMDp2D4ZvvxG4cTNe1fkFhUP6CBg8Bj59QzE/Mgp3EhJUqteqC1JL0afPq2U5oQAFKEABClCAAhSwXYEsD3ibP/zK4K3f7lNBrny97/sDfOHi/GBobV9rgvnTRiD8g0DMmL8C167f0Gvq6kYM8UfY+LkqONVXppJZrQXM167fxLKI8YhaOhWDAo2/NW1IXx/1TWvzp4XiRPQZjJo0T33b2v4tK9S3uvXz6wyv9q1UXsrKli6eSi8sogAFKACACBSgAAUoYDMCD6LKLB7Oh0E9tKu5n+PjT9ehVvVKeP65CilGVL5sKRQqkB9XY6+nqKvwdGnkyOGB8xevpKgzLIiJjUP1Ks8ih4e7Kq5auSI8c+dSecOJh7s7hgf3wr5DR3DuwiXDKuYpQAEKUIACFKAABTIgYAtNbSLgLV2yGORK76q1m9Hbp1OqLidPn0e+fHlQpmTRFPXHT57Frdu3UbxooRR1hgXtWjfDhs07IbctLFq+BqfOXDCsNsrn8cyNiuXLQNZtVMEZClCAAhSgAAUoQAG7EnC2hdHev38fP/x0DHnz5MY/J04ZDWnBx1Hq/tl3ew5B105t4fzwVgdppKsLmzgH4R/0UbcfSHlaqVyZEli1eBK8vdpqgexpeAcMw4nos2k1N+orrUa3b9+C5dNtJCQkWKEfa2wL+3h0vNzG3bt3rbZfb926BdtN9jm2R/vS+LhO63zBcgpQwDYF7ty5bZVzsW1uffYYlU0EvFHrtqrbGIYP8sPkmZGQAFjH36tbR+zeGImwof6YNHMJYq89uqVB6uRe2uUR4/By7WpqkXx5PREbd0PlZXI1Jg75tSvDkpfk7uaGei/WwLjQAdpV5brYseegFKdIiUlJkA+lSZCcotKgwM3NHZZO7u7ucHV1tXg/lt4Ort892T50g4uLS7Iyd4vNe3i4g8m8Bmkd0wanCGYpQAE7EHB1dbPYudfwPGESBRtZRCDLA96Y2Gv49ItN6O3TETWrV0ZZ7Srs2o3fGG2sm5srXmveENWefwar1z96UoNRo4czNatVxqZtexB/67YqiVq3BTWrVVL5o8f+gvQnM/J0hhPRZ1C4YD6ZNUqJiYmYu3iVup+4VImUt1AYNpaAxdJJrmpLsnQ/XL+LCkCt6WDN/ers7KL91YLJnA4u2i8sqSXDcwTzFKCA7Quk9j62RJntSzjuCJ2zetOmzlmGrl5vQK7MyliCer+HpSvX6R8XJmW61KfHu/hi/TbI1VddWfLXJg3roHGD2ug1MBw+fUJw5WocAn29IP/OX7yMblqZ1LXxCkSRQvnxestGUqWSPCFC7u/tGRQOd3c3jNCuKqsKTihgWwIcDQUoQAEKUIACGRDI8oB3zPC+eLvtq/ohFylcEBs+naWenhCgBardO7fT1z1dtiS+/nwuXLWrKsnr9I20jJ93B6yYNx6Rc8ZgbEh/FC5UQCsFWjVrgPWfzMSC6WGQ2yQmjhykbhWQyoUzwiC3RkRMCUHk7NHw9+kED3d3qdKnzh3aIMjf+FFm+kpmKEABClCAAhSwsgC7o4BpAlke8Jo2TLaiAAUoQAEKUIACFKBA5gQY8GbOjUvZkQCHSgEKUIACFKBA9hZgwJu99z+3ngIUoAAFso8At5QC2VaAAW+23fXccApQwJICMS1HgMmxDM42DMaVFiHcrw52bJ9vNMSSpwKu20YEGPDayI6wmWFwIBSgAAUoQAEKUMDBBBjwOtgO5eZQgAIUoIB5BLgWClDAcQQY8DrOvuSWUIACNiRQYOsoMDmWQcnvpqLQ9jHcrw52bBffPdmGzhwciqUEGPA+kSwXpgAFKEABClCAAhSwdQEGvLa+hzg+ClCAAvYgwDFSgAIUsGEBmwh4d+w5CL+gcHQNGIbXOvrjy0079GRfbd0N334j0KN/GHoOCMP3Px7V10Us+QxLP12nn5fMyIkR2LRtt2RVuhl/C03b9dDnwybMRSffYHTsHqzWe+NmvKrT9R8weAx8+oZifmQU7iQkqFSvVReklqJPn1fLckIBClCAAhSgAAUoYLsC1gx4U1W4d+8eRk+Zj94+HbA8YhzWLJuB8mVLqba79x/G/I+/wLjQ/lg8MxxD+/siZOxs/HP8lKrP6GT1hu24dv0mlkWMR9TSqRgU2NVoFUP6+iBiSgjmTwvFiegzGDVpHjzc3bF/ywqV+vl1hlf7ViovZWVLFzdanjMUoAAFKEABClCAArYnkOUB7+07CUrlharPqddcOXOgepVnVf7ztZvRvXM7FHuqsJp/tkJZvPVGc0St26rmMzqJiY1T687h4a4WrVq5Ijxz51J5w4kEucODe2HfoSM4d+GSYRXzFKAABcwgwFVQgAIUoIA1BbI84JUA963Xm6Fzr/cxfOwsbN91AHLVVxDOnr+EalpQKnlder7SMzh97qJuNkOv7Vo3w4bNOyG3LSxavganzlxIc/k8nrlRsXwZHD95Ns02rKAABShAAQpQgAIUeAIBKy2a5QGvbGe/Xu9hxrj38dwz5TBn8SqMnbpQilVycnJSr+aYlCtTAqsWT4K3V1stkD0N74BhOBGddkDr7Px4nps3b8DSKT7+Ju7cuW3xfiy9HVy/8bEi+zUh4Q73qxXeQ9Y+9sxxvuI6KEAB6wncuhVvlXOx9baIPSUXeHxEl3wJC82XKPaUCkTnTxuBrTv34/79+yhZ/Cn8+vvfRj3+9sc/KF2iqFGZ4Uy+vJ6IjbuhL7oaE4f8+fLo593d3FDvxRoYFzoAzRvXhXxgTl9pkElMSoJ8KE2CZIPiFNncuT1h6ZQrV254eOSweD+W3o6MrT+3tr2OnXLlygV3dw8rbqen1pddJrsbd4oTBQsoQAGbFsiZM5d2njHXz5y0z7M2jeDgg3PO6u2TJyEYPnnh8JHfUDB/Xjg5OaFT+9fUUxgu/3dVDfPPf05CPnjWqX0rNZ/apGa1yti0bQ/ib91W1VHrtqBmtUoqf/TYX4iJvabyN27Ga1d3z6BwwXxq3nCSmJiIudqV5lrVK6FUOsG14TLMm1tAruxnhyRu1tpO6YuJAhSgAAVSFzDXuTj1tZunlGvJrIBZA14JSL9YvxWS/j4ebfKYln/+lXpUmDwubMa8FXh/gK9atlG9WvDzfhvvh8+APJJs8qylGD2sLyqUKw3dvwUfRxk9MqxhvZpo3KA2eg0Mh0+fEFy5GodAXy/Iv/MXL6ObViZ1bbwCUaRQfrzespFUqTR5dqS6v7dnULh25c0NI4b6q3JOKEABClCAAhSgAAXsV8BsAe/UOcswfe5ynD57EX8fP43RkxdgesTyx8rIExFmT/wQny+ZqtLmqHmo/9IL+uUkIF0yaxQWfRSuktyOoKsM0AJZeTyYYXJ1cdGC5A5YMW88IueMwdiQ/ihcqIBapFWzBlj/yUwsmB6G3RsjMXHkILi6uqq6hTPC1GPRIqaEIHL2aPj7dIKMTVU+nHTu0AZB/saPMntYxRcK2IwAB0IBClCAAhSggLGA2QLeU2fOY960UAwM6IoPg3pgyaxw7Dv4s3FvnKMABShAAQpQgALWEWAvFNALmC3gdXVNuSr5gJi+J2YoQAEKUIACFKAABSiQBQIpo9RMDiJHjhwYHDoFX2//Dp9/uQX+wWPUlzwc+ulXSMrkarkYBSwrwLVTgAIUoAAFKODwAmYLeK9cjcWN+FtY9/W36lFfrq4uOHHqLBavWKuSw0tyAylAAQoYCMS0HAEmxzI42zAYV1qEOOx+za7H6/lGQwzeucw6qoDZAt55U0ORXnJUQG4XBShAAQpQgAIUoIBtC5gt4JXNvHs3UX1RhNzCoEtSzuQoAtwOClCAAhSgAAUoYH8CZgt4vzvwE97yDkLQsEmQ5+X2/2ACZi9caX8iHDEFKEABMwgU2DoKTI5lUPK7qSi0fcyD/cr9626KqogAABAASURBVDAOxXdPNsM7nquwdQGzBbxzFq/Cwo9G4pnyZdTzdJfOHq3ly9r69nN8FKAABShAAQpQgAIOLmC2gFc+pFbsqcKQ2xrErFLFpxF/K16y2TVxuylAAQpQgAIUoAAFbEDAbAFvrpw51Obkz+eJdZt2QG5xiIm9rsrSm8Rdu4EGrb3V1xEbtvMLCkfXgGHqq359+oZifmQU7iQkGDaBfLubfEXw/fv39eUjJ0Zg07bd+vmb8bfQtF0PNS/5sAlz1dcYd+weDN9+I3Dj5oOgPK3+pM96rboYfX2xbj769Hm1Xk4oQAEKUCA9AdZRgAIUyFoBswW8Hdu1ROy16wjs8Q627/oeK6I2one3Do/dum079+GZp0urZZI3HtLXBxFTQjB/WihORJ/BqEnz9E0kyN353UEUKpgfP/x8TF+eXmb1hu24dv0mlkWMR9TSqRgU2NWoeWr9ebi7Y/+WFSr18+sMr/atVF7KypYubrQ8ZyhAAQpQgAIUoAAFbE/AbAFvi8Z1kT9vHlQoVxqzJn6oHlFWs3rlx27x9p3fI7hPN5y/cBn/XY1Ntb0EncODe2HfoSM4d+GSaiNPgSiv9dXxzVex9dv9quxxk5jYOPVlGDk83FXTqpUrwjN3LpU3nKTWn2E98xSgAAUoQAEKUIAC9iNgtoC3fdcgyO0E6zfvxKX/rpokcOHif1qQG6OC0FbN6qtvaUtrwTyeuVGxfBkcP3lWNZEgt2XTemiuBdr7Dx5BYmKiKk9v0q51M2zQxhcweAwWLV+DU2cupNk8eX9pNbx37x6skeSKtjX6YR/W2Z/ifP/+Pdy/f98qx4/0x3TPatZpnS9MLGczClDAygLWOhdbebPYnYGA2QJeuar7/HPlse/gz+jS+0P8r8sAjJ220KCrlNmtO/fj1Sb1VEXb15pg22Ou1Do7PxiuBLcHDh1FiyZ1kTtXTi1groi9WtCrVpTOpFyZEli1eBK8vdpqgfNpeAcMw4nos2kuoesvzQZaxZ07t2HplJBwB3fv3rV4P5beDq7/ttE+vH37NverFd4/WXHcaacG/k8BCtiRgLXOE3ZEYiNDNd8wHkSQZlhfqRJF0el/reDX9W10e+dN3NOuXP3wU/r31m7feQCRK9epD4R18h2Mv49Hp3nVNTEpCfIhMQla937/M67ExKJJW1+17LffHdIHy/nyeiI27oZ+i67GxCF/vjz6eXc3N9R7sQbGhQ5QV4d37DmorzPMGPZnWJ48nzNnLlg65ciRE+7u7hbvx9LbwfWnPFa4X1OaOMJxkvw8wXkKUMC2BeTnrDXOPbat4NijczbX5o2aPE89VWHJp18id+6cmDNpGNYun5Hm6uV2gmvXb+g/ACYfAuva6Q1s+XZvimXkiu7cxatQq3olSGAtV4aHD/LTL7ttzQJ1ZVmeqFCzWmVs2rYH8bduq/VErduCmtUqqfzRY38hJvaaysvTGU5En0HhgvnUvOEkeX+GdcxTgAK2JcDRUIACFKAABR4nYLaA9969++p+RGcnp8f1qeq37PgOzRq9pPK6idyPu+WbRwHv5NmR6rFkPYPCtSucbhgx1F89muzAoSNo0vBF3WLqg2e1X6iMXXt/0MrroHGD2ug1MBw+fUJw5WocAn29IP/OX7yMblqZ1MnjzIoUyo/XWzaSKpVS609VcEIBClCAAhSgAAVsW4CjS0fAbAHvyPcDsGLeeHT1aqse/RU4ZCzkg2xp9e3n3QH9e71nVP3cM+XwReQ0VbZwRhiWR4xTjyWLnD0a/j6dIE9PkPTNl4tUkKsaPpxMDg9Gy6b11ZysW8YSOWcMxob0R+FCBVR5q2YNsP6TmVgwPQy7N0Zi4shBcHV1VXVp9acqH046d2iDIP+uD+f4QgEKUIACFKAABShgDwJmC3jl6ukX67diySdrseLzjbivXfGtVeN5ezDgGCmQfQS4pRSgAAUoQIFsKGC2gDdw8Fj8+vu/qP/SC1gyaxQ2rpqN0MG9siEpN5kCFKAABShAAVsX4Piyl4DZAl75gJrc1vDma03UB8uyFyO3lgIUoICxQEzLEWByLIOzDYNxpUUI96uDHdvnGw0xfvNyziEFzBbwyhdOyJMP5HFeoyfPR9t3+2LvwZ8dEo0blV0EuJ0UoAAFKEABCjiCgNkC3s/XblEfJPv+h19w4+ZNTB4VjIglnzmCEbeBAhSgAAUokL0FuPUUsHMBswW8Hh7uiuLw0d/QqH4dVKr4NJycTHtEmVqQEwpQgAIUoAAFKEABClhAwGwBr5ubK9Zs2I7d+35ErRqVIbc2yBc4WGDMXKVtCnBUFKCAgUCBraPA5FgGJb+bikLbx3C/OtixXXz3ZIN3LrOOKmC2gPeDAT3w39UY9bzc4kWLIPr0ObxSt5ajunG7KEABClCAAmkIsJgCFLA1AbMFvOXKlECvbh3RvPHLahsrlCuNwB7vqDwnFKAABShAAQpQgAIUyCoBswW8md0A+WBbvVZdYJjOnr9oNG9Y9+/JM2j0ho9Rd8s+24BZCz9VZSMnRmDTtt0qL5Ob8bfQtF0PyULyYRPmopNvMDp2D4ZvvxGQJ0tIpV9QOLoGDFNfZezTNxTzI6PU1xjfSUhIcyzRp8/LoplKXIgCFKAABShAAQpQwDoCWR7wymbKleH9W1ZAl0oWL6rP9/PrDK/2rfTzZUsXl0UylVZv2K6+9nhZxHhELZ2KQYHGXxM8pK+P+irj+dNCcSL6DEZNmqe+zlg3LnOOJVMbwIUoQAEKOJ4At4gCFKCAxQVsIuC1+FY+7CAmNg7VqzyLHA+fKFG1ckX1KLWH1foXD3d3DA/uhX2HjuDchUv6cmYoQAEKUIACFKAABexP4IkDXvlyifSSKSQLPo7S3zbQor1fykWSldy9m6hvL7c7yG0RyZqkOtuudTNs2LxT3bawaPkanDpzIdV2UpjHMzcqli+D4yfPymya6e7du7B0kqddJCUlWbwfS29HRtYv25wd0r17SbDWdmbEn21Ne18nJt7V9l/KlOYJgxUUoIBNCiQlJWrvZfOk9M6fNrnx2WRQTxzwyhdOpJdMcTS8pWH72oWPXUQegaa7zUBeA3y9HruMNJAP1q1aPAneXm21QPY0vAOG4UR02gGts/Pjee7duwdrpPv371ulH2tsiyl9yMnH8VOS2qfW2s779++BybwGSUn3kFqS842lEtdLAQqYXyBJu6iUpAW95kjp/Ywz/8i5RlMFHh/RPWZNH41/H+mlxyxu9up8eT0RG3dDv96rMXHIny+Pft7dzQ31XqyBcaED0LxxXezYc1BfZ5hJ1A5++VCaBMmG5cnzHh4esHRyd3eHq6urxfux9HZkbP05tO119OSh7Vc3q22nu7sHmMxrkNYxnfw8wXkKUMC2BeTc6OFhrp85HuC5wSr7O0OdPHHAa9ib3Grw6+9/49BPv+qTYb018jWrVcambXsQf+u26i5q3RbUrFZJ5Y8e+wsxsddUXp7OcCL6DAoXzKfmDSfyJ+a5i1ehVvVKKFWiqGEV8xSgAAUoQAEKUIACdiZgtoD3uwM/4S3vIAQNm4TJs5ai/wcTMHvhSpM4DO/hlXty/zl+yqTlUmvUpGEdNG5QG70GhsOnTwiuXI1D4MNbHs5fvIxuWpnUtfEKRJFC+fF6y0bQ/Zs8O1Ld39szKFy7EuaGEUP9dVV8pQAF7FGAY6YABShAAQpoAmYLeOdoV0QXfjQSz5Qvg8+XTMXS2aO1fFmti/T/l/tv5T5cwyTr0C3VuUMbBPk/enyYq4sLdm+M1FWrV7knVx4Zpma0iZ93B6yYNx6Rc8ZgbEh/FC5UQCsFWjVrgPWfzMSC6WGQdUwcOUj7k7Krqls4IwzLI8apx5JFamP39+kEeVqDqnw4ST6Wh8V8oQAFKEABClCAAjYtkN0HZ7aA19XVBcWeKgy5rUFQK1V8GvG34iXLRAEKUIACFKAABShAgSwTMFvAmytnDrUR+fN5Yt2mHZBbHGJir6syTihAAXsQ4BgpQAEKUIACjilgtoC3Y7uWiL12HYE93sH2Xd9jRdRG9O7WwTHVuFUUoAAFHiMQ03IEmBzL4GzDYFxpEcL96mDH9vlGQ1K+m1nicAJmC3hbNK6L/HnzoEK50pg18UPMmxqKmtUrOxwYN4gCFKAABShAAQpQwL4EzBbwypMWUkv2xcHRUsBkATakAAUoQAEKUMBOBMwW8Bpu783429i4dQ9OnbloWMw8BShAAQpQgAIOJ8ANooDtC5gt4O3VrSN0aWBAV3wRORU342/ZvgBHSAEKUMACAnWadUJ2SRbg4yopQAEKmFXAbAFv8lHJV/jevXs3eTHns6kAN5sCFKAABShAAQpklYDZAt7k9++Om7YISffuPdF2yTeiydcBJyYlQb6BbXrEcv36ln22AdKnFEQs+QxLP10nWYycGIFN23arvEzkKnPTdj0kq644h02Yi06+wejYPRi+/UZAvmJYKv2CwtE1YJj6pjWfvqGYHxmFOwkJKknfqaXo0+dlUSYKUIACFKCAqQJsRwEKZIGA2QLe5GMvXaoYpo4enLw40/M5PNyxZ/9hxMZdy/Q6Vm/YjmvXb2JZxHhELZ2KQYGPvsFNVjqkr4/6prX500JxIvoMRk2ap75tTfctcPJtbl7tW0E3X7Z0cVmMiQIUoAAFKEABClDAhgXMFvDq7t/VvXbt9AZ0X0bxpNvv5OSkvgK4XeumWLV2c6ZXFxMbh+pVnoUEz7KSqpUrwjN3LskaJflK4eHBvbDv0BGcu3DJqM4qM+yEAhSgAAUoQAEKUMBsAmYLeP2DR6cYVJfeH6Yoe5KCDu1exZYd+9StCZlZT7vWzbBh805128Ki5Wtw6syFNFeTxzM3KpYvg+Mnz6bZhhUUoAAFKGBZAa6dAhSggDkEzBbwJh+M3Dsr98AmL3+S+dy5cqJ18wb4Yt22TK2mXJkSWLV4Ery92mqB7Gl4BwzDiei0A1pn58fz3LlzG5ZPdyAfALR8P7etsC3sw3A/JibepblV3kPWPe4ydYKy44UMj2lHzvP9at33kbWOJfn5mpBwxyrnYjt+m9v90B8f0T1mE+WDY/KBriO//qk+WCZ5SV38P8Rbb7R4zNKmVd+/fx+SpPU7b7XGmo3bkZiYBCcnJwBS+ijly+uJ2Lgb+oKrMXHIny+Pfl6eHlHvxRoYFzoAzRvXxY49B/V1hhn5oJx8KE2CZMPy5HlnZxdYPjmrbbV8Py5W2Bb2YbgfAWeaW+U9ZN3jLvl5wtHnDY9pR847OfH96oj718nJCU5W2reOfi6w5e1zftLByT278iGuDm+21H+YS+bXLpuBd99u/aSrT7F83jyeWqD6snoSgy4INmxUs1plrW4P4m/dVsVR67agZrVKKi9PfIiJffChN3k6w4noMyhcMJ+qM5wkJiZi7uJVqFW9EkqVKGpYlSLv5uYGayRXV1er9GONbWEfj44ZV1cX7lcrvYesedylOFFYqyCL+rG1IbGlAAAQAElEQVSmbVb25eLC92tW+luqb2v+fM2ityi71QSeOODV1qH+D+7jDQkoP/9yi5r/70oMTp46p/LmnnTt1BYXL1/Vr/auFqB6uLup+SYN66Bxg9qQR5r59AnBlatxCPT1gvw7f/EyumllUtfGKxBFCuXH6y0bSZVKk2dHqvt7ewaFw11b34ih/qqcEwpQgAIUoAAFKEAB+xFIPlKzBbwfr1yP8TMWY92mb1UfcvV17LSFKp/ZyYLpYeqpCq7ab9Xb1z5aV4H8ebHnq0j1zW737t3Db38cR5lSxfXd+Hl3wIp54xE5ZwzGhvRH4UIFVF2rZg2w/pOZkPXu3hiJiSMHqac/SOXCGWFYHjFOPZYscvZo+Pt0Uo8kkzpd6tyhDYL8jR9lpqvjKwUoQAEKUIACFKCAbQqYLeDd/M0eLJs7Fnny5FZbWqRwQdyMj1d5S03kPtvm7f3wdNmSaPDyC5bqhuulAAUcUoAbRQEKUIAC2UXAbAGvR44ccHNzNXJzgpPRvLln5Mrvt+sW4/0BvnBysmxf5h4710cBClCAAhSgAAVsQiAbDMJsAW+BfHnx25//KjK5nWHxirV4pnwZNc8JBShAAQpQgAIUoAAFskrAbAFv2Pv+WLPxGxz74180et0Hp89ewMCALlm1XeyXAhQwrwDXlkGBH3Z8juySMkjD5hSgAAWsLmC2gDd/3jwICe6FTZ/NwdoVH2Hk+wHIr131tfoWsUMKUIACFKAABShgMQGu2B4FzBbwysb/+c9JbNmxFzu/O4i/j0dLERMFKEABClCAAhSgAAWyVMBsAe/UOcswfe5ynD57UQt2T2P05AWYHrE8SzeOnVMgqwTYLwUoQAEKUIACtiNgtoD31JnzmDctFAMDuuLDoB5YMisc+w7+bDtbypFQgAIUsKJAnWadYGvJipvPriigE+ArBWxCwGwBr6trylW5uz349jOb2FIOggIUoAAFKEABClAgWwqkjFIzyZAjRw4MDp2Cr7d/h8+/3AL/4DHqW9IO/fQrJKW3Wr+gcHQNGKa+Dti33wis//pb3ElIQL1WXVJN0afP45td36N731D0HDBSfR3wp19sUl2MnBiBTdt2q7xMbsbfQtN2PSQLyYdNmItOvsHo2D0Y0teNm/GqTjeGgMFj4KOtd35klBrD48ahFubkyQS4NAUoQAEKUIACFLCggNkC3itXY3FDCy7XacHqjj0H4erqghOnzkKexyvpcdswpK+P+srfkODemD5vhWq+f8sKSOrn1xle7VupvMyfv3gJU+d+jLD3A7Hoo5Hq64CfKlJQLZPeZPWG7bh2/SaWRYxH1NKpGBRo/DXBMoaIKSGYPy0UJ6LPYNSkeerrhaVPScnHUbb0o68zTq9f1lGAAhSgAAVMEWAbClDAMgJmCXgTk5LQp8c7mDc1NM1k6vCdXZzhmSsn3Fxd01xk5erN6NGlPcoZBJwtGtdNs72uIiY2Tl11zuHhroqqVq4Iz9y5VN5w4uHujuHBvbDv0BGcu3DJsIp5ClCAAhSgAAUoQAE7EzBLwCtf8btw2eon2vTeg0ap2xfe7TkEft5vw9k57aGdPnsBNao8l+H+2rVuhg2bd6pbIBYtX4NTZy6kuY48nrlRsXwZHD95Ns02WVPBXilAAQpQgAIUoAAFMiKQdlSZkbVobT083PDn3ye0XOb+nz9thLplYcX88VgRtREXL19Jd0VOTk7p1qdWWa5MCaxaPAneXm21QPY0vAOG4UR02gFtekG3bv3x8fGwdLp16xbu3EmweD+W3g6uP+WxkpDA/eqIx4Xu/GBrrw5nbYXzr6FZQsJdyPnYsIz5lOc1ezORn6/W2q+2dk7ITuMxW8B79vwl9WEvuULrHzwaupRRzArlSqN82VI4fOT3NBctXbIYjv72V6r1+fJ6Ijbuhr7uakwc8ufLo5+XJ0fUe7EGxoUOQPPGdSH3G+srDTJym4Z8OE6CZIPiFFn5sJ6lk4eHB9zcXGHpfrj+HFY3dnXlfnXE4w42+s8Rra25Ta6uLpDzsTX7ZF+WPy/Lz1dr7VfwX5YJmC3glefvzpzwAQb16abur5V7bCVldMvirt3AsT+Po1DBfGku+u7br2HBx6vx7XeH9G227zqg8jWrVcambXsQf+u2zCNq3RbUrFZJ5Y8e+wsxsddUXp7OcCL6DAqn0k9iYiLmLl6FWtUroVSJoqp9WhO5CszkrG5BoQMdeAw8OAbSOl9kdTn3z4P9Qwc6ZNUxkNXngOzcv9kC3hdrVlUfCJMPgUlel0zFnTw7Ev6DRuPNzv1Qt051vFSrWpqL1q1TA4O1wHrpJ1/iXb/30XfoOFy6fFW1b9KwDho3qK0ecebTJwRXrsYh0NcL8u/8xcvoppX1GhiONl6BKFIoP15v2UiqVJIxyGPJegaFw93dDSOG+qtyTihAAQrYvwC3gAIUoED2FTBbwCvfqva/9wYgbMIcpfnH3ycQNGyiyj9usnBGGJZHjFPf1LZr41IMH+RntEjnDm0Q5G/8CLHmjV/GsoixWLlwImZPGgZpo1vIz7sDVswbj8g5YzA2pD8KFyqgqlo1a4D1n8xUjz/bvTESE0cOgvxJWSp1Y5DHkkXOHg1/n07wcHeXKn2SPpKPQ1/JDAUoQAEKUIACFKCATQoYBbxPMsLZi1Zi4UcjUbBAfrWaShWfxuX/YlSeEwpQgAIUoAAFKEABCmSVgNkCXnlubvL7Xe/jflZtF/ulAAUo8CQCXJYCFKAABRxIwHwBr5sr5IkIOpvDR3/XX+3VlfGVAhSgAAUoQAEKUMCeBBxjrGYLeAf39cGoyfPwz/FT6sNnE2YsQv9enR1DiVtBAQpQIIMCP+z4HLaWMrgJbE4BClDAYQTMFvDKPbvTxgzByPcD0fF/r2Llosl4tkJZh4HihlCAAmkLsIYCFKAABShgywJPHPAeP3kWgUPGomm7HhgUMhnly5VE80Z14eL8xKu2ZTeOjQIUoAAFKEABCiQX4LyNCjxxVDpm6nxUe/4ZhH/QB2VKFcOkmZE2uqkcFgUoQAEKUIACFKBAdhR44oD32vUbCOjuhUb1amFggDfk28uyIyS3mQImC7AhBShAAQpQgAJWFXjigNdwtE5OTuorZsF/FKAABShAAQpQ4DECrKaAtQSeOOA9e/4S6rXqok8XLv2nz0t5WhviFxSOo8f+Mqo+8MMRDPhwoiqTvCy/a+8Pal4mA4dPxqGffpUsDJe/9N9VvOU9EHv2H8bIiRHYtG23aiOTm/G31P3FunzYhLno5BuMjt2D4dtvBG7cjJcqtb6uAcMQMHgMfPqGYn5kFO4kJKgk40gtRZ8+r5blhAIUoAAFKEABClDAdgWeOOCdOeEDpJeeZNNLFHsKH69an+4qYuOuof8H49HX7128Uq9Wum1Xb9iOa9dvYlnEeEQtnYpBgV2N2g/p6wP5auH500LVrRmjJs1TXy+8f8sKSOrn1xle7VupvMyXLV3caHnOWEKA66QABShAAQpQgAJPJvDEAe+LNasivZTZ4Tk5OaknPuTNkxvf//hLitVo1Yi/dQv9PpgA3/fao9krL6Vok7wgJjYO1as8ixwe7qqqauWK8MydS+UNJx7u7hge3Av7Dh3BuQuXDKuYpwAFKEABCmSNAHulAAUyLfDEAW+mezZxwe6d/5fqVd7794EJM5agdYtX0LJpfZjyr13rZtiweae6bWHR8jU4deZCmovl8cyNiuXLQB67lmYjVlCAAhSgAAUoQAEK2LyAzQe8Nao+h6SkJPz+1/EUmKVKFMX2nfvVfbYpKlMpKFemBFYtngRvr7ZaIHsa3gHDcCL6bCotHxQ5m/As4fj4m7B0unUrHgkJd0zph22ssD/Mub8TEhK4z+xsn5my/+UMYko7trH8+dOcxnfvJkDOx+ZcJ9eV9ceA/Hy11n6VcwNT1gjYbMB7X7uEK0lYfN5th8XaFVnJ65Lc0tDbpyPKli6BoWHTkagFxVKXL68nYuNuSFalqzFxyJ8vj8rLxN3NDfVerIFxoQPQvHFd7NhzUIpTJFmffChNguQUlQYFuXLlhqVTzpy54O7uYfF+LL0dXH/KY8Xd3Z371QrvIWsfe3KKsHaf7C/5+8v8825u7pDzMa3Nb5uVpu7az1dr7Vc5NzBljYBz1nSbsV4lQP1PC1xPnUn5VITQwb2QM4c7QsfNggTINatVxqZtexB/67bqJGrdFtSsVknl5akQMbHXVF6eznAi+gwKF8yn5g0niYmJmLt4FWpVrwS5imxYxzwFKEABClCAAhSggH0JZGnA23vQKP0jzOQxY+nRde3UFoYfINMuAKsAV247GBPSX13VnTwrEk0a1kHjBrXRa2A4fPqE4MrVOAT6ekH+nb94Gd20Mqlr4xWIIoXy4/WWjaRKpcmzI9X9vT2DwrUrqm4YMdRflXNCAQpQgAIUoAAFKGC/AlkW8C6cEaZ/vJc84kvm69apgY/Gv680JT9l1GCVl0nzRi+p9vJECJmX9vLEBcm7uriox4kN7d9dZuHn3QEr5o1H5JwxGKsFw4ULFVDlrZo1wPpPZmLB9DDs3hiJiSMHwdXVVdXJ+pZHjFPriZw9Gv4+ndQjyVTlw0nnDm0Q5G/8KLOHVXyhAAUoYM8CHDsFKEABhxbIsoDXoVW5cRSgAAUoQAEKUIACNiNgesBrM0PmQChAAQpQgAIUoAAFKGC6AANe063YkgIUoIAS4IQCFKAABexLgAGvfe0vjpYCFKAABShAAQrYioDdjIMBr93sKg6UAhSgAAUoQAEKUCAzAgx4M6PGZShAAdMF2JICFKAABSiQxQIMeLN4B7B7ClCAAhSgAAWyhwC3MusEGPBmnT17pgAFKEABClCAAhSwggADXisgswsKmC7AlhSgAAUoQAEKmFvA4gFvYlIS6rXqgukRy/VjX/bZBiz4OErNRyz5TNVLG13670qMqpPJ1DnL0MYrEPfv35dZlWSZt7wHovegUegaMAxrNmxX5TIZOTECm7btlqxKN+NvoWm7Hvp82IS56OQbjI7dg+HbbwRu3IxXdX5B4WpdAYPHwKdvKOZHRuFOQoJKunElf40+fV4tywkFKEABClCAAmYW4OooYEYBiwe8MtYcHu7Ys/8wYuOuyWyK1KtbR+zfskKfChcqoNpIkLvzu4MoVDA/fvj5mCrTTdq+1gTzp41A+AeBmDF/Ba5dv6GrSvN1tRYYX7t+E8sixiNq6VQMCuxq1HZIXx9ETAnR1huKE9FnMGrSPHi4u+vH1c+vM7zat9LPly1d3Gh5zlCAAhSgAAUoQAEK2J6AxQNeJycnuLq6ol3rpli1dnOGBA799CvKlyuNjm++iq3f7k912fJlS6FQgfy4Gns91XrDwpjYOFSv8iwkAJfyqpUrwjN3LskaJQlyhwf3wr5DR3DuwiWjOs7YlAAHQwEKUIACFKAABR4rYPGAVzeCDu1exZYd+yC3GOjKdK9ye4PudoEW7f10xSrIdk6IGAAAEABJREFUbdm0Hpo3rov9B48gMTFRX6fLnDx9Hvny5UGZkkV1RWm+tmvdDBs274TctrBo+RqcOnMhzbZ5PHOjYvkyOH7ybJptpCIpKQnWSPfu3bNKP9bYFvbx6Jjhfn1k4UjHhTXPDY7kZuvbYtvvV8d8L1njmLDmfpVzA1PWCDhbq9vcuXKidfMG+GLdthRdGt7SsH3tQlUvwe2BQ0fRokldyLLVq1TEXi3oVZXaRBckv9tzCLp2agtn58dvSrkyJbBq8SR4e7XVAtnT8A4YhhPRaQe0pqzz7t27sHQSC3nTW7ofrt/y+zK5Mfer9c2T7wNLzGunKIufFywxbq4z/eMxKemeuvBCp/Sd7M1HzsPyc9Ya45ZzA1PWCDw+SnzCccl9uJJkNe+81RprNm7XThhJcHJykqI0097vf8aVmFg0aeurPtT27XeHsM3gtgYJkndvjETYUH9MmrkEsdce3NKQL68nYuNu6Nd7NSYO+bUrwLoCdzc31HuxBsaFDlBXjnfsOairMnpN1K7cyofSJEg2qkg2kyNHDlg6eXh4wE0b95P2w+Utv68yasz9anv7JKP7MLX2cppIrZxl9r2/3dxcIedj7kf73o/J95+b9vPVWvtVzg1MWSNg8YDXcLPy5vHUgsyX1VMUdEGwYb1hfuvO/Rg+yE//AbFtaxZg38Gf1VMTdO3ctJPPa80botrzz2D1+u2quGa1ytr69yD+1m01H7VuC2pWq6TyR4/9hZjYBx+ck6cznIg+g8IF86k6w4n8pjd38SrUql4JpUo8/lYJw2WZpwAFKEABmxfgAClAgWwmYNWAV2y7dmqLi5evSlafdLcn6O7j/e3Pf3Hg0BE0afiivo18uKz2C5Wxa+8P+jJdpk+Pd/HF+m2Qq7JNGtZB4wa10WtgOHz6hODK1TgE+npB/p2/eBndtDKpk0edFSmUH6+3bCRVKk2eHanu7+0ZFA53dzeM0K4eqwpOKEABClCAAhSgAAXsVsDiAa+riwt09+WKUoH8ebHnq0jILQkyH6AFo4aPJJP8889VwDdfLkrxBIXJ4cFo2bQ+ZJnundvJ4io9XbYkvv58LqQvKfDz7oAV88Yjcs4YjA3pD91jzlo1a4D1n8zEgulhkNshJo4cpJ4gIcssnBGG5RHj1GPJImePhr9PJ3i4u0uVPnXu0AZB/l3188xQgAIUoAAFKEABCti+gMUDXtsn4AgpQAEKUCA9AdZRgAIUsHcBBrz2vgc5fgpQgAIUoAAFKECBdAXMFPCm2wcrKUABClCAAhSgAAUokGUCDHizjJ4dU4ACDinAjaIABShAAZsTYMBrc7uEA6IABShAAQpQgAL2L2BLW8CA15b2BsdCAQpQgAIUoAAFKGB2AQa8ZiflCilAAdMF2JICFKAABShgeQEGvJY3Zg8UoAAFKEABClAgfQHWWlSAAa9FeblyClCAAhSgAAUoQIGsFrBowBsbdw0jJ0agS+8P0WfIWAwfMxMnos+qbf7vaiw+GDUD8vW/XQOGYfz0RbhxM17VHfjhCORrhjds2anmZfLzL3+osi/Wb5VZRCz5DG95D0TvQaPQLXA4Dh7+RZVLf5u27VZ5mdyMv4Wm7XpIFpIPmzAXnXyD0bF7MHz7jdD36RcUDhlHwOAx8OkbivmRUbiTkKCSjCW1FH36vFovJxSwkgC7oQAFKEABClAgEwIWDXgHj5iGfHk9sWL+eMyZPByD+ngjJu6aGubg0Cmo8HRpRM4Zg2VzxyLhbiLGTVuo6pycnFCuTEl8s+t7NS+T7Vr+6bIl4eTkJLMqtX2tCeZPG4ERQ/wRNn6uCk5VRRqT1Ru249r1m1gWMR5RS6diUKDx1wQP6euDiCkh2jpDcSL6DEZNmqe+Xnj/lhWQ1M+vM7zat1J5mS9bungaPbGYAhSgAAUoQAHLCXDNFMiYgMUC3qPH/sLFy1fQz+9d/YgKFciPWtUr46ejvyM27jp832uv6pycnFTwue/gEfx3JUaVlSrxlGojV33v37+PQz/9gprasqoy2UQC5xw5PHD+4pVkNcazMbFxqF7lWeTwcFcVVStXhGfuXCpvOPFwd8fw4F7Yd+gIzl24ZFjFPAUoQAEKUIACFKCAnQlYLOA9deY8qjxXHq6urilITp+7iEoVy8HF+VH3eTxzQ66YRp8+p2/f7JWXtau8B7Rg91ctUH4ezk7OkOBX3+Bh5vjJs7h1+zaKFy30sCT1l3atm2HD5p2Q2xYWLV+DU2cupN5QK5XxVCxfBrJubTbN/+/eTYA1UlJSolX6sca2WKsPe+iH+9U67x9rHwtywrB2n+zP8scS36+WN86K49ia+1XODUxZI/Ao4rRE/9qV2zRXm17dw4VaNq0HuZVBbm1o0fjlh6WPXhZ8HKXu6w2bOAfhH/RRtx88qk2ZK1emBFYtngRvr7ZaIHsa3gHDcOLhPcUpWwPOBgF5avUsowAFKEABCtiBAIdIgWwvYLGAt0yp4vjtz+NITEpKgVy6RFH8+c9J3Lt3T193/cZNRJ8+r13lLaGu4sqV3GJFCyPh7l38+vs/qFXjeX1bXaZXt47qftrlEePwcu1qqljuGY6Nu6HyMrkaE4f8+fJIViV3NzfUe7EGxoUOQPPGdbFjz0FVnnwi45bxSJCcvM5w3s3NHdZILi6uVunHGtvCPh4dM9yvjywc6biQc4QjbQ+35cFxyvfrAwdHOx6suV/l3MCUNQIWC3jlXtmnChfEyAkRuBITq7ZOXg8f/V3di5svjyeWfLJWlUtwO3XOMjR4+QUULlRAlekmcp+vJCcnJ11Ruq81q1XGpm17EH/rtmoXtW4LalarpPJyX3FM7DWVl3uDT0SfQeGC+dS84SQxMRFzF69CreqVUEoLzg3rHDbPDaMABShAAQpQgAIOKmCxgFe8powaBFdXF/TsP1LdNztNC2oL5MsrVZgyejD+OXEa8ggw78Dh8HB3w4cDe6o6w4lcuW2eyu0Mhm0M800a1kHjBrXRa2C4euTZlatxCPT1gvw7f/EyuvUJUXVtvAJRpFB+vN6ykVSpNHl2pBpnz6BwuGvjGTHUX5VzQgEKUIAC2UeAW0oBCjiegEUD3vxacDvy/QCsXT5DPe5rbEh/yKPFhLFwwfyYMCIIkbNHQ25JkGBX98SEunVqYMqowdLMKAX38UaHN1uqsgAtiO3euZ3KJ5/4eXfAinnjIY88kz51V41bNWuA9Z/MxILpYdi9MRITR0pA7qoWXzgjTI0jYkoIZEz+Pp20INxd1ekmnTu0QZC/8aPMdHV8pQAFKEABClCAAhSwTQGLBry2ucnmGBXXQQEKUIACFKAABShgLwIMeO1lT3GcFKAABWxRgGOiAAUoYAcCDHjtYCdxiBSgAAUoQAEKUIACmRewRsCb+dFxSQpQgAIUoAAFKEABCjyhAAPeJwTk4hSgAAVMF2BLClCAAhTICgEGvFmhzj4pQAEKUIACFKBAdhaw8rYz4LUyOLujAAUoQAEKUIACFLCuAANe63qzNwpQwHQBtqQABShAAQqYRSBLA16/oHB0DRimvvnMt98IrP/6W/1GSZ13wHD9/LE//oV/8Gg1f+CHI3j1rV5qvov/hwibMBf/XYlRdSMnRmDTtt0qL5Ob8bfQtF0PyULy0raTbzA6dg+G9HnjZryqk/5kLAGDx6hvf5sfGYU7CQkq1WvVBaml6NPn1bKcUIACFKAABShAAcsJcM1PKpClAa8MfkhfH/XNZyHBvTF93goVYEq5JAlQ9x78WbIp0vPPVcC8qaGQb1Nzc3PF519uSdEmecHqDdtx7fpNLIsYj6ilUzEo0Phb02Qs8k1r86eF4kT0GYyaNE9929r+LSsgqZ9fZ3i1b6XyMl+2dPHkXXCeAhSgAAUoQAEKUMDGBLI84NV5OLs4wzNXTri5uqoiJyeg2ztt8fHKdWo+rYmz1tDJyQkFC+RPq4m+PCY2DtWrPIscHg++Mrhq5YrQfZ2xvpGW8XB3x/DgXth36AjOXbiklfB/Cti+AEdIAQpQgAIUoEDqAlke8PYeNErdLvBuzyHw834bzs6PhvRcxadVAHzk1z9TjP7g4V/Ucg1ae+OX3/7CG60apWiTvKBd62bYsHkn5LaFRcvX4NSZC8mb6OfzeOZGxfJlcPzkWX0ZMxSgAAUoQAEK2LwAB0iBFAKPossUVdYpmD9thLpFYMX88VgRtREXL18x6tinczss/fRLJP/3Uq1qarlvvlyEV5vUR8SSz5M3STFfrkwJrFo8Cd5ebbVA9jS8A4bhRHTaAa1h8J1iZQ8Lbt++Bcun20hISLBCP9bYFvbx6Hi5jbt371ptv966dQtM5jV4tC+Nj2s5PaRVx3Jjq4x4ZPXxq3u/ZvU4zNl/Rvwdta3s1zt3blvlXCznBqasEcjygFe32RXKlUb5sqVw+Mjvquj+fe1Fm7xYsyquxlzTAtMzcHJy0gqN/8+VMwca16+Ng9oVX6nJl9cTsXE3JKvS1Zg45M+XR+Vl4u7mhnov1sC40AFo3rguduw5KMUpUmJSEuRDaRIkp6g0KHBzc4elk7u7O1xdXS3ej6W3w6bW7+ZuA55ucHFxsdo4PDzcwWReg7SOaTlFpFXHcvdMH/NZffzKedjd3cOh3kc8Ht3VedjV1S3Tx2VGDOXcwJQ1AjYT8MZdu4Fjfx5HoYL5UkjIrQ6RK9fhvhYAp6jUCg788AsKPbyHt2a1yti0bQ/ib93WaoCodVtQs1ollT967C/ExF5TeXk6w4noMyicSn+JiYmYu3gValWvhFIliqr2aU0kYLF0kivNkizdD9fvok581nSw5n51dnYBk3kNXLRfWFJLcr5IrZxlLk/0Hsvq49fJyUl7DzlrycVhkhyT2T05Ozs/0XGZET/wX5YJOGdZzw87njw7Ev6DRuPNzv1Qt051yK0KD6v0L6/Uq6X95uWqn5fMb38+eEyZV4/B+HT1V+jX610pRpOGddC4QW31qDOfPiG4cjUOgb5ekH/nL15GN62s18BwtPEKRJFC+fF6y0f3/spY5P7enkHhcHd3w4ih/rIYEwUoQAEKUIACFKCAHQtkacC7cEYYlkeMw7xpodi1cSmGD/LTU0qdfGhNV7By4ST1GDKZr1unBratWaDmP1s8BZs+m4sqlZ6RKpX8vDtgxbzx6pFlY0P6o3ChAqq8VbMGWP/JTCyYHobdGyMxceQgdauAVEp/MhZ5LFnk7NHw9+kED3d3qdKnzh3aIMjf+FFm+kqHznDjKEABClCAAhSggP0KZGnAa79sHDkFKEABCmRLAW40BShglwIMeO1yt3HQFKAABShAAQpQgAKmCjDgNVXK9HZsSQEKUIACFKAABShgQwIMeG1oZ3AoFKAABRxLgFtDAQpQwDYEGPDaxn7gKChAAQpQgAIUoAAFLCSQ5QGvhbaLq6UABShAAQpQgAIUoIASYMCrGDihAAUokOUCHAAFKEABClhIgAGvhWC5WgpQgAIUoFOQAs4AABAASURBVAAFKECBzAiYfxkGvOY35RopQAEKUIACFKAABWxIwOoBb5feH2L4mJmK4Iefj6FH/zCV102S7t1Dy7d747+rsapo6pxl6muA79+/r+Zl8s2u7xE4ZKxkVTry65/oFjgcsuzIiRHYtG23KpfJzfhbaNquh2Qh+bAJc9HJNxgduwfDt98I3LgZr+r8gsLRNWAY5KuFffqGYn5kFO4kJKhUr1UXpJaiT59Xy3JCAQpYX4A9UoACFKAABUwVsGrAeyL6LBLuJuDwkd8Rf+s2atd4HucvXsaFi//px3vgh6N4pnwZFC6YHxLk7vzuIAppeQmOdY2aN35ZZbd+u08FuZNnR+L9Ab5wcU5/c1Zv2I5r129iWcR4RC2dikGBXdV6dJMhfX0QMSUE86eF4kT0GYyaNA8e7u7Yv2WFSv38OsOrfSuVl7KypYvrFuUrBShAAQpQgAIUyAoB9mmCQPoRogkryEgTCVBbt2iEl2pXw669P8DJyQmvNqmHzTv26lezfecBtHgY0B766VeUL1caHd98FVu/3a9vI5kPg3ogYsnn+PjTdahVvRKef66CFKebYmLjUL3Ks8jh4a7aVa1cEZ65c6m84USC3OHBvbDv0BGcu3DJsIp5ClCAAhSgAAUoQAE7E7BqwLt91wG0btEArzVvgG079ymqlk3r45vd36t8YmIi9n7/E5o3qqvmJcht2bQemjeui/0Hj0DqVYU2KV2ymFb+Mlat3YzePp20ksf/3651M2zYvFPdtrBo+RqcOnMhzYXyeOZGRe1K8/GTZ9NswwoK2I0AB0oBClCAAhTIxgJWC3iP/fEvChXIj2JPFUbdOtXx9/HTiLt2A1UqVcCtW7ch98N+d+BnVK1cAfnyeqrg9sCho2jRpC5y58qpXZmtiL1a0KvbV3K7ww8/HUPePLnxz4lTuuJ0X8uVKYFViyfB26stjp88De+AYTgRnXZA6/yYWySks5s3b8DSKT7+Ju7cuW3xfiy9HVy/8bEi+zUh4Q73qxXeQ9Y+9qx1brD2dmX3/uT9Ku/b7O5g79uffPx37tzR4pB4q5yL5dzAlDUCVgt4t367D0eO/ak+/FX/ta7470qMdmX3gNpqua1Brvhu27Ufrzapr8r2fv8zrsTEoklbX7XMt98dwjaD2xqi1m1VtzEMH+SHyTMj1f2+sqAEy7FxNySr0tWYOOTPl0flZeLu5oZ6L9bAuNAB2hXiutix56AUp0iJSUkqCJcgOUWlQUHu3J6wdMqVKzc8PHJYvB9Lb0fG1p9b217HTrly5YK7u4cVt9NT64spY8dh5rzkFGGNfthH5vZPZt3k/ZpLOx9ndnnbXM6xz7O5cz9++zw8PJAzZy7t/Pj4tqasL739LOcGpqwRcLZGt3I1dtvO/VizbLr+A1/TxgzB9l3fq+7ltgYJiA///BsaN6ijyrZq7SWYlQ+HSdq2ZgH2HfxZPTUhJvYaPv1iE3r7dETN6pVRVrtyu3bjN2q5mtUqY9O2PepDcVIQtW4LalarJFkcPfYXZFmZuXEzXru6ewaFC+aTWaMkt07MXbxK3RtcqkRRozrOWEvASesoq5I1+9U2E9bqT/piogAFKGAoYK3zjy33o/Mw1xh16+OrLQlYJeD98chveKpIIRQvWkS/7fLBtX9PnFaPH3u6bEm4u7mjVo3KyJUzhwpqDxw6giYNX9S3lw+X1X6hsvqwmzyqrKvXG+rWB2kQ1Ps9LF25Tj1irEnDOlrQXBu9BobDp08IrlyNQ6CvF+SfPBGim1YmdW28AlGkUH683rKRVKkkT3uQx5L1DArXrry5YcRQf1XOCQUoQAEKUCBbCnCjKeAgAlYJeOu8UAWRs0cbkbk4O2PLF/O0K6z5VfmK+eMxNqS/ystTEr75clGKJyhMDg+GXA0eM7wv3m77qmorkyKFC2LDp7P07f28O2DFvPGInDNGrbNwoQLSDK2aNcD6T2ZiwfQw7N4YiYkjB8HV1VXVLZwRhuUR49RjyWSs/j6dIONQlQ8nnTu0QZC/8aPMHlbxhQIUoAAFKEABClDARgWsEvDa6LZzWOYR4FooQAEKUIACFKCATQsw4LXp3cPBUYACFKCA/QhwpBSggK0KMOC11T3DcVGAAhSgAAUoQAEKmEWAAa9ZGE1fCVtSgAIUoAAFKEABClhXgAGvdb3ZGwUoQAEKPBDglAIUoIDVBBjwWo2aHVGAAhSgAAUoQAEKZIWAbQe8WSFio33ebvsmYl99lcmBDOJatsSdN9txnzrQPtW9R6Ns9DzCYVGAAhTIrgIMeLPrnud2U4ACdiXAwVKAAhSgQOYFGPBm3o5LUoACFKAABShAAQpYVyBTvVkl4J06ZxnaeAXi/v37uJOQgHqtuqSaok+fx39XY/HBqBnw6ROCrgHDMH76Ity4Ga82LjEpSS0XPmmempdJYmIimrXrieFjZsosRk6MwKZtu1VeJjfjb6Fpux6SheTDJsxFJ99gdOweDN9+I/Tr9gsKV/0FDB4Dn76hmB8Zpcb6uPGqFXNCAQpQgAIUoAAFKGCzAhYPeCXI3fndQRQqmB8//HxMfV3v/i0rIKmfX2d4tW+l8jJftnRxDA6dggpPl1ZfC7xs7lgk3E3EuGkLFaCTkxNy58qJX3//GxLoSuGufYdRrGghyT42rd6wHdeu38SyiPGIWjoVgwKNvyZ4SF8f9dXC86eF4kT0GYzSAmv5emEZm6TUxvvYTtmAAhSwvgB7pAAFKEABChgIWDzgPfTTryhfrjQ6vvkqtn6736DrlNmfjv6O2Ljr8H2vvap0cnJSQem+g0fw35UYfVn9l17AXq1MCr7ZtR/NG9WV7GNTTGwcqld5Fjk83FXbqpUrwjN3LpU3nEiQOzy4F/YdOoJzFy4ZVjFPAQpQgAIUoAAF7EaAA30gYPGAV4Lclk3roXnjutivBam6K7MPujeenj53EZUqloOL86Nh5fHMDbnyG336nL6xrG/H7u9x+04CTmrl5cuV0tell2nXuhk2bN4JuW1h0fI1OHXmQprNpd+K5cvg+MmzabaRinv37sEaSfpiogAF7EfAGucF9mGd86/OWf5iqcvz1br2lvSW/SrJkn3o1m0/ZzDHG+mjyNIC2ybB7YFDR9GiSV11K0L1KhX1V2bT7E67qptm3cOKKpWewV//nMCO3QfQ7JWX1L3BD6vSfSlXpgRWLZ4Eb6+2WiB7Gt4Bw3AiOu2A1tkg8E5rxXfu3IalU0LCnbS6ZzkFzCDAVVhCwNLnBa7f8ufe5MbyM03Ox8nLOW/9fWFO87t3Eyz+c1w3Xkuca7hO0wQsGvDu/f5nXImJRZO2vurDZt9+dwjb0rmtoXSJovjzn5Pqiqlu+Ndv3ET06fPaVd4SKrCV38KkrmG9Wpi9aBVaNm0gs/qUL68nYuNu6OevxsQhf748+nl3NzfUe7EGxoUOUFedd+w5qK8zzMgH5KRfCZINy5Pnc+bMBUunHDlyJu+W8xSggI0LWPq8wPVb/tyb3NhN+/kh5+Pk5Zy3/r4wp7m7uwf0+9XCP9Nt/LTl0MOzaMC7ded+DB/kp/9Q2rY1C7Dv4M/q6QepqdasXhn58nhiySdrVbUEt/KEhwYvv4DChQqoMt3kzdeaovPbr6NMqWK6IvVas1plbNq2B/G3bqv5qHVbULNaJZU/euwvxMReU3l58sOJ6DMoXDCfmjecyG/xcxevQq3qlVBKC8IN65inAAUoQAEKUIACFLAvAYsFvPI4rwOHjqBJwxf1IvIBsdovVMauvT/oy5JnpowejH9OnIY8Gsw7cDg83N3w4cCeyZuhdMli6NLp9RTlTRrWQeMGtdFrYDjk0WZXrsYh0NcL8u/8xcvo1idE1clj0ooUyo/XWzaSKpUmz45U9/f2DAqHu9bviKH+qpwTChgIMEsBClCAAhSggJ0JWCzg9XB3xzdfLkrxFITJ4cFo2bS+YurcoQ2C/I0fDVa4YH5MGBGEyNmjsTxinAp2JVCWBVxdXLB97YNHlMm8Lsl9vGND+utm4efdASvmjUfknDGQct3V4VbNGmD9JzOxYHoYdm+MxMSRg+Dq6qqWWzgjTPUXMSUE0re/Tyct2HZXdbpJauPV1fGVAhSgAAUokL0EuLUUsB8BiwW89kPAkVKAAhSgAAUoQAEKOLIAA15H3rs2sG0cAgUoQAEKUIACFMhqAQa8Wb0HTOw/x4b1yL9tG5MDGeTbuhUe69dxnzrQPtW9Rzua+L5ms2wlwI2lAAWyUIABbxbis2sKUIACFKAABShAAcsLMOC1vLHpPbAlBShAAQpQgAIUoIDZBRjwmp2UK6QABShAgScV4PIUoAAFzCnAgNecmhZc1+22byL21VeZHMggrmVL3HmzHfepA+1T3Xs0yoLnAq6aAhSgAAUyLmDHAW/GN5ZLUIACFKAABShAAQpkPwEGvNlvn3OLKUABRxPg9lCAAhSgQLoCNhXwdun9IYaPmWk0YL+gcHQNGAafPiEIGjYR5y5cwqyFn6Jeqy4pUui42Rg5MQKbtu3Wr+Nm/C00bddDzUs+bMJcdPINRsfuwfDtNwI3bsarOl0/AYPHwKdvKOZHRuFOQoJKqfUlZdGnz6tlOaEABShAAQpQgAIUyHqBtEZgMwHvieizSLibgMNHfkf8rdtG4x3S1weRc8bglXq1MGnmUvTz64z9W1aolDtXTmxfu1DlRw/ra7Rc8pnVG7bj2vWbWBYxHlFLp2JQYFejJtJPxJQQzJ8WihPRZzBq0jx4uLurdUt/0q9X+1b6+bKlixstzxkKUIACFKAABShAAdsTsJmAd+u3+9C6RSO8VLsadu39IVWpl2tXx78nTqdaZ0phTGwcqld5Fjk83FXzqpUrwjN3LpU3nEiQOzy4F/YdOqKuKBvWMU8BCti7AMdPAQpQgALZTcBmAt7tuw5oAW8DvNa8Abbt3Jfqfvjh52MoX650qnWmFLZr3QwbNu+E3LawaPkanDpzIc3F8njmRsXyZXD85Nk020jF3bt3YemUmJgoXTFRgAJ2JJCYeBdM5jWw9Ln2cetPSkpS+/Rx7eypXn6+ZPck+zUpKVHbt+ZJ6e1/mzuFZaMB2UTAe+yPf1GoQH4Ue6ow6tapjr+Pn0bctRv63dB70Ci88roPdn53CEP6+SCz/8qVKYFViyfB26utFsiehnfAMJyITjugdXZ+PM+9e/dgjZTZbeZyFKBA1ggkJd0Dk3kN7t+/h6xMwH3tfH8/S8dg7u2XQC+7J/kZnqT9MpOkBb3mSLK+tFLWnI3Yqwg8PqKTVhZOcjvDkWN/qg+h1X+tK/67EoNvdh/Q9zp/2gjs+SoSM8a9j1IliurLU8vky+uJ2LhHwfLVmDjkz5dH39TdzQ31XqyBcaED0LxxXezYc1BfZ5hJ1A5++VCaBMmG5cnzHh4esHRyd39wC0byvjlPASsIsItMClj6vJAd1+/u7oGsTC4urlr/7lrK2nGY08DDIwc8snly0+Ll4+pOAAAQAElEQVQCMTWfgwfSen9m8nTCxcwgkOUB7/3797Ft536sWTZd/2GwaWOGYPuu7zO1eTWrVcambXv0H3yLWrcFNatVUus6euwvxMReU3l5OsOJ6DMoXDCfmjecyJ935i5ehVrVKz02wDZcjnkKUIACFKAABRxVgNtlzwJZHvD+eOQ3PFWkEIoXLaJ3fKl2NfXhtP+uxurLTM00aVgHjRvURq+B4epRZleuxiHQ1wvy7/zFy+jWJ0TVtfEKRJFC+fF6y0ZSpdLk2ZHq/t6eQeHab/BuGDHUX5VzQgEKUIACFKAABShgvwJZHvDWeaEKImePNhJ0cXbGli/maVdf82PhjDD1ZAWjBgYz8kgyeTSZQRH8vDtgxbzxkEeZjQ3pj8KFCqjqVs0aYP0nM7Fgehh2b4zExJGD4Orqquqkn+UR4yCPJZPx+Pt0gjytQVU+nHTu0AZB/l0fzvGFAikFWEIBClCAAhSggO0JZHnAa3skHBEFKEABClCAAk8owMUpYFMCDHhtandwMBSgAAUoQAEKUIAC5hZgwGtuUQutL8eG9ci/bZtjpWy+Pfm2boXH+nXcpw54HHS00HmAq6UABShAgcwJMODNnBuXogAFKEABCphNgCuiAAUsK8CA9wl9795NgKVTUlISXFxcLN6PpbeD6zc+VuRbuORDk3QxdnEEj02bvuL71QrnRmsfK/K81qSkRO5bB9u38vP13r0kq+zXJww5uPgTCDDgfQI86y7K3ihAAQpQgAIUoAAFMiPAgDczalyGAhSgAAWyToA9U4ACFMigAAPeDIJldfMvN+3Auz2HoF6rLvpvjcvqMbH/jAkkJiVh7LSF8Hn4JShnzl1IdQUfhE9X+1n2taRjf/ybajsW2o7Af1di0HfoOPj2G4Fhoz/Crdu3bWdwHInJAp9/uQVd/D+Ed8Bw7N5/ONXl+P5MlcWuCo8c+1N9EVWD1t7YvusA+M+xBRw14HXYvVa0SCGMGtZX/2UaDruhDrxhGzbvxNWYWPXFKB3efBUTZixJc2vnTh6O/VtWqFSlUoU027HCNgQ+mv8J6tapgSWzRiFv3jz4JGqTbQyMozBZIPr0eSxbtQHzp43ApJEDMXbqAty+k5Dq8nx/pspiN4U5PDzQu1sHNGlQx27GzIFmXoABb+btsmTJei/WQMXyZbOkb3ZqHoG9B35Cm1dfUStr1uhlHPvzX9yMv6XmObFvgb3f/4zXWz7Yt69r+/i773+ygQ3iEDIi8N2Bw2isBUC5c+VEsaKFUani0zh0+Ffwn+MJPPdMOdR+oQqcnRkKOd7eTblF3MspTVhCAYsKXNb+7F2yeFHVh6uLC4o9VRiXLl9V88knwaFT0bpjAKbM/hh37yYmr+a8DQnILy1OTkCB/HnVqEqXLIrL/6W+X1UDTmxS4PKVqyhRrIh+bKVKFMWl/67o5w0zfH8aajBPAdsWUAGvbQ8xe41uwIcT1T1FvQaGG70ePvp79oKw462ds3il0b7T7ctVazbrt8rJSYuMHs45G+QfFqmXQX26Yce6RZio/Vn1j79PYPnnG8F/ti1geKXIyYmnV9veW2mPzsngip+T06P3quESfH8aajBPAdsX4BnZxvbR2JB+mDp6cIpUq3plGxsph5OWgO977VPsP9mn7d9ophYpUqgArsbEqbxMrsZew1NFCkrWKD1V+EFZ9SrPomunN/D7X/zQmhGQZWYyvVb5E3hS0j0k3L2r1nElJhZFHu5DVcCJXQgUKVQQsbEG709tPz5VuFCKsT/1cN/y/ZmChgUUsEkBBrw2tls8c+dCHs/cKZKNDZPDSUcgZ44cKfaf7FMPd3e1VP2XX8D2Xd+r/Pc//oLyZUtCgiUp+Em7kq+7deHGzXgpQmJiIvYcOIzKz/JDawrEhif1X9L27c79aoRbv92Hhtq+VjOc2I1Aw7q11PvtTkKC+sX0tz+P4+U61dT4+f5UDJxkGwHH2lAGvHa2PyOWfKYeVSWPP2rjFYjBI6bY2RZwuG+2bgpnZyf1WLLFK9bg/QE99ChDR05H3LXrav7tboPUvpbXfHk94f1OW1XOie0KBPm/hw1bdqvHkp06fR7vdXzddgfLkaUqULZ0cbR/vTl69A9D0LBJGBjoDXc3N9V2KN+fysFRJgd+OKLOsdt3HUDouNlo0d7PUTaN25GKgHMqZSyyYYEAXy/1iCrdo6qmjBpsw6Pl0FITkA+qDR/kpx5LtmB6GMqUKqZvtm3NAv0j57Z8MU/t63WfzEQ/v86Q5fQNbSTDYRgLFC5UABFTQtRjycaFDoBc7TduwTl7EOj0v1ZYMW88lkWMReP6tfVD5vtTT+EQGXmEoO5nqbxuX7vQIbaLG5G6AAPe1F1YSgEKUIACFKAABUwVYDsbF2DAa+M7iMOjAAUoQAEKUIACFHgyAQa8T+bHpSlgugBbUoACFKAABSiQJQIMeLOEnZ1SgAIUoAAFsq8At5wC1hZgwGttcfZHAQpQgAIUoAAFKGBVAQa8VuVmZ6YLsCUFKEABClCAAhQwjwADXvM4ci0UoAAFKEABywhwrRSgwBMLMOB9YkKugAIUoAAFKEABClDAlgUY8Nry3jF9bGxJAQpQgAIUoAAFKJCGAAPeNGBYTAEKUIAC9ijAMVOAAhRIKcCAN6UJSyhAAQpQgAIUoAAFHEggWwa8DrT/uCkUoAAFKEABClCAAo8RYMD7GCBWU4ACFHBgAW4aBShAgWwhwIA3W+xmbiQFKEABClCAAhTIvgKPD3izrw23nAIUoAAFKEABClDAAQQY8DrATuQmUIAC1hFgLxSgAAUoYJ8CDHjtc79x1BSgAAUoQAEKUCCrBOyuXwa8drfLOGAKUIACFKAABShAgYwIMODNiBbbUoACpguwJQUoQAEKUMBGBBjw2siO4DAoQAEKUIACFHBMAW5V1gsw4M36fcARUIACFKAABShAAQpYUIABrwVxuWoKmC7AlhSgAAUoQAEKWEqAAa+lZLleClCAAhSgAAUyLsAlKGABAQa8FkDlKilAgfQFPgifjo7dg+E/aDS6+H+IL9Zv1S9w42Y8uvT+EHfvJurLMppJTEpC517vI/ba9YwumqL90k/XYdbCT1OUm7vgn+On0LC1N/yDH5gMHjEFZ85d1Hfzy29/Y/iYmfp5w8yhn35F36HjDIsskl+/eSciln5mkXVzpRSgAAUsKcCA15K6XLelBLheBxDo8GZLzJsWio/Gv4/ln22EBG2yWSuiNuK15g3h5uYqs5lKri4u+F+bZljx+cZMLW+40GvN66t1GZZZKp87dy7MmxqKFfPG4/nnnsHoKfP1Xc1etBJdOr2hn8+KTJtXX8G2bw8g7tqNrOiefVKAAhTItAAD3kzTcUEKUMAcAoUK5EflZ5/G73+dUKvbtO07tGjyssrLRK72ytVPyUvyCwrH0WN/SVZdDZ340RL0e388OvgMwtzFq1S5TFo0rouvtu6RbKqpXqsuiFjyGXoNDEd77yAcPvo7psz+GD59Q9F70Chc+u+qWm7zN/vw5aYdKi9BudQPG/2RajNw+GR9ux17DkKuXKuG2uTAD0cw4MOJWg4qmA8OnQzffiPQor0fdu37UZWnN2lUrxb++jdaNTl99gL+uxKrOZVX8zKRAFiukgcOGYude3+QIn1avGKtunLuHTBcC5oXQK6aS2Ubr0B9sBo0bBIkSbkEsFIn+QUfR0G2r69m2nNAGMbPWAy5Yi518otE3TrVsWXHXpllsgkBDoICFDBFgAGvKUpsQwEKWEwgJvYaftOC3eeeKQcJ7JydnFDsqcIm93f7ToK6SvzpwolaIPw3vv3ukFq2YIF8yOOZE/+ePK3mU5tUrFAWC6aHwc/7bQSHTsGrTeoicvZo1H/xBSz55MvUFkH06XPo5dMJ86eNQOsWDdJsZ7jw7IUr4d+9E5bMGoWNq+agRpWKhtWp5vd+/zOe1cYnlYeP/IaqlZ+RrErf7D6A3ft+wFJtrDPGDYXhLwQSeG/atgezJ36IJbNH4crVGCz9ZK1arnaN5/H9j0dVAHvx8hVIkmBWyqRONdImFy5dwYQRA7Doo3A4OTlhx+7vtdIH/1fXxv7TL78/mOGUAhSggJ0IMOC1kx31JMPkshSwRYEZ85ZDrrIGDh4Nb6838HLtajh7/iIKFyqQoeE2rl8Hzs7OcHdzQ/2XX8DPBsFY0SKFcfrMo/tgk6+4Uf3aquiFqs/Bw90NNbRXKahR9VkcTyNQfubpMihXurg0Q/GiRdJspxo8nNSqUVldTV64fDV++e0v5M+X92GN8cu16zeUSdN2PfDL738hdHBv1eDchcsoWqSgysvkp6N/ou1rTeGZO5fa7rfbtpBilQ4f+R1y64H0IVdk3327DX7UyqTyxVpV8cNPv+HYH/+gSqUKKkn+0E/H8GLNKtJEJcnLumWm2FOFjH5pkG0+c+6SVDFRgAIUsBsBBrx2s6s4UAo4lkCQf1fs37ICKxdNhtzPK1vn7u6OxMREyeqTi4szku7d088nr9dXpJJJuHsXbu6uqdQ8KJIgWXLOWsDspgXMkpck84mJSZJNkWQ8ukLDdi4uLsnG+WjMA3p3waBAb5QqXhTT5nwM+fCXbh2Gr3nzeCqTb9ctxpRRg1GqRFFV7ebmirsGLvdxHxLMqkpt4ur6aBuT17lry96/f19rBRXU/qhdLT50+BjqvPC8ShIAS5AswbBqpE1cXB79aHDWbAwt5Iq6u4GV1tye/udYKUCBbCrw6KyWTQG42RSggO0IVCxfRrvKa3z1sFTJYjh15rwapDy14ET0WZXXTdZ+9Y0KkuXq6Nfb96Bmted1VTh1+jyef/bRfa/6CgtkypYuAbklQ7fqPQcO67LqvtlSJYqhdYuGeK35Kzjy64N7kPUNHpN55umyRk9sqFW9EvYe/Bm6QFZuf9CtonaN5/H1N3sgHnK7wso1X6POw6u3cnXWyQnYtnOfVlZVpa3f7oWUSZ1uHem9njl3AbpbLdJrxzoKUIACtiTAgDf53uA8BSiQZQJ5PHOj2vPP6D+sJQN5p/1rmLvkM/UBtU+ivkLZh7cTSJ2kEsWKwDtwuPpA2Ct1a6FJwzpSjJOnzqGCFkAXyJ/67QOqkRkncptD+bKlIB8UGxw6Rd1qoFt970HhePWtXpDyv45Hw+fdN3VVJr02ePkFtT26K93NG9XFc8+UVR+KGxQyCZcffsBOVtbslZfQonE9BA4eC9++I5DH0xPdO/9PqlSqVf15yH3ShQvmhyTJS5mqNGFy+OgfaNWsvgkt2YQCFKCA7Qgw4LWdfcGRUCDbCEwIGwiv9q1S3V6553TD5l36umrPV8TaZTPU47reH+CLj+eORfUqz+rrmzV6CZ8umIgvIqchsMc7+vINW3ZCgmV9QbKM3E6hK5IPyW34dJZuVq1fPmAmBd07t0M/v86SxYs1q6pxqBltIvfB6tppsxgXOgDLIsZiyujBCO7jDXnkmpSvWjQZ29YsMvMBhwAAA9NJREFUUOVjh/dDae2qtZQbpme04HzLF/MMi/R5uaWheeOXsdvg6Q4yppkTPsC0MUMhr7MnDdO379n1LayYP16NJXRwL3WvLx7+Gzaop7qN5OGsykuZbr5Xt46QJPOSvL3a6rdfPmB45UosXqhWSaqYKEABCtiNAANeu9lVHCgFsoeABJVlShUzuh82o1suV0ILFyyAhnVrZnRRm23v7fUmrt+4maXjO3nqLAYGds3SMbBzClCAApkReMKANzNdchkKUIAC6Qt0bNcSLs6PPz3JlzRIgJx8bS7Oznj37dbJi+16PlfOHHjztSZZug01q1eGPD4uSwfBzilAAQpkQuDxP1EysVIuQgEKUCDbCXCDKUABClDAZgUY8NrsruHAKEABClCAAhSggP0J2OKIGfDa4l7hmChAAQpQgAIUoAAFzCbAgNdslFwRBShgugBbUoACFKAABawnwIDXetbsiQIUoAAFKEABChgLcM4qAgx4rcLMTihAAQpQgAIUoAAFskqAAW9WybNfCpguwJYUoAAFKEABCjyBAAPeJ8DjohSgAAUoQAEKWFOAfVEgcwIMeDPnxqUoQAEKUIACFKAABexEgAGvnewoDtN0AbakAAUoQAEKUIAChgIMeA01mKcABShAAQo4jgC3hAIUeCjAgPchBF8oQAEKUIACFKAABRxTgAGvY+5X07eKLSlAAQpQgAIUoICDCzDgdfAdzM2jAAUoQAHTBNiKAhRwXAEGvI67b7llFKAABShAAQpQgAKaAANeDcH0/9mSAhSgAAUoQAEKUMDeBBjw2tse43gpQAEK2IIAx0ABClDAjgQY8NrRzuJQKUABClCAAhSgAAUyLmDJgDfjo+ESFKAABShAAQpQgAIUMLMAA14zg3J1FKAABVIKsIQCFKAABbJSgAFvVuqzbwpQgAIUoAAFKJCdBLJoWxnwZhE8u6UABShAAQpQgAIUsI4AA17rOLMXClDAdAG2pAAFKEABCphVgAGvWTm5MgpQgAIUoAAFKGAuAa7HXAIMeM0lyfVQgAIUoAAFKEABCtikAANem9wtHBQFTBdgSwpQgAIUoAAF0hdgwJu+D2spQAEKUIACFLAPAY6SAmkKMOBNk4YVFKAABShAAQpQgAKOIMCA1xH2IrfBdAG2pAAFKEABClAg2wkw4M12u5wbTAEKUIACFABoQIHsJMCANzvtbW4rBShAAQpQgAIUyIYCDHiz4U43fZPZkgIUoAAFKEABCti/AANe+9+H3AIKUIACFLC0ANdPAQrYtQADXrvefRw8BShAAQpQgAIUoMDjBP4PAAD//65sjKkAAAAGSURBVAMAtcZX8TasNi0AAAAASUVORK5CYII="
      },
      "metadata": {
       "image/png": {
-       "alt": "Horizontal bar chart of the directional edge, P(up) minus P(down), for each perpetual in the live cross-section, sorted and coloured by the intent it produced. short: 10, flat: 6, long: 2."
+       "alt": "Horizontal bar chart of the directional edge, P(up) minus P(down), for each perpetual in the live cross-section, sorted and coloured by the intent it produced. short: 2, flat: 7, long: 9."
       }
      },
      "output_type": "display_data"
@@ -2614,7 +3089,15 @@
   {
    "cell_type": "markdown",
    "id": "b18a8c3b",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.008361,
+     "end_time": "2026-09-11T14:39:22.707650+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T14:39:22.699289+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "## 6. Trade: Alpaca Paper Crypto\n",
     "\n",
@@ -2635,12 +3118,19 @@
    "id": "b65c8499",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T01:27:56.085249Z",
-     "iopub.status.busy": "2026-09-09T01:27:56.085043Z",
-     "iopub.status.idle": "2026-09-09T01:27:56.088119Z",
-     "shell.execute_reply": "2026-09-09T01:27:56.087481Z"
+     "iopub.execute_input": "2026-09-11T14:39:22.724806Z",
+     "iopub.status.busy": "2026-09-11T14:39:22.724511Z",
+     "iopub.status.idle": "2026-09-11T14:39:22.728577Z",
+     "shell.execute_reply": "2026-09-11T14:39:22.727936Z"
     },
-    "lines_to_next_cell": 2
+    "lines_to_next_cell": 2,
+    "papermill": {
+     "duration": 0.014202,
+     "end_time": "2026-09-11T14:39:22.729491+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T14:39:22.715289+00:00",
+     "status": "completed"
+    }
    },
    "outputs": [
     {
@@ -2664,7 +3154,14 @@
    "cell_type": "markdown",
    "id": "3d4902f0",
    "metadata": {
-    "lines_to_next_cell": 2
+    "lines_to_next_cell": 2,
+    "papermill": {
+     "duration": 0.011047,
+     "end_time": "2026-09-11T14:39:22.754384+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T14:39:22.743337+00:00",
+     "status": "completed"
+    }
    },
    "source": [
     "Classification distinguishes model inactivity, venue mismatch, disabled execution, and unsupported shorts."
@@ -2676,12 +3173,19 @@
    "id": "74be4ec0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T01:27:56.115232Z",
-     "iopub.status.busy": "2026-09-09T01:27:56.115054Z",
-     "iopub.status.idle": "2026-09-09T01:27:56.118473Z",
-     "shell.execute_reply": "2026-09-09T01:27:56.118086Z"
+     "iopub.execute_input": "2026-09-11T14:39:22.785970Z",
+     "iopub.status.busy": "2026-09-11T14:39:22.785591Z",
+     "iopub.status.idle": "2026-09-11T14:39:22.795112Z",
+     "shell.execute_reply": "2026-09-11T14:39:22.793254Z"
     },
-    "lines_to_next_cell": 2
+    "lines_to_next_cell": 2,
+    "papermill": {
+     "duration": 0.027426,
+     "end_time": "2026-09-11T14:39:22.796383+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T14:39:22.768957+00:00",
+     "status": "completed"
+    }
    },
    "outputs": [],
    "source": [
@@ -2718,7 +3222,14 @@
    "cell_type": "markdown",
    "id": "db32ce92",
    "metadata": {
-    "lines_to_next_cell": 2
+    "lines_to_next_cell": 2,
+    "papermill": {
+     "duration": 0.011528,
+     "end_time": "2026-09-11T14:39:22.822973+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T14:39:22.811445+00:00",
+     "status": "completed"
+    }
    },
    "source": [
     "Only an authorized long intent reaches the broker; every publication-default record returns earlier."
@@ -2730,12 +3241,19 @@
    "id": "04cec8c2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T01:27:56.143524Z",
-     "iopub.status.busy": "2026-09-09T01:27:56.143394Z",
-     "iopub.status.idle": "2026-09-09T01:27:56.146252Z",
-     "shell.execute_reply": "2026-09-09T01:27:56.145831Z"
+     "iopub.execute_input": "2026-09-11T14:39:22.852016Z",
+     "iopub.status.busy": "2026-09-11T14:39:22.851608Z",
+     "iopub.status.idle": "2026-09-11T14:39:22.857976Z",
+     "shell.execute_reply": "2026-09-11T14:39:22.857168Z"
     },
-    "lines_to_next_cell": 2
+    "lines_to_next_cell": 2,
+    "papermill": {
+     "duration": 0.021564,
+     "end_time": "2026-09-11T14:39:22.858678+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T14:39:22.837114+00:00",
+     "status": "completed"
+    }
    },
    "outputs": [],
    "source": [
@@ -2767,7 +3285,14 @@
    "cell_type": "markdown",
    "id": "3a769dcf",
    "metadata": {
-    "lines_to_next_cell": 2
+    "lines_to_next_cell": 2,
+    "papermill": {
+     "duration": 0.012595,
+     "end_time": "2026-09-11T14:39:22.884899+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T14:39:22.872304+00:00",
+     "status": "completed"
+    }
    },
    "source": [
     "The venue session opens only when credentials and explicit paper-order authorization are both present."
@@ -2779,10 +3304,17 @@
    "id": "01556c00",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T01:27:56.169360Z",
-     "iopub.status.busy": "2026-09-09T01:27:56.169247Z",
-     "iopub.status.idle": "2026-09-09T01:27:56.171780Z",
-     "shell.execute_reply": "2026-09-09T01:27:56.171313Z"
+     "iopub.execute_input": "2026-09-11T14:39:22.915501Z",
+     "iopub.status.busy": "2026-09-11T14:39:22.914977Z",
+     "iopub.status.idle": "2026-09-11T14:39:22.921506Z",
+     "shell.execute_reply": "2026-09-11T14:39:22.919882Z"
+    },
+    "papermill": {
+     "duration": 0.026162,
+     "end_time": "2026-09-11T14:39:22.924217+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T14:39:22.898055+00:00",
+     "status": "completed"
     }
    },
    "outputs": [],
@@ -2804,10 +3336,17 @@
    "id": "a8e7a7a3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T01:27:56.183218Z",
-     "iopub.status.busy": "2026-09-09T01:27:56.183096Z",
-     "iopub.status.idle": "2026-09-09T01:27:56.186961Z",
-     "shell.execute_reply": "2026-09-09T01:27:56.186539Z"
+     "iopub.execute_input": "2026-09-11T14:39:22.955260Z",
+     "iopub.status.busy": "2026-09-11T14:39:22.954823Z",
+     "iopub.status.idle": "2026-09-11T14:39:22.965717Z",
+     "shell.execute_reply": "2026-09-11T14:39:22.963473Z"
+    },
+    "papermill": {
+     "duration": 0.026631,
+     "end_time": "2026-09-11T14:39:22.966357+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T14:39:22.939726+00:00",
+     "status": "completed"
     }
    },
    "outputs": [
@@ -2817,30 +3356,29 @@
      "text": [
       "\n",
       "Execution summary:\n",
-      "  dry_run                1\n",
-      "  short_unsupported      6\n",
-      "  signal_only            5\n",
-      "  skipped_flat           6\n",
+      "  dry_run                8\n",
+      "  signal_only            3\n",
+      "  skipped_flat           7\n",
       "\n",
       "Per-symbol detail:\n",
-      "  AAVEUSDT   short  p_up=0.00 → short_unsupported    AAVE/USD\n",
-      "  ADAUSDT    short  p_up=0.00 → short_unsupported    ADA/USD\n",
+      "  AAVEUSDT   long   p_up=1.00 → dry_run              AAVE/USD\n",
+      "  ADAUSDT    long   p_up=1.00 → dry_run              ADA/USD\n",
       "  APTUSDT    short  p_up=0.00 → signal_only          \n",
-      "  ATOMUSDT   long   p_up=1.00 → signal_only          \n",
+      "  ATOMUSDT   short  p_up=0.00 → signal_only          \n",
       "  AVAXUSDT   flat   p_up=0.00 → skipped_flat         \n",
       "  BNBUSDT    flat   p_up=0.00 → skipped_flat         \n",
-      "  BTCUSDT    flat   p_up=0.00 → skipped_flat         \n",
-      "  COMPUSDT   short  p_up=0.00 → signal_only          \n",
-      "  DOGEUSDT   flat   p_up=0.00 → skipped_flat         \n",
+      "  BTCUSDT    flat   p_up=0.16 → skipped_flat         \n",
+      "  COMPUSDT   flat   p_up=0.00 → skipped_flat         \n",
+      "  DOGEUSDT   long   p_up=1.00 → dry_run              DOGE/USD\n",
       "  DOTUSDT    long   p_up=1.00 → dry_run              DOT/USD\n",
-      "  ETHUSDT    flat   p_up=0.00 → skipped_flat         \n",
-      "  INJUSDT    flat   p_up=0.00 → skipped_flat         \n",
-      "  LINKUSDT   short  p_up=0.00 → short_unsupported    LINK/USD\n",
-      "  NEARUSDT   short  p_up=0.00 → signal_only          \n",
-      "  SOLUSDT    short  p_up=0.00 → short_unsupported    SOL/USD\n",
-      "  SUIUSDT    short  p_up=0.00 → signal_only          \n",
-      "  UNIUSDT    short  p_up=0.00 → short_unsupported    UNI/USD\n",
-      "  XRPUSDT    short  p_up=0.00 → short_unsupported    XRP/USD\n"
+      "  ETHUSDT    long   p_up=1.00 → dry_run              ETH/USD\n",
+      "  INJUSDT    flat   p_up=0.25 → skipped_flat         \n",
+      "  LINKUSDT   flat   p_up=0.00 → skipped_flat         \n",
+      "  NEARUSDT   flat   p_up=0.00 → skipped_flat         \n",
+      "  SOLUSDT    long   p_up=1.00 → dry_run              SOL/USD\n",
+      "  SUIUSDT    long   p_up=1.00 → signal_only          \n",
+      "  UNIUSDT    long   p_up=1.00 → dry_run              UNI/USD\n",
+      "  XRPUSDT    long   p_up=1.00 → dry_run              XRP/USD\n"
      ]
     }
    ],
@@ -2876,7 +3414,15 @@
   {
    "cell_type": "markdown",
    "id": "545169b3",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.006964,
+     "end_time": "2026-09-11T14:39:22.981660+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T14:39:22.974696+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "The execution summary distinguishes flat intent, an absent\n",
     "mapping, an unsupported spot short, an intentional dry run, and a missing\n",
@@ -2887,7 +3433,15 @@
   {
    "cell_type": "markdown",
    "id": "be10e690",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.006524,
+     "end_time": "2026-09-11T14:39:22.995443+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T14:39:22.988919+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "## 7. Persist Run JSON\n",
     "\n",
@@ -2903,10 +3457,17 @@
    "id": "c885de42",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T01:27:56.218767Z",
-     "iopub.status.busy": "2026-09-09T01:27:56.218652Z",
-     "iopub.status.idle": "2026-09-09T01:27:56.223285Z",
-     "shell.execute_reply": "2026-09-09T01:27:56.222888Z"
+     "iopub.execute_input": "2026-09-11T14:39:23.013866Z",
+     "iopub.status.busy": "2026-09-11T14:39:23.013589Z",
+     "iopub.status.idle": "2026-09-11T14:39:23.022507Z",
+     "shell.execute_reply": "2026-09-11T14:39:23.021568Z"
+    },
+    "papermill": {
+     "duration": 0.020137,
+     "end_time": "2026-09-11T14:39:23.023474+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T14:39:23.003337+00:00",
+     "status": "completed"
     }
    },
    "outputs": [
@@ -2918,7 +3479,7 @@
       "======================================================================\n",
       "STEP 7: PERSIST RUN\n",
       "======================================================================\n",
-      "Run persisted: 25_live_trading/output/crypto_funding_deployment/runs/20260909T012756Z.json\n"
+      "Run persisted: 25_live_trading/output/crypto_funding_deployment/runs/20260911T143923Z.json\n"
      ]
     }
    ],
@@ -2938,6 +3499,10 @@
     "        \"instruments_fetched\": available_symbols,\n",
     "        \"coverage\": coverage,\n",
     "        \"minimum_coverage\": MIN_OKX_LIVE_COVERAGE,\n",
+    "        \"instruments_scored\": latest_features[\"symbol\"].to_list(),\n",
+    "        \"coverage_after_funding_freshness\": fresh_coverage,\n",
+    "        \"maximum_funding_age_hours\": MAX_FUNDING_AGE_HOURS,\n",
+    "        \"stale_funding\": stale_funding.to_dicts(),\n",
     "        \"fetch_errors\": [{\"symbol\": s, \"error\": e} for s, e in fetch_errors],\n",
     "        \"latest_bar_ts_utc\": str(live_prices[\"timestamp\"].max()),\n",
     "        \"candle_parser_audit\": audit_frame.to_dicts(),\n",
@@ -2968,7 +3533,15 @@
   {
    "cell_type": "markdown",
    "id": "bb3956e1",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.010562,
+     "end_time": "2026-09-11T14:39:23.042520+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T14:39:23.031958+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "## Key Takeaways\n",
     "\n",
@@ -2981,7 +3554,11 @@
     "   fixed teaching map routes eleven perps to Alpaca paper and records the\n",
     "   remaining eight as signal-only. The OKX data plane separately records\n",
     "   instruments retired by the live venue and stops if coverage falls below\n",
-    "   the declared floor. Both gaps are explicit deployment inputs.\n",
+    "   the declared floor. A symbol can also drop out while still returning\n",
+    "   data: the funding as-of join carries the last print forward for as long\n",
+    "   as the feed is silent, so freshness is checked as an age against the\n",
+    "   eight-hour settlement grid rather than as a null. All three gaps are\n",
+    "   explicit deployment inputs.\n",
     "3. **The deployment artefact is not the research artefact.** Same data,\n",
     "   same labels, different feature subset (the thirteen the live pipeline\n",
     "   can compute), different code path. Hyperparameters cross over from\n",
@@ -3006,8 +3583,8 @@
  ],
  "metadata": {
   "jupytext": {
-   "formats": "py:percent,ipynb",
-   "cell_metadata_filter": "tags,-all"
+   "cell_metadata_filter": "tags,-all",
+   "formats": "py:percent,ipynb"
   },
   "kernelspec": {
    "display_name": "Python 3",
@@ -3027,13 +3604,25 @@
    "version": "3.14.3"
   },
   "ml4t_provenance": {
-   "executed_at": "2026-09-09T01:28:03.894965+00:00",
+   "source_py_blob": "967639dcbe6626c7a72d412fde2df887900483f9",
+   "outputs_digest": "bedbfbad6e696fba296728e961d8d7088f237997f783edecd3381ddb7780cf9e",
+   "library_digest": "894fb6271c562eb996268b5202f48ae8261e2680ca0fec39cec2e92868ad1460",
+   "executed_at": "2026-09-11T14:40:16.177610+00:00",
    "executor": "local-uv",
-   "library_digest": "b59cd33da6276c72e12c6fcf3c973a3cb07064dfaeb7175fc6ba10a599b2b1ff",
-   "outputs_digest": "c29a9c2311f996609ac5b5122dc11dcc157dd71f9f2257b80b241dc71ffe0a78",
-   "parameters": {},
    "production": true,
-   "source_py_blob": "cbe8da012f843fd45af58fc7d72a30211cb4f887"
+   "parameters": {}
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 27.344018,
+   "end_time": "2026-09-11T14:39:26.478228+00:00",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "25_live_trading/09_crypto_funding_deployment_loop.ipynb",
+   "output_path": "25_live_trading/09_crypto_funding_deployment_loop.ipynb",
+   "parameters": {},
+   "start_time": "2026-09-11T14:38:59.134210+00:00",
+   "version": "2.7.0"
   }
  },
  "nbformat": 4,

--- a/25_live_trading/09_crypto_funding_deployment_loop.py
+++ b/25_live_trading/09_crypto_funding_deployment_loop.py
@@ -140,6 +140,7 @@ PROB_SHORT_THRESHOLD = (
 NOTIONAL_PER_LEG_USD = 100.0  # paper notional per symbol
 SUBMIT_PAPER_ORDERS = False  # explicit opt-in only; publication execution is dry-run
 MIN_OKX_LIVE_COVERAGE = 0.75
+MAX_FUNDING_AGE_HOURS = 8.0  # funding settles every 8h; one missed settlement is the limit
 
 # %% [markdown]
 # ## 1. Setup and Venue Connections
@@ -922,14 +923,14 @@ if len(live_funding) > 0:
                 [
                     pl.lit(None, dtype=pl.Float64).alias("funding_rate"),
                     pl.lit(None, dtype=pl.Float64).alias("premium"),
+                    pl.lit(None, dtype=pl.Datetime("ms", "UTC")).alias("funding_asof"),
                 ]
             )
         else:
-            joined = sym_bars.join_asof(
-                sym_fund.select(["timestamp", "funding_rate"]),
-                on="timestamp",
-                strategy="backward",
+            sym_fund_asof = sym_fund.select(["timestamp", "funding_rate"]).with_columns(
+                pl.col("timestamp").alias("funding_asof")
             )
+            joined = sym_bars.join_asof(sym_fund_asof, on="timestamp", strategy="backward")
             sym_bars = joined.with_columns((pl.col("funding_rate") * 3.0).alias("premium"))
         parts.append(sym_bars)
     live_panel = pl.concat(parts).sort(["symbol", "timestamp"])
@@ -938,26 +939,65 @@ else:
         [
             pl.lit(None, dtype=pl.Float64).alias("funding_rate"),
             pl.lit(None, dtype=pl.Float64).alias("premium"),
+            pl.lit(None, dtype=pl.Datetime("ms", "UTC")).alias("funding_asof"),
         ]
     )
 
 
 # %% [markdown]
-# The latest fully populated row per symbol is the only live observation eligible for inference.
+# The latest fully populated row per symbol is the only live observation eligible for inference,
+# and populated is not the same as current. The as-of join carries the last funding print forward
+# for as long as the feed stays silent, so `funding_rate` and the `premium` derived from it are
+# never null once a single rate has arrived: a symbol whose funding stopped publishing a week ago
+# still produces a complete feature row, and the null check cannot distinguish it from a live one.
+# A null count answers when the series began, never whether it kept going. The age of the matched
+# print against the eight-hour settlement grid answers the second question, and a symbol reading a
+# rate older than `MAX_FUNDING_AGE_HOURS` leaves the cross-section rather than being scored.
 
 
 # %%
-live_features = compute_features_8h(live_panel)
+live_features = compute_features_8h(live_panel).with_columns(
+    ((pl.col("timestamp") - pl.col("funding_asof")).dt.total_minutes() / 60.0).alias(
+        "funding_age_hours"
+    )
+)
 
-# The latest valid feature row per symbol becomes the prediction input
-latest_features = (
+# The latest valid feature row per symbol is the prediction candidate
+latest_candidates = (
     live_features.filter(pl.all_horizontal([pl.col(c).is_not_null() for c in FEATURE_COLS]))
     .group_by("symbol")
     .agg(pl.all().last())
     .sort("symbol")
 )
-print(f"Latest valid feature rows: {latest_features.shape[0]} of {len(CASE_STUDY_UNIVERSE)} perps")
-assert set(latest_features["symbol"]) == set(available_symbols)
+print(
+    f"Latest valid feature rows: {latest_candidates.shape[0]} of {len(CASE_STUDY_UNIVERSE)} perps"
+)
+assert set(latest_candidates["symbol"]) == set(available_symbols)
+
+funding_age = latest_candidates["funding_age_hours"]
+print(
+    f"Funding age at the inference row: median {funding_age.median():.1f}h, "
+    f"max {funding_age.max():.1f}h (tolerance {MAX_FUNDING_AGE_HOURS:.0f}h)"
+)
+is_fresh = pl.col("funding_age_hours").is_not_null() & (
+    pl.col("funding_age_hours") <= MAX_FUNDING_AGE_HOURS
+)
+stale_funding = latest_candidates.filter(~is_fresh).select("symbol", "funding_age_hours")
+if len(stale_funding) > 0:
+    print("Dropped for stale funding: " + ", ".join(stale_funding["symbol"]))
+    print(stale_funding)
+
+latest_features = latest_candidates.filter(is_fresh)
+fresh_coverage = len(latest_features) / len(CASE_STUDY_UNIVERSE)
+print(
+    f"Inference cross-section: {len(latest_features)} of "
+    f"{len(CASE_STUDY_UNIVERSE)} requested perps ({fresh_coverage:.1%})"
+)
+if fresh_coverage < MIN_OKX_LIVE_COVERAGE:
+    raise RuntimeError(
+        f"Coverage after the funding-freshness gate is {fresh_coverage:.1%}, below the "
+        f"{MIN_OKX_LIVE_COVERAGE:.0%} deployment floor"
+    )
 
 # %% [markdown]
 # ## 5. Predict Direction Probabilities
@@ -1215,6 +1255,10 @@ run = {
         "instruments_fetched": available_symbols,
         "coverage": coverage,
         "minimum_coverage": MIN_OKX_LIVE_COVERAGE,
+        "instruments_scored": latest_features["symbol"].to_list(),
+        "coverage_after_funding_freshness": fresh_coverage,
+        "maximum_funding_age_hours": MAX_FUNDING_AGE_HOURS,
+        "stale_funding": stale_funding.to_dicts(),
         "fetch_errors": [{"symbol": s, "error": e} for s, e in fetch_errors],
         "latest_bar_ts_utc": str(live_prices["timestamp"].max()),
         "candle_parser_audit": audit_frame.to_dicts(),
@@ -1253,7 +1297,11 @@ print(f"Run persisted: {display_path(run_path)}")
 #    fixed teaching map routes eleven perps to Alpaca paper and records the
 #    remaining eight as signal-only. The OKX data plane separately records
 #    instruments retired by the live venue and stops if coverage falls below
-#    the declared floor. Both gaps are explicit deployment inputs.
+#    the declared floor. A symbol can also drop out while still returning
+#    data: the funding as-of join carries the last print forward for as long
+#    as the feed is silent, so freshness is checked as an age against the
+#    eight-hour settlement grid rather than as a null. All three gaps are
+#    explicit deployment inputs.
 # 3. **The deployment artefact is not the research artefact.** Same data,
 #    same labels, different feature subset (the thirteen the live pipeline
 #    can compute), different code path. Hyperparameters cross over from


### PR DESCRIPTION
An as-of join never fails. It carries the last value forward for as long as there is one, so a null count on its result reports whether the right series ever *started*, not whether it kept going. Three notebooks decided something on that count. This is the sweep of all 26 live `join_asof` sites plus the three fixes it produced.

Each fix has the same shape: carry the right frame's timestamp through the join, measure the age of the matched observation against the interval the source actually publishes on, declare the tolerance before printing the measurement, and act on the age.

## Chapter 16: yield-curve coverage asserted from a row count

`01_backtest_first_principles.py` and `10_regime_backtest_analysis.py` both joined the FRED yield curve onto the ETF panel and then asserted coverage from the height of the result:

```python
regime_panel = (
    price_panel.select("timestamp")
    .join_asof(yield_curve.sort("timestamp"), on="timestamp", strategy="backward")
    .drop_nulls()
)
assert regime_panel.height == price_panel.height, "Yield-curve history does not cover the panel"
```

That assert fires only if the Treasury series begins after the panel does. A month in which nothing was published would be carried across and still fill every row, and 01's message claimed coverage it had not checked. Both now assert on `MAX_SLOPE_AGE_DAYS = 4` against the matched observation's own timestamp.

**No number moves.** Match age is median 0d and max 0d across all 3,522 panel rows: FRED has an observation on every ETF trading day in 2010-2024. The only new output in either render is the age line.

**The check is not vacuous.** Deleting a month of publications from the curve and re-running, the height assert stayed silent and the age assert fired at 30d.

## Chapter 25: live inference gated on a null that cannot fail

`09_crypto_funding_deployment_loop.py` is the consequential one, because its output is an order. OKX publishes funding every eight hours; the notebook as-of joins it onto the eight-hour bars and then picks the row to score with

```python
live_features.filter(pl.all_horizontal([pl.col(c).is_not_null() for c in FEATURE_COLS]))
```

`funding_rate` is never null after a symbol's first print, and `premium` is `funding_rate * 3.0`, so both go stale together and neither can fail that filter. A perp whose funding feed stalled days ago is scored on the old rate and reaches the trade step.

The publication timestamp now rides through the join, the age of the matched print at the inference row is printed beside its tolerance, and a symbol above `MAX_FUNDING_AGE_HOURS` (8h, one missed settlement) leaves the cross-section before scoring. The surviving cross-section is re-checked against the existing `MIN_OKX_LIVE_COVERAGE` floor and recorded in the run manifest alongside the instruments the venue no longer lists: a stalled feed and a retired instrument both remove a symbol from the tradable set.

Re-executed against the live venue: age is 0.0h at median and max across the eighteen perps OKX still lists (MKR-USDT-SWAP is retired, as in the previous render), so again no number moves. On a synthetic panel whose funding stops nine settlements early, the null check keeps the symbol and the age gate drops it at 72h. The render is a fresh dry-run snapshot; `SUBMIT_PAPER_ORDERS` stays `False` and no broker session is opened.

## The sweep

All 26 live `join_asof` sites, hand-adjudicated after a mechanical pass. Twelve had a null-count claim and no age measure; nine of those are fine on reading:

- `22_pandas_polars_benchmark.py` measures join throughput and says in prose to read the row count as a property of the generator.
- `07_news_return_signals.py`, `09_filing_text_signals.py` use `strategy="forward"` onto a trading calendar - a different failure mode, at the tail rather than the start.
- `latent_factors/panel.py` computes the null count but words its error correctly: *"Macro context is unavailable on or before the first requested date"*. That is what the null count means, stated accurately.
- `conformal.py` gates on `entity_n >= min_calibration_n`, a sufficiency check rather than a null count.
- `crypto_perps_funding/04_model_based_features.py` documents the carry-forward as the intent and aggregates across symbols.
- `07_stochastic_discount_factor.py`, `05_trade_shap_diagnostics.py` drop nulls without claiming coverage from the result.

## One site left alone

`case_studies/nasdaq100_microstructure/17_costs.py:656` aligns 15-minute predictions onto coarser cadence bars with a backward join and drops nulls, so a symbol whose predictions stop mid-sample keeps trading the last one at every later bar. It is the same shape and it is untouched here: that case study has a production run in flight, and the age has not been measured against the registry yet. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HduEssoPyjTKmdbP4KuujG
