### PR TITLE
Section citations quote the published heading, not the pre-print draft

### DIFF
--- a/02_financial_data_universe/README.md
+++ b/02_financial_data_universe/README.md
@@ -33,7 +33,7 @@ This section broadens the discussion from data categories to the practical reali
 - [`11_crypto_premium_analysis`](11_crypto_premium_analysis.ipynb) — This notebook demonstrates how to work with Binance perpetual futures premium index data - the foundation for funding rate arbitrage strategies. We load, explore, and analyze premium dynamics across major cryptocurrencies to identify potential arbitrage opportunities.
 - [`12_fx_pairs_eda`](12_fx_pairs_eda.ipynb) — This notebook introduces the FX dataset from OANDA. FX markets are OTC with no centralized exchange, so prices aggregate from multiple liquidity providers.
 
-### 2.3 Data Sourcing: The Due Diligence Framework
+### 2.3 A Due Diligence Framework for Data Sourcing
 
 This is the chapter's risk-control core. It explains that many apparent research successes are manufactured by data defects, then organizes due diligence around general quality dimensions, finance-specific failure modes, vendor evaluation, and internal governance. The section turns abstract warnings into operational rules: point-in-time correctness, survivorship handling, corporate action methodology, identifier integrity, legal rights, and reproducible versioning.
 
@@ -42,7 +42,7 @@ This is the chapter's risk-control core. It explains that many apparent research
 - [`15_survivorship_bias_detection`](15_survivorship_bias_detection.ipynb) — Survivorship bias is arguably the most dangerous form of data contamination in quantitative finance. This notebook uses real historical data from the US equities dataset (US Equities, originally Quandl WIKI) to demonstrate, detect, and quantify survivorship bias.
 - [`16_provider_comparison`](16_provider_comparison.ipynb) — ML4T Third Edition - Chapter 2: The Financial Data...
 
-### 2.4 Data Storage
+### 2.4 Storing Data
 
 This section translates data discipline into infrastructure decisions. Rather than promoting a single stack, it explains how storage choice depends on access patterns, scale, concurrency, and operational maturity, and it benchmarks the trade-offs among file formats, embedded engines, and server databases. It gives readers a practical default architecture for modern research workflows while also teaching when more complex systems are justified.
 

--- a/03_market_microstructure/README.md
+++ b/03_market_microstructure/README.md
@@ -13,7 +13,7 @@ The chapter explains why market data cannot be treated as a neutral price series
 
 ## Sections
 
-### 3.1 Microstructure: The DNA of Price Formation
+### 3.1 How Microstructure Impacts Price Formation
 
 This section explains why market data cannot be treated as a neutral price series. It shows how spreads, depth, resiliency, order types, and intraday trading regimes shape both execution quality and the meaning of observed trades and quotes. For readers building trading systems, this is the section that turns "price data" into an economic object with frictions, incentives, and timing effects.
 
@@ -54,7 +54,7 @@ This section separates the continuous and jump components of intraday returns us
 
 - [`18_algoseek_jump_detection`](18_algoseek_jump_detection.ipynb) — Decomposes daily realized variance into continuous (bipower) and jump components on AlgoSeek minute bars; applies the Lee–Mykland nonparametric test to time individual jumps with a multiple-testing-correct critical value; compares with a naive |z|>4 rule that misses most jumps because a single daily volatility ignores time-of-day shape; emits a per-symbol-day jump-feature panel.
 
-### 3.6 Data Quality and Sessionization
+### 3.6 Microstructure Data Quality and Sessionization
 
 This section focuses on intraday failure modes that quietly corrupt research: sequencing errors, timestamp confusion, stale quotes, invalid book transitions, bad qualifiers, and session-boundary mistakes. It is especially useful because it frames data quality as invariants and auditability rather than generic cleaning, giving readers a practical QA mindset for microstructure work.
 

--- a/05_synthetic_data/02_tailgan_tail_risk.ipynb
+++ b/05_synthetic_data/02_tailgan_tail_risk.ipynb
@@ -16,7 +16,7 @@
     "# Tail-GAN: Learning to Generate Tail-Risk Preserving Scenarios\n",
     "\n",
     "**Chapter 5: Synthetic Data Generation**\n",
-    "**Section Reference**: Section 5.5 (GANs for Time Series)\n",
+    "**Section Reference**: Section 5.5 (GANs for financial time series)\n",
     "\n",
     "**Docker image**: `ml4t-gpu`\n",
     "\n",
@@ -8967,11 +8967,11 @@
    "executed_at": "2026-09-09T22:37:38.196241+00:00",
    "executor": "local-uv",
    "library_digest": "aa8c16933805769ff3b25fe75d6992c6998ecd4b0a572e59cf21d4728f8cb804",
+   "notes": "prose synced from the .py at 2026-09-11T14:18:54.086785+00:00 without re-executing; every code cell is identical to blob 574db375d72d",
    "outputs_digest": "0f973d0461d5a51f0f871c012f7d1fdf9e9e20e670173d73bcffddbd0d14470c",
    "parameters": {},
    "production": true,
-   "source_py_blob": "574db375d72d39a73f2d10cf7d0cf15dca61a8c2",
-   "notes": "prose synced from the .py at 2026-09-09T22:40:03.009157+00:00 without re-executing; every code cell is identical to blob 87d57922090a"
+   "source_py_blob": "97e28d6103d1f57648ff56bd406ccf179b2dd424"
   },
   "papermill": {
    "default_parameters": {},

--- a/05_synthetic_data/02_tailgan_tail_risk.py
+++ b/05_synthetic_data/02_tailgan_tail_risk.py
@@ -17,7 +17,7 @@
 # # Tail-GAN: Learning to Generate Tail-Risk Preserving Scenarios
 #
 # **Chapter 5: Synthetic Data Generation**
-# **Section Reference**: Section 5.5 (GANs for Time Series)
+# **Section Reference**: Section 5.5 (GANs for financial time series)
 #
 # **Docker image**: `ml4t-gpu`
 #

--- a/08_financial_features/README.md
+++ b/08_financial_features/README.md
@@ -37,7 +37,7 @@ This section shows how fundamentals, calendars, and macro variables enter ML sys
 
 - [`04_fundamentals_macro_calendar`](04_fundamentals_macro_calendar.ipynb) — Slow-moving features that condition faster signals: SEC XBRL fundamentals (value/quality factors with point-in-time ASOF alignment), FRED macro indicators (yield curve, VIX regimes, credit spreads with publication-lag handling), and calendar encodings (cyclical sin/cos, time-to-event proximity).
 
-### 8.5 Cross-Cutting Features and the Limits of Aggregation
+### 8.5 Cross-Cutting Feature Types and the Limits of Direct Aggregation
 
 This section marks the conceptual boundary of the chapter. It explains when deterministic rolling transformations are enough and when hidden structure -- latent states, conditional dynamics, cycle strength, or path shape -- requires fitted models and learned representations, which sets up Chapter 9 cleanly without duplicating it.
 

--- a/11_ml_pipeline/05_shap_analysis.ipynb
+++ b/11_ml_pipeline/05_shap_analysis.ipynb
@@ -39,8 +39,7 @@
     "- Compare feature drivers for correct vs incorrect high-conviction predictions\n",
     "- Build a SHAP stability chart and bootstrap confidence bands within a fold\n",
     "\n",
-    "**Book reference**: Section 11.4 - Inside the Black Box: Model\n",
-    "Interpretability with SHAP.\n",
+    "**Book reference**: Section 11.4 - Interpreting models with SHAP.\n",
     "\n",
     "**Prerequisites**\n",
     "\n",
@@ -2913,11 +2912,11 @@
    "executed_at": "2026-09-10T05:16:39.206918+00:00",
    "executor": "local-uv",
    "library_digest": "8f88fb28963d5a775ce5a083a08f5b0306deb97d43f7edd438d3a89a215174c2",
+   "notes": "prose synced from the .py at 2026-09-11T14:18:56.560511+00:00 without re-executing; every code cell is identical to blob e8fc5528b51d",
    "outputs_digest": "1db6995d2aebabfc0621a2572707a9f2f222eb938069d25ff39948a46df05792",
    "parameters": {},
    "production": true,
-   "source_py_blob": "e8fc5528b51d59e181cf7fa2aa8ebb9519d3b86a",
-   "notes": "prose synced from the .py at 2026-09-10T05:58:25.435514+00:00 without re-executing; every code cell is identical to blob e8fc5528b51d"
+   "source_py_blob": "d57c7936eb8ec8620588e4367d77e47f20e40763"
   },
   "papermill": {
    "default_parameters": {},

--- a/11_ml_pipeline/05_shap_analysis.py
+++ b/11_ml_pipeline/05_shap_analysis.py
@@ -40,8 +40,7 @@
 # - Compare feature drivers for correct vs incorrect high-conviction predictions
 # - Build a SHAP stability chart and bootstrap confidence bands within a fold
 #
-# **Book reference**: Section 11.4 - Inside the Black Box: Model
-# Interpretability with SHAP.
+# **Book reference**: Section 11.4 - Interpreting models with SHAP.
 #
 # **Prerequisites**
 #

--- a/11_ml_pipeline/07_case_study_insights.ipynb
+++ b/11_ml_pipeline/07_case_study_insights.ipynb
@@ -36,7 +36,7 @@
     "- Inspect coefficient sign consistency, Lasso sparsity, and the overlap\n",
     "  of selected features across case studies\n",
     "\n",
-    "**Book reference**: Section 11.6 - Linear Models Across Nine Case Studies.\n",
+    "**Book reference**: Section 11.6 - Case study insights.\n",
     "\n",
     "**Prerequisites**: each case study's `06_linear.py` pipeline has populated\n",
     "`run_log/registry.db` for the linear family. Teaching notebooks NB01-NB06\n",
@@ -4064,7 +4064,8 @@
    "outputs_digest": "830dc7529e062b8f53d8b82bb3bf75f35aa1d9359e238d8c374b9ce7ef9b2880",
    "parameters": {},
    "production": true,
-   "source_py_blob": "84aefbb7b7aa35708f98133ae67aa6a54d759c49"
+   "source_py_blob": "e3c57f6e7e9e4c99b33bdb40ce5ca69fe4bbed41",
+   "notes": "prose synced from the .py at 2026-09-11T14:18:59.226063+00:00 without re-executing; every code cell is identical to blob 84aefbb7b7aa"
   },
   "papermill": {
    "default_parameters": {},

--- a/11_ml_pipeline/07_case_study_insights.py
+++ b/11_ml_pipeline/07_case_study_insights.py
@@ -36,7 +36,7 @@
 # - Inspect coefficient sign consistency, Lasso sparsity, and the overlap
 #   of selected features across case studies
 #
-# **Book reference**: Section 11.6 - Linear Models Across Nine Case Studies.
+# **Book reference**: Section 11.6 - Case study insights.
 #
 # **Prerequisites**: each case study's `06_linear.py` pipeline has populated
 # `run_log/registry.db` for the linear family. Teaching notebooks NB01-NB06

--- a/11_ml_pipeline/08_ml_backtest_intro.ipynb
+++ b/11_ml_pipeline/08_ml_backtest_intro.ipynb
@@ -32,7 +32,7 @@
     "- Quantify how transaction-cost drag, charged at `COST_BPS` per side, separates\n",
     "  high-turnover ML strategies from low-turnover baselines\n",
     "\n",
-    "**Book reference**: Section 11.6 - Linear Models Across Nine Case Studies\n",
+    "**Book reference**: Section 11.6 - Case study insights\n",
     "(the chapter synthesis paragraph on IC vs net Sharpe).\n",
     "\n",
     "**Prerequisites**\n",
@@ -1309,11 +1309,11 @@
    "executed_at": "2026-09-10T06:03:22.700683+00:00",
    "executor": "local-uv",
    "library_digest": "9024a561186204febf4eaf1c85e5072237ea508170f625e71c85a8031776983c",
+   "notes": "prose synced from the .py at 2026-09-11T14:19:01.716010+00:00 without re-executing; every code cell is identical to blob 32b54d9ef637",
    "outputs_digest": "0c2158251537d56198203c2c0256cea67eedaeaaa32c46d2d87648aab18f7999",
    "parameters": {},
    "production": true,
-   "source_py_blob": "32b54d9ef63703b77caf161dfaa96325a42d6709",
-   "notes": "prose synced from the .py at 2026-09-10T06:11:24.381866+00:00 without re-executing; every code cell is identical to blob 32b54d9ef637"
+   "source_py_blob": "74b7fe75390045318b35291de55f6bd238aa8e33"
   },
   "papermill": {
    "default_parameters": {},

--- a/11_ml_pipeline/08_ml_backtest_intro.py
+++ b/11_ml_pipeline/08_ml_backtest_intro.py
@@ -32,7 +32,7 @@
 # - Quantify how transaction-cost drag, charged at `COST_BPS` per side, separates
 #   high-turnover ML strategies from low-turnover baselines
 #
-# **Book reference**: Section 11.6 - Linear Models Across Nine Case Studies
+# **Book reference**: Section 11.6 - Case study insights
 # (the chapter synthesis paragraph on IC vs net Sharpe).
 #
 # **Prerequisites**

--- a/11_ml_pipeline/README.md
+++ b/11_ml_pipeline/README.md
@@ -61,7 +61,7 @@ forecasts will be turned into trades.
   02_regularization_paths. Direction prediction is often more tractable than magnitude prediction because most trading
   decisions reduce to long/short/flat.
 
-### 11.4 Inside the Black Box: Model Interpretability with SHAP
+### 11.4 Interpreting Models with SHAP
 
 This section argues that interpretability is part of model validation, not a cosmetic extra. It uses SHAP to connect
 predictions back to features, making it possible to test whether the model is learning economically sensible
@@ -86,7 +86,7 @@ raw predictions become risk-aware forecasts.
   assume Gaussian residuals, conformal prediction provides finite-sample valid intervals under minimal assumptions (
   exchangeability).
   
-### 11.6 Linear Models Across Nine Case Studies
+### 11.6 Case Study Insights
 
 This section broadens the chapter from method exposition to empirical judgment. It shows where linear models work well,
 where they are only marginally useful, and where they largely fail, while also highlighting label sensitivity, horizon

--- a/12_gradient_boosting/12_case_study_insights.ipynb
+++ b/12_gradient_boosting/12_case_study_insights.ipynb
@@ -37,7 +37,7 @@
     "- Inspect feature-importance rank shift versus the linear baseline, per-fold rank\n",
     "  stability, and the TabM-vs-GBM-vs-linear three-way picture\n",
     "\n",
-    "**Book reference**: Section 12.6 - Gradient Boosting Across Nine Case Studies.\n",
+    "**Book reference**: Section 12.6 - Case study insights.\n",
     "\n",
     "**Prerequisites**: each case study's `07_gbm.py` pipeline has populated\n",
     "`run_log/registry.db` for the GBM family. Where present, `tabular_dl.py`\n",
@@ -4665,7 +4665,8 @@
    "outputs_digest": "cec6d13f794e4a7b3c2054d675a15d5e39221dbef9b456bc1a0c1cb33e1a2f4c",
    "parameters": {},
    "production": true,
-   "source_py_blob": "70e97b3d3ec174148fb94020a4ef561360c276e4"
+   "source_py_blob": "c8f02de061f552c28bda41bca9fbd6af79de8cac",
+   "notes": "prose synced from the .py at 2026-09-11T14:19:04.561040+00:00 without re-executing; every code cell is identical to blob 70e97b3d3ec1"
   },
   "papermill": {
    "default_parameters": {},

--- a/12_gradient_boosting/12_case_study_insights.py
+++ b/12_gradient_boosting/12_case_study_insights.py
@@ -38,7 +38,7 @@
 # - Inspect feature-importance rank shift versus the linear baseline, per-fold rank
 #   stability, and the TabM-vs-GBM-vs-linear three-way picture
 #
-# **Book reference**: Section 12.6 - Gradient Boosting Across Nine Case Studies.
+# **Book reference**: Section 12.6 - Case study insights.
 #
 # **Prerequisites**: each case study's `07_gbm.py` pipeline has populated
 # `run_log/registry.db` for the GBM family. Where present, `tabular_dl.py`

--- a/12_gradient_boosting/README.md
+++ b/12_gradient_boosting/README.md
@@ -24,7 +24,7 @@ This section gives readers the conceptual bridge from single trees to GBMs. It e
 
 - [`01_ensemble_foundations`](01_ensemble_foundations.ipynb) — Benchmarks RF vs XGBoost/LightGBM/CatBoost on the Chen-Pelger-Zhu academic firm characteristics panel; quantifies the GBM-over-bagging advantage and the small spread across boosting libraries. _Runtime: ~6 min._
 
-### 12.2 The Workhorse: Gradient Boosting Machines
+### 12.2 Gradient Boosting Machines
 
 This is the operational core of the chapter. It explains the shared boosting framework, why GBMs fit tabular financial data so well, and how XGBoost, LightGBM, and CatBoost differ in regularization, speed, categorical handling, GPU behavior, and deployment tradeoffs. It also moves beyond library comparison into decisions practitioners actually face: when ranking matters more than point forecasts, when monotonic constraints improve robustness, and why native feature importance is not enough.
 
@@ -54,7 +54,7 @@ This section positions explainability as part of the model workflow rather than 
 - [`10_shap_nlp_sentiment`](10_shap_nlp_sentiment.ipynb) — SHAP token-level attribution on FinBERT sentiment classification; GPU recommended for transformer inference.
 - [`11_conformal_gbm`](11_conformal_gbm.ipynb) — Conformal prediction intervals for GBM regression (split conformal, QR-conformal, CQR) with empirical coverage diagnostics.
 
-### 12.6 GBMs Across Nine Asset Classes
+### 12.6 Case Study Insights
 
 This section provides the empirical payoff for the chapter. Instead of treating GBMs as abstract best practice, it shows where they help across the book's case studies, where linear models still win, which losses and tree sizes tend to work, how horizon and label design can matter as much as model class, and why validation results remain fragile without holdout confirmation. It gives the chapter its most concrete message: nonlinear models often help, but the real edge often comes from matching model, label, horizon, and evaluation design.
 

--- a/14_latent_factors/01_pca_equity_sectors.ipynb
+++ b/14_latent_factors/01_pca_equity_sectors.ipynb
@@ -45,7 +45,7 @@
     "## Cross-References\n",
     "- **Upstream**: Chapter 3 (ETF data loading)\n",
     "- **Downstream**: Chapter 16 (factor investing), Chapter 18 (factor-based backtesting)\n",
-    "- **Related**: [`02_eigenportfolios`](02_eigenportfolios.ipynb) (stock-level PCA), Section 9.4 (HMM regimes)\n",
+    "- **Related**: [`02_eigenportfolios`](02_eigenportfolios.ipynb) (stock-level PCA), Section 9.5 (Regime features)\n",
     "\n",
     "## Data Source\n",
     "ETF Universe parquet (canonical data, no API calls)\n",
@@ -13083,7 +13083,8 @@
    "outputs_digest": "916237b0af5b2651cae713a2506fe30b75325d0eba7db7094435755f42e0bd42",
    "parameters": {},
    "production": true,
-   "source_py_blob": "478989d369ede64b8d084938624d49c1d30b9dc5"
+   "source_py_blob": "d81605ea6d80d0377e89df8b5cca014dcb098906",
+   "notes": "prose synced from the .py at 2026-09-11T14:19:07.250688+00:00 without re-executing; every code cell is identical to blob 478989d369ed"
   },
   "papermill": {
    "default_parameters": {},

--- a/14_latent_factors/01_pca_equity_sectors.py
+++ b/14_latent_factors/01_pca_equity_sectors.py
@@ -46,7 +46,7 @@
 # ## Cross-References
 # - **Upstream**: Chapter 3 (ETF data loading)
 # - **Downstream**: Chapter 16 (factor investing), Chapter 18 (factor-based backtesting)
-# - **Related**: [`02_eigenportfolios`](02_eigenportfolios.ipynb) (stock-level PCA), Section 9.4 (HMM regimes)
+# - **Related**: [`02_eigenportfolios`](02_eigenportfolios.ipynb) (stock-level PCA), Section 9.5 (Regime features)
 #
 # ## Data Source
 # ETF Universe parquet (canonical data, no API calls)

--- a/14_latent_factors/02_eigenportfolios.ipynb
+++ b/14_latent_factors/02_eigenportfolios.ipynb
@@ -48,7 +48,7 @@
     "## Cross-References\n",
     "- **Upstream**: [`01_pca_equity_sectors`](01_pca_equity_sectors.ipynb) (sector ETF PCA, bootstrap stability)\n",
     "- **Downstream**: Chapter 18 (factor-based portfolio construction)\n",
-    "- **Related**: Section 9.4 (HMM regimes for factor timing)\n",
+    "- **Related**: Section 9.5 (Regime features)\n",
     "\n",
     "## Data Source\n",
     "US Equities (NASDAQ Data Link), with sector ETF returns used only for descriptive labels"
@@ -2500,7 +2500,8 @@
    "outputs_digest": "5f05466f89b67eeed42e55ad35e1e24fdf669f0d88387cf54ebb45fa55d6e5c6",
    "parameters": {},
    "production": true,
-   "source_py_blob": "a3c39f55367e18bd8d3554e23c057e3e67d3a2bb"
+   "source_py_blob": "cb0ca18fc59692c2664fc0f99bd83c22e01b80f2",
+   "notes": "prose synced from the .py at 2026-09-11T14:19:09.583905+00:00 without re-executing; every code cell is identical to blob a3c39f55367e"
   },
   "papermill": {
    "default_parameters": {},

--- a/14_latent_factors/02_eigenportfolios.py
+++ b/14_latent_factors/02_eigenportfolios.py
@@ -49,7 +49,7 @@
 # ## Cross-References
 # - **Upstream**: [`01_pca_equity_sectors`](01_pca_equity_sectors.ipynb) (sector ETF PCA, bootstrap stability)
 # - **Downstream**: Chapter 18 (factor-based portfolio construction)
-# - **Related**: Section 9.4 (HMM regimes for factor timing)
+# - **Related**: Section 9.5 (Regime features)
 #
 # ## Data Source
 # US Equities (NASDAQ Data Link), with sector ETF returns used only for descriptive labels

--- a/14_latent_factors/04_ipca.ipynb
+++ b/14_latent_factors/04_ipca.ipynb
@@ -45,7 +45,7 @@
     "\n",
     "**Prerequisite**: [`01_pca_equity_sectors`](01_pca_equity_sectors.ipynb)\n",
     "\n",
-    "**Book section**: Section 14.5, \"Dynamic betas with instrumented PCA\"\n",
+    "**Book section**: Section 14.5, \"Bridging economics and statistics with advanced models\"\n",
     "\n",
     "**Next**: [`05_rp_pca`](05_rp_pca.ipynb) changes the Stage 1 objective to\n",
     "emphasize priced variation."
@@ -1540,7 +1540,8 @@
    "outputs_digest": "138e13ea0ee61bd5a88a70ee1947201c5fc3a6cc338ea935116b79cf7c1c659a",
    "parameters": {},
    "production": true,
-   "source_py_blob": "acb92ab35a5e0ceb4d3bb79353dfc1921749138a"
+   "source_py_blob": "973ebbf750aba7d361da3b9c12536b50abbe9369",
+   "notes": "prose synced from the .py at 2026-09-11T14:19:11.877807+00:00 without re-executing; every code cell is identical to blob acb92ab35a5e"
   },
   "papermill": {
    "default_parameters": {},

--- a/14_latent_factors/04_ipca.py
+++ b/14_latent_factors/04_ipca.py
@@ -46,7 +46,7 @@
 #
 # **Prerequisite**: [`01_pca_equity_sectors`](01_pca_equity_sectors.ipynb)
 #
-# **Book section**: Section 14.5, "Dynamic betas with instrumented PCA"
+# **Book section**: Section 14.5, "Bridging economics and statistics with advanced models"
 #
 # **Next**: [`05_rp_pca`](05_rp_pca.ipynb) changes the Stage 1 objective to
 # emphasize priced variation.

--- a/14_latent_factors/05_rp_pca.ipynb
+++ b/14_latent_factors/05_rp_pca.ipynb
@@ -51,7 +51,7 @@
     "**Prerequisites**: [`01_pca_equity_sectors`](01_pca_equity_sectors.ipynb) and\n",
     "[`04_ipca`](04_ipca.ipynb)\n",
     "\n",
-    "**Book section**: Section 14.5, \"Finding priced factors with risk-premium PCA\"\n",
+    "**Book section**: Section 14.5, \"Bridging economics and statistics with advanced models\"\n",
     "\n",
     "**Next**: [`06_conditional_autoencoder`](06_conditional_autoencoder.ipynb)\n",
     "replaces the static linear loading map with a neural network."
@@ -1236,7 +1236,8 @@
    "outputs_digest": "096507bab982fe6b04abd646b8c86dd2e2776e8a036abba17f2154da1fb824f9",
    "parameters": {},
    "production": true,
-   "source_py_blob": "7cbae4c4b193b468fa6f26a1b550e72908aec59f"
+   "source_py_blob": "619c052f0798c969ec0d900a602b561d4fef149c",
+   "notes": "prose synced from the .py at 2026-09-11T14:19:13.869481+00:00 without re-executing; every code cell is identical to blob 7cbae4c4b193"
   },
   "papermill": {
    "default_parameters": {},

--- a/14_latent_factors/05_rp_pca.py
+++ b/14_latent_factors/05_rp_pca.py
@@ -52,7 +52,7 @@
 # **Prerequisites**: [`01_pca_equity_sectors`](01_pca_equity_sectors.ipynb) and
 # [`04_ipca`](04_ipca.ipynb)
 #
-# **Book section**: Section 14.5, "Finding priced factors with risk-premium PCA"
+# **Book section**: Section 14.5, "Bridging economics and statistics with advanced models"
 #
 # **Next**: [`06_conditional_autoencoder`](06_conditional_autoencoder.ipynb)
 # replaces the static linear loading map with a neural network.

--- a/15_causal_estimation/11_factor_zoo_validation.ipynb
+++ b/15_causal_estimation/11_factor_zoo_validation.ipynb
@@ -29,8 +29,8 @@
     "- carry the selected union into an intercept-inclusive OLS regression with HAC inference;\n",
     "- interpret what the exercise does and does not establish about the factor zoo.\n",
     "\n",
-    "**Book references**: Chapter 14, Section 14.5 (Taming the Factor Zoo), and\n",
-    "Chapter 15, Section 15.3 (Double Machine Learning).\n",
+    "**Book references**: Chapter 14, Section 14.1 (Making the case for latent factors), and\n",
+    "Chapter 15, Section 15.4 (Isolating factor effects with DML).\n",
     "\n",
     "**Prerequisites**: [`01_pca_equity_sectors`](../14_latent_factors/01_pca_equity_sectors.ipynb)\n",
     "and [`03_econml_dml`](03_econml_dml.ipynb)."
@@ -1237,7 +1237,8 @@
    "outputs_digest": "6156d48f9146061ee6a09b584a2c9adb7f3d3ffd3b97b1486c0cc57e4477a468",
    "parameters": {},
    "production": true,
-   "source_py_blob": "016ac5356c212dad0311fb004bbfcdff3c637182"
+   "source_py_blob": "7d0399ee59f91fec6c4ee287e566476ebacfe811",
+   "notes": "prose synced from the .py at 2026-09-11T14:19:16.256154+00:00 without re-executing; every code cell is identical to blob 016ac5356c21"
   },
   "papermill": {
    "default_parameters": {},

--- a/15_causal_estimation/11_factor_zoo_validation.py
+++ b/15_causal_estimation/11_factor_zoo_validation.py
@@ -30,8 +30,8 @@
 # - carry the selected union into an intercept-inclusive OLS regression with HAC inference;
 # - interpret what the exercise does and does not establish about the factor zoo.
 #
-# **Book references**: Chapter 14, Section 14.5 (Taming the Factor Zoo), and
-# Chapter 15, Section 15.3 (Double Machine Learning).
+# **Book references**: Chapter 14, Section 14.1 (Making the case for latent factors), and
+# Chapter 15, Section 15.4 (Isolating factor effects with DML).
 #
 # **Prerequisites**: [`01_pca_equity_sectors`](../14_latent_factors/01_pca_equity_sectors.ipynb)
 # and [`03_econml_dml`](03_econml_dml.ipynb).

--- a/17_portfolio_construction/README.md
+++ b/17_portfolio_construction/README.md
@@ -14,7 +14,7 @@ The chapter explains why good forecasts are not yet portfolios. It frames alloca
 
 ## Sections
 
-### 17.1 From Signals to Positions: Defining the Allocation Problem
+### 17.1 Defining the Allocation Problem
 
 This section explains why good forecasts are not yet portfolios. It frames allocation as the step that combines expected returns, risk estimates, and admissible-risk constraints into actual weights, leverage, and rebalancing choices. It matters because small modeling decisions at this stage can amplify a weak edge or destroy a strong one through concentration, unstable sizing, or excess turnover.
 

--- a/18_transaction_costs/09_frequency_tradeoff.ipynb
+++ b/18_transaction_costs/09_frequency_tradeoff.ipynb
@@ -35,7 +35,7 @@
     "- Model the interaction between signal decay and transaction costs\n",
     "- Use a persistence-cost scenario to explain when a faster signal may still be worth trading\n",
     "\n",
-    "**Book Reference:** Chapter 18: Section 18.8 (Practical Guardrails)\n",
+    "**Book Reference:** Chapter 18: Section 18.8 (Designing practical cost guardrails)\n",
     "\n",
     "**Prerequisites:** Read [`01_cost_taxonomy`](01_cost_taxonomy.ipynb) for breakeven framing and\n",
     "[`10_gross_vs_net_performance`](10_gross_vs_net_performance.ipynb) for the full net-of-cost waterfall."
@@ -3251,7 +3251,8 @@
    "outputs_digest": "70e75e793e121e60e5ad54562df82040ccece607cb02ee66fb3d4bc5e98b0edc",
    "parameters": {},
    "production": true,
-   "source_py_blob": "d2a9daa86cef0e2f627505948e6e6f3389450637"
+   "source_py_blob": "2e5aa818d16f9656925c9d876c54bc1b84d78487",
+   "notes": "prose synced from the .py at 2026-09-11T14:19:17.524459+00:00 without re-executing; every code cell is identical to blob d2a9daa86cef"
   },
   "papermill": {
    "default_parameters": {},

--- a/18_transaction_costs/09_frequency_tradeoff.py
+++ b/18_transaction_costs/09_frequency_tradeoff.py
@@ -36,7 +36,7 @@
 # - Model the interaction between signal decay and transaction costs
 # - Use a persistence-cost scenario to explain when a faster signal may still be worth trading
 #
-# **Book Reference:** Chapter 18: Section 18.8 (Practical Guardrails)
+# **Book Reference:** Chapter 18: Section 18.8 (Designing practical cost guardrails)
 #
 # **Prerequisites:** Read [`01_cost_taxonomy`](01_cost_taxonomy.ipynb) for breakeven framing and
 # [`10_gross_vs_net_performance`](10_gross_vs_net_performance.ipynb) for the full net-of-cost waterfall.

--- a/18_transaction_costs/10_gross_vs_net_performance.ipynb
+++ b/18_transaction_costs/10_gross_vs_net_performance.ipynb
@@ -27,7 +27,7 @@
     "- Compute net Sharpe under a parameterised cost stack\n",
     "- Compare three archetypes driven by real ETF return series under a common cost stack\n",
     "\n",
-    "**Book Reference:** Chapter 18: Section 18.8 (Practical Guardrails: When Costs Kill a Strategy)\n",
+    "**Book Reference:** Chapter 18: Section 18.8 (Designing practical cost guardrails)\n",
     "\n",
     "**Prerequisites:** Read [`01_cost_taxonomy`](01_cost_taxonomy.ipynb) for the cost stack and\n",
     "[`09_frequency_tradeoff`](09_frequency_tradeoff.ipynb) for turnover-driven breakeven logic."
@@ -7638,7 +7638,8 @@
    "outputs_digest": "f76cf9ff262362222e19800de937833ab02b535914b835232df466a257eb3e14",
    "parameters": {},
    "production": true,
-   "source_py_blob": "84568007335b70086b22be5edcb9387126d787e7"
+   "source_py_blob": "21157a4a8aa8f98d5635d35fabba4f3d4a40908a",
+   "notes": "prose synced from the .py at 2026-09-11T14:19:19.261283+00:00 without re-executing; every code cell is identical to blob 84568007335b"
   },
   "papermill": {
    "default_parameters": {},

--- a/18_transaction_costs/10_gross_vs_net_performance.py
+++ b/18_transaction_costs/10_gross_vs_net_performance.py
@@ -27,7 +27,7 @@
 # - Compute net Sharpe under a parameterised cost stack
 # - Compare three archetypes driven by real ETF return series under a common cost stack
 #
-# **Book Reference:** Chapter 18: Section 18.8 (Practical Guardrails: When Costs Kill a Strategy)
+# **Book Reference:** Chapter 18: Section 18.8 (Designing practical cost guardrails)
 #
 # **Prerequisites:** Read [`01_cost_taxonomy`](01_cost_taxonomy.ipynb) for the cost stack and
 # [`09_frequency_tradeoff`](09_frequency_tradeoff.ipynb) for turnover-driven breakeven logic.

--- a/18_transaction_costs/11_cost_cliff.ipynb
+++ b/18_transaction_costs/11_cost_cliff.ipynb
@@ -36,7 +36,7 @@
     "- Estimate the turnover ceiling implied by a target net Sharpe\n",
     "- Use the cost cliff as a publication-quality sanity check for intraday claims\n",
     "\n",
-    "**Book Reference:** Chapter 18: Section 18.8 (Practical Guardrails)\n",
+    "**Book Reference:** Chapter 18: Section 18.8 (Designing practical cost guardrails)\n",
     "\n",
     "**Prerequisites:** Read [`02_spread_estimation`](02_spread_estimation.ipynb) for spread realism and\n",
     "[`09_frequency_tradeoff`](09_frequency_tradeoff.ipynb) for the slower-frequency guardrail framing."
@@ -2479,7 +2479,8 @@
    "outputs_digest": "91ac154c56535e13837e7cf6a30596147156617cd0353c250f5e4ef69cb6a5ba",
    "parameters": {},
    "production": true,
-   "source_py_blob": "5bbed586feeae963f1b7b33bca3b1c5487220bbd"
+   "source_py_blob": "40d58f9c06ef7f9c073846423debf74cbb161e92",
+   "notes": "prose synced from the .py at 2026-09-11T14:19:20.810373+00:00 without re-executing; every code cell is identical to blob 5bbed586feea"
   },
   "papermill": {
    "default_parameters": {},

--- a/18_transaction_costs/11_cost_cliff.py
+++ b/18_transaction_costs/11_cost_cliff.py
@@ -37,7 +37,7 @@
 # - Estimate the turnover ceiling implied by a target net Sharpe
 # - Use the cost cliff as a publication-quality sanity check for intraday claims
 #
-# **Book Reference:** Chapter 18: Section 18.8 (Practical Guardrails)
+# **Book Reference:** Chapter 18: Section 18.8 (Designing practical cost guardrails)
 #
 # **Prerequisites:** Read [`02_spread_estimation`](02_spread_estimation.ipynb) for spread realism and
 # [`09_frequency_tradeoff`](09_frequency_tradeoff.ipynb) for the slower-frequency guardrail framing.

--- a/18_transaction_costs/README.md
+++ b/18_transaction_costs/README.md
@@ -36,7 +36,7 @@ This section explains why cost parameters are not stationary and must be conditi
 - [`02_spread_estimation`](02_spread_estimation.ipynb) — This notebook estimates bid-ask spreads from OHLCV data using two classical estimators, validates them against ground-truth microstructure data, and applies them across all seven asset classes. Uses cme_futures, crypto_perps, etfs and 5 more data.
 - [`03_market_impact_calibration`](03_market_impact_calibration.ipynb) — This notebook calibrates market impact models using real market data, estimates Kyle's lambda from NASDAQ-100 trade classification data, maps intraday volume profiles, and estimates strategy capacity limits for each asset class. Uses cme_futures, crypto_perps, etfs and 5 more data.
 
-### 18.4 Baseline Backtest Cost Models
+### 18.4 Baseline Backtesting Cost Models
 
 This section gives readers a practical ladder of cost models, from spread-only assumptions to linear slippage and square-root impact. It is useful because it offers a concrete modeling toolkit for research backtests while making clear when simple models are acceptable, when they are too optimistic, and why conservative calibration is often the right default.
 
@@ -51,20 +51,20 @@ This section demystifies execution algorithms by presenting TWAP, VWAP, and regi
 - [`07_ml4t_volume_participation`](07_ml4t_volume_participation.ipynb) — This notebook demonstrates VolumeParticipationLimit from ml4t.backtest.execution for realistic institutional order execution: Uses synthetic data.
 - [`08_ml_dynamic_execution`](08_ml_dynamic_execution.ipynb) — This notebook explores how machine learning can be used to dynamically adapt execution strategies based on real-time market conditions. Instead of following a fixed VWAP/TWAP schedule, we use ML to predict optimal execution parameters.
 
-### 18.6 Optimal Execution: Almgren-Chriss as a Unifying Framework
+### 18.6 Optimizing Execution with Almgren-Chriss as a Unifying Framework
 
 This section introduces Almgren-Chriss as the cleanest framework for thinking about impact, timing risk, and urgency in one model. Its importance is less in deriving a perfect trading schedule than in giving readers a disciplined way to reason about execution feasibility and to connect portfolio intent with execution reality.
 
 - [`05_almgren_chriss_optimal_execution`](05_almgren_chriss_optimal_execution.ipynb) — This notebook implements the seminal Almgren-Chriss (2001) framework for optimal trade execution. We derive the efficient frontier of execution strategies, compute optimal trajectories, and demonstrate Transaction Cost Analysis (TCA) methodology.
 
-### 18.7 Transaction Cost Analysis (TCA) and Model Validation
+### 18.7 Transaction Cost Analysis and Model Validation
 
 This section turns realized fills into model feedback through implementation shortfall, decomposition, regime-aware benchmarking, and calibration. It matters because it closes the loop: cost assumptions stop being static research inputs and become hypotheses that are tested, decomposed, and revised against live evidence.
 
 - [`01_cost_taxonomy`](01_cost_taxonomy.ipynb) — This notebook maps the transaction cost landscape across our seven asset classes, comparing exchange fee structures, spread regimes, and the resulting breakeven alpha requirements for each case study. Uses cme_futures, crypto_perps, etfs and 3 more data.
 - [`10_gross_vs_net_performance`](10_gross_vs_net_performance.ipynb) — This notebook provides a comprehensive framework for analyzing the gap between gross (theoretical) and net (realized) strategy performance. This is the ultimate reality check for any trading strategy.
 
-### 18.8 Practical Guardrails: When Costs Should Kill a Strategy
+### 18.8 Designing Practical Cost Guardrails
 
 This section provides decision rules such as break-even turnover, minimum required edge, alpha-to-go, capacity analysis, and kill criteria. Readers should care because this is where the chapter becomes operational: it shows how to decide whether a strategy can be deployed, scaled, modified, or abandoned once trading frictions are treated honestly.
 

--- a/19_risk_management/05_trade_shap_diagnostics.ipynb
+++ b/19_risk_management/05_trade_shap_diagnostics.ipynb
@@ -26,7 +26,8 @@
     "3. Read clustered error patterns and the hypotheses the library generates.\n",
     "4. Connect SHAP-driven diagnosis to feature-engineering or regime decisions.\n",
     "\n",
-    "**Book reference**: §19.5 (Trade-Level SHAP as Diagnostic Tool).\n",
+    "**Book reference**: §19.5 (Decomposing factor, sector, and macro exposures), under\n",
+    "\"Trade-level SHAP as a diagnostic tool\".\n",
     "\n",
     "**Prerequisites**: Familiarity with SHAP values (Lundberg & Lee 2017), gradient\n",
     "boosting on cross-sectional features, and the ML4T trade-record contract\n",
@@ -2119,11 +2120,11 @@
    "executed_at": "2026-09-11T04:56:21.117123+00:00",
    "executor": "local-uv",
    "library_digest": "468b267050807ec3f6dec615e9c817cf59ed6c7b5021d6b15754d59877821c8b",
-   "notes": "prose synced from the .py at 2026-09-11T05:00:28.822109+00:00 without re-executing; every code cell is identical to blob d9780a37d8d0",
+   "notes": "prose synced from the .py at 2026-09-11T14:19:22.171571+00:00 without re-executing; every code cell is identical to blob b235f1436002",
    "outputs_digest": "8aafa67f783f21c78ca3b0558fa6ccdb9303a4889acd6959a5e945d03f787db0",
    "parameters": {},
    "production": true,
-   "source_py_blob": "b235f1436002703ab12122f250b43fdc9f9502f3"
+   "source_py_blob": "9d4c61e6ec24f28d92807c7c866863170828f9a1"
   },
   "papermill": {
    "default_parameters": {},

--- a/19_risk_management/05_trade_shap_diagnostics.py
+++ b/19_risk_management/05_trade_shap_diagnostics.py
@@ -27,7 +27,8 @@
 # 3. Read clustered error patterns and the hypotheses the library generates.
 # 4. Connect SHAP-driven diagnosis to feature-engineering or regime decisions.
 #
-# **Book reference**: §19.5 (Trade-Level SHAP as Diagnostic Tool).
+# **Book reference**: §19.5 (Decomposing factor, sector, and macro exposures), under
+# "Trade-level SHAP as a diagnostic tool".
 #
 # **Prerequisites**: Familiarity with SHAP values (Lundberg & Lee 2017), gradient
 # boosting on cross-sectional features, and the ML4T trade-record contract

--- a/19_risk_management/08_ml_exit_signals.ipynb
+++ b/19_risk_management/08_ml_exit_signals.ipynb
@@ -29,7 +29,8 @@
     "- Recognize when an architectural change does not pay off on AUC but still matters operationally.\n",
     "\n",
     "## Book reference\n",
-    "§19.7 Adaptive Risk Controls, Figure 19.5 (signal-strength-conditioned barrier outcomes).\n",
+    "§19.7 Adaptive risk controls without leakage, Figure 19.5\n",
+    "(signal-strength-conditioned barrier outcomes).\n",
     "\n",
     "## Prerequisites\n",
     "Complete [`02_exit_strategies`](02_exit_strategies.ipynb) first for the rule-based exit\n",
@@ -3518,10 +3519,11 @@
    "executed_at": "2026-09-11T05:00:57.521425+00:00",
    "executor": "local-uv",
    "library_digest": "5f7027edf2af1647332d7c124e09ca84d65e501d739d419e2fac4ab1aed2205f",
+   "notes": "prose synced from the .py at 2026-09-11T14:35:37.480684+00:00 without re-executing; every code cell is identical to blob 64ec878856b9",
    "outputs_digest": "bdaffa259ef60f741207bbbb46c963eb96e61b6f8b1956128f090652a0a15e03",
    "parameters": {},
    "production": true,
-   "source_py_blob": "54779726dda7c72a54b56c2a3fb57c243f1703ca"
+   "source_py_blob": "d25ed2a8556a73fbb9c7258cfb2f5f67c8f09edd"
   },
   "papermill": {
    "default_parameters": {},

--- a/19_risk_management/08_ml_exit_signals.py
+++ b/19_risk_management/08_ml_exit_signals.py
@@ -30,7 +30,8 @@
 # - Recognize when an architectural change does not pay off on AUC but still matters operationally.
 #
 # ## Book reference
-# §19.7 Adaptive Risk Controls, Figure 19.5 (signal-strength-conditioned barrier outcomes).
+# §19.7 Adaptive risk controls without leakage, Figure 19.5
+# (signal-strength-conditioned barrier outcomes).
 #
 # ## Prerequisites
 # Complete [`02_exit_strategies`](02_exit_strategies.ipynb) first for the rule-based exit

--- a/19_risk_management/README.md
+++ b/19_risk_management/README.md
@@ -13,7 +13,7 @@ This opening section reframes risk management as part of system design rather th
 
 ## Sections
 
-### 19.1 Risk in the ML4T Workflow: From Backtest Winner to Tradable System
+### 19.1 Turning Your Backtest Winner into a Tradable System
 
 This opening section reframes risk management as part of system design rather than post hoc reporting. It explains why a strategy is not deployable until its limits, escalation rules, and governance artifacts are defined in advance, auditable, and point-in-time safe.
 
@@ -42,7 +42,7 @@ This section shifts the focus from point losses to lived investor experience. By
 - [`03_position_sizing_mae_mfe`](03_position_sizing_mae_mfe.ipynb) — This notebook demonstrates position sizing methods and MAE/MFE analysis for stop calibration. We implement fixed fractional and volatility-based sizing, then use trade excursion analysis to optimize stop placement.
 - [`10_ml4t_backtest_risk_demo`](10_ml4t_backtest_risk_demo.ipynb) — Demonstrates the ml4t.backtest.risk module—the library implementation of risk management concepts discussed in Chapter 19. This provides production-ready stop-loss rules, rule composition, and portfolio-level kill switches.
 
-### 19.5 Decomposing Risk: Factor, Sector, and Macro Exposure
+### 19.5 Decomposing Factor, Sector, and Macro Exposures
 
 This section asks where portfolio risk really comes from. It shows how factor, sector, geographic, and macro decomposition reveal whether performance reflects intended exposures, accidental bets, or risks that were never part of the original thesis.
 
@@ -65,7 +65,7 @@ This is the chapter's operational core for live implementation. It explains how 
 - [`09_deep_hedging`](09_deep_hedging.ipynb) — This notebook demonstrates deep hedging (Buehler et al., 2019): a neural network learns hedging positions that minimize CVaR of terminal PnL under transaction costs. Where Section 19.7 builds adaptive risk controls from rules (vol targeting, regime caps, stops), this notebook shows how the same risk objective can be optimized end-to-end by a neural network — bridging the gap between measurement (Section 19.3) and learned control.
 - [`11_systematic_risk_sweep`](11_systematic_risk_sweep.ipynb) — Demonstrates how to systematically optimize position-level exit rules (StopLoss, TakeProfit, TrailingStop) through 1D sweeps, 2D grid searches, and MAE/MFE-calibrated stops. Rather than hand-picking 3-5 configurations, we sweep the full parameter space and visualize Sharpe/Calmar trade-offs as heatmaps --- letting the data reveal the optimal risk regime.
 
-### 19.8 Kill Switches and Risk Governance
+### 19.8 Applying Kill Switches and Risk Governance
 
 This section turns metrics and controls into institutional process. It defines what failure conditions look like, how escalation should work, when re-research is required, and why drift detection and written risk governance are necessary for any strategy that is meant to survive contact with the market.
 

--- a/20_strategy_synthesis/00_holdout_predictions.ipynb
+++ b/20_strategy_synthesis/00_holdout_predictions.ipynb
@@ -37,7 +37,8 @@
     "- Compare validation vs holdout Sharpe ratios to surface overfit\n",
     "- Read the validation→holdout decay pattern per case study\n",
     "\n",
-    "**Book Reference**: Chapter 20, Section 20.6 (Stability Across Time and Regimes)\n",
+    "**Book Reference**: Chapter 20, Section 20.1 (First-pass results across nine case\n",
+    "studies), under \"From validation to holdout\"\n",
     "\n",
     "**Prerequisites**: A case study appears in the table below only once its signal-stage backtests\n",
     "are in the registry. One whose earlier stages have not been run reports the reason it could not\n",
@@ -673,7 +674,7 @@
     "pre-holdout data, the rank IC on holdout, and the arithmetic decay\n",
     "`(HO − Val) / Val`.\n",
     "\n",
-    "The chapter prose (§20.6, *Stability Across Time and Regimes*) uses\n",
+    "The chapter prose (§20.1, *First-pass results across nine case studies*) uses\n",
     "this output to discuss three *decay patterns*. In the first the prediction itself degrades and\n",
     "the rank IC falls toward zero. In the second the IC holds while the Sharpe halves or changes\n",
     "sign, because portfolio construction, costs or a regime shift stand between a correct ranking\n",
@@ -770,11 +771,12 @@
    "version": "3.14.3"
   },
   "ml4t_provenance": {
-   "source_py_blob": "44674d0893da05d06cbd6c2b0310910fae7c177c",
    "executed_at": "2026-08-20T07:12:08.338253+00:00",
    "executor": "local-uv",
+   "parameters": {},
    "production": true,
-   "parameters": {}
+   "source_py_blob": "fd666173a03c18da941bbc7190588b73156a8ace",
+   "notes": "prose synced from the .py at 2026-09-11T14:19:24.706436+00:00 without re-executing; every code cell is identical to blob 44674d0893da"
   },
   "papermill": {
    "default_parameters": {},

--- a/20_strategy_synthesis/00_holdout_predictions.ipynb
+++ b/20_strategy_synthesis/00_holdout_predictions.ipynb
@@ -675,11 +675,12 @@
     "`(HO − Val) / Val`.\n",
     "\n",
     "The chapter prose (§20.1, *First-pass results across nine case studies*) uses\n",
-    "this output to discuss three *decay patterns*. In the first the prediction itself degrades and\n",
-    "the rank IC falls toward zero. In the second the IC holds while the Sharpe halves or changes\n",
-    "sign, because portfolio construction, costs or a regime shift stand between a correct ranking\n",
-    "and a return. In the third the relationship breaks structurally. This notebook does not grade\n",
-    "case studies; it produces the numbers that discussion rests on.\n",
+    "this output to name three mechanisms behind a validation-to-holdout fall. Under\n",
+    "*prediction-quality drift* the signal itself weakens and the rank IC falls toward zero. Under\n",
+    "*portfolio-translation drift* the IC holds while the Sharpe halves or changes sign, because\n",
+    "portfolio construction and costs stand between a correct ranking and a return. Under *regime\n",
+    "change* the fitted relationships stop being informative on the holdout tape. This notebook\n",
+    "does not grade case studies; it produces the numbers that discussion rests on.\n",
     "\n",
     "Two design disciplines apply when reading the table:\n",
     "\n",
@@ -773,10 +774,10 @@
   "ml4t_provenance": {
    "executed_at": "2026-08-20T07:12:08.338253+00:00",
    "executor": "local-uv",
+   "notes": "prose synced from the .py at 2026-09-11T14:50:32.239826+00:00 without re-executing; every code cell is identical to blob fd666173a03c",
    "parameters": {},
    "production": true,
-   "source_py_blob": "fd666173a03c18da941bbc7190588b73156a8ace",
-   "notes": "prose synced from the .py at 2026-09-11T14:19:24.706436+00:00 without re-executing; every code cell is identical to blob 44674d0893da"
+   "source_py_blob": "0dbef2b9f9cfdada3151eb829f343b720f131bd6"
   },
   "papermill": {
    "default_parameters": {},

--- a/20_strategy_synthesis/00_holdout_predictions.py
+++ b/20_strategy_synthesis/00_holdout_predictions.py
@@ -277,11 +277,12 @@ summary_df
 # `(HO − Val) / Val`.
 #
 # The chapter prose (§20.1, *First-pass results across nine case studies*) uses
-# this output to discuss three *decay patterns*. In the first the prediction itself degrades and
-# the rank IC falls toward zero. In the second the IC holds while the Sharpe halves or changes
-# sign, because portfolio construction, costs or a regime shift stand between a correct ranking
-# and a return. In the third the relationship breaks structurally. This notebook does not grade
-# case studies; it produces the numbers that discussion rests on.
+# this output to name three mechanisms behind a validation-to-holdout fall. Under
+# *prediction-quality drift* the signal itself weakens and the rank IC falls toward zero. Under
+# *portfolio-translation drift* the IC holds while the Sharpe halves or changes sign, because
+# portfolio construction and costs stand between a correct ranking and a return. Under *regime
+# change* the fitted relationships stop being informative on the holdout tape. This notebook
+# does not grade case studies; it produces the numbers that discussion rests on.
 #
 # Two design disciplines apply when reading the table:
 #

--- a/20_strategy_synthesis/00_holdout_predictions.py
+++ b/20_strategy_synthesis/00_holdout_predictions.py
@@ -38,7 +38,8 @@
 # - Compare validation vs holdout Sharpe ratios to surface overfit
 # - Read the validation→holdout decay pattern per case study
 #
-# **Book Reference**: Chapter 20, Section 20.6 (Stability Across Time and Regimes)
+# **Book Reference**: Chapter 20, Section 20.1 (First-pass results across nine case
+# studies), under "From validation to holdout"
 #
 # **Prerequisites**: A case study appears in the table below only once its signal-stage backtests
 # are in the registry. One whose earlier stages have not been run reports the reason it could not
@@ -275,7 +276,7 @@ summary_df
 # pre-holdout data, the rank IC on holdout, and the arithmetic decay
 # `(HO − Val) / Val`.
 #
-# The chapter prose (§20.6, *Stability Across Time and Regimes*) uses
+# The chapter prose (§20.1, *First-pass results across nine case studies*) uses
 # this output to discuss three *decay patterns*. In the first the prediction itself degrades and
 # the rank IC falls toward zero. In the second the IC holds while the Sharpe halves or changes
 # sign, because portfolio construction, costs or a regime shift stand between a correct ranking

--- a/20_strategy_synthesis/01_aggregate_synthesis.ipynb
+++ b/20_strategy_synthesis/01_aggregate_synthesis.ipynb
@@ -19,7 +19,7 @@
     "- Build cross-dataset comparison tables\n",
     "- Export summary DataFrames for downstream notebooks (02–06)\n",
     "\n",
-    "**Book Reference**: Chapter 20, Section 20.1 (The Nine Case Studies)\n",
+    "**Book Reference**: Chapter 20, Section 20.1 (First-pass results across nine case studies)\n",
     "\n",
     "**Prerequisites**: Case studies must have run Ch16–19 backtests."
    ]

--- a/20_strategy_synthesis/01_aggregate_synthesis.py
+++ b/20_strategy_synthesis/01_aggregate_synthesis.py
@@ -28,7 +28,7 @@
 # - Build cross-dataset comparison tables
 # - Export summary DataFrames for downstream notebooks (02–06)
 #
-# **Book Reference**: Chapter 20, Section 20.1 (The Nine Case Studies)
+# **Book Reference**: Chapter 20, Section 20.1 (First-pass results across nine case studies)
 #
 # **Prerequisites**: Case studies must have run Ch16–19 backtests.
 

--- a/20_strategy_synthesis/03_signal_quality.ipynb
+++ b/20_strategy_synthesis/03_signal_quality.ipynb
@@ -31,7 +31,7 @@
     "- Compare validation IC with holdout IC (signal persistence)\n",
     "- Identify reproducibility and stability concerns\n",
     "\n",
-    "**Book Reference**: Chapter 20, Section 20.2 (Signal Evidence)\n",
+    "**Book Reference**: Chapter 20, Section 20.3 (Signal quality and prediction uncertainty)\n",
     "\n",
     "**Prerequisites**: Run [`01_aggregate_synthesis`](01_aggregate_synthesis.ipynb) first."
    ]
@@ -1050,11 +1050,12 @@
    "version": "3.14.3"
   },
   "ml4t_provenance": {
-   "source_py_blob": "8d65e3c4dbbabeaa16831e8e7c8cb116a45a3d59",
    "executed_at": "2026-08-20T07:57:30.879312+00:00",
    "executor": "local-uv",
+   "parameters": {},
    "production": true,
-   "parameters": {}
+   "source_py_blob": "d47d6b0bc69bd24555e06720c479411bb4871596",
+   "notes": "prose synced from the .py at 2026-09-11T14:35:13.725165+00:00 without re-executing; every code cell is identical to blob 4223a74456d6"
   },
   "papermill": {
    "default_parameters": {},

--- a/20_strategy_synthesis/03_signal_quality.py
+++ b/20_strategy_synthesis/03_signal_quality.py
@@ -32,7 +32,7 @@
 # - Compare validation IC with holdout IC (signal persistence)
 # - Identify reproducibility and stability concerns
 #
-# **Book Reference**: Chapter 20, Section 20.2 (Signal Evidence)
+# **Book Reference**: Chapter 20, Section 20.3 (Signal quality and prediction uncertainty)
 #
 # **Prerequisites**: Run [`01_aggregate_synthesis`](01_aggregate_synthesis.ipynb) first.
 

--- a/20_strategy_synthesis/04_signal_to_strategy.ipynb
+++ b/20_strategy_synthesis/04_signal_to_strategy.ipynb
@@ -32,7 +32,7 @@
     "- Compare validation and holdout Sharpe (does the translation persist?)\n",
     "- Understand which implementation factors mediate conversion\n",
     "\n",
-    "**Book Reference**: Chapter 20, Section 20.3 (Translation to Strategy)\n",
+    "**Book Reference**: Chapter 20, Section 20.4 (From signals to strategies)\n",
     "\n",
     "**Prerequisites**: Run [`01_aggregate_synthesis`](01_aggregate_synthesis.ipynb) first."
    ]
@@ -1321,11 +1321,12 @@
    "version": "3.14.3"
   },
   "ml4t_provenance": {
-   "source_py_blob": "fc68820ca09f1c2220531601932f9660ec44bfcb",
    "executed_at": "2026-08-20T08:03:30.756263+00:00",
    "executor": "local-uv",
+   "parameters": {},
    "production": true,
-   "parameters": {}
+   "source_py_blob": "8015d11778ac3d9a981f7387d6b508fb2bbdf26a",
+   "notes": "prose synced from the .py at 2026-09-11T14:19:27.601378+00:00 without re-executing; every code cell is identical to blob fc68820ca09f"
   },
   "papermill": {
    "default_parameters": {},

--- a/20_strategy_synthesis/04_signal_to_strategy.py
+++ b/20_strategy_synthesis/04_signal_to_strategy.py
@@ -33,7 +33,7 @@
 # - Compare validation and holdout Sharpe (does the translation persist?)
 # - Understand which implementation factors mediate conversion
 #
-# **Book Reference**: Chapter 20, Section 20.3 (Translation to Strategy)
+# **Book Reference**: Chapter 20, Section 20.4 (From signals to strategies)
 #
 # **Prerequisites**: Run [`01_aggregate_synthesis`](01_aggregate_synthesis.ipynb) first.
 

--- a/22_rag_financial_research/README.md
+++ b/22_rag_financial_research/README.md
@@ -14,11 +14,11 @@ The chapter explains why text classification is not enough once the practitioner
 
 ## Sections
 
-### 22.1 Introduction: The Generative Leap Beyond Feature Extraction
+### 22.1 From Feature Extraction to Generation
 
 This section explains why text classification is not enough once the practitioner's task becomes open-ended analysis rather than fixed-label prediction. It positions LLMs as a shift from extracting features to answering analyst-style questions, but immediately frames hallucination as the central obstacle in finance. Readers should care because it sets up the chapter's core claim: generative AI only becomes usable in high-stakes financial settings when it is grounded in verifiable evidence rather than trusted as an oracle.
 
-### 22.2 The Solution: Grounding LLMs with Retrieval-Augmented Generation
+### 22.2 Grounding LLMs with Retrieval-Augmented Generation
 
 This section introduces RAG as the architectural answer to hallucination and lays out the index, retrieve, generate pipeline in clear engineering terms. It also distinguishes the appealing simplicity of the baseline design from the much harder production reality in financial documents, where naive pipelines fail quickly. Readers should care because this is the conceptual backbone of the chapter: the model is valuable not because it "knows," but because it can synthesize over retrieved evidence.
 
@@ -53,7 +53,7 @@ This section treats RAG as a system that must be measured and debugged, not admi
 - [`04_ragas_evaluation`](04_ragas_evaluation.ipynb) — This notebook implements a finance-oriented evaluation harness that...
 - [`08_rag_security`](08_rag_security.ipynb) — This notebook demonstrates attack and defense evaluation for document-grounded finance assistants, a critical concern when RAG systems operate on untrusted or adversarial document corpora.
 
-### 22.8 From Theory to Practice: Applications and Strategic Choices
+### 22.8 Applications and Strategic Choices
 
 This section anchors the architecture in concrete financial use cases, especially a 10-K due diligence assistant and an ESG analysis comparison. It also gives the clearest strategic boundary in the chapter: fine-tuning is for repeatable label-producing skills, while RAG is for evidence-grounded reasoning over changing documents. Readers should care because this section translates technical design choices into organizational decisions about what kind of AI workflow they are actually building.
 
@@ -61,7 +61,7 @@ This section anchors the architecture in concrete financial use cases, especiall
 - [`06_esg_rag_vs_finetune`](06_esg_rag_vs_finetune.ipynb) — This notebook compares two approaches to ESG (Environmental, Social, Governance) analysis: Uses finbert_pipeline data.
 - [`07_institutional_holdings_graph`](07_institutional_holdings_graph.ipynb) — Build a bipartite institution-stock graph from the 13F holdings artifact and derive co-ownership similarity, institutional momentum, and crowding signals for alpha research.
 
-### 22.9 The Next Frontier: Introduction to Agentic Frameworks
+### 22.9 Introducing Agentic Frameworks
 
 This section positions RAG not as the endpoint, but as one tool inside broader multi-step agent workflows. It introduces the controller, tool, and memory pattern, then shows how grounded document retrieval fits into a larger architecture that may also use code, APIs, and databases. Readers should care because it opens the path from cited question-answering to goal-directed analytical workflows while keeping grounding as a core control mechanism.
 

--- a/23_knowledge_graphs/03_graph_rag_qa.ipynb
+++ b/23_knowledge_graphs/03_graph_rag_qa.ipynb
@@ -36,7 +36,7 @@
     "- Enforce dated queries and row limits against queries written to defeat them\n",
     "- Audit the validator with a hostile control set, not only with queries built to pass\n",
     "\n",
-    "**Book Reference**: Chapter 23, Section 23.3 (Graph RAG: Deterministic Relational Reasoning)\n",
+    "**Book Reference**: Chapter 23, Section 23.3 (Deterministic relational reasoning with graph RAG)\n",
     "\n",
     "**Prerequisites**: Run `05_institutional_holdings_kg` to load the 13F graph into\n",
     "Neo4j. This notebook requires a live Neo4j connection and does not use canned\n",
@@ -1731,7 +1731,8 @@
    "outputs_digest": "7df1b038b3f017a7d2acac0150731b6394ee63a896d7032bcadc6ca7a3f1bb21",
    "parameters": {},
    "production": true,
-   "source_py_blob": "afda9b6f5c95f8491ee0c8b386ee0d23a133f47a"
+   "source_py_blob": "3245aea4eda543072016a493ed7b4a9daca40b66",
+   "notes": "prose synced from the .py at 2026-09-11T14:19:28.872336+00:00 without re-executing; every code cell is identical to blob afda9b6f5c95"
   },
   "papermill": {
    "default_parameters": {},

--- a/23_knowledge_graphs/03_graph_rag_qa.py
+++ b/23_knowledge_graphs/03_graph_rag_qa.py
@@ -37,7 +37,7 @@
 # - Enforce dated queries and row limits against queries written to defeat them
 # - Audit the validator with a hostile control set, not only with queries built to pass
 #
-# **Book Reference**: Chapter 23, Section 23.3 (Graph RAG: Deterministic Relational Reasoning)
+# **Book Reference**: Chapter 23, Section 23.3 (Deterministic relational reasoning with graph RAG)
 #
 # **Prerequisites**: Run `05_institutional_holdings_kg` to load the 13F graph into
 # Neo4j. This notebook requires a live Neo4j connection and does not use canned

--- a/23_knowledge_graphs/04_rag_comparison_benchmark.ipynb
+++ b/23_knowledge_graphs/04_rag_comparison_benchmark.ipynb
@@ -27,7 +27,7 @@
     "- Compare graph retrieval and vector retrieval on direct lookup and multi-entity questions\n",
     "- Measure support recall and retrieval-token budgets on the same corpus\n",
     "\n",
-    "**Book Reference**: Chapter 23, Section 23.3 (Graph RAG: Deterministic Relational Reasoning)\n",
+    "**Book Reference**: Chapter 23, Section 23.3 (Deterministic relational reasoning with graph RAG)\n",
     "\n",
     "**Prerequisites**: The 13F artifacts written by\n",
     "`data/equities/positioning/13f_download.py` (run that first if missing).\n",
@@ -1593,7 +1593,8 @@
    "outputs_digest": "bc680b282c9a9b969d5b092eb1e33165285232f17669eb6468b3c7a3f410d433",
    "parameters": {},
    "production": true,
-   "source_py_blob": "d5d84b11a622e59cf7d93aeae3d8ae5e2a77dd50"
+   "source_py_blob": "3d2cd338e2ba04eb18242292cc8c058ea66bb66b",
+   "notes": "prose synced from the .py at 2026-09-11T14:19:30.204948+00:00 without re-executing; every code cell is identical to blob d5d84b11a622"
   },
   "papermill": {
    "default_parameters": {},

--- a/23_knowledge_graphs/04_rag_comparison_benchmark.py
+++ b/23_knowledge_graphs/04_rag_comparison_benchmark.py
@@ -28,7 +28,7 @@
 # - Compare graph retrieval and vector retrieval on direct lookup and multi-entity questions
 # - Measure support recall and retrieval-token budgets on the same corpus
 #
-# **Book Reference**: Chapter 23, Section 23.3 (Graph RAG: Deterministic Relational Reasoning)
+# **Book Reference**: Chapter 23, Section 23.3 (Deterministic relational reasoning with graph RAG)
 #
 # **Prerequisites**: The 13F artifacts written by
 # `data/equities/positioning/13f_download.py` (run that first if missing).

--- a/23_knowledge_graphs/10_network_portfolio_construction.ipynb
+++ b/23_knowledge_graphs/10_network_portfolio_construction.ipynb
@@ -29,7 +29,7 @@
     "- Construct network-diversified portfolios that underweight central nodes\n",
     "- Run a stylized, order-independent shock-propagation sensitivity\n",
     "\n",
-    "**Book Reference**: Chapter 23, Section 23.5 (Financial Networks: From Correlations to Portfolios)\n",
+    "**Book Reference**: Chapter 23, Section 23.5 (Correlations and portfolios in financial networks)\n",
     "\n",
     "**Prerequisites**: Familiarity with correlation matrices and portfolio construction.\n",
     "Requires the US equities dataset (3,199 current and delisted securities).\n",
@@ -2572,7 +2572,8 @@
    "outputs_digest": "fe06d6f61dba1fb456cb24593c7209a8547426c1e8c5019143699496458a6767",
    "parameters": {},
    "production": true,
-   "source_py_blob": "a61900f9e1d3250e4791b8beb953daaf1c35cd0f"
+   "source_py_blob": "6589ebb1e71a6464705b97cc29383f8abdf9332e",
+   "notes": "prose synced from the .py at 2026-09-11T14:19:31.719200+00:00 without re-executing; every code cell is identical to blob a61900f9e1d3"
   },
   "papermill": {
    "default_parameters": {},

--- a/23_knowledge_graphs/10_network_portfolio_construction.py
+++ b/23_knowledge_graphs/10_network_portfolio_construction.py
@@ -30,7 +30,7 @@
 # - Construct network-diversified portfolios that underweight central nodes
 # - Run a stylized, order-independent shock-propagation sensitivity
 #
-# **Book Reference**: Chapter 23, Section 23.5 (Financial Networks: From Correlations to Portfolios)
+# **Book Reference**: Chapter 23, Section 23.5 (Correlations and portfolios in financial networks)
 #
 # **Prerequisites**: Familiarity with correlation matrices and portfolio construction.
 # Requires the US equities dataset (3,199 current and delisted securities).

--- a/25_live_trading/01_unified_framework_demo.ipynb
+++ b/25_live_trading/01_unified_framework_demo.ipynb
@@ -33,7 +33,7 @@
     "- Compare two signal tapes field by field, and fail the comparison rather than describe it\n",
     "- Say what a parity test on replayed bars establishes, and what it leaves untested\n",
     "\n",
-    "**Book Reference**: Chapter 25, Section 25.1 (The unified framework advantage)\n",
+    "**Book Reference**: Chapter 25, Section 25.1 (The unified research-to-production framework)\n",
     "\n",
     "**Prerequisites**: The `Strategy` interface, and the distinction between an engine that pulls bars\n",
     "from history and one that receives them from a feed."
@@ -1691,7 +1691,8 @@
    "outputs_digest": "e4fa94e6fbb9cb22265cca09938681a708ff79e53000167a18cae400238cb008",
    "parameters": {},
    "production": true,
-   "source_py_blob": "fa178cd3984f3b4a16b4b92810254ad4f8a7cc0e"
+   "source_py_blob": "0c57ee93ab0d8f40eefd9c1dbd46d4d3dbe8257f",
+   "notes": "prose synced from the .py at 2026-09-11T14:19:33.510598+00:00 without re-executing; every code cell is identical to blob fa178cd3984f"
   },
   "papermill": {
    "default_parameters": {},

--- a/25_live_trading/01_unified_framework_demo.py
+++ b/25_live_trading/01_unified_framework_demo.py
@@ -34,7 +34,7 @@
 # - Compare two signal tapes field by field, and fail the comparison rather than describe it
 # - Say what a parity test on replayed bars establishes, and what it leaves untested
 #
-# **Book Reference**: Chapter 25, Section 25.1 (The unified framework advantage)
+# **Book Reference**: Chapter 25, Section 25.1 (The unified research-to-production framework)
 #
 # **Prerequisites**: The `Strategy` interface, and the distinction between an engine that pulls bars
 # from history and one that receives them from a feed.

--- a/27_systematic_edge/README.md
+++ b/27_systematic_edge/README.md
@@ -8,11 +8,11 @@ The chapter argues that the most important lesson of the book transcends any ind
 
 This section argues that the most important lesson of the book transcends any individual technique: process is the durable edge, not any single strategy. The 5-Stage ML4T Workflow functions as an alpha factory blueprint that defends against cognitive biases through falsifiable hypotheses, rigorous out-of-sample testing, and statistical corrections for multiple testing. The transition from learning steps to embodying a systematic mindset is framed as the critical career shift, with the chapter providing a strategic roadmap for career paths, learning resources, emerging technologies, and personal development.
 
-### 27.2 The Anatomy of a Modern Quant Career
+### 27.2 The Modern Quant Career
 
 The section maps five core quant archetypes (researcher, trader, developer, portfolio manager, risk manager) with their distinct skill requirements and compensation trajectories, then highlights the rise of quantamental roles that blend systematic techniques with fundamental analysis as the most significant industry trend. It surveys how institutional ecosystems (hedge funds, prop shops, banks, asset managers) shape the nature of work more than role titles alone, and argues that the most successful practitioners develop T-shaped expertise combining deep primary knowledge with broad cross-functional understanding across the trading lifecycle.
 
-### 27.3 The Practitioner's Learning Arsenal
+### 27.3 Building a Learning Practice
 
 This section provides a curated approach to continuous learning that addresses information overload as a genuine career risk, recommending canonical texts (Chan, Lopez de Prado, Ang, Harris, Hull) alongside targeted digital intelligence gathering through practitioner blogs, arXiv, and aggregators. It emphasizes understanding tool categories and their interplay across the full workflow rather than chasing individual libraries, and frames community participation and brand building through open-source contributions, publishing, and conference attendance as strategic career activities that compound learning while expanding professional networks.
 
@@ -20,7 +20,7 @@ This section provides a curated approach to continuous learning that addresses i
 
 The section evaluates three frontiers with pragmatic attention allocation: quantum computing remains in the NISQ era with meaningful financial advantage projected for the mid-2030s at earliest, making it worth monitoring but not investing in immediately; DeFi provides live alpha opportunities today through on-chain data, AMM optimization, and yield farming, though with novel risks from smart contract vulnerabilities and regulatory uncertainty. AI ethics has transitioned from philosophy to compliance requirement with the EU AI Act mandating explainability for high-risk financial AI, requiring practitioners to demonstrate proficiency in interpretability, bias detection, robustness testing, and auditability.
 
-### 27.5 Building Your Strategic Path Forward
+### 27.5 Building Your Path Forward
 
 This section shifts from knowledge to career design, recommending honest skills assessment against the quant archetypes, deliberate learning systems with daily habits and personal knowledge management, and accountability mechanisms that improve follow-through. Burnout is treated as a professional risk rather than personal weakness, with cognitive research cited showing that fatigued decision-makers exhibit heightened susceptibility to the very biases that systematic approaches aim to overcome. Four common career failure modes are identified: over-specialization, underestimating soft skills, ignoring regulatory evolution, and perpetual learning without application.
 

--- a/case_studies/etfs/11a_pca.ipynb
+++ b/case_studies/etfs/11a_pca.ipynb
@@ -52,7 +52,7 @@
     "- Read a model with no epochs and say why it still publishes a checkpoint.\n",
     "- Read a population published for every declared label rather than only the traded one.\n",
     "\n",
-    "**Book reference**: Chapter 13, Section 13.3 (PCA for algorithmic trading) and Chapter 14,\n",
+    "**Book reference**: Chapter 14, Section 14.2 (Extracting latent factors with PCA) and\n",
     "Section 14.5 (Bridging economics and statistics with advanced models). Chapter 6, Section 6.7\n",
     "(Search accounting and run logging) introduces the run log this notebook writes to.\n",
     "\n",
@@ -1630,7 +1630,8 @@
    "outputs_digest": "1e6fe87e5baf06a5286d32e15475f7992ad4e10f304ec907ace219af2855a966",
    "parameters": {},
    "production": true,
-   "source_py_blob": "bd3343d1742f4e9fa0c56e96d7e8b226044f682d"
+   "source_py_blob": "21538ccf8a504a7c75925c457420d6e28d74f695",
+   "notes": "prose synced from the .py at 2026-09-11T14:55:16.658157+00:00 without re-executing; every code cell is identical to blob bd3343d1742f"
   },
   "papermill": {
    "default_parameters": {},

--- a/case_studies/etfs/11a_pca.py
+++ b/case_studies/etfs/11a_pca.py
@@ -53,7 +53,7 @@
 # - Read a model with no epochs and say why it still publishes a checkpoint.
 # - Read a population published for every declared label rather than only the traded one.
 #
-# **Book reference**: Chapter 13, Section 13.3 (PCA for algorithmic trading) and Chapter 14,
+# **Book reference**: Chapter 14, Section 14.2 (Extracting latent factors with PCA) and
 # Section 14.5 (Bridging economics and statistics with advanced models). Chapter 6, Section 6.7
 # (Search accounting and run logging) introduces the run log this notebook writes to.
 #

--- a/case_studies/etfs/11c_conditional_autoencoder.ipynb
+++ b/case_studies/etfs/11c_conditional_autoencoder.ipynb
@@ -53,7 +53,7 @@
     "  learning from one that has begun fitting its training window.\n",
     "- Say why the training device is part of a model's identity rather than a note about how it ran.\n",
     "\n",
-    "**Book reference**: Chapter 14, Section 14.6 (Nonlinear conditional factor models). Chapter 6,\n",
+    "**Book reference**: Chapter 14, Section 14.6 (The conditional autoencoder). Chapter 6,\n",
     "Section 6.7 (Search accounting and run logging) introduces the run log this notebook writes to.\n",
     "\n",
     "**Prerequisites**: [`03_financial_features`](03_financial_features.ipynb) and\n",
@@ -1721,7 +1721,8 @@
    "outputs_digest": "f0ba4ca17f04a9f9e76b6db1a2412b4cc8758ee3d33819b195abea18aab17b0e",
    "parameters": {},
    "production": true,
-   "source_py_blob": "df5fe226b79039f3f7c91cd6ef8fe625e623c39a"
+   "source_py_blob": "71a3944beb2a2afa02e671696b937d49e3757e1e",
+   "notes": "prose synced from the .py at 2026-09-11T14:55:18.308074+00:00 without re-executing; every code cell is identical to blob df5fe226b790"
   },
   "papermill": {
    "default_parameters": {},

--- a/case_studies/etfs/11c_conditional_autoencoder.py
+++ b/case_studies/etfs/11c_conditional_autoencoder.py
@@ -55,7 +55,7 @@
 #   learning from one that has begun fitting its training window.
 # - Say why the training device is part of a model's identity rather than a note about how it ran.
 #
-# **Book reference**: Chapter 14, Section 14.6 (Nonlinear conditional factor models). Chapter 6,
+# **Book reference**: Chapter 14, Section 14.6 (The conditional autoencoder). Chapter 6,
 # Section 6.7 (Search accounting and run logging) introduces the run log this notebook writes to.
 #
 # **Prerequisites**: [`03_financial_features`](03_financial_features.ipynb) and

--- a/case_studies/sp500_equity_option_analytics/12_causal_dml.ipynb
+++ b/case_studies/sp500_equity_option_analytics/12_causal_dml.ipynb
@@ -40,7 +40,7 @@
     "- Read the estimand and its temporal controls off the resolved specification\n",
     "- Compare the adjusted estimate with naive OLS and a block-permutation null\n",
     "\n",
-    "**Book Reference**: Chapter 15, Section 15.6 (Cross-Dataset Causal Evidence)\n",
+    "**Book Reference**: Chapter 15, Section 15.7 (Case study causal evidence)\n",
     "\n",
     "**Prerequisites**: `03_financial_features.py`, `04_model_based_features.py`"
    ]
@@ -775,7 +775,8 @@
    "outputs_digest": "9e891ad2f08c67cb145bd4281a82c2481d9f30b137517b7fcc9fd755f8e6fe7d",
    "parameters": {},
    "production": true,
-   "source_py_blob": "a65ad804338df6d3d9b69d23d988cd030ce1d7f8"
+   "source_py_blob": "1617af5d39b77893da70a7129ed286e5d01b8b0f",
+   "notes": "prose synced from the .py at 2026-09-11T14:55:19.833788+00:00 without re-executing; every code cell is identical to blob a65ad804338d"
   },
   "papermill": {
    "default_parameters": {},

--- a/case_studies/sp500_equity_option_analytics/12_causal_dml.py
+++ b/case_studies/sp500_equity_option_analytics/12_causal_dml.py
@@ -42,7 +42,7 @@
 # - Read the estimand and its temporal controls off the resolved specification
 # - Compare the adjusted estimate with naive OLS and a block-permutation null
 #
-# **Book Reference**: Chapter 15, Section 15.6 (Cross-Dataset Causal Evidence)
+# **Book Reference**: Chapter 15, Section 15.7 (Case study causal evidence)
 #
 # **Prerequisites**: `03_financial_features.py`, `04_model_based_features.py`
 

--- a/case_studies/sp500_options/04_model_based_features.ipynb
+++ b/case_studies/sp500_options/04_model_based_features.ipynb
@@ -59,7 +59,7 @@
     "recorded beside it. There is no `fold` column: what a value was fitted on is decided by the refit\n",
     "schedule in `setup.yaml`, not by which fold reads it.\n",
     "\n",
-    "**Book reference**: Chapter 9, Section 9.3 (Volatility Models)\n",
+    "**Book reference**: Chapter 9, Section 9.3 (Volatility features)\n",
     "\n",
     "**Prerequisites**: [`02_labels`](02_labels.ipynb),\n",
     "[`03_financial_features`](03_financial_features.ipynb)"
@@ -5237,7 +5237,8 @@
    "outputs_digest": "51dddea5a239601696f209613ac270ee6eac8222dbde426a988616adc4b446eb",
    "parameters": {},
    "production": true,
-   "source_py_blob": "c1b2438718683e7f8bc476a2ea89f8d59bc0e6d6"
+   "source_py_blob": "b63c3ce581f362b833a22b5348addaefaca8fe9d",
+   "notes": "prose synced from the .py at 2026-09-11T14:55:21.760216+00:00 without re-executing; every code cell is identical to blob c1b243871868"
   },
   "papermill": {
    "default_parameters": {},

--- a/case_studies/sp500_options/04_model_based_features.py
+++ b/case_studies/sp500_options/04_model_based_features.py
@@ -60,7 +60,7 @@
 # recorded beside it. There is no `fold` column: what a value was fitted on is decided by the refit
 # schedule in `setup.yaml`, not by which fold reads it.
 #
-# **Book reference**: Chapter 9, Section 9.3 (Volatility Models)
+# **Book reference**: Chapter 9, Section 9.3 (Volatility features)
 #
 # **Prerequisites**: [`02_labels`](02_labels.ipynb),
 # [`03_financial_features`](03_financial_features.ipynb)


### PR DESCRIPTION
Forty-nine cross-references across 33 files named a book section by a title the book does not use. They came from `chapter/summary/summary.json`, a March 2026 teaching outline that the print-faithful corpus superseded on 2026-07-23; 102 of its 181 entries disagreed with the heading at their number. Every citation here is now checked against the first `# NN.M Title` heading of the matching section file, which is what the book repo's `verify_sections_against_print.py` holds against the publisher's typeset layout.

## Seven sent a reader to a different topic

| file | cites | the book's section there is | the topic actually lives at |
|---|---|---|---|
| `14/01_pca_equity_sectors` | 9.4 "HMM regimes" | Uncertainty features | 9.5 Regime features |
| `14/02_eigenportfolios` | 9.4 "HMM regimes for factor timing" | Uncertainty features | 9.5 Regime features |
| `15/11_factor_zoo_validation` | 14.5 "Taming the Factor Zoo" | Bridging economics and statistics | 14.1 Making the case for latent factors |
| `15/11_factor_zoo_validation` | 15.3 "Double Machine Learning" | Validation and refutation | 15.4 Isolating factor effects with DML |
| `20/03_signal_quality` | 20.2 "Signal Evidence" | Setup and feature evaluation | 20.3 Signal quality and prediction uncertainty |
| `20/04_signal_to_strategy` | 20.3 "Translation to Strategy" | Signal quality and prediction uncertainty | 20.4 From signals to strategies |
| `20/00_holdout_predictions` | 20.6 "Stability Across Time and Regimes" | Trading realism - costs, capacity, and execution | 20.1, under "From validation to holdout" |

No section of the printed chapter 20 is called "Stability Across Time and Regimes". The three mechanisms `00_holdout_predictions` describes are in 20.1, and the second commit gives them the chapter's names - prediction-quality drift, portfolio-translation drift, regime change - because the notebook had called them "decay patterns" while 20.1 uses "pattern" for the five groups it sorts the nine case studies into.

The other 42 quote the right section under a draft title. README headings keep each file's Title Case and take the print wording; notebook references quote the heading as printed.

## Case studies

The same check over `case_studies/*.py`, with `us_equities_panel` and `nasdaq100_microstructure` excluded because they have runs in flight, found four more. `etfs/11a_pca` cited 13.3 "PCA for algorithmic trading" where 13.3 is attention for time series and PCA is 14.2; `sp500_equity_option_analytics/12_causal_dml` cited 15.6 where the case study causal evidence is 15.7; `etfs/11c_conditional_autoencoder` and `sp500_options/04_model_based_features` carried draft titles at the right number. Seven hits there are descriptions rather than title quotes ("GBM libraries" for 12.2 in six case studies) and resolve correctly.

`etfs/09_dl_lstm`, `10_dl_tsmixer` and `10a_dl_nlinear` cite 13.8 "Case Study Results" where 13.8 is prediction uncertainty and case study insights is 13.9. Each says it twice, once in a markdown cell and once inside a display string in a code cell. All three are stamped and clean, so fixing only the markdown half would leave the rendered output contradicting the source and fixing both costs a re-run of three deep-learning notebooks. They are left for whoever next executes them.

## Five that look the same are left alone, each checked

`§3.2`, `§3.3` and `§16.4` are descriptions rather than title quotes and resolve to the right section. Table 15.1 is in section 15.1 and Table 15.2 is in section 15.4, where `15/01` and `15/02` say they are.

## Cost

Markdown cells only, so every notebook keeps its outputs and its original `executed_at`: `jupytext --sync` then `notebook_provenance.py sync-prose`, tier 1. The provenance gate reports 0 stale, 0 contradicted, 0 outputs-changed, identical to before the edit. `check_notebook_pair_sync`, `ruff` and `ruff format` are clean, and RoboRev 21458 and 21463 are both quiet.

`20_strategy_synthesis/01_aggregate_synthesis.ipynb` carries no provenance stamp and no outputs; that is advisory and predates this branch.

## The source is fixed too

`chapter/summary/summary.json` is retired in the book repo (`ml4t/book` 7b8a6cb8), its `generate_readme.py` and the `generate-readme` skill now take section titles from the section headings, and the website importer that read it gets the same treatment on a branch awaiting review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
