### PR TITLE
BacktestExplorer reads a metric that is NULL on every older row

### DIFF
--- a/case_studies/utils/backtest_explorer.py
+++ b/case_studies/utils/backtest_explorer.py
@@ -170,7 +170,13 @@ class BacktestExplorer:
             rows = db.execute(sql, params).fetchall()
             if not rows:
                 return pl.DataFrame()
-            return pl.DataFrame([dict(r) for r in rows])
+            # Scan every row for the schema, not the default first 100. A metric added after a
+            # registry was first written is NULL on every earlier row, so a query returning more
+            # than 100 of those before the first real value types the column `Null` and then
+            # raises `could not append value: 0.0 of type: f64` on it. `ruin` did exactly that to
+            # `etfs` once #834 started recording it: 180 NULLs, then a float. The cost is one
+            # extra pass over rows already in memory.
+            return pl.DataFrame([dict(r) for r in rows], infer_schema_length=None)
         finally:
             db.close()
 

--- a/tests/test_backtest_explorer_schema_inference.py
+++ b/tests/test_backtest_explorer_schema_inference.py
@@ -1,0 +1,69 @@
+"""A metric added after a registry was written must not break every query that selects it.
+
+`BacktestExplorer._query` builds a frame from `sqlite3.Row` mappings. Polars infers a schema
+from the first `infer_schema_length` rows, 100 by default, so a column that is NULL on every
+early row and carries a float later is typed `Null` and then refuses the float. That is the
+shape a new metric always has: `ruin` arrived with #834 and is NULL on every backtest recorded
+before it.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import polars as pl
+import pytest
+
+from case_studies.utils.backtest_explorer import BacktestExplorer
+
+
+def _registry_with_a_late_metric(path: Path, n_null_rows: int, n_valued_rows: int) -> None:
+    db = sqlite3.connect(path)
+    db.execute("CREATE TABLE backtest_metrics (backtest_hash TEXT, sharpe REAL, ruin REAL)")
+    db.executemany(
+        "INSERT INTO backtest_metrics VALUES (?, ?, NULL)",
+        [(f"h{i:04d}", 0.5) for i in range(n_null_rows)],
+    )
+    db.executemany(
+        "INSERT INTO backtest_metrics VALUES (?, ?, ?)",
+        [(f"h{n_null_rows + i:04d}", 0.5, 0.0) for i in range(n_valued_rows)],
+    )
+    db.commit()
+    db.close()
+
+
+@pytest.fixture
+def explorer(tmp_path: Path) -> BacktestExplorer:
+    case_dir = tmp_path / "run_log"
+    case_dir.mkdir(parents=True)
+    _registry_with_a_late_metric(case_dir / "registry.db", n_null_rows=180, n_valued_rows=18)
+    instance = BacktestExplorer.__new__(BacktestExplorer)
+    instance._db_path = case_dir / "registry.db"
+    return instance
+
+
+def test_a_metric_null_for_more_than_a_schema_window_still_reads(
+    explorer: BacktestExplorer,
+) -> None:
+    """180 NULL `ruin` rows ahead of the first float is what broke `etfs` in production."""
+    frame = explorer._query("SELECT * FROM backtest_metrics")
+
+    assert frame.height == 198
+    assert frame.schema["ruin"] == pl.Float64
+    assert frame.get_column("ruin").null_count() == 180
+    assert frame.get_column("ruin").drop_nulls().to_list() == [0.0] * 18
+
+
+def test_a_column_null_in_every_row_stays_readable(explorer: BacktestExplorer) -> None:
+    """The all-NULL case must keep working: a metric no row has yet is not an error."""
+    frame = explorer._query("SELECT backtest_hash, ruin FROM backtest_metrics LIMIT 180")
+
+    assert frame.height == 180
+    assert frame.get_column("ruin").null_count() == 180
+
+
+def test_an_empty_result_is_an_empty_frame(explorer: BacktestExplorer) -> None:
+    frame = explorer._query("SELECT * FROM backtest_metrics WHERE backtest_hash = 'absent'")
+
+    assert frame.is_empty()


### PR DESCRIPTION
`BacktestExplorer._query` built its frame with polars' default `infer_schema_length=100`,
so a column that is NULL on the first hundred rows was typed `Null` and then refused the
first real value:

    ComputeError: could not append value: 0.0 of type: f64 to the builder

That is the shape every newly added metric has. `ruin` arrived with the later risk-metric
block and is NULL on every backtest recorded before it; `etfs` holds 180 such rows ahead of
the first float, so `compare_allocators` raises on that registry today and
`etfs/15_portfolio_management` cannot execute at all.

## Evidence

Reproduced from a plain checkout with no notebook involved, which is what separates a
registry-contents problem from a branch problem:

```
REPRODUCED: ComputeError could not append value: 0.0 of type: f64 to the builder
MIXED ruin {'NoneType': 180, 'float': 18} first float at row 180
```

After the change, `etfs/15_portfolio_management` executes to `exit 0`.

**Three of the nine live registries are affected, not one.** Reading `backtest_metrics` whole
at the default raises today on `etfs` (2,248 rows), `fx_pairs` (1,915) and
`sp500_equity_option_analytics` (4,009), and succeeds on all three with the parameter. Eight
columns are NULL across more than a hundred rows in each of them - `ruin`, `ruin_period`, and
the six `risk_triggers*` columns - so this is the whole risk-metric block, not one column.

## Why this parameter rather than a schema

Every other sqlite-to-polars site in the tree already passes `infer_schema_length=None` -
`case_studies/utils/analytics.py:163`, `case_studies/utils/insight_chapter.py:212,213,308`,
`case_studies/utils/registry/queries.py:89,1524`. The explorer was the only straggler, so
this restores the convention rather than inventing one. The cost is one extra pass over rows
already in memory.

## Tests

`tests/test_backtest_explorer_schema_inference.py`, on a registry with 180 NULL rows ahead
of 18 valued ones:

- the mixed column reads with the right dtype, null count and values
- an all-NULL column stays readable, because a metric no row has yet is not an error
- an empty result is still an empty frame

The first fails on the previous implementation with the production error, so the suite can
fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
