### PR TITLE
etfs/15_portfolio_management states its reuse without opening on a zero

### DIFF
--- a/case_studies/etfs/15_portfolio_management.ipynb
+++ b/case_studies/etfs/15_portfolio_management.ipynb
@@ -2,13 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "89b1d269",
+   "id": "dcc050a9",
    "metadata": {
     "papermill": {
-     "duration": 0.00227,
-     "end_time": "2026-09-11T14:35:00.466978+00:00",
+     "duration": 0.007499,
+     "end_time": "2026-09-11T14:39:02.860654+00:00",
      "exception": false,
-     "start_time": "2026-09-11T14:35:00.464708+00:00",
+     "start_time": "2026-09-11T14:39:02.853155+00:00",
      "status": "completed"
     }
    },
@@ -54,19 +54,19 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "1635774b",
+   "id": "5a4ae0da",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T14:35:00.473720Z",
-     "iopub.status.busy": "2026-09-11T14:35:00.473455Z",
-     "iopub.status.idle": "2026-09-11T14:35:08.931062Z",
-     "shell.execute_reply": "2026-09-11T14:35:08.930054Z"
+     "iopub.execute_input": "2026-09-11T14:39:02.877570Z",
+     "iopub.status.busy": "2026-09-11T14:39:02.877074Z",
+     "iopub.status.idle": "2026-09-11T14:39:10.386210Z",
+     "shell.execute_reply": "2026-09-11T14:39:10.385326Z"
     },
     "papermill": {
-     "duration": 8.461763,
-     "end_time": "2026-09-11T14:35:08.932365+00:00",
+     "duration": 7.523607,
+     "end_time": "2026-09-11T14:39:10.388292+00:00",
      "exception": false,
-     "start_time": "2026-09-11T14:35:00.470602+00:00",
+     "start_time": "2026-09-11T14:39:02.864685+00:00",
      "status": "completed"
     }
    },
@@ -111,19 +111,19 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "e66e0c21",
+   "id": "da85ce94",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T14:35:08.942126Z",
-     "iopub.status.busy": "2026-09-11T14:35:08.941487Z",
-     "iopub.status.idle": "2026-09-11T14:35:08.945659Z",
-     "shell.execute_reply": "2026-09-11T14:35:08.944757Z"
+     "iopub.execute_input": "2026-09-11T14:39:10.396005Z",
+     "iopub.status.busy": "2026-09-11T14:39:10.395395Z",
+     "iopub.status.idle": "2026-09-11T14:39:10.399268Z",
+     "shell.execute_reply": "2026-09-11T14:39:10.398665Z"
     },
     "papermill": {
-     "duration": 0.008818,
-     "end_time": "2026-09-11T14:35:08.946235+00:00",
+     "duration": 0.008049,
+     "end_time": "2026-09-11T14:39:10.399677+00:00",
      "exception": false,
-     "start_time": "2026-09-11T14:35:08.937417+00:00",
+     "start_time": "2026-09-11T14:39:10.391628+00:00",
      "status": "completed"
     },
     "tags": [
@@ -147,13 +147,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "60eecd5d",
+   "id": "82a4911e",
    "metadata": {
     "papermill": {
-     "duration": 0.002913,
-     "end_time": "2026-09-11T14:35:08.951404+00:00",
+     "duration": 0.001502,
+     "end_time": "2026-09-11T14:39:10.402802+00:00",
      "exception": false,
-     "start_time": "2026-09-11T14:35:08.948491+00:00",
+     "start_time": "2026-09-11T14:39:10.401300+00:00",
      "status": "completed"
     }
    },
@@ -175,19 +175,19 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "dd10b7a9",
+   "id": "8cec92d2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T14:35:08.965159Z",
-     "iopub.status.busy": "2026-09-11T14:35:08.964832Z",
-     "iopub.status.idle": "2026-09-11T14:35:09.056845Z",
-     "shell.execute_reply": "2026-09-11T14:35:09.054150Z"
+     "iopub.execute_input": "2026-09-11T14:39:10.412099Z",
+     "iopub.status.busy": "2026-09-11T14:39:10.411817Z",
+     "iopub.status.idle": "2026-09-11T14:39:10.501141Z",
+     "shell.execute_reply": "2026-09-11T14:39:10.498194Z"
     },
     "papermill": {
-     "duration": 0.102203,
-     "end_time": "2026-09-11T14:35:09.058287+00:00",
+     "duration": 0.096293,
+     "end_time": "2026-09-11T14:39:10.502143+00:00",
      "exception": false,
-     "start_time": "2026-09-11T14:35:08.956084+00:00",
+     "start_time": "2026-09-11T14:39:10.405850+00:00",
      "status": "completed"
     }
    },
@@ -212,13 +212,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8634687b",
+   "id": "03825ba3",
    "metadata": {
     "papermill": {
-     "duration": 0.003939,
-     "end_time": "2026-09-11T14:35:09.070021+00:00",
+     "duration": 0.002821,
+     "end_time": "2026-09-11T14:39:10.508781+00:00",
      "exception": false,
-     "start_time": "2026-09-11T14:35:09.066082+00:00",
+     "start_time": "2026-09-11T14:39:10.505960+00:00",
      "status": "completed"
     }
    },
@@ -239,19 +239,19 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "88cd4ef1",
+   "id": "9dc305c2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T14:35:09.080661Z",
-     "iopub.status.busy": "2026-09-11T14:35:09.080342Z",
-     "iopub.status.idle": "2026-09-11T14:35:09.162922Z",
-     "shell.execute_reply": "2026-09-11T14:35:09.162077Z"
+     "iopub.execute_input": "2026-09-11T14:39:10.516049Z",
+     "iopub.status.busy": "2026-09-11T14:39:10.515613Z",
+     "iopub.status.idle": "2026-09-11T14:39:10.630319Z",
+     "shell.execute_reply": "2026-09-11T14:39:10.628784Z"
     },
     "papermill": {
-     "duration": 0.091395,
-     "end_time": "2026-09-11T14:35:09.165103+00:00",
+     "duration": 0.119298,
+     "end_time": "2026-09-11T14:39:10.631009+00:00",
      "exception": false,
-     "start_time": "2026-09-11T14:35:09.073708+00:00",
+     "start_time": "2026-09-11T14:39:10.511711+00:00",
      "status": "completed"
     }
    },
@@ -283,19 +283,19 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "23517fb8",
+   "id": "ff01c260",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T14:35:09.179486Z",
-     "iopub.status.busy": "2026-09-11T14:35:09.179221Z",
-     "iopub.status.idle": "2026-09-11T14:35:09.439704Z",
-     "shell.execute_reply": "2026-09-11T14:35:09.438881Z"
+     "iopub.execute_input": "2026-09-11T14:39:10.639953Z",
+     "iopub.status.busy": "2026-09-11T14:39:10.639792Z",
+     "iopub.status.idle": "2026-09-11T14:39:10.852367Z",
+     "shell.execute_reply": "2026-09-11T14:39:10.851442Z"
     },
     "papermill": {
-     "duration": 0.268012,
-     "end_time": "2026-09-11T14:35:09.440700+00:00",
+     "duration": 0.219732,
+     "end_time": "2026-09-11T14:39:10.854887+00:00",
      "exception": false,
-     "start_time": "2026-09-11T14:35:09.172688+00:00",
+     "start_time": "2026-09-11T14:39:10.635155+00:00",
      "status": "completed"
     }
    },
@@ -365,13 +365,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d1433b25",
+   "id": "25880896",
    "metadata": {
     "papermill": {
-     "duration": 0.006602,
-     "end_time": "2026-09-11T14:35:09.449689+00:00",
+     "duration": 0.004722,
+     "end_time": "2026-09-11T14:39:10.865823+00:00",
      "exception": false,
-     "start_time": "2026-09-11T14:35:09.443087+00:00",
+     "start_time": "2026-09-11T14:39:10.861101+00:00",
      "status": "completed"
     }
    },
@@ -387,19 +387,19 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "eed793e2",
+   "id": "2f717d98",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T14:35:09.455621Z",
-     "iopub.status.busy": "2026-09-11T14:35:09.455338Z",
-     "iopub.status.idle": "2026-09-11T14:35:10.263001Z",
-     "shell.execute_reply": "2026-09-11T14:35:10.261933Z"
+     "iopub.execute_input": "2026-09-11T14:39:10.878760Z",
+     "iopub.status.busy": "2026-09-11T14:39:10.878373Z",
+     "iopub.status.idle": "2026-09-11T14:39:11.854697Z",
+     "shell.execute_reply": "2026-09-11T14:39:11.853914Z"
     },
     "papermill": {
-     "duration": 0.813072,
-     "end_time": "2026-09-11T14:35:10.265162+00:00",
+     "duration": 0.983881,
+     "end_time": "2026-09-11T14:39:11.855157+00:00",
      "exception": false,
-     "start_time": "2026-09-11T14:35:09.452090+00:00",
+     "start_time": "2026-09-11T14:39:10.871276+00:00",
      "status": "completed"
     }
    },
@@ -459,13 +459,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "182db6c1",
+   "id": "ce486fc9",
    "metadata": {
     "papermill": {
-     "duration": 0.003672,
-     "end_time": "2026-09-11T14:35:10.272830+00:00",
+     "duration": 0.001642,
+     "end_time": "2026-09-11T14:39:11.859165+00:00",
      "exception": false,
-     "start_time": "2026-09-11T14:35:10.269158+00:00",
+     "start_time": "2026-09-11T14:39:11.857523+00:00",
      "status": "completed"
     }
    },
@@ -479,13 +479,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "df9dff09",
+   "id": "fc0b39c7",
    "metadata": {
     "papermill": {
-     "duration": 0.002995,
-     "end_time": "2026-09-11T14:35:10.280226+00:00",
+     "duration": 0.001609,
+     "end_time": "2026-09-11T14:39:11.862522+00:00",
      "exception": false,
-     "start_time": "2026-09-11T14:35:10.277231+00:00",
+     "start_time": "2026-09-11T14:39:11.860913+00:00",
      "status": "completed"
     }
    },
@@ -500,19 +500,19 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "ae1a45db",
+   "id": "10b558bb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T14:35:10.289294Z",
-     "iopub.status.busy": "2026-09-11T14:35:10.288897Z",
-     "iopub.status.idle": "2026-09-11T14:35:24.649774Z",
-     "shell.execute_reply": "2026-09-11T14:35:24.649139Z"
+     "iopub.execute_input": "2026-09-11T14:39:11.871365Z",
+     "iopub.status.busy": "2026-09-11T14:39:11.871210Z",
+     "iopub.status.idle": "2026-09-11T14:39:24.521881Z",
+     "shell.execute_reply": "2026-09-11T14:39:24.520264Z"
     },
     "papermill": {
-     "duration": 14.367354,
-     "end_time": "2026-09-11T14:35:24.650546+00:00",
+     "duration": 12.654024,
+     "end_time": "2026-09-11T14:39:24.522665+00:00",
      "exception": false,
-     "start_time": "2026-09-11T14:35:10.283192+00:00",
+     "start_time": "2026-09-11T14:39:11.868641+00:00",
      "status": "completed"
     }
    },
@@ -525,14 +525,14 @@
       "\n",
       "--- top_k = 5 ---\n",
       "  SKIP backtest (complete (hash=7007dfbbe77c)) — reusing cached result\n",
-      "  [1/180] k=5 gbm/leaves_63_huber x score_weighted: Sharpe=+0.594\n"
+      "  [1/180] k=5 gbm/leaves_63_huber x score_weighted: Sharpe=+0.594\n",
+      "  SKIP backtest (complete (hash=e9a1f631d390)) — reusing cached result\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  SKIP backtest (complete (hash=e9a1f631d390)) — reusing cached result\n",
       "  [2/180] k=5 gbm/leaves_63_huber x inverse_vol: Sharpe=+0.713\n"
      ]
     },
@@ -544,13 +544,7 @@
       "  [3/180] k=5 gbm/leaves_63_huber x risk_parity: Sharpe=+0.684\n",
       "  SKIP backtest (complete (hash=4401eba4fc30)) — reusing cached result\n",
       "  [4/180] k=5 gbm/leaves_63_huber x mvo_ledoit_wolf: Sharpe=+0.579\n",
-      "  SKIP backtest (complete (hash=a7e082d956af)) — reusing cached result\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "  SKIP backtest (complete (hash=a7e082d956af)) — reusing cached result\n",
       "  [5/180] k=5 gbm/leaves_63_huber x hrp: Sharpe=+0.626\n"
      ]
     },
@@ -559,24 +553,24 @@
      "output_type": "stream",
      "text": [
       "  SKIP backtest (complete (hash=7d9da5f5bc7f)) — reusing cached result\n",
-      "  [6/180] k=5 gbm/leaves_63_huber x conformal_weighted: Sharpe=+0.795\n",
+      "  [6/180] k=5 gbm/leaves_63_huber x conformal_weighted: Sharpe=+0.795\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "  SKIP backtest (complete (hash=22bfd698df7a)) — reusing cached result\n",
-      "  [7/180] k=5 latent_factors/cae x score_weighted: Sharpe=+0.699\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "  [7/180] k=5 latent_factors/cae x score_weighted: Sharpe=+0.699\n",
       "  SKIP backtest (complete (hash=ab8deb48db5e)) — reusing cached result\n",
-      "  [8/180] k=5 latent_factors/cae x inverse_vol: Sharpe=+0.741\n"
+      "  [8/180] k=5 latent_factors/cae x inverse_vol: Sharpe=+0.741\n",
+      "  SKIP backtest (complete (hash=f84969df2d57)) — reusing cached result\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  SKIP backtest (complete (hash=f84969df2d57)) — reusing cached result\n",
       "  [9/180] k=5 latent_factors/cae x risk_parity: Sharpe=+0.734\n",
       "  SKIP backtest (complete (hash=54572c323d46)) — reusing cached result\n",
       "  [10/180] k=5 latent_factors/cae x mvo_ledoit_wolf: Sharpe=+0.344\n"
@@ -587,15 +581,15 @@
      "output_type": "stream",
      "text": [
       "  SKIP backtest (complete (hash=56ccab7e06ba)) — reusing cached result\n",
-      "  [11/180] k=5 latent_factors/cae x hrp: Sharpe=+0.680\n"
+      "  [11/180] k=5 latent_factors/cae x hrp: Sharpe=+0.680\n",
+      "  SKIP backtest (complete (hash=5faa94568361)) — reusing cached result\n",
+      "  [12/180] k=5 latent_factors/cae x conformal_weighted: Sharpe=+0.833\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  SKIP backtest (complete (hash=5faa94568361)) — reusing cached result\n",
-      "  [12/180] k=5 latent_factors/cae x conformal_weighted: Sharpe=+0.833\n",
       "  SKIP backtest (complete (hash=d799a6a22a33)) — reusing cached result\n",
       "  [13/180] k=5 gbm/default_huber x score_weighted: Sharpe=+0.734\n"
      ]
@@ -605,24 +599,18 @@
      "output_type": "stream",
      "text": [
       "  SKIP backtest (complete (hash=33900b169856)) — reusing cached result\n",
-      "  [14/180] k=5 gbm/default_huber x inverse_vol: Sharpe=+0.681\n"
+      "  [14/180] k=5 gbm/default_huber x inverse_vol: Sharpe=+0.681\n",
+      "  SKIP backtest (complete (hash=805b2215139b)) — reusing cached result\n",
+      "  [15/180] k=5 gbm/default_huber x risk_parity: Sharpe=+0.679\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  SKIP backtest (complete (hash=805b2215139b)) — reusing cached result\n",
-      "  [15/180] k=5 gbm/default_huber x risk_parity: Sharpe=+0.679\n",
       "  SKIP backtest (complete (hash=4c980459e2d8)) — reusing cached result\n",
       "  [16/180] k=5 gbm/default_huber x mvo_ledoit_wolf: Sharpe=+0.256\n",
-      "  SKIP backtest (complete (hash=97889be8a3ea)) — reusing cached result\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "  SKIP backtest (complete (hash=97889be8a3ea)) — reusing cached result\n",
       "  [17/180] k=5 gbm/default_huber x hrp: Sharpe=+0.734\n",
       "  SKIP backtest (complete (hash=eaefd57920bd)) — reusing cached result\n",
       "  [18/180] k=5 gbm/default_huber x conformal_weighted: Sharpe=+0.738\n"
@@ -656,76 +644,76 @@
       "  [23/180] k=5 gbm/leaves_7_mse x hrp: Sharpe=+0.611\n",
       "  SKIP backtest (complete (hash=ddcf681f2133)) — reusing cached result\n",
       "  [24/180] k=5 gbm/leaves_7_mse x conformal_weighted: Sharpe=+0.669\n",
-      "  SKIP backtest (complete (hash=2b774d110270)) — reusing cached result\n",
-      "  [25/180] k=5 gbm/leaves_15_mse x score_weighted: Sharpe=+0.415\n"
+      "  SKIP backtest (complete (hash=2b774d110270)) — reusing cached result\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "  [25/180] k=5 gbm/leaves_15_mse x score_weighted: Sharpe=+0.415\n",
       "  SKIP backtest (complete (hash=6ff63b0fe922)) — reusing cached result\n",
       "  [26/180] k=5 gbm/leaves_15_mse x inverse_vol: Sharpe=+0.568\n",
       "  SKIP backtest (complete (hash=e6e27815bca1)) — reusing cached result\n",
-      "  [27/180] k=5 gbm/leaves_15_mse x risk_parity: Sharpe=+0.564\n",
+      "  [27/180] k=5 gbm/leaves_15_mse x risk_parity: Sharpe=+0.564\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "  SKIP backtest (complete (hash=6b517d2cb5e3)) — reusing cached result\n",
       "  [28/180] k=5 gbm/leaves_15_mse x mvo_ledoit_wolf: Sharpe=-0.002\n",
       "  SKIP backtest (complete (hash=2322f33b8eea)) — reusing cached result\n",
-      "  [29/180] k=5 gbm/leaves_15_mse x hrp: Sharpe=+0.430\n"
+      "  [29/180] k=5 gbm/leaves_15_mse x hrp: Sharpe=+0.430\n",
+      "  SKIP backtest (complete (hash=2c5700121c88)) — reusing cached result\n",
+      "  [30/180] k=5 gbm/leaves_15_mse x conformal_weighted: Sharpe=+0.658\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  SKIP backtest (complete (hash=2c5700121c88)) — reusing cached result\n",
-      "  [30/180] k=5 gbm/leaves_15_mse x conformal_weighted: Sharpe=+0.658\n",
       "  SKIP backtest (complete (hash=45474dabc0b9)) — reusing cached result\n",
       "  [31/180] k=5 latent_factors/sae x score_weighted: Sharpe=+0.589\n",
       "  SKIP backtest (complete (hash=df6678134c30)) — reusing cached result\n",
-      "  [32/180] k=5 latent_factors/sae x inverse_vol: Sharpe=+0.659\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "  [32/180] k=5 latent_factors/sae x inverse_vol: Sharpe=+0.659\n",
       "  SKIP backtest (complete (hash=3b3d1daf403c)) — reusing cached result\n",
       "  [33/180] k=5 latent_factors/sae x risk_parity: Sharpe=+0.646\n",
       "  SKIP backtest (complete (hash=cb1f469255ce)) — reusing cached result\n",
-      "  [34/180] k=5 latent_factors/sae x mvo_ledoit_wolf: Sharpe=+0.300\n",
+      "  [34/180] k=5 latent_factors/sae x mvo_ledoit_wolf: Sharpe=+0.300\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "  SKIP backtest (complete (hash=6594a42c8656)) — reusing cached result\n",
       "  [35/180] k=5 latent_factors/sae x hrp: Sharpe=+0.644\n",
-      "  SKIP backtest (complete (hash=3e46484e43e9)) — reusing cached result\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "  SKIP backtest (complete (hash=3e46484e43e9)) — reusing cached result\n",
       "  [36/180] k=5 latent_factors/sae x conformal_weighted: Sharpe=+0.714\n",
       "  SKIP backtest (complete (hash=467dbc652750)) — reusing cached result\n",
-      "  [37/180] k=5 deep_learning/nlinear x score_weighted: Sharpe=+0.349\n",
-      "  SKIP backtest (complete (hash=36d76cdb05cb)) — reusing cached result\n",
-      "  [38/180] k=5 deep_learning/nlinear x inverse_vol: Sharpe=+0.721\n"
+      "  [37/180] k=5 deep_learning/nlinear x score_weighted: Sharpe=+0.349\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "  SKIP backtest (complete (hash=36d76cdb05cb)) — reusing cached result\n",
+      "  [38/180] k=5 deep_learning/nlinear x inverse_vol: Sharpe=+0.721\n",
       "  SKIP backtest (complete (hash=2ca7cded6729)) — reusing cached result\n",
       "  [39/180] k=5 deep_learning/nlinear x risk_parity: Sharpe=+0.732\n",
       "  SKIP backtest (complete (hash=8aba508f72af)) — reusing cached result\n",
-      "  [40/180] k=5 deep_learning/nlinear x mvo_ledoit_wolf: Sharpe=+0.021\n",
-      "  SKIP backtest (complete (hash=12799dcd1b88)) — reusing cached result\n",
-      "  [41/180] k=5 deep_learning/nlinear x hrp: Sharpe=+0.462\n"
+      "  [40/180] k=5 deep_learning/nlinear x mvo_ledoit_wolf: Sharpe=+0.021\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "  SKIP backtest (complete (hash=12799dcd1b88)) — reusing cached result\n",
+      "  [41/180] k=5 deep_learning/nlinear x hrp: Sharpe=+0.462\n",
       "  SKIP backtest (complete (hash=21b5ee8eed9c)) — reusing cached result\n",
       "  [42/180] k=5 deep_learning/nlinear x conformal_weighted: Sharpe=+0.789\n",
       "  SKIP backtest (complete (hash=c3f212552f81)) — reusing cached result\n",
@@ -743,101 +731,95 @@
       "  SKIP backtest (complete (hash=c458854f3412)) — reusing cached result\n",
       "  [46/180] k=5 gbm/leaves_63_mse x mvo_ledoit_wolf: Sharpe=+0.272\n",
       "  SKIP backtest (complete (hash=40683a25bab5)) — reusing cached result\n",
-      "  [47/180] k=5 gbm/leaves_63_mse x hrp: Sharpe=+0.829\n"
+      "  [47/180] k=5 gbm/leaves_63_mse x hrp: Sharpe=+0.829\n",
+      "  SKIP backtest (complete (hash=9299301ac920)) — reusing cached result\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  SKIP backtest (complete (hash=9299301ac920)) — reusing cached result\n",
       "  [48/180] k=5 gbm/leaves_63_mse x conformal_weighted: Sharpe=+0.722\n",
       "  SKIP backtest (complete (hash=b305e9825a1f)) — reusing cached result\n",
       "  [49/180] k=5 gbm/leaves_31_huber x score_weighted: Sharpe=+0.464\n",
       "  SKIP backtest (complete (hash=179b96408bd7)) — reusing cached result\n",
       "  [50/180] k=5 gbm/leaves_31_huber x inverse_vol: Sharpe=+0.664\n",
-      "  SKIP backtest (complete (hash=ad89fe90d2b7)) — reusing cached result\n"
+      "  SKIP backtest (complete (hash=ad89fe90d2b7)) — reusing cached result\n",
+      "  [51/180] k=5 gbm/leaves_31_huber x risk_parity: Sharpe=+0.659\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  [51/180] k=5 gbm/leaves_31_huber x risk_parity: Sharpe=+0.659\n",
       "  SKIP backtest (complete (hash=3d7b4effa5e8)) — reusing cached result\n",
       "  [52/180] k=5 gbm/leaves_31_huber x mvo_ledoit_wolf: Sharpe=+0.444\n",
       "  SKIP backtest (complete (hash=f1e47d14047c)) — reusing cached result\n",
-      "  [53/180] k=5 gbm/leaves_31_huber x hrp: Sharpe=+0.570\n"
+      "  [53/180] k=5 gbm/leaves_31_huber x hrp: Sharpe=+0.570\n",
+      "  SKIP backtest (complete (hash=880440c36cb8)) — reusing cached result\n",
+      "  [54/180] k=5 gbm/leaves_31_huber x conformal_weighted: Sharpe=+0.753\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  SKIP backtest (complete (hash=880440c36cb8)) — reusing cached result\n",
-      "  [54/180] k=5 gbm/leaves_31_huber x conformal_weighted: Sharpe=+0.753\n",
       "  SKIP backtest (complete (hash=2699d0fbcf63)) — reusing cached result\n",
       "  [55/180] k=5 gbm/leaves_31_mse x score_weighted: Sharpe=+0.178\n",
       "  SKIP backtest (complete (hash=2cb58d13a4d8)) — reusing cached result\n",
-      "  [56/180] k=5 gbm/leaves_31_mse x inverse_vol: Sharpe=+0.485\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "  [56/180] k=5 gbm/leaves_31_mse x inverse_vol: Sharpe=+0.485\n",
       "  SKIP backtest (complete (hash=883d009def1d)) — reusing cached result\n",
       "  [57/180] k=5 gbm/leaves_31_mse x risk_parity: Sharpe=+0.505\n",
-      "  SKIP backtest (complete (hash=599a2d2dcb81)) — reusing cached result\n",
-      "  [58/180] k=5 gbm/leaves_31_mse x mvo_ledoit_wolf: Sharpe=+0.219\n",
-      "  SKIP backtest (complete (hash=a7c421616ce0)) — reusing cached result\n",
-      "  [59/180] k=5 gbm/leaves_31_mse x hrp: Sharpe=+0.526\n"
+      "  SKIP backtest (complete (hash=599a2d2dcb81)) — reusing cached result\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "  [58/180] k=5 gbm/leaves_31_mse x mvo_ledoit_wolf: Sharpe=+0.219\n",
+      "  SKIP backtest (complete (hash=a7c421616ce0)) — reusing cached result\n",
+      "  [59/180] k=5 gbm/leaves_31_mse x hrp: Sharpe=+0.526\n",
       "  SKIP backtest (complete (hash=6aa621f01fda)) — reusing cached result\n",
       "  [60/180] k=5 gbm/leaves_31_mse x conformal_weighted: Sharpe=+0.533\n",
       "\n",
       "--- top_k = 10 ---\n",
-      "  SKIP backtest (complete (hash=dd0a661e424f)) — reusing cached result\n",
-      "  [61/180] k=10 gbm/leaves_63_huber x score_weighted: Sharpe=+0.454\n",
-      "  SKIP backtest (complete (hash=dbd143f7d9f1)) — reusing cached result\n",
-      "  [62/180] k=10 gbm/leaves_63_huber x inverse_vol: Sharpe=+0.471\n"
+      "  SKIP backtest (complete (hash=dd0a661e424f)) — reusing cached result\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "  [61/180] k=10 gbm/leaves_63_huber x score_weighted: Sharpe=+0.454\n",
+      "  SKIP backtest (complete (hash=dbd143f7d9f1)) — reusing cached result\n",
+      "  [62/180] k=10 gbm/leaves_63_huber x inverse_vol: Sharpe=+0.471\n",
       "  SKIP backtest (complete (hash=0f64f2f7bab1)) — reusing cached result\n",
       "  [63/180] k=10 gbm/leaves_63_huber x risk_parity: Sharpe=+0.450\n",
       "  SKIP backtest (complete (hash=35b2a8df3499)) — reusing cached result\n",
-      "  [64/180] k=10 gbm/leaves_63_huber x mvo_ledoit_wolf: Sharpe=+0.663\n",
+      "  [64/180] k=10 gbm/leaves_63_huber x mvo_ledoit_wolf: Sharpe=+0.663\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "  SKIP backtest (complete (hash=ee753e5654a0)) — reusing cached result\n",
       "  [65/180] k=10 gbm/leaves_63_huber x hrp: Sharpe=+0.390\n",
       "  SKIP backtest (complete (hash=4050f5e8342c)) — reusing cached result\n",
-      "  [66/180] k=10 gbm/leaves_63_huber x conformal_weighted: Sharpe=+0.552\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "  [66/180] k=10 gbm/leaves_63_huber x conformal_weighted: Sharpe=+0.552\n",
       "  SKIP backtest (complete (hash=4e840ad7b2ff)) — reusing cached result\n",
       "  [67/180] k=10 latent_factors/cae x score_weighted: Sharpe=+0.721\n",
       "  SKIP backtest (complete (hash=786f9cb56695)) — reusing cached result\n",
-      "  [68/180] k=10 latent_factors/cae x inverse_vol: Sharpe=+0.700\n",
-      "  SKIP backtest (complete (hash=3402752b8514)) — reusing cached result\n",
-      "  [69/180] k=10 latent_factors/cae x risk_parity: Sharpe=+0.674\n"
+      "  [68/180] k=10 latent_factors/cae x inverse_vol: Sharpe=+0.700\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "  SKIP backtest (complete (hash=3402752b8514)) — reusing cached result\n",
+      "  [69/180] k=10 latent_factors/cae x risk_parity: Sharpe=+0.674\n",
       "  SKIP backtest (complete (hash=464139c9235e)) — reusing cached result\n",
       "  [70/180] k=10 latent_factors/cae x mvo_ledoit_wolf: Sharpe=+0.474\n",
       "  SKIP backtest (complete (hash=55ecbca3a3ef)) — reusing cached result\n",
@@ -855,73 +837,67 @@
       "  SKIP backtest (complete (hash=1c2f79dcecf7)) — reusing cached result\n",
       "  [74/180] k=10 gbm/default_huber x inverse_vol: Sharpe=+0.509\n",
       "  SKIP backtest (complete (hash=49dac2cbbf0b)) — reusing cached result\n",
-      "  [75/180] k=10 gbm/default_huber x risk_parity: Sharpe=+0.502\n",
-      "  SKIP backtest (complete (hash=ebc61083754b)) — reusing cached result\n"
+      "  [75/180] k=10 gbm/default_huber x risk_parity: Sharpe=+0.502\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "  SKIP backtest (complete (hash=ebc61083754b)) — reusing cached result\n",
       "  [76/180] k=10 gbm/default_huber x mvo_ledoit_wolf: Sharpe=+0.493\n",
       "  SKIP backtest (complete (hash=6347d4bd29dc)) — reusing cached result\n",
       "  [77/180] k=10 gbm/default_huber x hrp: Sharpe=+0.501\n",
       "  SKIP backtest (complete (hash=6eb290538afb)) — reusing cached result\n",
-      "  [78/180] k=10 gbm/default_huber x conformal_weighted: Sharpe=+0.585\n"
+      "  [78/180] k=10 gbm/default_huber x conformal_weighted: Sharpe=+0.585\n",
+      "  SKIP backtest (complete (hash=298acef2aca4)) — reusing cached result\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  SKIP backtest (complete (hash=298acef2aca4)) — reusing cached result\n",
       "  [79/180] k=10 gbm/leaves_7_mse x score_weighted: Sharpe=+0.367\n",
       "  SKIP backtest (complete (hash=2144b9918f47)) — reusing cached result\n",
       "  [80/180] k=10 gbm/leaves_7_mse x inverse_vol: Sharpe=+0.571\n",
       "  SKIP backtest (complete (hash=3d3d7365c1ae)) — reusing cached result\n",
-      "  [81/180] k=10 gbm/leaves_7_mse x risk_parity: Sharpe=+0.565\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "  [81/180] k=10 gbm/leaves_7_mse x risk_parity: Sharpe=+0.565\n",
       "  SKIP backtest (complete (hash=b87ff08084f9)) — reusing cached result\n",
       "  [82/180] k=10 gbm/leaves_7_mse x mvo_ledoit_wolf: Sharpe=-0.163\n",
       "  SKIP backtest (complete (hash=fa1f09de5789)) — reusing cached result\n",
-      "  [83/180] k=10 gbm/leaves_7_mse x hrp: Sharpe=+0.535\n",
-      "  SKIP backtest (complete (hash=df8ca178d6e8)) — reusing cached result\n",
-      "  [84/180] k=10 gbm/leaves_7_mse x conformal_weighted: Sharpe=+0.653\n"
+      "  [83/180] k=10 gbm/leaves_7_mse x hrp: Sharpe=+0.535\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "  SKIP backtest (complete (hash=df8ca178d6e8)) — reusing cached result\n",
+      "  [84/180] k=10 gbm/leaves_7_mse x conformal_weighted: Sharpe=+0.653\n",
       "  SKIP backtest (complete (hash=34c09d4a95f6)) — reusing cached result\n",
       "  [85/180] k=10 gbm/leaves_15_mse x score_weighted: Sharpe=+0.530\n",
       "  SKIP backtest (complete (hash=5f85414f9e30)) — reusing cached result\n",
-      "  [86/180] k=10 gbm/leaves_15_mse x inverse_vol: Sharpe=+0.612\n",
-      "  SKIP backtest (complete (hash=9b5e91272568)) — reusing cached result\n",
-      "  [87/180] k=10 gbm/leaves_15_mse x risk_parity: Sharpe=+0.602\n",
-      "  SKIP backtest (complete (hash=ddbba7ded63c)) — reusing cached result\n"
+      "  [86/180] k=10 gbm/leaves_15_mse x inverse_vol: Sharpe=+0.612\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "  SKIP backtest (complete (hash=9b5e91272568)) — reusing cached result\n",
+      "  [87/180] k=10 gbm/leaves_15_mse x risk_parity: Sharpe=+0.602\n",
+      "  SKIP backtest (complete (hash=ddbba7ded63c)) — reusing cached result\n",
       "  [88/180] k=10 gbm/leaves_15_mse x mvo_ledoit_wolf: Sharpe=+0.079\n",
       "  SKIP backtest (complete (hash=e451297fdc6c)) — reusing cached result\n",
       "  [89/180] k=10 gbm/leaves_15_mse x hrp: Sharpe=+0.547\n",
-      "  SKIP backtest (complete (hash=40ef44df2b4d)) — reusing cached result\n",
-      "  [90/180] k=10 gbm/leaves_15_mse x conformal_weighted: Sharpe=+0.684\n"
+      "  SKIP backtest (complete (hash=40ef44df2b4d)) — reusing cached result\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "  [90/180] k=10 gbm/leaves_15_mse x conformal_weighted: Sharpe=+0.684\n",
       "  SKIP backtest (complete (hash=3268a4e7551c)) — reusing cached result\n",
       "  [91/180] k=10 latent_factors/sae x score_weighted: Sharpe=+0.597\n",
       "  SKIP backtest (complete (hash=75baa0bb6022)) — reusing cached result\n",
@@ -939,37 +915,31 @@
       "  SKIP backtest (complete (hash=6cf0e73c4456)) — reusing cached result\n",
       "  [95/180] k=10 latent_factors/sae x hrp: Sharpe=+0.591\n",
       "  SKIP backtest (complete (hash=9d7b88c2af68)) — reusing cached result\n",
-      "  [96/180] k=10 latent_factors/sae x conformal_weighted: Sharpe=+0.703\n"
+      "  [96/180] k=10 latent_factors/sae x conformal_weighted: Sharpe=+0.703\n",
+      "  SKIP backtest (complete (hash=d6b782e2349b)) — reusing cached result\n",
+      "  [97/180] k=10 deep_learning/nlinear x score_weighted: Sharpe=+0.392\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  SKIP backtest (complete (hash=d6b782e2349b)) — reusing cached result\n",
-      "  [97/180] k=10 deep_learning/nlinear x score_weighted: Sharpe=+0.392\n",
       "  SKIP backtest (complete (hash=c42a877f10b9)) — reusing cached result\n",
       "  [98/180] k=10 deep_learning/nlinear x inverse_vol: Sharpe=+0.602\n",
       "  SKIP backtest (complete (hash=887025997f5b)) — reusing cached result\n",
-      "  [99/180] k=10 deep_learning/nlinear x risk_parity: Sharpe=+0.547\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "  [99/180] k=10 deep_learning/nlinear x risk_parity: Sharpe=+0.547\n",
       "  SKIP backtest (complete (hash=2db8bd6d82fc)) — reusing cached result\n",
       "  [100/180] k=10 deep_learning/nlinear x mvo_ledoit_wolf: Sharpe=+0.205\n",
       "  SKIP backtest (complete (hash=77856b8dc3d6)) — reusing cached result\n",
-      "  [101/180] k=10 deep_learning/nlinear x hrp: Sharpe=+0.461\n",
-      "  SKIP backtest (complete (hash=5349680e56a9)) — reusing cached result\n",
-      "  [102/180] k=10 deep_learning/nlinear x conformal_weighted: Sharpe=+0.738\n"
+      "  [101/180] k=10 deep_learning/nlinear x hrp: Sharpe=+0.461\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "  SKIP backtest (complete (hash=5349680e56a9)) — reusing cached result\n",
+      "  [102/180] k=10 deep_learning/nlinear x conformal_weighted: Sharpe=+0.738\n",
       "  SKIP backtest (complete (hash=59011f9cba45)) — reusing cached result\n",
       "  [103/180] k=10 gbm/leaves_63_mse x score_weighted: Sharpe=+0.406\n",
       "  SKIP backtest (complete (hash=d157c5cfb947)) — reusing cached result\n",
@@ -987,37 +957,31 @@
       "  SKIP backtest (complete (hash=a061dffd737c)) — reusing cached result\n",
       "  [107/180] k=10 gbm/leaves_63_mse x hrp: Sharpe=+0.653\n",
       "  SKIP backtest (complete (hash=d22528bc14c3)) — reusing cached result\n",
-      "  [108/180] k=10 gbm/leaves_63_mse x conformal_weighted: Sharpe=+0.667\n"
+      "  [108/180] k=10 gbm/leaves_63_mse x conformal_weighted: Sharpe=+0.667\n",
+      "  SKIP backtest (complete (hash=ac72edc4c91c)) — reusing cached result\n",
+      "  [109/180] k=10 gbm/leaves_31_huber x score_weighted: Sharpe=+0.542\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  SKIP backtest (complete (hash=ac72edc4c91c)) — reusing cached result\n",
-      "  [109/180] k=10 gbm/leaves_31_huber x score_weighted: Sharpe=+0.542\n",
       "  SKIP backtest (complete (hash=13257ec78377)) — reusing cached result\n",
       "  [110/180] k=10 gbm/leaves_31_huber x inverse_vol: Sharpe=+0.726\n",
       "  SKIP backtest (complete (hash=c729f95ee188)) — reusing cached result\n",
-      "  [111/180] k=10 gbm/leaves_31_huber x risk_parity: Sharpe=+0.752\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "  [111/180] k=10 gbm/leaves_31_huber x risk_parity: Sharpe=+0.752\n",
       "  SKIP backtest (complete (hash=8608af0b86fe)) — reusing cached result\n",
       "  [112/180] k=10 gbm/leaves_31_huber x mvo_ledoit_wolf: Sharpe=+0.495\n",
       "  SKIP backtest (complete (hash=9796322099d7)) — reusing cached result\n",
-      "  [113/180] k=10 gbm/leaves_31_huber x hrp: Sharpe=+0.774\n",
-      "  SKIP backtest (complete (hash=c730e91723d7)) — reusing cached result\n",
-      "  [114/180] k=10 gbm/leaves_31_huber x conformal_weighted: Sharpe=+0.765\n"
+      "  [113/180] k=10 gbm/leaves_31_huber x hrp: Sharpe=+0.774\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "  SKIP backtest (complete (hash=c730e91723d7)) — reusing cached result\n",
+      "  [114/180] k=10 gbm/leaves_31_huber x conformal_weighted: Sharpe=+0.765\n",
       "  SKIP backtest (complete (hash=844c4d26afd1)) — reusing cached result\n",
       "  [115/180] k=10 gbm/leaves_31_mse x score_weighted: Sharpe=+0.335\n",
       "  SKIP backtest (complete (hash=6a8406590da5)) — reusing cached result\n",
@@ -1049,86 +1013,80 @@
       "  SKIP backtest (complete (hash=1c886458773f)) — reusing cached result\n",
       "  [122/180] k=20 gbm/leaves_63_huber x inverse_vol: Sharpe=+0.543\n",
       "  SKIP backtest (complete (hash=4b87e3afa056)) — reusing cached result\n",
-      "  [123/180] k=20 gbm/leaves_63_huber x risk_parity: Sharpe=+0.521\n"
+      "  [123/180] k=20 gbm/leaves_63_huber x risk_parity: Sharpe=+0.521\n",
+      "  SKIP backtest (complete (hash=359f7ff91dff)) — reusing cached result\n",
+      "  [124/180] k=20 gbm/leaves_63_huber x mvo_ledoit_wolf: Sharpe=+0.606\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  SKIP backtest (complete (hash=359f7ff91dff)) — reusing cached result\n",
-      "  [124/180] k=20 gbm/leaves_63_huber x mvo_ledoit_wolf: Sharpe=+0.606\n",
       "  SKIP backtest (complete (hash=1742d7a4f2b9)) — reusing cached result\n",
       "  [125/180] k=20 gbm/leaves_63_huber x hrp: Sharpe=+0.441\n",
       "  SKIP backtest (complete (hash=0cdb003f04b4)) — reusing cached result\n",
-      "  [126/180] k=20 gbm/leaves_63_huber x conformal_weighted: Sharpe=+0.607\n"
+      "  [126/180] k=20 gbm/leaves_63_huber x conformal_weighted: Sharpe=+0.607\n",
+      "  SKIP backtest (complete (hash=9cede1a0404e)) — reusing cached result\n",
+      "  [127/180] k=20 latent_factors/cae x score_weighted: Sharpe=+0.728\n",
+      "  SKIP backtest (complete (hash=b8a53866d904)) — reusing cached result\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  SKIP backtest (complete (hash=9cede1a0404e)) — reusing cached result\n",
-      "  [127/180] k=20 latent_factors/cae x score_weighted: Sharpe=+0.728\n",
-      "  SKIP backtest (complete (hash=b8a53866d904)) — reusing cached result\n",
       "  [128/180] k=20 latent_factors/cae x inverse_vol: Sharpe=+0.724\n",
       "  SKIP backtest (complete (hash=14942f2adae0)) — reusing cached result\n",
       "  [129/180] k=20 latent_factors/cae x risk_parity: Sharpe=+0.710\n",
-      "  SKIP backtest (complete (hash=ad3b632a1365)) — reusing cached result\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "  SKIP backtest (complete (hash=ad3b632a1365)) — reusing cached result\n",
       "  [130/180] k=20 latent_factors/cae x mvo_ledoit_wolf: Sharpe=+0.636\n",
       "  SKIP backtest (complete (hash=3ad6f1d7445e)) — reusing cached result\n",
-      "  [131/180] k=20 latent_factors/cae x hrp: Sharpe=+0.754\n",
+      "  [131/180] k=20 latent_factors/cae x hrp: Sharpe=+0.754\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "  SKIP backtest (complete (hash=2b3e495d505c)) — reusing cached result\n",
       "  [132/180] k=20 latent_factors/cae x conformal_weighted: Sharpe=+0.774\n",
-      "  SKIP backtest (complete (hash=72a7707b7e13)) — reusing cached result\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "  SKIP backtest (complete (hash=72a7707b7e13)) — reusing cached result\n",
       "  [133/180] k=20 gbm/default_huber x score_weighted: Sharpe=+0.565\n",
       "  SKIP backtest (complete (hash=192dda89fbc1)) — reusing cached result\n",
-      "  [134/180] k=20 gbm/default_huber x inverse_vol: Sharpe=+0.567\n",
-      "  SKIP backtest (complete (hash=8994fb92c2f0)) — reusing cached result\n",
-      "  [135/180] k=20 gbm/default_huber x risk_parity: Sharpe=+0.573\n"
+      "  [134/180] k=20 gbm/default_huber x inverse_vol: Sharpe=+0.567\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "  SKIP backtest (complete (hash=8994fb92c2f0)) — reusing cached result\n",
+      "  [135/180] k=20 gbm/default_huber x risk_parity: Sharpe=+0.573\n",
       "  SKIP backtest (complete (hash=3c62bf678f5c)) — reusing cached result\n",
       "  [136/180] k=20 gbm/default_huber x mvo_ledoit_wolf: Sharpe=+0.616\n",
       "  SKIP backtest (complete (hash=27428733583c)) — reusing cached result\n",
-      "  [137/180] k=20 gbm/default_huber x hrp: Sharpe=+0.554\n",
-      "  SKIP backtest (complete (hash=045a4811b445)) — reusing cached result\n",
-      "  [138/180] k=20 gbm/default_huber x conformal_weighted: Sharpe=+0.566\n"
+      "  [137/180] k=20 gbm/default_huber x hrp: Sharpe=+0.554\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "  SKIP backtest (complete (hash=045a4811b445)) — reusing cached result\n",
+      "  [138/180] k=20 gbm/default_huber x conformal_weighted: Sharpe=+0.566\n",
       "  SKIP backtest (complete (hash=a91ad215ce65)) — reusing cached result\n",
       "  [139/180] k=20 gbm/leaves_7_mse x score_weighted: Sharpe=+0.561\n",
       "  SKIP backtest (complete (hash=0bba83d238e6)) — reusing cached result\n",
-      "  [140/180] k=20 gbm/leaves_7_mse x inverse_vol: Sharpe=+0.665\n",
-      "  SKIP backtest (complete (hash=7c1beae429ad)) — reusing cached result\n",
-      "  [141/180] k=20 gbm/leaves_7_mse x risk_parity: Sharpe=+0.620\n",
-      "  SKIP backtest (complete (hash=15ed24af5cb2)) — reusing cached result\n"
+      "  [140/180] k=20 gbm/leaves_7_mse x inverse_vol: Sharpe=+0.665\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "  SKIP backtest (complete (hash=7c1beae429ad)) — reusing cached result\n",
+      "  [141/180] k=20 gbm/leaves_7_mse x risk_parity: Sharpe=+0.620\n",
+      "  SKIP backtest (complete (hash=15ed24af5cb2)) — reusing cached result\n",
       "  [142/180] k=20 gbm/leaves_7_mse x mvo_ledoit_wolf: Sharpe=+0.096\n",
       "  SKIP backtest (complete (hash=ac43d31ee7d4)) — reusing cached result\n",
       "  [143/180] k=20 gbm/leaves_7_mse x hrp: Sharpe=+0.525\n",
@@ -1145,14 +1103,14 @@
       "  SKIP backtest (complete (hash=dd900730477e)) — reusing cached result\n",
       "  [146/180] k=20 gbm/leaves_15_mse x inverse_vol: Sharpe=+0.728\n",
       "  SKIP backtest (complete (hash=c801b5c2f7b5)) — reusing cached result\n",
-      "  [147/180] k=20 gbm/leaves_15_mse x risk_parity: Sharpe=+0.711\n",
-      "  SKIP backtest (complete (hash=a6b1700eef2f)) — reusing cached result\n"
+      "  [147/180] k=20 gbm/leaves_15_mse x risk_parity: Sharpe=+0.711\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "  SKIP backtest (complete (hash=a6b1700eef2f)) — reusing cached result\n",
       "  [148/180] k=20 gbm/leaves_15_mse x mvo_ledoit_wolf: Sharpe=+0.293\n",
       "  SKIP backtest (complete (hash=f80cf752f695)) — reusing cached result\n",
       "  [149/180] k=20 gbm/leaves_15_mse x hrp: Sharpe=+0.622\n",
@@ -1169,27 +1127,27 @@
       "  SKIP backtest (complete (hash=d50531e44b60)) — reusing cached result\n",
       "  [152/180] k=20 latent_factors/sae x inverse_vol: Sharpe=+0.563\n",
       "  SKIP backtest (complete (hash=504ba4ad8908)) — reusing cached result\n",
-      "  [153/180] k=20 latent_factors/sae x risk_parity: Sharpe=+0.575\n"
+      "  [153/180] k=20 latent_factors/sae x risk_parity: Sharpe=+0.575\n",
+      "  SKIP backtest (complete (hash=aba77338435b)) — reusing cached result\n",
+      "  [154/180] k=20 latent_factors/sae x mvo_ledoit_wolf: Sharpe=+0.209\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  SKIP backtest (complete (hash=aba77338435b)) — reusing cached result\n",
-      "  [154/180] k=20 latent_factors/sae x mvo_ledoit_wolf: Sharpe=+0.209\n",
       "  SKIP backtest (complete (hash=65ae8679376c)) — reusing cached result\n",
       "  [155/180] k=20 latent_factors/sae x hrp: Sharpe=+0.524\n",
       "  SKIP backtest (complete (hash=dd5c9fa7a347)) — reusing cached result\n",
-      "  [156/180] k=20 latent_factors/sae x conformal_weighted: Sharpe=+0.620\n"
+      "  [156/180] k=20 latent_factors/sae x conformal_weighted: Sharpe=+0.620\n",
+      "  SKIP backtest (complete (hash=82ac9cc42360)) — reusing cached result\n",
+      "  [157/180] k=20 deep_learning/nlinear x score_weighted: Sharpe=+0.352\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  SKIP backtest (complete (hash=82ac9cc42360)) — reusing cached result\n",
-      "  [157/180] k=20 deep_learning/nlinear x score_weighted: Sharpe=+0.352\n",
       "  SKIP backtest (complete (hash=5c362935da8f)) — reusing cached result\n",
       "  [158/180] k=20 deep_learning/nlinear x inverse_vol: Sharpe=+0.626\n",
       "  SKIP backtest (complete (hash=7d8f4a8b2c06)) — reusing cached result\n",
@@ -1207,14 +1165,14 @@
       "  SKIP backtest (complete (hash=09ed7cffa291)) — reusing cached result\n",
       "  [162/180] k=20 deep_learning/nlinear x conformal_weighted: Sharpe=+0.694\n",
       "  SKIP backtest (complete (hash=0b48801f748f)) — reusing cached result\n",
-      "  [163/180] k=20 gbm/leaves_63_mse x score_weighted: Sharpe=+0.397\n"
+      "  [163/180] k=20 gbm/leaves_63_mse x score_weighted: Sharpe=+0.397\n",
+      "  SKIP backtest (complete (hash=572847b848f8)) — reusing cached result\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  SKIP backtest (complete (hash=572847b848f8)) — reusing cached result\n",
       "  [164/180] k=20 gbm/leaves_63_mse x inverse_vol: Sharpe=+0.646\n",
       "  SKIP backtest (complete (hash=e656777b9d9e)) — reusing cached result\n",
       "  [165/180] k=20 gbm/leaves_63_mse x risk_parity: Sharpe=+0.651\n",
@@ -1227,53 +1185,53 @@
      "output_type": "stream",
      "text": [
       "  SKIP backtest (complete (hash=9bb075dab294)) — reusing cached result\n",
-      "  [167/180] k=20 gbm/leaves_63_mse x hrp: Sharpe=+0.581\n",
-      "  SKIP backtest (complete (hash=1d316491b89e)) — reusing cached result\n",
-      "  [168/180] k=20 gbm/leaves_63_mse x conformal_weighted: Sharpe=+0.653\n"
+      "  [167/180] k=20 gbm/leaves_63_mse x hrp: Sharpe=+0.581\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "  SKIP backtest (complete (hash=1d316491b89e)) — reusing cached result\n",
+      "  [168/180] k=20 gbm/leaves_63_mse x conformal_weighted: Sharpe=+0.653\n",
       "  SKIP backtest (complete (hash=d9538b80edaa)) — reusing cached result\n",
       "  [169/180] k=20 gbm/leaves_31_huber x score_weighted: Sharpe=+0.521\n",
       "  SKIP backtest (complete (hash=782d88549954)) — reusing cached result\n",
-      "  [170/180] k=20 gbm/leaves_31_huber x inverse_vol: Sharpe=+0.687\n",
-      "  SKIP backtest (complete (hash=287b4433f459)) — reusing cached result\n",
-      "  [171/180] k=20 gbm/leaves_31_huber x risk_parity: Sharpe=+0.693\n"
+      "  [170/180] k=20 gbm/leaves_31_huber x inverse_vol: Sharpe=+0.687\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "  SKIP backtest (complete (hash=287b4433f459)) — reusing cached result\n",
+      "  [171/180] k=20 gbm/leaves_31_huber x risk_parity: Sharpe=+0.693\n",
       "  SKIP backtest (complete (hash=5ef658a6a61e)) — reusing cached result\n",
       "  [172/180] k=20 gbm/leaves_31_huber x mvo_ledoit_wolf: Sharpe=+0.429\n",
       "  SKIP backtest (complete (hash=d52a8444eb22)) — reusing cached result\n",
-      "  [173/180] k=20 gbm/leaves_31_huber x hrp: Sharpe=+0.594\n",
-      "  SKIP backtest (complete (hash=af5f38b6009f)) — reusing cached result\n",
-      "  [174/180] k=20 gbm/leaves_31_huber x conformal_weighted: Sharpe=+0.674\n"
+      "  [173/180] k=20 gbm/leaves_31_huber x hrp: Sharpe=+0.594\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "  SKIP backtest (complete (hash=af5f38b6009f)) — reusing cached result\n",
+      "  [174/180] k=20 gbm/leaves_31_huber x conformal_weighted: Sharpe=+0.674\n",
       "  SKIP backtest (complete (hash=5ba5f96fc3d8)) — reusing cached result\n",
       "  [175/180] k=20 gbm/leaves_31_mse x score_weighted: Sharpe=+0.447\n",
       "  SKIP backtest (complete (hash=e7418d6628d5)) — reusing cached result\n",
       "  [176/180] k=20 gbm/leaves_31_mse x inverse_vol: Sharpe=+0.629\n",
       "  SKIP backtest (complete (hash=7aedd3dbc88f)) — reusing cached result\n",
       "  [177/180] k=20 gbm/leaves_31_mse x risk_parity: Sharpe=+0.609\n",
-      "  SKIP backtest (complete (hash=aa5746b96e1b)) — reusing cached result\n",
-      "  [178/180] k=20 gbm/leaves_31_mse x mvo_ledoit_wolf: Sharpe=+0.360\n"
+      "  SKIP backtest (complete (hash=aa5746b96e1b)) — reusing cached result\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "  [178/180] k=20 gbm/leaves_31_mse x mvo_ledoit_wolf: Sharpe=+0.360\n",
       "  SKIP backtest (complete (hash=5e2e49e80ee8)) — reusing cached result\n",
       "  [179/180] k=20 gbm/leaves_31_mse x hrp: Sharpe=+0.530\n",
       "  SKIP backtest (complete (hash=86ce82653ebb)) — reusing cached result\n",
@@ -1399,13 +1357,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dcabaab6",
+   "id": "41f15209",
    "metadata": {
     "papermill": {
-     "duration": 0.006627,
-     "end_time": "2026-09-11T14:35:24.661254+00:00",
+     "duration": 0.004618,
+     "end_time": "2026-09-11T14:39:24.532685+00:00",
      "exception": false,
-     "start_time": "2026-09-11T14:35:24.654627+00:00",
+     "start_time": "2026-09-11T14:39:24.528067+00:00",
      "status": "completed"
     }
    },
@@ -1424,19 +1382,19 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "7534fb1c",
+   "id": "c27f5da8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T14:35:24.673408Z",
-     "iopub.status.busy": "2026-09-11T14:35:24.673145Z",
-     "iopub.status.idle": "2026-09-11T14:35:24.730291Z",
-     "shell.execute_reply": "2026-09-11T14:35:24.725657Z"
+     "iopub.execute_input": "2026-09-11T14:39:24.549149Z",
+     "iopub.status.busy": "2026-09-11T14:39:24.548848Z",
+     "iopub.status.idle": "2026-09-11T14:39:24.613310Z",
+     "shell.execute_reply": "2026-09-11T14:39:24.612328Z"
     },
     "papermill": {
-     "duration": 0.067786,
-     "end_time": "2026-09-11T14:35:24.734431+00:00",
+     "duration": 0.07456,
+     "end_time": "2026-09-11T14:39:24.614524+00:00",
      "exception": false,
-     "start_time": "2026-09-11T14:35:24.666645+00:00",
+     "start_time": "2026-09-11T14:39:24.539964+00:00",
      "status": "completed"
     }
    },
@@ -1455,13 +1413,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0b60a26a",
+   "id": "cf26165d",
    "metadata": {
     "papermill": {
-     "duration": 0.012462,
-     "end_time": "2026-09-11T14:35:24.754601+00:00",
+     "duration": 0.00649,
+     "end_time": "2026-09-11T14:39:24.632487+00:00",
      "exception": false,
-     "start_time": "2026-09-11T14:35:24.742139+00:00",
+     "start_time": "2026-09-11T14:39:24.625997+00:00",
      "status": "completed"
     }
    },
@@ -1478,19 +1436,19 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "9cd75c47",
+   "id": "fba7c51a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T14:35:24.776283Z",
-     "iopub.status.busy": "2026-09-11T14:35:24.775916Z",
-     "iopub.status.idle": "2026-09-11T14:35:24.786916Z",
-     "shell.execute_reply": "2026-09-11T14:35:24.785750Z"
+     "iopub.execute_input": "2026-09-11T14:39:24.649185Z",
+     "iopub.status.busy": "2026-09-11T14:39:24.648839Z",
+     "iopub.status.idle": "2026-09-11T14:39:24.656700Z",
+     "shell.execute_reply": "2026-09-11T14:39:24.655559Z"
     },
     "papermill": {
-     "duration": 0.024751,
-     "end_time": "2026-09-11T14:35:24.791481+00:00",
+     "duration": 0.017367,
+     "end_time": "2026-09-11T14:39:24.657452+00:00",
      "exception": false,
-     "start_time": "2026-09-11T14:35:24.766730+00:00",
+     "start_time": "2026-09-11T14:39:24.640085+00:00",
      "status": "completed"
     },
     "tags": [
@@ -1538,19 +1496,19 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "ef51e21b",
+   "id": "87786a7c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T14:35:24.809484Z",
-     "iopub.status.busy": "2026-09-11T14:35:24.805901Z",
-     "iopub.status.idle": "2026-09-11T14:35:27.323956Z",
-     "shell.execute_reply": "2026-09-11T14:35:27.322900Z"
+     "iopub.execute_input": "2026-09-11T14:39:24.669101Z",
+     "iopub.status.busy": "2026-09-11T14:39:24.668879Z",
+     "iopub.status.idle": "2026-09-11T14:39:27.576956Z",
+     "shell.execute_reply": "2026-09-11T14:39:27.575954Z"
     },
     "papermill": {
-     "duration": 2.528572,
-     "end_time": "2026-09-11T14:35:27.325011+00:00",
+     "duration": 2.915794,
+     "end_time": "2026-09-11T14:39:27.578730+00:00",
      "exception": false,
-     "start_time": "2026-09-11T14:35:24.796439+00:00",
+     "start_time": "2026-09-11T14:39:24.662936+00:00",
      "status": "completed"
     }
    },
@@ -1590,6 +1548,7 @@
        "layout": {
         "height": 380,
         "margin": {
+         "l": 150,
          "t": 90
         },
         "shapes": [
@@ -1694,7 +1653,7 @@
         }
        }
       },
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAyAAAAF8CAYAAAA3o9/NAAAQAElEQVR4AezdBYAV1dvH8d8uuYABovKK/EGQTkkBQcVusQsMursbhKVDOkRKUbEQCwMxEAVFEJESJFQMkJDOd57D3nV32d57t+5X98ydOHPmnM+ZvTvPPTOX0OPHj50hYcA5wDnAOcA5wDnAOcA5wDnAOcA5kBrnQKj4DwEE0kiAwyKAAAIIIIAAAsEnQAASfH1OixFAAAEEEEAAAQQQSDMBApA0o+fACCCAAAIIIIBA8AnQYgQIQDgHEEAAAQQQQAABBBBAINUECEBSjTrmgVhGAAEEEEAAAQQQQCD4BAhAgq/PaTECCCCAAAIIIIAAAmkmQACSZvQcGAEEEEAAgeAToMUIIIAAAQjnAAIIIIAAAggggAACmV8g3bSQACTddAUVQQABBBBAAAEEEEAg8wsQgGT+PqaFMQVYRgABBBBAAAEEEEgzAQKQNKPnwAgggEDwCdBiBBBAAAEECEA4BxBAAAEEEEAAgcwvQAsRSDcCBCDppiuoCAIIIIAAAggggAACmV8g+AKQzN+ntBABBBBAAAEEEEAAgXQrQACSbruGiiGQ+QRoEQIIIIAAAgggQADCOYAAAggggEDmF6CFCCCAQLoRIABJN11BRRBAAAEEEEAAAQQynwAtiilAABJThGUEEEAAAQQQQAABBBAImAABSMBoKTimAMsIIIAAAggggAACCBCAcA4ggAACmV+AFiKAAAIIIJBuBAhA0k1XUBEEEEAAAQQQyHwCtAgBBGIKEIDEFGEZAQQQQAABBBBAAAEEAiaQagFIwFpAwQgggAACCCCAAAIIIJBhBAhAMkxXUVEEki3AjggggAACCCCAQLoRIABJN11BRRBAAAEEMp8ALUIAAQQQiClAABJThGUEEEAAAQQQQACBjC9AC9KtAAFIuu0aKoYAAggggAACCCCAQOYTIADJfH0as0UsI4AAAggggAACCCCQbgQIQNJNV1ARBBDIfAK0CAEEEEAAAQRiChCAxBRhGQEEEEAAAQQyvgAtQACBdCtAAJJuu4aKIYAAAggggAACCCCQ8QQSqjEBSEJCbEcAAQQQQAABBBBAAAG/CRCA+I2SghCIKcAyAggggAACCCCAQEwBApCYIiwjgAACUQRGjX9et933dJQ16X92+YpVuvDyijp69Fi6ruyU519S3VseTlIdH3iipQYNey7hfWLkSM6xYhQR8MWM0m8Bh+AACCCQ6QUIQDJ9F9NABFJfoEqdu9wF8IuvLjzn4LfWf8ptGzvphXO2pcWKTz9frkeebqOSV93g0sNPttbQ0VPSoipBd8z/K3CJKlUo4/d2/690bb37wafRyg3UsaIdhAUEEHACTBBISIAAJCEhtiOAQLIEihS+XK++8W60fX/a8LPW/LheF+fPF219Wi188dVK3fd4CxUt8j8N6d9ZMyYO1TMNH9aef/alVZWC6rj33HGjnhvRL1XanJrHSpUGcRAEEEAgAwsQgASs8ygYgeAVCAkJ0YP33qavV36v7Tt+i4R4acFCPVT/DuXKFRa5zmZOnTql8VPm6JqbHlTBEjV1/R2P6e33PrZNLh08dFjPDh+vm+9tqEKlaum62x/VG29/4Lb5JnZrTp9nR6lDj2dVuupNKn/1bRo49DmdPHnSl+Wc1y+Xr9SVRb3go18X3X/PbapTq5puuaGORjzb/Zy8M2a/rGrX3q2i5a9V49bd9cdff0fmscCqa59w1bi+vuzT93seaeoCrcgM3kz+IlU0+6XXdd9jLVSkbB0NGzNVvltunp/ziq677VFdXrKmbr//GX2/Zp23x38/GzZt1RNNOqhU5RtVvNL1atG+j/btP/BfhjjmPv9qRazl7tj5u/IWqqQf1m2Ituesea+5Y5w4cSLaelv4eOkyFS5zTaTn1m07ZLd5de4VbptdGjp6sqwf3II3SajeMW+L+vfgIbXrOlAlrqrn+q/ngBGure27D/JK++/n1KnTcfazjb4d+PegHm/c3tWvTLWb3Y4xj+W7tW7aC/Pj7NfE1scdIGJi52r7boNU68b73fHtfH5uyuyIrZLVrXu/Ye6Ydq7YiNuHS76I3G4z9ntjvwN2rt/1UGN99/1aWx2ZLL+NJFp/VK17txuxs98hXwbrg77PjlbbLgPcqN61tz6iBW++J8sz8rkZ3nl6r8zphbkLfLu414T6y2ViggACCPhBINQPZVAEAgggcI5Anjx5dM8dN2nO/NfdNruonb/gbT364F1uOepk+Nipevv9jzWgdwf99O2H6ta+ufoPGasPPv7cZTt+/Lhy5MipMeF9tGb5e2rVpIF6Dhgpuyh2GSImL77ytqpVrqBlHy3Q6PBemuldYL2+8IOIree+5L8or37f9bfswuvcrf+t2frLDr3zwadq36qRurZvpmVff6eho/67TWv/gQMqX7aUXp09Qcu8Y9e7tpYXaDSPFqRYaRZ0PN3gAW347mO1aPy4rXLppQWLXH2/X/auSpUopvqPNZcvwPjr7z265+EmqliujBYteF4fLpyjCy7Io4eebK3Tp0+7/eOaTJ7xYmS5pUte6crdu2+//lfoMt10fW29/NqiaLvO95YfeeBOZcuWLdp6W7i62lU6dPhIZHD01Ter3EjWV998a5tdWr7ie9WsUcXNJ6fe3fsO08pVazRv+hh9+u5LCg0N1ZLPvnLlRZ28/Po7OnnipIYP6u4CXbvA9/Xzd18s0vnn5dGLM8Zq369r9NPKD6PuGm1+9dqfvP7/UwvmTNJbL0/V1m07o/VrYusTtdBxk2Zq245fNWPCMP22abnmvzBOBf/vksgsjzdq7xn+pPEjB3jn+kdq8vSj2r//38jtNjN87DTdd9etGjO0j44cPabm7XvpzJkztkmfffmN2nYeoKeeuF/W1sljBmnFt2s0IHyc2+6bvPL6u8qSNYtGDO6hqyqVVZM2PdS0bS/9+ddu9enaVtWrVJIF65u3bHe7JKe/3I5MEEAAgWQIEIAkA41dEEAgcQKPPXi3LCiwC+VF73+iSy7OL7uQjbr3sWPHZc+DDPKCjxu8C/cLzj9Pt95UV08+/oA3YvCay5ov74Xq0q6JypYuLpt/sP7tesrbHvMC+kbvotqOaXluuv4a3XBdbe+Cdq0rI7bJEw/XV53aVXV1vfqyEQj7NNpGAQ4dPhwt+wlvFGX+zHF6/KF71LzRY2r2zGP65tvVkXlqVq+sBo/UV+H/FVShyy9TuxZPqVyZknpv8aeReWzmMS/4uuu2G5QzZw53kayI/3p0aqHKlcq5C/qhA7p6AUDWyBEeC6IqlCvp2l+8WGFdUbiQwvt31bqfNnsXstFHSiKKi3xp1bRBZLnh/bu4ct9ctNhtf9xr+yvehbwFhrZi08/bXJtsvS3HTHly53LB3Zde8GXblnsBSOMnH5FdwNpo0FHvQtmCklo1rrLNLvhLSr1ttOElL0Dt1qGFqletKAsOB/bqcM5omRVeoWxJ7wK+v8yyb/e2uvG6Wlrx3Q+2KUkp74UXqH/P9rLbBSt4AeTjD93tlXO2X5NSn6gH3fXH37qiSCGVKXWlcufKpbq1q7vRNctjt/xZmjRmoPs9MNMbvXPUzmfb7kv9erRVm+YN9YA3ihjer7MztsDBto+ZONMFLY/cf5czqlalonp2buG8bbsvVapQ2gvYe+vu2290r5f936WyvrbRvTtvq6cJo/rronwXatXqs78fKTnPfMf0vfKKAAIIJCRAAJKQENsRQCDJAvZpraVrr6mhPHly6cMlX8pGPx73LuBjFvbL9l9lQcitEQ+n2209lvoNHqNftv0amX3+a2/rjgcauVucbLvd7rPz112R222moHeRZa++dHH+vPp79x7f4jmvYWE59fIL4/XzmqXq3rGFu3AcNeF5Vb+uvnb++ntk/mJFC8vy+lYU+d/l0co97I0M2IPr1932qC6+oqq79cY+qd4Zo36Vypf1FRHt1S5+fSuyZ8/mBVol3Kfxtm7LL9v10afLXJnWbkt2+5QFSWZneeJK8ZV7+83XKlvWbG5kx/af+/Lrqn11VVmQY8uxJQsuln/zndu01Pskvl7dq1WrRmV9+dW3LnjJ7o2c2AiUZUhqve22MDtnLGix/S3ZCEi5MiVsNlqy0ZyoKyzw273nn6irEjVfqOD/RcuX/6KLZCMBtjIp9bH8vlT/7ls056U3ZMHsiHHT9f6Hn0WOXvy8ZZssECh2RWFf9lhfy5b+r81FvIDTMv0d0b6Nm7fKvgXMzgNfuvHuBrJbv3b98ZdldclG0tyMNwkJCVHRIv9T6ZLFvKWzP1myZHHB8u49e92KpPaX24kJAgikN4EMUx8CkAzTVVQUgYwnEBISokcfvEfjp8zWF8u/1cP333lOI0JCQty65Z+8LrtlJmr6eskbbpt9Um+3L/Xt3kYrlr7l8vXu2kbHYzyrEBp6tiy3U+Tk7K0rkYuxzNin7TbqMnRAN3cL1b//HtTLr78bmTOrd7EWueDNhISERF5UeovqOWCkVq9dp/Hep8qbvv/E1c9Gc2LWL2dYDsueqGQX45YxJCRE9nxKVBffvH1CbnmSknzl2m1WTzxyj155Y5H7ZHzBG+/Lbr+Kr6xaXoBi/WijHgcPHtJVFcuqpjf6Y7deLV+xypu/SlmzZnVFhIT4t96u0IhJ1qxZIubOvoSEWL8n3M9nc/83tQDnv6Wzcz6fs0tJn1q/L3n3RdmtaD9v3aZm7XrqsUbtIgsKCbG6Ri7GOhP1fAsJOZvfV6+QkBCNGtLTnWO+88D3at/05SvwXCMpNPRct6jl+vM889WDVwQQQCA2gdDYVrIOgQwtQOXTlcDjD92tr7xPzW+76Tp3i1HMyhW7opAbXfhk6bn3+vvyfv3tatWuUUU1qlZSgUsvdqvXxniA2q30w8SeH8iTJ7cOHTqU6NLs4vvOW29Q+TIllffCC9yIzroNmxO9f9SHwY8fP6F16zfpisKXu/1LFi+mZV9/qyNHjrrlpEziK9fKafjo/fpoyTLNmf+GDh85ovu8T+9tfVzJ/E+ePKWJ0+eo1tWVXbBR++oqrn5ffeMFIF4f+fZNar3tuZSQkBD98ONGXxHuGZcff9oUuZzYmbCcOXX6zOnEZo81X0rqU7FcabVv+bSmjhusWVNHuFGQ/Qf+1ZXFirhnTrZu2xHrMROzskzJK7Xk8+WJyZqkPEntryQVTmYEEEAghgABSAwQFhFAwL8CFjDs3blaL0weHmvB9ol557ZNNXrC87JnAP7Zu89dbL/21vua98pbbp/yZUrou9U/yrbZfeyW98MY3xzkMiZxMnHaXG90Zo7svnxLdttUt75DZbeyXF+3ZqJLK1+2pD5ftsJ9Q5Td0tKiQx/ZBWdiCxg+dqpWee37e/c/6t5vuDcicVIP3Hu72/2ZBg+41yZte+gHL+iy52nWb/zZfcNXQseIr1wr1C6y7Taq3oNG6757bnXPLNj6uJI9s1D1qvLudrraNaq6bHbL1c9bt7tbsGrVuEpuEOcFjAAAEABJREFUpTdJar3P84I+e35nyMiJsoeqzbHv4DGy50u84pL0Y7fMrVuf+AAwtsKTWx87pxZ/8oX7xin71qnPv1zhgmYLbO1b1q6pWVUt2vdx3xB38NBh90UK9g1VSuR/ndo2dv/GSfioSdq2/VfZ+WDnrY0QJrKIWLMltb9iLYSVCCCAQCIFCEASCUU2BBAInEDH1s/Ibq+yB2HL17hNdW55yAUfuSO+rtceOL/jlut0w51PyJ7PsE/FO7RqlOIKWZCxe88e9Q8fp0efbqv23Qbpz7/2aOHL02TPryT2AEP6dXEXgvbVq3VvfVglixdVvWsTH8B0bNVYjzfuoHI1btGGTVv05ktTdOEF57vD24jK4jdnK1dYmBo06agiZeuoY4/B2vLLDmWLuN3JZYxlEl+5vuyPPHCXC/ge9V596+J7tSDDntmxkQ/LlzNnDtlFddYsWd1D6rbOUnLqPXRgN1mA83jj9ipV5UYvEDuhm+vV0QXn5bEiE53aNHtSE6fNkT0j4fsa3kTvHCVjcupz6vRpte7UVxcVruzSu4uXaPr4cIWEhLiS50wbpQreCEmrjn3d1y43btXdnTtuYyImNatX1qJXZ8geuq935+MqXeUmjRo/Q8ePH0vE3nFnSU5/xV0aW9JIgMMikGEECEAyTFdRUQQyjoB9PajdghJXjdd89Z67RcW3PSQkRBZkfPz2XPfVpd9+/rbemj9V9e+6xWUJDQ1Vn25t9f2yd1yaOWmYurZvqk/ffcltt8lr8ya5PDbvS/ZMx+ypo3yL57zaNxUN6NVBnyyap183Lndlz5oywn1zkS9zpzaN9P4bL/gW3es9d9yoLT985uZtcsnFF2nGhKFasXSh+9rXbh2aua+BHdy3s212afe272TfeOQWYkyuq1ND67/9SH9uWan3Xp/pnq2ImsUesp723BCZ2471y1x9Zk8dGes3RNl+dpFqzwXYcy3xlWt5t+343X31r91eZcsJJesHK9ue//Dltb76bdNyd0uWb529JlRv+0axzxe/YlldslGHiaMHavPqT2Ve1n/20PUVEQ9iW6bE9PNtN1+rnRu+cs9J+L6GN+axEtOviamP1Slqatv8SVd/M7K08rO3ZSMfvjx2oW/fRGW/I7Z927ovIp+N8vWbBXW+/PZ8kuWL+oUCVp4FqVvXfqaN33+it1+ZHu3cj83IghY7L33l2qv9/rRu1tBmXUqov1wmJggggIAfBDJfAOIHFIpAAAEEgkFgzz/7NP2F+WrU8MF00dxVq3/Ui68ulN2KZg+62z+kt+efvaqfwLMpgap8eqtPoNpJuQgggEBqCxCApLY4x0MgEwvQtIwj0KJ9H1W79h7dd88tevqJ9BGAhIWFyb4xrXil63Vr/Yb67fc/9cZLU2T/NkxayKa3+qSFAcdEAAEEAiFAABIIVcpEAAEEEiEQ2y03idjNL1kmjx0ku4XHnl+xLwLwS6EpLKR0yWKyr162W47sFrc3XprsvlkshcUme/f0Vp8EGsJmBBBAIMMIEIBkmK6ioggggAACCCCAAALpT4AaJVWAACSpYuRHAAEEEEAAAQQQQACBZAsQgCSbjh1jCrCMAAIIIIAAAggggEBCAgQgCQmxHQEEEEj/AtQQAQQQQACBDCNAAJJhuoqKIoAAAggggED6E6BGCCCQVAECkKSKkR8BBBBAAAEEEEAAAQSSLeC3ACTZNWBHBBBAAAEEEEAAAQQQCBoBApCg6WoamokFaBoCCCCAAAIIIJBhBAhAMkxXUVEEEEAAgfQnQI0QQAABBJIqQACSVDHyI4AAAggggAACCKS9ADXIsAIEIBm266g4AggggAACCCCAAAIZT4AAJOP1Wcwas4wAAggggAACCCCAQIYRIADJMF1FRRFAIP0JUCMEEEAAAQQQSKoAAUhSxciPAAIIIIAAAmkvQA0QQCDDChCAZNiuo+IIIIAAAggggAACCKS+QEqPSACSUkH2RwABBBBAAAEEEEAAgUQLEIAkmoqMCMQUYBkBBBBAAAEEEEAgqQIEIEkVIz8CCCCAQNoLUAMEEEAAgQwrQACSYbuOiiOAAAIIIIAAAqkvwBERSKkAAUhKBdkfAQQQQAABBBBAAAEEEi1AAJJoqpgZWUYAAQQQQAABBBBAAIGkChCAJFWM/AggkPYC1AABBBBAAAEEMqwAAUiG7ToqjgACCCCAQOoLcEQEEEAgpQIEICkVZH8EEEAAAQQQQAABBAIvkGmOQACSabqShiCAAAIIIIAAAgggkP4FCEDSfx9Rw5gCLCOAAAIIIIAAAghkWAECkAzbdVQcAQQQSH0BjogAAggggEBKBQhAUirI/ggggAACCCCAQOAFOAICmUaAACTTdCUNQQABBBBAAAEEEEAg/QtkvAAk/ZtSQwQQQAABBBBAAAEEEIhDgAAkDhhWI4DAuQKsQQABBBBAAAEEUipAAJJSQfZHAAEEEEAg8AIcAQEEEMg0AgQgmaYraQgCCCCAAAIIIICA/wUo0d8CBCD+FqU8BBBAAAEEEEAAAQQQiFOAACROGjbEFGAZAQQQQAABBBBAAIGUChCApFSQ/RFAAIHAC3AEBBBAAAEEMo0AAUim6UoaggACCCCAAAL+F6BEBBDwtwABiL9FKQ8BBBBAAAEEEEAAAQTiFEh0ABJnCWxAAAEEEEAAAQQQQAABBBIpQACSSCiyIZCGAhwaAQQQQAABBBDINAIEIJmmK2kIAggggID/BSgRAQQQQMDfAgQgKRS9/fY7lC1bdlIADEJCQnX69BlsA2Br5+ypU6cUGhqKbwB8s2bNphMnTmAbAFs7d6UQnTkjfAPke/LkSWXJkhXfAPiaq/naeUxKxLVTEvvgjL0xKHXeG7zD8JMCgdAU7MuuCCCAAAIIIIAAAggggECSBAhAksSVJpk5KAIIIIAAAggggAACmUaAACSFXbn3VF4NHjGBFACD8FGTNGzMFGwDYGvn7LAxU2XGNk+K63c4eeuHjJyo4WOnce4G6NwdOnqyLHHeJu/8TMht+NipsnM4oXxsT7q/uZovdkm3i2mWwss3dk9jAQIQP3SAvaGQJro/WP50sAuMYV4A4s8yKeu/frI/guGjJvu93zA+azxi3DRsvUAsEOcD7w1nz7FA2FqZFjyHex8A2XyapgCdP2nZJnM137SsQ2Y5th8u3ygiDQUIQNIQn0MjgAACCCCAAAIIIJDeBAJdHwKQQAtTPgIIIIAAAggggAACCEQKEIBEUjCDQEwBlhFAAAEEEEAAAQT8LUAA4m9RykMAAQQQSLkAJSCAAAIIZFoBApBM27U0DAEEEEAAAQQQSLoAeyAQaAECkEALUz4CCCCAAAIIIIAAAghEChCARFLEnGEZAQQQQAABBBBAAAEE/C1AAJJC0YO7t6ewBHZHAIFzBFiBAAIIIIAAAplWIFUCkAP/HtTDjTr7HdHKfeiZTgmWa3ksb8yMXyxfpS3bdsZcneByh14jtHHzLwnmIwMCCCCAAAIZTYD6IoAAAoEWSJUAJFCNyJUrTH27NE928ctXrtEv239L9v7siAACCCCAAAIIIICAnwSCppjQNxZ9rKda99ETzXto+pzXIhtuowZjJs9R627hWvj+p3qkcRf1evY5PRrxuuqH9WrR+VlZvg0RowHbd+7Sg0930uNNu6t5x0Haui1xF/ftew7Xpi1nb2Vq0KKnps993dVj6qwFeuOdj9384iXLZNusnlavU6dP6/DhIxo4YorbbpPZ8992x7c6W11feu09W+3SrPkL1bhdPzXvNEh/7/5Hm7du1xfLv9Pz3rFsndV9z959ro12DMu7bsMWt++x48fVb+gkZ9Sx93AdPHTYrWeCAAIIIIAAAggggAACSRMIff7FNzV6UGdNH9tPS75YIRsV8BVRqGABTRjWQ7WrV9Lvf/ytJg0f0NypQ7X7n316/+MvNWF4T3Vv31hTXnjV7ZL3wvM0eWRvvThtqBo1qK+RE2e59QlNKpQtodVrN7gL+xzZs2vtus1ulx/WbVKlcqVlwcEsL7gYN6Sb5kwarGPHT2rRB0tdHt/EAoq33luimeMHKrxPW63f9Itvk3u9onBBzRg3QDdfV1PzFryj4kULq07NKl4979eUUX1UuND/afy0+apUvpTmTQlXn87N1X/YJLfvwvc+1YF/D7ljN25wv35cf7Z+biMT/wtQIgIIIIAAAggggECmFQi97ppqypf3AoXlzKnbb6oru+j3tfa6a6r7ZnVZgYtV5H+XKWuWLCp5ZWGVK1VMWUJDVa70ldr+6y6XL2fOHPr4s2/Utf9oPT/vTS9w+N2tT2hSuUIprfGCDTt2zWoVdcgb2Th56pR2eOUWLVJQa37c4Nb19EZgWnYZ7C1v1E8btkYr9sf1P+va2lV0Xp7cLtWr+1/dLWOt6pXsRRXLldS2HWfr61ZEmVgQ9NHS5W6UJHzsDBdo2WjJ2p8269476inUa2+ZksVkKcpuzCKAAAKZRoCGIIAAAhlB4NChg4qZjh49oiNHjpyzPmY+fyxnBKP0XMfQbFmzRNbPgoszOhO5nD1b1sj5rFn+m7cL8WwR22z+5MlTLt+rb36onb//oY4tGmrSiF7eSXBMifmvXJni+tG7yF+zbqMqlSuh0iWKaqE3mlHWC3Lc/iEh3mhFZTdSYaMV86cPU8+Ojd0m3+TMmTPK4gVHvuWsUdpl67JlPVv/kJBQnfKCG1sXWxo+oGPkcT5d+Lwuzp/PZTMbN+NNYpbtreIHAQQQQAABBBBIiQD7JkEgd+48iply5gxTWFjYOetj5vPHchKqStZYBEI/++o7/bN3v44cPar3Pv5CV5UvFUu2xK2yEYvK5UurwKX5tXzlDzp56mSidrSLe9vn0y9WyIKRil4QMv/191Wh3Nm6VK1URku/XKktv+x05e3dd+Ccb68qV7q4Vq1ZLwtELH37/TqXN75JWFgOHThwMDJLtcrlNOWFBa4MW/nt6rNllPcCpJXfr7VV2rf/gDZu3ubmmSCAAAIIIIAAAggggEDSBEIbPHinOvYZqSbtB6huzcqqUaVC0kqIkvuBe27S5Bdekd0mteqHn3TB+edF2Rr/bIWyxXX+eXmUI3t2d5vUb7v+8oKhkm6nywpcok6tntTg0dNlD6I3bNlL+7wgxG2MmJQoVljX1a6mNt3C1bnvSOXPd6Hy5MkVsTX2l9tvrKPl365x9bXnTFo1fkTHjx9Xg+Y9dddjbfTmO5+4He+5/Xrt3fev2nYfqgHDp3oB1kVuPRMEEEAAAQQQQAABBBBImkDofXfdqFkTBrkHr+0hc9/ur84c5QICW85/UV7Nmxpusy61b97APS9iCzZ6seil8TYrCwJemzXa3X7Vpslj8q23wOKV50e6PHFNWjV61D0kbtsvyZ9PyxfPc7di2bKlenWquwfM504e4sqtUqmsq5/V07ZbsgDIHox/tlcb7dt/UOVKFbfVsjxWB1soWqSge3je5otdUUgjBk+TbLcAABAASURBVHRy9bWH0C/0Aib7Wl9rq9V9cO+2lk32YPyA7i313NDuGjO4i16eMUIli1/htuXJX9i9MkEgMwjQBgQQQAABBBBAINACoYE+QGqW323AWPe1wM+06St7uN6CjdQ8PsdCAAEEEEAgmQLshgACCASNQKoGICtWrXX/doj9+yG+ZP++hr+07SuDbbRj/vTheuS+W/1VLOUggAACCCCAAAIIZFoBGpbaAqkagFSvXN79OyH2b4X4kt3alNqN5ngIIIAAAggggAACCCCQNgKpGoCkTRM5amIFyIcAAggggAACCCCAQKAFCEACLUz5CCCAQMIC5EAAAQQQQCBoBAhAgqaraSgCCCCAAAIInCvAGgQQSG0BApDUFud4CCCAAAIIIIAAAggEsUBkABLEBjQdAQQQQAABBBBAAAEEUkmAACSF0Ad3b09hCeyOgCBAAAEEEEAAAQSCRoAAJIVdfX7uHOrZuRUpAAbdO7ZQtw7NsQ2ArZ2zXds3U49OLfANkG+Xdk2xDZCtf98beP+294OoqWv7pt57Q0vO3wCcvz06tZT5RvVmPnm/gym8fGP3NBYgAElhB1yQJ4d6dWlNCoCBvVFbAIJvYM6vbh2auYsMfP3vaxcUdpGBrf9tzdQCEEs2T/K/cVfvwwk7h7H1v625mi+2EbYpuHZI4eUbu6exAAFIGncAh0cAAQQQQAABBBBAIJgECEDSvrepAQIIIIAAAggggAACQSNAABI0XU1DEUDgXAHWIIAAAggggEBqCxCApLY4x0MAAQQQQAABCQMEEAhaAQKQoO16Go4AAggggAACCCAQjAJp3WYCkBT2wP6DxzR4xARSAAzCR03SsDFTsA2ArZ2zw8ZMlRnbPMm/v8NDRk7U8LHTOHcDdO4OHT1Zljhv/Xve+jyHj50qO4d9y7z6z9lczTc1TZ+f/UoKr3TYHQH/CxCApND0dFgB90ZtbyqkiX61sAuMYV4AEjhX/9Y3o9XT/giGj5rs1z7LaAaBrO+IcdOw9QKxQBjz3hDY9y4LnsO9D4AC0XfBXqa5mm9qOjw/hwAkhZd67B4AAQKQAKBSJAIIIIBAAgJsRgABBBAIWgECkKDtehqOAAIIIIAAAsEoQJsRSGsBApC07gGOjwACCCCAAAIIIIBAEAkEcQASRL1MUxFAAAEEEEAAAQQQSCcCBCDppCOoBgJBJUBjEUAAAQQQQCBoBQhAgrbraTgCCCCAQDAK0GYEEEAgrQUIQNK6Bzg+AggggAACCCCAQDAI0MYIAQKQCAheEEAAAQQQQAABBBBAIPACAQ1ARk2co8VLlgW+Fal8hCea99DuPXvdUQ/u3u5emSRBgKwIIIAAAggggAACQSsQ0ADkgbtvUtWrygYtLg1HAAEE0psA9UEAAQQQQCCtBQIagLz29kf69vt1ro0PPdNJz017Uc07DlK7HsP09+5/3Ppn2vTVll92unmbNO80SOs2bNGevfvU69nnZKMNjdv1c+tsu42otO85XK27DlH3gWO1ZdtOdR8wRk+37qOb72+mX3//w7K5kZcGLXq6/cdMnqNTp0+79TEny75Z7crxrV/5/Y/q0GuEW3xj0cd6yivX6jB9zmtuHRMEEEAAAQQQQCAZAuyCAAIRAgENQCKOEflyReGCmjK6jx6qf4vmLXjHrb+hbg199NlyN7/7n33648/dKluqmMZPm69K5Utp3pRw9encXP2HTXJ5bPLbrj81rH8HDe3bXi8teE933Xa9XpgwSG/MGaN8eS/U9p27NGv+2xo3pJvmTBqsY8dPatEHS23Xc9LV1Spo3fqfdfTYcbft46Vf66bramjrtt/0/ItvavSgzpo+tp+WfLFCy1eucXmYIIAAAggggAACCCCAQPIEUjUAuaZGZcmrZ4FLLtK2Hbu8OemWG2rrk8++cfMfLvlKt9Sr5eZXr92gj5Yul42IhI+dIQtOfKMmlSuWUe5cYS5fhbLFNf/19zV97uva+dsfyhWWU2t+3KBDh4+opzeC0rLLYG95o37asNXljznJEhqqmtUqaemXK9woyefLV6lurapas26DrrummhfQXKCwnDl1+0119cO6TTF3ZxkBBBBAAAEEEEi3AqdPn9ahQweDIh09ekRHjhxJlbam2w7PIBVL1QAkS5azhwtRqE6dOiX7L3++C3WRN2qxcfMv+vizr73Rh5q22qXhAzpqyqg+Ln268HldnD+fW589Wzb3apN7bq+n3h2bqGCBi9V78ASt3+QFGiEhqlOzstvP9p8/fZh6dmxs2WNNN3ojHnbsr1f+oIpeQJMndy6XL1vWLO7VJlmzZNEZ73+bJyGQUQWoNwIIIIBAcAmEeh+05s6dR8GQcuYMU1hYWKq0NbjOIv+39mxE4P9yk1RivbrVNW/Bu/r34CFdWfR/bt9qlctpygsLdObMGbf87eqzz5K4hSgT26fApfndCEV1bx8LQKpWKuONaKyMfLZk774D7lmRKLtFm612VTlt2rJDiz74VDddfzYAqli2lD776jv9s3e/jhw9qvc+/kJXlS8VbT8WEEAAAQQQSKQA2RBAAAEEIgTSRQByS73abvTDXiPqpVaNH9Hx48fVoHlP3fVYG735zie+TdFehz/3gm6s30Sd+4zU8RMnZWVcVuASdWr1pAaPni57EL1hy17a5wUh0XaMshAS4o2YXF1ZX3+7VrUjbhMrWqSgGjx4pzp65TZpP0B1vRGVGlUqRNmLWQQQQAABBBBAAIH0L0AN05tAQAOQTq0auoDAGv3qzFE6/7w8Niu7uJ8wvKebt8kF5+fR8sXz1LjBfbbo0oXnn6e+XZpr3tRwLXppvAb3buvWW4Bh5boFbzKoZ2t9/OZ0jRzUWX06N5Xv2ZB6dapr5viBmjt5iNu/SqWyXu64f7q0eUpLF81UzhzZ5fvvvrtu1KwJg2QPwjdp+IBvtVvOf1HeyGVmEEAAAQQQQAABBBBAIHECAQ1AEleFjJ0rT/7CGaYBVBQBBBBAAAEEEEAAgbQWCKoApN/QSWrR+dloacWqtWndBxwfAQQyvwAtRAABBBBAAIEIgaAKQAZ0b6nJI3tHS9Url4+g4AUBBBBAAAEEMp8ALUIAgfQmEFQBSHrDpz4IIIAAAggggAACCGRagTgaRgASBwyrEUAAAQQQQAABBBBAwP8CBCD+N6VEBGIKsIwAAggggAACCCAQIUAAEgHBCwIIIIBAZhSgTQgggAAC6U2AACS99Qj1QQABBBBAAAEEMoMAbUAgDgECkDhgWI0AAggggAACCCCAAAL+FyAASaFp6JE/1LNzq/gS25Lp071jC3Xr0By/ZPoldF52bd9MPTq1wDdAvl3aNcU2QLa8NwT2b07X9k2994aWnL8BOH97dGop803o/dmf2xs1fDiFVzrsjoD/BQhAUmh6QZ4c6tWlNSkABvZGbQEIvoE5v7p1aOYuMjK3b2DsEjKziwe7yEgoH9uT1z8WgFjCL3l+Cbl19T6csHM4oXxsT7q/uZpvato1epIAJIWXeuweAAECkACgUiQCCCCAAAJBLwAAAgggEIcAAUgcMKxGAAEEEEAAAQQQQCAjCqT3OhOApPceon4IIIAAAggggAACCGQiAQKQTNSZNCWmAMsIIIAAAggggAAC6U2AACS99Qj1QQABBDKDAG1AAAEEEEAgDgECkDhgErt6/8FjGjxiAikABuGjJmnYmCnYBsDWztlhY6bKjG2e5N/f4SEjJ2r42GmcuwE6d4eOnixLnLf+PW99nsPHTpWdw75lXv3nbK7mGyjT337/w12+MEEgvQsQgKSwhw4cOubeqO1NhTTRrxZ2gTHMC0Bw9a+rz9P+CIaPmuzXPvOVzetEjRg3DVsvEAvEucB7Q2DeE3x9ZcFzuPcBkG+ZV/95m6v5BsqUACSFF3XsnmoCmTgASR3DPPkLp86BOAoCCCCAAAIIIIAAAplAgAAkE3QiTUAg3QlQIQQQQAABBBBAIA4BApA4YFiNAAIIIIBARhSgzggggEB6FyAASe89RP0QQAABBBBAAAEEMoIAdUykAAFIIqHIhgACCCCAAAIIIIAAAikXSFEAcvLUKa39aXPKa0EJmUuA1iCAAAIIIIAAAgggEIdAigKQrFmyaPqc1+MomtUIIIAAAqktwPEQQAABBBBI7wIpCkCscTlyZNPGzb/YLAkBBBBAAAEEEAhWAdqNAAKJFEhxAPLbrr/0VOs+erRxFzXvNCgyJeb4B/49qIee6RRn1t179uqJZj3i3O7vDXYsO6aV++pbi3Xk6FGbJSGAAAIIIIAAAggggICfBFIcgHRo0UDPDe2ujq2eVKMn6qtRREpM/XLlClPfLs0TkzVV8vTo0FgXnH+eO9ab736io0ePu/n4Jgd3b49vM9sQQAABBBBAAAEEEEAgikCKA5BqV5VTbCnKMSJnbXTh4Uad1XPQOLXsMli/bP9VA0dMcdu3bNup7gPG6GlvNOXm+5vp19//cOt9k+07d+mJ5j20aUvsF/yLlyxT+57D1brrEDcaM2HGfN+umjzzFd31WBvZsWfM/e+ZFRt9GTN5jlp3C9enX65U+JgZ2n/gX7374ef648/d6tJvtDr0GqEps17VS6+9F628+a+/H7nMDALpRYB6IIAAAggggAAC6V0gxQHIug0/q3Ofkbr94ZYudek3Sus2bImz3Tt+/UONG96vSSN66dKLL4rM99KC93TXbdfrhQmD9MacMcqX90IpJMRL0uat29Vj0Fg926utShQrrLj++23XnxrWv4PmTgnX5i079M13a13WW+pdo0UvjdfsSUP04/ot+m71OrfeJoUKFtCEYT10/TXVbNGlO26uqwKX5teIAR01ZnAX3XnztVr4/hK37cyZM/rw0+W685a6bpkJAggggAACkkBAAAEEEEikQIoDkMGjp6twof/TxOG9XLIL+vCxM+I8/P8uL6CihS8/Z3uFssVlowrTvRGKnb/9oVxhOSXvYv/v3XvVtf8YDe/fUUW845yzY5QVFcuVVO5cYcqaNauurlrBCzZ+dluPHT8mG+no2HuELEj5+Zdf3XqbXHdNdXuJN11+2aXKny+v1m/aqq9WrFHpElfovDy5492HjQgggAACCCCAQGoKHDlyWIcOHQzCdLbNR48e0ZEjR1Kl/anZr5nxWCkOQM54QUKbpo/risIFXWrrzR8/HvezE9myZovV8Z7b66l3xyYqWOBi9R48wV3s2whIvrwXqNBlBfT1t2ti3S/qSq8qURe9+OWMTpw4qT5DJuiGule70Yxb6tXW4SP/PVyePVvWaPvEtXDXrdfqnQ8/99JS3XHLtXFlYz0CCCCAAAIIIJAmAmFhuZQ7d56gTTlzhiksLCxV2p8mHZyJDpriAOT06dPau+9AJIk95xG5kISZfw8ecrc93X5TXVWvXO5sAOLtnyVLqEYM7KjFS5brg0++9NbE/bN85Wr9vfsf9+1V7338hcqXuVL79h9QtmzZVKFsCWXTak4vAAAQAElEQVT3XpevTDiQsSOE5cyp/QcO2qxL19eprq9X/qCNm7erVrWKbl16m1AfBBBAAAEEEEAAAQTSu0CKA5BH779dDzfqEvn1u4817a4nHrwzye0e/twLurF+E/c8yXFv1MJGKnyF5Mie3Y1ezH3lHX321Xe+1ee8lihWRB37jNRTrXqrRpXyXqqgi/PnU5mSxdwD7F36jpLdTnXOjrGseOyB2zV++ovuIXTbbHWoUrGMbr2hljcwE2KrSAgggIBPgFcEEEAAAQQQSKRAigOQe2+vp5njB+jGa2u4NHP8QN192/WxHj7/RXk1b2p45Lbzz8ujV2eOcsuDerbWx29O18hBndWnc1PZsxz5812oeVPO5s+TO5denDZU19aq4vLHNrHnT+ZOHqJXnh+p1o0fjcxi5Vk5VvaA7i319GP3uG12bKuDW/AmVjerozfrteVqjRrUxQU+tmy3mv2y4zfdfWvsbbM8JAQQQAABBBBIbQGOhwACGU0gxQHIqIlzdPllBfTA3Te7ZCMMg0ZOy2gO8db3l+2/qUGLnt5IyhXuNrF4M7MRAQQQQAABBBBAAIFgEEhmG1McgNhX5MY89k8bNsdc5bflFavWqkXnZ6OlfkMnyW7Z6tSqod+OE7Uge8DeRlA6tDi3/Dz54/5a4KhlMI8AAggggAACCCCAAAJSsgOQtz9Y6p77+HnrDvfavNMg9/pky14qWqRQwGyrVy6vySN7R0t2W1XADkjBCCQsQA4EEEAAAQQQQACBRAokOwCpXKG0Gj1RXwUuye9ebd5SeN92Gty7bSIPTzYEEEAAAQRSIsC+CCCAAAIZTSDZAYg961HtqnKyB7ft1ZcuK3BJRjOgvggggAACCCCAAAJJFSA/AskUSHYA4jvesePHNXv+22rfc5i7Bct3K5ZvO68IIIAAAggggAACCCCAgE8gxQHIwOFT9Peevdq9Z5/q31FPeXKFqVTxIr7yg+GVNiKAAAIIIIAAAggggEAiBVIcgGzdtlOdWz+p3LnD3DdR2b+18evvfyby8GRDAAEEUiLAvggggAACCCCQ0QRSHIDkzp3LtfnkyVM6fOSomz9x4pR7ZYIAAggggAACmVSAZiGAAALJFEhxAJInd27tO/CvalevpKdb9/ZSHxW45CIF0389O7cSyf8G3Tu2ULcOzbEN0PnVtX0z9ejUAt8A+XZp1xTbANny3uD/99uof8O6tm/qvTe05PwNwPnbo1NLmW9Ub3/OF7ysQDBdfgV1WzN641McgIwd0lUXnn+ennmivnp2aKKWjR5W13bPZHSXRNc/b5a96tWlNSkABvZGbQEIvoE5v7p1aOYuMvD1v69dUNhFBrb+tzVTC0As2TzJ/8ZdvQ8n7BzG1v+25mq+gbIlAEn05RsZ01ggxQHIll926tDhI64ZFcuVVOkSRbVtx29umQkCgRWgdAQQQAABBBBAAIGMJpDiAKTf0EnKni1bZLuzZcuqfuGTIpeZQQABBBDIhAI0CQEEEEAAgWQKpDgAOXnqpCzo8B0/R/bssn8bxLfMKwIIIIAAAggggID/BCgJgYwukOIAJCQkRN9890Okw/KVa6KNiERuYAYBBBBAAAEEEEAAAQSCXiDFAUjvTk01auLsyH8FfeyUuerVqUkqwHIIBBBAAAEEEEAAAQQQyGgCKQ5Aypa6UvNnjNBD997i0vzpw1WmZLGM5pDs+u4/eEyDR0wgBcAgfNQkDRszBdsA2No5O2zMVJmxzSc5BahOmaUeQ0ZO1PCx0zh3A3SeDB09WZYyy/mS3toxfOxU2Tmc3uqVGvVJ9sUAOyKAQJIEUhyA2NFCQ0JUpFBBl0JCQmxV0KQDh465N2p7syZN9KuFXWAM8wIQXP3r6vO0i4zwUZP92me+snmdqBHjpmHrBWKBOBeC/b0hEKZRy7TgOdz7ACjqumCZPxzxrZ5BcxFDQxFII4EUByAL31uim+5rqrbdw126+f5mevuDpWnUHA6LAAIIIIAAAggggEBABCjUTwIpDkDmLXhX/bu11KL5413q26W55r6yyE/VS//F5MlfOP1XkhoigAACCCCAAAIIIJBOBFIcgGTNmlXXXH2VQkJCXKpTs7JCQ0PSSfOoRkAEKBQBBBBAAAEEEEAAgWQKpDgAyZIlVPbVu77jf/n198qePbtvkVcEEEAAAT8KUBQCCCCAAAIZXSDFAUj3ds9o5ITZqnnLEy7Z1/DauowOQ/0RQAABBBBAAIEoAswigICfBFIcgJQrXVyvzRqlF6cOc2nBC6NkX83rp/pRDAIIIIAAAggggAACCGQigaQHIBGNX7ZitXzpq5VrtOuvv12yeVsfkY0XBBBAAAEEEEAAAQQQQCBSINkByKtvLlZ8KfIIzCCAgN8EKAgBBBBAAAEEEMjoAskOQMaFd1N8KSPAPPRMJx3492BGqCp1RAABBBBIWwGOjgACCCDgJ4FkByB2m1V8yU/1oxgEEEAAAQQQQACBoBag8ZlNINkBSHy3X9m2jAI1a/5CNW7XT807DdLfu/9x1Q4fM0MDR0xR627hmj7nNS1eskztew5X665D9GjjLpowY77LZ5ODu7fbCwkBBBBAAAEEEEAAAQQSIZDsACS+269sWyKOnS6yXFG4oGaMG6Cbr6upeQveiazTseMn9Fx4NzVp+IBb99uuPzWsfwfNnRKuzVt26Jvv1rr1qTnhWAgggAACCCCAAAIIZHSBZAcgsTX86LHjeuu9JXqqVe/YNqfLdbWqV3L1qliupLbt2OXmbXJtrSoKDf2Px7bnzhWmrFmz6uqqFfTj+p8tGwkBBIJDgFYigEAQCBw6dFCBTIcPH9KxY8cCeoxA1j+9l3306BEdOXIkVXyD4NchoE387wo7BYfZsm2nhj/3gm5/qKXefOcT3VKvdgpKS91ds3kBhR0xJCRUp06dslmXLNBwMxGTM2ciZiJezsRcEbGeFwQQQAABBBDwp0DqlZU7dx4FMuXKlVs5cuQI6DECWf/0XnbOnGEKCwtLFd/UOysz55FCk9us4ydO6L2Pv1Djdv3Vrf8YXZw/n9fhYZo9abAevf+25BabbvdbvnK1e0bkyNGjrt3ly1yZbutKxRBAAAEEEEAAAQQQSLFAgApIdgBy16Nt9O7iz9Xi6Qf12qzRevqxe5Q1S5YAVTPtiy1RrIg69hnpbi+rUaW8alSpkPaVogYIIIAAAggggAACCGQwgWQHIE88dKf+2v2PXnhpod7/+EvZiEgGa7tenTlK55+Xx1W7aJGCmjC8p5vv0aGx6tWp7uZ9k0IFC2ju5CF65fmRat34Ud9qXoNDgFYigAACCCCAAAII+Ekg2QFIAy8AWfDCKD3+4B36fPm3uvOR1tp34F999tV3OnX6tJ+qRzEIIIAAAsEtQOsRQAABBDKbQLIDEB9EzWoVFd6nvV6aNlRPPHinRk2c7YIR3/bM8GoP1Xdq1TAzNIU2IIAAAggggAACiRMgFwIBEkhxAOKrV/6L8qrRE/X11tyx6t6+kW91pn/Nk79wpm8jDUQAAQQQQAABBBBAwF8CfgtAfBWyfzvD/g0N33ImeKUJCCCAAAIIIIAAAggg4CcBvwcgfqoXxSCAAAKSQEAAAQQQQACBzCZAAJLZepT2IIAAAggg4A8BykAAAQQCJEAAEiBYikUAAQQQQAABBBBAIDkCmX0fApDM3sO0DwEEEEAAAQQQQACBdCRAAJKOOoOqxBRgGQEEEEAAAQQQQCCzCRCA+KFHe3ZuJZL/Dbp3bKFuHZpjG6Dzq2v7ZurRqQW+AfLt0q5pxrYNkIs/3it5b/D/+23Ufunavqn33tAyKM/fXLnC/HBVQBEIIJCQAAFIQkKJ2N6rS2uR/G/Qo1NLF4Bg2zog51e3Ds3cRQa+/ve1izm7iMPW/7ZmagGIJZsn+d+4q/fhhJ3DwWibiD/5qZKFgyCQ2QUIQFLYw3mz7E1hCeyOAAIIIIAAAggggEDwCKTjACR4OoGWIoAAAggggAACCCAQLAIEIMHS07QTgaQIkBcBBBBAAAEEEAiQAAFIgGApFgEEEEAAgeQIsA8CCCCQ2QUIQDJ7D9M+BBBAAAEEEEAAgcQIkCeVBAhAUgi9/+AxDR4xgRQAg/BRkzRszBRsA2Br5+ywMVNlxjZP8u/v8JCREzV87DTO3QCdu0NHT5Ylzlv/nrfmOWn63BT+VWR3BBBAIGEBApCEjeLNceDQMdnFRqZK3sVTemiPXWAM8wKQ9FCXzFiH4WMtAJnM+Rug833EuGnYBsiW94aJATu3Js+YF+/fPDYigAAC/hAgAPGHImUggAACfhKgGAQQQAABBDK7AAFIZu9h2ocAAggggAACiREgDwIIpJIAAUgKofPkL5zCEtgdAQQQQAABBBBAAIHgETg3AAmettNSBBBAAAEEEEAAAQQQSGUBApBUBudwCMQnwDYEEEAAAQQQQCCzCxCAZPYepn0IIIAAAokRIA8CCCCAQCoJEICkEjSHQQABBBBAAAEEEIhNgHXBJkAAEmw9TnsRQAABBBBAAAEEEEhDgQwdgBz496AeeqZTgnyWx/LGzPjF8lXasm1nzNUJLnfoNUIbN/+SYL6kZiA/AggggAACCCCAAAKZXSBDByC5coWpb5fmye6j5SvX6JftvyV7f3ZEAIFMI0BDEEAAAQQQQCCVBFwAcujwEQ0aOU3NOg7Uzfc304effuUOb69Pt+6jR5t0VaO2/dy6P/7arU59RuipVr3Vqstgbfnl7AjC4iXL1L7ncLXuOkTdB47Vnr371OvZ5/RE8x5q3K6f1m3Y4vaPbWL7bdqy3W1q0KKnps993c1PnbVAb7zzsZu38m2blTdm8hydOn1ah716DxwxxW23yez5b+vBpzupdbdwd+yXXnvPVrs0a/5CV4/mnQbp793/aPPW7fpi+Xd63juWrdu+c1ecdT52/Lj6DZ3k2tKx93AdPHTYlckEAQQQQAABBFIqwP4IIBBsAi4AWfrlSuW98DxNHd1X7706SVUrlZVdkI+ZPE+DerbW/OnD1SdipGH8tJdUukQxzZr4rG678RqFj30+0uy3XX9qWP8OGtq3vcZPm69K5Utp3pRw9encXP2HTYrMF3OmQtkSWr12g7uwz5E9u9au2+yy/LBukyqVK+3qMssLLsYN6aY5kwbr2PGTWvTBUpfHN7GA4q33lmjm+IEK79NW6zdFv0XqisIFNWPcAN18XU3NW/COihctrDo1q6hRg/s1ZVQfFS70f3HWeeF7n+rAv4fcsRt7+X9cf7Z+duyDu88GTjZPQgABBBBAAAEEEEAgwwikUUVD7bglriysr1as1rTZC7xRgVXKl/cCrflxg66/ppouv+xSy6Ii3gW6zfzw02Y9cM9NNqs7bq6rbTt+08mTJ91y5YpllDtXmJu3gOKjpctlowvhY2do9z/73MiD2xhjUrlCKa3xgg0LOGpWqygbkTl56pR2/LpLRYsUlNXF1vX0RlRaeqMua37cK+dXtQAAEABJREFUqJ82bI1Wyo/rf9a1tavovDy5XapXt3q07bWqV3LLFcuV9Oq8y83HnMRV57Vem++9o55CQ0NVpmQxl2LuyzICCCCAAAIZXeDMmTM6duyYDh8+pEOHDpL8bGCu5ottYM6to0eP6MiRI6ly3mb03/W0rr8LQGw0YNqYfirljWy8+tZivfzGB7I3oWzZssRav2xZs7r1ISEhCgnxkndhbiuyZ8tmL5Fp+ICObnTBRhg+Xfi8Ls6fL3Jb1JlyZYrrR+8if826jd6IRwlvhKWoFnqjGWVLFTubzTtGnZqVI8uaP32YenZsfHZbxNTqmyXLf/XNmvW/ecvyX51DdcoLbmxdbCmuOmeNp+zYymFdhhKgsggggAACnkBISIhy5MihXLlyK3fuPCQ/G5ir+WIbmHMrZ84whYWFpcp56/268JMCgVDbd/+Bg8qTO5fqehf59915g2w0oVL50vr0y2/16+9/WhY3KmEzFbxg4fVFZ5/LsGdEivyvoLKEumJsc2SqVrmcprywwAUytvLb1evsJdZkF/cFLs2vT79YIQtGKpYrofmvv68K5Uq5/FUrlZHdJuZ73mTvvgPnfHtVudLFtWrNenc8C0a+/T7u47lCvUlYWA4d8NruzbqfuOpc3mvzyu/Xujz79h/Qxs3b3DwTBBBAAIGUCrA/AggggECwCbjI4dMvV6jOHU/Jbm/6bNl3evrxe9wzEa0aPayeg55zD6E3btff2bRp+pi7JcoeQl/43qfq3v4Ztz7mpFXjR3T8+HE1aN5Tdz3WRm++80nMLNGWK5QtrvPPyyN7BqRiuZL6bddfuqp8SZfnsgKXqFOrJzV49HTZg+gNW/bSPi8IcRsjJiWKFdZ1taupTbdwde47UvnzXag8eXJFbI395fYb62j5t2tcu+2Zl7jqfM/t12vvvn/VtvtQDRg+VQUuvSj2AlmLAAIIIIAAAghkFAHqiUAaCbgA5N7b6+mLd2dp0oheerZXaxUrUshV55Z6tTVn8mD3ELrd9mQrC1ySX6MGddGsic9qopc/at5OrRpaFpcuPP889xW586aGa9FL4zW4d1u3Pq5Jq0aPuofEbfsl+fNp+eJ57lYsW7ZUr05194D53MlDXHlVKpV1AcurM0fZZpfs2ZQJw3t6bWijffsPqlyp4m695bHgxhaKFikoy2Pzxa4opBEDOrl220PocdXZgqIB3VvquaHdNWZwF708Y4RKFr/CiiAhgAACCCCAAAIIIIBAEgRcAJKE/Ok6a7cBY90/TPhMm7667ppq7gH2RFSYLAgggAACCCCAAAIIIJBKAqkagKxYtVYtOj8bLdm/r+Gvtk4Y1kM22mFfG/zIfbf6q1jKQQCBgAlQMAIIIIAAAggEm0CqBiDVK5fX5JG9oyW7tSnY0GkvAggggAACaS5ABRBAAIE0EkjVACSN2hjQw+bJXzig5VM4AggggAACCCCAQOYSCPbWEIAE+xlA+xFAAAEEEEAAAQQQSEUBApBUxOZQMQVYRgABBBBAAAEEEAg2AQKQYOtx2osAAgiYAAkBBBBAAIE0EiAASSN4DosAAggggAACwSlAqxEIdgECkGA/A2g/AggggAACCCCAAAKpKJCGAUgqtjLAh+rZuZVI/jfo3rGFunVojm2Azq+u7ZupR6cW+AbIt0u7ptgGyJb3Bv+/3/r+hrVo/ESA/2JSPAIIICARgPjhLOjVpbVI/jfo0amlC0Cwbe3/88s7Z7t1aOYFIC0DUnaw95ldzHVt3xRb7zwLxLlgAYilQJQd7GW2bNLAD38VKQIBBBCIX4AAJH4ftiKAAAIIIOBXAQpDAAEEgl2AACSFZ0DeLHtTWAK7I4AAAggggAACCKSCAIdIJwIEIOmkI6gGAggggAACCCCAAALBIEAAEgy9HLONLCOAAAIIIIAAAgggkEYCBCBpBM9hEUAgOAVoNQIIIIAAAsEuQACSwjNg/8FjGjxiAikABuGjJmnYmCnYBsDWztlhY6bKjG2e5N/f4SEjJ2r42Gnu3H3rnQ9T+C7D7ggg4CcBikEAgXQiQACSwo44cOiY7GKDNNHvDkNHT3YBCLb+tzXT4WMtAJns936zskkTNWLcNGe78N0PU/guw+4IIIAAAghkdIHo9ScAie7BEgIIIIAAAggggAACCARQgAAkgLgUjUBMAZYRQAABBBBAAIFgFyAACfYzgPYjgAACwSFAKxFAAAEE0okAAUgKOyJP/sIpLIHdEUAAAQQQQACBzCxA2xCILkAAEt2DJQQQQAABBBBAAAEEEAigAAFIAHFjFs0yAggggAACCCCAAALBLkAAEuxnAO1HIDgEaCUCCCCAAAIIpBMBApB00hFUAwEEEEAAgcwpQKsQQACB6AKpFoA80byHdu/ZG/3o8Syt27BFnfuOjCeHtOSLFQofM8Pl+WL5Km3ZttPN+3vijjP2eVfs/gMH1XvwBDXvNChgx3MHYoIAAggggAACCCCAQEoE0um+qRaABKL9V5UvpUfvv90VvXzlGv2y/Tc3H8jJ58u/1aWX5NOUUX1UrEihQB6KshFAAAEEEEAAAQQQyHQCoYNHT1ebbuG669HWWrFqrfoPm6zHmnbTsHEzXWOXfbNa3QeOdfM2Wfn9j+rQa4TN6vsf1qtJ+wF6smUv9RkyQf8ePOTWJzRZvGSZGrToKRsVGTN5jk6dPu12sSDi8abdXZnvLP7MrbPJH3/tVqc+I/RUq95q1WWwtvxydqTj+7UbNP/197R563Z9sfw7PT/3dTcysX3nLtstWjrtHaN+g/Zu3cFDh1Xr1gb6bvU6t9y84yBt8/aJ6zgukzf5aeMWzXl5kZZ8vsKZeav4yRgC1BIBBBBAAAEEEEAgnQiEnj59RuPCu6lnxybqMXCcGjx0p+ZOCdfO3//Uj+s36+pqFbRu/c86euy4q/LHS7/WTdfV0MlTp9Q3fKJaPPOQZk8arCxZsmjuK4tcnvgmFhzMmv+2xg3ppjnefseOn9SiD5a68gaPmq4eHRpp2pi++nvPP5HFjJ/2kkqXKKZZE5/VbTdeo/CI26F8GYoXLaw6NauoUYP73chE4UL/59sU+RoaGqpCBQu426ZWr92oCmVKaM26ze64v+36U0W8fRI6TpmSxfRw/Vu8OtTW+GE9IstmBgEEEEAgLgHWI4AAAgggEF0gtEaVcrKL83Klr1Se3LlU7IpCyhIaqlLFi+iXHb+5+ZrVKmnplyvcSMXny1epbq2q+u33v3TeeblVuUJpV+JD996sH7wLercQz2TNjxt06PAR9Xz2ObX0RjPW/LhRP23Y6sq7KN8FKle6uEJCQlT/zhsjS/nhp8164J6b3PIdN9fVNq9eJ0+edMtJmVQsV1JrvOBjzboNavDwXbJjr9vws8qVudIVk5zjHNy93e3LBAEEEIhNwN6rDh06KJL/DI4cOayjR49gGqDz6tixYzp8+BC+AfA1V/NNtfeDALQhPdfd3heOHEmd94bY3u9Zl3iB0KxZs7rcFoRky3Z23lZkCQ3VyZOnbFY3eiMeH3/2tb5e+YMqli3uAhXbkC1iX5u3cs7ojM3Gn7zgok7Nym6kwp6jmD99mDf60tjtY6MobsabZPVGVLyXyB/fsUJCQlyAEuLVL3JjImcqlSuh1V7As3bdz6pRtbwXCB3W6h82qlK50pEl+OM4kYUxgwACQS9g7425c+cRyX8GYWG5lDNnGKYBOq9y5MihXLly4xsAX3M1X94P/Pd+ENXS3hfCwlLnvSHo/7ilECA0MftXu6qcNm3ZoUUffKqbrq/pdil42SU68O8hrVm30S0vWPihKpUv6ebjm1StVMYbTVkZ+RzH3n0H3G1RVt4/e/fLlm1/ex7FXi1VKFNcry/62Gb14adfqcj/CrqRGbciYhIWlkMHDhyMWIr2ErlQzitnrTeaEpolVBbg2K1bixYvjax3Yo4j/kMAAQQQQAABBBBAAIFkCyQqAAkJCVGdqyvr62/XqnaNyu5gdgHft0szTZj+snsI/ejRY2rw0F1uW3yTywpcok6tnpQ9/G4Pojds2Uv7vCDEyrPnP+wh+HY9hkUGKFZWm6aPac2PG2QPoS9871N1b/+MrY6Wbr+xjpZ/u8bd1mXPmUTbGLGQI3t22W1eZUsVdWsqlC2hPV7QU7zo/9xyYo7jMjJBAIFECpANAQQQQAABBBCILhBar051tyZ3rjC9Nmu0m7dJi2ceVv07brBZl7q0eUpLF81UzhzZ5fvvqgqlNX1sP/cQ+qCerSNvzfJtj/o6b0q48l+U162yY84cP1BzJw/RopfGq0qlsm59jSoVZA/EWxo7pJtGDuzs1he4JL9GDeqiWROf1cQRvVQs4utvrZweHRq7PPbsyogBnTTJ2x7bQ+gukzeZMW6AWjV61JuT7IH2Txc+756BsRXxHqd9I8uiB+6+WU2ffNDNM0EAAQQQQCDdClAxBBBAIJ0KJGoEJJ3WnWohgAACCCCAAAIIIJDuBKhQ/AJ+D0D6DZ2kFp2fjZaiPs8Rf3X8s/XFBe9GO77Vx9b5p3RKQQABBBBAAAEEEEAAgeQK+D0AGdC9pSaP7B0tVa9cPrn1S9Z+jz94R7TjW31snfgvlQU4HAIIIIAAAggggAAC0QX8HoBEL54lBBBAAIE0EeCgCCCAAAIIpFMBApAUdkye/IVTWAK7I4AAAggggEBmEqAtCCAQvwABSPw+bEUAAQQQQAABBBBAAAE/CgQwAPFjLSkKAQQQQAABBBBAAAEEMoUAAUim6EYagUAMARYRQAABBBBAAIF0KkAAkk47hmohgAACCGRMAWqNAAIIIBC/AAFI/D6J2tqzcyuR/G/QvWMLdevQHNsAnV9d2zdTj04t8A2Qb5d2TZ3tPXfcnKj3ETIhgAACCKRYgAIyiAABiB86qleX1iL536BHp5YuAMG2dUDOr24dmnkBSMuAlB3sfWYfSHRt39TZ3nsnAYgf3mYpAgEEEEAgEwkQgGSizoxsCjMIIIAAAggggAACCKRTAQKQdNoxVAsBBDKmALVGAAEEEEAAgfgFCEDi90lw6/LF83TixHFSAAzOnDmt0NAQbANga+dslixZdPr0aXwD4Hvy5Ally5YN2wDY2rkrnVFIiPANkG/WrFl16tTJjOib7utsruZr5zHJ/9dOISHeG4N35ZYatt5h+EmBAAFICvDYFQEEEEAAAQQQQAABBJImQACSNC9yI4AAAggggAACCCCAQAoECECSibd7z1617jpEz7Tpq56DxunI0aPJLIndEmO5d98Bde4zUtff00jDn3sh3aKlx4q9+tZiPdG8hxq26KXPl6+KtYqTnn9ZjzTuojsfaa2BI6bo2PHjseZjZXSBk6dOafDo6XqqVW817TBAv/7+R/QM3tKp06dVv0F71bzlCT3wVEeNn/6St5afxAis+XGjnmrdRw1a9NSMua/Hu4u9R9S7p7Emz3wl3nxs/E8gMe8N3QeMceeunb+W1m3Y8l8BzCBjCXUAABAASURBVMUpkJi/a7bzP3v3R/5tu/7uZ7Ruw8+2mpSAQGLeG2Keu3XvfMrddpxA0WxOJQECkGRCj5v6oq6uWlEzxw/U+eefpxcXvJfMktgtsZa331xXTRrcD1gSBLbv3KU5Ly/S1NF9Nbx/Bw0eNU1Hj50bXFQsX0ovzxihOZMHy/4gvvnOkiQcJXizLvpgqee1T7MmPqsH7r5JQ8fOPAcjNCREk0f1lj0vNmpQF61as14rVq09Jx8rogucOXNGfcMnqmubp/TChEFa8sUKff/D+uiZoiyNmjhHlSuWkkLEf4kQSOx7gxU1aUQvd/7aOVy2VDFbRUpAILF/1/oPm6yLLsqrN2aP0RtzxuryywokUDKbE/veMLRfh8jztl/X5rqmxlUKDeWyN72cQfREMnti2TerdcfNddzed9xUR19+872bZ5J0gcRY5r3wfNWrU11hYTmSfoAg3uPLr1fp2tpVlTtXmApcml+lil+hlat+VMz/alev5Fbly3uBKnnByF+797hlJvELLPv6e93u/f5brnp1a2jdxi06dPiILUamkJAQFbgkv1u+KN8F7tW7tnavTOIW2PjzNuXyztsyJYspa5Ysuvn6WvrCO59j28M+DQ3z3hvKlipuz6fHloV1MQQS+94QYzcWEymQmL9rf/69Rzbi0bFlA+X1/sZZuuD8PIk8QnrLlnr1Scp7g69WH3zylfceUtu3yGs6ECAASUYn2AWGd03h3jBs90IFL9Xfu/+xWVISBbBMIlgSs/+95x9dVuDiyL0uv+xS/RVPcHHk6FG9s/gzVa9cLnIfZuIW+HvPXhX8v0tdBrtItkDjr79jfy+ofVtD3XRfU9W5urJqVCnv9mESt8CfnmPBKOeuvc/++de5gfHJkyc1fvp8tWnyaNyFseUcgb+T8N7Qqc8o3fZgC42cMFsnTpw8pyxWRBdI7N+133f9pUsuzqcOvUbohnsbu9tf7T04emksxRRI7HuDb7/9Bw5qw+atuubqsx+0+dbzmrYCBCDJ9I86jBcScpYxmUUF/W5YBvYUCIky5BwSEvf9KTas3XvweDfSZLcXBrZWmaf0kJD/TO12q7hatuz9OVrwwkj98NMmfbVidVzZWB9FICT0P1sp9vdZu/31vrtu0Pnn8clxFLpEzYYk4r2hY6sntWThDA3r38G7iPtFc199R/yXsEBi/q7Z82E7fv1DjRvcp7fmjVPOHDk0D9+Ecb0ciXlv8LK5n8VLlqluzaqyrz92K5ikC4HY39HTRdXSbyXsdpZTp07r+IkTrpJ79u7TxfnzuXkmSRPAMmleSc198UX5tG/f/sjd/vHO1UvyXxS5HHXGHvK1W7RaNnok6uqMMp8m9bz4orz6Z28U330H3CeacVXG7u++qnxprV67Ia4srI8QuNT7ZHjvvn8jluQ579Oll5x77trtr4NGTHUPSk+bvUBzXlmksVPmRu7HTOwCiX1vuCTib1uFsiXU4KE7tX4TD6HHLvrf2sT+XcvvvT/nz3ehKlcorfPy5FaNqhW0acv2/wpiLlaBxL43+HZevOQr3VKvpm+R13QiQACSzI6oVb2SPl663O394adf6ZoaDO05jGRM4rL846/d2rbj92SUyC4+gWuuruzum7dvtbIL5Z82bvX+yJ29/efnrTtkwbPlfeXNxdq9Z5+aNHzAFkmJFKjl/d5//Nk3Lvc3361V0cIF3fM2dgvGj+s3u/V2n/cff+528wcPHXYPoJe88gq3zCRugZJXFvHOyb3a+dsfsk+KP/Gc7Xy2PaK+N0wf2y/yQdOmTz6ohg/fpfbNG1g2UjwCZmnP1MT23mAP+/tutbJz1oqxW90sf+kSsT2EbjlIUQXi+rsW9b2hSKH/U65cObVl206363erf1QJ77x3C0ziFIjvvSHq3zUrwN4//t6zV5UrlrFFUjoSIABJZme0b/64Fi3+3H0N746du/T4g3cksyR2i8tyyecrNP+N9x3QyVOn3Cec9hW8b777iZvfuPkXt41J3AKFvT9w9e+4QY3a9lP7nsPVoWVDZc+Wze0w1fu0+Nvv18ls7RPjtz9Y6lztqzYHjZzm8jCJX+Du265XaGiI+xre5+e9oW7tGrkdfvUumgeNnOrmT3gjpW26hztbewbkwgvPV7261d02JnELhISEaED3luozZILzrXJVGdknxbZH1PcGWyYlXSC+94au/cdo/4F/XaH3P9nRnbv2ag9IN3zkLreeSfwCcf1di/reYCUM7NFKA4dPkX1N+tGjJ7xRJnzNJb4UEhL3e4Pv75pv/w+WLNNN19ZQSEiIb1Xme82gLQrNoPVO82rnvyivJo/sLfsa3iF92iksZ840r1NGrUBclo89cLt6tD97QWcP+NpXQEZNJYvzKXJi+vyhe2/RvCnh7it2r61VJXKXEQM6ecPStd03DEV1tfk+nZtG5mMmbgE7L3t1bCL7Gt5pY/rpf5ef/QpNOzdfeX6k29Fuu1rwwqjIT+kH92rDH0Mnk/CkYrmSznbu5CHRvoI76ntD1FKefuwetXjm4airmI9HIK73ho/emCZ7X7ZdF782xZ27C198Tm2aPObeL2w9KX4B84vtGiHqe4OVULxoYc2eNNi9P/fs2Fg5c2S31aQEBOJ6b/D9XfPtbl/d36bp475FXtORAAFIOuoMqpJsAXZEAAEEEEAAAQQQyCACBCAZpKOoJgIIIJA+BagVAggggAACSRMgAEmaF7kRQAABBBBAAIH0IUAtEMigAgQgGbTjqDYCCCCAAAIIIIAAAhlRIDMEIBnRnTojgAACCCCAAAIIIBCUAgQgQdntNBoBfwlQDgIIIIAAAgggkDQBApCkeZEbAQQQQACB9CFALRBAAIEMKkAAkkE7jmojgAACCCCAAAIIpI0AR02ZAAFIyvzYGwEEEEAAAQQQQAABBJIgQACSBCyyxhRgGQEEEEAAAQQQQACBpAkQgCTNi9wIIIBA+hCgFggggAACCGRQAQKQDNpxVBsBBBBAAAEE0kaAoyKAQMoECEBS5sfeCCCAAAIIIIAAAgggkASBFAQgSTgKWRFAAAEEEEAAAQQQQAABT4AAxEPgB4EMJ0CFEUAAAQQQQACBDCpAAJJBO45qI4AAAgikjQBHRQABBBBImQABSMr82BsBBBBAAAEEEEAgdQQ4SiYRIADJJB1JMxBAAAEEEEAAAQQQyAgCBCAZoZdi1pFlBBBAAAEEEEAAAQQyqAABSAbtOKqNAAJpI8BREUAAAQQQQCBlAgQgKfNjbwQQQAABBBBIHQGOggACmUSAACSTdCTNQAABBBBAAAEEEEAgMAL+LZUAxL+elIYAAggggAACCCCAAALxCBCAxIPDJgRiCrAcXaD7gDGqecsT+vX3PyI32Lyts22RKwM4c/LUKY2bOk9PNOuhJ5r30G0PttDriz5yR1z5/Y9q3mmQm89ok+9Wr9M3362NrPYP6zbpmTZ9I5czw8z0ua/r9OnTkU2xvrI+i1zh55l2PYZp2TerXalR590KP012/fm3Fr63JFppgTpWtIOwgAACCGQgAQKQDNRZVBWBdCcQEqLiRQvr3Q+/iKyazV9Z9H+St02p8N8HH3/pXVR+r7FDumrelHC9+sJIFS18eSocObCH+H7tRq1a81PkQYoWuVxd2jwVuZwZZma9tFCnz5xJbFMyRL4//tytd6L8PlilWzV+RGVLF7NZEgIIIICAJ0AA4iHwgwACyRe49cZr9MEny3TGu5C0ZPM3X18rWoGvvrVYDVr0dKnnoHHas3ef277qh/W694l2atiil0vLV65x623S3Bu5GDlhtlp1Gey2LVj4oa0+J/21e69Klyim/BflddvOy5NbV1Uo7eZtcvTYcdkxn2rVW627heuv3f/Yav2zd7+rz2NNu+nhRp0179V33XqbTJu9QD0GjVXrrkPUuF1/2SiLjeqMn/aimnYYoEcbd9FHS5dbVpdWrFqrZh0H6smWvdzrTxu3uPUxJ9am4c+94ModNGJqnHX4Zftvevejz7V4yVduBMfavnXbrxoxflZkkZ8t+9arWz891bqP7BN22ydyY5SZl9/4QLc91FLWzvY9h2nnb/+NVtloQ/OOg/S0V8ZN9zXVl19/7/a0tk56/mW17T5U819/X1u3/+qOYYY2CuPLd+LESY2dMlctOj+r+xp2cHW1AmwUoPfgCc7ilgeaa/LMV2x1tDRhxnzZ6EfrLkPcftZPluGzZd+5Pr//yY6ydts6S1ZvG1WzkS47l973Ak9bHzPFd07FzOtbjqt9tj0uI2vfXY+21iPeuTB49HQdOXrUsmui57Z1207XpiGjZ5xdN+NlrVt/9pyI71jmPnXWAlmfNGk/QKvXbnD7x5xYnTr1GeFGxG6s30SfffWdtu343Z2Xltd+D6+/p5HmvLzIFt252mvweDcf37ka1zY7np1nXfqNUqO2/WR12/jzNlcek2ARoJ0I+FeAAMS/npSGQNAJnJcnTMWL/U92kWKp5JWFlSd3mLyIxFksW7HaXUiPH9ZDcycPUaXypTR83Ey37fLLLtWsSc9qzuTB6t+tpYaMmaFDh4+4bTaxC9TnvP1s+xuLPooMHmybL91967Xa4l3w2YXxYO9C8NMvV7oLW9/27Tt/V9OnHtKsic+qSsUymvniW25TWFgODendVi9NG6YZ4wZoyRffyC5e3UZvYhd0w/p38Lb1V9YsWbw1UuFCl2namH56bmgPjZ44xwVSFkw9O2q6urR+SrMnDVbHlg3VY+A4F7S4nWJMjhw95u3fXX26NFNcdbiicEHdcVNd3VKvlqaM6qMH77k5Wim79+xV/+GT3bFmTRjkTAeOmBItj2+heuXyWvTSc66dN3vlhY993m2yenftP0YNHrlLL3hlvDZrtEqVuMJts4n1zXNDu+vR+29THy+YqFG1gjNs1+xx9QmfoL37DugrL2Dc9cffmjyyt96YM8brwxa2q1558wOVK32lpo7uq/dfnaT7777JrY86ad34UYWGhmrCiJ6ujTlzZHebT506Jevz58cP8C6g347s835DJ6lu7aqaNzVc4716zZr/ljb+fO5FsNU7vnPKHSTGJK72xWfU0HNbNH+CV5+h7vyYt+BsANuq0SMqWqSQa1PPjo1jHElxWvoyWt9PGd1HQ/u109BxZ/vKt833OmH6fDV/+iHNHD9Q77w8URXLFleR/12m/f8e0u5/9mndhp9VttSV+i5iBO3b1T+paqUy7nyN61y1tsa1zY67ZesOtXzmET3/3AA9+cjdGjRyqq0mIYAAAskSCE3WXkG6E81GAIHYBe64+Vq9//EyvffRl7rNu3COmuvrlT9o3/5/1X3AWNkIwIeffqUffvrZZbGLzkUffKau/Udr+PiZOnLkqH6N8gl93VqVlSX07NvUJRfn1y/bf3X7RZ3YyMcc78K/a9unle/C8zVywiz1GTIhMkvRwperSKH/c8tVKpbWVi9YsYWcOXLo+7UbNGD4FHXwZ3vSAAAL1ElEQVTpN9pdUG/Y9IttcqlWtYrKncsLpNzS2Um9ujXczMX583kX60W1dt3PWvPjJh31goqRE2e79o2ZPFf7DxzUjl93ubwxJzd4ZdiFt61PqA6WJ7a0Zt1md4FZpmQxt/nxB293F+NRgze3wZuEZgnVjHlvuBGMt99fqk0/b/PWytW7VPErVLt6Jbd8wfl5lD/fhW7eJrfcUNteXFt2/v6HHrr3ZrdcsVxJlShWWGvX/6ziRQtpqzdaY6MlNlKSMyKIKF+6hBvBsZGk9z/+UhdFKdcVEs/kmppn+/zC889zF/LW5wf+Paj1m7bK6t/cGxnr7gV4hw4dlT0XE7Moq8OieM6pmPmtr+Jq3xqvb+MysjqNnjRb7boP1dqfNmvj5v/OnZjH8C3HdyxfnhuuvdrNXpT3Qu36Y3esgWxl7zy2USV7hmbtT5t04QXnu30s2Pz2+x+1YtU63X7TNfrz77P726181a4q6/o8rnPV2hrXNiu8iBcUX+Elm7/m6qu839M/5Ru1snUkBBBAICkCZ/+yJ2UP8iKAAAI+AXfblVS7RiXv4majuyC0ed9mew0JOeN9ml/HfSJsn+bbaIN9Km7bxkyep4MHD6lDiwbuU/QCl+TXYS8IsW2WsmQ5O/IgyX1afvLkaVt9Tgr1ghS7UGzxzMOaOLyXN5qxQgcPHXb5smXL6l5tYuWdPHnKZvXOh59pyeffqMFDd2nC8J665urKinrsHBEX0y5zPJOQkBCVvLJIZPusjUsXzYzzOZQcObJFlpZQHSIzxpzx3LNm+e/tO1vWrAr16hEzmy137DXcCxiKqH+3Fhrujegc8YIlW28pe7Zs9hJrypE9u1t/RmdcEJg1Sl/Y8c54dbiswCVuZKVGlfL646/datJ+gOy2rBuuraEJw3p6QVoxffL517LbzVxhiZhkj9JfoV6/Wp9bv2X12jhpRK9I53dennDOyJAVn9A5ZXmipvjaZ/myx2K0fecuPTtymjdCVVujnu2iZ56or6NHj1v2eFNCx7Kds4T+16+hWUJlI0K2Pmpq1+wJN/p1+f9d6o3EzdbbHyx1my3IsNGO71avkwUjFcqU1Gdffuv65PLLCigkJO5zNSQk7m2u8FgmJ0+ejGUtqxBAAIGEBf57p0s4LzkQQACBWAXs4tRuPbFk81Ez1fI+YX/zvSXeJ+VnRy+OnzgReavTth2/qaY30vB/l16sX7x5S1H3Tcz8ug1b9Psff0VmtU97beQiLCxn5LrYZrZ5n9yXL1PC+5S9oE56QcnylatjyxZtnT1PYSvs02775Ll82StVyRsRsFuBPvnsG9vk0vKVa9xrQpP46pAndy7t80ZSYiujYrkSsnZviPjUff7r76uEFwRZu6PmP3L0qPbuP+AFV1cprzc69PFnX0dutjI2/vyLotb1Xy8YjMwQMWMjERZo+L5ZbK33af+mLdtVoUxxNzqSzQsYqlQqq5aNHnYjXXYrj33SbyMqdb3RjGcer68f12+OKC36i9XXRseirz13yfKV8kZrnpv2ouy2PMux5ZedslvRbD5qSuo5FV/74jLa6Y3SXV6wgBuFshGXT7xA1leHPHly6cC///oWo73Gd6xoGRNYMF8LKG678RrdekMdL/jf5Pao6o1yfPv9Ou33RoxsNKvqVWU0dfarquqttwzxnavxbZMk87ZbLK2cN975WIUuLyA7R22ZhAACCCRVgAAkqWLkRwCBWAXsU29LMTdeXbWiGnmfEA8cMVX2EPMdD7fS2nVnL0gbN7xf/YdNdg8xv/TaeyperHDM3RNc3rN3v1p3DXcPx97zeFv3jEffri3cp/bx7Vz/zhv1wSdfyh747T9skjdKkPCxDx854h7mtvzd2j0ju03GLuyH9msvuyizB3VvfbC53nz3k/gOHbktvjrUq1tde/ftV7sew6I9jG07221nvTs1dQ+l2wPk9nW9fTo3s03RUljOnHr8gTv0aONurpw9/+yL3G51H9ijlWbPf9v1y3V3PaNVa9ZHbo86M6hXa33+1Sr3sLrdYta3S3MX0Hzz3Q+qdWsD2cP3A4dPkQUbBbxRrMkvvKq6dz7l+tWCo06tnoxaXOR80yfv15DR02S3VSV0O8+A7i28gGO/GjTvqQef7iR7DuVUlK/w9RWanHMqrvbFZVS9Sjl3ftmXJ3TsPVx5I26BsjoULVJIlcqVkq0fEvEQuq33pbiO5duemNdmHQfIvjSgc5+R2rR1u5569G6326UXX6Ts2bOqfOnibrlGlQra+dufqlqpjFvO6wWhcZ2r8W2znS3AtS9qeLxpd3e7pZ1/tp6EAAIBFsikxYdm0nbRLAQQSAWBof066O5brzvnSPXvuEG2zbfh3tvradaEQZo18Vl99MY0PRlxwWTPH7w1b5y7/couaCyP7xus7FamaleV8xWhMYO7uFu9IldEzNin7PYAtD0cu/DF52S35tg622z7Wzk2b6lsqWLuwV2bt4eVF7wwSu6B377tNaRPOzVucJ9tUtMnH3TJLUSZtG36uLvlaP6MEbrpupqRWypXKK2JI3rJ6v/Bgika3r9j5LaoM1YXq5NvXXx1uCR/PlfOuPBu7lajCmVLRNbd9r+2dlX3QLA9QG55roi4P9+2RU3Wptdnj5bladLwAS17f07kZrtNx9pv/WK3jVmZtnH54nn2EpmKFr7c7W/Hmjl+oBtRsY03X19LX30w1z18P7h3W/fAuq3v7gVnn78zy/WrrbdRLlsfMz1w980a/WxXd1uVjSTE9Ina5zYK86wXCL04bais3+zLA+yCO2aZ8Z1TZuC7RTDqfFzts7JjM7Lbsmx/+3IEq3/n1k+62/gsf5bQUPXo0Ni1y/cQuuX1HTe+Y8V0/3Th88oRcSucle1LL3vnn/0ejRzUWYN7tVEhbzTGt+3VmaNkwbEt2yiUlXnrDdfYokvxnavxbbP+sXaY//Sx/dxth65AJggggEAyBAhAkoHGLqkuwAERQAABBBBAAAEEMokAAUgm6UiagQACgRWwT5IDe4T0Wjr1CnYBG7Wz0algd6D9CCDgPwECEP9ZUhICCCCAAAIIIOA/AUpCIJMKEIBk0o6lWQgggAACCCCAAAIIpEeBjBCApEc36oQAAggggAACCCCAAALJECAASQYauyAQPAK0FAEEEEAAAQQQ8K8AAYh/PSkNAQQQQAAB/whQCgIIIJBJBQhAMmnH0iwEEEAAAQQQQACB5AmwV2AFCEAC60vpCCCAAAIIIIAAAgggEEWAACQKBrMxBVhGAAEEEEAAAQQQQMC/AgQg/vWkNAQQQMA/ApSCAAIIIIBAJhUgAMmkHUuzEEAAAQQQQCB5AuyFAAKBFSAACawvpSOAAAIIIIAAAggggEAUgXgCkCi5mEUAAQQQQAABBBBAAAEE/CBAAOIHRIpAwO8CFIgAAggggAACCGRSAQKQTNqxNAsBBBBAIHkC7IUAAgggEFgBApDA+lI6AggggAACCCCAQOIEyBUkAgQgQdLRNBMBBBBAAAEEEEAAgfQgQACSHnohZh1YRgABBBBAAAEEEEAgkwoQgGTSjqVZCCCQPAH2QgABBBBAAIHAChCABNaX0hFAAAEEEEAgcQLkQgCBIBEgAAmSjqaZCCCAAAIIIIAAAgjELpC6awlAUteboyGAAAIIIIAAAgggENQCBCBB3f00PqYAywgggAACCCCAAAKBFSAACawvpSOAAAIIJE6AXAgggAACQSJAABIkHU0zEUAAAQQQQACB2AVYi0DqChCApK43R0MAAQQQQAABBBBAIKgFCECidD+zCCCAAAIIIIAAAgggEFgBApDA+lI6AggkToBcCCCAAAIIIBAkAgQgQdLRNBMBBBBAAIHYBViLAAIIpK4AAUjqenM0BBBAAAEEEEAAAQTOCgTplAAkSDueZiOAAAIIIIAAAgggkBYCBCBpoc4xYwqwjAACCCCAAAIIIBAkAgQgQdLRNBMBBBCIXYC1CCCAAAIIpK4AAUjqenM0BBBAAAEEEEDgrABTBIJUgAAkSDueZiOAAAIIIIAAAgggkBYC/w8AAP//af8GLAAAAAZJREFUAwAodLn5cXpzegAAAABJRU5ErkJggg=="
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAyAAAAF8CAYAAAA3o9/NAAAQAElEQVR4AezdB2AUxRrA8S+FjkpTeSKCIL13qSoiKFYsKFJUeu+hhF4DCb03kSao2BBFUAREAaUjIE26iIXeO2+/Se5IQspdkkuu/Hlv9nZnZ6f8ZgP7ZXdP/2vXrt4mYcA5wDnAOcA5wDnAOcA5wDnAOcA5kBzngL/wBwEEUkiAZhFAAAEEEEAAAd8TIADxvTlnxAgggAACCCCAAAIIpJgAAUiK0dMwAggggAACCCDgewKMGAECEM4BBBBAAAEEEEAAAQQQSDYBApBko47eENsIIIAAAggggAACCPieAAGI7805I0YAAQQQQAABBBBAIMUECEBSjJ6GEUAAAQQQ8D0BRowAAggQgHAOIIAAAggggAACCCDg/QJuM0ICELeZCjqCAAIIIIAAAggggID3CxCAeP8cM8LoAmwjgAACCCCAAAIIpJgAAUiK0dMwAggg4HsCjBgBBBBAAAECEM4BBBBAAAEEEEDA+wUYIQJuI0AA4jZTQUcQQAABBBBAAAEEEPB+Ad8LQLx/ThkhAggggAACCCCAAAJuK0AA4rZTQ8cQ8D4BRoQAAggggAACCBCAcA4ggAACCCDg/QKMEAEEEHAbAQIQt5kKOoIAAggggAACCCDgfQKMKLoAAUh0EbYRQAABBBBAAAEEEEDAZQIEIC6jpeLoAmwjgAACCCCAAAIIIEAAwjmAAAIIeL8AI0QAAQQQQMBtBAhA3GYq6AgCCCCAAAIIeJ8AI0IAgegCBCDRRdhGAAEEEEAAAQQQQAABlwkkWwDishFQMQIIIIAAAggggAACCHiMAAGIx0wVHUUgwQIciAACCCCAAAIIuI0AAYjbTAUdQQABBBDwPgFGhAACCCAQXYAAJLoI2wgggAACCCCAAAKeL8AI3FaAAMRtp4aOIYAAAggggAACCCDgfQIEIN43p9FHxDYCCCCAAAIIIIAAAm4jQADiNlNBRxBAwPsEGBECCCCAAAIIRBcgAIkuwjYCCCCAAAIIeL4AI0AAAbcVIABx26mhYwgggAACCCCAAAIIeJ5AfD0mAIlPiP0IIIAAAggggAACCCCQZAIEIElGSUUIRBdgGwEEEEAAAQQQQCC6AAFIdBG2EUAAgUgCI8e/L8+9+l6kHPdfXbd+s2R6uIRcuXLVrTs75f35Uq3Wm0718fUGrWXQ8HHxHxOtRELailaFyzc9Zd5cDkEDCCDg9QIEIF4/xQwQgeQXKFP1RXMB/OEni+5q/Nk675p9YyZ9cNe+lMhYuXqdvPVeOylQ6mmT3nynrQwbNSUluuJzbf4v+wNSsnjhJB/3I4UqyzdLV0ap11VtRWmEDQQQMAIsEIhPgAAkPiH2I4BAggRy53pYPvn8myjH/r77D9m2Y5fcny1LlPyU2vhp7QZ5tX4ryZP7ERnav6vMmDhMGjd6U06eOpNSXfKpdl9+voaMC+uXLGNOzraSZUA0ggACCHiwAAGIyyaPihHwXQE/Pz9545Xn5JcNW+TwkWN2iPkLF0ndOs9L+vTp7Hm6cvPmTRk/ZY5UeeYNyZG/ojz1/Nvy1ZLlusukCxcvyeDQ8VLzlUaSs2AlebJ2Pfn8q6Vmn22hj+b0GTxSOvUcLIXKPiPFHn9OBg4bJzdu3LAVuevz53Ub5LE8VvDRL0hee/k5qVqpnNR6uqqEDe5xV9kZsz+Sck+8JHmKPSFN2/aQv//9z15GA6tufUKkwlN1RH/7/vJbzU2gZS9grWTLXUZmz/9MXn27leQuUlWGj54qtkdu3p/zsTz5XD15uEBFqf1aY9mybad1xJ3/7957QBo06yQFS9eQfCWfklYd+8iZs+fuFIhlbfXa9THWe+ToX5I5Z0n5befuKEfOmvepaeP69etR8nVj+ao1kqtwFbvngUNHRB/z6torRHebNGzUZNF5MBvWIr5+R38s6vyFi9Kh20DJX6q6mb/gAWFmrB17DLJqu/P/mzdvxTrPevft3PkLUr9pR9O/wuVqmgOjt2V7tG7aBwtinVdH+2MaiFjoudqx+yCpVOM1076ez+OmzI7YK6J969FvuGlTzxW94/bdip/s+3VFf270Z0DP9RfrNpVNW7Zrtj1peb2TqPNRttpL5o6d/gzZCugc9B08StoHDTB39Z549i1Z+MUS0TIjxs2wztNXRJ0+mLvQdoj5jG++TCEWCCCAQBII+CdBHVSBAAII3CWQMWNGefn5Z2TOgs/MPr2oXbDwK6n3xotmO/IidMxU+erb5TKgdyf5feN30r1jS+k/dIwsXb7aFLt27ZqkSZNWRof0kW3rlkibZg0leMAI0YtiUyBi8eHHX0m50sVlzfcLZVRIL5lpXWB9tmhpxN67P7JlzSx/Hf9P9MLr7r13cg4cPCJfL10pHds0kW4dW8iaXzbJsJF3HtM6e+6cFCtSUD6ZPUHWWG1Xf6KSFWi0jBKkaG0adLzX8HXZvWm5tGpaX7NMmr9wsenvljXfSMH8eaXO2y3FFmD8+99JefnNZlKiaGFZvPB9+W7RHLnvvoxS9522cuvWLXN8bIvJMz6011uowGOm3tNnzsojOR+SZ56qLB99ujjKoQus7bdef0FSpUoVJV83Hi9XSi5eumwPjtb+utncyVr760bdbdK69VukYoUyZj0h/e7Rd7hs2LxN5k0fLSu/mS/+/v6y4se1pr7Ii48++1puXL8hoYN6mEBXL/Bt87zpp8Vy7z0Z5cMZY+TMn9vk9w3fRT40yvrW7b9b8/+PLJwzSb78aKocOHQ0yrw62p/IlY6dNFMOHflTZkwYLsf2rpMFH4yVHP97wF6kfpOOluHvMn7EAOtc/16avVdPzp49b9+vK6FjpsmrLz4ro4f1kctXrkrLjr3k9u3bukt+/PlXad91gLzb4DXRsU4ePUjWb9wmA0LGmv22xceffSMBgQESNqSnlCpZRJq16ynN2/eSf/49IX26tZfyZUqKBuv79h82hyRkvsyBLBBAAIEECBCAJACNQxBAwDGBt994STQo0Avlxd/+IA/cn030Qjby0VevXhN9H2SQFXw8bV2433fvPfLsM9XknfqvW3cMPjVFs2TOJEEdmkmRQvlE19+oU1vetfZHv4CuYV1Ua5ta5pmnqsjTT1a2Lmi3mzpiWjR4s45UrVxWHq9eR/QOhP42Wu8CXLx0KUrx69ZdlAUzx0r9ui9LyyZvS4vGb8uvG7fay1QsX1oavlVHcj2SQ3I+/JB0aPWuFC1cQJYsW2kvoytvW8HXi889LWnTpjEXyRLxp2eXVlK6ZFFzQT9sQDcrAAi03+HRIKp40QJm/Pny5pJHc+WUkP7dZOfv+6wL2ah3SiKqs3+0ad7QXm9I/yBT7xeLl5n99a2xf2xdyGtgqBl7/zhkxqT5uh09ZcyQ3gR3P1vBl+5bZwUgTd95S/QCVu8GXbEulDUoqVShlO42wZ8z/da7DfOtALV7p1ZSvmwJ0eBwYK9Od90t08qLFylgXcD3F7Xs26O91Hiykqzf9JvuciplznSf9A/uKPq4YHErgKxf9yWrnvB5daY/kRs9/vd/8mjunFK44GOSIX16qVa5vLm7pmX0kT9Nk0YPND8HalrDOkf1fNb9ttSvZ3tp17KRvG7dRQzp19UYa+Cg+0dPnGmClrdee9EYlStTQoK7tjLeut+WShYvZAXsveWl2jXM50P/e1B0rvXu3gvPVZcJI/tL1iyZZPPW8J+PxJxntjZtn3wigAAC8QkQgMQnxH4EEHBaQH9bq+mJKhUkY8b08t2Kn0XvftS3LuCjV3bw8J+iQcizES+n62M9mvoNGS0HD/1pL77g06/k+debmEecdL8+7nP0z+P2/bqSw7rI0k9buj9bZvnvxEnb5l2f6dKllY8+GC9/bFslPTq3MheOIye8L+WfrCNH//zLXj5vnlyiZW0ZuR95OEq9l6w7A/ri+pPP1ZP7Hy1rHr3R31Qfjda/ksWK2KqI8qkXv7aM1KlTWYFWfvPbeM3bf/CwfL9yjalTx61JH5/SIEnttExsKa56a9d8QlIFpjJ3dvT4uR99JpUfLysa5Oh2TEmDi3W/bjK7Vlm/ia9e7XGpVKG0/Lx2owleUlt3TvQOlBZwtt/6WJieMxq06PGa9A5I0cL5dTVK0rs5kTM08Dtx8lTkLIfWc+b4X5Ry2bJmFb0ToJnO9EfL21Kdl2rJnPmfiwazYWOny7ff/Wi/e/HH/kOigUDeR3PZisf4WaTQnTHntgJOLfRfxPj27Dsg+i1geh7YUo2XGoo++nX873+1qEl6J82sWAs/Pz/Jk/sRKVQgr7UV/v+AgAATLJ84edpkODtf5iAWCCDgbgIe0x8CEI+ZKjqKgOcJ+Pn5Sb03XpbxU2bLT+s2ypuvvXDXIPz8/Ezeuh8+E31kJnL6ZcXnZp/+pl4fX+rbo52sX/WlKde7Wzu5Fu1dBX//8LrMQfZF+KMr9s0YVvS37XrXZdiA7uYRqvPnL8hHn31jLxloXazZN6wVPz8/+0WltSnBA0bI1u07Zbz1W+W9W34w/dO7OdH7lzZdGi3uUNKLcS3o5+cn+n5KZBfbuv6GXMs4k2z16mNWDd56WT7+fLH5zfjCz78VffwqrroqWQGKzqPe9bhw4aKUKlFEKlp3f/TRq3XrN1vrpSQwMNBU4eeXtP02lUYsAgMDItbCP/z8dN7jn+fw0neWGuDc2Qpfs/mEbzm/1Hlf8c2Hoo+i/XHgkLToECxvN+lgr8jPT/tq34xxJfL55ucXXt7WLz8/Pxk5NNicY7bzwPap3/Rlq/BuIxF//7vdIteblOeZrR98IoAAAjEJ+MeUSR4CHi1A591KoH7dl2St9Vvz55550jxiFL1zeR/Nae4u/LDq7mf9bWV/2bhVKlcoIxXKlpTsD95vsrdHe4HaZCbBQt8fyJgxg1y8eNHh2vTi+4Vnn5ZihQtI5kz3mTs6O3fvc/j4yC+DX7t2XXbu2iuP5nrYHF8gX15Z88tGuXz5itl2ZhFXvVpPo3qvyfcr1sicBZ/LpcuX5VXrt/eaH1tS/xs3bsrE6XOk0uOlTbBR+fEypn9rf7UCEGuObMc62299L8XPz09+27HHVoV5x2XH73vt246upEubVm7dvuVo8RjLJaY/JYoWko6t35OpY4fIrKlh5i7I2XPn5bG8uc07JwcOHYmxTUcyCxd4TFasXudIUafKODtfTlVOYQQQQCCaAAFINBA2EUAgaQU0YDh9dKt8MDk0xor1N+Zd2zeXURPeF30H4NTpM+Zi+9Mvv5V5H39pjilWOL9s2rpDdJ8+x65lv4v2zUGmoJOLidPmWndn5og+l69JH5vq3neY6KMsT1Wr6HBtxYoUkNVr1ptviNJHWlp16iN6weloBaFjpspma3z/nTglPfqFWnckbsjrr9Q2hzdu+Lr5bNa+p/xmBV36Ps2uPX+Yb/iKr4246tVK9SJbH6PqPWiUvPrys+adBc2PLek7C2VLFTOP01WuUNYU00eu/jhw2DyCValCKTGZyS9zEgAAEABJREFU1sLZft9jBX36/s7QERNFX6pWx75DRou+X2JV59T/9ZG5nbscDwBjqjyh/dFzatkPP5lvnNJvnVr983oTNGtgq9+yVqViWWnVsY/5hrgLFy+ZL1LQb6gSB/90ad/U/DdOQkZOkkOH/xQ9H/S81TuEDlYRYzFn5yvGSshEAAEEHBQgAHEQimIIIOA6gc5tG4s+XqUvwhar8JxUrVXXBB8ZIr6uV184f77Wk/L0Cw1E38/Q34p3atMk0R3SIOPEyZPSP2Ss1HuvvXTsPkj++fekLPpomuj7K442MLRfkLkQ1K9erfbsm1IgXx6p/oTjAUznNk2lftNOUrRCLdm9d798MX+KZLrvXtO83lFZ9sVsSZ8unTRs1llyF6kqnXsOkf0Hj0iqiMedTMEYFnHVayv+1usvmoCvnvVpy4vrU4MMfWdH73xoubRp04heVAcGBJqX1DVPU0L6PWxgd9EAp37TjlKwTA0rELsuNatXlfvuyahVOpzatXhHJk6bI/qOhO1reB0+OFLBhPTn5q1b0rZLX8maq7RJ3yxbIdPHh4ifn5+pec60kVLcukPSpnNf87XLTdv0MOeO2enAomL50rL4kxmiL91Xf6G+FCrzjIwcP0OuXbvqwNGxF0nIfMVeG3tSSIBmEfAYAQIQj5kqOoqA5wjo14PqIyix9Xjb2iXmERXbfj8/P9EgY/lXc81Xl25c/ZV8uWCq1Hmxlini7+8vfbq3ly1rvjZp5qTh0q1jc1n5zXyzXxefzptkyui6Lek7HbOnjrRt3vWp31Q0oFcn+WHxPPlzzzpT96wpYeabi2yFu7RrIt9+/oFt03y+/HwN2f/bj2ZdFw/cn1VmTBgm61ctMl/72r1TC/M1sEP6dtXdJp04tEn0G4/MRrTFk1UryK6N38s/+zfIks9mmncrIhfRl6ynjRsq6nZk1xrTn9lTR8T4DVF6nF6k6nsB+l5LXPVq2UNH/jJf/auPV+l2fEnnQevW9z9sZXWuju1dZx7JsuXpZ3z91m8UW73sYy1qkt51mDhqoOzbulLUS+dPX7p+NOJFbC3kyDw/V/MJObp7rXlPwvY1vNHbcmReHemP9ilyat/yHdN/NdK04cevRO982Mrohb5+E5X+jOj+Qzt/sr8bZZs3Deps5fX9JC0X+QsFtD4NUg9s/1H2bPlBvvp4epRzPyYjDVr0vLTVq5/689O2RSNdNSm++TKFWCCAAAJJIOB9AUgSoFAFAggg4AsCJ0+dkekfLJAmjd5wi+Fu3rpDPvxkkeijaPqiu/6H9E6eOi114nk3xVWdd7f+uGqc1IsAAggktwABSHKL0x4CXizA0DxHoFXHPlLuiZfl1ZdryXsN3CMASZcuneg3puUr+ZQ8W6eRHPvrH/l8/hTR/zZMSsi6W39SwoA2EUAAAVcIEIC4QpU6EUAAAQcEYnrkxoHDkqTI5DGDRB/h0fdX9IsAkqTSRFZSqEBe0a9e1keO9BG3z+dPNt8slshqE3y4u/UnnoGwGwEEEPAYAQIQj5kqOooAAggggAACCCDgfgL0yFkBAhBnxSiPAAIIIIAAAggggAACCRYgAEkwHQdGF2AbAQQQQAABBBBAAIH4BAhA4hNiPwIIIOD+AvQQAQQQQAABjxEgAPGYqaKjCCCAAAIIIOB+AvQIAQScFSAAcVaM8ggggAACCCCAAAIIIJBggSQLQBLcAw5EAAEEEEAAAQQQQAABnxEgAPGZqWagXizA0BBAAAEEEEAAAY8RIADxmKmiowgggAAC7idAjxBAAAEEnBUgAHFWjPIIIIAAAggggAACKS9ADzxWgADEY6eOjiOAAAIIIIAAAggg4HkCBCCeN2fRe8w2AggggAACCCCAAAIeI0AA4jFTRUcRQMD9BOgRAggggAACCDgrQADirBjlEUAAAQQQQCDlBegBAgh4rAABiMdOHR1HAAEEEEAAAQQQQCD5BRLbIgFIYgU5HgEEEEAAAQQQQAABBBwWIABxmIqCCEQXYBsBBBBAAAEEEEDAWQECEGfFKI8AAgggkPIC9AABBBBAwGMFCEA8duroOAIIIIAAAgggkPwCtIhAYgUIQBIryPEIIIAAAggggAACCCDgsAABiMNU0QuyjQACCCCAAAIIIIAAAs4KEIA4K0Z5BBBIeQF6gAACCCCAAAIeK0AA4rFTR8cRQAABBBBIfgFaRAABBBIrQACSWEGORwABBBBAAAEEEEDA9QJe0wIBiNdMJQNBAAEEEEAAAQQQQMD9BQhA3H+O6GF0AbYRQAABBBBAAAEEPFaAAMRjp46OI4AAAskvQIsIIIAAAggkVoAAJLGCHI8AAggggAACCLhegBYQ8BoBAhCvmUoGggACCCCAAAIIIICA+wt4XgDi/qb0EAEEEEAAAQQQQAABBGIRIACJBYZsBBC4W4AcBBBAAAEEEEAgsQIEIIkV5HgEEEAAAQRcL0ALCCCAgNcIEIB4zVQyEAQQQAABBBBAAIGkF6DGpBYgAElqUepDAAEEEEAAAQQQQACBWAUIQGKlYUd0AbYRQAABBBBAAAEEEEisAAFIYgU5HgEEEHC9AC0ggAACCCDgNQIEIF4zlQwEAQQQQAABBJJegBoRQCCpBQhAklqU+hBAAAEEEEAAAQQQQCBWAYcDkFhrYAcCCCCAAAIIIIAAAggg4KAAAYiDUBRDIAUFaBoBBBBAAAEEEPAaAQIQr5lKBoIAAgggkPQC1IgAAgggkNQCBCBJLUp9RqB27eclVarUJCcNrl27hpmTZnqeXbt2XQIDU2HnpN3169clICAQN6fdbkgAbk6fNzdu3BB//wCnj9OfcV9ON2/e9F03J382I58n6ubn5++y8034kygBApBE8XEwAggggAACCCCAAAIIOCNAAOKMVsqUpVUEEEAAAQQQQAABBLxGgADEa6bSvQZy+mZmGRI2geSkQdjYaZg5aabnmboNHTHRBXbefQ6HjpkmuDk/x6FjpuKWgJ9TdQsZOYmfUyftho+eKrjF/XO6es1697oIojfxChCAxEtEgYQK6IUNaaK5UHHUIWzsdKfKO1qvt5cLswI3bx+jK8anbnph44q6vblO3Jz7e812LmjA69T5Zv1SwXasL3/aAjdfNohv7D+tJQBJ6LVaSh1HAJJS8rSLAAIIIIAAAggggIAbCri6SwQgrhamfgQQQAABBBBAAAEEELALEIDYKVhBILoA2wgggAACCCCAAAJJLUAAktSi1IcAAgggkHgBakAAAQQQ8FoBAhCvnVoGhgACCCCAAAIIOC/AEQi4WoAAxNXC1I8AAggggAACCCCAAAJ2AQIQO0X0FbYRQAABBBBAAAEEEEAgqQUIQJJalPqMwIUTh80nCwQSJMBBCCCAAAIIIOC1AgQgEVN79twF6T1kgrTsMkj2Hzoakevaj3PnL8ibTbomeSNab93GXeKtV8to2egFf1q3OUEGnXqFyZ59B6NXxzYCCCCAgAcJ0FUEEEDA1QIEIBHCq9dtlAcfyCJTRvaRvLlzRuR65kf69Omkb1DLBHd+3YZtcvDwsQQfz4EIIIAAAggggAACTgv4zAEeH4CcOn1Weg0ZLw1a9pSar7WQH9dsNJP3+eLl8m7bPiZ/+pxPTZ4u9Lf+46Z9KC07D5IOPYfLfydOye979sucjxbLitXrpV33EC0mcR0/evIcaWuVW/TtSnmraZD0GjxO6kV8bv5tl7TqOli0nd0RdwMOHz0ub7zXReo372HaPXDIsYv7jsGhsnd/+KNMDVsFy/S5n5m+TZ21UD7/erlZX7Zijeg+Hb/26+atW3Lp0mUZGDbF7NfF7AVfmfa1z9rX+Z8u0WyTZi1YJE079BO986MW+w4clp/WbZL3rbY0T/t+8vQZM0ZtQ8vu3L3fHHv12jXpN2ySMe7cO1QuXLxk8lkggAACCCCAAAIIIBCbgMcHIOOnL5DM990r86aEyOdzRkuRgnlFL/Df//ALGTWoq0wf009W/LRe9Lf6NoRHc+WQKaP6SN06tWTewq+lcIG88qa1/lyNyjJ+eM94j8+ZI7tMsMpVLl9S/vr7P2nW6HWZO3WYnDh1Rr5d/rNMCA2WHh2bypQPPjFNZs50j0we0Vs+nDZMmjSsIyMmzjL58S2KF8kvW7fvNhf2aVKnlu0795lDftu5V0oWLSQaHMyygouxQ7vLnElD5Oq1G7J46SpTxrbQgOLLJStk5viBEtKnvezaG/URKbWYMXaA1HyyorHIlyeXVK1Yxurna+ZuUK6c/5Px0xZIyWIFjXGfri2l//BJpvpFS1bKufMXTdtNG74mO3aF98/sTMyCYxFAAAEEEEAAAQS8VsDf00e2edvv0tS6qNdxZMyQXrJlzSzbdu6WJ6uUkyyZ75N0adNK7WeqiV60S8SfKhVKm7XsD2SVQ0eOm/XIi/iOf7JKeXvxh7LfL7kfeUgCAwKkwGO5pKgVAAX4+0vRQo/J4T/D606bNo0s//FX6dZ/lLw/7wsrcPjLfnxcK6WLF7TGstf0vWK5EnLRurNx4+ZNOWLVmyd3Dtm2Y7fJC7buwLQOGmJt75Hfdx+IUuWOXX/IE5XLyD0ZM5hUvdqdvmvBSuVL6oeUKFogRgvdqUHQ96vWmbskIWNmmEBL75Zs/32fvPJ8dfG3xqtBnCYtT0IAAc8VoOcIIICApwlcv35NLl68ECVdvXpFLl++FCUvepnEbHuakbv11+MDEAUNDAzUjygpVWCAfVuDg9ty274dEBA+bD/xl5vWBb3E8Ceu41OnutNeYMCddX/rQjxVxD5dv3Hjpqn5ky++k6N//S2dWzWSSWG9rB+Iq+LIn6KF88kO6yJ/2849UrJofimUP48ssu5m6F0ec7yfn3W3orS5U6HvriyYPlyCOzc1u2yL27dvS4AVHNm2AyO5aF6qwPD++/nFbqHlQgd0trezctH7cn+2LJptAi+zYi2i121l8X8EEEAAAQQQcEyAUgkUSJUqtWTIkDFKSpMmraRLlz5KXvQyidlOYFc5LEIg/Eo8YsMTP0oVLyQffPiFvesXLl6SEkUKyo9rN4m+H3L5yhVZsvwnKVWsoL1MfCuJPT56/XrHonSxQpL9wWyybsNvcuPmjehFYtzWwEmPWfnTetFgpIQVhCz47FspXjR8LGVLFpZVP2+Q/QePmuNPnzl317dXFS2UTzZv2yUaiGjauGWnKRvXIl26NHLu3AV7kXKli8qUDxaaOjRz49bwOopZAdKGLds1S86cPSd79h0y6ywQQAABBBBAAAEEEIhNwP0CkNh6Gkt+u+b15O9/T5oXsau/3FR+3fSb6ONJDd94QTr3GSHNOg6QahVLS4UyxcXRP4k9Pno7r7/8jEz+4GPRx6Q2//a73HfvPdGLxLpdvEg+ufeejKLvgJQoWkCOHf/XCqYKmPIPZX9AurR5R4aMmi76Inqj1r3kjBWEmJ0Ri/x5c8mTlcuZl+u79h0h2bJkkowZ00fsjfmjdo2qshxUji0AABAASURBVG7jNtNffc+kTdO35Nq1a9KwZbC8+HY7+eLrH8yBL9d+Sk6fOS/tewyTAaFTrQArq8lngQACCCCAAAIIIIBAbAIeH4BkzZxJhvRuL3MnD5UVi2bI09UeN2N99cUaMmvCIPPitL4kbjKtxSczR5oLemvVBCr6wriuv/5STWn+zhu6apIjx+v7JvOmhn9rlh7UsWVD876Jruvdi8Xzx+uqaBDw6axR5vGrds3eFlu+BhYfvz/ClIlt0aZJPdGXxHX/A9myyLpl88yjWLqtqXrV8uYFcx2/1lumZBEzPh2n7tekAZCOc3CvdnLm7AUpWjCfZouW0T7oRp7cOczL87qe99GcEjagi+mvvoSeyQqY9Gt9dazahnprOQ2KBvRoLeOG9ZDRQ4LkoxlhUiDfo7pLMmbLZT5ZeJYAvUUAAQQQQAABBFwt4PEBiKuBvKH+7gPGmK8Fbtyur3k5X4MNbxgXY0AAAQS8SIChIIAAAj4jQADiBlO9fvN2898O0f9+iC3pf18jqbqmXxmsdzsWTA+Vt159NqmqpR4EEEAAAQQQQMALBBhCcgsQgCS3eAztlS9dzPx3QvS/FWJL+mhTDEXJQgABBBBAAAEEEEDAowUIQDx6+pK289SGAAIIIIAAAggggICrBQhAXC1M/QgggED8ApRAAAEEEEDAZwQIQHxmqhkoAggggAACCNwtQA4CCCS3AAFIcovTHgIIIIAAAggggAACPixgD0B82IChI4AAAggggAACCCCAQDIJEIAkE7SvNXPhxGFfG3JixsuxCCCAAAIIIICAzwgQgPjMVCfvQO/NkEaCu7YhOWkQ1KEZZk6a6XkW1KE5bgl069mltY/bOf/3lJ5vuDnv1q1jc8EtIW4tcIvn77eqlcon70UOrSVagAAk0YRUEJPAfRnTSK+gtiQnDfTCBjfnzxt100AEO+fs9IIQN+fM9Bzr1rGFCdp0neS4n7ppAIKZ42Zq1b1TeACi616XnPw3MrbxV6tMABLTtZg75xGAuPPs0DcEEEAAAQQQQAABBLxMgAAk5SeUHiCAAAIIIIAAAggg4DMCBCA+M9UMFAEE7hYgBwEEEEAAAQSSW4AAJLnFaQ8BBBBAAAEERDBAAAGfFSAA8dmpZ+AIIIAAAggggAACviiQ0mMmAEnpGfDS9s9euCpDwiaQnDQIGzsNMyfN9DxTt6EjJmLnpF3omGmCm/N/T4WOmYqbk+ea/pyqW8jISfycOmk3fPRUSQ6302fOeukVCcNyRwECEHecFS/o06102c0/0Hpx475potv1MWzsdLfrkyfMX5gVuHlCP92tj+qmFzbu1i937w9uCfu7UwNezjfn7WyBm6t/LghAvODiy4OGQADiQZNFVxFAAAGvEWAgCCCAAAI+K0AA4rNTz8ARQAABBBBAwBcFGDMCKS1AAJLSM0D7CCCAAAIIIIAAAgj4kIAPByA+NMsMFQEEEEAAAQQQQAABNxEgAHGTiaAbCPiUAINFAAEEEEAAAZ8VIADx2aln4AgggAACvijAmBFAAIGUFiAASekZoH0EEEAAAQQQQAABXxBgjBECBCAREHwggAACCCCAAAIIIICA6wUIQFxvfFcLIyfOkWUr1tyV7+kZDVr2lBMnT5thXDhx2HzGuCATAQQQQAABBBBAwGcFCEBSYOpff+kZKVuqSAq0TJMIIODrAowfAQQQQACBlBYgAEmBGfj0q+9l45adpuW6jbvIuGkfSsvOg6RDz+Hy34lTJr9xu76y/+BRs66Lll0Gyc7d++Xk6TPSa/A40bsNTTv0M3m6X++odAwOlbbdhkqPgWNk/6Gj0mPAaHmvbR+p+VoL+fOvv7WYufPSsFWwOX705Dly89Ytkx99sebXraYeW/6GLTukU68ws/n54uXyrlWv9mH6nE9NHgsEEEAAAQQQiFOAnQggECFAABIBkZIfj+bKIVNG9ZG6dWrJvIVfm648Xa2CfP/jOrN+4tQZ+fufE1KkYF4ZP22BlCxWUOZNCZE+XVtK/+GTTBldHDv+jwzv30mG9e0o8xcukRefe0o+mDBIPp8zWrJkziSHjx6XWQu+krFDu8ucSUPk6rUbsnjpKj30rvR4ueKyc9cfcuXqNbNv+apf5JknK8iBQ8fk/Q+/kFGDusr0Mf1kxU/rZd2GbaYMCwQQQAABBBBAAAEE4hNI/gAkvh754P4qFUqbUWd/IKscOnLcrNd6urL88OOvZv27FWulVvVKZn3r9t3y/ap1ondEQsbMEA1ObHdNSpcoLBnSpzPlihfJJws++1amz/1Mjh77W9KnSyvbduyWi5cuS7B1B6V10BBre4/8vvuAKR99EeDvLxXLlZRVP683d0lWr9ss1SqVlW07d8uTVcpZAc19ki5tWqn9TDX5befe6IezjQACCCCAAAIeJHDp0kW5ePGC16SrV6/I5cuXXDYeD5pat+wqAYgbTEtAQPg0+Im/3Lx5U/RPtiyZJKt112LPvoOy/MdfrLsPFTXbpNABnWXKyD4mrVz0vtyfLYvJT50qlfnUxcu1q0vvzs0kR/b7pfeQCbJrrxVo+PlJ1YqlzXF6/ILpwyW4c1MtHmOqYd3x0LZ/2fCblLACmowZ0ptyqQIDzKcuAgMC5Lb1P10nub8APUQAAQQQQCAmgfTpM0iGDBm9JqVJk1bSpUvvsvHEZEie4wLhV76Ol6dkMgpUr1Ze5i38Rs5fuCiP5XnEtFyudFGZ8sFCuX37ttneuDX8XRKzEWmhx2R/MJu5Q1HeOkYDkLIlC1t3NDbY3y05feaceVck0mFRVsuVKip79x+RxUtXyjNPhQdAJYoUlB/XbpJTp8/K5StXZMnyn6RUsYJRjmMDAQQQQOAuATIQQAABBCIECEAiINzxo1b1yubuh37a+tem6Vty7do1adgyWF58u5188fUPtl1RPkPHfSA16jSTrn1GyLXrN0TreCj7A9KlzTsyZNR00RfRG7XuJWesICTKgZE2/PysOyaPl5ZfNm6XyhGPieXJnUMavvGCdLbqbdZxgFSz7qhUKFM80lGsIoAAAggggAAC7iRAX9xNgAAkBWakS5tGJiDQpj+ZOVLuvSejrope3E8IDTbrurjv3oyybtk8adrwVd00KdO990jfoJYyb2qILJ4/Xob0bm/yNcDQes2GtRgU3FaWfzFdRgzqKn26NpcMEe+GVK9aXmaOHyhzJw81x5cpWcQqHfv/g9q9K6sWz5S0aVKL7c+rL9aQWRMGib4I36zR67Zss50ta2b7NisIIIAAAggggAACCEQXIACJLuLF28k5tIzZciVnc7SFAAIIIIAAAggg4CECBCAeMlGu7Ga/YZOkVdfBUdL6zdtd2SR1I+BrAowXAQQQQAABBCIECEAiIHz5Y0CP1jJ5RO8oqXzpYr5MwtgRQAABBLxGgIEggIC7CRCAuNuM0B8EEEAAAQQQQAABBLxBIJYxEIDEAkM2AggggAACCCCAAAIIJL0AAUjSm1IjAtEF2EYAAQQQQAABBBCIECAAiYDgAwEEEEDAGwUYEwIIIICAuwkQgLjbjNAfBBBAAAEEEEDAGwQYAwKxCBCAxAJDNgIIIIAAAggggAACCCS9AAFI0ptGr9Ent/0v/y3BXduQnDQI6tAMMyfN9DwL6tActwS69ezSGjsn7fR8w835v9+7dWwuuCXErUWyuGXOdJ9PXq8w6JQRIABJGXevb/W+jGmkV1BbkpMGemGDm/PnjbppIHK3nfN1+VIdekGIm/PnSLeOLUzQ5kvnSlKMVd00AEmKunypju6dwgMQV4+ZAMTrL83caoAEIG41HXQGAQQQQAABLxFgGAgggEAsAgQgscCQjQACCCCAAAIIIICAJwq4e58JQNx9hugfAggggAACCCCAAAJeJEAA4kWTyVCiC7CNAAIIIIAAAggg4G4CBCDuNiP0BwEEEPAGAcaAAAIIIIBALAIEILHAkJ04gbMXrsqQsAkkJw3Cxk7DzEkzPc/UbeiIidg5aRc6Zprg5vzfU6FjpuLm5LmmP6fqFjJyEj+nTtoNHz1VnHVT77jSyVNnEvePPEcjkEgBApBEAnJ4zALnLl41/0DrxQ1posMWYWOnO1wW1zuuYVbghscdD0ct1E0vbBwtT7lwY9zCHZw9HzTg5Xxz3s4WuDnrHVf5U6cJQGK+eiE3uQS8OABJLkLaiUkgY7ZcMWWThwACCCCAAAIIIODjAgQgPn4CMHwEXCJApQgggAACCCCAQCwCBCCxwJCNAAIIIICAJwrQZwQQQMDdBQhA3H2G6B8CCCCAAAIIIICAJwjQRwcFCEAchKIYAggggAACCCCAAAIIJF6AACTxhnfVcOPmTdn++7678n0mg4EigAACCCCAAAIIIBCLAAFILDCJyQ4MCJDpcz5LTBUciwACCCRIgIMQQAABBBBwdwECEBfNUJo0qWTPvoMuqp1qEUAAAQQQQMDNBOgOAgg4KEAA4iCUs8WOHf9X3m3bR+o1DZKWXQbZkyP1nDt/Qeo27hJr0RMnT0uDFj1j3Z/UO7QtbVPr/eTLZXL5yhVdJSGAAAIIIIAAAggg4LRA0gcgTnfBOw/o1KqhjBvWQzq3eUeaNKhjT46MNn36dNI3qKUjRZOlTM9OTeW+e+8xbX3xzQ9y5co1sx7X4sKJw3HtZh8CCCCAAAIIIICAjwoQgLho4suVKioxpZia07sLbzbpKsGDxkrroCFy8PCfMjBsiim6/9BR6TFgtLxn3U2p+VoL+fOvv02+bXH46HFp0LKn7N0f8wX/shVrpGNwqLTtNtTcjZkwY4HtUJk882N58e12om3PmHvnnRW9+zJ68hxp2z1EVv68QUJGz5Cz587LN9+tlr//OSFB/UZJp15hMmXWJzL/0yVR6lvw2bf2bVaSX4AWEUAAAQQQQAABdxcgAHHRDO3c/Yd07TNCar/Z2qSgfiNl5+79sbZ25M+/pWmj12RSWC958P6s9nLzFy6RF597Sj6YMEg+nzNasmTOJOLnZyWRfQcOS89BY2Rwr/aSP28uie3PseP/yPD+nWTulBDZt/+I/Lppuylaq3oVWTx/vMyeNFR27Novm7buNPm6yJkju0wY3lOeqlJON016vmY1yf5gNgkb0FlGDwmSF2o+IYu+XWH23b59W75buU5eqFXNbLNAAAEEfEyA4SKAAAIIOChAAOIglLPFhoyaLrly/k8mhvYySS/oQ8bMiLWaRx7OLnlyPXzX/uJF8oneVZhu3aE4euxvSZ8urYh1sf/fidPSrf9oCe3fWXJb7dx1YKSMEkULSIb06SQwMFAeL1vcCjb+MHuvXrsqeqejc+8w0SDlj4N/mnxdPFmlvH7EmR5+6EHJliWz7Np7QNau3yaF8j8q92TMEOcx7EQAAQQQQACBlBW4dOmiXLx4wYvS3WO5evWKXL58yWVjTNkZ9PzWCUBcNIe3rSChXfP68miuHCa1t9avXYv93YlUgali7MnLtatL787gf65xAAAQAElEQVTNJEf2+6X3kAnmYl/vgGTJfJ/kfCi7/LJxW4zHRc60uhJ504pfbsv16zekz9AJ8nS1x83djFrVK8uly3deLk+dKjDKMbFtvPjsE/L1d6uttEqer/VEbMXIRwABBBBAAAE3EUifPoNkyJDRq1OaNGklXbr0Lhujm0ylx3aDAMRFU3fr1i05feacvXZ9z8O+4cTK+QsXzWNPtZ+pJuVLFw0PQKzjAwL8JWxgZ1m2Yp0s/eFnK0cktsW6DVvlvxOnzLdXLVn+kxQr/JicOXtOUqVKJcWL5JfU1ue6DfEHMlp/urRp5ey5C7pq0lNVy8svG36TPfsOS6VyJUweCwQQQAABBBBAAAEEYhMgAIlNJpH59V6rLW82CbJ//e7bzXtIgzdecLrW0HEfSI06zcz7JNesuxZ6p8JWSZrUqc3di7kffy0/rt1ky77rM3/e3NK5zwh5t01vqVCmmJWKy/3ZskjhAnnNC+xBfUeKPk5114ExZLz9em0ZP/1D8xK67tY+lClRWJ59upJ1Y8ZPs0gI+KIAY0YAAQQQQAABBwUIQByEcrbYK7Wry8zxA6TGExVMmjl+oLz03FMxVpMta2aZNzXEvu/eezLKJzNHmu1BwW1l+RfTZcSgrtKna3PJkD6dZMuSSeZNCS+fMUN6+XDaMHmiUhlTPqaFvn8yd/JQ+fj9EdK2aT17Ea1P69G6B/RoLe+9/bLZp21rH8yGtdC+aR+tVWssj8vIQUEm8NFtfdTs4JFj8tKzMY9Ny5AQQAABBBBwnQA1I4CApwkQgLhoxkZOnCMPP5RdXn+ppkl6h2HQiGkuai1lqj14+Jg0bBVs3Ul51DwmljK9oFUEEEAAAQQQQACBFBFIYKMEIAmEi+8w/Yrc6GV+370velaSba/fvF1adR0cJfUbNkn0ka0ubRolWTuRK9IX7PUOSqdWd9efMVvsXwscuQ7WEUAAAQQQQAABBHxLgAAkief7q6WrzHsffxw4Yj5bdhlkPt9p3Uvy5M6ZxK3dqa586WIyeUTvKEkfq7pTgjUXClA1AggggAACCCCAgIMCBCAOQjlarHTxQtKkQR3J/kA286nrmkL6dpAhvds7Wg3lEEAAAQQcEqAQAggggICnCRCAJPGM6bse5UoVFX1xWz9t6aHsDyRxS1SHAAIIIIAAAgikoABNI5BAAQKQBMLFd9jVa9dk9oKvpGPwcPMIlu1RrPiOYz8CCCCAAAIIIIAAAt4sQACS+NmNsYaBoVPkv5On5cTJM1Ln+eqSMX06KZgvd4xlyUQAAQQQQAABBBBAwFcECEBcNNMHDh2Vrm3fkQwZ0plvotL/1saff/3jotaoFgFfFWDcCCCAAAIIIOBpAgQgLpqxDBnSm5pv3Lgply5fMevXr980nywQQAABBBDweAEGgAACCCRQgAAkgXDxHZYxQwY5c+68VC5fUt5r29tKfST7A1nFl/4Ed20jJOcMgjo0wywB501Qh+a4JdCtZ5fW2Dlpp+cbbs793ab/FnTr2FxwS4hbiyR3y5I5ky9djnjlWD19UAQgLprBMUO7SaZ775HGDepIcKdm0rrJm9KtQ2MXteZ+1WYOOC29gtqSnDTQCxvcnD9v1E0vcLBzzk4vCHFzzkzPsW4dW5igTddJjvupmwYgmDluplbdO4UHILqeVClrFgIQ97ty8q0eEYC4aL73HzwqFy9dNrWXKFpACuXPI4eOHDPbLJJKgHoQQAABBBBAAAEEPE2AAMRFM9Zv2CRJnSqVvfZUqQKlX8gk+zYrCCCAgEcL0HkEEEAAAQQSKEAAkkC4+A67cfOGaNBhK5cmdWrR/zaIbZtPBBBAAAEEEEAgIQIcg4CnCxCAuGgG/fz85NdNv9lrX7dhW5Q7IvYdrCCAAAIIIIAAAggg4EMCHhyAuPcs9e7SXEZOnC0tuwwyacyUudKrSzP37jS9QwABBBBAAAEEEEDAxQIEIC4CLlLwMVkwI0zqvlLLpAXTQ6Vwgbwuas39qj174aoMCZtActIgbOw0zzBzclyuPhfUbeiIidg5OS+hY6YJbs7/PRU6ZipuTp5r+neAuoWMnOS1P6dH//zL/f4xpkcIuKkAAYgLJ8bfz09y58xhkp+fnwtbcr+qz128av6B1osb0kSHLcLGTne4LK53XMOswA2POx6OWqibXhA6Wp5y4cYp7eap86ABrzefb0cIQNzvYoQeua0AAYiLpmbRkhXyzKvNpX2PEJNqvtZCvlq6ykWtUS0CCCCAAAIIIICAiwWoPokECECSCDJ6NfMWfiP9u7eWxQvGm9Q3qKXM/Xhx9GJeu50xWy6vHRsDQwABBBBAAAEEEEi4AAFIwu3iPDIwMFCqPF5K/Pz8TKpasbT4+/vFeYzH7KSjCCCAAAIIIIAAAggkUIAAJIFw8R0WEOAv+tW7tnI//7JFUqdObdvkEwEEEEiQAAchgAACCCDg6QIEIC6awR4dGsuICbOlYq0GJunX8Gqei5qjWgQQQAABBBBwrQC1I4BAEgkQgCQRZPRqihbKJ5/OGikfTh1u0sIPRop+NW/0cmwjgAACCCCAAAIIIOBLAs4HIL6kk4Cxrlm/VWxp7YZtcvzf/0zSdc1PQJUcggACCCCAAAIIIICA1wgQgCTxVH7yxTKJKyVxc1TnYwIMFwEEEEAAAQQQ8HQBApAknsGxId0lrpTEzbmkurqNu8i58xdcUjeVIoAAAh4qQLcRQAABBJJIgAAkiSBt1ehjVnElWzk+EUAAAQQQQAABBBwRoIy3CRCAJPGMxvX4le5L4uZcVt2sBYukaYd+0rLLIPnvxCnTTsjoGTIwbIq07R4i0+d8KstWrJGOwaHStttQqdc0SCbMWGDK6eLCicP6QUIAAQQQQAABBBBAIIoAAUgUjsRvxPX4le5LTAvJeeyjuXLIjLEDpOaTFWXewq/tTV+9dl3GhXSXZo1eN3nHjv8jw/t3krlTQmTf/iPy66btJp8FAggggAACCCCAAAIxCRCAxKSSxHlXrl6TL5eskHfb9E7iml1XXaXyJU3lJYoWkENHjpt1XTxRqYz4+985bXR/hvTpJDAwUB4vW1x27PpDi5EQ8DYBxoMAAgjEKXD58mW5ePFCkqerV6/IpUsXk7xeV/TVnepUt8uXL7nMLc6TgZ3xCty5koy3KAWcFdh/6KiEjvtAatdtLV98/YPUql7Z2SpSrHwqK6DQxv38/OXmzZu6apIGGmYlYnH7dsRKxMft6BkR+XwggAACCCCQMAHPOCpdunSSIUPGJE9p0qSV9OkzJHm9ruirO9WpbunSpXeZm2ecle7bSwKQJJ6ba9evy5LlP0nTDv2le//Rcn+2LNbJn05mTxoi9V57LolbS/nq1m3Yat4RuXzlihl3scKPpXyn6AECCCCAAAIIIIBA4gVcVAMBSBLDvlivnXyzbLW0eu8N+XTWKHnv7ZclMCAgiVtxn+ry580tnfuMMI+XVShTTCqUKe4+naMnCCCAAAIIIIAAAm4nQACSxFPSoO4L8u+JU/LB/EXy7fKfRe+IJHETLq/uk5kj5d57Mpp28uTOIRNCg816z05NpXrV8mbdtsiZI7vMnTxUPn5/hLRtWs+W7W2fjAcBBBBAAAEEEEAgiQQIQJII0lZNQysAWfjBSKn/xvOyet1GeeGttnLm3Hn5ce0muXnrlq0YnwgggAACDglQCAEEEEDA2wQIQFw0oxXLlZCQPh1l/rRh0uCNF2TkxNkmGHFRcylSrb5U36VNoxRpm0YRQAABBBBAwMUCVI+AiwQIQFwEa6s2W9bM0qRBHfly7hjp0bGJLdvrPzNmy+X1Y2SACCCAAAIIIIAAAs4LEIDEb5YkJfS/naH/DY0kqYxKEEAAAQQQQAABBBDwUAECEA+dOLqNgG8IMEoEEEAAAQQQ8DYBAhBvm1HGgwACCCCAQFIIUAcCCCDgIgECEBfBUi0CCCCAAAIIIIAAAgkR8PZjCEC8fYYZHwIIIIAAAggggAACbiRAAOJGk0FXoguwjQACCCCAAAIIIOBtAgQg3jajbjSe4K5thOScQVCHZpgl4LwJ6tActwS69ezSOma7BNTnKz/ver7h5tzfbXpudOvYXLzZ7ZGHH3Kjf4HpCgLuLUAA4t7z49G96xXUVkjOGeiFDWbOmamXuukFjq6THPfTC0LcHPeynVvdOrYwQZttm0/HDNVNAxBv9cqZhAGIR//jT+cRcECAAMQBJIo4L5A54LTzB3EEAggggAACCCCAgNcLuHEA4vX2DBABBBBAAAEEEEAAAZ8TIADxuSlnwAg4IEARBBBAAAEEEEDARQIEIC6CpVoEEEAAAQQSIsAxCCCAgLcLEIB4+wwzPgQQQAABBBBAAAFHBCiTTAIEIMkE7WvNnL1wVYaETSA5aRA2dhpmTprpeaZuQ0dMxM5Ju9Ax0wQ35/+eCh0zFTcnz7WQkZN87Z9BxosAAnEIEIDEgeOzu5Jg4OcuXjX/QOvFDWmiwxZhY6c7XBbXO65hVuCGxx0PRy3UTS8MHS1PuXBj3MIdnDkfho+ekgT/slAFAgh4iwABiLfMJONAAAGvEGAQCCCAAAIIeLsAAYi3zzDjQwABBBBAAAFHBCiDAALJJEAAkkzQvtZMxmy5fG3IjBcBBBBAAAEEEEDAAYG7AxAHDqIIAggggAACCCCAAAIIIJAQAQKQhKhxDAIuEqBaBBBAAAEEEEDA2wUIQLx9hhkfAggggIAjApRBAAEEEEgmAQKQZIKmGQQQQAABBBBAAIGYBMjzNQECEF+bccaLAAIIIIAAAggggEAKChCApCB+9KaTavvc+QtSt3GXeKvTMlo2esGf1m2W/YeORs+Od7tTrzDZs+9gvOUogAACCCCAAAIIIOC7AgQgXjj36dOnk75BLRM8snUbtsnBw8cSfDwHIuCBAnQZAQQQQAABBJJJgAAkDuiLly7LoBHTpEXngVLztRby3cq1prR+vte2j9Rr1k2atO9n8v7+94R06RMm77bpLW2Chsj+g+F3EJatWCMdg0Olbbeh0mPgGDl5+oz0GjxOGrTsKU079JOdu/eb42Na6HF79x82uxq2Cpbpcz8z61NnLZTPv15u1rV+3af1jZ48R27euiWXrH4PDJti9uti9oKv5I33ukjb7iGm7fmfLtFsk2YtWGT60bLLIPnvxCnZd+Cw/LRuk7xvtaV5h48ej7XPV69dk37DJpmxdO4dKhcuXjJ1skAAAQQQQMBxAUoigICvCRCAxDHjq37eIJkz3SNTR/WVJZ9MkrIli4hekI+ePE8GBbeVBdNDpU/EnYbx0+ZLofx5ZdbEwfJcjSoSMuZ9e83Hjv8jw/t3kmF9O8r4aQukZLGCMm9KiPTp2lL6D59kLxd9pXiR/LJ1+25zYZ8mdWrZvnOfKfLbzr1Ssmgh05dZVnAxdmh3mTNpiFy9dkMWL11lytgWGlB8uWSFzBw/UEL6tJdde6M+IvVorhwyY+wAqflkRZm33vJj6gAAEABJREFU8GvJlyeXVK1YRpo0fE2mjOwjuXL+L9Y+L1qyUs6dv2jabmqV37ErvH/a9oUT4YGTrpMQQAABBBBAAAEE3FAghbrkn0LtekSz+R/LJWvXb5VpsxdadwU2S5bM98m2HbvlqSrl5OGHHjRjyG1doOvKb7/vk9dffkZX5fma1eTQkWNy48YNs126RGHJkD6dWdeA4vtV60TvLoSMmSEnTp0xdx7MzmiL0sULyjYr2NCAo2K5EqJ3ZG7cvClH/jwueXLnEO2L5gVbd1RaW3ddtu3YI7/vPhCllh27/pAnKpeRezJmMKl6tfJR9lcqX9JslyhawOrzcbMefRFbn7dbY37l+eri7+8vhQvkNSn6sWwjgAACCCCgAlevXrXu0F+UixcvkJwwuHr1Cm5OeNnOL3W7fPmSy841PadJCRcgAInDTu8GTBvdTwpadzY++XKZfPT5Url9+7akShUQ41GpAgNNvp+fn/j5Wcm6MNeM1KlS6Yc9hQ7obO4u6B2GlYvel/uzZbHvi7xStHA+2WFd5G/buce645HfusOSRxZZdzOKFMwbXsxqo2rF0va6FkwfLsGdm4bvi1hqfwMC7vQ3MPDOuha502d/uWkFN5oXU4qtz4Fx1B1TPW6aR7cQQAABBFwskCZNGkmfPoNkyJCR5IRBmjRpcXPCy3Z+qVu6dOlddq65+MfF66v39/oRJmKAZ89dkIwZ0ks16yL/1ReeFr2bULJYIVn580b5869/TM16B0JXilvBwmeLw9/L0HdEcj+SQwL87+YtV7qoTPlgoQlk9LiNW3fqR4xJL+6zP5hNVv60XjQYKVE0vyz47FspXrSgKV+2ZGHRx8Rs75ucPnPurm+vKloon2zetsu0p8HIxi2xt2cqtRbp0qWRc9bYrVXz/9j6XMwa84Yt202ZM2fPyZ59h8w6CwQQQMBxAUoigAACCPiawN1XyL4mEMd4V/68Xqo+/67o400/rtkk79V/2bwT0abJmxI8aJx5Cb1ph/6mhnbN3zaPROlL6IuWrJQeHRub/OiLNk3fkmvXrknDlsHy4tvt5Iuvf4heJMp28SL55N57Moq+A1KiaAE5dvxfKVWsgCnzUPYHpEubd2TIqOmiL6I3at1LzlhBiNkZscifN5c8WbmctOseIl37jpBsWTJJxozpI/bG/FG7RlVZt3GbGbe+8xJbn1+u/ZScPnNe2vcYJgNCp0r2B7PGXCG5CCCAAAIIIOB+AvQIgRQSIACJA/6V2tXlp29myaSwXjK4V1vJmzunKV2remWZM3mIeQldH3vSzOwPZJORg4Jk1sTBMtEqH7lslzaNtIhJme69x3xF7rypIbJ4/ngZ0ru9yY9t0aZJPfOSuO5/IFsWWbdsnnkUS7c1Va9a3rxgPnfyUFNfmZJFTMDyycyRutskfTdlQmiwNYZ2cubsBSlaMJ/J1zIa3OhGntw5RMvoet5Hc0rYgC5m3PoSemx91qBoQI/WMm5YDxk9JEg+mhEmBfI9qlWQEEAAAQQQQAABBBCIUYAARCRGGG/K7D5gjPkPEzZu11eerFLOvMDuTeNjLAgggAACCCCAAAKeI0AA4gZztX7zdmnVdXCUpP99jaTq2oThPUXvdujXBr/16rNJVS31IJAEAlSBAAIIIIAAAr4mQADiBjNevnQxmTyid5Skjza5QdfoAgIIIICAtwowLgQQQCCFBAhAUgje25vNmC2Xtw+R8SGAAAIIIIAAAgkS8PWDCEB8/Qxg/AgggAACCCCAAAIIJKMAAUgyYtNUdAG2EUAAAQQQQAABBHxNgADE12ac8SKAAAIqQEIAAQQQQCCFBAhAUgieZhFAAAEEEEDANwUYNQK+LkAA4utnAONHAAEEEEAAAQQQQCAZBVIwAEnGUdJUiggEd20jJOcMgjo0wywB501Qh+a4JdCtZ5fW2Dlpp+cbbs793da9U8sU+XeIRhFAwD0FCEDcc168ole9gtoKyTkDvbBJFjMvmxt102AXO+fOt24dwwM33Jx1a2GCNtwcd9OAzSv+YWMQCCCQJAIEIEnCSCUIIIAAAgg4JkApBBBAwNcFCEB8/Qxw0fgzB5x2Uc1UiwACCCCAAAIIJEiAg9xEgADETSaCbiCAAAIIIIAAAggg4AsCBCC+MMvRx8g2AggggAACCCCAAAIpJEAAkkLwNIsAAr4pwKgRQAABBBDwdQECEF8/A1w0/rMXrsqQsAkkJw3Cxk7DzEkzPc/UbeiIidg5aRc6Zpqo2+Ily130NwHVIuBWAnQGAQTcRIAAxE0mwtu6ce7iVXNhoxc3pIkOW4SNne5wWVzvuIZZgRsedzwctVC3kJGTZPG3P3jbX0GMBwEEEEDArQSidoYAJKoHWwgggAACCCCAAAIIIOBCAQIQF+JSNQLRBdhGAAEEEEAAAQR8XYAAxNfPAMaPAAII+IYAo0QAAQQQcBMBAhA3mQhv60bGbLm8bUiMBwEEEEAAAQQSJMBBCEQVIACJ6sEWAggggAACCCCAAAIIuFCAAMSFuNGrZhsBBBBAAAEEEEAAAV8XIADx9TOA8SPgGwKMEgEEEEAAAQTcRIAAxE0mgm4ggAACCCDgnQKMCgEEEIgqQAAS1SPZtxq07CknTp52uN2du/dL174j4iy/4qf1EjJ6hinz07rNsv/QUbOe1AvTzpj3TbVnz12Q3kMmSMsug1zWnmmIBQIIIIAAAggggIBjAm5aigDETScmMd0qVayg1Huttqli3YZtcvDwMbPuysXqdRvlwQeyyJSRfSRv7pyubIq6EUAAAQQQQAABBDxYgAAkhsnTuwdDRk2Xdt1D5MV6bWX95u3Sf/hkebt5dxk+dqY5Ys2vW6XHwDFmXRcbtuyQTr3CdFW2/LZLmnUcIO+07iV9hk6Q8xcumvz4FstWrJGGrYJF74qMnjxHbt66ZQ7RIKJ+8x6mzq+X/WjydPH3vyekS58webdNb2kTNET2Hwy/07Fl+25Z8NkS2XfgsPy0bpO8P/czc2fi8NHjeliUdMtqo07DjibvwsVLUunZhrJp606z3bLzIDlkHRNbO6aQtfh9z36Z89FiWbF6vTGzstzt//QHAQQQQAABBBBAwE0ECEBimYhbt27L2JDuEty5mfQcOFYa1n1B5k4JkaN//SM7du2Tx8sVl527/pArV6+ZGpav+kWeebKC3Lh5U/qGTJRWjevK7ElDJCAgQOZ+vNiUiWuhwcGsBV/J2KHdZY513NVrN2Tx0lWmviEjp0vPTk1k2ui+8t/JU/Zqxk+bL4Xy55VZEwfLczWqSEjE41C2Avny5JKqFctIk4avmTsTuXL+z7bL/unv7y85c2Q3j01t3b5HihfOL9t27jPtHjv+j+S2jomvncIF8sqbdWpZfags44f3tNfNCgIIICCCAQIIIIAAAlEF/KNusmUTqFCmqOjFedFCj0nGDOkl76M5JcDfXwrmyy0Hjxwz6xXLlZRVP683dypWr9ss1SqVlWN//Sv33JNBShcvZKqq+0pN+c26oDcbcSy27dgtFy9dluDB46S1dTdj24498vvuA6a+rFnuk6KF8omfn5/UeaGGvZbfft8nr7/8jNl+vmY1OWT168aNG2bbmUWJogVkmxV8bNu5Wxq++aJo2zt3/yFFCz9mqklIOxdOHDbHskAAAfcX0L83Ll68ICTHDK5duyqXLl3Ey8lz5upV3BLyM3b16pWEn29OzlFC+ueux6jb5cuXXPZz6v5/s7t3DwlAYpmfwMBAs0eDkFSpwtc1I8DfX27cuKmrUsO647H8x1/klw2/SYki+UygojtSRRyr61rPbbmtq3EnK7ioWrG0uVOh71EsmD7cuvvS1Byjd1HMirUItO6oWB/2/9va8vPzMwGKn9U/+04HV0oWzS9brYBn+84/pELZYlYgdEm2/rZHShYtZK8hKdqxV8YKAgi4lYD+PZUhQ0YhOWaQOnUaSZ8+A15OnjNp0uCWkJ+xNGnScr45ea6ps7qlS5feZT+nbvWXuAd2xt8D++xsl11WvlyporJ3/xFZvHSlPPNURdNOjocekHPnL8q2nXvM9sJF30nJYgXMelyLsiULW3dTNtjf4zh95px5LErrO3X6rOi2Hq/vo+inpuKF88lni5frqny3cq3kfiSHuTNjMiIW6dKlkXPnLkRsxfxR1Kpnu3U3xT/AXzTA0Ue3Fi9bZe+3I+0IfxBAAAEEEEAAAQQQcECAAMQBpNiK+Pn5SdXHS8svG7dL5QqlTTG9gO8b1EImTP/IvIR+5cpVaVj3RbMvrsVD2R+QLm3eEX35XV9Eb9S6l5yxghCtT9//0JfgO/Qcbg9QtK52zd+WbTt2i76EvmjJSunRsbFmR0m1a1SVdRu3mce69D2TKDsjNtKkTi36mFeRgnlMTvEi+eWkFfTky/OI2XakHVOQBQJ3CZCBAAIIIIAAAghEFSAAiephtnp2airVq5Y36xnSp5NPZ40y67po1fhNqfP807pqUlC7d2XV4pmSNk1qsf0pVbyQTB/TT/Ql9EHBbe2PZtn2R/6cNyVEsmXNbLK0zZnjB8rcyUNl8fzxUqZkEZNfoUxx0RfiNY0Z2l1GDOxq8rM/kE1GDgqSWRMHy8SwXpI34utvtZ6e1hi0kL67Ejagi0yy9sf0ErqW0TRj7ABp06Seroq+0L5y0fvmHRjNiLOdjk20iLz+Uk1p/s4bZp0FAggggIAbCNAFBBBAwE0FCEDcdGLoFgIIIIAAAggggIBnCtDruAUIQOL2SbK9/YZNklZdB0dJkd/nSLKG4qjow4XfRGlf+6N5cRzCLgQQQAABBBBAAAEEklSAACRJOWOvbECP1jJ5RO8oqXzpYrEf4II99d94Pkr72h/NE5f9oWIEEEAAAQQQQAABBKIKEIBE9WALAQQQ8A4BRoEAAggggICbChCAuOnEeHq3MmbL5elDoP8IIIAAAggkSICDEEAgbgECkLh92IsAAggggAACCCCAAAJJKODCACQJe0lVCCCAAAIIIIAAAggg4BUCBCBeMY0MAoFoAmwigAACCCCAAAJuKkAA4qYTQ7cQQAABBDxTgF4jgAACCMQtQAAStw97EyEQ3LWNkJwzCOrQDLMEnDdBHZrjlkC3nl1ay4vPPZ2In3QORQABBNxGgI54iAABiIdMlCd2s1dQWyE5Z6AX0pg5Z6Ze6qbBrq6THPfr1jE8cHuxdg1P/CuGPiOAAAIIeKgAAYiHTlyc3WYnAggggAACCCCAAAJuKkAA4qYTQ7cQQMAzBeg1AggggAACCMQtQAAStw97Eyiwbtk8uX79GslJg9SpU2PmpJmeZ6lTp5IbN65j56RdqlSp5ObNG7g57RaIm5Nm+nMaGBgot27ddOX55pV1BwQE4JaA803dbt++5bJzIoGXRxwWIUAAEgHBBwIIIIAAAggggAACCCREwLljCECc86I0AggggAACCCCAAAIIJEKAACQReBx6t8CJk6elbbeh0rhdXwkeNNQyFvYAABAASURBVFYuX7lydyEvznFkaDdu3pQho6bLu216S/NOA+TPv/6O8bAvl6yQek2DpGKtBnL6zLkYy/ha5idfLpMGLXtKo1a9ZPW6zTEOf9L7H8lbltsLb7WVgWFT5Oq1azGW86VMR9z6DZtkzrWar7WQXoPHyfkLF32JKMaxOuJmO3D8tA+Nn/582/J89dMRtx4DRhsv/ftN087d+32Vyz5uR9z0/Bo5cY4890YrqfRsQ/no86X24311xRG36OdbtRfelVu3bvkqmVuMmwDELabBezoxduqH8njZEjJz/EC599575MOFS7xncEk0ksVLV8mp02dk1sTB8vpLz8iwMTNjrPnB+7PKwOC2ki1r5hj3+1rm4aPHZc5Hi2XqqL4S2r+TDBk5Ta5cvTu4KFGsoHw0I0zmTB5iOZ+VL75e4WtUUcbrqFvThq/K2qVzLbtQyZghvcz/dEmUejxgI0m76KibNnrw8DHZu/+IpE6VSvz8/DTLZ5MzbpPCeom+L6ipSMG8PmumA3fUTf8O3Ln7D5kY1ltWf/2BVHm8lB7us8lRt2H9OtnPtX7dWkqVCqXE359L4JQ8cdBPSX0vbHvNr1vl+ZpVzcief6aq/PzrFrPO4o7Aml+2SG3LRnOqV6sgO/fsl4uXLutmlFSxXAnJlydXlDxf3vj5l83yROWykiF9Osn+YDYpmO9R2bB5h0T/U7l8SZOVJfN9UtIKRv49cdJs++rCUbecObKbi+dM991j/mG+Lbd9lcyM21E3LRw2YZZ07/CeJWap3cbNkZ9TdSPdEXD0fPt2+U/SqVVDyZM7h+hL/Q8/9OCdSlJ0LWUad9Qtcu+W/rBWaj5VOXIW6ykgQACSAuje2qReROsv/zJnutcMMWeOB+W/E6fMOos7Av+dPC05/hf+j0ZgQIBkfyCb/PsfTneEYl777+QpeSj7/fad+g/vv3EEF5evXJGvl/0o5UsXtR/jiyvOuOnjk5WfayT//HdCmjZ41Re57GN21G2JdUFYtkRhefih7PZjfXnFUTc16tJnpHmUaMSE2XL9+g3N8tnkiJs+MqT/VnzxzQ/y9CtNpW33EDnyZ8yP8PoKpCNukS3Onrsgu/cdsO4chf+iKvI+1pNXgAAkCb2pSsxvTm0Ofn6cXjaL6J9+fn72LP9I6/ZMVmIU8It0y9zP745h9MK3rd9C9x4yXqpXLS/6SGD0/b627ajbhNBg+XbhZHn0kRwy88MvfI3prvHG53bh4iXziF+jei/ddawvZ8Tnpjad27wjKxbNkOH9O1kXhAdl7idfi6//ccTt2vXrkjd3Tvlq/nh5tnolCRkzw9fZxBE3G9KyFWukWsWy5u6RLY/PlBHgCjFl3L2yVX005ubNW6J/QeoAT54+I/dny6KrpEgC92fNbN5NsGWdOnNOHrgfJ5tHbJ/3Z80iZ86cte/W92geyJbVth3lc8bcz8wjWq2bvBUl3xc3nHFTn0z33iNPWYHb+s07ddNnkyNuO3btE01Va79jXqjW3+Lrut4N9lU4R9zU5oGIfxuKF8kvDeu+ILv2+vZL6I646TsL2bJkkmqVyphHUfXn9I8DR5TTZ5MjbpFxlq1YK7WqV4ycxXoKCRCApBC8tzZbqXxJWb5qnRnedyvXSpUK3OY0GJEWlSyT5T/+anJ+3bRd8uTKYf4x0Ywtv+3y+UcR1CGmVOXx0vLTL5vNt1qdOn1Wft9zQCqULWaKRnb7+ItlcuLkGWnW6HWzz9cXjrpt/32fobp565asWrNRCuTLbbZ9deGIm95d0xeobSlVqkD5acls+8+z79jdGWlcbnqxrL+Y0tJ690g/b9y4YX6uC+X37ZfQHXWrbP09uGFL+Ltv6zfvkHx5ffs9QUfd9Fw7euxv+e/kaSldorBuklJYgAAkhSfA25rv2LK+LF622nwN75Gjx6X+G8972xATPZ6XnntK/P39zNfwvj/vc+neoYm9zm79R8vZc+fN9uSZH5vfqupXG9d+s7V07TvC5PvqIlfO/0md55+WJu37ScfgUOnUupH51iH16BbhduPmTRkzZa58tXSVsdOv9xw0YpoW8dnkiJviTJ39qTGr8lwj+WXjb/LOW779WJGjbmpHuiMQl9vU2Qtl45bwO2uvvdPZnG/6ed+9GaXRWy/eqcQH1xx1a/VeXVm9drO827aPfPnNCgnu1NQHte4M2VE3PWLpijXyzBMVxM8v9sd3tZzHJQ/tsL+H9ptuu6lAtqyZZfKI3qJfwzu0TwdJlzatm/Y05bqlL5736tzMfA3vtNH95JGH77y8+v3n0+xfu9uq8Zv2rw3U37COGNg15TrtJi3XfaWWzJsSYr5i94lKZey9srmprVpFTn26NreX89WV+NzUZcLwnvbzTY1tj8joPl9NjrhFtln99SzRczByni+ux+YWNqCL1Koe/u1Dyz6dYs63RR+Ok3bN3sbNOlEccdNgbczQbjJrwiAZG9Jd9Ms4rEN9+v+OuClQs4avSbvm9XWV5AYCBCBuMAl0IdECVIAAAggggAACCCDgIQIEIB4yUXQTAQQQcE8BeoUAAggggIBzAgQgznlRGgEEEEAAAQQQcA8BeoGAhwoQgHjoxNFtBBBAAAEEEEAAAQQ8UcAbAhBPdKfPCCCAAAIIIIAAAgj4pAABiE9OO4NGIKkEqAcBBBBAAAEEEHBOgADEOS9KI4AAAggg4B4C9AIBBBDwUAECEA+dOLqNAAIIIIAAAgggkDICtJo4AQKQxPlxNAIIIIAAAggggAACCDghQADiBBZFowuwjQACCCCAAAIIIICAcwIEIM55URoBBBBwDwF6gQACCCCAgIcKEIB46MTRbQQQQAABBBBIGQFaRQCBxAkQgCTOj6MRQAABBBBAAAEEEEDACYFEBCBOtEJRBBBAAAEEEEAAAQQQQMASIACxEPg/Ah4nQIcRQAABBBBAAAEPFSAA8dCJo9sIIIAAAikjQKsIIIAAAokTIABJnB9HI4AAAggggAACCCSPAK14iQABiJdMJMNAAAEEEEAAAQQQQMATBAhAPGGWoveRbQQQQAABBBBAAAEEPFSAAMRDJ45uI4BAygjQKgIIIIAAAggkToAAJHF+HI0AAggggAACySNAKwgg4CUCBCBeMpEMAwEEEEAAAQQQQAAB1wgkba0EIEnrSW0IIIAAAggggAACCCAQhwABSBw47EIgugDb7ivQY8BoqVirgfz519/2Tuq65uk+e6YLV27cvCljp86TBi16SoOWPeW5N1rJZ4u/Ny1u2LJDWnYZZNY9bbFp6075ddN2e7d/27lXGrfra9/2hpXpcz+TW7du2Yeic6VzZs9I4pUOPYfLml+3mlojr5uMJFoc/+c/WbRkRZTaXNVWlEbYQAABBOIRIACJB4jdCCDgIQJ+fpIvTy755ruf7B3W9cfyPCJi7ZNk+LN0+c/WReUWGTO0m8ybEiKffDBC8uR6OBladm0TW7bvkc3bfrc3kif3wxLU7l37djKtuLSZWfMXya3bt13aRnJX/vc/J+TrSD8P2n6bpm9JkUJ5dZWEAAIIpJgAAUiK0dMwAggktcCzNarI0h/WyG3rQlKTrtd8qlKUZj75cpk0bBVsUvCgsXLy9Bmzf/Nvu+SVBh2kUateJq3bsM3k66KldedixITZ0iZoiNm3cNF3mn1X+vfEaSmUP69ky5rZ7LsnYwYpVbyQWdfFlavXRNt8t01vads9RP49cUqz5dTps6Y/bzfvLm826SrzPvnG5Oti2uyF0nPQGGnbbag07dBf9C6L3tUZP+1Dad5pgNRrGiTfr1qnRU1av3m7tOg8UN5p3ct8/r5nv8mPvtAxhY77wNQ7KGxqrH04ePiYfPP9alm2Yq25g6NjP3DoTwkbP8te5Y9rNlp96yfvtu0j+ht2Pca+M9LKR58vlefqthYdZ8fg4XL02J27VXq3oWXnQfKeVcczrzaXn3/ZYo7UsU56/yNp32OYLPjsWzlw+E/ThhrqXRhbuevXb8iYKXOlVdfB8mqjTqavWoHeBeg9ZIKxqPV6S5k882PNjpImzFggevejbdBQc5zOkxb4cc0mM+evvdNZdNyap0n7rXfV9E6XnkvfWoGn5kdPcZ1T0cvatmMbn+6PzUjH92K9tvKWdS4MGTVdLl+5osVlouV24NBRM6aho2aE5834SHbuCj8n4mpL3afOWig6J806DpCt23eb46MvtE9d+oSZO2I16jSTH9dukkNH/jLnpZbVn8OnXm4icz5arJvmXO01ZLxZj+tcjW2ftqfnWVC/kdKkfT/Rvu3545Cpj4UrBagbgaQVIABJWk9qQwCBFBS4J2M6yZf3EdGLFE0FHsslGTOkEysiMb1as36ruZAeP7ynzJ08VEoWKyihY2eafQ8/9KDMmjRY5kweIv27t5aho2fIxUuXzT5d6AXqOOs43f/54u/twYPus6WXnn1C9lsXfHphPMS6EFz58wZzYWvbf/joX9L83boya+JgKVOisMz88EuzK126NDK0d3uZP224zBg7QFb89KvoxavZaS30gm54/07Wvv4SGBBg5YjkyvmQTBvdT8YN6ymjJs4xgZQGU4NHTpegtu/K7ElDpHPrRtJz4FgTtJiDoi0uX7lqHd9D+gS1kNj68GiuHPL8M9WkVvVKMmVkH3nj5ZpRajlx8rT0D51s2po1YZAxHRg2JUoZ20b50sVk8fxxZpw1rfpCxrxvdmm/u/UfLQ3felE+sOr4dNYoKZj/UbNPFzo344b1kHqvPSd9rGCiQtnixrBDi/rSJ2SCnD5zTtZaAePxv/+TySN6y+dzRltz2EoPlY+/WCpFCz0mU0f1lW8/mSSvvfSMyY+8aNu0nvj7+8uEsGAzxrRpUpvdN2/eFJ3z98cPsC6gv7LPeb9hk6Ra5bIyb2qIjLf6NWvBl7Lnj7svgrXfcZ1TppFoi9jGF5dRI8tt8YIJVn+GmfNj3sLwALZNk7ckT+6cZkzBnZtGa0litbQV1LmfMqqPDOvXQYaNDZ8r2z7b54TpC6Tle3Vl5viB8vVHE6VEkXyS+5GH5Oz5i3Li1BnZufsPKVLwMdkUcQdt49bfpWzJwuZ8je1c1bHGtk/b3X/giLRu/Ja8P26AvPPWSzJoxFTNJiGAgAcJ+HtQX1O8q3QAAQTcX+D5mk/It8vXyJLvf5bnrAvnyD3+ZcNvcubseekxYIzoHYDvVq6V337/wxTRi87FS3+Ubv1HSej4mXL58hX5M9Jv6KtVKi0B/uF/ZT5wfzY5ePhPc1zkhd75mGNd+Hdr/55kyXSvjJgwS/oMnWAvkifXw5I75//MdpkSheSAFazoRto0aWTL9t0yIHSKBPUbZS6od+89qLtMqlSuhGRIbwVSZit8Ub1aBbNyf7Ys1sV6Htm+8w/ZtmOvXLGCihETZ5vxjZ48V86euyBH/jxuykZfPG3VoRfemh9fH7RMTGnbzn3mArNwgbxmd/03apuL8cjBm9lhLfwD/GVTDDG8AAALY0lEQVTGvM/NHYyvvl0le/84ZOWK6XfBfI9K5fIlzfZ992aUbFkymXVd1Hq6sn6YsRz962+p+0pNs12iaAHJnzeXbN/1h+TLk1MOWHdr9G6J3ilJGxFEFCuU39zB0TtJ3y7/WbJGqtdUEseiSsXwOc907z3mQl7n/Nz5C7Jr7wHR/re07oz1sAK8ixeviL4XE70q7cPiOM6p6OV1rmIb3zZrbmMz0j6NmjRbOvQYJtt/3yd79t05d6K3YduOqy1bmaefeNysZs2cSY7/fSLGQLa0dR7rXSV9h2b773sl0333mmM02Ny4ZYes37xTaj9TRf75L/x4fZSvXKkiZs5jO1d1rLHt08pzW0Hxo1bS9SqPl7J+Tv8R210rzSMhgID7C4T/a+r+/aSHCCDg2wLxj948diVSuUJJ6+Jmj7kg1PXIB/r53bZ+m1/V/EZYf5uvdxv0t+JaZvTkeXLhwkXp1Kqh+S169geyySUrCNF9mgICwu886Lq/FYjcuHFLV+9Kuk8vFFs1flMmhvay7maslwsXL5lyqVIFmk9daH03btzUVfn6ux9lxepfpWHdF2VCaLBUeby0RG47TcTFtCkcx8LPz08KPJbbPj4d46rFM2N9DyVNmlT22uLrg71g9BXLPTDgzj8lqQIDxd/qR/Riut25V6gVMOSW/t1bSah1R+eyFSxpvqbUqVLpR4wpTerUJv+23DZBYGCkudD2blt9eCj7A+bOSoUyxeTvf09Is44DRB/LevqJCjJheLAVpOWVH1b/Ivq4manMgUXqSPPlHzHnOm+B1hgnhfWyO3/90YS77gxp9fGdU1omcoprfFoudQxGh48el8Ejpll3qCrLyMFB0rhBHbly5ZoWjzPF15YeHOB/Z179A/xF7whpfuTUoUUDc/fr4f89aN2Jmy1fLV1ldmuQoXc7Nm3dKRqMFC9cQH78eaOZk4cfyi5+frGfq35+se8zlcewuHHjRgy5ZCGAgLsK3PnbxV17SL8QQAABJwT04lQfPdGk65EPrWT9hv2LJSus35SH3724dv26/VGnQ0eOSUXrTsP/HrxfDlrrmiIf68j6zt375a+//7UX1d/26p2LdOnS2vNiWjlk/ea+WOH81m/Zc8gNKyhZt2FrTMWi5On7FJqhv+3W3zwXK/KYlLTuCOijQD/8+KvuMmndhm3mM75FXH3ImCG9nLHupMRUR4mi+UXHvTvit+4LPvtW8ltBkI47cvnLV67I6bPnrOCqlGS27g4t//EX+26tY88fByVyX89bwaC9QMSK3onQQMP2zWLbrd/2791/WIoXzmfujqSyAoYyJYtI6yZvmjtd+iiP/qZf76hUs+5mNK5fR3bs2hdRW9QP7a/eHYuae/eWlito3a0ZN+1D0cfytMT+g0dFH0XT9cjJ2XMqrvHFZnTUukv3cI7s5i6U3nH5wQpkbX3ImDG9nDt/3rYZ5TOutqIUNBuxL9RXA4rnalSRZ5+uagX/e03hstZdjo1bdspZ646R3s0qW6qwTJ39iZS18rVAXOdqXPv0WPXWRyx1/fOvl0vOh7OLnqO6TUIAAc8QIADxjHmilwgg4ISA/tZbU/RDHi9bQppYvyEeGDZV9CXm599sI9t3hl+QNm30mvQfPtm8xDz/0yWSL2+u6IfHu33y9Flp2y3EvBz7cv325h2Pvt1amd/ax3VwnRdqyNIffhZ94bf/8EnWXYL42750+bJ5mVvLd+/QWPQxGb2wH9avo+hFmb6o++wbLeWLb36Iq2n7vrj6UL1aeTl95qx06Dk8ysvYerA+dta7S3PzUrq+QK5f19unawvdFSWlS5tW6r/+vNRr2t3Uc/LUGft+7fvAnm1k9oKvzLw8+WJj2bxtl31/5JVBvdrK6rWbzcvq+ohZ36CWJqD5ddNvUunZhqIv3w8MnSIabGS37mJN/uATqfbCu2ZeNTjq0uadyNXZ15u/85oMHTVN9LGq+B7nGdCjlRVwnJWGLYPljfe6iL6HcjPSV/jaKk3IORXb+GIzKl+mqDm/9MsTOvcOlcwRj0BpH/LkziklixYUzR8a8RK65ttSbG3Z9jvy2aLzANEvDejaZ4TsPXBY3q33kjnswfuzSurUgVKsUD6zXaFMcTl67B8pW7Kw2c5sBaGxnatx7dODNcDVL2qo37yHedxSzz/NJyHglQJeOih/Lx0Xw0IAAR8TGNavk7z07JN3jbrO80+L7rPteKV2dZk1YZDMmjhYvv98mrwTccGk7x98OW+sefxKL2i0jO0brPRRpnKlitqqkNFDgsyjXvaMiBX9Lbu+AK0vxy76cJzoozmap7v1eK1H1zUVKZjXvLir6/qy8sIPRop54bdvRxnap4M0bfiq7pLm77xhktmItGjfvL555GjBjDB55smK9j2lixeSiWG9RPu/dOEUCe3f2b4v8or2Rftky4urDw9ky2LqGRvS3TxqVLxIfnvf9fgnKpc1LwTrC+Ra5tGI5/N1X+SkY/ps9ijRMs0avS5rvp1j362P6ej4dV70sTGtU3euWzZPP+wpT66HzfHa1szxA80dFd1Z86lKsnbpXPPy/ZDe7c0L65rfwwrOVn89y8yr5utdLs2Pnl5/qaaMGtzNPFaldxKi+0Sec70LM9gKhD6cNkx03vTLA/SCO3qdcZ1TamB7RDDyemzj07pjMtLHsvR4/XIE7X/Xtu+Yx/i0fIC/v/Ts1NSMy/YSupa1tRtXW9HdVy56X9JEPAqnddvSR9b5pz9HIwZ1lSG92klO626Mbd8nM0eKBse6rXehtM5nn66imybFda7GtU/nR8eh/tPH9DOPHZoKWSCAgMcIEIB4zFT5dEcZPAIIIIAAAggggICXCBCAeMlEMgwEEPAdAf1NcvKNlpYQcB8BvWund6fcp0f0BAEEEiJAAJIQNY5BAAEEEEAAAQRcLUD9CHipAAGIl04sw0IAAQQQQAABBBBAwB0FPCEAcUc3+oQAAggggAACCCCAAAIJECAASQAahyDgOwKMFAEEEEAAAQQQSFoBApCk9aQ2BBBAAAEEkkaAWhBAAAEvFSAA8dKJZVgIIIAAAggggAACCRPgKNcKEIC41pfaEUAAAQQQQAABBBBAIJIAAUgkDFajC7CNAAIIIIAAAggggEDSChCAJK0ntSGAAAJJI0AtCCCAAAIIeKkAAYiXTizDQgABBBBAAIGECXAUAgi4VoAAxLW+1I4AAggggAACCCCAAAKRBOIIQCKVYhUBBBBAAAEEEEAAAQQQSAIBApAkQKQKBJJcgAoRQAABBBBAAAEvFSAA8dKJZVgIIIAAAgkT4CgEEEAAAdcKEIC41pfaEUAAAQQQQAABBBwToJSPCBCA+MhEM0wEEEAAAQQQQAABBNxBgADEHWYheh/YRgABBBBAAAEEEEDASwUIQLx0YhkWAggkTICjEEAAAQQQQMC1AgQgrvWldgQQQAABBBBwTIBSCCDgIwIEID4y0QwTAQQQQAABBBBAAIGYBZI3lwAkeb1pDQEEEEAAAQQQQAABnxYgAPHp6Wfw0QXYRgABBBBAAAEEEHCtAAGIa32pHQEEEEDAMQFKIYAAAgj4iAABiI9MNMNEAAEEEEAAAQRiFiAXgeQVIABJXm9aQwABBBBAAAEEEEDApwUIQCJNP6sIIIAAAggggAACCCDgWgECENf6UjsCCDgmQCkEEEAAAQQQ8BEBAhAfmWiGiQACCCCAQMwC5CKAAALJK0AAkrzetIYAAggggAACCCCAQLiAjy4JQHx04hk2AggggAACCCCAAAIpIUAAkhLqtBldgG0EEEAAAQQQQAABHxEgAPGRiWaYCCCAQMwC5CKAAAIIIJC8AgQgyetNawgggAACCCCAQLgASwR8VIAAxEcnnmEjgAACCCCAAAIIIJASAv8HAAD//wS7cqkAAAAGSURBVAMA843mcn1zHo4AAAAASUVORK5CYII="
      },
      "metadata": {
       "image/png": {
@@ -1722,7 +1681,10 @@
     "    title=\"Mean Sharpe by weighting scheme\",\n",
     "    height=380,\n",
     "    width=800,\n",
-    "    margin=dict(t=90),\n",
+    "    # The left margin is explicit because the allocator names are the y tick labels and the\n",
+    "    # longest of them ran off the canvas: the rendered PNG read \"ormal_weighted\" and\n",
+    "    # \"score_weighted\". Plotly sizes the default margin before it lays the labels out.\n",
+    "    margin=dict(t=90, l=150),\n",
     ")\n",
     "_span = ordered[\"avg_sharpe\"]\n",
     "show_plotly_with_alt(\n",
@@ -1735,14 +1697,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "db3df97c",
+   "id": "ae58702c",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.004887,
-     "end_time": "2026-09-11T14:35:27.335650+00:00",
+     "duration": 0.006981,
+     "end_time": "2026-09-11T14:39:27.592606+00:00",
      "exception": false,
-     "start_time": "2026-09-11T14:35:27.330763+00:00",
+     "start_time": "2026-09-11T14:39:27.585625+00:00",
      "status": "completed"
     }
    },
@@ -1760,19 +1722,19 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "94b0998a",
+   "id": "806a2c59",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T14:35:27.346020Z",
-     "iopub.status.busy": "2026-09-11T14:35:27.345804Z",
-     "iopub.status.idle": "2026-09-11T14:35:27.419084Z",
-     "shell.execute_reply": "2026-09-11T14:35:27.418282Z"
+     "iopub.execute_input": "2026-09-11T14:39:27.614845Z",
+     "iopub.status.busy": "2026-09-11T14:39:27.613860Z",
+     "iopub.status.idle": "2026-09-11T14:39:27.730558Z",
+     "shell.execute_reply": "2026-09-11T14:39:27.729580Z"
     },
     "papermill": {
-     "duration": 0.080746,
-     "end_time": "2026-09-11T14:35:27.419798+00:00",
+     "duration": 0.128266,
+     "end_time": "2026-09-11T14:39:27.733039+00:00",
      "exception": false,
-     "start_time": "2026-09-11T14:35:27.339052+00:00",
+     "start_time": "2026-09-11T14:39:27.604773+00:00",
      "status": "completed"
     }
    },
@@ -1830,13 +1792,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "10ca08b2",
+   "id": "30c14355",
    "metadata": {
     "papermill": {
-     "duration": 0.003878,
-     "end_time": "2026-09-11T14:35:27.430225+00:00",
+     "duration": 0.007125,
+     "end_time": "2026-09-11T14:39:27.749130+00:00",
      "exception": false,
-     "start_time": "2026-09-11T14:35:27.426347+00:00",
+     "start_time": "2026-09-11T14:39:27.742005+00:00",
      "status": "completed"
     }
    },
@@ -1851,19 +1813,19 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "c762ce54",
+   "id": "a7f18d31",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T14:35:27.441785Z",
-     "iopub.status.busy": "2026-09-11T14:35:27.441581Z",
-     "iopub.status.idle": "2026-09-11T14:35:27.448673Z",
-     "shell.execute_reply": "2026-09-11T14:35:27.448125Z"
+     "iopub.execute_input": "2026-09-11T14:39:27.767659Z",
+     "iopub.status.busy": "2026-09-11T14:39:27.766983Z",
+     "iopub.status.idle": "2026-09-11T14:39:27.784123Z",
+     "shell.execute_reply": "2026-09-11T14:39:27.782226Z"
     },
     "papermill": {
-     "duration": 0.012214,
-     "end_time": "2026-09-11T14:35:27.449002+00:00",
+     "duration": 0.027685,
+     "end_time": "2026-09-11T14:39:27.784897+00:00",
      "exception": false,
-     "start_time": "2026-09-11T14:35:27.436788+00:00",
+     "start_time": "2026-09-11T14:39:27.757212+00:00",
      "status": "completed"
     },
     "tags": [
@@ -1920,13 +1882,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3021ab72",
+   "id": "8baa4365",
    "metadata": {
     "papermill": {
-     "duration": 0.005734,
-     "end_time": "2026-09-11T14:35:27.459757+00:00",
+     "duration": 0.003061,
+     "end_time": "2026-09-11T14:39:27.792704+00:00",
      "exception": false,
-     "start_time": "2026-09-11T14:35:27.454023+00:00",
+     "start_time": "2026-09-11T14:39:27.789643+00:00",
      "status": "completed"
     }
    },
@@ -1937,19 +1899,19 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "77e9aa4d",
+   "id": "26e52f3c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T14:35:27.473842Z",
-     "iopub.status.busy": "2026-09-11T14:35:27.473670Z",
-     "iopub.status.idle": "2026-09-11T14:35:27.517409Z",
-     "shell.execute_reply": "2026-09-11T14:35:27.516884Z"
+     "iopub.execute_input": "2026-09-11T14:39:27.800016Z",
+     "iopub.status.busy": "2026-09-11T14:39:27.799825Z",
+     "iopub.status.idle": "2026-09-11T14:39:27.833509Z",
+     "shell.execute_reply": "2026-09-11T14:39:27.832100Z"
     },
     "papermill": {
-     "duration": 0.051961,
-     "end_time": "2026-09-11T14:35:27.517992+00:00",
+     "duration": 0.04286,
+     "end_time": "2026-09-11T14:39:27.838904+00:00",
      "exception": false,
-     "start_time": "2026-09-11T14:35:27.466031+00:00",
+     "start_time": "2026-09-11T14:39:27.796044+00:00",
      "status": "completed"
     },
     "tags": [
@@ -2015,13 +1977,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "aad39b20",
+   "id": "97c2c125",
    "metadata": {
     "papermill": {
-     "duration": 0.005851,
-     "end_time": "2026-09-11T14:35:27.529650+00:00",
+     "duration": 0.007202,
+     "end_time": "2026-09-11T14:39:27.854010+00:00",
      "exception": false,
-     "start_time": "2026-09-11T14:35:27.523799+00:00",
+     "start_time": "2026-09-11T14:39:27.846808+00:00",
      "status": "completed"
     }
    },
@@ -2053,13 +2015,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "53a2718d",
+   "id": "ac28e6f1",
    "metadata": {
     "papermill": {
-     "duration": 0.007051,
-     "end_time": "2026-09-11T14:35:27.542696+00:00",
+     "duration": 0.006303,
+     "end_time": "2026-09-11T14:39:27.867087+00:00",
      "exception": false,
-     "start_time": "2026-09-11T14:35:27.535645+00:00",
+     "start_time": "2026-09-11T14:39:27.860784+00:00",
      "status": "completed"
     }
    },
@@ -2092,24 +2054,24 @@
    "version": "3.14.3"
   },
   "ml4t_provenance": {
-   "executed_at": "2026-09-11T14:35:43.517715+00:00",
+   "executed_at": "2026-09-11T14:39:46.738108+00:00",
    "executor": "local-uv",
    "library_digest": "cddf49f24ce0e7761fd0ed05a1b88e98faae531080df9eb1cb8644a0efbf553b",
-   "outputs_digest": "4424b909ecdd739fbecd07309485bda0eb35403ed199f544a2a239fb06e5bbbc",
+   "outputs_digest": "34038d282a2cacd0c8b313e4aa0f4d77bce394ea97aa0a75b07a5eb65b8a4f3d",
    "parameters": {},
    "production": true,
-   "source_py_blob": "632d3e43f52c8cfa858237339155977afb5a77b3"
+   "source_py_blob": "21ceb4361308f4c2d8a2b5427a11eaf814f83bbe"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 31.355746,
-   "end_time": "2026-09-11T14:35:30.512855+00:00",
+   "duration": 29.295766,
+   "end_time": "2026-09-11T14:39:31.055191+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "~/ml4t/public-teach-f/case_studies/etfs/.15_portfolio_management.build.342602.ipynb",
-   "output_path": "~/ml4t/public-teach-f/case_studies/etfs/.15_portfolio_management.papermill.342602.ipynb",
+   "input_path": "~/ml4t/public-teach-f/case_studies/etfs/.15_portfolio_management.build.375554.ipynb",
+   "output_path": "~/ml4t/public-teach-f/case_studies/etfs/.15_portfolio_management.papermill.375554.ipynb",
    "parameters": {},
-   "start_time": "2026-09-11T14:34:59.157109+00:00",
+   "start_time": "2026-09-11T14:39:01.759425+00:00",
    "version": "2.7.0"
   }
  },

--- a/case_studies/etfs/15_portfolio_management.ipynb
+++ b/case_studies/etfs/15_portfolio_management.ipynb
@@ -2,13 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "6475a04f",
+   "id": "75938619",
    "metadata": {
     "papermill": {
-     "duration": 0.001395,
-     "end_time": "2026-09-07T07:15:19.001020+00:00",
+     "duration": 0.002625,
+     "end_time": "2026-09-11T14:27:36.170574+00:00",
      "exception": false,
-     "start_time": "2026-09-07T07:15:18.999625+00:00",
+     "start_time": "2026-09-11T14:27:36.167949+00:00",
      "status": "completed"
     }
    },
@@ -53,9 +53,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "72ca8938",
-   "metadata": {},
+   "execution_count": 1,
+   "id": "9896c8f0",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-11T14:27:36.176585Z",
+     "iopub.status.busy": "2026-09-11T14:27:36.176318Z",
+     "iopub.status.idle": "2026-09-11T14:27:41.123245Z",
+     "shell.execute_reply": "2026-09-11T14:27:41.122644Z"
+    },
+    "papermill": {
+     "duration": 4.951435,
+     "end_time": "2026-09-11T14:27:41.124242+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T14:27:36.172807+00:00",
+     "status": "completed"
+    }
+   },
    "outputs": [],
    "source": [
     "\"\"\"Sweep portfolio allocators and concentration levels over the leading ETF predictions.\"\"\"\n",
@@ -67,7 +81,7 @@
     "import plotly.graph_objects as go\n",
     "import polars as pl\n",
     "\n",
-    "from case_studies.research import open_study, split_unpublished_members\n",
+    "from case_studies.research import open_study, reuse_disclosure, split_unpublished_members\n",
     "from case_studies.utils.backtest_explorer import BacktestExplorer\n",
     "from case_studies.utils.backtest_loaders import get_backtest_config, load_backtest_prices_for\n",
     "from case_studies.utils.backtest_presets import (\n",
@@ -96,9 +110,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "4c87d926",
+   "execution_count": 2,
+   "id": "653d728f",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-11T14:27:41.132913Z",
+     "iopub.status.busy": "2026-09-11T14:27:41.132395Z",
+     "iopub.status.idle": "2026-09-11T14:27:41.136186Z",
+     "shell.execute_reply": "2026-09-11T14:27:41.135293Z"
+    },
+    "papermill": {
+     "duration": 0.009866,
+     "end_time": "2026-09-11T14:27:41.136652+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T14:27:41.126786+00:00",
+     "status": "completed"
+    },
     "tags": [
      "parameters"
     ]
@@ -120,13 +147,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2b327606",
+   "id": "113ffad3",
    "metadata": {
     "papermill": {
-     "duration": 0.000951,
-     "end_time": "2026-09-07T07:15:21.354791+00:00",
+     "duration": 0.00136,
+     "end_time": "2026-09-11T14:27:41.139774+00:00",
      "exception": false,
-     "start_time": "2026-09-07T07:15:21.353840+00:00",
+     "start_time": "2026-09-11T14:27:41.138414+00:00",
      "status": "completed"
     }
    },
@@ -147,10 +174,32 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "0e473c80",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 3,
+   "id": "1e01e2bf",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-11T14:27:41.143392Z",
+     "iopub.status.busy": "2026-09-11T14:27:41.143077Z",
+     "iopub.status.idle": "2026-09-11T14:27:41.188019Z",
+     "shell.execute_reply": "2026-09-11T14:27:41.187192Z"
+    },
+    "papermill": {
+     "duration": 0.047789,
+     "end_time": "2026-09-11T14:27:41.188829+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T14:27:41.141040+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Case study: etfs, label: fwd_ret_21d\n"
+     ]
+    }
+   ],
    "source": [
     "bt_config = get_backtest_config(CASE_STUDY_ID)\n",
     "if TOP_N_PREDICTIONS is None:\n",
@@ -163,13 +212,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cdbfc3cd",
+   "id": "00f1eec1",
    "metadata": {
     "papermill": {
-     "duration": 0.001035,
-     "end_time": "2026-09-07T07:15:21.396369+00:00",
+     "duration": 0.002724,
+     "end_time": "2026-09-11T14:27:41.194733+00:00",
      "exception": false,
-     "start_time": "2026-09-07T07:15:21.395334+00:00",
+     "start_time": "2026-09-11T14:27:41.192009+00:00",
      "status": "completed"
     }
    },
@@ -189,10 +238,32 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "d155e1bd",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 4,
+   "id": "eb924554",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-11T14:27:41.203510Z",
+     "iopub.status.busy": "2026-09-11T14:27:41.203216Z",
+     "iopub.status.idle": "2026-09-11T14:27:41.261563Z",
+     "shell.execute_reply": "2026-09-11T14:27:41.260782Z"
+    },
+    "papermill": {
+     "duration": 0.064,
+     "end_time": "2026-09-11T14:27:41.262083+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T14:27:41.198083+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Live prediction sets: 283\n"
+     ]
+    }
+   ],
    "source": [
     "LIVE_PREDICTIONS = (\n",
     "    split_unpublished_members(\n",
@@ -211,10 +282,68 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "99d65356",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 5,
+   "id": "80027f19",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-11T14:27:41.269469Z",
+     "iopub.status.busy": "2026-09-11T14:27:41.269081Z",
+     "iopub.status.idle": "2026-09-11T14:27:41.429735Z",
+     "shell.execute_reply": "2026-09-11T14:27:41.429033Z"
+    },
+    "papermill": {
+     "duration": 0.165463,
+     "end_time": "2026-09-11T14:27:41.430258+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T14:27:41.264795+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "10 prediction sets advance, ranked by equal-weight top-k Sharpe:\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div><style>\n",
+       ".dataframe > thead > tr,\n",
+       ".dataframe > tbody > tr {\n",
+       "  text-align: right;\n",
+       "  white-space: pre-wrap;\n",
+       "}\n",
+       "</style>\n",
+       "<small>shape: (10, 2)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>source</th><th>sharpe</th></tr><tr><td>str</td><td>f64</td></tr></thead><tbody><tr><td>&quot;gbm/leaves_63_huber&quot;</td><td>0.739773</td></tr><tr><td>&quot;latent_factors/cae&quot;</td><td>0.734171</td></tr><tr><td>&quot;gbm/default_huber&quot;</td><td>0.709296</td></tr><tr><td>&quot;gbm/leaves_7_mse&quot;</td><td>0.704736</td></tr><tr><td>&quot;gbm/leaves_15_mse&quot;</td><td>0.704393</td></tr><tr><td>&quot;latent_factors/sae&quot;</td><td>0.669824</td></tr><tr><td>&quot;deep_learning/nlinear&quot;</td><td>0.654045</td></tr><tr><td>&quot;gbm/leaves_63_mse&quot;</td><td>0.648882</td></tr><tr><td>&quot;gbm/leaves_31_huber&quot;</td><td>0.644103</td></tr><tr><td>&quot;gbm/leaves_31_mse&quot;</td><td>0.631503</td></tr></tbody></table></div>"
+      ],
+      "text/plain": [
+       "shape: (10, 2)\n",
+       "┌───────────────────────┬──────────┐\n",
+       "│ source                ┆ sharpe   │\n",
+       "│ ---                   ┆ ---      │\n",
+       "│ str                   ┆ f64      │\n",
+       "╞═══════════════════════╪══════════╡\n",
+       "│ gbm/leaves_63_huber   ┆ 0.739773 │\n",
+       "│ latent_factors/cae    ┆ 0.734171 │\n",
+       "│ gbm/default_huber     ┆ 0.709296 │\n",
+       "│ gbm/leaves_7_mse      ┆ 0.704736 │\n",
+       "│ gbm/leaves_15_mse     ┆ 0.704393 │\n",
+       "│ latent_factors/sae    ┆ 0.669824 │\n",
+       "│ deep_learning/nlinear ┆ 0.654045 │\n",
+       "│ gbm/leaves_63_mse     ┆ 0.648882 │\n",
+       "│ gbm/leaves_31_huber   ┆ 0.644103 │\n",
+       "│ gbm/leaves_31_mse     ┆ 0.631503 │\n",
+       "└───────────────────────┴──────────┘"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "top_preds = resolve_best_predictions(\n",
     "    CASE_STUDY_ID,\n",
@@ -236,13 +365,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "13c00556",
+   "id": "30bc15c2",
    "metadata": {
     "papermill": {
-     "duration": 0.001163,
-     "end_time": "2026-09-07T07:15:23.670833+00:00",
+     "duration": 0.002697,
+     "end_time": "2026-09-11T14:27:41.436055+00:00",
      "exception": false,
-     "start_time": "2026-09-07T07:15:23.669670+00:00",
+     "start_time": "2026-09-11T14:27:41.433358+00:00",
      "status": "completed"
     }
    },
@@ -257,10 +386,35 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "74b2ee06",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 6,
+   "id": "3cda1948",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-11T14:27:41.444950Z",
+     "iopub.status.busy": "2026-09-11T14:27:41.444618Z",
+     "iopub.status.idle": "2026-09-11T14:27:42.131642Z",
+     "shell.execute_reply": "2026-09-11T14:27:42.130519Z"
+    },
+    "papermill": {
+     "duration": 0.693411,
+     "end_time": "2026-09-11T14:27:42.132255+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T14:27:41.438844+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Prices: 198,877 rows, 100 tradeable funds\n",
+      "Concentration grid: top_k in [5, 10, 20]\n",
+      "Allocators (6): score_weighted, inverse_vol, risk_parity, mvo_ledoit_wolf, hrp, conformal_weighted\n",
+      "Grid: 10 predictions x 3 concentrations x 6 allocators = 180 backtests\n"
+     ]
+    }
+   ],
    "source": [
     "prices = load_backtest_prices_for(CASE_STUDY_ID, LABEL, split=\"validation\", max_symbols=MAX_SYMBOLS)\n",
     "\n",
@@ -305,13 +459,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9dfb7771",
+   "id": "37745f64",
    "metadata": {
     "papermill": {
-     "duration": 0.001907,
-     "end_time": "2026-09-07T07:15:24.442460+00:00",
+     "duration": 0.002525,
+     "end_time": "2026-09-11T14:27:42.137894+00:00",
      "exception": false,
-     "start_time": "2026-09-07T07:15:24.440553+00:00",
+     "start_time": "2026-09-11T14:27:42.135369+00:00",
      "status": "completed"
     }
    },
@@ -325,13 +479,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e50491ae",
+   "id": "7ba493a2",
    "metadata": {
     "papermill": {
-     "duration": 0.001094,
-     "end_time": "2026-09-07T07:15:24.444741+00:00",
+     "duration": 0.002422,
+     "end_time": "2026-09-11T14:27:42.143714+00:00",
      "exception": false,
-     "start_time": "2026-09-07T07:15:24.443647+00:00",
+     "start_time": "2026-09-11T14:27:42.141292+00:00",
      "status": "completed"
     }
    },
@@ -345,10 +499,701 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "738ecc46",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 7,
+   "id": "ad961a16",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-11T14:27:42.149351Z",
+     "iopub.status.busy": "2026-09-11T14:27:42.149094Z",
+     "iopub.status.idle": "2026-09-11T14:27:52.861033Z",
+     "shell.execute_reply": "2026-09-11T14:27:52.859984Z"
+    },
+    "papermill": {
+     "duration": 10.720927,
+     "end_time": "2026-09-11T14:27:52.867293+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T14:27:42.146366+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Allocation-stage backtests already registered: 378\n",
+      "\n",
+      "--- top_k = 5 ---\n",
+      "  SKIP backtest (complete (hash=7007dfbbe77c)) — reusing cached result\n",
+      "  [1/180] k=5 gbm/leaves_63_huber x score_weighted: Sharpe=+0.594\n",
+      "  SKIP backtest (complete (hash=e9a1f631d390)) — reusing cached result\n",
+      "  [2/180] k=5 gbm/leaves_63_huber x inverse_vol: Sharpe=+0.713\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  SKIP backtest (complete (hash=bd26475d0d98)) — reusing cached result\n",
+      "  [3/180] k=5 gbm/leaves_63_huber x risk_parity: Sharpe=+0.684\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  SKIP backtest (complete (hash=4401eba4fc30)) — reusing cached result\n",
+      "  [4/180] k=5 gbm/leaves_63_huber x mvo_ledoit_wolf: Sharpe=+0.579\n",
+      "  SKIP backtest (complete (hash=a7e082d956af)) — reusing cached result\n",
+      "  [5/180] k=5 gbm/leaves_63_huber x hrp: Sharpe=+0.626\n",
+      "  SKIP backtest (complete (hash=7d9da5f5bc7f)) — reusing cached result\n",
+      "  [6/180] k=5 gbm/leaves_63_huber x conformal_weighted: Sharpe=+0.795\n",
+      "  SKIP backtest (complete (hash=22bfd698df7a)) — reusing cached result\n",
+      "  [7/180] k=5 latent_factors/cae x score_weighted: Sharpe=+0.699\n",
+      "  SKIP backtest (complete (hash=ab8deb48db5e)) — reusing cached result\n",
+      "  [8/180] k=5 latent_factors/cae x inverse_vol: Sharpe=+0.741\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  SKIP backtest (complete (hash=f84969df2d57)) — reusing cached result\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  [9/180] k=5 latent_factors/cae x risk_parity: Sharpe=+0.734\n",
+      "  SKIP backtest (complete (hash=54572c323d46)) — reusing cached result\n",
+      "  [10/180] k=5 latent_factors/cae x mvo_ledoit_wolf: Sharpe=+0.344\n",
+      "  SKIP backtest (complete (hash=56ccab7e06ba)) — reusing cached result\n",
+      "  [11/180] k=5 latent_factors/cae x hrp: Sharpe=+0.680\n",
+      "  SKIP backtest (complete (hash=5faa94568361)) — reusing cached result\n",
+      "  [12/180] k=5 latent_factors/cae x conformal_weighted: Sharpe=+0.833\n",
+      "  SKIP backtest (complete (hash=d799a6a22a33)) — reusing cached result\n",
+      "  [13/180] k=5 gbm/default_huber x score_weighted: Sharpe=+0.734\n",
+      "  SKIP backtest (complete (hash=33900b169856)) — reusing cached result\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  [14/180] k=5 gbm/default_huber x inverse_vol: Sharpe=+0.681\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  SKIP backtest (complete (hash=805b2215139b)) — reusing cached result\n",
+      "  [15/180] k=5 gbm/default_huber x risk_parity: Sharpe=+0.679\n",
+      "  SKIP backtest (complete (hash=4c980459e2d8)) — reusing cached result\n",
+      "  [16/180] k=5 gbm/default_huber x mvo_ledoit_wolf: Sharpe=+0.256\n",
+      "  SKIP backtest (complete (hash=97889be8a3ea)) — reusing cached result\n",
+      "  [17/180] k=5 gbm/default_huber x hrp: Sharpe=+0.734\n",
+      "  SKIP backtest (complete (hash=eaefd57920bd)) — reusing cached result\n",
+      "  [18/180] k=5 gbm/default_huber x conformal_weighted: Sharpe=+0.738\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  SKIP backtest (complete (hash=857f29029abb)) — reusing cached result\n",
+      "  [19/180] k=5 gbm/leaves_7_mse x score_weighted: Sharpe=+0.239\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  SKIP backtest (complete (hash=c53f9c3fcfe8)) — reusing cached result\n",
+      "  [20/180] k=5 gbm/leaves_7_mse x inverse_vol: Sharpe=+0.623\n",
+      "  SKIP backtest (complete (hash=611f44996454)) — reusing cached result\n",
+      "  [21/180] k=5 gbm/leaves_7_mse x risk_parity: Sharpe=+0.642\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  SKIP backtest (complete (hash=e0fd8b90fa7d)) — reusing cached result\n",
+      "  [22/180] k=5 gbm/leaves_7_mse x mvo_ledoit_wolf: Sharpe=-0.128\n",
+      "  SKIP backtest (complete (hash=a09668969904)) — reusing cached result\n",
+      "  [23/180] k=5 gbm/leaves_7_mse x hrp: Sharpe=+0.611\n",
+      "  SKIP backtest (complete (hash=ddcf681f2133)) — reusing cached result\n",
+      "  [24/180] k=5 gbm/leaves_7_mse x conformal_weighted: Sharpe=+0.669\n",
+      "  SKIP backtest (complete (hash=2b774d110270)) — reusing cached result\n",
+      "  [25/180] k=5 gbm/leaves_15_mse x score_weighted: Sharpe=+0.415\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  SKIP backtest (complete (hash=6ff63b0fe922)) — reusing cached result\n",
+      "  [26/180] k=5 gbm/leaves_15_mse x inverse_vol: Sharpe=+0.568\n",
+      "  SKIP backtest (complete (hash=e6e27815bca1)) — reusing cached result\n",
+      "  [27/180] k=5 gbm/leaves_15_mse x risk_parity: Sharpe=+0.564\n",
+      "  SKIP backtest (complete (hash=6b517d2cb5e3)) — reusing cached result\n",
+      "  [28/180] k=5 gbm/leaves_15_mse x mvo_ledoit_wolf: Sharpe=-0.002\n",
+      "  SKIP backtest (complete (hash=2322f33b8eea)) — reusing cached result\n",
+      "  [29/180] k=5 gbm/leaves_15_mse x hrp: Sharpe=+0.430\n",
+      "  SKIP backtest (complete (hash=2c5700121c88)) — reusing cached result\n",
+      "  [30/180] k=5 gbm/leaves_15_mse x conformal_weighted: Sharpe=+0.658\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  SKIP backtest (complete (hash=45474dabc0b9)) — reusing cached result\n",
+      "  [31/180] k=5 latent_factors/sae x score_weighted: Sharpe=+0.589\n",
+      "  SKIP backtest (complete (hash=df6678134c30)) — reusing cached result\n",
+      "  [32/180] k=5 latent_factors/sae x inverse_vol: Sharpe=+0.659\n",
+      "  SKIP backtest (complete (hash=3b3d1daf403c)) — reusing cached result\n",
+      "  [33/180] k=5 latent_factors/sae x risk_parity: Sharpe=+0.646\n",
+      "  SKIP backtest (complete (hash=cb1f469255ce)) — reusing cached result\n",
+      "  [34/180] k=5 latent_factors/sae x mvo_ledoit_wolf: Sharpe=+0.300\n",
+      "  SKIP backtest (complete (hash=6594a42c8656)) — reusing cached result\n",
+      "  [35/180] k=5 latent_factors/sae x hrp: Sharpe=+0.644\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  SKIP backtest (complete (hash=3e46484e43e9)) — reusing cached result\n",
+      "  [36/180] k=5 latent_factors/sae x conformal_weighted: Sharpe=+0.714\n",
+      "  SKIP backtest (complete (hash=467dbc652750)) — reusing cached result\n",
+      "  [37/180] k=5 deep_learning/nlinear x score_weighted: Sharpe=+0.349\n",
+      "  SKIP backtest (complete (hash=36d76cdb05cb)) — reusing cached result\n",
+      "  [38/180] k=5 deep_learning/nlinear x inverse_vol: Sharpe=+0.721\n",
+      "  SKIP backtest (complete (hash=2ca7cded6729)) — reusing cached result\n",
+      "  [39/180] k=5 deep_learning/nlinear x risk_parity: Sharpe=+0.732\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  SKIP backtest (complete (hash=8aba508f72af)) — reusing cached result\n",
+      "  [40/180] k=5 deep_learning/nlinear x mvo_ledoit_wolf: Sharpe=+0.021\n",
+      "  SKIP backtest (complete (hash=12799dcd1b88)) — reusing cached result\n",
+      "  [41/180] k=5 deep_learning/nlinear x hrp: Sharpe=+0.462\n",
+      "  SKIP backtest (complete (hash=21b5ee8eed9c)) — reusing cached result\n",
+      "  [42/180] k=5 deep_learning/nlinear x conformal_weighted: Sharpe=+0.789\n",
+      "  SKIP backtest (complete (hash=c3f212552f81)) — reusing cached result\n",
+      "  [43/180] k=5 gbm/leaves_63_mse x score_weighted: Sharpe=+0.486\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  SKIP backtest (complete (hash=b3a807649ae9)) — reusing cached result\n",
+      "  [44/180] k=5 gbm/leaves_63_mse x inverse_vol: Sharpe=+0.719\n",
+      "  SKIP backtest (complete (hash=de1918574ab0)) — reusing cached result\n",
+      "  [45/180] k=5 gbm/leaves_63_mse x risk_parity: Sharpe=+0.750\n",
+      "  SKIP backtest (complete (hash=c458854f3412)) — reusing cached result\n",
+      "  [46/180] k=5 gbm/leaves_63_mse x mvo_ledoit_wolf: Sharpe=+0.272\n",
+      "  SKIP backtest (complete (hash=40683a25bab5)) — reusing cached result\n",
+      "  [47/180] k=5 gbm/leaves_63_mse x hrp: Sharpe=+0.829\n",
+      "  SKIP backtest (complete (hash=9299301ac920)) — reusing cached result\n",
+      "  [48/180] k=5 gbm/leaves_63_mse x conformal_weighted: Sharpe=+0.722\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  SKIP backtest (complete (hash=b305e9825a1f)) — reusing cached result\n",
+      "  [49/180] k=5 gbm/leaves_31_huber x score_weighted: Sharpe=+0.464\n",
+      "  SKIP backtest (complete (hash=179b96408bd7)) — reusing cached result\n",
+      "  [50/180] k=5 gbm/leaves_31_huber x inverse_vol: Sharpe=+0.664\n",
+      "  SKIP backtest (complete (hash=ad89fe90d2b7)) — reusing cached result\n",
+      "  [51/180] k=5 gbm/leaves_31_huber x risk_parity: Sharpe=+0.659\n",
+      "  SKIP backtest (complete (hash=3d7b4effa5e8)) — reusing cached result\n",
+      "  [52/180] k=5 gbm/leaves_31_huber x mvo_ledoit_wolf: Sharpe=+0.444\n",
+      "  SKIP backtest (complete (hash=f1e47d14047c)) — reusing cached result\n",
+      "  [53/180] k=5 gbm/leaves_31_huber x hrp: Sharpe=+0.570\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  SKIP backtest (complete (hash=880440c36cb8)) — reusing cached result\n",
+      "  [54/180] k=5 gbm/leaves_31_huber x conformal_weighted: Sharpe=+0.753\n",
+      "  SKIP backtest (complete (hash=2699d0fbcf63)) — reusing cached result\n",
+      "  [55/180] k=5 gbm/leaves_31_mse x score_weighted: Sharpe=+0.178\n",
+      "  SKIP backtest (complete (hash=2cb58d13a4d8)) — reusing cached result\n",
+      "  [56/180] k=5 gbm/leaves_31_mse x inverse_vol: Sharpe=+0.485\n",
+      "  SKIP backtest (complete (hash=883d009def1d)) — reusing cached result\n",
+      "  [57/180] k=5 gbm/leaves_31_mse x risk_parity: Sharpe=+0.505\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  SKIP backtest (complete (hash=599a2d2dcb81)) — reusing cached result\n",
+      "  [58/180] k=5 gbm/leaves_31_mse x mvo_ledoit_wolf: Sharpe=+0.219\n",
+      "  SKIP backtest (complete (hash=a7c421616ce0)) — reusing cached result\n",
+      "  [59/180] k=5 gbm/leaves_31_mse x hrp: Sharpe=+0.526\n",
+      "  SKIP backtest (complete (hash=6aa621f01fda)) — reusing cached result\n",
+      "  [60/180] k=5 gbm/leaves_31_mse x conformal_weighted: Sharpe=+0.533\n",
+      "\n",
+      "--- top_k = 10 ---\n",
+      "  SKIP backtest (complete (hash=dd0a661e424f)) — reusing cached result\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  [61/180] k=10 gbm/leaves_63_huber x score_weighted: Sharpe=+0.454\n",
+      "  SKIP backtest (complete (hash=dbd143f7d9f1)) — reusing cached result\n",
+      "  [62/180] k=10 gbm/leaves_63_huber x inverse_vol: Sharpe=+0.471\n",
+      "  SKIP backtest (complete (hash=0f64f2f7bab1)) — reusing cached result\n",
+      "  [63/180] k=10 gbm/leaves_63_huber x risk_parity: Sharpe=+0.450\n",
+      "  SKIP backtest (complete (hash=35b2a8df3499)) — reusing cached result\n",
+      "  [64/180] k=10 gbm/leaves_63_huber x mvo_ledoit_wolf: Sharpe=+0.663\n",
+      "  SKIP backtest (complete (hash=ee753e5654a0)) — reusing cached result\n",
+      "  [65/180] k=10 gbm/leaves_63_huber x hrp: Sharpe=+0.390\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  SKIP backtest (complete (hash=4050f5e8342c)) — reusing cached result\n",
+      "  [66/180] k=10 gbm/leaves_63_huber x conformal_weighted: Sharpe=+0.552\n",
+      "  SKIP backtest (complete (hash=4e840ad7b2ff)) — reusing cached result\n",
+      "  [67/180] k=10 latent_factors/cae x score_weighted: Sharpe=+0.721\n",
+      "  SKIP backtest (complete (hash=786f9cb56695)) — reusing cached result\n",
+      "  [68/180] k=10 latent_factors/cae x inverse_vol: Sharpe=+0.700\n",
+      "  SKIP backtest (complete (hash=3402752b8514)) — reusing cached result\n",
+      "  [69/180] k=10 latent_factors/cae x risk_parity: Sharpe=+0.674\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  SKIP backtest (complete (hash=464139c9235e)) — reusing cached result\n",
+      "  [70/180] k=10 latent_factors/cae x mvo_ledoit_wolf: Sharpe=+0.474\n",
+      "  SKIP backtest (complete (hash=55ecbca3a3ef)) — reusing cached result\n",
+      "  [71/180] k=10 latent_factors/cae x hrp: Sharpe=+0.551\n",
+      "  SKIP backtest (complete (hash=6132d7546e16)) — reusing cached result\n",
+      "  [72/180] k=10 latent_factors/cae x conformal_weighted: Sharpe=+0.785\n",
+      "  SKIP backtest (complete (hash=78746e4f0b5a)) — reusing cached result\n",
+      "  [73/180] k=10 gbm/default_huber x score_weighted: Sharpe=+0.654\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  SKIP backtest (complete (hash=1c2f79dcecf7)) — reusing cached result\n",
+      "  [74/180] k=10 gbm/default_huber x inverse_vol: Sharpe=+0.509\n",
+      "  SKIP backtest (complete (hash=49dac2cbbf0b)) — reusing cached result\n",
+      "  [75/180] k=10 gbm/default_huber x risk_parity: Sharpe=+0.502\n",
+      "  SKIP backtest (complete (hash=ebc61083754b)) — reusing cached result\n",
+      "  [76/180] k=10 gbm/default_huber x mvo_ledoit_wolf: Sharpe=+0.493\n",
+      "  SKIP backtest (complete (hash=6347d4bd29dc)) — reusing cached result\n",
+      "  [77/180] k=10 gbm/default_huber x hrp: Sharpe=+0.501\n",
+      "  SKIP backtest (complete (hash=6eb290538afb)) — reusing cached result\n",
+      "  [78/180] k=10 gbm/default_huber x conformal_weighted: Sharpe=+0.585\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  SKIP backtest (complete (hash=298acef2aca4)) — reusing cached result\n",
+      "  [79/180] k=10 gbm/leaves_7_mse x score_weighted: Sharpe=+0.367\n",
+      "  SKIP backtest (complete (hash=2144b9918f47)) — reusing cached result\n",
+      "  [80/180] k=10 gbm/leaves_7_mse x inverse_vol: Sharpe=+0.571\n",
+      "  SKIP backtest (complete (hash=3d3d7365c1ae)) — reusing cached result\n",
+      "  [81/180] k=10 gbm/leaves_7_mse x risk_parity: Sharpe=+0.565\n",
+      "  SKIP backtest (complete (hash=b87ff08084f9)) — reusing cached result\n",
+      "  [82/180] k=10 gbm/leaves_7_mse x mvo_ledoit_wolf: Sharpe=-0.163\n",
+      "  SKIP backtest (complete (hash=fa1f09de5789)) — reusing cached result\n",
+      "  [83/180] k=10 gbm/leaves_7_mse x hrp: Sharpe=+0.535\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  SKIP backtest (complete (hash=df8ca178d6e8)) — reusing cached result\n",
+      "  [84/180] k=10 gbm/leaves_7_mse x conformal_weighted: Sharpe=+0.653\n",
+      "  SKIP backtest (complete (hash=34c09d4a95f6)) — reusing cached result\n",
+      "  [85/180] k=10 gbm/leaves_15_mse x score_weighted: Sharpe=+0.530\n",
+      "  SKIP backtest (complete (hash=5f85414f9e30)) — reusing cached result\n",
+      "  [86/180] k=10 gbm/leaves_15_mse x inverse_vol: Sharpe=+0.612\n",
+      "  SKIP backtest (complete (hash=9b5e91272568)) — reusing cached result\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  [87/180] k=10 gbm/leaves_15_mse x risk_parity: Sharpe=+0.602\n",
+      "  SKIP backtest (complete (hash=ddbba7ded63c)) — reusing cached result\n",
+      "  [88/180] k=10 gbm/leaves_15_mse x mvo_ledoit_wolf: Sharpe=+0.079\n",
+      "  SKIP backtest (complete (hash=e451297fdc6c)) — reusing cached result\n",
+      "  [89/180] k=10 gbm/leaves_15_mse x hrp: Sharpe=+0.547\n",
+      "  SKIP backtest (complete (hash=40ef44df2b4d)) — reusing cached result\n",
+      "  [90/180] k=10 gbm/leaves_15_mse x conformal_weighted: Sharpe=+0.684\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  SKIP backtest (complete (hash=3268a4e7551c)) — reusing cached result\n",
+      "  [91/180] k=10 latent_factors/sae x score_weighted: Sharpe=+0.597\n",
+      "  SKIP backtest (complete (hash=75baa0bb6022)) — reusing cached result\n",
+      "  [92/180] k=10 latent_factors/sae x inverse_vol: Sharpe=+0.624\n",
+      "  SKIP backtest (complete (hash=2aa4b4368720)) — reusing cached result\n",
+      "  [93/180] k=10 latent_factors/sae x risk_parity: Sharpe=+0.608\n",
+      "  SKIP backtest (complete (hash=0b57bf7ed4b2)) — reusing cached result\n",
+      "  [94/180] k=10 latent_factors/sae x mvo_ledoit_wolf: Sharpe=+0.235\n",
+      "  SKIP backtest (complete (hash=6cf0e73c4456)) — reusing cached result\n",
+      "  [95/180] k=10 latent_factors/sae x hrp: Sharpe=+0.591\n",
+      "  SKIP backtest (complete (hash=9d7b88c2af68)) — reusing cached result\n",
+      "  [96/180] k=10 latent_factors/sae x conformal_weighted: Sharpe=+0.703\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  SKIP backtest (complete (hash=d6b782e2349b)) — reusing cached result\n",
+      "  [97/180] k=10 deep_learning/nlinear x score_weighted: Sharpe=+0.392\n",
+      "  SKIP backtest (complete (hash=c42a877f10b9)) — reusing cached result\n",
+      "  [98/180] k=10 deep_learning/nlinear x inverse_vol: Sharpe=+0.602\n",
+      "  SKIP backtest (complete (hash=887025997f5b)) — reusing cached result\n",
+      "  [99/180] k=10 deep_learning/nlinear x risk_parity: Sharpe=+0.547\n",
+      "  SKIP backtest (complete (hash=2db8bd6d82fc)) — reusing cached result\n",
+      "  [100/180] k=10 deep_learning/nlinear x mvo_ledoit_wolf: Sharpe=+0.205\n",
+      "  SKIP backtest (complete (hash=77856b8dc3d6)) — reusing cached result\n",
+      "  [101/180] k=10 deep_learning/nlinear x hrp: Sharpe=+0.461\n",
+      "  SKIP backtest (complete (hash=5349680e56a9)) — reusing cached result\n",
+      "  [102/180] k=10 deep_learning/nlinear x conformal_weighted: Sharpe=+0.738\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  SKIP backtest (complete (hash=59011f9cba45)) — reusing cached result\n",
+      "  [103/180] k=10 gbm/leaves_63_mse x score_weighted: Sharpe=+0.406\n",
+      "  SKIP backtest (complete (hash=d157c5cfb947)) — reusing cached result\n",
+      "  [104/180] k=10 gbm/leaves_63_mse x inverse_vol: Sharpe=+0.652\n",
+      "  SKIP backtest (complete (hash=e3cf8ac82672)) — reusing cached result\n",
+      "  [105/180] k=10 gbm/leaves_63_mse x risk_parity: Sharpe=+0.692\n",
+      "  SKIP backtest (complete (hash=2d11c330f4df)) — reusing cached result\n",
+      "  [106/180] k=10 gbm/leaves_63_mse x mvo_ledoit_wolf: Sharpe=+0.257\n",
+      "  SKIP backtest (complete (hash=a061dffd737c)) — reusing cached result\n",
+      "  [107/180] k=10 gbm/leaves_63_mse x hrp: Sharpe=+0.653\n",
+      "  SKIP backtest (complete (hash=d22528bc14c3)) — reusing cached result\n",
+      "  [108/180] k=10 gbm/leaves_63_mse x conformal_weighted: Sharpe=+0.667\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  SKIP backtest (complete (hash=ac72edc4c91c)) — reusing cached result\n",
+      "  [109/180] k=10 gbm/leaves_31_huber x score_weighted: Sharpe=+0.542\n",
+      "  SKIP backtest (complete (hash=13257ec78377)) — reusing cached result\n",
+      "  [110/180] k=10 gbm/leaves_31_huber x inverse_vol: Sharpe=+0.726\n",
+      "  SKIP backtest (complete (hash=c729f95ee188)) — reusing cached result\n",
+      "  [111/180] k=10 gbm/leaves_31_huber x risk_parity: Sharpe=+0.752\n",
+      "  SKIP backtest (complete (hash=8608af0b86fe)) — reusing cached result\n",
+      "  [112/180] k=10 gbm/leaves_31_huber x mvo_ledoit_wolf: Sharpe=+0.495\n",
+      "  SKIP backtest (complete (hash=9796322099d7)) — reusing cached result\n",
+      "  [113/180] k=10 gbm/leaves_31_huber x hrp: Sharpe=+0.774\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  SKIP backtest (complete (hash=c730e91723d7)) — reusing cached result\n",
+      "  [114/180] k=10 gbm/leaves_31_huber x conformal_weighted: Sharpe=+0.765\n",
+      "  SKIP backtest (complete (hash=844c4d26afd1)) — reusing cached result\n",
+      "  [115/180] k=10 gbm/leaves_31_mse x score_weighted: Sharpe=+0.335\n",
+      "  SKIP backtest (complete (hash=6a8406590da5)) — reusing cached result\n",
+      "  [116/180] k=10 gbm/leaves_31_mse x inverse_vol: Sharpe=+0.558\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  SKIP backtest (complete (hash=e9efb5b0228e)) — reusing cached result\n",
+      "  [117/180] k=10 gbm/leaves_31_mse x risk_parity: Sharpe=+0.558\n",
+      "  SKIP backtest (complete (hash=216c8996b6ff)) — reusing cached result\n",
+      "  [118/180] k=10 gbm/leaves_31_mse x mvo_ledoit_wolf: Sharpe=+0.202\n",
+      "  SKIP backtest (complete (hash=74922d9aaf3d)) — reusing cached result\n",
+      "  [119/180] k=10 gbm/leaves_31_mse x hrp: Sharpe=+0.488\n",
+      "  SKIP backtest (complete (hash=cfc5ec04de8e)) — reusing cached result\n",
+      "  [120/180] k=10 gbm/leaves_31_mse x conformal_weighted: Sharpe=+0.628\n",
+      "\n",
+      "--- top_k = 20 ---\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  SKIP backtest (complete (hash=f04acdd15758)) — reusing cached result\n",
+      "  [121/180] k=20 gbm/leaves_63_huber x score_weighted: Sharpe=+0.476\n",
+      "  SKIP backtest (complete (hash=1c886458773f)) — reusing cached result\n",
+      "  [122/180] k=20 gbm/leaves_63_huber x inverse_vol: Sharpe=+0.543\n",
+      "  SKIP backtest (complete (hash=4b87e3afa056)) — reusing cached result\n",
+      "  [123/180] k=20 gbm/leaves_63_huber x risk_parity: Sharpe=+0.521\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  SKIP backtest (complete (hash=359f7ff91dff)) — reusing cached result\n",
+      "  [124/180] k=20 gbm/leaves_63_huber x mvo_ledoit_wolf: Sharpe=+0.606\n",
+      "  SKIP backtest (complete (hash=1742d7a4f2b9)) — reusing cached result\n",
+      "  [125/180] k=20 gbm/leaves_63_huber x hrp: Sharpe=+0.441\n",
+      "  SKIP backtest (complete (hash=0cdb003f04b4)) — reusing cached result\n",
+      "  [126/180] k=20 gbm/leaves_63_huber x conformal_weighted: Sharpe=+0.607\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  SKIP backtest (complete (hash=9cede1a0404e)) — reusing cached result\n",
+      "  [127/180] k=20 latent_factors/cae x score_weighted: Sharpe=+0.728\n",
+      "  SKIP backtest (complete (hash=b8a53866d904)) — reusing cached result\n",
+      "  [128/180] k=20 latent_factors/cae x inverse_vol: Sharpe=+0.724\n",
+      "  SKIP backtest (complete (hash=14942f2adae0)) — reusing cached result\n",
+      "  [129/180] k=20 latent_factors/cae x risk_parity: Sharpe=+0.710\n",
+      "  SKIP backtest (complete (hash=ad3b632a1365)) — reusing cached result\n",
+      "  [130/180] k=20 latent_factors/cae x mvo_ledoit_wolf: Sharpe=+0.636\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  SKIP backtest (complete (hash=3ad6f1d7445e)) — reusing cached result\n",
+      "  [131/180] k=20 latent_factors/cae x hrp: Sharpe=+0.754\n",
+      "  SKIP backtest (complete (hash=2b3e495d505c)) — reusing cached result\n",
+      "  [132/180] k=20 latent_factors/cae x conformal_weighted: Sharpe=+0.774\n",
+      "  SKIP backtest (complete (hash=72a7707b7e13)) — reusing cached result\n",
+      "  [133/180] k=20 gbm/default_huber x score_weighted: Sharpe=+0.565\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  SKIP backtest (complete (hash=192dda89fbc1)) — reusing cached result\n",
+      "  [134/180] k=20 gbm/default_huber x inverse_vol: Sharpe=+0.567\n",
+      "  SKIP backtest (complete (hash=8994fb92c2f0)) — reusing cached result\n",
+      "  [135/180] k=20 gbm/default_huber x risk_parity: Sharpe=+0.573\n",
+      "  SKIP backtest (complete (hash=3c62bf678f5c)) — reusing cached result\n",
+      "  [136/180] k=20 gbm/default_huber x mvo_ledoit_wolf: Sharpe=+0.616\n",
+      "  SKIP backtest (complete (hash=27428733583c)) — reusing cached result\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  [137/180] k=20 gbm/default_huber x hrp: Sharpe=+0.554\n",
+      "  SKIP backtest (complete (hash=045a4811b445)) — reusing cached result\n",
+      "  [138/180] k=20 gbm/default_huber x conformal_weighted: Sharpe=+0.566\n",
+      "  SKIP backtest (complete (hash=a91ad215ce65)) — reusing cached result\n",
+      "  [139/180] k=20 gbm/leaves_7_mse x score_weighted: Sharpe=+0.561\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  SKIP backtest (complete (hash=0bba83d238e6)) — reusing cached result\n",
+      "  [140/180] k=20 gbm/leaves_7_mse x inverse_vol: Sharpe=+0.665\n",
+      "  SKIP backtest (complete (hash=7c1beae429ad)) — reusing cached result\n",
+      "  [141/180] k=20 gbm/leaves_7_mse x risk_parity: Sharpe=+0.620\n",
+      "  SKIP backtest (complete (hash=15ed24af5cb2)) — reusing cached result\n",
+      "  [142/180] k=20 gbm/leaves_7_mse x mvo_ledoit_wolf: Sharpe=+0.096\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  SKIP backtest (complete (hash=ac43d31ee7d4)) — reusing cached result\n",
+      "  [143/180] k=20 gbm/leaves_7_mse x hrp: Sharpe=+0.525\n",
+      "  SKIP backtest (complete (hash=129be5d863ce)) — reusing cached result\n",
+      "  [144/180] k=20 gbm/leaves_7_mse x conformal_weighted: Sharpe=+0.738\n",
+      "  SKIP backtest (complete (hash=385ff7af761a)) — reusing cached result\n",
+      "  [145/180] k=20 gbm/leaves_15_mse x score_weighted: Sharpe=+0.645\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  SKIP backtest (complete (hash=dd900730477e)) — reusing cached result\n",
+      "  [146/180] k=20 gbm/leaves_15_mse x inverse_vol: Sharpe=+0.728\n",
+      "  SKIP backtest (complete (hash=c801b5c2f7b5)) — reusing cached result\n",
+      "  [147/180] k=20 gbm/leaves_15_mse x risk_parity: Sharpe=+0.711\n",
+      "  SKIP backtest (complete (hash=a6b1700eef2f)) — reusing cached result\n",
+      "  [148/180] k=20 gbm/leaves_15_mse x mvo_ledoit_wolf: Sharpe=+0.293\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  SKIP backtest (complete (hash=f80cf752f695)) — reusing cached result\n",
+      "  [149/180] k=20 gbm/leaves_15_mse x hrp: Sharpe=+0.622\n",
+      "  SKIP backtest (complete (hash=9da2038274d0)) — reusing cached result\n",
+      "  [150/180] k=20 gbm/leaves_15_mse x conformal_weighted: Sharpe=+0.801\n",
+      "  SKIP backtest (complete (hash=90a2cd26eff8)) — reusing cached result\n",
+      "  [151/180] k=20 latent_factors/sae x score_weighted: Sharpe=+0.535\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  SKIP backtest (complete (hash=d50531e44b60)) — reusing cached result\n",
+      "  [152/180] k=20 latent_factors/sae x inverse_vol: Sharpe=+0.563\n",
+      "  SKIP backtest (complete (hash=504ba4ad8908)) — reusing cached result\n",
+      "  [153/180] k=20 latent_factors/sae x risk_parity: Sharpe=+0.575\n",
+      "  SKIP backtest (complete (hash=aba77338435b)) — reusing cached result\n",
+      "  [154/180] k=20 latent_factors/sae x mvo_ledoit_wolf: Sharpe=+0.209\n",
+      "  SKIP backtest (complete (hash=65ae8679376c)) — reusing cached result\n",
+      "  [155/180] k=20 latent_factors/sae x hrp: Sharpe=+0.524\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  SKIP backtest (complete (hash=dd5c9fa7a347)) — reusing cached result\n",
+      "  [156/180] k=20 latent_factors/sae x conformal_weighted: Sharpe=+0.620\n",
+      "  SKIP backtest (complete (hash=82ac9cc42360)) — reusing cached result\n",
+      "  [157/180] k=20 deep_learning/nlinear x score_weighted: Sharpe=+0.352\n",
+      "  SKIP backtest (complete (hash=5c362935da8f)) — reusing cached result\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  [158/180] k=20 deep_learning/nlinear x inverse_vol: Sharpe=+0.626\n",
+      "  SKIP backtest (complete (hash=7d8f4a8b2c06)) — reusing cached result\n",
+      "  [159/180] k=20 deep_learning/nlinear x risk_parity: Sharpe=+0.574\n",
+      "  SKIP backtest (complete (hash=e922aeb934dc)) — reusing cached result\n",
+      "  [160/180] k=20 deep_learning/nlinear x mvo_ledoit_wolf: Sharpe=+0.273\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  SKIP backtest (complete (hash=3ebf7518b173)) — reusing cached result\n",
+      "  [161/180] k=20 deep_learning/nlinear x hrp: Sharpe=+0.407\n",
+      "  SKIP backtest (complete (hash=09ed7cffa291)) — reusing cached result\n",
+      "  [162/180] k=20 deep_learning/nlinear x conformal_weighted: Sharpe=+0.694\n",
+      "  SKIP backtest (complete (hash=0b48801f748f)) — reusing cached result\n",
+      "  [163/180] k=20 gbm/leaves_63_mse x score_weighted: Sharpe=+0.397\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  SKIP backtest (complete (hash=572847b848f8)) — reusing cached result\n",
+      "  [164/180] k=20 gbm/leaves_63_mse x inverse_vol: Sharpe=+0.646\n",
+      "  SKIP backtest (complete (hash=e656777b9d9e)) — reusing cached result\n",
+      "  [165/180] k=20 gbm/leaves_63_mse x risk_parity: Sharpe=+0.651\n",
+      "  SKIP backtest (complete (hash=fd7374791025)) — reusing cached result\n",
+      "  [166/180] k=20 gbm/leaves_63_mse x mvo_ledoit_wolf: Sharpe=+0.312\n",
+      "  SKIP backtest (complete (hash=9bb075dab294)) — reusing cached result\n",
+      "  [167/180] k=20 gbm/leaves_63_mse x hrp: Sharpe=+0.581\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  SKIP backtest (complete (hash=1d316491b89e)) — reusing cached result\n",
+      "  [168/180] k=20 gbm/leaves_63_mse x conformal_weighted: Sharpe=+0.653\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  SKIP backtest (complete (hash=d9538b80edaa)) — reusing cached result\n",
+      "  [169/180] k=20 gbm/leaves_31_huber x score_weighted: Sharpe=+0.521\n",
+      "  SKIP backtest (complete (hash=782d88549954)) — reusing cached result\n",
+      "  [170/180] k=20 gbm/leaves_31_huber x inverse_vol: Sharpe=+0.687\n",
+      "  SKIP backtest (complete (hash=287b4433f459)) — reusing cached result\n",
+      "  [171/180] k=20 gbm/leaves_31_huber x risk_parity: Sharpe=+0.693\n",
+      "  SKIP backtest (complete (hash=5ef658a6a61e)) — reusing cached result\n",
+      "  [172/180] k=20 gbm/leaves_31_huber x mvo_ledoit_wolf: Sharpe=+0.429\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  SKIP backtest (complete (hash=d52a8444eb22)) — reusing cached result\n",
+      "  [173/180] k=20 gbm/leaves_31_huber x hrp: Sharpe=+0.594\n",
+      "  SKIP backtest (complete (hash=af5f38b6009f)) — reusing cached result\n",
+      "  [174/180] k=20 gbm/leaves_31_huber x conformal_weighted: Sharpe=+0.674\n",
+      "  SKIP backtest (complete (hash=5ba5f96fc3d8)) — reusing cached result\n",
+      "  [175/180] k=20 gbm/leaves_31_mse x score_weighted: Sharpe=+0.447\n",
+      "  SKIP backtest (complete (hash=e7418d6628d5)) — reusing cached result\n",
+      "  [176/180] k=20 gbm/leaves_31_mse x inverse_vol: Sharpe=+0.629\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  SKIP backtest (complete (hash=7aedd3dbc88f)) — reusing cached result\n",
+      "  [177/180] k=20 gbm/leaves_31_mse x risk_parity: Sharpe=+0.609\n",
+      "  SKIP backtest (complete (hash=aa5746b96e1b)) — reusing cached result\n",
+      "  [178/180] k=20 gbm/leaves_31_mse x mvo_ledoit_wolf: Sharpe=+0.360\n",
+      "  SKIP backtest (complete (hash=5e2e49e80ee8)) — reusing cached result\n",
+      "  [179/180] k=20 gbm/leaves_31_mse x hrp: Sharpe=+0.530\n",
+      "  SKIP backtest (complete (hash=86ce82653ebb)) — reusing cached result\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  [180/180] k=20 gbm/leaves_31_mse x conformal_weighted: Sharpe=+0.705\n",
+      "\n",
+      "Sweep complete in 0.2 minutes: reused all 180 from the registry, computed by an earlier run\n",
+      "no backtest raised\n"
+     ]
+    }
+   ],
    "source": [
     "BUDGET_SECONDS = 3600\n",
     "MVO_METHODS = (\"mvo\", \"mvo_ledoit_wolf\")\n",
@@ -436,8 +1281,7 @@
     "\n",
     "print(\n",
     "    f\"\\nSweep complete in {(time.monotonic() - sweep_start) / 60:.1f} minutes: \"\n",
-    "    f\"{n_done - served - len(failures)} computed, {served} served from the registry, \"\n",
-    "    f\"{len(failures)} failed\"\n",
+    "    f\"{reuse_disclosure(n_done - served - len(failures), served, len(failures))}\"\n",
     ")\n",
     "\n",
     "# What this sweep actually advanced, which is narrower than \"every live prediction\". The\n",
@@ -465,13 +1309,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2b0186ea",
+   "id": "79531a08",
    "metadata": {
     "papermill": {
-     "duration": 0.001688,
-     "end_time": "2026-09-07T07:15:29.915597+00:00",
+     "duration": 0.004399,
+     "end_time": "2026-09-11T14:27:52.880986+00:00",
      "exception": false,
-     "start_time": "2026-09-07T07:15:29.913909+00:00",
+     "start_time": "2026-09-11T14:27:52.876587+00:00",
      "status": "completed"
     }
    },
@@ -489,9 +1333,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "ad83db58",
-   "metadata": {},
+   "execution_count": 8,
+   "id": "e69d1d4f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-11T14:27:52.897281Z",
+     "iopub.status.busy": "2026-09-11T14:27:52.896807Z",
+     "iopub.status.idle": "2026-09-11T14:27:52.947801Z",
+     "shell.execute_reply": "2026-09-11T14:27:52.946323Z"
+    },
+    "papermill": {
+     "duration": 0.064625,
+     "end_time": "2026-09-11T14:27:52.949706+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T14:27:52.885081+00:00",
+     "status": "completed"
+    }
+   },
    "outputs": [],
    "source": [
     "explorer = BacktestExplorer(CASE_STUDY_ID)\n",
@@ -507,13 +1365,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "16e6129d",
+   "id": "2e4efc74",
    "metadata": {
     "papermill": {
-     "duration": 0.001699,
-     "end_time": "2026-09-07T07:15:29.940287+00:00",
+     "duration": 0.004965,
+     "end_time": "2026-09-11T14:27:52.960854+00:00",
      "exception": false,
-     "start_time": "2026-09-07T07:15:29.938588+00:00",
+     "start_time": "2026-09-11T14:27:52.955889+00:00",
      "status": "completed"
     }
    },
@@ -529,24 +1387,233 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "fd580d43",
+   "execution_count": 9,
+   "id": "1cc7109a",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-11T14:27:52.976926Z",
+     "iopub.status.busy": "2026-09-11T14:27:52.976201Z",
+     "iopub.status.idle": "2026-09-11T14:27:52.986614Z",
+     "shell.execute_reply": "2026-09-11T14:27:52.983987Z"
+    },
+    "papermill": {
+     "duration": 0.021278,
+     "end_time": "2026-09-11T14:27:52.988360+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T14:27:52.967082+00:00",
+     "status": "completed"
+    },
     "tags": [
      "results"
     ]
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div><style>\n",
+       ".dataframe > thead > tr,\n",
+       ".dataframe > tbody > tr {\n",
+       "  text-align: right;\n",
+       "  white-space: pre-wrap;\n",
+       "}\n",
+       "</style>\n",
+       "<small>shape: (6, 6)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>allocator</th><th>n</th><th>ruined</th><th>avg_sharpe</th><th>best_sharpe</th><th>avg_max_dd</th></tr><tr><td>str</td><td>u32</td><td>u32</td><td>f64</td><td>f64</td><td>f64</td></tr></thead><tbody><tr><td>&quot;conformal_weighted&quot;</td><td>30</td><td>0</td><td>0.693205</td><td>0.832983</td><td>-0.38627</td></tr><tr><td>&quot;inverse_vol&quot;</td><td>30</td><td>0</td><td>0.632516</td><td>0.741001</td><td>-0.387701</td></tr><tr><td>&quot;risk_parity&quot;</td><td>30</td><td>0</td><td>0.62613</td><td>0.752106</td><td>-0.387704</td></tr><tr><td>&quot;hrp&quot;</td><td>30</td><td>0</td><td>0.571151</td><td>0.828794</td><td>-0.38023</td></tr><tr><td>&quot;score_weighted&quot;</td><td>30</td><td>0</td><td>0.49906</td><td>0.734213</td><td>-0.432876</td></tr><tr><td>&quot;mvo_ledoit_wolf&quot;</td><td>30</td><td>0</td><td>0.30256</td><td>0.662568</td><td>-0.586499</td></tr></tbody></table></div>"
+      ],
+      "text/plain": [
+       "shape: (6, 6)\n",
+       "┌────────────────────┬─────┬────────┬────────────┬─────────────┬────────────┐\n",
+       "│ allocator          ┆ n   ┆ ruined ┆ avg_sharpe ┆ best_sharpe ┆ avg_max_dd │\n",
+       "│ ---                ┆ --- ┆ ---    ┆ ---        ┆ ---         ┆ ---        │\n",
+       "│ str                ┆ u32 ┆ u32    ┆ f64        ┆ f64         ┆ f64        │\n",
+       "╞════════════════════╪═════╪════════╪════════════╪═════════════╪════════════╡\n",
+       "│ conformal_weighted ┆ 30  ┆ 0      ┆ 0.693205   ┆ 0.832983    ┆ -0.38627   │\n",
+       "│ inverse_vol        ┆ 30  ┆ 0      ┆ 0.632516   ┆ 0.741001    ┆ -0.387701  │\n",
+       "│ risk_parity        ┆ 30  ┆ 0      ┆ 0.62613    ┆ 0.752106    ┆ -0.387704  │\n",
+       "│ hrp                ┆ 30  ┆ 0      ┆ 0.571151   ┆ 0.828794    ┆ -0.38023   │\n",
+       "│ score_weighted     ┆ 30  ┆ 0      ┆ 0.49906    ┆ 0.734213    ┆ -0.432876  │\n",
+       "│ mvo_ledoit_wolf    ┆ 30  ┆ 0      ┆ 0.30256    ┆ 0.662568    ┆ -0.586499  │\n",
+       "└────────────────────┴─────┴────────┴────────────┴─────────────┴────────────┘"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "alloc_comparison"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "2d9d2ef2",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 10,
+   "id": "49674987",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-11T14:27:53.006276Z",
+     "iopub.status.busy": "2026-09-11T14:27:53.005532Z",
+     "iopub.status.idle": "2026-09-11T14:27:56.028706Z",
+     "shell.execute_reply": "2026-09-11T14:27:56.028124Z"
+    },
+    "papermill": {
+     "duration": 3.035515,
+     "end_time": "2026-09-11T14:27:56.029306+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T14:27:52.993791+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.plotly.v1+json": {
+       "config": {
+        "plotlyServerURL": "https://plot.ly"
+       },
+       "data": [
+        {
+         "marker": {
+          "color": "#0a1628"
+         },
+         "orientation": "h",
+         "showlegend": false,
+         "type": "bar",
+         "x": [
+          0.30255950229818807,
+          0.4990596012825102,
+          0.5711510840251182,
+          0.6261300430190045,
+          0.6325162278646944,
+          0.6932054769380863
+         ],
+         "y": [
+          "mvo_ledoit_wolf",
+          "score_weighted",
+          "hrp",
+          "risk_parity",
+          "inverse_vol",
+          "conformal_weighted"
+         ]
+        }
+       ],
+       "layout": {
+        "height": 380,
+        "margin": {
+         "t": 90
+        },
+        "shapes": [
+         {
+          "line": {
+           "color": "#334155",
+           "dash": "dash",
+           "width": 1
+          },
+          "type": "line",
+          "x0": 0,
+          "x1": 0,
+          "xref": "x",
+          "y0": 0,
+          "y1": 1,
+          "yref": "y domain"
+         }
+        ],
+        "template": {
+         "layout": {
+          "colorway": [
+           "#0a1628",
+           "#D4A84B",
+           "#C87533",
+           "#10b981",
+           "#ef4444",
+           "#94a3b8"
+          ],
+          "font": {
+           "color": "#334155",
+           "family": "DM Sans, DejaVu Sans, sans-serif",
+           "size": 11
+          },
+          "hoverlabel": {
+           "bgcolor": "white",
+           "font": {
+            "family": "DM Sans, DejaVu Sans, sans-serif",
+            "size": 11
+           }
+          },
+          "legend": {
+           "bgcolor": "rgba(255,255,255,0.8)",
+           "bordercolor": "#e8e8e6",
+           "borderwidth": 1,
+           "font": {
+            "size": 10
+           }
+          },
+          "paper_bgcolor": "#FAFAF9",
+          "plot_bgcolor": "white",
+          "title": {
+           "font": {
+            "color": "#0a1628",
+            "size": 14
+           },
+           "x": 0.5,
+           "xanchor": "center"
+          },
+          "xaxis": {
+           "gridcolor": "#e8e8e6",
+           "gridwidth": 0.5,
+           "linecolor": "#e8e8e6",
+           "showgrid": true,
+           "tickfont": {
+            "size": 10
+           },
+           "title": {
+            "font": {
+             "size": 11
+            }
+           }
+          },
+          "yaxis": {
+           "gridcolor": "#e8e8e6",
+           "gridwidth": 0.5,
+           "linecolor": "#e8e8e6",
+           "showgrid": true,
+           "tickfont": {
+            "size": 10
+           },
+           "title": {
+            "font": {
+             "size": 11
+            }
+           }
+          }
+         }
+        },
+        "title": {
+         "text": "Mean Sharpe by weighting scheme"
+        },
+        "width": 800,
+        "xaxis": {
+         "title": {
+          "text": "Mean Sharpe ratio across the allocation sweep"
+         }
+        },
+        "yaxis": {
+         "title": {
+          "text": "Allocator"
+         }
+        }
+       }
+      },
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAyAAAAF8CAYAAAA3o9/NAAAQAElEQVR4AezdBYAV1dvH8d8uuYABovKK/EGQTkkBQcVusQsMursbhKVDOkRKUbEQCwMxEAVFEJESJFQMkJDOd57D3nV32d57t+5X98ydOHPmnM+ZvTvPPTOX0OPHj50hYcA5wDnAOcA5wDnAOcA5wDnAOcA5kBrnQKj4DwEE0kiAwyKAAAIIIIAAAsEnQAASfH1OixFAAAEEEEAAAQQQSDMBApA0o+fACCCAAAIIIIBA8AnQYgQIQDgHEEAAAQQQQAABBBBAINUECEBSjTrmgVhGAAEEEEAAAQQQQCD4BAhAgq/PaTECCCCAAAIIIIAAAmkmQACSZvQcGAEEEEAAgeAToMUIIIAAAQjnAAIIIIAAAggggAACmV8g3bSQACTddAUVQQABBBBAAAEEEEAg8wsQgGT+PqaFMQVYRgABBBBAAAEEEEgzAQKQNKPnwAgggEDwCdBiBBBAAAEECEA4BxBAAAEEEEAAgcwvQAsRSDcCBCDppiuoCAIIIIAAAggggAACmV8g+AKQzN+ntBABBBBAAAEEEEAAgXQrQACSbruGiiGQ+QRoEQIIIIAAAgggQADCOYAAAggggEDmF6CFCCCAQLoRIABJN11BRRBAAAEEEEAAAQQynwAtiilAABJThGUEEEAAAQQQQAABBBAImAABSMBoKTimAMsIIIAAAggggAACCBCAcA4ggAACmV+AFiKAAAIIIJBuBAhA0k1XUBEEEEAAAQQQyHwCtAgBBGIKEIDEFGEZAQQQQAABBBBAAAEEAiaQagFIwFpAwQgggAACCCCAAAIIIJBhBAhAMkxXUVEEki3AjggggAACCCCAQLoRIABJN11BRRBAAAEEMp8ALUIAAQQQiClAABJThGUEEEAAAQQQQACBjC9AC9KtAAFIuu0aKoYAAggggAACCCCAQOYTIADJfH0as0UsI4AAAggggAACCCCQbgQIQNJNV1ARBBDIfAK0CAEEEEAAAQRiChCAxBRhGQEEEEAAAQQyvgAtQACBdCtAAJJuu4aKIYAAAggggAACCCCQ8QQSqjEBSEJCbEcAAQQQQAABBBBAAAG/CRCA+I2SghCIKcAyAggggAACCCCAQEwBApCYIiwjgAACUQRGjX9et933dJQ16X92+YpVuvDyijp69Fi6ruyU519S3VseTlIdH3iipQYNey7hfWLkSM6xYhQR8MWM0m8Bh+AACCCQ6QUIQDJ9F9NABFJfoEqdu9wF8IuvLjzn4LfWf8ptGzvphXO2pcWKTz9frkeebqOSV93g0sNPttbQ0VPSoipBd8z/K3CJKlUo4/d2/690bb37wafRyg3UsaIdhAUEEHACTBBISIAAJCEhtiOAQLIEihS+XK++8W60fX/a8LPW/LheF+fPF219Wi188dVK3fd4CxUt8j8N6d9ZMyYO1TMNH9aef/alVZWC6rj33HGjnhvRL1XanJrHSpUGcRAEEEAgAwsQgASs8ygYgeAVCAkJ0YP33qavV36v7Tt+i4R4acFCPVT/DuXKFRa5zmZOnTql8VPm6JqbHlTBEjV1/R2P6e33PrZNLh08dFjPDh+vm+9tqEKlaum62x/VG29/4Lb5JnZrTp9nR6lDj2dVuupNKn/1bRo49DmdPHnSl+Wc1y+Xr9SVRb3go18X3X/PbapTq5puuaGORjzb/Zy8M2a/rGrX3q2i5a9V49bd9cdff0fmscCqa59w1bi+vuzT93seaeoCrcgM3kz+IlU0+6XXdd9jLVSkbB0NGzNVvltunp/ziq677VFdXrKmbr//GX2/Zp23x38/GzZt1RNNOqhU5RtVvNL1atG+j/btP/BfhjjmPv9qRazl7tj5u/IWqqQf1m2Ituesea+5Y5w4cSLaelv4eOkyFS5zTaTn1m07ZLd5de4VbptdGjp6sqwf3II3SajeMW+L+vfgIbXrOlAlrqrn+q/ngBGure27D/JK++/n1KnTcfazjb4d+PegHm/c3tWvTLWb3Y4xj+W7tW7aC/Pj7NfE1scdIGJi52r7boNU68b73fHtfH5uyuyIrZLVrXu/Ye6Ydq7YiNuHS76I3G4z9ntjvwN2rt/1UGN99/1aWx2ZLL+NJFp/VK17txuxs98hXwbrg77PjlbbLgPcqN61tz6iBW++J8sz8rkZ3nl6r8zphbkLfLu414T6y2ViggACCPhBINQPZVAEAgggcI5Anjx5dM8dN2nO/NfdNruonb/gbT364F1uOepk+Nipevv9jzWgdwf99O2H6ta+ufoPGasPPv7cZTt+/Lhy5MipMeF9tGb5e2rVpIF6Dhgpuyh2GSImL77ytqpVrqBlHy3Q6PBemuldYL2+8IOIree+5L8or37f9bfswuvcrf+t2frLDr3zwadq36qRurZvpmVff6eho/67TWv/gQMqX7aUXp09Qcu8Y9e7tpYXaDSPFqRYaRZ0PN3gAW347mO1aPy4rXLppQWLXH2/X/auSpUopvqPNZcvwPjr7z265+EmqliujBYteF4fLpyjCy7Io4eebK3Tp0+7/eOaTJ7xYmS5pUte6crdu2+//lfoMt10fW29/NqiaLvO95YfeeBOZcuWLdp6W7i62lU6dPhIZHD01Ter3EjWV998a5tdWr7ie9WsUcXNJ6fe3fsO08pVazRv+hh9+u5LCg0N1ZLPvnLlRZ28/Po7OnnipIYP6u4CXbvA9/Xzd18s0vnn5dGLM8Zq369r9NPKD6PuGm1+9dqfvP7/UwvmTNJbL0/V1m07o/VrYusTtdBxk2Zq245fNWPCMP22abnmvzBOBf/vksgsjzdq7xn+pPEjB3jn+kdq8vSj2r//38jtNjN87DTdd9etGjO0j44cPabm7XvpzJkztkmfffmN2nYeoKeeuF/W1sljBmnFt2s0IHyc2+6bvPL6u8qSNYtGDO6hqyqVVZM2PdS0bS/9+ddu9enaVtWrVJIF65u3bHe7JKe/3I5MEEAAgWQIEIAkA41dEEAgcQKPPXi3LCiwC+VF73+iSy7OL7uQjbr3sWPHZc+DDPKCjxu8C/cLzj9Pt95UV08+/oA3YvCay5ov74Xq0q6JypYuLpt/sP7tesrbHvMC+kbvotqOaXluuv4a3XBdbe+Cdq0rI7bJEw/XV53aVXV1vfqyEQj7NNpGAQ4dPhwt+wlvFGX+zHF6/KF71LzRY2r2zGP65tvVkXlqVq+sBo/UV+H/FVShyy9TuxZPqVyZknpv8aeReWzmMS/4uuu2G5QzZw53kayI/3p0aqHKlcq5C/qhA7p6AUDWyBEeC6IqlCvp2l+8WGFdUbiQwvt31bqfNnsXstFHSiKKi3xp1bRBZLnh/bu4ct9ctNhtf9xr+yvehbwFhrZi08/bXJtsvS3HTHly53LB3Zde8GXblnsBSOMnH5FdwNpo0FHvQtmCklo1rrLNLvhLSr1ttOElL0Dt1qGFqletKAsOB/bqcM5omRVeoWxJ7wK+v8yyb/e2uvG6Wlrx3Q+2KUkp74UXqH/P9rLbBSt4AeTjD93tlXO2X5NSn6gH3fXH37qiSCGVKXWlcufKpbq1q7vRNctjt/xZmjRmoPs9MNMbvXPUzmfb7kv9erRVm+YN9YA3ihjer7MztsDBto+ZONMFLY/cf5czqlalonp2buG8bbsvVapQ2gvYe+vu2290r5f936WyvrbRvTtvq6cJo/rronwXatXqs78fKTnPfMf0vfKKAAIIJCRAAJKQENsRQCDJAvZpraVrr6mhPHly6cMlX8pGPx73LuBjFvbL9l9lQcitEQ+n2209lvoNHqNftv0amX3+a2/rjgcauVucbLvd7rPz112R222moHeRZa++dHH+vPp79x7f4jmvYWE59fIL4/XzmqXq3rGFu3AcNeF5Vb+uvnb++ntk/mJFC8vy+lYU+d/l0co97I0M2IPr1932qC6+oqq79cY+qd4Zo36Vypf1FRHt1S5+fSuyZ8/mBVol3Kfxtm7LL9v10afLXJnWbkt2+5QFSWZneeJK8ZV7+83XKlvWbG5kx/af+/Lrqn11VVmQY8uxJQsuln/zndu01Pskvl7dq1WrRmV9+dW3LnjJ7o2c2AiUZUhqve22MDtnLGix/S3ZCEi5MiVsNlqy0ZyoKyzw273nn6irEjVfqOD/RcuX/6KLZCMBtjIp9bH8vlT/7ls056U3ZMHsiHHT9f6Hn0WOXvy8ZZssECh2RWFf9lhfy5b+r81FvIDTMv0d0b6Nm7fKvgXMzgNfuvHuBrJbv3b98ZdldclG0tyMNwkJCVHRIv9T6ZLFvKWzP1myZHHB8u49e92KpPaX24kJAgikN4EMUx8CkAzTVVQUgYwnEBISokcfvEfjp8zWF8u/1cP333lOI0JCQty65Z+8LrtlJmr6eskbbpt9Um+3L/Xt3kYrlr7l8vXu2kbHYzyrEBp6tiy3U+Tk7K0rkYuxzNin7TbqMnRAN3cL1b//HtTLr78bmTOrd7EWueDNhISERF5UeovqOWCkVq9dp/Hep8qbvv/E1c9Gc2LWL2dYDsueqGQX45YxJCRE9nxKVBffvH1CbnmSknzl2m1WTzxyj155Y5H7ZHzBG+/Lbr+Kr6xaXoBi/WijHgcPHtJVFcuqpjf6Y7deLV+xypu/SlmzZnVFhIT4t96u0IhJ1qxZIubOvoSEWL8n3M9nc/83tQDnv6Wzcz6fs0tJn1q/L3n3RdmtaD9v3aZm7XrqsUbtIgsKCbG6Ri7GOhP1fAsJOZvfV6+QkBCNGtLTnWO+88D3at/05SvwXCMpNPRct6jl+vM889WDVwQQQCA2gdDYVrIOgQwtQOXTlcDjD92tr7xPzW+76Tp3i1HMyhW7opAbXfhk6bn3+vvyfv3tatWuUUU1qlZSgUsvdqvXxniA2q30w8SeH8iTJ7cOHTqU6NLs4vvOW29Q+TIllffCC9yIzroNmxO9f9SHwY8fP6F16zfpisKXu/1LFi+mZV9/qyNHjrrlpEziK9fKafjo/fpoyTLNmf+GDh85ovu8T+9tfVzJ/E+ePKWJ0+eo1tWVXbBR++oqrn5ffeMFIF4f+fZNar3tuZSQkBD98ONGXxHuGZcff9oUuZzYmbCcOXX6zOnEZo81X0rqU7FcabVv+bSmjhusWVNHuFGQ/Qf+1ZXFirhnTrZu2xHrMROzskzJK7Xk8+WJyZqkPEntryQVTmYEEEAghgABSAwQFhFAwL8CFjDs3blaL0weHmvB9ol557ZNNXrC87JnAP7Zu89dbL/21vua98pbbp/yZUrou9U/yrbZfeyW98MY3xzkMiZxMnHaXG90Zo7svnxLdttUt75DZbeyXF+3ZqJLK1+2pD5ftsJ9Q5Td0tKiQx/ZBWdiCxg+dqpWee37e/c/6t5vuDcicVIP3Hu72/2ZBg+41yZte+gHL+iy52nWb/zZfcNXQseIr1wr1C6y7Taq3oNG6757bnXPLNj6uJI9s1D1qvLudrraNaq6bHbL1c9bt7tbsGrVuEpuEOcFjAAAEABJREFUpTdJar3P84I+e35nyMiJsoeqzbHv4DGy50u84pL0Y7fMrVuf+AAwtsKTWx87pxZ/8oX7xin71qnPv1zhgmYLbO1b1q6pWVUt2vdx3xB38NBh90UK9g1VSuR/ndo2dv/GSfioSdq2/VfZ+WDnrY0QJrKIWLMltb9iLYSVCCCAQCIFCEASCUU2BBAInEDH1s/Ibq+yB2HL17hNdW55yAUfuSO+rtceOL/jlut0w51PyJ7PsE/FO7RqlOIKWZCxe88e9Q8fp0efbqv23Qbpz7/2aOHL02TPryT2AEP6dXEXgvbVq3VvfVglixdVvWsTH8B0bNVYjzfuoHI1btGGTVv05ktTdOEF57vD24jK4jdnK1dYmBo06agiZeuoY4/B2vLLDmWLuN3JZYxlEl+5vuyPPHCXC/ge9V596+J7tSDDntmxkQ/LlzNnDtlFddYsWd1D6rbOUnLqPXRgN1mA83jj9ipV5UYvEDuhm+vV0QXn5bEiE53aNHtSE6fNkT0j4fsa3kTvHCVjcupz6vRpte7UVxcVruzSu4uXaPr4cIWEhLiS50wbpQreCEmrjn3d1y43btXdnTtuYyImNatX1qJXZ8geuq935+MqXeUmjRo/Q8ePH0vE3nFnSU5/xV0aW9JIgMMikGEECEAyTFdRUQQyjoB9PajdghJXjdd89Z67RcW3PSQkRBZkfPz2XPfVpd9+/rbemj9V9e+6xWUJDQ1Vn25t9f2yd1yaOWmYurZvqk/ffcltt8lr8ya5PDbvS/ZMx+ypo3yL57zaNxUN6NVBnyyap183Lndlz5oywn1zkS9zpzaN9P4bL/gW3es9d9yoLT985uZtcsnFF2nGhKFasXSh+9rXbh2aua+BHdy3s212afe272TfeOQWYkyuq1ND67/9SH9uWan3Xp/pnq2ImsUesp723BCZ2471y1x9Zk8dGes3RNl+dpFqzwXYcy3xlWt5t+343X31r91eZcsJJesHK9ue//Dltb76bdNyd0uWb529JlRv+0axzxe/YlldslGHiaMHavPqT2Ve1n/20PUVEQ9iW6bE9PNtN1+rnRu+cs9J+L6GN+axEtOviamP1Slqatv8SVd/M7K08rO3ZSMfvjx2oW/fRGW/I7Z927ovIp+N8vWbBXW+/PZ8kuWL+oUCVp4FqVvXfqaN33+it1+ZHu3cj83IghY7L33l2qv9/rRu1tBmXUqov1wmJggggIAfBDJfAOIHFIpAAAEEgkFgzz/7NP2F+WrU8MF00dxVq3/Ui68ulN2KZg+62z+kt+efvaqfwLMpgap8eqtPoNpJuQgggEBqCxCApLY4x0MgEwvQtIwj0KJ9H1W79h7dd88tevqJ9BGAhIWFyb4xrXil63Vr/Yb67fc/9cZLU2T/NkxayKa3+qSFAcdEAAEEAiFAABIIVcpEAAEEEiEQ2y03idjNL1kmjx0ku4XHnl+xLwLwS6EpLKR0yWKyr162W47sFrc3XprsvlkshcUme/f0Vp8EGsJmBBBAIMMIEIBkmK6ioggggAACCCCAAALpT4AaJVWAACSpYuRHAAEEEEAAAQQQQACBZAsQgCSbjh1jCrCMAAIIIIAAAggggEBCAgQgCQmxHQEEEEj/AtQQAQQQQACBDCNAAJJhuoqKIoAAAggggED6E6BGCCCQVAECkKSKkR8BBBBAAAEEEEAAAQSSLeC3ACTZNWBHBBBAAAEEEEAAAQQQCBoBApCg6WoamokFaBoCCCCAAAIIIJBhBAhAMkxXUVEEEEAAgfQnQI0QQAABBJIqQACSVDHyI4AAAggggAACCKS9ADXIsAIEIBm266g4AggggAACCCCAAAIZT4AAJOP1Wcwas4wAAggggAACCCCAQIYRIADJMF1FRRFAIP0JUCMEEEAAAQQQSKoAAUhSxciPAAIIIIAAAmkvQA0QQCDDChCAZNiuo+IIIIAAAggggAACCKS+QEqPSACSUkH2RwABBBBAAAEEEEAAgUQLEIAkmoqMCMQUYBkBBBBAAAEEEEAgqQIEIEkVIz8CCCCAQNoLUAMEEEAAgQwrQACSYbuOiiOAAAIIIIAAAqkvwBERSKkAAUhKBdkfAQQQQAABBBBAAAEEEi1AAJJoqpgZWUYAAQQQQAABBBBAAIGkChCAJFWM/AggkPYC1AABBBBAAAEEMqwAAUiG7ToqjgACCCCAQOoLcEQEEEAgpQIEICkVZH8EEEAAAQQQQAABBAIvkGmOQACSabqShiCAAAIIIIAAAgggkP4FCEDSfx9Rw5gCLCOAAAIIIIAAAghkWAECkAzbdVQcAQQQSH0BjogAAggggEBKBQhAUirI/ggggAACCCCAQOAFOAICmUaAACTTdCUNQQABBBBAAAEEEEAg/QtkvAAk/ZtSQwQQQAABBBBAAAEEEIhDgAAkDhhWI4DAuQKsQQABBBBAAAEEUipAAJJSQfZHAAEEEEAg8AIcAQEEEMg0AgQgmaYraQgCCCCAAAIIIICA/wUo0d8CBCD+FqU8BBBAAAEEEEAAAQQQiFOAACROGjbEFGAZAQQQQAABBBBAAIGUChCApFSQ/RFAAIHAC3AEBBBAAAEEMo0AAUim6UoaggACCCCAAAL+F6BEBBDwtwABiL9FKQ8BBBBAAAEEEEAAAQTiFEh0ABJnCWxAAAEEEEAAAQQQQAABBBIpQACSSCiyIZCGAhwaAQQQQAABBBDINAIEIJmmK2kIAggggID/BSgRAQQQQMDfAgQgKRS9/fY7lC1bdlIADEJCQnX69BlsA2Br5+ypU6cUGhqKbwB8s2bNphMnTmAbAFs7d6UQnTkjfAPke/LkSWXJkhXfAPiaq/naeUxKxLVTEvvgjL0xKHXeG7zD8JMCgdAU7MuuCCCAAAIIIIAAAggggECSBAhAksSVJpk5KAIIIIAAAggggAACmUaAACSFXbn3VF4NHjGBFACD8FGTNGzMFGwDYGvn7LAxU2XGNk+K63c4eeuHjJyo4WOnce4G6NwdOnqyLHHeJu/8TMht+NipsnM4oXxsT7q/uZovdkm3i2mWwss3dk9jAQIQP3SAvaGQJro/WP50sAuMYV4A4s8yKeu/frI/guGjJvu93zA+azxi3DRsvUAsEOcD7w1nz7FA2FqZFjyHex8A2XyapgCdP2nZJnM137SsQ2Y5th8u3ygiDQUIQNIQn0MjgAACCCCAAAIIIJDeBAJdHwKQQAtTPgIIIIAAAggggAACCEQKEIBEUjCDQEwBlhFAAAEEEEAAAQT8LUAA4m9RykMAAQQQSLkAJSCAAAIIZFoBApBM27U0DAEEEEAAAQQQSLoAeyAQaAECkEALUz4CCCCAAAIIIIAAAghEChCARFLEnGEZAQQQQAABBBBAAAEE/C1AAJJC0YO7t6ewBHZHAIFzBFiBAAIIIIAAAplWIFUCkAP/HtTDjTr7HdHKfeiZTgmWa3ksb8yMXyxfpS3bdsZcneByh14jtHHzLwnmIwMCCCCAAAIZTYD6IoAAAoEWSJUAJFCNyJUrTH27NE928ctXrtEv239L9v7siAACCCCAAAIIIICAnwSCppjQNxZ9rKda99ETzXto+pzXIhtuowZjJs9R627hWvj+p3qkcRf1evY5PRrxuuqH9WrR+VlZvg0RowHbd+7Sg0930uNNu6t5x0Haui1xF/ftew7Xpi1nb2Vq0KKnps993dVj6qwFeuOdj9384iXLZNusnlavU6dP6/DhIxo4YorbbpPZ8992x7c6W11feu09W+3SrPkL1bhdPzXvNEh/7/5Hm7du1xfLv9Pz3rFsndV9z959ro12DMu7bsMWt++x48fVb+gkZ9Sx93AdPHTYrWeCAAIIIIAAAggggAACSRMIff7FNzV6UGdNH9tPS75YIRsV8BVRqGABTRjWQ7WrV9Lvf/ytJg0f0NypQ7X7n316/+MvNWF4T3Vv31hTXnjV7ZL3wvM0eWRvvThtqBo1qK+RE2e59QlNKpQtodVrN7gL+xzZs2vtus1ulx/WbVKlcqVlwcEsL7gYN6Sb5kwarGPHT2rRB0tdHt/EAoq33luimeMHKrxPW63f9Itvk3u9onBBzRg3QDdfV1PzFryj4kULq07NKl4979eUUX1UuND/afy0+apUvpTmTQlXn87N1X/YJLfvwvc+1YF/D7ljN25wv35cf7Z+biMT/wtQIgIIIIAAAggggECmFQi97ppqypf3AoXlzKnbb6oru+j3tfa6a6r7ZnVZgYtV5H+XKWuWLCp5ZWGVK1VMWUJDVa70ldr+6y6XL2fOHPr4s2/Utf9oPT/vTS9w+N2tT2hSuUIprfGCDTt2zWoVdcgb2Th56pR2eOUWLVJQa37c4Nb19EZgWnYZ7C1v1E8btkYr9sf1P+va2lV0Xp7cLtWr+1/dLWOt6pXsRRXLldS2HWfr61ZEmVgQ9NHS5W6UJHzsDBdo2WjJ2p8269476inUa2+ZksVkKcpuzCKAAAKZRoCGIIAAAhlB4NChg4qZjh49oiNHjpyzPmY+fyxnBKP0XMfQbFmzRNbPgoszOhO5nD1b1sj5rFn+m7cL8WwR22z+5MlTLt+rb36onb//oY4tGmrSiF7eSXBMifmvXJni+tG7yF+zbqMqlSuh0iWKaqE3mlHWC3Lc/iEh3mhFZTdSYaMV86cPU8+Ojd0m3+TMmTPK4gVHvuWsUdpl67JlPVv/kJBQnfKCG1sXWxo+oGPkcT5d+Lwuzp/PZTMbN+NNYpbtreIHAQQQQAABBBBIiQD7JkEgd+48iply5gxTWFjYOetj5vPHchKqStZYBEI/++o7/bN3v44cPar3Pv5CV5UvFUu2xK2yEYvK5UurwKX5tXzlDzp56mSidrSLe9vn0y9WyIKRil4QMv/191Wh3Nm6VK1URku/XKktv+x05e3dd+Ccb68qV7q4Vq1ZLwtELH37/TqXN75JWFgOHThwMDJLtcrlNOWFBa4MW/nt6rNllPcCpJXfr7VV2rf/gDZu3ubmmSCAAAIIIIAAAggggEDSBEIbPHinOvYZqSbtB6huzcqqUaVC0kqIkvuBe27S5Bdekd0mteqHn3TB+edF2Rr/bIWyxXX+eXmUI3t2d5vUb7v+8oKhkm6nywpcok6tntTg0dNlD6I3bNlL+7wgxG2MmJQoVljX1a6mNt3C1bnvSOXPd6Hy5MkVsTX2l9tvrKPl365x9bXnTFo1fkTHjx9Xg+Y9dddjbfTmO5+4He+5/Xrt3fev2nYfqgHDp3oB1kVuPRMEEEAAAQQQQAABBBBImkDofXfdqFkTBrkHr+0hc9/ur84c5QICW85/UV7Nmxpusy61b97APS9iCzZ6seil8TYrCwJemzXa3X7Vpslj8q23wOKV50e6PHFNWjV61D0kbtsvyZ9PyxfPc7di2bKlenWquwfM504e4sqtUqmsq5/V07ZbsgDIHox/tlcb7dt/UOVKFbfVsjxWB1soWqSge3je5otdUUgjBk+TbLcAABAASURBVHRy9bWH0C/0Aib7Wl9rq9V9cO+2lk32YPyA7i313NDuGjO4i16eMUIli1/htuXJX9i9MkEgMwjQBgQQQAABBBBAINACoYE+QGqW323AWPe1wM+06St7uN6CjdQ8PsdCAAEEEEAgmQLshgACCASNQKoGICtWrXX/doj9+yG+ZP++hr+07SuDbbRj/vTheuS+W/1VLOUggAACCCCAAAIIZFoBGpbaAqkagFSvXN79OyH2b4X4kt3alNqN5ngIIIAAAggggAACCCCQNgKpGoCkTRM5amIFyIcAAggggAACCCCAQKAFCEACLUz5CCCAQMIC5EAAAQQQQCBoBAhAgqaraSgCCCCAAAIInCvAGgQQSG0BApDUFud4CCCAAAIIIIAAAggEsUBkABLEBjQdAQQQQAABBBBAAAEEUkmAACSF0Ad3b09hCeyOgCBAAAEEEEAAAQSCRoAAJIVdfX7uHOrZuRUpAAbdO7ZQtw7NsQ2ArZ2zXds3U49OLfANkG+Xdk2xDZCtf98beP+294OoqWv7pt57Q0vO3wCcvz06tZT5RvVmPnm/gym8fGP3NBYgAElhB1yQJ4d6dWlNCoCBvVFbAIJvYM6vbh2auYsMfP3vaxcUdpGBrf9tzdQCEEs2T/K/cVfvwwk7h7H1v625mi+2EbYpuHZI4eUbu6exAAFIGncAh0cAAQQQQAABBBBAIJgECEDSvrepAQIIIIAAAggggAACQSNAABI0XU1DEUDgXAHWIIAAAggggEBqCxCApLY4x0MAAQQQQAABCQMEEAhaAQKQoO16Go4AAggggAACCCAQjAJp3WYCkBT2wP6DxzR4xARSAAzCR03SsDFTsA2ArZ2zw8ZMlRnbPMm/v8NDRk7U8LHTOHcDdO4OHT1Zljhv/Xve+jyHj50qO4d9y7z6z9lczTc1TZ+f/UoKr3TYHQH/CxCApND0dFgB90ZtbyqkiX61sAuMYV4AEjhX/9Y3o9XT/giGj5rs1z7LaAaBrO+IcdOw9QKxQBjz3hDY9y4LnsO9D4AC0XfBXqa5mm9qOjw/hwAkhZd67B4AAQKQAKBSJAIIIIBAAgJsRgABBBAIWgECkKDtehqOAAIIIIAAAsEoQJsRSGsBApC07gGOjwACCCCAAAIIIIBAEAkEcQASRL1MUxFAAAEEEEAAAQQQSCcCBCDppCOoBgJBJUBjEUAAAQQQQCBoBQhAgrbraTgCCCCAQDAK0GYEEEAgrQUIQNK6Bzg+AggggAACCCCAQDAI0MYIAQKQCAheEEAAAQQQQAABBBBAIPACAQ1ARk2co8VLlgW+Fal8hCea99DuPXvdUQ/u3u5emSRBgKwIIIAAAggggAACQSsQ0ADkgbtvUtWrygYtLg1HAAEE0psA9UEAAQQQQCCtBQIagLz29kf69vt1ro0PPdNJz017Uc07DlK7HsP09+5/3Ppn2vTVll92unmbNO80SOs2bNGevfvU69nnZKMNjdv1c+tsu42otO85XK27DlH3gWO1ZdtOdR8wRk+37qOb72+mX3//w7K5kZcGLXq6/cdMnqNTp0+79TEny75Z7crxrV/5/Y/q0GuEW3xj0cd6yivX6jB9zmtuHRMEEEAAAQQQQCAZAuyCAAIRAgENQCKOEflyReGCmjK6jx6qf4vmLXjHrb+hbg199NlyN7/7n33648/dKluqmMZPm69K5Utp3pRw9encXP2HTXJ5bPLbrj81rH8HDe3bXi8teE933Xa9XpgwSG/MGaN8eS/U9p27NGv+2xo3pJvmTBqsY8dPatEHS23Xc9LV1Spo3fqfdfTYcbft46Vf66bramjrtt/0/ItvavSgzpo+tp+WfLFCy1eucXmYIIAAAggggAACCCCAQPIEUjUAuaZGZcmrZ4FLLtK2Hbu8OemWG2rrk8++cfMfLvlKt9Sr5eZXr92gj5Yul42IhI+dIQtOfKMmlSuWUe5cYS5fhbLFNf/19zV97uva+dsfyhWWU2t+3KBDh4+opzeC0rLLYG95o37asNXljznJEhqqmtUqaemXK9woyefLV6lurapas26DrrummhfQXKCwnDl1+0119cO6TTF3ZxkBBBBAAAEEEEi3AqdPn9ahQweDIh09ekRHjhxJlbam2w7PIBVL1QAkS5azhwtRqE6dOiX7L3++C3WRN2qxcfMv+vizr73Rh5q22qXhAzpqyqg+Ln268HldnD+fW589Wzb3apN7bq+n3h2bqGCBi9V78ASt3+QFGiEhqlOzstvP9p8/fZh6dmxs2WNNN3ojHnbsr1f+oIpeQJMndy6XL1vWLO7VJlmzZNEZ73+bJyGQUQWoNwIIIIBAcAmEeh+05s6dR8GQcuYMU1hYWKq0NbjOIv+39mxE4P9yk1RivbrVNW/Bu/r34CFdWfR/bt9qlctpygsLdObMGbf87eqzz5K4hSgT26fApfndCEV1bx8LQKpWKuONaKyMfLZk774D7lmRKLtFm612VTlt2rJDiz74VDddfzYAqli2lD776jv9s3e/jhw9qvc+/kJXlS8VbT8WEEAAAQQQSKQA2RBAAAEEIgTSRQByS73abvTDXiPqpVaNH9Hx48fVoHlP3fVYG735zie+TdFehz/3gm6s30Sd+4zU8RMnZWVcVuASdWr1pAaPni57EL1hy17a5wUh0XaMshAS4o2YXF1ZX3+7VrUjbhMrWqSgGjx4pzp65TZpP0B1vRGVGlUqRNmLWQQQQAABBBBAAIH0L0AN05tAQAOQTq0auoDAGv3qzFE6/7w8Niu7uJ8wvKebt8kF5+fR8sXz1LjBfbbo0oXnn6e+XZpr3tRwLXppvAb3buvWW4Bh5boFbzKoZ2t9/OZ0jRzUWX06N5Xv2ZB6dapr5viBmjt5iNu/SqWyXu64f7q0eUpLF81UzhzZ5fvvvrtu1KwJg2QPwjdp+IBvtVvOf1HeyGVmEEAAAQQQQAABBBBAIHECAQ1AEleFjJ0rT/7CGaYBVBQBBBBAAAEEEEAAgbQWCKoApN/QSWrR+dloacWqtWndBxwfAQQyvwAtRAABBBBAAIEIgaAKQAZ0b6nJI3tHS9Url4+g4AUBBBBAAAEEMp8ALUIAgfQmEFQBSHrDpz4IIIAAAggggAACCGRagTgaRgASBwyrEUAAAQQQQAABBBBAwP8CBCD+N6VEBGIKsIwAAggggAACCCAQIUAAEgHBCwIIIIBAZhSgTQgggAAC6U2AACS99Qj1QQABBBBAAAEEMoMAbUAgDgECkDhgWI0AAggggAACCCCAAAL+FyAASaFp6JE/1LNzq/gS25Lp071jC3Xr0By/ZPoldF52bd9MPTq1wDdAvl3aNcU2QLa8NwT2b07X9k2994aWnL8BOH97dGop803o/dmf2xs1fDiFVzrsjoD/BQhAUmh6QZ4c6tWlNSkABvZGbQEIvoE5v7p1aOYuMjK3b2DsEjKziwe7yEgoH9uT1z8WgFjCL3l+Cbl19T6csHM4oXxsT7q/uZpvato1epIAJIWXeuweAAECkACgUiQCCCCAAAJBLwAAAgggEIcAAUgcMKxGAAEEEEAAAQQQQCAjCqT3OhOApPceon4IIIAAAggggAACCGQiAQKQTNSZNCWmAMsIIIAAAggggAAC6U2AACS99Qj1QQABBDKDAG1AAAEEEEAgDgECkDhgErt6/8FjGjxiAikABuGjJmnYmCnYBsDWztlhY6bKjG2e5N/f4SEjJ2r42GmcuwE6d4eOnixLnLf+PW99nsPHTpWdw75lXv3nbK7mGyjT337/w12+MEEgvQsQgKSwhw4cOubeqO1NhTTRrxZ2gTHMC0Bw9a+rz9P+CIaPmuzXPvOVzetEjRg3DVsvEAvEucB7Q2DeE3x9ZcFzuPcBkG+ZV/95m6v5BsqUACSFF3XsnmoCmTgASR3DPPkLp86BOAoCCCCAAAIIIIAAAplAgAAkE3QiTUAg3QlQIQQQQAABBBBAIA4BApA4YFiNAAIIIIBARhSgzggggEB6FyAASe89RP0QQAABBBBAAAEEMoIAdUykAAFIIqHIhgACCCCAAAIIIIAAAikXSFEAcvLUKa39aXPKa0EJmUuA1iCAAAIIIIAAAgggEIdAigKQrFmyaPqc1+MomtUIIIAAAqktwPEQQAABBBBI7wIpCkCscTlyZNPGzb/YLAkBBBBAAAEEEAhWAdqNAAKJFEhxAPLbrr/0VOs+erRxFzXvNCgyJeb4B/49qIee6RRn1t179uqJZj3i3O7vDXYsO6aV++pbi3Xk6FGbJSGAAAIIIIAAAggggICfBFIcgHRo0UDPDe2ujq2eVKMn6qtRREpM/XLlClPfLs0TkzVV8vTo0FgXnH+eO9ab736io0ePu/n4Jgd3b49vM9sQQAABBBBAAAEEEEAgikCKA5BqV5VTbCnKMSJnbXTh4Uad1XPQOLXsMli/bP9VA0dMcdu3bNup7gPG6GlvNOXm+5vp19//cOt9k+07d+mJ5j20aUvsF/yLlyxT+57D1brrEDcaM2HGfN+umjzzFd31WBvZsWfM/e+ZFRt9GTN5jlp3C9enX65U+JgZ2n/gX7374ef648/d6tJvtDr0GqEps17VS6+9F628+a+/H7nMDALpRYB6IIAAAggggAAC6V0gxQHIug0/q3Ofkbr94ZYudek3Sus2bImz3Tt+/UONG96vSSN66dKLL4rM99KC93TXbdfrhQmD9MacMcqX90IpJMRL0uat29Vj0Fg926utShQrrLj++23XnxrWv4PmTgnX5i079M13a13WW+pdo0UvjdfsSUP04/ot+m71OrfeJoUKFtCEYT10/TXVbNGlO26uqwKX5teIAR01ZnAX3XnztVr4/hK37cyZM/rw0+W685a6bpkJAggggAACkkBAAAEEEEikQIoDkMGjp6twof/TxOG9XLIL+vCxM+I8/P8uL6CihS8/Z3uFssVlowrTvRGKnb/9oVxhOSXvYv/v3XvVtf8YDe/fUUW845yzY5QVFcuVVO5cYcqaNauurlrBCzZ+dluPHT8mG+no2HuELEj5+Zdf3XqbXHdNdXuJN11+2aXKny+v1m/aqq9WrFHpElfovDy5492HjQgggAACCCCAQGoKHDlyWIcOHQzCdLbNR48e0ZEjR1Kl/anZr5nxWCkOQM54QUKbpo/risIFXWrrzR8/HvezE9myZovV8Z7b66l3xyYqWOBi9R48wV3s2whIvrwXqNBlBfT1t2ti3S/qSq8qURe9+OWMTpw4qT5DJuiGule70Yxb6tXW4SP/PVyePVvWaPvEtXDXrdfqnQ8/99JS3XHLtXFlYz0CCCCAAAIIIJAmAmFhuZQ7d56gTTlzhiksLCxV2p8mHZyJDpriAOT06dPau+9AJIk95xG5kISZfw8ecrc93X5TXVWvXO5sAOLtnyVLqEYM7KjFS5brg0++9NbE/bN85Wr9vfsf9+1V7338hcqXuVL79h9QtmzZVKFsCWXTak4vAAAQAElEQVT3XpevTDiQsSOE5cyp/QcO2qxL19eprq9X/qCNm7erVrWKbl16m1AfBBBAAAEEEEAAAQTSu0CKA5BH779dDzfqEvn1u4817a4nHrwzye0e/twLurF+E/c8yXFv1MJGKnyF5Mie3Y1ezH3lHX321Xe+1ee8lihWRB37jNRTrXqrRpXyXqqgi/PnU5mSxdwD7F36jpLdTnXOjrGseOyB2zV++ovuIXTbbHWoUrGMbr2hljcwE2KrSAgggIBPgFcEEEAAAQQQSKRAigOQe2+vp5njB+jGa2u4NHP8QN192/WxHj7/RXk1b2p45Lbzz8ujV2eOcsuDerbWx29O18hBndWnc1PZsxz5812oeVPO5s+TO5denDZU19aq4vLHNrHnT+ZOHqJXnh+p1o0fjcxi5Vk5VvaA7i319GP3uG12bKuDW/AmVjerozfrteVqjRrUxQU+tmy3mv2y4zfdfWvsbbM8JAQQQAABBBBIbQGOhwACGU0gxQHIqIlzdPllBfTA3Te7ZCMMg0ZOy2gO8db3l+2/qUGLnt5IyhXuNrF4M7MRAQQQQAABBBBAAIFgEEhmG1McgNhX5MY89k8bNsdc5bflFavWqkXnZ6OlfkMnyW7Z6tSqod+OE7Uge8DeRlA6tDi3/Dz54/5a4KhlMI8AAggggAACCCCAAAJSsgOQtz9Y6p77+HnrDvfavNMg9/pky14qWqRQwGyrVy6vySN7R0t2W1XADkjBCCQsQA4EEEAAAQQQQACBRAokOwCpXKG0Gj1RXwUuye9ebd5SeN92Gty7bSIPTzYEEEAAAQRSIsC+CCCAAAIZTSDZAYg961HtqnKyB7ft1ZcuK3BJRjOgvggggAACCCCAAAJJFSA/AskUSHYA4jvesePHNXv+22rfc5i7Bct3K5ZvO68IIIAAAggggAACCCCAgE8gxQHIwOFT9Peevdq9Z5/q31FPeXKFqVTxIr7yg+GVNiKAAAIIIIAAAggggEAiBVIcgGzdtlOdWz+p3LnD3DdR2b+18evvfyby8GRDAAEEUiLAvggggAACCCCQ0QRSHIDkzp3LtfnkyVM6fOSomz9x4pR7ZYIAAggggAACmVSAZiGAAALJFEhxAJInd27tO/CvalevpKdb9/ZSHxW45CIF0389O7cSyf8G3Tu2ULcOzbEN0PnVtX0z9ejUAt8A+XZp1xTbANny3uD/99uof8O6tm/qvTe05PwNwPnbo1NLmW9Ub3/OF7ysQDBdfgV1WzN641McgIwd0lUXnn+ennmivnp2aKKWjR5W13bPZHSXRNc/b5a96tWlNSkABvZGbQEIvoE5v7p1aOYuMvD1v69dUNhFBrb+tzVTC0As2TzJ/8ZdvQ8n7BzG1v+25mq+gbIlAEn05RsZ01ggxQHIll926tDhI64ZFcuVVOkSRbVtx29umQkCgRWgdAQQQAABBBBAAIGMJpDiAKTf0EnKni1bZLuzZcuqfuGTIpeZQQABBBDIhAI0CQEEEEAAgWQKpDgAOXnqpCzo8B0/R/bssn8bxLfMKwIIIIAAAggggID/BCgJgYwukOIAJCQkRN9890Okw/KVa6KNiERuYAYBBBBAAAEEEEAAAQSCXiDFAUjvTk01auLsyH8FfeyUuerVqUkqwHIIBBBAAAEEEEAAAQQQyGgCKQ5Aypa6UvNnjNBD997i0vzpw1WmZLGM5pDs+u4/eEyDR0wgBcAgfNQkDRszBdsA2No5O2zMVJmxzSc5BahOmaUeQ0ZO1PCx0zh3A3SeDB09WZYyy/mS3toxfOxU2Tmc3uqVGvVJ9sUAOyKAQJIEUhyA2NFCQ0JUpFBBl0JCQmxV0KQDh465N2p7syZN9KuFXWAM8wIQXP3r6vO0i4zwUZP92me+snmdqBHjpmHrBWKBOBeC/b0hEKZRy7TgOdz7ACjqumCZPxzxrZ5BcxFDQxFII4EUByAL31uim+5rqrbdw126+f5mevuDpWnUHA6LAAIIIIAAAggggEBABCjUTwIpDkDmLXhX/bu11KL5413q26W55r6yyE/VS//F5MlfOP1XkhoigAACCCCAAAIIIJBOBFIcgGTNmlXXXH2VQkJCXKpTs7JCQ0PSSfOoRkAEKBQBBBBAAAEEEEAAgWQKpDgAyZIlVPbVu77jf/n198qePbtvkVcEEEAAAT8KUBQCCCCAAAIZXSDFAUj3ds9o5ITZqnnLEy7Z1/DauowOQ/0RQAABBBBAAIEoAswigICfBFIcgJQrXVyvzRqlF6cOc2nBC6NkX83rp/pRDAIIIIAAAggggAACCGQigaQHIBGNX7ZitXzpq5VrtOuvv12yeVsfkY0XBBBAAAEEEEAAAQQQQCBSINkByKtvLlZ8KfIIzCCAgN8EKAgBBBBAAAEEEMjoAskOQMaFd1N8KSPAPPRMJx3492BGqCp1RAABBBBIWwGOjgACCCDgJ4FkByB2m1V8yU/1oxgEEEAAAQQQQACBoBag8ZlNINkBSHy3X9m2jAI1a/5CNW7XT807DdLfu/9x1Q4fM0MDR0xR627hmj7nNS1eskztew5X665D9GjjLpowY77LZ5ODu7fbCwkBBBBAAAEEEEAAAQQSIZDsACS+269sWyKOnS6yXFG4oGaMG6Cbr6upeQveiazTseMn9Fx4NzVp+IBb99uuPzWsfwfNnRKuzVt26Jvv1rr1qTnhWAgggAACCCCAAAIIZHSBZAcgsTX86LHjeuu9JXqqVe/YNqfLdbWqV3L1qliupLbt2OXmbXJtrSoKDf2Px7bnzhWmrFmz6uqqFfTj+p8tGwkBBIJDgFYigEAQCBw6dFCBTIcPH9KxY8cCeoxA1j+9l3306BEdOXIkVXyD4NchoE387wo7BYfZsm2nhj/3gm5/qKXefOcT3VKvdgpKS91ds3kBhR0xJCRUp06dslmXLNBwMxGTM2ciZiJezsRcEbGeFwQQQAABBBDwp0DqlZU7dx4FMuXKlVs5cuQI6DECWf/0XnbOnGEKCwtLFd/UOysz55FCk9us4ydO6L2Pv1Djdv3Vrf8YXZw/n9fhYZo9abAevf+25BabbvdbvnK1e0bkyNGjrt3ly1yZbutKxRBAAAEEEEAAAQQQSLFAgApIdgBy16Nt9O7iz9Xi6Qf12qzRevqxe5Q1S5YAVTPtiy1RrIg69hnpbi+rUaW8alSpkPaVogYIIIAAAggggAACCGQwgWQHIE88dKf+2v2PXnhpod7/+EvZiEgGa7tenTlK55+Xx1W7aJGCmjC8p5vv0aGx6tWp7uZ9k0IFC2ju5CF65fmRat34Ud9qXoNDgFYigAACCCCAAAII+Ekg2QFIAy8AWfDCKD3+4B36fPm3uvOR1tp34F999tV3OnX6tJ+qRzEIIIAAAsEtQOsRQAABBDKbQLIDEB9EzWoVFd6nvV6aNlRPPHinRk2c7YIR3/bM8GoP1Xdq1TAzNIU2IIAAAggggAACiRMgFwIBEkhxAOKrV/6L8qrRE/X11tyx6t6+kW91pn/Nk79wpm8jDUQAAQQQQAABBBBAwF8CfgtAfBWyfzvD/g0N33ImeKUJCCCAAAIIIIAAAggg4CcBvwcgfqoXxSCAAAKSQEAAAQQQQACBzCZAAJLZepT2IIAAAggg4A8BykAAAQQCJEAAEiBYikUAAQQQQAABBBBAIDkCmX0fApDM3sO0DwEEEEAAAQQQQACBdCRAAJKOOoOqxBRgGQEEEEAAAQQQQCCzCRCA+KFHe3ZuJZL/Dbp3bKFuHZpjG6Dzq2v7ZurRqQW+AfLt0q5pxrYNkIs/3it5b/D/+23Ufunavqn33tAyKM/fXLnC/HBVQBEIIJCQAAFIQkKJ2N6rS2uR/G/Qo1NLF4Bg2zog51e3Ds3cRQa+/ve1izm7iMPW/7ZmagGIJZsn+d+4q/fhhJ3DwWibiD/5qZKFgyCQ2QUIQFLYw3mz7E1hCeyOAAIIIIAAAggggEDwCKTjACR4OoGWIoAAAggggAACCCAQLAIEIMHS07QTgaQIkBcBBBBAAAEEEAiQAAFIgGApFgEEEEAAgeQIsA8CCCCQ2QUIQDJ7D9M+BBBAAAEEEEAAgcQIkCeVBAhAUgi9/+AxDR4xgRQAg/BRkzRszBRsA2Br5+ywMVNlxjZP8u/v8JCREzV87DTO3QCdu0NHT5Ylzlv/nrfmOWn63BT+VWR3BBBAIGEBApCEjeLNceDQMdnFRqZK3sVTemiPXWAM8wKQ9FCXzFiH4WMtAJnM+Rug833EuGnYBsiW94aJATu3Js+YF+/fPDYigAAC/hAgAPGHImUggAACfhKgGAQQQAABBDK7AAFIZu9h2ocAAggggAACiREgDwIIpJIAAUgKofPkL5zCEtgdAQQQQAABBBBAAIHgETg3AAmettNSBBBAAAEEEEAAAQQQSGUBApBUBudwCMQnwDYEEEAAAQQQQCCzCxCAZPYepn0IIIAAAokRIA8CCCCAQCoJEICkEjSHQQABBBBAAAEEEIhNgHXBJkAAEmw9TnsRQAABBBBAAAEEEEhDgQwdgBz496AeeqZTgnyWx/LGzPjF8lXasm1nzNUJLnfoNUIbN/+SYL6kZiA/AggggAACCCCAAAKZXSBDByC5coWpb5fmye6j5SvX6JftvyV7f3ZEAIFMI0BDEEAAAQQQQCCVBFwAcujwEQ0aOU3NOg7Uzfc304effuUOb69Pt+6jR5t0VaO2/dy6P/7arU59RuipVr3Vqstgbfnl7AjC4iXL1L7ncLXuOkTdB47Vnr371OvZ5/RE8x5q3K6f1m3Y4vaPbWL7bdqy3W1q0KKnps993c1PnbVAb7zzsZu38m2blTdm8hydOn1ah716DxwxxW23yez5b+vBpzupdbdwd+yXXnvPVrs0a/5CV4/mnQbp793/aPPW7fpi+Xd63juWrdu+c1ecdT52/Lj6DZ3k2tKx93AdPHTYlckEAQQQQAABBFIqwP4IIBBsAi4AWfrlSuW98DxNHd1X7706SVUrlZVdkI+ZPE+DerbW/OnD1SdipGH8tJdUukQxzZr4rG678RqFj30+0uy3XX9qWP8OGtq3vcZPm69K5Utp3pRw9encXP2HTYrMF3OmQtkSWr12g7uwz5E9u9au2+yy/LBukyqVK+3qMssLLsYN6aY5kwbr2PGTWvTBUpfHN7GA4q33lmjm+IEK79NW6zdFv0XqisIFNWPcAN18XU3NW/COihctrDo1q6hRg/s1ZVQfFS70f3HWeeF7n+rAv4fcsRt7+X9cf7Z+duyDu88GTjZPQgABBBBAAAEEEEAgwwikUUVD7bglriysr1as1rTZC7xRgVXKl/cCrflxg66/ppouv+xSy6Ii3gW6zfzw02Y9cM9NNqs7bq6rbTt+08mTJ91y5YpllDtXmJu3gOKjpctlowvhY2do9z/73MiD2xhjUrlCKa3xgg0LOGpWqygbkTl56pR2/LpLRYsUlNXF1vX0RlRaeqMua37cK+dXtQAAEABJREFUqJ82bI1Wyo/rf9a1tavovDy5XapXt3q07bWqV3LLFcuV9Oq8y83HnMRV57Vem++9o55CQ0NVpmQxl2LuyzICCCCAAAIZXeDMmTM6duyYDh8+pEOHDpL8bGCu5ottYM6to0eP6MiRI6ly3mb03/W0rr8LQGw0YNqYfirljWy8+tZivfzGB7I3oWzZssRav2xZs7r1ISEhCgnxkndhbiuyZ8tmL5Fp+ICObnTBRhg+Xfi8Ls6fL3Jb1JlyZYrrR+8if826jd6IRwlvhKWoFnqjGWVLFTubzTtGnZqVI8uaP32YenZsfHZbxNTqmyXLf/XNmvW/ecvyX51DdcoLbmxdbCmuOmeNp+zYymFdhhKgsggggAACnkBISIhy5MihXLlyK3fuPCQ/G5ir+WIbmHMrZ84whYWFpcp56/268JMCgVDbd/+Bg8qTO5fqehf59915g2w0oVL50vr0y2/16+9/WhY3KmEzFbxg4fVFZ5/LsGdEivyvoLKEumJsc2SqVrmcprywwAUytvLb1evsJdZkF/cFLs2vT79YIQtGKpYrofmvv68K5Uq5/FUrlZHdJuZ73mTvvgPnfHtVudLFtWrNenc8C0a+/T7u47lCvUlYWA4d8NruzbqfuOpc3mvzyu/Xujz79h/Qxs3b3DwTBBBAAIGUCrA/AggggECwCbjI4dMvV6jOHU/Jbm/6bNl3evrxe9wzEa0aPayeg55zD6E3btff2bRp+pi7JcoeQl/43qfq3v4Ztz7mpFXjR3T8+HE1aN5Tdz3WRm++80nMLNGWK5QtrvPPyyN7BqRiuZL6bddfuqp8SZfnsgKXqFOrJzV49HTZg+gNW/bSPi8IcRsjJiWKFdZ1taupTbdwde47UvnzXag8eXJFbI395fYb62j5t2tcu+2Zl7jqfM/t12vvvn/VtvtQDRg+VQUuvSj2AlmLAAIIIIAAAghkFAHqiUAaCbgA5N7b6+mLd2dp0oheerZXaxUrUshV55Z6tTVn8mD3ELrd9mQrC1ySX6MGddGsic9qopc/at5OrRpaFpcuPP889xW586aGa9FL4zW4d1u3Pq5Jq0aPuofEbfsl+fNp+eJ57lYsW7ZUr05194D53MlDXHlVKpV1AcurM0fZZpfs2ZQJw3t6bWijffsPqlyp4m695bHgxhaKFikoy2Pzxa4opBEDOrl220PocdXZgqIB3VvquaHdNWZwF708Y4RKFr/CiiAhgAACCCCAAAIIIIBAEgRcAJKE/Ok6a7cBY90/TPhMm7667ppq7gH2RFSYLAgggAACCCCAAAIIIJBKAqkagKxYtVYtOj8bLdm/r+Gvtk4Y1kM22mFfG/zIfbf6q1jKQQCBgAlQMAIIIIAAAggEm0CqBiDVK5fX5JG9oyW7tSnY0GkvAggggAACaS5ABRBAAIE0EkjVACSN2hjQw+bJXzig5VM4AggggAACCCCAQOYSCPbWEIAE+xlA+xFAAAEEEEAAAQQQSEUBApBUxOZQMQVYRgABBBBAAAEEEAg2AQKQYOtx2osAAgiYAAkBBBBAAIE0EiAASSN4DosAAggggAACwSlAqxEIdgECkGA/A2g/AggggAACCCCAAAKpKJCGAUgqtjLAh+rZuZVI/jfo3rGFunVojm2Azq+u7ZupR6cW+AbIt0u7ptgGyJb3Bv+/3/r+hrVo/ESA/2JSPAIIICARgPjhLOjVpbVI/jfo0amlC0Cwbe3/88s7Z7t1aOYFIC0DUnaw95ldzHVt3xRb7zwLxLlgAYilQJQd7GW2bNLAD38VKQIBBBCIX4AAJH4ftiKAAAIIIOBXAQpDAAEEgl2AACSFZ0DeLHtTWAK7I4AAAggggAACCKSCAIdIJwIEIOmkI6gGAggggAACCCCAAALBIEAAEgy9HLONLCOAAAIIIIAAAgggkEYCBCBpBM9hEUAgOAVoNQIIIIAAAsEuQACSwjNg/8FjGjxiAikABuGjJmnYmCnYBsDWztlhY6bKjG2e5N/f4SEjJ2r42Gnu3H3rnQ9T+C7D7ggg4CcBikEAgXQiQACSwo44cOiY7GKDNNHvDkNHT3YBCLb+tzXT4WMtAJns936zskkTNWLcNGe78N0PU/guw+4IIIAAAghkdIHo9ScAie7BEgIIIIAAAggggAACCARQgAAkgLgUjUBMAZYRQAABBBBAAIFgFyAACfYzgPYjgAACwSFAKxFAAAEE0okAAUgKOyJP/sIpLIHdEUAAAQQQQACBzCxA2xCILkAAEt2DJQQQQAABBBBAAAEEEAigAAFIAHFjFs0yAggggAACCCCAAALBLkAAEuxnAO1HIDgEaCUCCCCAAAIIpBMBApB00hFUAwEEEEAAgcwpQKsQQACB6AKpFoA80byHdu/ZG/3o8Syt27BFnfuOjCeHtOSLFQofM8Pl+WL5Km3ZttPN+3vijjP2eVfs/gMH1XvwBDXvNChgx3MHYoIAAggggAACCCCAQEoE0um+qRaABKL9V5UvpUfvv90VvXzlGv2y/Tc3H8jJ58u/1aWX5NOUUX1UrEihQB6KshFAAAEEEEAAAQQQyHQCoYNHT1ebbuG669HWWrFqrfoPm6zHmnbTsHEzXWOXfbNa3QeOdfM2Wfn9j+rQa4TN6vsf1qtJ+wF6smUv9RkyQf8ePOTWJzRZvGSZGrToKRsVGTN5jk6dPu12sSDi8abdXZnvLP7MrbPJH3/tVqc+I/RUq95q1WWwtvxydqTj+7UbNP/197R563Z9sfw7PT/3dTcysX3nLtstWjrtHaN+g/Zu3cFDh1Xr1gb6bvU6t9y84yBt8/aJ6zgukzf5aeMWzXl5kZZ8vsKZeav4yRgC1BIBBBBAAAEEEEAgnQiEnj59RuPCu6lnxybqMXCcGjx0p+ZOCdfO3//Uj+s36+pqFbRu/c86euy4q/LHS7/WTdfV0MlTp9Q3fKJaPPOQZk8arCxZsmjuK4tcnvgmFhzMmv+2xg3ppjnefseOn9SiD5a68gaPmq4eHRpp2pi++nvPP5HFjJ/2kkqXKKZZE5/VbTdeo/CI26F8GYoXLaw6NauoUYP73chE4UL/59sU+RoaGqpCBQu426ZWr92oCmVKaM26ze64v+36U0W8fRI6TpmSxfRw/Vu8OtTW+GE9IstmBgEEEEAgLgHWI4AAAgggEF0gtEaVcrKL83Klr1Se3LlU7IpCyhIaqlLFi+iXHb+5+ZrVKmnplyvcSMXny1epbq2q+u33v3TeeblVuUJpV+JD996sH7wLercQz2TNjxt06PAR9Xz2ObX0RjPW/LhRP23Y6sq7KN8FKle6uEJCQlT/zhsjS/nhp8164J6b3PIdN9fVNq9eJ0+edMtJmVQsV1JrvOBjzboNavDwXbJjr9vws8qVudIVk5zjHNy93e3LBAEEEIhNwN6rDh06KJL/DI4cOayjR49gGqDz6tixYzp8+BC+AfA1V/NNtfeDALQhPdfd3heOHEmd94bY3u9Zl3iB0KxZs7rcFoRky3Z23lZkCQ3VyZOnbFY3eiMeH3/2tb5e+YMqli3uAhXbkC1iX5u3cs7ojM3Gn7zgok7Nym6kwp6jmD99mDf60tjtY6MobsabZPVGVLyXyB/fsUJCQlyAEuLVL3JjImcqlSuh1V7As3bdz6pRtbwXCB3W6h82qlK50pEl+OM4kYUxgwACQS9g7425c+cRyX8GYWG5lDNnGKYBOq9y5MihXLly4xsAX3M1X94P/Pd+ENXS3hfCwlLnvSHo/7ilECA0MftXu6qcNm3ZoUUffKqbrq/pdil42SU68O8hrVm30S0vWPihKpUv6ebjm1StVMYbTVkZ+RzH3n0H3G1RVt4/e/fLlm1/ex7FXi1VKFNcry/62Gb14adfqcj/CrqRGbciYhIWlkMHDhyMWIr2ErlQzitnrTeaEpolVBbg2K1bixYvjax3Yo4j/kMAAQQQQAABBBBAAIFkCyQqAAkJCVGdqyvr62/XqnaNyu5gdgHft0szTZj+snsI/ejRY2rw0F1uW3yTywpcok6tnpQ9/G4Pojds2Uv7vCDEyrPnP+wh+HY9hkUGKFZWm6aPac2PG2QPoS9871N1b/+MrY6Wbr+xjpZ/u8bd1mXPmUTbGLGQI3t22W1eZUsVdWsqlC2hPV7QU7zo/9xyYo7jMjJBAIFECpANAQQQQAABBBCILhBar051tyZ3rjC9Nmu0m7dJi2ceVv07brBZl7q0eUpLF81UzhzZ5fvvqgqlNX1sP/cQ+qCerSNvzfJtj/o6b0q48l+U162yY84cP1BzJw/RopfGq0qlsm59jSoVZA/EWxo7pJtGDuzs1he4JL9GDeqiWROf1cQRvVQs4utvrZweHRq7PPbsyogBnTTJ2x7bQ+gukzeZMW6AWjV61JuT7IH2Txc+756BsRXxHqd9I8uiB+6+WU2ffNDNM0EAAQQQQCDdClAxBBBAIJ0KJGoEJJ3WnWohgAACCCCAAAIIIJDuBKhQ/AJ+D0D6DZ2kFp2fjZaiPs8Rf3X8s/XFBe9GO77Vx9b5p3RKQQABBBBAAAEEEEAAgeQK+D0AGdC9pSaP7B0tVa9cPrn1S9Z+jz94R7TjW31snfgvlQU4HAIIIIAAAggggAAC0QX8HoBEL54lBBBAAIE0EeCgCCCAAAIIpFMBApAUdkye/IVTWAK7I4AAAggggEBmEqAtCCAQvwABSPw+bEUAAQQQQAABBBBAAAE/CgQwAPFjLSkKAQQQQAABBBBAAAEEMoUAAUim6EYagUAMARYRQAABBBBAAIF0KkAAkk47hmohgAACCGRMAWqNAAIIIBC/AAFI/D6J2tqzcyuR/G/QvWMLdevQHNsAnV9d2zdTj04t8A2Qb5d2TZ3tPXfcnKj3ETIhgAACCKRYgAIyiAABiB86qleX1iL536BHp5YuAMG2dUDOr24dmnkBSMuAlB3sfWYfSHRt39TZ3nsnAYgf3mYpAgEEEEAgEwkQgGSizoxsCjMIIIAAAggggAACCKRTAQKQdNoxVAsBBDKmALVGAAEEEEAAgfgFCEDi90lw6/LF83TixHFSAAzOnDmt0NAQbANga+dslixZdPr0aXwD4Hvy5Ally5YN2wDY2rkrnVFIiPANkG/WrFl16tTJjOib7utsruZr5zHJ/9dOISHeG4N35ZYatt5h+EmBAAFICvDYFQEEEEAAAQQQQAABBJImQACSNC9yI4AAAggggAACCCCAQAoECECSibd7z1617jpEz7Tpq56DxunI0aPJLIndEmO5d98Bde4zUtff00jDn3sh3aKlx4q9+tZiPdG8hxq26KXPl6+KtYqTnn9ZjzTuojsfaa2BI6bo2PHjseZjZXSBk6dOafDo6XqqVW817TBAv/7+R/QM3tKp06dVv0F71bzlCT3wVEeNn/6St5afxAis+XGjnmrdRw1a9NSMua/Hu4u9R9S7p7Emz3wl3nxs/E8gMe8N3QeMceeunb+W1m3Y8l8BzCBjCXUAABAASURBVMUpkJi/a7bzP3v3R/5tu/7uZ7Ruw8+2mpSAQGLeG2Keu3XvfMrddpxA0WxOJQECkGRCj5v6oq6uWlEzxw/U+eefpxcXvJfMktgtsZa331xXTRrcD1gSBLbv3KU5Ly/S1NF9Nbx/Bw0eNU1Hj50bXFQsX0ovzxihOZMHy/4gvvnOkiQcJXizLvpgqee1T7MmPqsH7r5JQ8fOPAcjNCREk0f1lj0vNmpQF61as14rVq09Jx8rogucOXNGfcMnqmubp/TChEFa8sUKff/D+uiZoiyNmjhHlSuWkkLEf4kQSOx7gxU1aUQvd/7aOVy2VDFbRUpAILF/1/oPm6yLLsqrN2aP0RtzxuryywokUDKbE/veMLRfh8jztl/X5rqmxlUKDeWyN72cQfREMnti2TerdcfNddzed9xUR19+872bZ5J0gcRY5r3wfNWrU11hYTmSfoAg3uPLr1fp2tpVlTtXmApcml+lil+hlat+VMz/alev5Fbly3uBKnnByF+797hlJvELLPv6e93u/f5brnp1a2jdxi06dPiILUamkJAQFbgkv1u+KN8F7tW7tnavTOIW2PjzNuXyztsyJYspa5Ysuvn6WvrCO59j28M+DQ3z3hvKlipuz6fHloV1MQQS+94QYzcWEymQmL9rf/69Rzbi0bFlA+X1/sZZuuD8PIk8QnrLlnr1Scp7g69WH3zylfceUtu3yGs6ECAASUYn2AWGd03h3jBs90IFL9Xfu/+xWVISBbBMIlgSs/+95x9dVuDiyL0uv+xS/RVPcHHk6FG9s/gzVa9cLnIfZuIW+HvPXhX8v0tdBrtItkDjr79jfy+ofVtD3XRfU9W5urJqVCnv9mESt8CfnmPBKOeuvc/++de5gfHJkyc1fvp8tWnyaNyFseUcgb+T8N7Qqc8o3fZgC42cMFsnTpw8pyxWRBdI7N+133f9pUsuzqcOvUbohnsbu9tf7T04emksxRRI7HuDb7/9Bw5qw+atuubqsx+0+dbzmrYCBCDJ9I86jBcScpYxmUUF/W5YBvYUCIky5BwSEvf9KTas3XvweDfSZLcXBrZWmaf0kJD/TO12q7hatuz9OVrwwkj98NMmfbVidVzZWB9FICT0P1sp9vdZu/31vrtu0Pnn8clxFLpEzYYk4r2hY6sntWThDA3r38G7iPtFc199R/yXsEBi/q7Z82E7fv1DjRvcp7fmjVPOHDk0D9+Ecb0ciXlv8LK5n8VLlqluzaqyrz92K5ikC4HY39HTRdXSbyXsdpZTp07r+IkTrpJ79u7TxfnzuXkmSRPAMmleSc198UX5tG/f/sjd/vHO1UvyXxS5HHXGHvK1W7RaNnok6uqMMp8m9bz4orz6Z28U330H3CeacVXG7u++qnxprV67Ia4srI8QuNT7ZHjvvn8jluQ579Oll5x77trtr4NGTHUPSk+bvUBzXlmksVPmRu7HTOwCiX1vuCTib1uFsiXU4KE7tX4TD6HHLvrf2sT+XcvvvT/nz3ehKlcorfPy5FaNqhW0acv2/wpiLlaBxL43+HZevOQr3VKvpm+R13QiQACSzI6oVb2SPl663O394adf6ZoaDO05jGRM4rL846/d2rbj92SUyC4+gWuuruzum7dvtbIL5Z82bvX+yJ29/efnrTtkwbPlfeXNxdq9Z5+aNHzAFkmJFKjl/d5//Nk3Lvc3361V0cIF3fM2dgvGj+s3u/V2n/cff+528wcPHXYPoJe88gq3zCRugZJXFvHOyb3a+dsfsk+KP/Gc7Xy2PaK+N0wf2y/yQdOmTz6ohg/fpfbNG1g2UjwCZmnP1MT23mAP+/tutbJz1oqxW90sf+kSsT2EbjlIUQXi+rsW9b2hSKH/U65cObVl206363erf1QJ77x3C0ziFIjvvSHq3zUrwN4//t6zV5UrlrFFUjoSIABJZme0b/64Fi3+3H0N746du/T4g3cksyR2i8tyyecrNP+N9x3QyVOn3Cec9hW8b777iZvfuPkXt41J3AKFvT9w9e+4QY3a9lP7nsPVoWVDZc+Wze0w1fu0+Nvv18ls7RPjtz9Y6lztqzYHjZzm8jCJX+Du265XaGiI+xre5+e9oW7tGrkdfvUumgeNnOrmT3gjpW26hztbewbkwgvPV7261d02JnELhISEaED3luozZILzrXJVGdknxbZH1PcGWyYlXSC+94au/cdo/4F/XaH3P9nRnbv2ag9IN3zkLreeSfwCcf1di/reYCUM7NFKA4dPkX1N+tGjJ7xRJnzNJb4UEhL3e4Pv75pv/w+WLNNN19ZQSEiIb1Xme82gLQrNoPVO82rnvyivJo/sLfsa3iF92iksZ840r1NGrUBclo89cLt6tD97QWcP+NpXQEZNJYvzKXJi+vyhe2/RvCnh7it2r61VJXKXEQM6ecPStd03DEV1tfk+nZtG5mMmbgE7L3t1bCL7Gt5pY/rpf5ef/QpNOzdfeX6k29Fuu1rwwqjIT+kH92rDH0Mnk/CkYrmSznbu5CHRvoI76ntD1FKefuwetXjm4airmI9HIK73ho/emCZ7X7ZdF782xZ27C198Tm2aPObeL2w9KX4B84vtGiHqe4OVULxoYc2eNNi9P/fs2Fg5c2S31aQEBOJ6b/D9XfPtbl/d36bp475FXtORAAFIOuoMqpJsAXZEAAEEEEAAAQQQyCACBCAZpKOoJgIIIJA+BagVAggggAACSRMgAEmaF7kRQAABBBBAAIH0IUAtEMigAgQgGbTjqDYCCCCAAAIIIIAAAhlRIDMEIBnRnTojgAACCCCAAAIIIBCUAgQgQdntNBoBfwlQDgIIIIAAAgggkDQBApCkeZEbAQQQQACB9CFALRBAAIEMKkAAkkE7jmojgAACCCCAAAIIpI0AR02ZAAFIyvzYGwEEEEAAAQQQQAABBJIgQACSBCyyxhRgGQEEEEAAAQQQQACBpAkQgCTNi9wIIIBA+hCgFggggAACCGRQAQKQDNpxVBsBBBBAAAEE0kaAoyKAQMoECEBS5sfeCCCAAAIIIIAAAgggkASBFAQgSTgKWRFAAAEEEEAAAQQQQAABT4AAxEPgB4EMJ0CFEUAAAQQQQACBDCpAAJJBO45qI4AAAgikjQBHRQABBBBImQABSMr82BsBBBBAAAEEEEAgdQQ4SiYRIADJJB1JMxBAAAEEEEAAAQQQyAgCBCAZoZdi1pFlBBBAAAEEEEAAAQQyqAABSAbtOKqNAAJpI8BREUAAAQQQQCBlAgQgKfNjbwQQQAABBBBIHQGOggACmUSAACSTdCTNQAABBBBAAAEEEEAgMAL+LZUAxL+elIYAAggggAACCCCAAALxCBCAxIPDJgRiCrAcXaD7gDGqecsT+vX3PyI32Lyts22RKwM4c/LUKY2bOk9PNOuhJ5r30G0PttDriz5yR1z5/Y9q3mmQm89ok+9Wr9M3362NrPYP6zbpmTZ9I5czw8z0ua/r9OnTkU2xvrI+i1zh55l2PYZp2TerXalR590KP012/fm3Fr63JFppgTpWtIOwgAACCGQgAQKQDNRZVBWBdCcQEqLiRQvr3Q+/iKyazV9Z9H+St02p8N8HH3/pXVR+r7FDumrelHC9+sJIFS18eSocObCH+H7tRq1a81PkQYoWuVxd2jwVuZwZZma9tFCnz5xJbFMyRL4//tytd6L8PlilWzV+RGVLF7NZEgIIIICAJ0AA4iHwgwACyRe49cZr9MEny3TGu5C0ZPM3X18rWoGvvrVYDVr0dKnnoHHas3ef277qh/W694l2atiil0vLV65x623S3Bu5GDlhtlp1Gey2LVj4oa0+J/21e69Klyim/BflddvOy5NbV1Uo7eZtcvTYcdkxn2rVW627heuv3f/Yav2zd7+rz2NNu+nhRp0179V33XqbTJu9QD0GjVXrrkPUuF1/2SiLjeqMn/aimnYYoEcbd9FHS5dbVpdWrFqrZh0H6smWvdzrTxu3uPUxJ9am4c+94ModNGJqnHX4Zftvevejz7V4yVduBMfavnXbrxoxflZkkZ8t+9arWz891bqP7BN22ydyY5SZl9/4QLc91FLWzvY9h2nnb/+NVtloQ/OOg/S0V8ZN9zXVl19/7/a0tk56/mW17T5U819/X1u3/+qOYYY2CuPLd+LESY2dMlctOj+r+xp2cHW1AmwUoPfgCc7ilgeaa/LMV2x1tDRhxnzZ6EfrLkPcftZPluGzZd+5Pr//yY6ydts6S1ZvG1WzkS47l973Ak9bHzPFd07FzOtbjqt9tj0uI2vfXY+21iPeuTB49HQdOXrUsmui57Z1207XpiGjZ5xdN+NlrVt/9pyI71jmPnXWAlmfNGk/QKvXbnD7x5xYnTr1GeFGxG6s30SfffWdtu343Z2Xltd+D6+/p5HmvLzIFt252mvweDcf37ka1zY7np1nXfqNUqO2/WR12/jzNlcek2ARoJ0I+FeAAMS/npSGQNAJnJcnTMWL/U92kWKp5JWFlSd3mLyIxFksW7HaXUiPH9ZDcycPUaXypTR83Ey37fLLLtWsSc9qzuTB6t+tpYaMmaFDh4+4bTaxC9TnvP1s+xuLPooMHmybL91967Xa4l3w2YXxYO9C8NMvV7oLW9/27Tt/V9OnHtKsic+qSsUymvniW25TWFgODendVi9NG6YZ4wZoyRffyC5e3UZvYhd0w/p38Lb1V9YsWbw1UuFCl2namH56bmgPjZ44xwVSFkw9O2q6urR+SrMnDVbHlg3VY+A4F7S4nWJMjhw95u3fXX26NFNcdbiicEHdcVNd3VKvlqaM6qMH77k5Wim79+xV/+GT3bFmTRjkTAeOmBItj2+heuXyWvTSc66dN3vlhY993m2yenftP0YNHrlLL3hlvDZrtEqVuMJts4n1zXNDu+vR+29THy+YqFG1gjNs1+xx9QmfoL37DugrL2Dc9cffmjyyt96YM8brwxa2q1558wOVK32lpo7uq/dfnaT7777JrY86ad34UYWGhmrCiJ6ujTlzZHebT506Jevz58cP8C6g347s835DJ6lu7aqaNzVc4716zZr/ljb+fO5FsNU7vnPKHSTGJK72xWfU0HNbNH+CV5+h7vyYt+BsANuq0SMqWqSQa1PPjo1jHElxWvoyWt9PGd1HQ/u109BxZ/vKt833OmH6fDV/+iHNHD9Q77w8URXLFleR/12m/f8e0u5/9mndhp9VttSV+i5iBO3b1T+paqUy7nyN61y1tsa1zY67ZesOtXzmET3/3AA9+cjdGjRyqq0mIYAAAskSCE3WXkG6E81GAIHYBe64+Vq9//EyvffRl7rNu3COmuvrlT9o3/5/1X3AWNkIwIeffqUffvrZZbGLzkUffKau/Udr+PiZOnLkqH6N8gl93VqVlSX07NvUJRfn1y/bf3X7RZ3YyMcc78K/a9unle/C8zVywiz1GTIhMkvRwperSKH/c8tVKpbWVi9YsYWcOXLo+7UbNGD4FHXwZ3vSAAAL1ElEQVTpN9pdUG/Y9IttcqlWtYrKncsLpNzS2Um9ujXczMX583kX60W1dt3PWvPjJh31goqRE2e79o2ZPFf7DxzUjl93ubwxJzd4ZdiFt61PqA6WJ7a0Zt1md4FZpmQxt/nxB293F+NRgze3wZuEZgnVjHlvuBGMt99fqk0/b/PWytW7VPErVLt6Jbd8wfl5lD/fhW7eJrfcUNteXFt2/v6HHrr3ZrdcsVxJlShWWGvX/6ziRQtpqzdaY6MlNlKSMyKIKF+6hBvBsZGk9z/+UhdFKdcVEs/kmppn+/zC889zF/LW5wf+Paj1m7bK6t/cGxnr7gV4hw4dlT0XE7Moq8OieM6pmPmtr+Jq3xqvb+MysjqNnjRb7boP1dqfNmvj5v/OnZjH8C3HdyxfnhuuvdrNXpT3Qu36Y3esgWxl7zy2USV7hmbtT5t04QXnu30s2Pz2+x+1YtU63X7TNfrz77P726181a4q6/o8rnPV2hrXNiu8iBcUX+Elm7/m6qu839M/5Ru1snUkBBBAICkCZ/+yJ2UP8iKAAAI+AXfblVS7RiXv4majuyC0ed9mew0JOeN9ml/HfSJsn+bbaIN9Km7bxkyep4MHD6lDiwbuU/QCl+TXYS8IsW2WsmQ5O/IgyX1afvLkaVt9Tgr1ghS7UGzxzMOaOLyXN5qxQgcPHXb5smXL6l5tYuWdPHnKZvXOh59pyeffqMFDd2nC8J665urKinrsHBEX0y5zPJOQkBCVvLJIZPusjUsXzYzzOZQcObJFlpZQHSIzxpzx3LNm+e/tO1vWrAr16hEzmy137DXcCxiKqH+3Fhrujegc8YIlW28pe7Zs9hJrypE9u1t/RmdcEJg1Sl/Y8c54dbiswCVuZKVGlfL646/datJ+gOy2rBuuraEJw3p6QVoxffL517LbzVxhiZhkj9JfoV6/Wp9bv2X12jhpRK9I53dennDOyJAVn9A5ZXmipvjaZ/myx2K0fecuPTtymjdCVVujnu2iZ56or6NHj1v2eFNCx7Kds4T+16+hWUJlI0K2Pmpq1+wJN/p1+f9d6o3EzdbbHyx1my3IsNGO71avkwUjFcqU1Gdffuv65PLLCigkJO5zNSQk7m2u8FgmJ0+ejGUtqxBAAIGEBf57p0s4LzkQQACBWAXs4tRuPbFk81Ez1fI+YX/zvSXeJ+VnRy+OnzgReavTth2/qaY30vB/l16sX7x5S1H3Tcz8ug1b9Psff0VmtU97beQiLCxn5LrYZrZ5n9yXL1PC+5S9oE56QcnylatjyxZtnT1PYSvs02775Ll82StVyRsRsFuBPvnsG9vk0vKVa9xrQpP46pAndy7t80ZSYiujYrkSsnZviPjUff7r76uEFwRZu6PmP3L0qPbuP+AFV1cprzc69PFnX0dutjI2/vyLotb1Xy8YjMwQMWMjERZo+L5ZbK33af+mLdtVoUxxNzqSzQsYqlQqq5aNHnYjXXYrj33SbyMqdb3RjGcer68f12+OKC36i9XXRseirz13yfKV8kZrnpv2ouy2PMux5ZedslvRbD5qSuo5FV/74jLa6Y3SXV6wgBuFshGXT7xA1leHPHly6cC///oWo73Gd6xoGRNYMF8LKG678RrdekMdL/jf5Pao6o1yfPv9Ou33RoxsNKvqVWU0dfarquqttwzxnavxbZMk87ZbLK2cN975WIUuLyA7R22ZhAACCCRVgAAkqWLkRwCBWAXsU29LMTdeXbWiGnmfEA8cMVX2EPMdD7fS2nVnL0gbN7xf/YdNdg8xv/TaeyperHDM3RNc3rN3v1p3DXcPx97zeFv3jEffri3cp/bx7Vz/zhv1wSdfyh747T9skjdKkPCxDx854h7mtvzd2j0ju03GLuyH9msvuyizB3VvfbC53nz3k/gOHbktvjrUq1tde/ftV7sew6I9jG07221nvTs1dQ+l2wPk9nW9fTo3s03RUljOnHr8gTv0aONurpw9/+yL3G51H9ijlWbPf9v1y3V3PaNVa9ZHbo86M6hXa33+1Sr3sLrdYta3S3MX0Hzz3Q+qdWsD2cP3A4dPkQUbBbxRrMkvvKq6dz7l+tWCo06tnoxaXOR80yfv15DR02S3VSV0O8+A7i28gGO/GjTvqQef7iR7DuVUlK/w9RWanHMqrvbFZVS9Sjl3ftmXJ3TsPVx5I26BsjoULVJIlcqVkq0fEvEQuq33pbiO5duemNdmHQfIvjSgc5+R2rR1u5569G6326UXX6Ts2bOqfOnibrlGlQra+dufqlqpjFvO6wWhcZ2r8W2znS3AtS9qeLxpd3e7pZ1/tp6EAAIBFsikxYdm0nbRLAQQSAWBof066O5brzvnSPXvuEG2zbfh3tvradaEQZo18Vl99MY0PRlxwWTPH7w1b5y7/couaCyP7xus7FamaleV8xWhMYO7uFu9IldEzNin7PYAtD0cu/DF52S35tg622z7Wzk2b6lsqWLuwV2bt4eVF7wwSu6B377tNaRPOzVucJ9tUtMnH3TJLUSZtG36uLvlaP6MEbrpupqRWypXKK2JI3rJ6v/Bgika3r9j5LaoM1YXq5NvXXx1uCR/PlfOuPBu7lajCmVLRNbd9r+2dlX3QLA9QG55roi4P9+2RU3Wptdnj5bladLwAS17f07kZrtNx9pv/WK3jVmZtnH54nn2EpmKFr7c7W/Hmjl+oBtRsY03X19LX30w1z18P7h3W/fAuq3v7gVnn78zy/WrrbdRLlsfMz1w980a/WxXd1uVjSTE9Ina5zYK86wXCL04bais3+zLA+yCO2aZ8Z1TZuC7RTDqfFzts7JjM7Lbsmx/+3IEq3/n1k+62/gsf5bQUPXo0Ni1y/cQuuX1HTe+Y8V0/3Th88oRcSucle1LL3vnn/0ejRzUWYN7tVEhbzTGt+3VmaNkwbEt2yiUlXnrDdfYokvxnavxbbP+sXaY//Sx/dxth65AJggggEAyBAhAkoHGLqkuwAERQAABBBBAAAEEMokAAUgm6UiagQACgRWwT5IDe4T0Wjr1CnYBG7Wz0algd6D9CCDgPwECEP9ZUhICCCCAAAIIIOA/AUpCIJMKEIBk0o6lWQgggAACCCCAAAIIpEeBjBCApEc36oQAAggggAACCCCAAALJECAASQYauyAQPAK0FAEEEEAAAQQQ8K8AAYh/PSkNAQQQQAAB/whQCgIIIJBJBQhAMmnH0iwEEEAAAQQQQACB5AmwV2AFCEAC60vpCCCAAAIIIIAAAgggEEWAACQKBrMxBVhGAAEEEEAAAQQQQMC/AgQg/vWkNAQQQMA/ApSCAAIIIIBAJhUgAMmkHUuzEEAAAQQQQCB5AuyFAAKBFSAACawvpSOAAAIIIIAAAggggEAUgXgCkCi5mEUAAQQQQAABBBBAAAEE/CBAAOIHRIpAwO8CFIgAAggggAACCGRSAQKQTNqxNAsBBBBAIHkC7IUAAgggEFgBApDA+lI6AggggAACCCCAQOIEyBUkAgQgQdLRNBMBBBBAAAEEEEAAgfQgQACSHnohZh1YRgABBBBAAAEEEEAgkwoQgGTSjqVZCCCQPAH2QgABBBBAAIHAChCABNaX0hFAAAEEEEAgcQLkQgCBIBEgAAmSjqaZCCCAAAIIIIAAAgjELpC6awlAUteboyGAAAIIIIAAAgggENQCBCBB3f00PqYAywgggAACCCCAAAKBFSAACawvpSOAAAIIJE6AXAgggAACQSJAABIkHU0zEUAAAQQQQACB2AVYi0DqChCApK43R0MAAQQQQAABBBBAIKgFCECidD+zCCCAAAIIIIAAAgggEFgBApDA+lI6AggkToBcCCCAAAIIIBAkAgQgQdLRNBMBBBBAAIHYBViLAAIIpK4AAUjqenM0BBBAAAEEEEAAAQTOCgTplAAkSDueZiOAAAIIIIAAAgggkBYCBCBpoc4xYwqwjAACCCCAAAIIIBAkAgQgQdLRNBMBBBCIXYC1CCCAAAIIpK4AAUjqenM0BBBAAAEEEEDgrABTBIJUgAAkSDueZiOAAAIIIIAAAgggkBYC/w8AAP//af8GLAAAAAZJREFUAwAodLn5cXpzegAAAABJRU5ErkJggg=="
+     },
+     "metadata": {
+      "image/png": {
+       "alt": "Horizontal bar chart of the mean Sharpe ratio of every allocation-stage backtest, one bar per weighting scheme, with a dashed line at zero. Counted from the frame: 6 allocators, mean Sharpe from +0.303 to +0.693."
+      }
+     },
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "ordered = alloc_comparison.sort(\"avg_sharpe\")\n",
     "fig = go.Figure(\n",
@@ -578,14 +1645,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ae8800c9",
+   "id": "bf7c3197",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.003814,
-     "end_time": "2026-09-07T07:15:31.272383+00:00",
+     "duration": 0.005169,
+     "end_time": "2026-09-11T14:27:56.039985+00:00",
      "exception": false,
-     "start_time": "2026-09-07T07:15:31.268569+00:00",
+     "start_time": "2026-09-11T14:27:56.034816+00:00",
      "status": "completed"
     }
    },
@@ -602,9 +1669,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "a933b2a0",
-   "metadata": {},
+   "execution_count": 11,
+   "id": "9f9af3eb",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-11T14:27:56.049834Z",
+     "iopub.status.busy": "2026-09-11T14:27:56.049170Z",
+     "iopub.status.idle": "2026-09-11T14:27:56.184038Z",
+     "shell.execute_reply": "2026-09-11T14:27:56.182830Z"
+    },
+    "papermill": {
+     "duration": 0.141883,
+     "end_time": "2026-09-11T14:27:56.186131+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T14:27:56.044248+00:00",
+     "status": "completed"
+    }
+   },
    "outputs": [],
    "source": [
     "def _strategy_field(spec_json: str, section: str, field: str):\n",
@@ -659,13 +1740,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6f80bd83",
+   "id": "34ecc3ff",
    "metadata": {
     "papermill": {
-     "duration": 0.003681,
-     "end_time": "2026-09-07T07:15:31.329230+00:00",
+     "duration": 0.005585,
+     "end_time": "2026-09-11T14:27:56.198194+00:00",
      "exception": false,
-     "start_time": "2026-09-07T07:15:31.325549+00:00",
+     "start_time": "2026-09-11T14:27:56.192609+00:00",
      "status": "completed"
     }
    },
@@ -679,14 +1760,50 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "abb60ead",
+   "execution_count": 12,
+   "id": "05637586",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-11T14:27:56.211643Z",
+     "iopub.status.busy": "2026-09-11T14:27:56.211317Z",
+     "iopub.status.idle": "2026-09-11T14:27:56.227348Z",
+     "shell.execute_reply": "2026-09-11T14:27:56.226910Z"
+    },
+    "papermill": {
+     "duration": 0.027728,
+     "end_time": "2026-09-11T14:27:56.231487+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T14:27:56.203759+00:00",
+     "status": "completed"
+    },
     "tags": [
      "results"
     ]
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "spread in mean Sharpe across 6 allocators:         0.391\n",
+      "spread in mean Sharpe across 10 prediction sources: 0.215\n",
+      "the allocator moved performance more than the prediction did\n",
+      "\n",
+      "Mean Sharpe by concentration and allocator:\n",
+      "shape: (3, 7)\n",
+      "┌───────┬─────────────────┬──────────┬─────────────┬────────────────┬─────────────┬────────────────┐\n",
+      "│ top_k ┆ conformal_weigh ┆ hrp      ┆ inverse_vol ┆ mvo_ledoit_wol ┆ risk_parity ┆ score_weighted │\n",
+      "│ ---   ┆ ted             ┆ ---      ┆ ---         ┆ f              ┆ ---         ┆ ---            │\n",
+      "│ i64   ┆ ---             ┆ f64      ┆ f64         ┆ ---            ┆ f64         ┆ f64            │\n",
+      "│       ┆ f64             ┆          ┆             ┆ f64            ┆             ┆                │\n",
+      "╞═══════╪═════════════════╪══════════╪═════════════╪════════════════╪═════════════╪════════════════╡\n",
+      "│ 5     ┆ 0.720391        ┆ 0.611229 ┆ 0.657297    ┆ 0.230631       ┆ 0.659503    ┆ 0.474689       │\n",
+      "│ 10    ┆ 0.676069        ┆ 0.549033 ┆ 0.60247     ┆ 0.293904       ┆ 0.595054    ┆ 0.499721       │\n",
+      "│ 20    ┆ 0.683156        ┆ 0.553192 ┆ 0.637781    ┆ 0.383143       ┆ 0.623833    ┆ 0.522769       │\n",
+      "└───────┴─────────────────┴──────────┴─────────────┴────────────────┴─────────────┴────────────────┘\n"
+     ]
+    }
+   ],
    "source": [
     "by_source = allocation_rows.group_by(\"source\").agg(pl.col(\"sharpe\").mean().alias(\"avg_sharpe\"))\n",
     "allocator_span = _span.max() - _span.min()\n",
@@ -713,13 +1830,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "abeeb20a",
+   "id": "81208bd6",
    "metadata": {
     "papermill": {
-     "duration": 0.001952,
-     "end_time": "2026-09-07T07:15:31.344294+00:00",
+     "duration": 0.005251,
+     "end_time": "2026-09-11T14:27:56.241884+00:00",
      "exception": false,
-     "start_time": "2026-09-07T07:15:31.342342+00:00",
+     "start_time": "2026-09-11T14:27:56.236633+00:00",
      "status": "completed"
     }
    },
@@ -729,14 +1846,64 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "e79a62b1",
+   "execution_count": 13,
+   "id": "8b9932d9",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-11T14:27:56.256543Z",
+     "iopub.status.busy": "2026-09-11T14:27:56.255327Z",
+     "iopub.status.idle": "2026-09-11T14:27:56.308921Z",
+     "shell.execute_reply": "2026-09-11T14:27:56.306753Z"
+    },
+    "papermill": {
+     "duration": 0.062555,
+     "end_time": "2026-09-11T14:27:56.310463+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T14:27:56.247908+00:00",
+     "status": "completed"
+    },
     "tags": [
      "results"
     ]
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div><style>\n",
+       ".dataframe > thead > tr,\n",
+       ".dataframe > tbody > tr {\n",
+       "  text-align: right;\n",
+       "  white-space: pre-wrap;\n",
+       "}\n",
+       "</style>\n",
+       "<small>shape: (10, 5)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>source</th><th>signal_method</th><th>sharpe</th><th>cagr</th><th>max_drawdown</th></tr><tr><td>str</td><td>str</td><td>f64</td><td>f64</td><td>f64</td></tr></thead><tbody><tr><td>&quot;latent_factors/cae&quot;</td><td>&quot;equal_weight_top_k&quot;</td><td>0.832983</td><td>0.187693</td><td>-0.330279</td></tr><tr><td>&quot;gbm/leaves_63_mse&quot;</td><td>&quot;equal_weight_top_k&quot;</td><td>0.828794</td><td>0.157052</td><td>-0.376832</td></tr><tr><td>&quot;gbm/leaves_15_mse&quot;</td><td>&quot;equal_weight_top_k&quot;</td><td>0.800576</td><td>0.127645</td><td>-0.389958</td></tr><tr><td>&quot;gbm/leaves_63_huber&quot;</td><td>&quot;equal_weight_top_k&quot;</td><td>0.795395</td><td>0.148885</td><td>-0.422997</td></tr><tr><td>&quot;deep_learning/nlinear&quot;</td><td>&quot;equal_weight_top_k&quot;</td><td>0.789131</td><td>0.12437</td><td>-0.211525</td></tr><tr><td>&quot;latent_factors/cae&quot;</td><td>&quot;equal_weight_top_k&quot;</td><td>0.785388</td><td>0.155115</td><td>-0.350833</td></tr><tr><td>&quot;gbm/leaves_31_huber&quot;</td><td>&quot;equal_weight_top_k&quot;</td><td>0.774499</td><td>0.126383</td><td>-0.43465</td></tr><tr><td>&quot;latent_factors/cae&quot;</td><td>&quot;equal_weight_top_k&quot;</td><td>0.774409</td><td>0.135112</td><td>-0.290294</td></tr><tr><td>&quot;gbm/leaves_31_huber&quot;</td><td>&quot;equal_weight_top_k&quot;</td><td>0.765378</td><td>0.131011</td><td>-0.434598</td></tr><tr><td>&quot;latent_factors/cae&quot;</td><td>&quot;equal_weight_top_k&quot;</td><td>0.754056</td><td>0.115612</td><td>-0.239022</td></tr></tbody></table></div>"
+      ],
+      "text/plain": [
+       "shape: (10, 5)\n",
+       "┌───────────────────────┬────────────────────┬──────────┬──────────┬──────────────┐\n",
+       "│ source                ┆ signal_method      ┆ sharpe   ┆ cagr     ┆ max_drawdown │\n",
+       "│ ---                   ┆ ---                ┆ ---      ┆ ---      ┆ ---          │\n",
+       "│ str                   ┆ str                ┆ f64      ┆ f64      ┆ f64          │\n",
+       "╞═══════════════════════╪════════════════════╪══════════╪══════════╪══════════════╡\n",
+       "│ latent_factors/cae    ┆ equal_weight_top_k ┆ 0.832983 ┆ 0.187693 ┆ -0.330279    │\n",
+       "│ gbm/leaves_63_mse     ┆ equal_weight_top_k ┆ 0.828794 ┆ 0.157052 ┆ -0.376832    │\n",
+       "│ gbm/leaves_15_mse     ┆ equal_weight_top_k ┆ 0.800576 ┆ 0.127645 ┆ -0.389958    │\n",
+       "│ gbm/leaves_63_huber   ┆ equal_weight_top_k ┆ 0.795395 ┆ 0.148885 ┆ -0.422997    │\n",
+       "│ deep_learning/nlinear ┆ equal_weight_top_k ┆ 0.789131 ┆ 0.12437  ┆ -0.211525    │\n",
+       "│ latent_factors/cae    ┆ equal_weight_top_k ┆ 0.785388 ┆ 0.155115 ┆ -0.350833    │\n",
+       "│ gbm/leaves_31_huber   ┆ equal_weight_top_k ┆ 0.774499 ┆ 0.126383 ┆ -0.43465     │\n",
+       "│ latent_factors/cae    ┆ equal_weight_top_k ┆ 0.774409 ┆ 0.135112 ┆ -0.290294    │\n",
+       "│ gbm/leaves_31_huber   ┆ equal_weight_top_k ┆ 0.765378 ┆ 0.131011 ┆ -0.434598    │\n",
+       "│ latent_factors/cae    ┆ equal_weight_top_k ┆ 0.754056 ┆ 0.115612 ┆ -0.239022    │\n",
+       "└───────────────────────┴────────────────────┴──────────┴──────────┴──────────────┘"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# Ranked over the whole advanced allocation stage, then narrowed to the allocators whose grid\n",
     "# completed - so a truncated allocator cannot lead the table on the easier subset it finished.\n",
@@ -758,13 +1925,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f9db9ceb",
+   "id": "467c9d26",
    "metadata": {
     "papermill": {
-     "duration": 0.003783,
-     "end_time": "2026-09-07T07:15:31.376713+00:00",
+     "duration": 0.007723,
+     "end_time": "2026-09-11T14:27:56.326187+00:00",
      "exception": false,
-     "start_time": "2026-09-07T07:15:31.372930+00:00",
+     "start_time": "2026-09-11T14:27:56.318464+00:00",
      "status": "completed"
     }
    },
@@ -796,13 +1963,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "92cb9452",
+   "id": "9a6b743e",
    "metadata": {
     "papermill": {
-     "duration": 0.002921,
-     "end_time": "2026-09-07T07:15:31.383452+00:00",
+     "duration": 0.007056,
+     "end_time": "2026-09-11T14:27:56.340722+00:00",
      "exception": false,
-     "start_time": "2026-09-07T07:15:31.380531+00:00",
+     "start_time": "2026-09-11T14:27:56.333666+00:00",
      "status": "completed"
     }
    },
@@ -833,6 +2000,27 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.14.3"
+  },
+  "ml4t_provenance": {
+   "executed_at": "2026-09-11T14:28:18.576550+00:00",
+   "executor": "local-uv",
+   "library_digest": "cddf49f24ce0e7761fd0ed05a1b88e98faae531080df9eb1cb8644a0efbf553b",
+   "outputs_digest": "4960e3851725d424949f6b618bf91a49734c9b28549de9c5b633598426a77a23",
+   "parameters": {},
+   "production": true,
+   "source_py_blob": "3c60a48c748d48bb37996ed439a5d9ace2008ce1"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 24.232909,
+   "end_time": "2026-09-11T14:27:59.553186+00:00",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "~/ml4t/public-teach-f/case_studies/etfs/.15_portfolio_management.build.279915.ipynb",
+   "output_path": "~/ml4t/public-teach-f/case_studies/etfs/.15_portfolio_management.papermill.279915.ipynb",
+   "parameters": {},
+   "start_time": "2026-09-11T14:27:35.320277+00:00",
+   "version": "2.7.0"
   }
  },
  "nbformat": 4,

--- a/case_studies/etfs/15_portfolio_management.ipynb
+++ b/case_studies/etfs/15_portfolio_management.ipynb
@@ -2,13 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "75938619",
+   "id": "89b1d269",
    "metadata": {
     "papermill": {
-     "duration": 0.002625,
-     "end_time": "2026-09-11T14:27:36.170574+00:00",
+     "duration": 0.00227,
+     "end_time": "2026-09-11T14:35:00.466978+00:00",
      "exception": false,
-     "start_time": "2026-09-11T14:27:36.167949+00:00",
+     "start_time": "2026-09-11T14:35:00.464708+00:00",
      "status": "completed"
     }
    },
@@ -54,19 +54,19 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "9896c8f0",
+   "id": "1635774b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T14:27:36.176585Z",
-     "iopub.status.busy": "2026-09-11T14:27:36.176318Z",
-     "iopub.status.idle": "2026-09-11T14:27:41.123245Z",
-     "shell.execute_reply": "2026-09-11T14:27:41.122644Z"
+     "iopub.execute_input": "2026-09-11T14:35:00.473720Z",
+     "iopub.status.busy": "2026-09-11T14:35:00.473455Z",
+     "iopub.status.idle": "2026-09-11T14:35:08.931062Z",
+     "shell.execute_reply": "2026-09-11T14:35:08.930054Z"
     },
     "papermill": {
-     "duration": 4.951435,
-     "end_time": "2026-09-11T14:27:41.124242+00:00",
+     "duration": 8.461763,
+     "end_time": "2026-09-11T14:35:08.932365+00:00",
      "exception": false,
-     "start_time": "2026-09-11T14:27:36.172807+00:00",
+     "start_time": "2026-09-11T14:35:00.470602+00:00",
      "status": "completed"
     }
    },
@@ -111,19 +111,19 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "653d728f",
+   "id": "e66e0c21",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T14:27:41.132913Z",
-     "iopub.status.busy": "2026-09-11T14:27:41.132395Z",
-     "iopub.status.idle": "2026-09-11T14:27:41.136186Z",
-     "shell.execute_reply": "2026-09-11T14:27:41.135293Z"
+     "iopub.execute_input": "2026-09-11T14:35:08.942126Z",
+     "iopub.status.busy": "2026-09-11T14:35:08.941487Z",
+     "iopub.status.idle": "2026-09-11T14:35:08.945659Z",
+     "shell.execute_reply": "2026-09-11T14:35:08.944757Z"
     },
     "papermill": {
-     "duration": 0.009866,
-     "end_time": "2026-09-11T14:27:41.136652+00:00",
+     "duration": 0.008818,
+     "end_time": "2026-09-11T14:35:08.946235+00:00",
      "exception": false,
-     "start_time": "2026-09-11T14:27:41.126786+00:00",
+     "start_time": "2026-09-11T14:35:08.937417+00:00",
      "status": "completed"
     },
     "tags": [
@@ -147,13 +147,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "113ffad3",
+   "id": "60eecd5d",
    "metadata": {
     "papermill": {
-     "duration": 0.00136,
-     "end_time": "2026-09-11T14:27:41.139774+00:00",
+     "duration": 0.002913,
+     "end_time": "2026-09-11T14:35:08.951404+00:00",
      "exception": false,
-     "start_time": "2026-09-11T14:27:41.138414+00:00",
+     "start_time": "2026-09-11T14:35:08.948491+00:00",
      "status": "completed"
     }
    },
@@ -175,19 +175,19 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "1e01e2bf",
+   "id": "dd10b7a9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T14:27:41.143392Z",
-     "iopub.status.busy": "2026-09-11T14:27:41.143077Z",
-     "iopub.status.idle": "2026-09-11T14:27:41.188019Z",
-     "shell.execute_reply": "2026-09-11T14:27:41.187192Z"
+     "iopub.execute_input": "2026-09-11T14:35:08.965159Z",
+     "iopub.status.busy": "2026-09-11T14:35:08.964832Z",
+     "iopub.status.idle": "2026-09-11T14:35:09.056845Z",
+     "shell.execute_reply": "2026-09-11T14:35:09.054150Z"
     },
     "papermill": {
-     "duration": 0.047789,
-     "end_time": "2026-09-11T14:27:41.188829+00:00",
+     "duration": 0.102203,
+     "end_time": "2026-09-11T14:35:09.058287+00:00",
      "exception": false,
-     "start_time": "2026-09-11T14:27:41.141040+00:00",
+     "start_time": "2026-09-11T14:35:08.956084+00:00",
      "status": "completed"
     }
    },
@@ -212,13 +212,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "00f1eec1",
+   "id": "8634687b",
    "metadata": {
     "papermill": {
-     "duration": 0.002724,
-     "end_time": "2026-09-11T14:27:41.194733+00:00",
+     "duration": 0.003939,
+     "end_time": "2026-09-11T14:35:09.070021+00:00",
      "exception": false,
-     "start_time": "2026-09-11T14:27:41.192009+00:00",
+     "start_time": "2026-09-11T14:35:09.066082+00:00",
      "status": "completed"
     }
    },
@@ -239,19 +239,19 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "eb924554",
+   "id": "88cd4ef1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T14:27:41.203510Z",
-     "iopub.status.busy": "2026-09-11T14:27:41.203216Z",
-     "iopub.status.idle": "2026-09-11T14:27:41.261563Z",
-     "shell.execute_reply": "2026-09-11T14:27:41.260782Z"
+     "iopub.execute_input": "2026-09-11T14:35:09.080661Z",
+     "iopub.status.busy": "2026-09-11T14:35:09.080342Z",
+     "iopub.status.idle": "2026-09-11T14:35:09.162922Z",
+     "shell.execute_reply": "2026-09-11T14:35:09.162077Z"
     },
     "papermill": {
-     "duration": 0.064,
-     "end_time": "2026-09-11T14:27:41.262083+00:00",
+     "duration": 0.091395,
+     "end_time": "2026-09-11T14:35:09.165103+00:00",
      "exception": false,
-     "start_time": "2026-09-11T14:27:41.198083+00:00",
+     "start_time": "2026-09-11T14:35:09.073708+00:00",
      "status": "completed"
     }
    },
@@ -283,19 +283,19 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "80027f19",
+   "id": "23517fb8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T14:27:41.269469Z",
-     "iopub.status.busy": "2026-09-11T14:27:41.269081Z",
-     "iopub.status.idle": "2026-09-11T14:27:41.429735Z",
-     "shell.execute_reply": "2026-09-11T14:27:41.429033Z"
+     "iopub.execute_input": "2026-09-11T14:35:09.179486Z",
+     "iopub.status.busy": "2026-09-11T14:35:09.179221Z",
+     "iopub.status.idle": "2026-09-11T14:35:09.439704Z",
+     "shell.execute_reply": "2026-09-11T14:35:09.438881Z"
     },
     "papermill": {
-     "duration": 0.165463,
-     "end_time": "2026-09-11T14:27:41.430258+00:00",
+     "duration": 0.268012,
+     "end_time": "2026-09-11T14:35:09.440700+00:00",
      "exception": false,
-     "start_time": "2026-09-11T14:27:41.264795+00:00",
+     "start_time": "2026-09-11T14:35:09.172688+00:00",
      "status": "completed"
     }
    },
@@ -365,13 +365,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "30bc15c2",
+   "id": "d1433b25",
    "metadata": {
     "papermill": {
-     "duration": 0.002697,
-     "end_time": "2026-09-11T14:27:41.436055+00:00",
+     "duration": 0.006602,
+     "end_time": "2026-09-11T14:35:09.449689+00:00",
      "exception": false,
-     "start_time": "2026-09-11T14:27:41.433358+00:00",
+     "start_time": "2026-09-11T14:35:09.443087+00:00",
      "status": "completed"
     }
    },
@@ -387,19 +387,19 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "3cda1948",
+   "id": "eed793e2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T14:27:41.444950Z",
-     "iopub.status.busy": "2026-09-11T14:27:41.444618Z",
-     "iopub.status.idle": "2026-09-11T14:27:42.131642Z",
-     "shell.execute_reply": "2026-09-11T14:27:42.130519Z"
+     "iopub.execute_input": "2026-09-11T14:35:09.455621Z",
+     "iopub.status.busy": "2026-09-11T14:35:09.455338Z",
+     "iopub.status.idle": "2026-09-11T14:35:10.263001Z",
+     "shell.execute_reply": "2026-09-11T14:35:10.261933Z"
     },
     "papermill": {
-     "duration": 0.693411,
-     "end_time": "2026-09-11T14:27:42.132255+00:00",
+     "duration": 0.813072,
+     "end_time": "2026-09-11T14:35:10.265162+00:00",
      "exception": false,
-     "start_time": "2026-09-11T14:27:41.438844+00:00",
+     "start_time": "2026-09-11T14:35:09.452090+00:00",
      "status": "completed"
     }
    },
@@ -459,13 +459,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "37745f64",
+   "id": "182db6c1",
    "metadata": {
     "papermill": {
-     "duration": 0.002525,
-     "end_time": "2026-09-11T14:27:42.137894+00:00",
+     "duration": 0.003672,
+     "end_time": "2026-09-11T14:35:10.272830+00:00",
      "exception": false,
-     "start_time": "2026-09-11T14:27:42.135369+00:00",
+     "start_time": "2026-09-11T14:35:10.269158+00:00",
      "status": "completed"
     }
    },
@@ -479,13 +479,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7ba493a2",
+   "id": "df9dff09",
    "metadata": {
     "papermill": {
-     "duration": 0.002422,
-     "end_time": "2026-09-11T14:27:42.143714+00:00",
+     "duration": 0.002995,
+     "end_time": "2026-09-11T14:35:10.280226+00:00",
      "exception": false,
-     "start_time": "2026-09-11T14:27:42.141292+00:00",
+     "start_time": "2026-09-11T14:35:10.277231+00:00",
      "status": "completed"
     }
    },
@@ -500,19 +500,19 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "ad961a16",
+   "id": "ae1a45db",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T14:27:42.149351Z",
-     "iopub.status.busy": "2026-09-11T14:27:42.149094Z",
-     "iopub.status.idle": "2026-09-11T14:27:52.861033Z",
-     "shell.execute_reply": "2026-09-11T14:27:52.859984Z"
+     "iopub.execute_input": "2026-09-11T14:35:10.289294Z",
+     "iopub.status.busy": "2026-09-11T14:35:10.288897Z",
+     "iopub.status.idle": "2026-09-11T14:35:24.649774Z",
+     "shell.execute_reply": "2026-09-11T14:35:24.649139Z"
     },
     "papermill": {
-     "duration": 10.720927,
-     "end_time": "2026-09-11T14:27:52.867293+00:00",
+     "duration": 14.367354,
+     "end_time": "2026-09-11T14:35:24.650546+00:00",
      "exception": false,
-     "start_time": "2026-09-11T14:27:42.146366+00:00",
+     "start_time": "2026-09-11T14:35:10.283192+00:00",
      "status": "completed"
     }
    },
@@ -525,7 +525,13 @@
       "\n",
       "--- top_k = 5 ---\n",
       "  SKIP backtest (complete (hash=7007dfbbe77c)) — reusing cached result\n",
-      "  [1/180] k=5 gbm/leaves_63_huber x score_weighted: Sharpe=+0.594\n",
+      "  [1/180] k=5 gbm/leaves_63_huber x score_weighted: Sharpe=+0.594\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "  SKIP backtest (complete (hash=e9a1f631d390)) — reusing cached result\n",
       "  [2/180] k=5 gbm/leaves_63_huber x inverse_vol: Sharpe=+0.713\n"
      ]
@@ -535,21 +541,33 @@
      "output_type": "stream",
      "text": [
       "  SKIP backtest (complete (hash=bd26475d0d98)) — reusing cached result\n",
-      "  [3/180] k=5 gbm/leaves_63_huber x risk_parity: Sharpe=+0.684\n"
+      "  [3/180] k=5 gbm/leaves_63_huber x risk_parity: Sharpe=+0.684\n",
+      "  SKIP backtest (complete (hash=4401eba4fc30)) — reusing cached result\n",
+      "  [4/180] k=5 gbm/leaves_63_huber x mvo_ledoit_wolf: Sharpe=+0.579\n",
+      "  SKIP backtest (complete (hash=a7e082d956af)) — reusing cached result\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  SKIP backtest (complete (hash=4401eba4fc30)) — reusing cached result\n",
-      "  [4/180] k=5 gbm/leaves_63_huber x mvo_ledoit_wolf: Sharpe=+0.579\n",
-      "  SKIP backtest (complete (hash=a7e082d956af)) — reusing cached result\n",
-      "  [5/180] k=5 gbm/leaves_63_huber x hrp: Sharpe=+0.626\n",
+      "  [5/180] k=5 gbm/leaves_63_huber x hrp: Sharpe=+0.626\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "  SKIP backtest (complete (hash=7d9da5f5bc7f)) — reusing cached result\n",
       "  [6/180] k=5 gbm/leaves_63_huber x conformal_weighted: Sharpe=+0.795\n",
       "  SKIP backtest (complete (hash=22bfd698df7a)) — reusing cached result\n",
-      "  [7/180] k=5 latent_factors/cae x score_weighted: Sharpe=+0.699\n",
+      "  [7/180] k=5 latent_factors/cae x score_weighted: Sharpe=+0.699\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "  SKIP backtest (complete (hash=ab8deb48db5e)) — reusing cached result\n",
       "  [8/180] k=5 latent_factors/cae x inverse_vol: Sharpe=+0.741\n"
      ]
@@ -558,29 +576,35 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  SKIP backtest (complete (hash=f84969df2d57)) — reusing cached result\n"
+      "  SKIP backtest (complete (hash=f84969df2d57)) — reusing cached result\n",
+      "  [9/180] k=5 latent_factors/cae x risk_parity: Sharpe=+0.734\n",
+      "  SKIP backtest (complete (hash=54572c323d46)) — reusing cached result\n",
+      "  [10/180] k=5 latent_factors/cae x mvo_ledoit_wolf: Sharpe=+0.344\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  [9/180] k=5 latent_factors/cae x risk_parity: Sharpe=+0.734\n",
-      "  SKIP backtest (complete (hash=54572c323d46)) — reusing cached result\n",
-      "  [10/180] k=5 latent_factors/cae x mvo_ledoit_wolf: Sharpe=+0.344\n",
       "  SKIP backtest (complete (hash=56ccab7e06ba)) — reusing cached result\n",
-      "  [11/180] k=5 latent_factors/cae x hrp: Sharpe=+0.680\n",
+      "  [11/180] k=5 latent_factors/cae x hrp: Sharpe=+0.680\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "  SKIP backtest (complete (hash=5faa94568361)) — reusing cached result\n",
       "  [12/180] k=5 latent_factors/cae x conformal_weighted: Sharpe=+0.833\n",
       "  SKIP backtest (complete (hash=d799a6a22a33)) — reusing cached result\n",
-      "  [13/180] k=5 gbm/default_huber x score_weighted: Sharpe=+0.734\n",
-      "  SKIP backtest (complete (hash=33900b169856)) — reusing cached result\n"
+      "  [13/180] k=5 gbm/default_huber x score_weighted: Sharpe=+0.734\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "  SKIP backtest (complete (hash=33900b169856)) — reusing cached result\n",
       "  [14/180] k=5 gbm/default_huber x inverse_vol: Sharpe=+0.681\n"
      ]
     },
@@ -592,7 +616,13 @@
       "  [15/180] k=5 gbm/default_huber x risk_parity: Sharpe=+0.679\n",
       "  SKIP backtest (complete (hash=4c980459e2d8)) — reusing cached result\n",
       "  [16/180] k=5 gbm/default_huber x mvo_ledoit_wolf: Sharpe=+0.256\n",
-      "  SKIP backtest (complete (hash=97889be8a3ea)) — reusing cached result\n",
+      "  SKIP backtest (complete (hash=97889be8a3ea)) — reusing cached result\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "  [17/180] k=5 gbm/default_huber x hrp: Sharpe=+0.734\n",
       "  SKIP backtest (complete (hash=eaefd57920bd)) — reusing cached result\n",
       "  [18/180] k=5 gbm/default_huber x conformal_weighted: Sharpe=+0.738\n"
@@ -641,49 +671,61 @@
       "  SKIP backtest (complete (hash=6b517d2cb5e3)) — reusing cached result\n",
       "  [28/180] k=5 gbm/leaves_15_mse x mvo_ledoit_wolf: Sharpe=-0.002\n",
       "  SKIP backtest (complete (hash=2322f33b8eea)) — reusing cached result\n",
-      "  [29/180] k=5 gbm/leaves_15_mse x hrp: Sharpe=+0.430\n",
-      "  SKIP backtest (complete (hash=2c5700121c88)) — reusing cached result\n",
-      "  [30/180] k=5 gbm/leaves_15_mse x conformal_weighted: Sharpe=+0.658\n"
+      "  [29/180] k=5 gbm/leaves_15_mse x hrp: Sharpe=+0.430\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "  SKIP backtest (complete (hash=2c5700121c88)) — reusing cached result\n",
+      "  [30/180] k=5 gbm/leaves_15_mse x conformal_weighted: Sharpe=+0.658\n",
       "  SKIP backtest (complete (hash=45474dabc0b9)) — reusing cached result\n",
       "  [31/180] k=5 latent_factors/sae x score_weighted: Sharpe=+0.589\n",
       "  SKIP backtest (complete (hash=df6678134c30)) — reusing cached result\n",
-      "  [32/180] k=5 latent_factors/sae x inverse_vol: Sharpe=+0.659\n",
+      "  [32/180] k=5 latent_factors/sae x inverse_vol: Sharpe=+0.659\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "  SKIP backtest (complete (hash=3b3d1daf403c)) — reusing cached result\n",
       "  [33/180] k=5 latent_factors/sae x risk_parity: Sharpe=+0.646\n",
       "  SKIP backtest (complete (hash=cb1f469255ce)) — reusing cached result\n",
       "  [34/180] k=5 latent_factors/sae x mvo_ledoit_wolf: Sharpe=+0.300\n",
       "  SKIP backtest (complete (hash=6594a42c8656)) — reusing cached result\n",
-      "  [35/180] k=5 latent_factors/sae x hrp: Sharpe=+0.644\n"
+      "  [35/180] k=5 latent_factors/sae x hrp: Sharpe=+0.644\n",
+      "  SKIP backtest (complete (hash=3e46484e43e9)) — reusing cached result\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  SKIP backtest (complete (hash=3e46484e43e9)) — reusing cached result\n",
       "  [36/180] k=5 latent_factors/sae x conformal_weighted: Sharpe=+0.714\n",
       "  SKIP backtest (complete (hash=467dbc652750)) — reusing cached result\n",
       "  [37/180] k=5 deep_learning/nlinear x score_weighted: Sharpe=+0.349\n",
       "  SKIP backtest (complete (hash=36d76cdb05cb)) — reusing cached result\n",
-      "  [38/180] k=5 deep_learning/nlinear x inverse_vol: Sharpe=+0.721\n",
-      "  SKIP backtest (complete (hash=2ca7cded6729)) — reusing cached result\n",
-      "  [39/180] k=5 deep_learning/nlinear x risk_parity: Sharpe=+0.732\n"
+      "  [38/180] k=5 deep_learning/nlinear x inverse_vol: Sharpe=+0.721\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "  SKIP backtest (complete (hash=2ca7cded6729)) — reusing cached result\n",
+      "  [39/180] k=5 deep_learning/nlinear x risk_parity: Sharpe=+0.732\n",
       "  SKIP backtest (complete (hash=8aba508f72af)) — reusing cached result\n",
       "  [40/180] k=5 deep_learning/nlinear x mvo_ledoit_wolf: Sharpe=+0.021\n",
       "  SKIP backtest (complete (hash=12799dcd1b88)) — reusing cached result\n",
-      "  [41/180] k=5 deep_learning/nlinear x hrp: Sharpe=+0.462\n",
+      "  [41/180] k=5 deep_learning/nlinear x hrp: Sharpe=+0.462\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "  SKIP backtest (complete (hash=21b5ee8eed9c)) — reusing cached result\n",
       "  [42/180] k=5 deep_learning/nlinear x conformal_weighted: Sharpe=+0.789\n",
       "  SKIP backtest (complete (hash=c3f212552f81)) — reusing cached result\n",
@@ -701,20 +743,26 @@
       "  SKIP backtest (complete (hash=c458854f3412)) — reusing cached result\n",
       "  [46/180] k=5 gbm/leaves_63_mse x mvo_ledoit_wolf: Sharpe=+0.272\n",
       "  SKIP backtest (complete (hash=40683a25bab5)) — reusing cached result\n",
-      "  [47/180] k=5 gbm/leaves_63_mse x hrp: Sharpe=+0.829\n",
-      "  SKIP backtest (complete (hash=9299301ac920)) — reusing cached result\n",
-      "  [48/180] k=5 gbm/leaves_63_mse x conformal_weighted: Sharpe=+0.722\n"
+      "  [47/180] k=5 gbm/leaves_63_mse x hrp: Sharpe=+0.829\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "  SKIP backtest (complete (hash=9299301ac920)) — reusing cached result\n",
+      "  [48/180] k=5 gbm/leaves_63_mse x conformal_weighted: Sharpe=+0.722\n",
       "  SKIP backtest (complete (hash=b305e9825a1f)) — reusing cached result\n",
       "  [49/180] k=5 gbm/leaves_31_huber x score_weighted: Sharpe=+0.464\n",
       "  SKIP backtest (complete (hash=179b96408bd7)) — reusing cached result\n",
       "  [50/180] k=5 gbm/leaves_31_huber x inverse_vol: Sharpe=+0.664\n",
-      "  SKIP backtest (complete (hash=ad89fe90d2b7)) — reusing cached result\n",
+      "  SKIP backtest (complete (hash=ad89fe90d2b7)) — reusing cached result\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "  [51/180] k=5 gbm/leaves_31_huber x risk_parity: Sharpe=+0.659\n",
       "  SKIP backtest (complete (hash=3d7b4effa5e8)) — reusing cached result\n",
       "  [52/180] k=5 gbm/leaves_31_huber x mvo_ledoit_wolf: Sharpe=+0.444\n",
@@ -731,47 +779,53 @@
       "  SKIP backtest (complete (hash=2699d0fbcf63)) — reusing cached result\n",
       "  [55/180] k=5 gbm/leaves_31_mse x score_weighted: Sharpe=+0.178\n",
       "  SKIP backtest (complete (hash=2cb58d13a4d8)) — reusing cached result\n",
-      "  [56/180] k=5 gbm/leaves_31_mse x inverse_vol: Sharpe=+0.485\n",
-      "  SKIP backtest (complete (hash=883d009def1d)) — reusing cached result\n",
-      "  [57/180] k=5 gbm/leaves_31_mse x risk_parity: Sharpe=+0.505\n"
+      "  [56/180] k=5 gbm/leaves_31_mse x inverse_vol: Sharpe=+0.485\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "  SKIP backtest (complete (hash=883d009def1d)) — reusing cached result\n",
+      "  [57/180] k=5 gbm/leaves_31_mse x risk_parity: Sharpe=+0.505\n",
       "  SKIP backtest (complete (hash=599a2d2dcb81)) — reusing cached result\n",
       "  [58/180] k=5 gbm/leaves_31_mse x mvo_ledoit_wolf: Sharpe=+0.219\n",
       "  SKIP backtest (complete (hash=a7c421616ce0)) — reusing cached result\n",
-      "  [59/180] k=5 gbm/leaves_31_mse x hrp: Sharpe=+0.526\n",
+      "  [59/180] k=5 gbm/leaves_31_mse x hrp: Sharpe=+0.526\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "  SKIP backtest (complete (hash=6aa621f01fda)) — reusing cached result\n",
       "  [60/180] k=5 gbm/leaves_31_mse x conformal_weighted: Sharpe=+0.533\n",
       "\n",
       "--- top_k = 10 ---\n",
-      "  SKIP backtest (complete (hash=dd0a661e424f)) — reusing cached result\n"
+      "  SKIP backtest (complete (hash=dd0a661e424f)) — reusing cached result\n",
+      "  [61/180] k=10 gbm/leaves_63_huber x score_weighted: Sharpe=+0.454\n",
+      "  SKIP backtest (complete (hash=dbd143f7d9f1)) — reusing cached result\n",
+      "  [62/180] k=10 gbm/leaves_63_huber x inverse_vol: Sharpe=+0.471\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  [61/180] k=10 gbm/leaves_63_huber x score_weighted: Sharpe=+0.454\n",
-      "  SKIP backtest (complete (hash=dbd143f7d9f1)) — reusing cached result\n",
-      "  [62/180] k=10 gbm/leaves_63_huber x inverse_vol: Sharpe=+0.471\n",
       "  SKIP backtest (complete (hash=0f64f2f7bab1)) — reusing cached result\n",
       "  [63/180] k=10 gbm/leaves_63_huber x risk_parity: Sharpe=+0.450\n",
       "  SKIP backtest (complete (hash=35b2a8df3499)) — reusing cached result\n",
       "  [64/180] k=10 gbm/leaves_63_huber x mvo_ledoit_wolf: Sharpe=+0.663\n",
       "  SKIP backtest (complete (hash=ee753e5654a0)) — reusing cached result\n",
-      "  [65/180] k=10 gbm/leaves_63_huber x hrp: Sharpe=+0.390\n"
+      "  [65/180] k=10 gbm/leaves_63_huber x hrp: Sharpe=+0.390\n",
+      "  SKIP backtest (complete (hash=4050f5e8342c)) — reusing cached result\n",
+      "  [66/180] k=10 gbm/leaves_63_huber x conformal_weighted: Sharpe=+0.552\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  SKIP backtest (complete (hash=4050f5e8342c)) — reusing cached result\n",
-      "  [66/180] k=10 gbm/leaves_63_huber x conformal_weighted: Sharpe=+0.552\n",
       "  SKIP backtest (complete (hash=4e840ad7b2ff)) — reusing cached result\n",
       "  [67/180] k=10 latent_factors/cae x score_weighted: Sharpe=+0.721\n",
       "  SKIP backtest (complete (hash=786f9cb56695)) — reusing cached result\n",
@@ -789,20 +843,26 @@
       "  SKIP backtest (complete (hash=55ecbca3a3ef)) — reusing cached result\n",
       "  [71/180] k=10 latent_factors/cae x hrp: Sharpe=+0.551\n",
       "  SKIP backtest (complete (hash=6132d7546e16)) — reusing cached result\n",
-      "  [72/180] k=10 latent_factors/cae x conformal_weighted: Sharpe=+0.785\n",
-      "  SKIP backtest (complete (hash=78746e4f0b5a)) — reusing cached result\n",
-      "  [73/180] k=10 gbm/default_huber x score_weighted: Sharpe=+0.654\n"
+      "  [72/180] k=10 latent_factors/cae x conformal_weighted: Sharpe=+0.785\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "  SKIP backtest (complete (hash=78746e4f0b5a)) — reusing cached result\n",
+      "  [73/180] k=10 gbm/default_huber x score_weighted: Sharpe=+0.654\n",
       "  SKIP backtest (complete (hash=1c2f79dcecf7)) — reusing cached result\n",
       "  [74/180] k=10 gbm/default_huber x inverse_vol: Sharpe=+0.509\n",
       "  SKIP backtest (complete (hash=49dac2cbbf0b)) — reusing cached result\n",
       "  [75/180] k=10 gbm/default_huber x risk_parity: Sharpe=+0.502\n",
-      "  SKIP backtest (complete (hash=ebc61083754b)) — reusing cached result\n",
+      "  SKIP backtest (complete (hash=ebc61083754b)) — reusing cached result\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "  [76/180] k=10 gbm/default_huber x mvo_ledoit_wolf: Sharpe=+0.493\n",
       "  SKIP backtest (complete (hash=6347d4bd29dc)) — reusing cached result\n",
       "  [77/180] k=10 gbm/default_huber x hrp: Sharpe=+0.501\n",
@@ -819,32 +879,38 @@
       "  SKIP backtest (complete (hash=2144b9918f47)) — reusing cached result\n",
       "  [80/180] k=10 gbm/leaves_7_mse x inverse_vol: Sharpe=+0.571\n",
       "  SKIP backtest (complete (hash=3d3d7365c1ae)) — reusing cached result\n",
-      "  [81/180] k=10 gbm/leaves_7_mse x risk_parity: Sharpe=+0.565\n",
-      "  SKIP backtest (complete (hash=b87ff08084f9)) — reusing cached result\n",
-      "  [82/180] k=10 gbm/leaves_7_mse x mvo_ledoit_wolf: Sharpe=-0.163\n",
-      "  SKIP backtest (complete (hash=fa1f09de5789)) — reusing cached result\n",
-      "  [83/180] k=10 gbm/leaves_7_mse x hrp: Sharpe=+0.535\n"
+      "  [81/180] k=10 gbm/leaves_7_mse x risk_parity: Sharpe=+0.565\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "  SKIP backtest (complete (hash=b87ff08084f9)) — reusing cached result\n",
+      "  [82/180] k=10 gbm/leaves_7_mse x mvo_ledoit_wolf: Sharpe=-0.163\n",
+      "  SKIP backtest (complete (hash=fa1f09de5789)) — reusing cached result\n",
+      "  [83/180] k=10 gbm/leaves_7_mse x hrp: Sharpe=+0.535\n",
       "  SKIP backtest (complete (hash=df8ca178d6e8)) — reusing cached result\n",
-      "  [84/180] k=10 gbm/leaves_7_mse x conformal_weighted: Sharpe=+0.653\n",
+      "  [84/180] k=10 gbm/leaves_7_mse x conformal_weighted: Sharpe=+0.653\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "  SKIP backtest (complete (hash=34c09d4a95f6)) — reusing cached result\n",
       "  [85/180] k=10 gbm/leaves_15_mse x score_weighted: Sharpe=+0.530\n",
       "  SKIP backtest (complete (hash=5f85414f9e30)) — reusing cached result\n",
       "  [86/180] k=10 gbm/leaves_15_mse x inverse_vol: Sharpe=+0.612\n",
-      "  SKIP backtest (complete (hash=9b5e91272568)) — reusing cached result\n"
+      "  SKIP backtest (complete (hash=9b5e91272568)) — reusing cached result\n",
+      "  [87/180] k=10 gbm/leaves_15_mse x risk_parity: Sharpe=+0.602\n",
+      "  SKIP backtest (complete (hash=ddbba7ded63c)) — reusing cached result\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  [87/180] k=10 gbm/leaves_15_mse x risk_parity: Sharpe=+0.602\n",
-      "  SKIP backtest (complete (hash=ddbba7ded63c)) — reusing cached result\n",
       "  [88/180] k=10 gbm/leaves_15_mse x mvo_ledoit_wolf: Sharpe=+0.079\n",
       "  SKIP backtest (complete (hash=e451297fdc6c)) — reusing cached result\n",
       "  [89/180] k=10 gbm/leaves_15_mse x hrp: Sharpe=+0.547\n",
@@ -861,7 +927,13 @@
       "  SKIP backtest (complete (hash=75baa0bb6022)) — reusing cached result\n",
       "  [92/180] k=10 latent_factors/sae x inverse_vol: Sharpe=+0.624\n",
       "  SKIP backtest (complete (hash=2aa4b4368720)) — reusing cached result\n",
-      "  [93/180] k=10 latent_factors/sae x risk_parity: Sharpe=+0.608\n",
+      "  [93/180] k=10 latent_factors/sae x risk_parity: Sharpe=+0.608\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "  SKIP backtest (complete (hash=0b57bf7ed4b2)) — reusing cached result\n",
       "  [94/180] k=10 latent_factors/sae x mvo_ledoit_wolf: Sharpe=+0.235\n",
       "  SKIP backtest (complete (hash=6cf0e73c4456)) — reusing cached result\n",
@@ -879,7 +951,13 @@
       "  SKIP backtest (complete (hash=c42a877f10b9)) — reusing cached result\n",
       "  [98/180] k=10 deep_learning/nlinear x inverse_vol: Sharpe=+0.602\n",
       "  SKIP backtest (complete (hash=887025997f5b)) — reusing cached result\n",
-      "  [99/180] k=10 deep_learning/nlinear x risk_parity: Sharpe=+0.547\n",
+      "  [99/180] k=10 deep_learning/nlinear x risk_parity: Sharpe=+0.547\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "  SKIP backtest (complete (hash=2db8bd6d82fc)) — reusing cached result\n",
       "  [100/180] k=10 deep_learning/nlinear x mvo_ledoit_wolf: Sharpe=+0.205\n",
       "  SKIP backtest (complete (hash=77856b8dc3d6)) — reusing cached result\n",
@@ -897,7 +975,13 @@
       "  SKIP backtest (complete (hash=d157c5cfb947)) — reusing cached result\n",
       "  [104/180] k=10 gbm/leaves_63_mse x inverse_vol: Sharpe=+0.652\n",
       "  SKIP backtest (complete (hash=e3cf8ac82672)) — reusing cached result\n",
-      "  [105/180] k=10 gbm/leaves_63_mse x risk_parity: Sharpe=+0.692\n",
+      "  [105/180] k=10 gbm/leaves_63_mse x risk_parity: Sharpe=+0.692\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "  SKIP backtest (complete (hash=2d11c330f4df)) — reusing cached result\n",
       "  [106/180] k=10 gbm/leaves_63_mse x mvo_ledoit_wolf: Sharpe=+0.257\n",
       "  SKIP backtest (complete (hash=a061dffd737c)) — reusing cached result\n",
@@ -915,31 +999,37 @@
       "  SKIP backtest (complete (hash=13257ec78377)) — reusing cached result\n",
       "  [110/180] k=10 gbm/leaves_31_huber x inverse_vol: Sharpe=+0.726\n",
       "  SKIP backtest (complete (hash=c729f95ee188)) — reusing cached result\n",
-      "  [111/180] k=10 gbm/leaves_31_huber x risk_parity: Sharpe=+0.752\n",
+      "  [111/180] k=10 gbm/leaves_31_huber x risk_parity: Sharpe=+0.752\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "  SKIP backtest (complete (hash=8608af0b86fe)) — reusing cached result\n",
       "  [112/180] k=10 gbm/leaves_31_huber x mvo_ledoit_wolf: Sharpe=+0.495\n",
       "  SKIP backtest (complete (hash=9796322099d7)) — reusing cached result\n",
-      "  [113/180] k=10 gbm/leaves_31_huber x hrp: Sharpe=+0.774\n"
+      "  [113/180] k=10 gbm/leaves_31_huber x hrp: Sharpe=+0.774\n",
+      "  SKIP backtest (complete (hash=c730e91723d7)) — reusing cached result\n",
+      "  [114/180] k=10 gbm/leaves_31_huber x conformal_weighted: Sharpe=+0.765\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  SKIP backtest (complete (hash=c730e91723d7)) — reusing cached result\n",
-      "  [114/180] k=10 gbm/leaves_31_huber x conformal_weighted: Sharpe=+0.765\n",
       "  SKIP backtest (complete (hash=844c4d26afd1)) — reusing cached result\n",
       "  [115/180] k=10 gbm/leaves_31_mse x score_weighted: Sharpe=+0.335\n",
       "  SKIP backtest (complete (hash=6a8406590da5)) — reusing cached result\n",
-      "  [116/180] k=10 gbm/leaves_31_mse x inverse_vol: Sharpe=+0.558\n"
+      "  [116/180] k=10 gbm/leaves_31_mse x inverse_vol: Sharpe=+0.558\n",
+      "  SKIP backtest (complete (hash=e9efb5b0228e)) — reusing cached result\n",
+      "  [117/180] k=10 gbm/leaves_31_mse x risk_parity: Sharpe=+0.558\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  SKIP backtest (complete (hash=e9efb5b0228e)) — reusing cached result\n",
-      "  [117/180] k=10 gbm/leaves_31_mse x risk_parity: Sharpe=+0.558\n",
       "  SKIP backtest (complete (hash=216c8996b6ff)) — reusing cached result\n",
       "  [118/180] k=10 gbm/leaves_31_mse x mvo_ledoit_wolf: Sharpe=+0.202\n",
       "  SKIP backtest (complete (hash=74922d9aaf3d)) — reusing cached result\n",
@@ -984,123 +1074,123 @@
       "  [128/180] k=20 latent_factors/cae x inverse_vol: Sharpe=+0.724\n",
       "  SKIP backtest (complete (hash=14942f2adae0)) — reusing cached result\n",
       "  [129/180] k=20 latent_factors/cae x risk_parity: Sharpe=+0.710\n",
-      "  SKIP backtest (complete (hash=ad3b632a1365)) — reusing cached result\n",
-      "  [130/180] k=20 latent_factors/cae x mvo_ledoit_wolf: Sharpe=+0.636\n"
+      "  SKIP backtest (complete (hash=ad3b632a1365)) — reusing cached result\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "  [130/180] k=20 latent_factors/cae x mvo_ledoit_wolf: Sharpe=+0.636\n",
       "  SKIP backtest (complete (hash=3ad6f1d7445e)) — reusing cached result\n",
       "  [131/180] k=20 latent_factors/cae x hrp: Sharpe=+0.754\n",
       "  SKIP backtest (complete (hash=2b3e495d505c)) — reusing cached result\n",
       "  [132/180] k=20 latent_factors/cae x conformal_weighted: Sharpe=+0.774\n",
-      "  SKIP backtest (complete (hash=72a7707b7e13)) — reusing cached result\n",
-      "  [133/180] k=20 gbm/default_huber x score_weighted: Sharpe=+0.565\n"
+      "  SKIP backtest (complete (hash=72a7707b7e13)) — reusing cached result\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "  [133/180] k=20 gbm/default_huber x score_weighted: Sharpe=+0.565\n",
       "  SKIP backtest (complete (hash=192dda89fbc1)) — reusing cached result\n",
       "  [134/180] k=20 gbm/default_huber x inverse_vol: Sharpe=+0.567\n",
       "  SKIP backtest (complete (hash=8994fb92c2f0)) — reusing cached result\n",
-      "  [135/180] k=20 gbm/default_huber x risk_parity: Sharpe=+0.573\n",
+      "  [135/180] k=20 gbm/default_huber x risk_parity: Sharpe=+0.573\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "  SKIP backtest (complete (hash=3c62bf678f5c)) — reusing cached result\n",
       "  [136/180] k=20 gbm/default_huber x mvo_ledoit_wolf: Sharpe=+0.616\n",
-      "  SKIP backtest (complete (hash=27428733583c)) — reusing cached result\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "  SKIP backtest (complete (hash=27428733583c)) — reusing cached result\n",
       "  [137/180] k=20 gbm/default_huber x hrp: Sharpe=+0.554\n",
       "  SKIP backtest (complete (hash=045a4811b445)) — reusing cached result\n",
-      "  [138/180] k=20 gbm/default_huber x conformal_weighted: Sharpe=+0.566\n",
-      "  SKIP backtest (complete (hash=a91ad215ce65)) — reusing cached result\n",
-      "  [139/180] k=20 gbm/leaves_7_mse x score_weighted: Sharpe=+0.561\n"
+      "  [138/180] k=20 gbm/default_huber x conformal_weighted: Sharpe=+0.566\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "  SKIP backtest (complete (hash=a91ad215ce65)) — reusing cached result\n",
+      "  [139/180] k=20 gbm/leaves_7_mse x score_weighted: Sharpe=+0.561\n",
       "  SKIP backtest (complete (hash=0bba83d238e6)) — reusing cached result\n",
       "  [140/180] k=20 gbm/leaves_7_mse x inverse_vol: Sharpe=+0.665\n",
       "  SKIP backtest (complete (hash=7c1beae429ad)) — reusing cached result\n",
       "  [141/180] k=20 gbm/leaves_7_mse x risk_parity: Sharpe=+0.620\n",
-      "  SKIP backtest (complete (hash=15ed24af5cb2)) — reusing cached result\n",
-      "  [142/180] k=20 gbm/leaves_7_mse x mvo_ledoit_wolf: Sharpe=+0.096\n"
+      "  SKIP backtest (complete (hash=15ed24af5cb2)) — reusing cached result\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "  [142/180] k=20 gbm/leaves_7_mse x mvo_ledoit_wolf: Sharpe=+0.096\n",
       "  SKIP backtest (complete (hash=ac43d31ee7d4)) — reusing cached result\n",
       "  [143/180] k=20 gbm/leaves_7_mse x hrp: Sharpe=+0.525\n",
       "  SKIP backtest (complete (hash=129be5d863ce)) — reusing cached result\n",
-      "  [144/180] k=20 gbm/leaves_7_mse x conformal_weighted: Sharpe=+0.738\n",
-      "  SKIP backtest (complete (hash=385ff7af761a)) — reusing cached result\n",
-      "  [145/180] k=20 gbm/leaves_15_mse x score_weighted: Sharpe=+0.645\n"
+      "  [144/180] k=20 gbm/leaves_7_mse x conformal_weighted: Sharpe=+0.738\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "  SKIP backtest (complete (hash=385ff7af761a)) — reusing cached result\n",
+      "  [145/180] k=20 gbm/leaves_15_mse x score_weighted: Sharpe=+0.645\n",
       "  SKIP backtest (complete (hash=dd900730477e)) — reusing cached result\n",
       "  [146/180] k=20 gbm/leaves_15_mse x inverse_vol: Sharpe=+0.728\n",
       "  SKIP backtest (complete (hash=c801b5c2f7b5)) — reusing cached result\n",
       "  [147/180] k=20 gbm/leaves_15_mse x risk_parity: Sharpe=+0.711\n",
-      "  SKIP backtest (complete (hash=a6b1700eef2f)) — reusing cached result\n",
-      "  [148/180] k=20 gbm/leaves_15_mse x mvo_ledoit_wolf: Sharpe=+0.293\n"
+      "  SKIP backtest (complete (hash=a6b1700eef2f)) — reusing cached result\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "  [148/180] k=20 gbm/leaves_15_mse x mvo_ledoit_wolf: Sharpe=+0.293\n",
       "  SKIP backtest (complete (hash=f80cf752f695)) — reusing cached result\n",
       "  [149/180] k=20 gbm/leaves_15_mse x hrp: Sharpe=+0.622\n",
       "  SKIP backtest (complete (hash=9da2038274d0)) — reusing cached result\n",
-      "  [150/180] k=20 gbm/leaves_15_mse x conformal_weighted: Sharpe=+0.801\n",
-      "  SKIP backtest (complete (hash=90a2cd26eff8)) — reusing cached result\n",
-      "  [151/180] k=20 latent_factors/sae x score_weighted: Sharpe=+0.535\n"
+      "  [150/180] k=20 gbm/leaves_15_mse x conformal_weighted: Sharpe=+0.801\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "  SKIP backtest (complete (hash=90a2cd26eff8)) — reusing cached result\n",
+      "  [151/180] k=20 latent_factors/sae x score_weighted: Sharpe=+0.535\n",
       "  SKIP backtest (complete (hash=d50531e44b60)) — reusing cached result\n",
       "  [152/180] k=20 latent_factors/sae x inverse_vol: Sharpe=+0.563\n",
       "  SKIP backtest (complete (hash=504ba4ad8908)) — reusing cached result\n",
-      "  [153/180] k=20 latent_factors/sae x risk_parity: Sharpe=+0.575\n",
+      "  [153/180] k=20 latent_factors/sae x risk_parity: Sharpe=+0.575\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "  SKIP backtest (complete (hash=aba77338435b)) — reusing cached result\n",
       "  [154/180] k=20 latent_factors/sae x mvo_ledoit_wolf: Sharpe=+0.209\n",
       "  SKIP backtest (complete (hash=65ae8679376c)) — reusing cached result\n",
-      "  [155/180] k=20 latent_factors/sae x hrp: Sharpe=+0.524\n"
+      "  [155/180] k=20 latent_factors/sae x hrp: Sharpe=+0.524\n",
+      "  SKIP backtest (complete (hash=dd5c9fa7a347)) — reusing cached result\n",
+      "  [156/180] k=20 latent_factors/sae x conformal_weighted: Sharpe=+0.620\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  SKIP backtest (complete (hash=dd5c9fa7a347)) — reusing cached result\n",
-      "  [156/180] k=20 latent_factors/sae x conformal_weighted: Sharpe=+0.620\n",
       "  SKIP backtest (complete (hash=82ac9cc42360)) — reusing cached result\n",
       "  [157/180] k=20 deep_learning/nlinear x score_weighted: Sharpe=+0.352\n",
-      "  SKIP backtest (complete (hash=5c362935da8f)) — reusing cached result\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "  SKIP backtest (complete (hash=5c362935da8f)) — reusing cached result\n",
       "  [158/180] k=20 deep_learning/nlinear x inverse_vol: Sharpe=+0.626\n",
       "  SKIP backtest (complete (hash=7d8f4a8b2c06)) — reusing cached result\n",
       "  [159/180] k=20 deep_learning/nlinear x risk_parity: Sharpe=+0.574\n",
@@ -1129,15 +1219,15 @@
       "  SKIP backtest (complete (hash=e656777b9d9e)) — reusing cached result\n",
       "  [165/180] k=20 gbm/leaves_63_mse x risk_parity: Sharpe=+0.651\n",
       "  SKIP backtest (complete (hash=fd7374791025)) — reusing cached result\n",
-      "  [166/180] k=20 gbm/leaves_63_mse x mvo_ledoit_wolf: Sharpe=+0.312\n",
-      "  SKIP backtest (complete (hash=9bb075dab294)) — reusing cached result\n",
-      "  [167/180] k=20 gbm/leaves_63_mse x hrp: Sharpe=+0.581\n"
+      "  [166/180] k=20 gbm/leaves_63_mse x mvo_ledoit_wolf: Sharpe=+0.312\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "  SKIP backtest (complete (hash=9bb075dab294)) — reusing cached result\n",
+      "  [167/180] k=20 gbm/leaves_63_mse x hrp: Sharpe=+0.581\n",
       "  SKIP backtest (complete (hash=1d316491b89e)) — reusing cached result\n",
       "  [168/180] k=20 gbm/leaves_63_mse x conformal_weighted: Sharpe=+0.653\n"
      ]
@@ -1151,42 +1241,42 @@
       "  SKIP backtest (complete (hash=782d88549954)) — reusing cached result\n",
       "  [170/180] k=20 gbm/leaves_31_huber x inverse_vol: Sharpe=+0.687\n",
       "  SKIP backtest (complete (hash=287b4433f459)) — reusing cached result\n",
-      "  [171/180] k=20 gbm/leaves_31_huber x risk_parity: Sharpe=+0.693\n",
-      "  SKIP backtest (complete (hash=5ef658a6a61e)) — reusing cached result\n",
-      "  [172/180] k=20 gbm/leaves_31_huber x mvo_ledoit_wolf: Sharpe=+0.429\n"
+      "  [171/180] k=20 gbm/leaves_31_huber x risk_parity: Sharpe=+0.693\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "  SKIP backtest (complete (hash=5ef658a6a61e)) — reusing cached result\n",
+      "  [172/180] k=20 gbm/leaves_31_huber x mvo_ledoit_wolf: Sharpe=+0.429\n",
       "  SKIP backtest (complete (hash=d52a8444eb22)) — reusing cached result\n",
       "  [173/180] k=20 gbm/leaves_31_huber x hrp: Sharpe=+0.594\n",
       "  SKIP backtest (complete (hash=af5f38b6009f)) — reusing cached result\n",
-      "  [174/180] k=20 gbm/leaves_31_huber x conformal_weighted: Sharpe=+0.674\n",
+      "  [174/180] k=20 gbm/leaves_31_huber x conformal_weighted: Sharpe=+0.674\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "  SKIP backtest (complete (hash=5ba5f96fc3d8)) — reusing cached result\n",
       "  [175/180] k=20 gbm/leaves_31_mse x score_weighted: Sharpe=+0.447\n",
       "  SKIP backtest (complete (hash=e7418d6628d5)) — reusing cached result\n",
-      "  [176/180] k=20 gbm/leaves_31_mse x inverse_vol: Sharpe=+0.629\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "  [176/180] k=20 gbm/leaves_31_mse x inverse_vol: Sharpe=+0.629\n",
       "  SKIP backtest (complete (hash=7aedd3dbc88f)) — reusing cached result\n",
       "  [177/180] k=20 gbm/leaves_31_mse x risk_parity: Sharpe=+0.609\n",
       "  SKIP backtest (complete (hash=aa5746b96e1b)) — reusing cached result\n",
-      "  [178/180] k=20 gbm/leaves_31_mse x mvo_ledoit_wolf: Sharpe=+0.360\n",
-      "  SKIP backtest (complete (hash=5e2e49e80ee8)) — reusing cached result\n",
-      "  [179/180] k=20 gbm/leaves_31_mse x hrp: Sharpe=+0.530\n",
-      "  SKIP backtest (complete (hash=86ce82653ebb)) — reusing cached result\n"
+      "  [178/180] k=20 gbm/leaves_31_mse x mvo_ledoit_wolf: Sharpe=+0.360\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "  SKIP backtest (complete (hash=5e2e49e80ee8)) — reusing cached result\n",
+      "  [179/180] k=20 gbm/leaves_31_mse x hrp: Sharpe=+0.530\n",
+      "  SKIP backtest (complete (hash=86ce82653ebb)) — reusing cached result\n",
       "  [180/180] k=20 gbm/leaves_31_mse x conformal_weighted: Sharpe=+0.705\n",
       "\n",
       "Sweep complete in 0.2 minutes: reused all 180 from the registry, computed by an earlier run\n",
@@ -1309,13 +1399,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "79531a08",
+   "id": "dcabaab6",
    "metadata": {
     "papermill": {
-     "duration": 0.004399,
-     "end_time": "2026-09-11T14:27:52.880986+00:00",
+     "duration": 0.006627,
+     "end_time": "2026-09-11T14:35:24.661254+00:00",
      "exception": false,
-     "start_time": "2026-09-11T14:27:52.876587+00:00",
+     "start_time": "2026-09-11T14:35:24.654627+00:00",
      "status": "completed"
     }
    },
@@ -1334,19 +1424,19 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "e69d1d4f",
+   "id": "7534fb1c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T14:27:52.897281Z",
-     "iopub.status.busy": "2026-09-11T14:27:52.896807Z",
-     "iopub.status.idle": "2026-09-11T14:27:52.947801Z",
-     "shell.execute_reply": "2026-09-11T14:27:52.946323Z"
+     "iopub.execute_input": "2026-09-11T14:35:24.673408Z",
+     "iopub.status.busy": "2026-09-11T14:35:24.673145Z",
+     "iopub.status.idle": "2026-09-11T14:35:24.730291Z",
+     "shell.execute_reply": "2026-09-11T14:35:24.725657Z"
     },
     "papermill": {
-     "duration": 0.064625,
-     "end_time": "2026-09-11T14:27:52.949706+00:00",
+     "duration": 0.067786,
+     "end_time": "2026-09-11T14:35:24.734431+00:00",
      "exception": false,
-     "start_time": "2026-09-11T14:27:52.885081+00:00",
+     "start_time": "2026-09-11T14:35:24.666645+00:00",
      "status": "completed"
     }
    },
@@ -1365,13 +1455,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2e4efc74",
+   "id": "0b60a26a",
    "metadata": {
     "papermill": {
-     "duration": 0.004965,
-     "end_time": "2026-09-11T14:27:52.960854+00:00",
+     "duration": 0.012462,
+     "end_time": "2026-09-11T14:35:24.754601+00:00",
      "exception": false,
-     "start_time": "2026-09-11T14:27:52.955889+00:00",
+     "start_time": "2026-09-11T14:35:24.742139+00:00",
      "status": "completed"
     }
    },
@@ -1388,19 +1478,19 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "1cc7109a",
+   "id": "9cd75c47",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T14:27:52.976926Z",
-     "iopub.status.busy": "2026-09-11T14:27:52.976201Z",
-     "iopub.status.idle": "2026-09-11T14:27:52.986614Z",
-     "shell.execute_reply": "2026-09-11T14:27:52.983987Z"
+     "iopub.execute_input": "2026-09-11T14:35:24.776283Z",
+     "iopub.status.busy": "2026-09-11T14:35:24.775916Z",
+     "iopub.status.idle": "2026-09-11T14:35:24.786916Z",
+     "shell.execute_reply": "2026-09-11T14:35:24.785750Z"
     },
     "papermill": {
-     "duration": 0.021278,
-     "end_time": "2026-09-11T14:27:52.988360+00:00",
+     "duration": 0.024751,
+     "end_time": "2026-09-11T14:35:24.791481+00:00",
      "exception": false,
-     "start_time": "2026-09-11T14:27:52.967082+00:00",
+     "start_time": "2026-09-11T14:35:24.766730+00:00",
      "status": "completed"
     },
     "tags": [
@@ -1448,19 +1538,19 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "49674987",
+   "id": "ef51e21b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T14:27:53.006276Z",
-     "iopub.status.busy": "2026-09-11T14:27:53.005532Z",
-     "iopub.status.idle": "2026-09-11T14:27:56.028706Z",
-     "shell.execute_reply": "2026-09-11T14:27:56.028124Z"
+     "iopub.execute_input": "2026-09-11T14:35:24.809484Z",
+     "iopub.status.busy": "2026-09-11T14:35:24.805901Z",
+     "iopub.status.idle": "2026-09-11T14:35:27.323956Z",
+     "shell.execute_reply": "2026-09-11T14:35:27.322900Z"
     },
     "papermill": {
-     "duration": 3.035515,
-     "end_time": "2026-09-11T14:27:56.029306+00:00",
+     "duration": 2.528572,
+     "end_time": "2026-09-11T14:35:27.325011+00:00",
      "exception": false,
-     "start_time": "2026-09-11T14:27:52.993791+00:00",
+     "start_time": "2026-09-11T14:35:24.796439+00:00",
      "status": "completed"
     }
    },
@@ -1608,7 +1698,7 @@
      },
      "metadata": {
       "image/png": {
-       "alt": "Horizontal bar chart of the mean Sharpe ratio of every allocation-stage backtest, one bar per weighting scheme, with a dashed line at zero. Counted from the frame: 6 allocators, mean Sharpe from +0.303 to +0.693."
+       "alt": "Horizontal bar chart of mean Sharpe by weighting scheme, one bar per allocator, over the allocation backtests for the prediction sets this sweep advanced, ordered by that mean, with a dashed line at zero."
       }
      },
      "output_type": "display_data"
@@ -1637,22 +1727,22 @@
     "_span = ordered[\"avg_sharpe\"]\n",
     "show_plotly_with_alt(\n",
     "    fig,\n",
-    "    \"Horizontal bar chart of the mean Sharpe ratio of every allocation-stage backtest, one bar per \"\n",
-    "    f\"weighting scheme, with a dashed line at zero. Counted from the frame: {ordered.height} \"\n",
-    "    f\"allocators, mean Sharpe from {_span.min():+.3f} to {_span.max():+.3f}.\",\n",
+    "    \"Horizontal bar chart of mean Sharpe by weighting scheme, one bar per allocator, over the \"\n",
+    "    \"allocation backtests for the prediction sets this sweep advanced, ordered by that mean, \"\n",
+    "    \"with a dashed line at zero.\",\n",
     ")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "bf7c3197",
+   "id": "db3df97c",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.005169,
-     "end_time": "2026-09-11T14:27:56.039985+00:00",
+     "duration": 0.004887,
+     "end_time": "2026-09-11T14:35:27.335650+00:00",
      "exception": false,
-     "start_time": "2026-09-11T14:27:56.034816+00:00",
+     "start_time": "2026-09-11T14:35:27.330763+00:00",
      "status": "completed"
     }
    },
@@ -1670,19 +1760,19 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "9f9af3eb",
+   "id": "94b0998a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T14:27:56.049834Z",
-     "iopub.status.busy": "2026-09-11T14:27:56.049170Z",
-     "iopub.status.idle": "2026-09-11T14:27:56.184038Z",
-     "shell.execute_reply": "2026-09-11T14:27:56.182830Z"
+     "iopub.execute_input": "2026-09-11T14:35:27.346020Z",
+     "iopub.status.busy": "2026-09-11T14:35:27.345804Z",
+     "iopub.status.idle": "2026-09-11T14:35:27.419084Z",
+     "shell.execute_reply": "2026-09-11T14:35:27.418282Z"
     },
     "papermill": {
-     "duration": 0.141883,
-     "end_time": "2026-09-11T14:27:56.186131+00:00",
+     "duration": 0.080746,
+     "end_time": "2026-09-11T14:35:27.419798+00:00",
      "exception": false,
-     "start_time": "2026-09-11T14:27:56.044248+00:00",
+     "start_time": "2026-09-11T14:35:27.339052+00:00",
      "status": "completed"
     }
    },
@@ -1740,13 +1830,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "34ecc3ff",
+   "id": "10ca08b2",
    "metadata": {
     "papermill": {
-     "duration": 0.005585,
-     "end_time": "2026-09-11T14:27:56.198194+00:00",
+     "duration": 0.003878,
+     "end_time": "2026-09-11T14:35:27.430225+00:00",
      "exception": false,
-     "start_time": "2026-09-11T14:27:56.192609+00:00",
+     "start_time": "2026-09-11T14:35:27.426347+00:00",
      "status": "completed"
     }
    },
@@ -1761,19 +1851,19 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "05637586",
+   "id": "c762ce54",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T14:27:56.211643Z",
-     "iopub.status.busy": "2026-09-11T14:27:56.211317Z",
-     "iopub.status.idle": "2026-09-11T14:27:56.227348Z",
-     "shell.execute_reply": "2026-09-11T14:27:56.226910Z"
+     "iopub.execute_input": "2026-09-11T14:35:27.441785Z",
+     "iopub.status.busy": "2026-09-11T14:35:27.441581Z",
+     "iopub.status.idle": "2026-09-11T14:35:27.448673Z",
+     "shell.execute_reply": "2026-09-11T14:35:27.448125Z"
     },
     "papermill": {
-     "duration": 0.027728,
-     "end_time": "2026-09-11T14:27:56.231487+00:00",
+     "duration": 0.012214,
+     "end_time": "2026-09-11T14:35:27.449002+00:00",
      "exception": false,
-     "start_time": "2026-09-11T14:27:56.203759+00:00",
+     "start_time": "2026-09-11T14:35:27.436788+00:00",
      "status": "completed"
     },
     "tags": [
@@ -1830,13 +1920,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "81208bd6",
+   "id": "3021ab72",
    "metadata": {
     "papermill": {
-     "duration": 0.005251,
-     "end_time": "2026-09-11T14:27:56.241884+00:00",
+     "duration": 0.005734,
+     "end_time": "2026-09-11T14:35:27.459757+00:00",
      "exception": false,
-     "start_time": "2026-09-11T14:27:56.236633+00:00",
+     "start_time": "2026-09-11T14:35:27.454023+00:00",
      "status": "completed"
     }
    },
@@ -1847,19 +1937,19 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "8b9932d9",
+   "id": "77e9aa4d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-11T14:27:56.256543Z",
-     "iopub.status.busy": "2026-09-11T14:27:56.255327Z",
-     "iopub.status.idle": "2026-09-11T14:27:56.308921Z",
-     "shell.execute_reply": "2026-09-11T14:27:56.306753Z"
+     "iopub.execute_input": "2026-09-11T14:35:27.473842Z",
+     "iopub.status.busy": "2026-09-11T14:35:27.473670Z",
+     "iopub.status.idle": "2026-09-11T14:35:27.517409Z",
+     "shell.execute_reply": "2026-09-11T14:35:27.516884Z"
     },
     "papermill": {
-     "duration": 0.062555,
-     "end_time": "2026-09-11T14:27:56.310463+00:00",
+     "duration": 0.051961,
+     "end_time": "2026-09-11T14:35:27.517992+00:00",
      "exception": false,
-     "start_time": "2026-09-11T14:27:56.247908+00:00",
+     "start_time": "2026-09-11T14:35:27.466031+00:00",
      "status": "completed"
     },
     "tags": [
@@ -1925,13 +2015,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "467c9d26",
+   "id": "aad39b20",
    "metadata": {
     "papermill": {
-     "duration": 0.007723,
-     "end_time": "2026-09-11T14:27:56.326187+00:00",
+     "duration": 0.005851,
+     "end_time": "2026-09-11T14:35:27.529650+00:00",
      "exception": false,
-     "start_time": "2026-09-11T14:27:56.318464+00:00",
+     "start_time": "2026-09-11T14:35:27.523799+00:00",
      "status": "completed"
     }
    },
@@ -1963,13 +2053,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9a6b743e",
+   "id": "53a2718d",
    "metadata": {
     "papermill": {
-     "duration": 0.007056,
-     "end_time": "2026-09-11T14:27:56.340722+00:00",
+     "duration": 0.007051,
+     "end_time": "2026-09-11T14:35:27.542696+00:00",
      "exception": false,
-     "start_time": "2026-09-11T14:27:56.333666+00:00",
+     "start_time": "2026-09-11T14:35:27.535645+00:00",
      "status": "completed"
     }
    },
@@ -2002,24 +2092,24 @@
    "version": "3.14.3"
   },
   "ml4t_provenance": {
-   "executed_at": "2026-09-11T14:28:18.576550+00:00",
+   "executed_at": "2026-09-11T14:35:43.517715+00:00",
    "executor": "local-uv",
    "library_digest": "cddf49f24ce0e7761fd0ed05a1b88e98faae531080df9eb1cb8644a0efbf553b",
-   "outputs_digest": "4960e3851725d424949f6b618bf91a49734c9b28549de9c5b633598426a77a23",
+   "outputs_digest": "4424b909ecdd739fbecd07309485bda0eb35403ed199f544a2a239fb06e5bbbc",
    "parameters": {},
    "production": true,
-   "source_py_blob": "3c60a48c748d48bb37996ed439a5d9ace2008ce1"
+   "source_py_blob": "632d3e43f52c8cfa858237339155977afb5a77b3"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 24.232909,
-   "end_time": "2026-09-11T14:27:59.553186+00:00",
+   "duration": 31.355746,
+   "end_time": "2026-09-11T14:35:30.512855+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "~/ml4t/public-teach-f/case_studies/etfs/.15_portfolio_management.build.279915.ipynb",
-   "output_path": "~/ml4t/public-teach-f/case_studies/etfs/.15_portfolio_management.papermill.279915.ipynb",
+   "input_path": "~/ml4t/public-teach-f/case_studies/etfs/.15_portfolio_management.build.342602.ipynb",
+   "output_path": "~/ml4t/public-teach-f/case_studies/etfs/.15_portfolio_management.papermill.342602.ipynb",
    "parameters": {},
-   "start_time": "2026-09-11T14:27:35.320277+00:00",
+   "start_time": "2026-09-11T14:34:59.157109+00:00",
    "version": "2.7.0"
   }
  },

--- a/case_studies/etfs/15_portfolio_management.py
+++ b/case_studies/etfs/15_portfolio_management.py
@@ -396,7 +396,10 @@ fig.update_layout(
     title="Mean Sharpe by weighting scheme",
     height=380,
     width=800,
-    margin=dict(t=90),
+    # The left margin is explicit because the allocator names are the y tick labels and the
+    # longest of them ran off the canvas: the rendered PNG read "ormal_weighted" and
+    # "score_weighted". Plotly sizes the default margin before it lays the labels out.
+    margin=dict(t=90, l=150),
 )
 _span = ordered["avg_sharpe"]
 show_plotly_with_alt(

--- a/case_studies/etfs/15_portfolio_management.py
+++ b/case_studies/etfs/15_portfolio_management.py
@@ -61,7 +61,7 @@ import warnings
 import plotly.graph_objects as go
 import polars as pl
 
-from case_studies.research import open_study, split_unpublished_members
+from case_studies.research import open_study, reuse_disclosure, split_unpublished_members
 from case_studies.utils.backtest_explorer import BacktestExplorer
 from case_studies.utils.backtest_loaders import get_backtest_config, load_backtest_prices_for
 from case_studies.utils.backtest_presets import (
@@ -319,8 +319,7 @@ for top_k in TOP_K_VALUES:
 
 print(
     f"\nSweep complete in {(time.monotonic() - sweep_start) / 60:.1f} minutes: "
-    f"{n_done - served - len(failures)} computed, {served} served from the registry, "
-    f"{len(failures)} failed"
+    f"{reuse_disclosure(n_done - served - len(failures), served, len(failures))}"
 )
 
 # What this sweep actually advanced, which is narrower than "every live prediction". The

--- a/case_studies/etfs/15_portfolio_management.py
+++ b/case_studies/etfs/15_portfolio_management.py
@@ -401,9 +401,9 @@ fig.update_layout(
 _span = ordered["avg_sharpe"]
 show_plotly_with_alt(
     fig,
-    "Horizontal bar chart of the mean Sharpe ratio of every allocation-stage backtest, one bar per "
-    f"weighting scheme, with a dashed line at zero. Counted from the frame: {ordered.height} "
-    f"allocators, mean Sharpe from {_span.min():+.3f} to {_span.max():+.3f}.",
+    "Horizontal bar chart of mean Sharpe by weighting scheme, one bar per allocator, over the "
+    "allocation backtests for the prediction sets this sweep advanced, ordered by that mean, "
+    "with a dashed line at zero.",
 )
 
 # %% [markdown]


### PR DESCRIPTION
## The disclosure

On a warm registry the sweep printed `0 computed, 180 served from the registry`. A reader of
the chapter rather than of the run takes that first clause as a sweep that computed nothing;
it reused 180, which is the intended idempotent behaviour and the opposite of doing nothing.
The disclosure itself has to stay - a notebook that serves results from the registry without
saying so is a silent skip - so this is a wording change.

`reuse_disclosure` in `case_studies/research/execution.py` already words all four cases and is
what `crypto_perps_funding`'s 14, 15 and 16 call. This routes `etfs` through it rather than
spelling a fifth phrasing. Re-executed; the committed output now reads:

    Sweep complete in 0.2 minutes: reused all 180 from the registry, computed by an earlier run

## Three sites deliberately not in this PR

`crypto_perps_funding/13_backtest`, `fx_pairs/13_backtest` and
`fx_pairs/14_portfolio_management` carry the same count-pair wording. The edit is written and
held back because none of the three can be re-executed today: each stops on a
population-supersedes guard wanting an explicit declaration about production data
(`a changed population named '...' must explicitly supersedes ...`). Making that declaration
is a decision about what the canonical population is, not something to do as a side effect of
changing printed text. They ride along with their next re-run.

`crypto_perps_funding/13_backtest` would in fact commit without complaint, because it carries
no provenance stamp and the gate cannot compute staleness for it - which is a reason to be
careful with it rather than a licence.

## The alt text in the same file

The second commit fixes the allocator chart's alt text, in the notebook this branch already
re-executes. It claimed "every allocation-stage backtest" where the frame is scoped to
`ADVANCED_PREDICTIONS`, and it ended on a computed count and value range that N8 bans. Caught
by nbcheck's universal-word advisory; settled by reading the frame.

## Based on

`fix/backtest-explorer-null-metric-columns`. Without it `etfs/15_portfolio_management` cannot
execute, so this PR's notebook could not be refreshed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
