### PR TITLE
Make a skip declare the condition its reason rests on, and check it

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1027,7 +1027,13 @@ jobs:
           # whether that file reads a redirect or the source tree. Both orders were
           # measured before this change landed and both are green: the roster tests
           # read a SEEDED redirect, which is the case the unset above never covered.
+          # tests/test_skip_blockers.py belongs here and in no other job. Its expiry checks
+          # measure a declared skip condition against the fixture - files under
+          # ML4T_DATA_PATH and the registries seeded_output_dir builds - so in test-unit,
+          # which checks out no test data, every one of them skips and the guard asserts
+          # nothing. That is the same "runs in no job at all" state this job was created for.
           .venv/bin/python -m pytest \
+            tests/test_skip_blockers.py \
             tests/test_eoa_universe_roster.py \
             tests/test_fixture_registry_identity.py \
             tests/test_reduced_universe_is_shared.py \

--- a/tests/overrides.yaml
+++ b/tests/overrides.yaml
@@ -25,8 +25,10 @@
   timeout: 300
 02_financial_data_universe/06_futures_continuous:
   skip: true
-  skip_reason: "Requires individual contract months \u2014 test data has only continuous series"
+  skip_reason: "Reads `futures/market/contract_definitions.parquet`, which the CI fixture does not carry: cell 11 raises FileNotFoundError on it. Measured 2026-09-11 by un-skipping and running it. The individual contract months the older reason said were missing are present - `futures/market/individual` ships CL, ES and NQ - so that reason had stopped describing the fixture."
   timeout: 300
+  skip_blocker:
+    absent_fixture_path: futures/market/contract_definitions.parquet
 02_financial_data_universe/07_sp500_options_eda:
   timeout: 180
 02_financial_data_universe/08_options_greeks_computation:
@@ -53,11 +55,15 @@
   skip_reason: "YahooFinanceProvider.fetch_ohlcv() makes network calls \u2014 CI has no guaranteed internet"
   tier: weekly
   timeout: 300
+  skip_blocker:
+    external: "outbound network for YahooFinanceProvider.fetch_ohlcv()"
 02_financial_data_universe/17_complete_pipeline:
   skip: true
   skip_reason: "YahooFinanceProvider.fetch_ohlcv() makes network calls \u2014 CI has no guaranteed internet"
   tier: weekly
   timeout: 300
+  skip_blocker:
+    external: "outbound network for YahooFinanceProvider.fetch_ohlcv()"
 02_financial_data_universe/18_data_management:
   timeout: 300
 02_financial_data_universe/19_incremental_updates:
@@ -75,6 +81,8 @@
   skip_reason: "Parses the raw NASDAQ ITCH binary (6 GB compressed); the fixture set has no raw/ directory"
   tier: weekly
   timeout: 300
+  skip_blocker:
+    absent_fixture_path: equities/market/microstructure/nasdaq_itch/raw
 03_market_microstructure/02_itch_lob_reconstruction:
   # The ITCH fixture's add messages are a head-of-day subsample and all fall before the
   # opening auction, so the production 09:30 window would reconstruct an empty book.
@@ -106,6 +114,8 @@
   skip_reason: "Parses raw IEX DEEP pcap; the fixture ships only the already-parsed output"
   tier: weekly
   timeout: 300
+  skip_blocker:
+    absent_fixture_path: equities/market/microstructure/iex/deep/raw
 03_market_microstructure/11_algoseek_taq_eda:
   timeout: 300
 03_market_microstructure/12_algoseek_taq_lob_reconstruction:
@@ -772,6 +782,10 @@
   skip: true
   skip_reason: Walk-forward CV needs more bars than the test-data window provides
   timeout: 360
+  skip_blocker:
+    fixture_shortfall:
+      note: "Cell 21 raises ValueError: No walk-forward splits available for training period. The fixture window is shorter than one walk-forward split at the notebook's configured horizon, and no parameter in this entry reduces the number of bars a split needs."
+      verified: 2026-09-11
 15_causal_estimation/06_fed_announcement_bsts:
   docker_env: py312
   # tfcausalimpact needs NumPy 1.x, the signature stack on /opt/ml4t needs 2.x,
@@ -808,8 +822,6 @@
     N_ESTIMATORS: 50
   timeout: 900
 15_causal_estimation/10_case_study_insights:
-  skip: true
-  skip_reason: "Reads nine case-study registries; CI has none of them, and the loader raises on a missing registry file"
   timeout: 300
 15_causal_estimation/11_factor_zoo_validation:
   timeout: 360
@@ -1164,6 +1176,8 @@
   skip_reason: Requires 08_8k_event_extraction, which needs a CUDA device
   tier: on_demand
   timeout: 600
+  skip_blocker:
+    external: "CUDA device"
 23_knowledge_graphs/06_gnn_feature_engineering:
   # It raises unless `torch.cuda.is_available()`, then pins `DEVICE = torch.device("cuda")` for
   # every tensor the fold loop builds. There is no CPU path. Measured: fails in 28s with the card
@@ -1264,8 +1278,6 @@
     LLM_PROVIDER: mock
     N_AGENTS: 3
     SUPERVISOR_QUERIES: 1
-  skip: true
-  skip_reason: Requires 'langgraph' (not in CI image)
   tier: weekly
   timeout: 300
 24_autonomous_agents/11_research_operator:
@@ -1273,6 +1285,8 @@
   skip_reason: Requires ~/ml4t/skills/ repo (not in CI workspace)
   tier: weekly
   timeout: 300
+  skip_blocker:
+    external: "checkout of ml4t/skills outside the repo"
 25_live_trading/01_unified_framework_demo:
   timeout: 180
 25_live_trading/02_etfs_deployment_loop:
@@ -1293,6 +1307,8 @@
   skip_reason: Requires running IB Gateway on 127.0.0.1:7497
   tier: weekly
   timeout: 180
+  skip_blocker:
+    external: "IB Gateway on 127.0.0.1:7497"
 25_live_trading/04_alpaca_paper_trading_demo:
   parameters:
     LIVE_FEED: 0
@@ -1325,6 +1341,8 @@
   skip_reason: Requires OKX SDK + live exchange credentials (not in CI image)
   tier: weekly
   timeout: 180
+  skip_blocker:
+    external: "OKX live-exchange credentials"
 25_live_trading/10_safety_risk_demo:
   timeout: 180
 25_live_trading/11_fx_deployment_loop:
@@ -1332,11 +1350,15 @@
   skip_reason: Requires running IB Gateway (not available in CI)
   tier: weekly
   timeout: 180
+  skip_blocker:
+    external: "IB Gateway"
 25_live_trading/12_ib_basket_rebalance_demo:
   skip: true
   skip_reason: Requires live TWS or IB Gateway paper session on 127.0.0.1:7497; no silent fallback.
   tier: weekly
   timeout: 180
+  skip_blocker:
+    external: "IB Gateway paper session on 127.0.0.1:7497"
 25_live_trading/13_runtime_safety_showcase:
   parameters:
     HEALTH_OBSERVATION_SECONDS: 4
@@ -1601,7 +1623,11 @@ case_studies/cme_futures/10a_pca:
   timeout: 300
 case_studies/cme_futures/10b_stochastic_discount_factor:
   skip: true
-  skip_reason: 'TEMPORARY: case-study end-to-end pipeline times out or fails with trimmed test-data; needs full fixture rebuild'
+  skip_reason: "The canonical model-catalog cell (`run_official_model_catalog` for `cme_futures-sdf-validation-v1`) does not finish inside the 300 second budget: measured 2026-09-11 by un-skipping and running it, the cell timed out. The earlier reason said the pipeline times out or fails with trimmed test data and called itself TEMPORARY; the timeout half is what actually happens."
+  skip_blocker:
+    fixture_shortfall:
+      note: "The canonical `run_official_model_catalog` cell exceeds the 300 second budget this entry allows: measured 2026-09-11 by un-skipping and running it, the cell was still executing when the timeout fired. The SDF catalog fits every requested configuration, and no parameter in this entry narrows it."
+      verified: 2026-09-11
 case_studies/cme_futures/11_causal_dml:
   parameters:
     # The DML resolver requires every one of its four preview fields, not merely a non-empty
@@ -1680,13 +1706,19 @@ case_studies/cme_futures/17_holdout_predictions:
   # Refits the selected configuration over the holdout fold - one training run, no sweep.
   timeout: 900
   skip: true
-  skip_reason: "Refuses before fitting, at `resolve_solvent_carrier`: 'No validation rank-1 candidate for cme_futures (label_filter=None)', measured at cell 6. The preview fixture registers no validation backtest for this case study, so there is no carrier to refit, and the refusal is one step earlier than the etfs pair's - etfs reaches `build_holdout_training_spec` and refuses on the missing resolved computation block, cme does not get that far. Both are the same shortfall in the fixture rather than two problems. Remove this skip when the fixture seeds a validation backtest population with a resolvable rank-1, not before: a fabricated carrier would let the job report a holdout refit of a configuration nothing selected."
+  skip_reason: "`resolve_canonical_rank1_lineage` refuses against the fixture registry: every one of the 68 ranked validation backtests for cme_futures belongs to a superseded generation or to none the case study publishes, so `resolve_solvent_carrier` has no carrier to refit. Measured 2026-09-11 against the seeded registry. The earlier reason said the fixture registers no validation backtest for this case study; it registers 68, and what disqualifies them is their generation. Remove this skip when the fixture registers a selectable one, not before."
+  skip_blocker:
+    no_canonical_selection:
+      of: cme_futures
 case_studies/cme_futures/18_holdout_backtest:
   research_preview: false
   # One backtest over the holdout window.
   timeout: 900
   skip: true
-  skip_reason: "Reads the holdout prediction set 17_holdout_predictions registers and resolves the same carrier to find it, so it refuses at `resolve_solvent_carrier` for the same reason and one step earlier than 17 does. Remove this skip together with 17's."
+  skip_reason: "Reads the holdout prediction set 17_holdout_predictions registers and resolves the same carrier to find it, so it refuses one step earlier than 17 does, on the same fixture-registry condition. Remove this skip together with 17's."
+  skip_blocker:
+    no_canonical_selection:
+      of: cme_futures
 case_studies/cme_futures/19_strategy_analysis:
   # Its inputs are registered by cme_futures::13_backtest into this same workspace,
   # and the seeded registry holds none of them: tests/conftest.py records that seeding
@@ -1900,12 +1932,22 @@ case_studies/crypto_perps_funding/16_costs:
 case_studies/crypto_perps_funding/17_holdout_predictions:
   skip: true
   skip_reason: "Refits the funnel winner on the holdout fold, so it needs a registry carrying the validation sweep - resolve_solvent_carrier has no candidate to resolve against the CI fixture. Compounding it, the seeded grid strides weekdays, so an 8-hourly holdout window is unrepresentable in the fixture at all (ml4t/agent-workspace#960). No parameter reduces either: there is nothing to refit until the sweep has run."
+  skip_blocker:
+    no_canonical_selection:
+      of: crypto_perps_funding
 case_studies/crypto_perps_funding/18_holdout_backtest:
   skip: true
   skip_reason: "Trades 17_holdout_predictions' prediction set and raises by design when it is absent, so it inherits that notebook's prerequisite - a registry carrying the validation sweep and the holdout refit, neither of which the test data builds."
+  skip_blocker:
+    no_canonical_selection:
+      of: crypto_perps_funding
 case_studies/crypto_perps_funding/19_strategy_analysis:
   skip: true
   skip_reason: "Signed pre-holdout freeze pins an exact production registry snapshot (whole-file md5 + production-scale table counts, e.g. backtest_runs: 698) that a reduced CI fixture cannot reproduce by construction - same class as us_firm_characteristics/08a_ipca, not a fixable reduction."
+  skip_blocker:
+    fixture_shortfall:
+      note: "The signed pre-holdout freeze pins an exact production registry snapshot (whole-file md5 plus production-scale table counts, e.g. backtest_runs: 698) that a reduced CI fixture cannot reproduce by construction. Same class as us_firm_characteristics/08a_ipca, not a fixable reduction."
+      verified: 2026-09-11
 case_studies/etfs/01_feasibility_analysis:
   # ADV_THRESHOLD is the only name this notebook declares that an override can reach.
   # MAX_SYMBOLS, N_SPLITS, TRAIN_YEARS and TEST_YEARS named nothing in it; START_DATE
@@ -2343,19 +2385,29 @@ case_studies/etfs/18_holdout_predictions:
   # budget is a single GBM fit over the full history before the window, on 24 funds.
   timeout: 900
   skip: true
-  skip_reason: "The seeded fixture carries no resolved training specification, so the holdout fold cannot be derived. `tests/fixtures/seed_results.py:578` writes each training run's spec as {family, config_name, label} with no `computation` block, and `build_holdout_training_spec` re-keys the validation CV onto the holdout fold by reading `computation.cv` - so it refuses with 'holdout CV derivation requires a current resolved training specification'. That refusal is correct and the notebook is correct: a holdout refit is defined by the CV interval it covers, and a spec that records none cannot produce one. Remove this skip when the fixture seeds a resolved computation, not before - a fabricated CV block would let the job report a holdout derived from fold boundaries no model was ever fitted on."
+  skip_reason: "`resolve_canonical_rank1_lineage` refuses against the fixture registry: cell 6 raises NoSelectableCandidates because every one of the 134 ranked validation backtests for etfs belongs to a superseded generation or to none the case study publishes, so there is no configuration to refit on the holdout fold. Measured 2026-09-11 by un-skipping and running it. The earlier reason named a missing `computation` block in the seeded training specs; 136 of the 140 seeded etfs specs carry one, so that is no longer what stops it. Remove this skip when the fixture registry carries a selectable candidate, not before."
+  skip_blocker:
+    no_canonical_selection:
+      of: etfs
 case_studies/etfs/19_holdout_backtest:
   research_preview: false
   # One backtest over the holdout window, on the engine path this case study's trailing-stop
   # carrier requires.
   timeout: 600
   skip: true
-  skip_reason: "Reads the holdout prediction set 18_holdout_predictions registers, and derives which one through the same `build_holdout_training_spec` call - so it refuses for the same reason and one step earlier than 18 does. The seeded fixture carries no resolved training specification, so the holdout fold cannot be derived. `tests/fixtures/seed_results.py:578` writes each training run's spec as {family, config_name, label} with no `computation` block, and `build_holdout_training_spec` re-keys the validation CV onto the holdout fold by reading `computation.cv` - so it refuses with 'holdout CV derivation requires a current resolved training specification'. That refusal is correct and the notebook is correct: a holdout refit is defined by the CV interval it covers, and a spec that records none cannot produce one. Remove this skip when the fixture seeds a resolved computation, not before - a fabricated CV block would let the job report a holdout derived from fold boundaries no model was ever fitted on."
+  skip_reason: "Reads the holdout prediction set 18_holdout_predictions registers and derives which one through the same canonical resolution, so it refuses one step earlier than 18 does, on the same fixture-registry condition. Remove this skip together with 18's."
+  skip_blocker:
+    no_canonical_selection:
+      of: etfs
 case_studies/etfs/20_strategy_analysis:
   research_preview: false
   timeout: 900
   skip: true
-  skip_reason: "Every risk-overlay backtest in the fixture sits below its family's coverage bar, so the complete-run filter admits none and the notebook refuses. The bar is the population's maximum ic_n_days: the seeded deep_learning predictions carry more scored days than the ones this job actually fits, so a fitted run can never reach a maximum a seeded row holds. Measured: 20 risk_overlay rows, all on 57b4d1ffd748 at 1536 days, all below the bar. The refusal is the guard working - an incomplete run compared as complete manufactures a false leader - and the fixture is what cannot satisfy it. Same shape as the `.preview` seeding removed in a1227f1d, one level up. Stages 14 through 17 run unskipped and pass, so the chain below this notebook is exercised."
+  skip_reason: "The complete-run filter admits no risk-overlay backtest in the fixture, so cell 8 indexes an empty selection and raises OutOfBoundsError: index 0 is out of bounds for sequence of length 0. Measured 2026-09-11 by un-skipping and running it. The bar is the population's maximum ic_n_days: the seeded deep_learning predictions carry more scored days than the ones this job fits, so a fitted run cannot reach a maximum a seeded row holds. The refusal is the guard working - an incomplete run compared as complete manufactures a false leader - and the fixture is what cannot satisfy it. Stages 14 through 17 run unskipped and pass, so the chain below this notebook is exercised."
+  skip_blocker:
+    fixture_shortfall:
+      note: "Cell 8 raises OutOfBoundsError: index 0 is out of bounds for sequence of length 0 - the complete-run filter admits no risk-overlay backtest from the fixture, so the selection it indexes is empty. Measured 2026-09-11 by un-skipping and running it."
+      verified: 2026-09-11
 case_studies/fx_pairs/01_feasibility_analysis:
   timeout: 120
 case_studies/fx_pairs/02_labels:
@@ -2470,6 +2522,10 @@ case_studies/fx_pairs/12_model_analysis:
     as 17_strategy_analysis - not a reduction that can be made to work. It reads no preview
     rows either, so a preview tier is not the alternative."
   timeout: 300
+  skip_blocker:
+    fixture_shortfall:
+      note: "Asserts the assembled canonical population equals the configured menu, and the fixture cannot present both consistently: _trim_label_configs trims the seeded config dir while the seeded registry carries the full production population, so the guard reports 117 unexpected members and nothing missing."
+      verified: 2026-09-11
 case_studies/fx_pairs/13_backtest:
   research_preview: false
   parameters:
@@ -2522,22 +2578,27 @@ case_studies/fx_pairs/16_costs:
   timeout: 900
 case_studies/fx_pairs/17_holdout_predictions:
   skip: true
-  skip_reason: "Refits the canonical validation selection on the holdout interval. The fixture
-    registry carries no fx_pairs:holdout-candidates set, and a seeded one would make the holdout
-    lineage resolve against a selection no validation run produced. The notebook takes no
-    reduction that would change this: the configuration it refits is whichever one selection
-    chose, and there is only ever one."
+  skip_reason: "Refits the canonical validation selection on the holdout interval, and `resolve_canonical_rank1_lineage` refuses against the fixture registry: every one of the 143 ranked validation backtests for fx_pairs belongs to a superseded generation or to none the case study publishes. Measured 2026-09-11 against the seeded registry. The notebook takes no reduction that would change this: the configuration it refits is whichever one selection chose, and there is only one."
   timeout: 300
+  skip_blocker:
+    no_canonical_selection:
+      of: fx_pairs
 case_studies/fx_pairs/18_holdout_backtest:
   skip: true
   skip_reason: "Replays the selected strategy against 17_holdout_predictions' output, so it is
     skipped for the same reason and would fail on the missing holdout prediction first."
   timeout: 300
+  skip_blocker:
+    no_canonical_selection:
+      of: fx_pairs
 case_studies/fx_pairs/19_strategy_analysis:
   skip: true
   skip_reason: "Reads back the holdout lineage 17 and 18 produce; with those skipped there is
     nothing for it to resolve."
   timeout: 300
+  skip_blocker:
+    no_canonical_selection:
+      of: fx_pairs
 # max_symbols stays 5 here. The arithmetic asks for 10 - top_k_grid [5, 10, 20] and
 # long-short, so the smallest declared concentration needs 2 x 5 = 10 disjoint names - and the
 # raw fixture could supply it: `data/equities/market/nasdaq100/minute_bars` carries 12 symbols,
@@ -2781,7 +2842,10 @@ case_studies/nasdaq100_microstructure/18_holdout_predictions:
   # here rather than the number of configurations.
   timeout: 900
   skip: true
-  skip_reason: "The seeded fixture carries no resolved training specification, so the holdout fold cannot be derived. `tests/fixtures/seed_results.py:578` writes each training run's spec as {family, config_name, label} with no `computation` block, and `build_holdout_training_spec` re-keys the validation CV onto the holdout fold by reading `computation.cv` - so it refuses with 'holdout CV derivation requires a current resolved training specification'. That refusal is correct and the notebook is correct: a holdout refit is defined by the CV interval it covers, and a spec that records none cannot produce one. Identical to the etfs 18/19 skip, because the limitation is the shared fixture rather than anything about this case study. Remove this skip when the fixture seeds a resolved computation, not before - a fabricated CV block would let the job report a holdout derived from fold boundaries no model was ever fitted on."
+  skip_reason: "`resolve_canonical_rank1_lineage` refuses against the fixture registry with 'No validation rank-1 candidate for nasdaq100_microstructure', so the holdout refit has no configuration to resolve. Measured 2026-09-11 against the seeded registry, by calling the resolver rather than running the notebook - this case study has a production run in flight. The earlier reason named a missing `computation` block in the seeded training specs; all 97 seeded nasdaq100_microstructure specs carry one, so that is no longer what stops it. Remove this skip when the fixture registry carries a selectable candidate, not before."
+  skip_blocker:
+    no_canonical_selection:
+      of: nasdaq100_microstructure
 case_studies/nasdaq100_microstructure/19_holdout_backtest:
   research_preview: false
   # One backtest over the six-month holdout window. The engine runs on the minute grid and
@@ -2789,11 +2853,17 @@ case_studies/nasdaq100_microstructure/19_holdout_backtest:
   # rather than its sessions.
   timeout: 600
   skip: true
-  skip_reason: "Reads the holdout prediction set 18_holdout_predictions registers, and derives which one through the same `build_holdout_training_spec` call - so it refuses for the same reason and one step earlier than 18 does. The seeded fixture carries no resolved training specification, so the holdout fold cannot be derived. Remove this skip when the fixture seeds a resolved computation, not before."
+  skip_reason: "Reads the holdout prediction set 18_holdout_predictions registers and derives which one through the same canonical resolution, so it refuses one step earlier than 18 does, on the same fixture-registry condition."
+  skip_blocker:
+    no_canonical_selection:
+      of: nasdaq100_microstructure
 case_studies/nasdaq100_microstructure/20_strategy_analysis:
   skip: true
   skip_reason: "Analyzes the cost-feasible ensemble carrier, which is registered out-of-band (session_6/7 drivers) and is not reproduced by the in-notebook test sweep, so an isolated test registry has no carrier rows. Runs clean in production."
   timeout: 180
+  skip_blocker:
+    no_canonical_selection:
+      of: nasdaq100_microstructure
 case_studies/sp500_equity_option_analytics/01_feasibility_analysis:
   timeout: 120
 case_studies/sp500_equity_option_analytics/02_labels:
@@ -3448,6 +3518,14 @@ case_studies/sp500_options/11_model_analysis:
   # skipping in CI, which is the opposite of what the mechanism is for.
   skip: true
   skip_reason: "Resolves four named official populations, and a preview run cannot create one (research/population.py::_refuse_preview_activation). Runnable when the fixture registry ships canonical populations under those names."
+  skip_blocker:
+    absent_population:
+      of: sp500_options
+      names:
+        - sp500-options-linear-validation-v1
+        - sp500-options-gbm-validation-v1
+        - sp500-options-tabular-dl-validation-v1
+        - sp500-options-sequence-validation-v1
 case_studies/sp500_options/12_backtest:
   # Its inputs are registered by sp500_options::06_linear into this same workspace,
   # and the seeded registry holds none of them: tests/conftest.py records that seeding
@@ -3510,6 +3588,11 @@ case_studies/sp500_options/14_risk_management:
   # conditions over the maintainer's registry.
   skip: true
   skip_reason: "Opens the canonical candidate set `sp500-options-strategy-candidates-v1` and refuses a preview tier, and a preview run of 13_portfolio_management cannot create one (`CandidateSet.create` refuses a preview member). Runnable when the fixture registry ships that candidate set."
+  skip_blocker:
+    absent_candidate_set:
+      of: sp500_options
+      names:
+        - sp500-options-strategy-candidates-v1
 case_studies/sp500_options/15_costs:
   # Its inputs are registered by sp500_options::12_backtest into this same workspace,
   # and the seeded registry holds none of them: tests/conftest.py records that seeding
@@ -3539,13 +3622,19 @@ case_studies/sp500_options/16_holdout_predictions:
   # budget is a single linear fit over the history before the window.
   timeout: 900
   skip: true
-  skip_reason: "The seeded fixture carries no resolved training specification, so the holdout fold cannot be derived. `tests/fixtures/seed_results.py` writes each training run's spec as {family, config_name, label} with no `computation` block, and `build_holdout_training_spec` re-keys the validation CV onto the holdout fold by reading `computation.cv` - so it refuses with 'holdout CV derivation requires a current resolved training specification'. Same shape as `case_studies/etfs/18_holdout_predictions`. That refusal is correct and the notebook is correct: a holdout refit is defined by the CV interval it covers, and a spec that records none cannot produce one. Remove this skip when the fixture seeds a resolved computation, not before - a fabricated CV block would let the job report a holdout derived from fold boundaries no model was ever fitted on."
+  skip_reason: "`resolve_canonical_rank1_lineage` refuses against the fixture registry with 'No validation rank-1 candidate for sp500_options (label_filter=ret_to_expiry)', so the holdout fold has no configuration to refit. Measured 2026-09-11 against the seeded registry. The earlier reason named a missing `computation` block in the seeded training specs; all 106 seeded sp500_options specs carry one, so that is no longer what stops it."
+  skip_blocker:
+    no_canonical_selection:
+      of: sp500_options
 case_studies/sp500_options/17_holdout_backtest:
   research_preview: false
   # One short-straddle backtest over the holdout window, through the HTM cohort engine.
   timeout: 900
   skip: true
-  skip_reason: "Derives which holdout prediction set to trade through the same `build_holdout_training_spec` call 16 makes, so it refuses for the same reason and one step earlier. The seeded fixture carries no resolved training specification, so the holdout fold cannot be derived. It would refuse a second time even if that were fixed: the option path resolves short straddles against the raw AlgoSeek chain and replays that resolution in a fresh interpreter, and the fixture carries neither. Remove this skip when the fixture seeds a resolved computation and an option chain, not before."
+  skip_reason: "Derives which holdout prediction set to trade through the same canonical resolution 16 makes, so it refuses one step earlier and on the same fixture-registry condition. It would refuse a second time even if that were fixed: the option path resolves short straddles against the raw AlgoSeek chain and replays that resolution in a fresh interpreter, and the fixture carries neither."
+  skip_blocker:
+    no_canonical_selection:
+      of: sp500_options
 case_studies/sp500_options/18_strategy_analysis:
   # Not `awaiting_rebuild`, for the reason recorded on 11_model_analysis and 14 above: it
   # resolves the named official populations `sp500-options-baseline-validation-v1` and
@@ -3556,7 +3645,12 @@ case_studies/sp500_options/18_strategy_analysis:
   # ML4T_ARTIFACT_ROOT, so declaring it there turned this file red on every workstation that
   # had run the models while still skipping here.
   skip: true
-  skip_reason: "Resolves the named official baseline and cost-sensitivity populations and requires them complete, and a preview run cannot create one (research/population.py::_refuse_preview_activation). Runnable when the fixture registry ships canonical populations under those names."
+  skip_reason: "Resolves the named official baseline population `sp500-options-baseline-validation-v1` and requires it complete, and a preview run cannot create one (research/population.py::_refuse_preview_activation). The fixture registry ships only `sp500-options-linear-validation-v1`. Runnable when it ships the baseline population."
+  skip_blocker:
+    absent_population:
+      of: sp500_options
+      names:
+        - sp500-options-baseline-validation-v1
 case_studies/sp500_options/90_ic_diagnostic:
   # MAX_SYMBOLS was 5 while the notebook screens every cross-section at MIN_SYMBOLS_PER_DATE = 10,
   # so the cap guaranteed that no date could ever qualify - a reduction that made the run
@@ -3900,6 +3994,9 @@ case_studies/us_equities_panel/20_strategy_analysis:
   skip_reason: >-
     Needs a registered holdout refit and backtest, which the reduced CI fixture does not produce -
     the production run does.
+  skip_blocker:
+    no_canonical_selection:
+      of: us_equities_panel
 case_studies/us_firm_characteristics/01_feasibility_analysis:
   timeout: 120
 case_studies/us_firm_characteristics/02_labels:
@@ -4281,19 +4378,31 @@ case_studies/us_firm_characteristics/13_risk_management:
   timeout: 600
 case_studies/us_firm_characteristics/15_holdout_predictions:
   skip: true
-  skip_reason: "Refits the case study's canonical validation rank-1 on the holdout fold, and the test-data registry holds no validation backtests for us_firm_characteristics - resolve_canonical_rank1_lineage raises 'No validation rank-1 candidate'. No parameter reduces it: there is nothing to refit until the sweep has run."
+  skip_reason: "Refits the canonical validation rank-1 on the holdout fold, and `resolve_canonical_rank1_lineage` refuses against the fixture registry: every one of the 75 ranked validation backtests for us_firm_characteristics belongs to a superseded generation or to none the case study publishes. Measured 2026-09-11 against the seeded registry. The earlier reason said the registry holds no validation backtests; it holds 75, and what disqualifies them is their generation. No parameter reduces it: there is nothing to refit until a selectable one exists."
+  skip_blocker:
+    no_canonical_selection:
+      of: us_firm_characteristics
 case_studies/us_firm_characteristics/16_holdout_backtest:
   skip: true
   skip_reason: "Trades 15_holdout_predictions' prediction set, so it inherits that notebook's prerequisite - a registry carrying the validation sweep and the holdout refit, neither of which the test data builds."
+  skip_blocker:
+    no_canonical_selection:
+      of: us_firm_characteristics
 case_studies/us_firm_characteristics/17_strategy_analysis:
   skip: true
   skip_reason: "Test-data load_firm_characteristics() returns 80 firms/day; the NB's liquidity-profile section requires >=100 firms/day. The notebook reads the registry and the feature panel, not the price panel, so no parameter reduces it - it needs an expanded test-data fixture (>=100 firms)."
+  skip_blocker:
+    fixture_shortfall:
+      note: "Test-data load_firm_characteristics() returns 80 firms per day and the liquidity-profile section requires at least 100. The notebook reads the registry and the feature panel, not the price panel, so no parameter reduces it: it needs a wider fixture."
+      verified: 2026-09-11
 data/equities/market/microstructure/dataset_card:
   timeout: 120
 data/equities/market/us_equities/dataset_card:
   skip: true
   skip_reason: Data download notebook (requires API access)
   tier: weekly
+  skip_blocker:
+    external: "vendor API credentials for the download"
 data/factors/dataset_card:
   timeout: 120
 data/fx/market/dataset_card:

--- a/tests/overrides.yaml
+++ b/tests/overrides.yaml
@@ -2578,27 +2578,33 @@ case_studies/fx_pairs/16_costs:
   timeout: 900
 case_studies/fx_pairs/17_holdout_predictions:
   skip: true
-  skip_reason: "Refits the canonical validation selection on the holdout interval, and `resolve_canonical_rank1_lineage` refuses against the fixture registry: every one of the 143 ranked validation backtests for fx_pairs belongs to a superseded generation or to none the case study publishes. Measured 2026-09-11 against the seeded registry. The notebook takes no reduction that would change this: the configuration it refits is whichever one selection chose, and there is only one."
+  skip_reason: "Refits the canonical validation selection on the holdout interval, and cell 5 raises ValueError: candidate set name 'fx_pairs:holdout-candidates' resolved to 0 unsuperseded identities. The fixture registry ships no such set and a preview run cannot create one. Measured 2026-09-11 in the cs-fx_pairs job, with this skip lifted. The notebook takes no reduction that would change it: the configuration it refits is whichever one selection chose, and there is only one."
   timeout: 300
   skip_blocker:
-    no_canonical_selection:
+    absent_candidate_set:
       of: fx_pairs
+      names:
+        - fx_pairs:holdout-candidates
 case_studies/fx_pairs/18_holdout_backtest:
   skip: true
   skip_reason: "Replays the selected strategy against 17_holdout_predictions' output, so it is
     skipped for the same reason and would fail on the missing holdout prediction first."
   timeout: 300
   skip_blocker:
-    no_canonical_selection:
+    absent_candidate_set:
       of: fx_pairs
+      names:
+        - fx_pairs:holdout-candidates
 case_studies/fx_pairs/19_strategy_analysis:
   skip: true
   skip_reason: "Reads back the holdout lineage 17 and 18 produce; with those skipped there is
     nothing for it to resolve."
   timeout: 300
   skip_blocker:
-    no_canonical_selection:
+    absent_candidate_set:
       of: fx_pairs
+      names:
+        - fx_pairs:holdout-candidates
 # max_symbols stays 5 here. The arithmetic asks for 10 - top_k_grid [5, 10, 20] and
 # long-short, so the smallest declared concentration needs 2 x 5 = 10 disjoint names - and the
 # raw fixture could supply it: `data/equities/market/nasdaq100/minute_bars` carries 12 symbols,

--- a/tests/overrides.yaml
+++ b/tests/overrides.yaml
@@ -82,7 +82,7 @@
   tier: weekly
   timeout: 300
   skip_blocker:
-    absent_fixture_path: equities/market/microstructure/nasdaq_itch/raw
+    absent_fixture_path: equities/market/microstructure/nasdaq_itch/raw/*
 03_market_microstructure/02_itch_lob_reconstruction:
   # The ITCH fixture's add messages are a head-of-day subsample and all fall before the
   # opening auction, so the production 09:30 window would reconstruct an empty book.
@@ -115,7 +115,7 @@
   tier: weekly
   timeout: 300
   skip_blocker:
-    absent_fixture_path: equities/market/microstructure/iex/deep/raw
+    absent_fixture_path: equities/market/microstructure/iex/deep/*.pcap.gz
 03_market_microstructure/11_algoseek_taq_eda:
   timeout: 300
 03_market_microstructure/12_algoseek_taq_lob_reconstruction:

--- a/tests/pm_helpers.py
+++ b/tests/pm_helpers.py
@@ -112,6 +112,7 @@ KNOWN_OVERRIDE_KEYS = frozenset(
         "research_preview",  # pm_helpers.injected_parameters
         "reruns",  # pm_helpers.get_reruns
         "skip",  # tests/test_chapter_notebooks.py
+        "skip_blocker",  # tests/skip_blockers.py
         "skip_reason",  # tests/test_chapter_notebooks.py
         "tier",  # pm_helpers.get_tier
         "timeout",  # tests/test_chapter_notebooks.py -> run_notebook

--- a/tests/skip_blockers.py
+++ b/tests/skip_blockers.py
@@ -1,0 +1,232 @@
+"""The condition a ``skip: true`` in ``overrides.yaml`` is claiming, in checkable form.
+
+A ``skip_reason`` is prose, and prose does not fail. The suite is green whether the reason is
+sound, stale, or was never true, so the notebook behind a wrong reason stays out of CI with
+nothing to say so. Three of the reasons on this file were wrong when this was written: one
+named a fixture that has been present for months, one described a refusal the notebook does
+not raise, and one covered a notebook that passes.
+
+So every skip declares the condition its reason rests on, beside the prose:
+
+    15_causal_estimation/10_case_study_insights:
+      skip: true
+      skip_reason: "..."
+      skip_blocker:
+        absent_fixture_path: futures/market/contract_definitions.parquet
+
+``blocker_unmet_reason`` returns a reason while the condition still holds and ``None`` once it
+has expired. The skip is honoured only while it returns a reason, so a fixture that grows the
+file, an image that gains the module, or a registry that gains a selectable candidate retires
+the skip with no edit to any file - and ``tests/test_skip_blockers.py`` fails the build on a
+declaration that has expired, so the retirement is a red test rather than a quiet gap.
+
+This is ``tests/awaiting_rebuild.py``'s mechanism pointed at a different registry. That one
+measures against ``ML4T_ARTIFACT_ROOT``, the maintainer's own artifacts; ``overrides.yaml``
+records at ``case_studies/sp500_options/11_model_analysis`` why that is the wrong instrument
+for a skip about the CI fixture - a condition over the maintainer's registry reads as satisfied
+on any workstation that has run the models while the fixture the job runs against still holds
+nothing. Everything here is measured against the fixture: ``ML4T_DATA_PATH`` for files and the
+seeded ``ML4T_OUTPUT_DIR`` for registries.
+
+Two kinds cannot be decided from inside the run and say so rather than pretending:
+``external`` (a service, credential or device the runner does not have) and
+``fixture_shortfall`` (a reduction that cannot carry what the notebook needs). Both are
+inspected by ``test_skip_blockers.py`` - ``external`` must be off the per-commit tier, and
+``fixture_shortfall`` must carry the date its reason was last confirmed by running the
+notebook.
+"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+from collections.abc import Sequence
+from datetime import date
+from pathlib import Path
+from typing import Any
+
+DECIDABLE_KINDS = (
+    "absent_fixture_path",
+    "no_canonical_selection",
+    "absent_population",
+    "absent_candidate_set",
+)
+UNDECIDABLE_KINDS = ("external", "fixture_shortfall")
+KINDS = DECIDABLE_KINDS + UNDECIDABLE_KINDS
+
+
+class UndecidableHere(Exception):
+    """The blocker is real but cannot be evaluated in this process."""
+
+
+def declared_kind(declaration: dict) -> str:
+    """The single kind a declaration names, or raise."""
+    named = [kind for kind in KINDS if kind in declaration]
+    if len(named) != 1:
+        raise ValueError(
+            f"skip_blocker must name exactly one of {', '.join(KINDS)}; got {sorted(declaration)}"
+        )
+    return named[0]
+
+
+def _fixture_root() -> Path | None:
+    from tests.conftest import _resolve_data_path
+
+    return _resolve_data_path()
+
+
+def _fixture_registry(case_study: str) -> Path | None:
+    """The registry the CI job actually reads, not the maintainer's."""
+    output_dir = os.environ.get("ML4T_OUTPUT_DIR")
+    if not output_dir:
+        return None
+    db = Path(output_dir) / case_study / "run_log" / "registry.db"
+    return db if db.is_file() else None
+
+
+def _distinct(db: Path, table: str, column: str) -> set[str] | None:
+    """``column``'s distinct values, or None when the table is not there to read."""
+    try:
+        con = sqlite3.connect(f"file:{db}?mode=ro", uri=True)
+    except sqlite3.OperationalError:
+        return None
+    try:
+        if not con.execute(
+            "select 1 from sqlite_master where type = 'table' and name = ?", (table,)
+        ).fetchone():
+            return None
+        return {str(row[0]) for row in con.execute(f"select distinct {column} from {table}")}
+    except sqlite3.DatabaseError:
+        # A registry the current schema cannot read is not one a notebook can read either.
+        return None
+    finally:
+        con.close()
+
+
+def _names(value: Any) -> list[str]:
+    if isinstance(value, str):
+        return [value]
+    return [str(name) for name in value]
+
+
+def blocker_unmet_reason(declaration: dict) -> str | None:
+    """Why the skip still applies, or ``None`` once its condition has expired.
+
+    Raises ``UndecidableHere`` when the condition needs something this process does not have -
+    a fixture root that is not populated, or a seeded registry that has not been built. The
+    caller decides whether that means "honour the skip" (a notebook run) or "report nothing"
+    (the guard test), and neither is allowed to read it as "the blocker is gone".
+    """
+    kind = declared_kind(declaration)
+
+    if kind == "absent_fixture_path":
+        root = _fixture_root()
+        if root is None:
+            raise UndecidableHere("no ML4T_DATA_PATH to measure against")
+        relative = str(declaration[kind])
+        if not (root / relative).exists():
+            return f"the CI fixture carries no {relative}"
+        return None
+
+    if kind == "no_canonical_selection":
+        case_study = declaration[kind]["of"]
+        if _fixture_registry(case_study) is None:
+            raise UndecidableHere(f"no seeded registry for {case_study}")
+        from case_studies.utils import strategy_analysis
+
+        try:
+            strategy_analysis.resolve_canonical_rank1_lineage(case_study)
+        except strategy_analysis.NoSelectableCandidates as refusal:
+            return f"the fixture registry has no selectable {case_study} candidate: {refusal}"
+        return None
+
+    if kind == "absent_population":
+        spec = declaration[kind]
+        case_study = spec["of"]
+        db = _fixture_registry(case_study)
+        if db is None:
+            raise UndecidableHere(f"no seeded registry for {case_study}")
+        wanted = _names(spec["names"])
+        present = _distinct(db, "official_populations", "name") or set()
+        absent = [name for name in wanted if name not in present]
+        if absent:
+            return (
+                f"the fixture registry has no official population named "
+                f"{', '.join(repr(name) for name in absent)}"
+            )
+        return None
+
+    if kind == "absent_candidate_set":
+        spec = declaration[kind]
+        case_study = spec["of"]
+        db = _fixture_registry(case_study)
+        if db is None:
+            raise UndecidableHere(f"no seeded registry for {case_study}")
+        wanted = _names(spec["names"])
+        present = _distinct(db, "candidate_sets", "name") or set()
+        absent = [name for name in wanted if name not in present]
+        if absent:
+            return (
+                f"the fixture registry ships no candidate set named "
+                f"{', '.join(repr(name) for name in absent)}"
+            )
+        return None
+
+    if kind == "external":
+        return f"the runner has no {declaration[kind]}"
+
+    if kind == "fixture_shortfall":
+        spec = declaration[kind]
+        return f"{spec['note']} (last confirmed by running it on {spec['verified']})"
+
+    raise AssertionError(f"unreachable kind {kind!r}")
+
+
+def confirmation_age_days(declaration: dict, *, today: date | None = None) -> int | None:
+    """How long ago a ``fixture_shortfall`` was last confirmed, or None for other kinds."""
+    if declared_kind(declaration) != "fixture_shortfall":
+        return None
+    verified = declaration["fixture_shortfall"]["verified"]
+    if not isinstance(verified, date):
+        verified = date.fromisoformat(str(verified))
+    return ((today or date.today()) - verified).days
+
+
+def skip_declarations(overrides: dict) -> dict[str, dict]:
+    """Every ``skip: true`` row, keyed the way ``get_overrides`` keys them."""
+    return {
+        key: value
+        for key, value in overrides.items()
+        if isinstance(value, dict) and value.get("skip") is True
+    }
+
+
+def per_commit_tier(row: dict) -> bool:
+    """Whether this row would run in the per-commit suite if it were not skipped."""
+    return str(row.get("tier", "per_commit")) == "per_commit"
+
+
+def unknown_keys(declaration: dict, kind: str) -> Sequence[str]:
+    return sorted(set(declaration) - {kind})
+
+
+def honoured_skip_reason(overrides: dict) -> str | None:
+    """The reason to skip this notebook, or ``None`` when the skip no longer applies.
+
+    A declared blocker that has expired stops the skip applying, so the notebook runs again
+    with no edit to any file - the same self-retiring contract ``awaiting_rebuild`` has. When
+    the condition cannot be measured here (no fixture root, no seeded registry), the skip is
+    honoured: an unmeasurable condition is not evidence that it has gone.
+    """
+    if not overrides.get("skip"):
+        return None
+    reason = overrides.get("skip_reason", "marked skip in overrides")
+    declaration = overrides.get("skip_blocker")
+    if not declaration:
+        return reason
+    try:
+        if blocker_unmet_reason(declaration) is None:
+            return None
+    except UndecidableHere:
+        return reason
+    return reason

--- a/tests/skip_blockers.py
+++ b/tests/skip_blockers.py
@@ -124,6 +124,14 @@ def blocker_unmet_reason(declaration: dict) -> str | None:
         if root is None:
             raise UndecidableHere("no ML4T_DATA_PATH to measure against")
         relative = str(declaration[kind])
+        # A glob, because the condition is usually "no file of this shape" rather than "this
+        # exact path is missing", and the two differ where it matters: the IEX notebook reads
+        # `iex/deep/*.pcap.gz` through `load_iex_hist(get_raw_files=True)`, so a declaration
+        # naming a `raw/` directory it never opens would stay unmet after the captures landed.
+        if any(char in relative for char in "*?["):
+            if not any(root.glob(relative)):
+                return f"the CI fixture carries no file matching {relative}"
+            return None
         if not (root / relative).exists():
             return f"the CI fixture carries no {relative}"
         return None

--- a/tests/skip_blockers.py
+++ b/tests/skip_blockers.py
@@ -28,6 +28,17 @@ on any workstation that has run the models while the fixture the job runs agains
 nothing. Everything here is measured against the fixture: ``ML4T_DATA_PATH`` for files and the
 seeded ``ML4T_OUTPUT_DIR`` for registries.
 
+**A condition has to be a property of the FIXTURE, not of the workspace the job is building.**
+The blocker is evaluated at the moment the notebook's test runs, and a ``cs-*`` job runs a case
+study's stages in order into one workspace, so anything the earlier stages register is there by
+the time a late stage is reached. The first version of this declared
+``no_canonical_selection`` for the fx_pairs holdout notebooks; their standalone refusal was
+measured correctly, but in the job the stages above them register a selectable validation
+rank-1, the blocker expired mid-job, the skip lifted, and all three failed on the condition
+their ORIGINAL reason had named - a candidate set the fixture does not ship. A named set or
+population the fixture never carries is stable in a way "what the registry currently resolves"
+is not.
+
 Two kinds cannot be decided from inside the run and say so rather than pretending:
 ``external`` (a service, credential or device the runner does not have) and
 ``fixture_shortfall`` (a reduction that cannot carry what the notebook needs). Both are

--- a/tests/test_case_studies.py
+++ b/tests/test_case_studies.py
@@ -34,6 +34,7 @@ from tests.pm_helpers import (
     run_notebook,
     stage_sort_key,
 )
+from tests.skip_blockers import honoured_skip_reason
 
 REPO_ROOT = Path(__file__).parent.parent
 
@@ -145,8 +146,8 @@ def test_case_study_pipeline(
     # Check case-study-level skip (e.g., "case_studies/nasdaq100_microstructure")
     cs_key = f"case_studies/{case_study}"
     cs_overrides = get_overrides(cs_key)
-    if cs_overrides.get("skip"):
-        pytest.skip(f"Skipped: {cs_overrides.get('skip_reason', 'case study skipped')}")
+    if cs_reason := honoured_skip_reason(cs_overrides):
+        pytest.skip(f"Skipped: {cs_reason}")
 
     rel_path = notebook_path.relative_to(REPO_ROOT).with_suffix("")
     overrides = get_overrides(str(rel_path))
@@ -157,9 +158,10 @@ def test_case_study_pipeline(
     if nb_tier != run_tier:
         pytest.skip(f"Tier {nb_tier} — current run tier is {run_tier}")
 
-    # Skip if overrides say so
-    if overrides.get("skip"):
-        reason = overrides.get("skip_reason", "marked skip in overrides")
+    # Skip if overrides say so. Honoured only while the condition the reason rests on still
+    # holds - see tests/skip_blockers.py - so a fixture registry that gains a selectable
+    # candidate retires the skip rather than outliving it.
+    if reason := honoured_skip_reason(overrides):
         pytest.skip(f"Skipped: {reason}")
 
     # Inputs the rebuild has not produced yet. Unlike `skip`, this is checked against the

--- a/tests/test_chapter_notebooks.py
+++ b/tests/test_chapter_notebooks.py
@@ -34,6 +34,7 @@ from tests.pm_helpers import (
     run_notebook,
     sole_invocation,
 )
+from tests.skip_blockers import honoured_skip_reason
 
 REPO_ROOT = Path(__file__).parent.parent
 
@@ -77,9 +78,12 @@ def test_chapter_notebook(notebook_path, populated_data_dir, seeded_output_dir):
     if nb_tier != run_tier:
         pytest.skip(f"Tier {nb_tier} — current run tier is {run_tier}")
 
-    # Skip if overrides say so (e.g., missing test data)
-    if overrides.get("skip"):
-        pytest.skip(f"Skipped: {overrides.get('skip_reason', 'marked skip in overrides')}")
+    # Skip if overrides say so (e.g., missing test data). The skip is honoured only while the
+    # condition its reason rests on still holds, so a fixture that grows the file or an image
+    # that gains the module retires it with no edit here; tests/test_skip_blockers.py fails the
+    # build on a declaration that has expired.
+    if reason := honoured_skip_reason(overrides):
+        pytest.skip(f"Skipped: {reason}")
 
     # Credentials the notebook cannot run without (e.g. EDGAR_IDENTITY).
     if absent := missing_required_env(overrides):

--- a/tests/test_skip_blockers.py
+++ b/tests/test_skip_blockers.py
@@ -139,6 +139,8 @@ def test_declaration_has_not_outlived_its_reason(key, populated_data_dir, seeded
     [
         ({"absent_fixture_path": "no/such/fixture/file.parquet"}, True),
         ({"absent_fixture_path": "etfs/market/etf_universe.parquet"}, False),
+        ({"absent_fixture_path": "equities/market/microstructure/iex/deep/*.pcap.gz"}, True),
+        ({"absent_fixture_path": "etfs/market/*.parquet"}, False),
     ],
 )
 def test_fixture_path_evaluator_reports_both_outcomes(

--- a/tests/test_skip_blockers.py
+++ b/tests/test_skip_blockers.py
@@ -1,0 +1,204 @@
+"""Guard the skips so a reason cannot stay true by never being asked.
+
+``tests/skip_blockers.py`` says why this exists. These tests are the half that makes a
+declaration cost something: a condition that has expired is a failure, not a warning, because
+it means the notebook could run and the skip is now hiding it.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+import yaml
+
+from tests.pm_helpers import OVERRIDES_PATH
+from tests.skip_blockers import (
+    DECIDABLE_KINDS,
+    UNDECIDABLE_KINDS,
+    UndecidableHere,
+    blocker_unmet_reason,
+    declared_kind,
+    per_commit_tier,
+    skip_declarations,
+    unknown_keys,
+)
+
+# The escape hatches exist because two conditions genuinely cannot be decided from inside the
+# run. The ceiling is what stops them becoming the comfortable answer: a new skip that cannot
+# be expressed as a decidable condition has to displace one, or raise this number in a commit
+# that says why.
+MAX_UNDECIDABLE = 16
+
+
+def _overrides() -> dict:
+    return yaml.safe_load(OVERRIDES_PATH.read_text()) or {}
+
+
+def _skips() -> dict[str, dict]:
+    return skip_declarations(_overrides())
+
+
+def test_every_skip_declares_a_blocker():
+    """A skip with no declared condition is the state this mechanism exists to end."""
+    undeclared = sorted(key for key, row in _skips().items() if not row.get("skip_blocker"))
+    assert not undeclared, (
+        "these rows are skipped with nothing checking the reason: "
+        + ", ".join(undeclared)
+        + ". Add a skip_blocker naming the condition the reason rests on."
+    )
+
+
+@pytest.mark.parametrize("key", sorted(_skips()))
+def test_declaration_is_well_formed(key):
+    declaration = _skips()[key]["skip_blocker"]
+    assert isinstance(declaration, dict), f"{key}: skip_blocker must be a mapping"
+    kind = declared_kind(declaration)
+    assert not unknown_keys(declaration, kind), (
+        f"{key}: skip_blocker carries keys beside {kind}: {unknown_keys(declaration, kind)}"
+    )
+    if kind == "fixture_shortfall":
+        spec = declaration[kind]
+        assert spec.get("note"), f"{key}: fixture_shortfall.note must say what falls short"
+        verified = spec.get("verified")
+        assert verified, (
+            f"{key}: fixture_shortfall.verified must carry the date the reason was last "
+            "confirmed by running the notebook"
+        )
+        if not isinstance(verified, date):
+            verified = date.fromisoformat(str(verified))
+        assert verified <= date.today(), f"{key}: fixture_shortfall.verified is in the future"
+
+
+def test_external_blockers_are_off_the_per_commit_tier():
+    """Nothing decidable checks an ``external``, so it may not sit in the per-commit suite.
+
+    A per-commit row skipped on an unverifiable reason is exactly the silent exclusion this
+    mechanism is about. On a weekly or on-demand tier the dedicated workflow is where the
+    service is either present or explicitly absent.
+    """
+    offenders = sorted(
+        key
+        for key, row in _skips().items()
+        if declared_kind(row["skip_blocker"]) == "external" and per_commit_tier(row)
+    )
+    assert not offenders, (
+        "external blockers must declare a tier other than per_commit: " + ", ".join(offenders)
+    )
+
+
+def test_undecidable_blockers_stay_a_minority():
+    kinds = [declared_kind(row["skip_blocker"]) for row in _skips().values()]
+    undecidable = [kind for kind in kinds if kind in UNDECIDABLE_KINDS]
+    assert len(undecidable) <= MAX_UNDECIDABLE, (
+        f"{len(undecidable)} of {len(kinds)} skips rest on a condition nothing can check. "
+        "Express the new one as a decidable condition or say in the commit why it cannot be."
+    )
+
+
+@pytest.mark.parametrize("key", sorted(_skips()))
+def test_declaration_has_not_outlived_its_reason(key, populated_data_dir, seeded_output_dir):
+    """The condition the skip rests on still holds.
+
+    When the fixture, the image or the registry grows what the reason says is missing, this
+    fails, which is the signal to delete the skip or rewrite the reason. The notebook's own
+    test then runs with no other edit.
+    """
+    declaration = _skips()[key]["skip_blocker"]
+    if declared_kind(declaration) in UNDECIDABLE_KINDS:
+        pytest.skip(f"{declared_kind(declaration)} cannot be decided from inside the run")
+    try:
+        reason = blocker_unmet_reason(declaration)
+    except UndecidableHere as absent:
+        pytest.skip(f"nothing to measure against here: {absent}")
+    assert reason is not None, (
+        f"{key}: the condition this skip rests on no longer holds. Un-skip the notebook and "
+        "run it: either the skip goes, or skip_reason and skip_blocker are rewritten to what "
+        "blocks it now."
+    )
+
+
+# --- the evaluators can report an expiry, which is what makes the check above worth running --
+
+
+@pytest.mark.parametrize(
+    "declaration,still_blocked",
+    [
+        ({"absent_fixture_path": "no/such/fixture/file.parquet"}, True),
+        ({"absent_fixture_path": "etfs/market/etf_universe.parquet"}, False),
+    ],
+)
+def test_fixture_path_evaluator_reports_both_outcomes(
+    declaration, still_blocked, populated_data_dir
+):
+    """A checker that can only say "still blocked" would pass on every stale declaration."""
+    assert (blocker_unmet_reason(declaration) is not None) is still_blocked
+
+
+@pytest.mark.parametrize(
+    "declaration,still_blocked",
+    [
+        # The fixture registry ships the linear validation population and no other, which makes
+        # it the control for both directions without constructing a registry.
+        ({"absent_population": {"of": "sp500_options", "names": ["no-such-population-v1"]}}, True),
+        (
+            {
+                "absent_population": {
+                    "of": "sp500_options",
+                    "names": ["sp500-options-linear-validation-v1"],
+                }
+            },
+            False,
+        ),
+        (
+            {"absent_candidate_set": {"of": "sp500_options", "names": ["no-such-candidate-set"]}},
+            True,
+        ),
+    ],
+)
+def test_registry_evaluators_report_both_outcomes(
+    declaration, still_blocked, populated_data_dir, seeded_output_dir
+):
+    try:
+        reason = blocker_unmet_reason(declaration)
+    except UndecidableHere as absent:
+        pytest.skip(f"nothing to measure against here: {absent}")
+    assert (reason is not None) is still_blocked
+
+
+def test_no_canonical_selection_reports_an_expiry_when_the_resolver_returns(
+    monkeypatch, populated_data_dir, seeded_output_dir
+):
+    """The branch the fixture cannot reach today, exercised so it is not dead code.
+
+    Every case study in the fixture registry refuses, so nothing in the declarations above
+    ever runs the "condition has expired" path for this kind. A resolver that returns is what
+    the fixture will look like once it carries a selectable candidate, and this is the only
+    way to see that the evaluator reports it rather than staying quiet.
+    """
+    from case_studies.utils import strategy_analysis
+
+    monkeypatch.setattr(
+        strategy_analysis, "resolve_canonical_rank1_lineage", lambda *a, **k: {"rank1": "present"}
+    )
+    assert blocker_unmet_reason({"no_canonical_selection": {"of": "etfs"}}) is None
+
+
+def test_a_declaration_naming_two_kinds_is_rejected():
+    with pytest.raises(ValueError, match="exactly one"):
+        declared_kind({"external": "x", "absent_fixture_path": "a/b.parquet"})
+
+
+def test_a_declaration_naming_no_kind_is_rejected():
+    with pytest.raises(ValueError, match="exactly one"):
+        declared_kind({"reason": "because"})
+
+
+def test_every_decidable_kind_is_exercised_by_the_declarations():
+    """A kind nothing declares is a kind nothing proves works on real data."""
+    declared = {declared_kind(row["skip_blocker"]) for row in _skips().values()}
+    unused = sorted(set(DECIDABLE_KINDS) - declared)
+    assert not unused, (
+        "these kinds are implemented but no row declares one, so nothing exercises them "
+        f"against the fixture: {', '.join(unused)}"
+    )

--- a/tests/test_skip_blockers.py
+++ b/tests/test_skip_blockers.py
@@ -16,7 +16,6 @@ from tests.pm_helpers import OVERRIDES_PATH
 from tests.skip_blockers import (
     DECIDABLE_KINDS,
     UNDECIDABLE_KINDS,
-    UndecidableHere,
     blocker_unmet_reason,
     declared_kind,
     per_commit_tier,
@@ -37,6 +36,20 @@ def _overrides() -> dict:
 
 def _skips() -> dict[str, dict]:
     return skip_declarations(_overrides())
+
+
+def _decidable_skips() -> dict[str, dict]:
+    """The rows whose condition this process can actually evaluate.
+
+    Parametrising the expiry check over every row instead would report the two undecidable
+    kinds as skips, and `test-unit-data` treats a skip as a failure precisely because a job
+    that runs nothing passes. The undecidable rows are inspected by the two tests below.
+    """
+    return {
+        key: row
+        for key, row in _skips().items()
+        if declared_kind(row["skip_blocker"]) in DECIDABLE_KINDS
+    }
 
 
 def test_every_skip_declares_a_blocker():
@@ -96,21 +109,21 @@ def test_undecidable_blockers_stay_a_minority():
     )
 
 
-@pytest.mark.parametrize("key", sorted(_skips()))
+@pytest.mark.parametrize("key", sorted(_decidable_skips()))
 def test_declaration_has_not_outlived_its_reason(key, populated_data_dir, seeded_output_dir):
     """The condition the skip rests on still holds.
 
-    When the fixture, the image or the registry grows what the reason says is missing, this
-    fails, which is the signal to delete the skip or rewrite the reason. The notebook's own
-    test then runs with no other edit.
+    When the fixture or the registry grows what the reason says is missing, this fails, which
+    is the signal to delete the skip or rewrite the reason. The notebook's own test then runs
+    with no other edit.
+
+    ``UndecidableHere`` is deliberately not caught. ``populated_data_dir`` has already skipped
+    the whole file when there is no fixture, so reaching it means the fixture is present and
+    the seeding produced no registry - a silent failure of the thing this check measures
+    against, which should be loud rather than another skip.
     """
-    declaration = _skips()[key]["skip_blocker"]
-    if declared_kind(declaration) in UNDECIDABLE_KINDS:
-        pytest.skip(f"{declared_kind(declaration)} cannot be decided from inside the run")
-    try:
-        reason = blocker_unmet_reason(declaration)
-    except UndecidableHere as absent:
-        pytest.skip(f"nothing to measure against here: {absent}")
+    declaration = _decidable_skips()[key]["skip_blocker"]
+    reason = blocker_unmet_reason(declaration)
     assert reason is not None, (
         f"{key}: the condition this skip rests on no longer holds. Un-skip the notebook and "
         "run it: either the skip goes, or skip_reason and skip_blocker are rewritten to what "
@@ -159,11 +172,7 @@ def test_fixture_path_evaluator_reports_both_outcomes(
 def test_registry_evaluators_report_both_outcomes(
     declaration, still_blocked, populated_data_dir, seeded_output_dir
 ):
-    try:
-        reason = blocker_unmet_reason(declaration)
-    except UndecidableHere as absent:
-        pytest.skip(f"nothing to measure against here: {absent}")
-    assert (reason is not None) is still_blocked
+    assert (blocker_unmet_reason(declaration) is not None) is still_blocked
 
 
 def test_no_canonical_selection_reports_an_expiry_when_the_resolver_returns(


### PR DESCRIPTION
`skip: true` in `tests/overrides.yaml` takes a notebook out of CI on a written reason, and
nothing asked whether the reason was still true. The suite was green whether it was sound,
stale, or never true, so a wrong reason was invisible by construction and the notebook behind
it stayed out of CI indefinitely.

Every skip now declares the condition beside the prose:

```yaml
case_studies/etfs/18_holdout_predictions:
  skip: true
  skip_reason: "..."
  skip_blocker:
    no_canonical_selection:
      of: etfs
```

`tests/skip_blockers.py` returns a reason while the condition holds and `None` once it has
expired. The notebook tests honour the skip only while a reason comes back, so a fixture that
grows the file or a registry that gains a selectable candidate retires the skip with no edit to
any file, and `tests/test_skip_blockers.py` fails the build on a declaration that has outlived
its reason.

This is `tests/awaiting_rebuild.py`'s mechanism pointed at a different registry. That one
measures against `ML4T_ARTIFACT_ROOT`, the maintainer's own artifacts; `overrides.yaml` records
at `case_studies/sp500_options/11_model_analysis` why that is the wrong instrument for a skip
about the CI fixture, because such a condition reads as satisfied on any workstation that has
run the models while the fixture the job runs against still holds nothing. Everything here is
measured against the fixture: `ML4T_DATA_PATH` for files, the seeded `ML4T_OUTPUT_DIR` for
registries.

Four kinds are decidable (`absent_fixture_path`, which takes a glob, `no_canonical_selection`,
`absent_population`, `absent_candidate_set`). Two say they are not rather than pretending:
`external`, for a service, credential or device the runner does not have, which must sit off
the per-commit tier, and `fixture_shortfall`, which must carry the date its reason was last
confirmed by running the notebook. A ceiling keeps those two from becoming the comfortable
answer.

## What the check found while it was being written

Four reasons were false, and the mechanism is what surfaced them.

| row | the reason said | what is true |
|---|---|---|
| `15_causal_estimation/10_case_study_insights` | CI has none of the nine case-study registries | the seeded output dir carries all nine and the notebook passes in 68s. **Skip removed** |
| `24_autonomous_agents/10_framework_comparison` | langgraph is not in the CI image | it is a main dependency, placed there so it reaches the image; the notebook passes on the weekly tier. **Skip removed** |
| `02_financial_data_universe/06_futures_continuous` | test data has only continuous series | `futures/market/individual` ships CL, ES and NQ. It fails on a missing `futures/market/contract_definitions.parquet`, which is now what the reason says and what the blocker checks |
| six rows in etfs, nasdaq100_microstructure, sp500_options | the seeded training specs carry no `computation` block | they carry one - 136/140, 97/97, 106/106. What stops them is that every ranked validation backtest belongs to a superseded generation |

Reasons were also rewritten for cme_futures 17 and 18 ("registers no validation backtest" - it
registers 68), us_firm_characteristics 15 ("holds no validation backtests" - it holds 75),
fx_pairs 17, etfs 20 and cme_futures 10b, each against what running it or querying the fixture
registry actually produced.

## The guard runs in a job that has the fixture

The first version of it asserted nothing: its per-row checks measure against the fixture, and
`test-unit`, the only job collecting the file, checks out no test data, so `populated_data_dir`
skipped every one. `test-unit-data` exists for exactly that failure, checks out the test-data
repo, and fails when any test in it skips. The file is in its list, and the undecidable kinds
no longer report as skips.

Verified by reproducing that job rather than reasoning about it: a venv built from its own
package list under `uv export --frozen --extra live --extra dev` as a constraint,
`ML4T_OUTPUT_DIR` unset the way the step unsets it, run against the test-data checkout. **75
passed, 0 skipped**, and the job's junit-XML skip gate reads PASS.

Both evaluator directions are exercised on real fixture data, and the branch the fixture cannot
reach today - a resolver that returns - is covered so it is not dead code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
