### PR TITLE
A column projection must not narrow the identity the run records

### DIFF
--- a/case_studies/utils/causal.py
+++ b/case_studies/utils/causal.py
@@ -1366,10 +1366,25 @@ def resolve_causal_request(study: Study, request: dict[str, Any]):
     study.require_writable()
     study.activate(tier)
     label_ref = study.labels.get(request["label"], execution_tier=tier)
+    # Read before the load, not after, which is the whole of the reordering. The estimand needs
+    # exactly the treatment, the confounders, the outcome and the two join keys; the loader adds
+    # the last three itself, so the only names supplied here come from setup.yaml and nothing in
+    # this block depends on the panel. Loading first and projecting the finished frame - which is
+    # what this did - has already paid for every column. Measured on us_equities_panel/fwd_ret_1d,
+    # 2026-09-11: the projected load hands back 9,973,233 x 7 at 0.441 GiB for a process peak of
+    # 4.93 GiB, where the unprojected join is 74 columns whose numeric block alone is 5.39 GiB
+    # (computed from the three artifact schemas, not loaded - there was no headroom to load it
+    # beside a running notebook, so that figure is arithmetic and the two beside it are measured).
+    # `study.activate` still precedes both, because it resolves the `study.root` read below.
+    setup = yaml.safe_load((study.root / "config" / "setup.yaml").read_text()) or {}
+    causal = setup.get("causal") or {}
+    treatment = str(causal["treatment"])
+    confounders = tuple(str(value) for value in causal["confounders"])
     mds = load_modeling_dataset(
         study.case_study,
         label_ref.name,
         max_symbols=int(reductions.get("max_symbols", 0)),
+        columns=[treatment, *confounders],
     )
     if mds.date_col != "timestamp" or not mds.entity_cols:
         raise ValueError("DML runner requires timestamp and an entity key")
@@ -1385,10 +1400,6 @@ def resolve_causal_request(study: Study, request: dict[str, Any]):
         config = configs[request["config_name"]]
     except KeyError as error:
         raise ValueError(f"unknown DML configuration {request['config_name']!r}") from error
-    setup = yaml.safe_load((study.root / "config" / "setup.yaml").read_text()) or {}
-    causal = setup.get("causal") or {}
-    treatment = str(causal["treatment"])
-    confounders = tuple(str(value) for value in causal["confounders"])
     seed = int(config.get("seed", RANDOM_SEED))
     n_folds = int(reductions.get("n_folds", config.get("n_folds", 5)))
     n_placebo = int(reductions.get("n_placebo", config.get("n_placebo", 100)))
@@ -1592,7 +1603,12 @@ def resolve_causal_request(study: Study, request: dict[str, Any]):
     computation = {
         "label_artifact": {"digest": label_ref.digest, "name": label_ref.name},
         "feature_artifacts": mds.input_lineage["artifacts"],
-        "feature_names": list(mds.feature_names),
+        # The panel's own feature list, not the projected load's. The load above asks for the
+        # seven columns the estimand reads; recording those seven here instead would move this
+        # run's identity for a change that reads the same artifacts and computes the same
+        # estimate, re-keying every causal run already registered against the other case
+        # studies. `panel_feature_names` is what the unprojected load would have reported.
+        "feature_names": list(mds.panel_feature_names or mds.feature_names),
         "estimand": {
             "method": "walk_forward_dml",
             "outcome": mds.label_col,

--- a/tests/test_a_projection_does_not_move_the_recorded_identity.py
+++ b/tests/test_a_projection_does_not_move_the_recorded_identity.py
@@ -1,0 +1,183 @@
+"""A ``columns=`` projection narrows the load and must not narrow the recorded identity.
+
+``load_modeling_dataset`` derives ``feature_names`` from the joined frame, and that list is
+hashed into every registered run twice: directly as ``computation.feature_names`` and again
+inside ``computation.input_data_spec``, both of which ``training_hash_from_spec`` covers. So
+a caller that asks for seven of seventy-four columns to save memory would, without this,
+re-key every run its case study has registered - for a change that reads the same artifacts,
+retains the same values in the columns it keeps, and computes the same estimate.
+
+``build_modeling_input_lineage`` already states the rule for the same event in the other
+direction, about why ``feature_dtype`` is written only when it is not the default: a key that
+moves the fingerprint of a case study whose declaration did not change invalidates every run
+registered against it.
+
+The control is the last test. Without it, the fingerprint comparison would pass just as well
+against an implementation that projects nothing at all, which is the outcome the parameter
+exists to avoid.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+
+import polars as pl
+import pytest
+import yaml
+
+from tests.test_column_projection_happens_in_the_scan import (  # noqa: F401
+    CASE,
+    FEATURES,
+    TEMPORAL,
+    seeded_case_study,
+)
+
+PROJECTION = ["beta", "latent_2"]
+
+
+def _lineage(mds) -> dict:  # type: ignore[no-untyped-def]
+    return mds.input_lineage
+
+
+def test_a_projected_load_records_the_panels_feature_list_not_its_own(
+    seeded_case_study: Path,  # noqa: F811
+) -> None:
+    from utils.modeling import load_modeling_dataset
+
+    full = load_modeling_dataset(CASE, "fwd_ret_1d")
+    projected = load_modeling_dataset(CASE, "fwd_ret_1d", columns=PROJECTION)
+
+    # Order, not just membership: the payload is json.dumps(..., sort_keys=True), which sorts
+    # dict keys and leaves list order alone, so a reordering moves the fingerprint too.
+    assert projected.panel_feature_names == full.feature_names
+
+
+def test_a_projection_does_not_move_the_input_lineage_fingerprint(
+    seeded_case_study: Path,  # noqa: F811
+) -> None:
+    from utils.modeling import load_modeling_dataset
+
+    full = load_modeling_dataset(CASE, "fwd_ret_1d")
+    projected = load_modeling_dataset(CASE, "fwd_ret_1d", columns=PROJECTION)
+
+    assert _lineage(projected)["feature_names"] == _lineage(full)["feature_names"]
+    assert _lineage(projected)["fingerprint"] == _lineage(full)["fingerprint"]
+
+
+def test_feature_names_still_describes_the_frame_the_caller_was_handed(
+    seeded_case_study: Path,  # noqa: F811
+) -> None:
+    """The two lists are different things, and the projected load is where that shows."""
+    from utils.modeling import load_modeling_dataset
+
+    projected = load_modeling_dataset(CASE, "fwd_ret_1d", columns=PROJECTION)
+
+    assert set(projected.feature_names) == set(PROJECTION)
+    assert set(projected.panel_feature_names) == set(FEATURES) | set(TEMPORAL)
+    assert set(projected.feature_names) < set(projected.panel_feature_names)
+
+
+def test_an_unprojected_load_records_exactly_what_it_always_did(
+    seeded_case_study: Path,  # noqa: F811
+) -> None:
+    """The new field must be inert when nothing is projected, or it moves every fingerprint."""
+    from utils.modeling import load_modeling_dataset
+
+    full = load_modeling_dataset(CASE, "fwd_ret_1d")
+
+    assert full.panel_feature_names == full.feature_names
+    assert _lineage(full)["feature_names"] == full.feature_names
+
+
+def test_the_fingerprint_comparison_can_fail(seeded_case_study: Path) -> None:  # noqa: F811
+    """Control: the lineage fingerprint does move when the recorded feature list moves.
+
+    Without this, the equality above is satisfied by any implementation whose fingerprint is
+    insensitive to ``feature_names``, including one that never projects.
+    """
+    from utils.modeling import load_modeling_dataset
+
+    full = load_modeling_dataset(CASE, "fwd_ret_1d")
+    projected = load_modeling_dataset(CASE, "fwd_ret_1d", columns=PROJECTION)
+
+    # What the projected load WOULD have registered if the projection reached the identity.
+    projected.panel_feature_names = list(projected.feature_names)
+    projected._input_lineage = None  # noqa: SLF001 - re-derive under the narrowed list
+
+    assert projected.feature_names != full.feature_names
+    assert _lineage(projected)["fingerprint"] != _lineage(full)["fingerprint"]
+
+
+COLLIDING = "shared_name"
+
+
+def _seed_colliding(tmp_path: Path) -> None:
+    case_dir = tmp_path / CASE
+    (case_dir / "config").mkdir(parents=True, exist_ok=True)
+    (case_dir / "features").mkdir(exist_ok=True)
+    (case_dir / "labels").mkdir(exist_ok=True)
+    (case_dir / "config" / "setup.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "strategy_id": CASE,
+                "labels": {"primary": "fwd_ret_1d", "buffer": "1D"},
+                "evaluation": {
+                    "n_splits": 2,
+                    "train_size": "1Y",
+                    "val_size": "6M",
+                    "calendar": "NYSE",
+                    "periods_per_year": 252,
+                },
+            }
+        )
+    )
+    days = pl.date_range(date(2018, 1, 1), date(2021, 6, 30), interval="1d", eager=True)
+    rows: dict[str, list] = {"timestamp": [], "symbol": []}
+    for symbol in ("AAA", "BBB", "CCC"):
+        rows["timestamp"].extend(days.to_list())
+        rows["symbol"].extend([symbol] * len(days))
+    frame = pl.DataFrame(rows)
+    frame.with_columns([pl.lit(1.0).alias("beta"), pl.lit(2.0).alias(COLLIDING)]).write_parquet(
+        case_dir / "features" / "financial.parquet"
+    )
+    frame.with_columns([pl.lit(3.0).alias("latent_2"), pl.lit(4.0).alias(COLLIDING)]).write_parquet(
+        case_dir / "features" / "model_based.parquet"
+    )
+    frame.with_columns(pl.lit(0.01).alias("fwd_ret_1d")).write_parquet(
+        case_dir / "labels" / "fwd_ret_1d.parquet"
+    )
+
+
+def test_a_name_carried_by_both_artifacts_is_refused_rather_than_guessed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """polars suffixes the second one ``_t``, and its position is not recoverable here.
+
+    No case study has such a name - checked across all eight on 2026-09-11 - so a projected
+    load refuses rather than registering an identity that differs from the unprojected load's.
+    An unprojected load is unaffected, because it reads ``feature_names`` itself.
+    """
+    monkeypatch.setenv("ML4T_OUTPUT_DIR", str(tmp_path))
+    _seed_colliding(tmp_path)
+
+    import utils.modeling as modeling
+    from case_studies.utils import cv_window
+
+    monkeypatch.setattr(modeling, "load_feature_spec", lambda *_args: {})
+    monkeypatch.setattr(modeling, "load_label_spec", lambda *_args: {})
+    monkeypatch.setattr(
+        modeling,
+        "resolve_storage_path",
+        lambda _case_id, _spec, fallback: tmp_path / CASE / fallback,
+    )
+    cv_window._fold_splits.cache_clear()
+    cv_window._load_setup_yaml.cache_clear()
+    try:
+        modeling.load_modeling_dataset(CASE, "fwd_ret_1d")  # unprojected: still fine
+
+        with pytest.raises(ValueError, match=f"both carry.*{COLLIDING}"):
+            modeling.load_modeling_dataset(CASE, "fwd_ret_1d", columns=["beta"])
+    finally:
+        cv_window._fold_splits.cache_clear()
+        cv_window._load_setup_yaml.cache_clear()

--- a/tests/test_causal_adapter.py
+++ b/tests/test_causal_adapter.py
@@ -85,6 +85,10 @@ def _causal_fixture(
     mds = SimpleNamespace(
         dataset=frame,
         feature_names=["feature", "treatment", "confounder"],
+        # The resolver projects its load and records the panel's own list, so the double
+        # has to carry both. Equal here because this fixture stands in for an unprojected
+        # panel: the two differ only when a caller narrows the load.
+        panel_feature_names=["feature", "treatment", "confounder"],
         label_col="fwd_ret_8h",
         label_buffer=label_buffer,
         date_col="timestamp",
@@ -657,6 +661,10 @@ def _session_causal_fixture(tmp_path, monkeypatch):
     mds = SimpleNamespace(
         dataset=frame,
         feature_names=["feature", "treatment", "confounder"],
+        # The resolver projects its load and records the panel's own list, so the double
+        # has to carry both. Equal here because this fixture stands in for an unprojected
+        # panel: the two differ only when a caller narrows the load.
+        panel_feature_names=["feature", "treatment", "confounder"],
         label_col="fwd_ret_5d",
         label_buffer="5D",
         date_col="timestamp",
@@ -723,6 +731,10 @@ def _patch_modeling_dataset(monkeypatch, frame, buffer: str = "5D") -> None:
     mds = SimpleNamespace(
         dataset=frame,
         feature_names=["feature", "treatment", "confounder"],
+        # The resolver projects its load and records the panel's own list, so the double
+        # has to carry both. Equal here because this fixture stands in for an unprojected
+        # panel: the two differ only when a caller narrows the load.
+        panel_feature_names=["feature", "treatment", "confounder"],
         label_col="fwd_ret_5d",
         label_buffer=buffer,
         date_col="timestamp",

--- a/utils/modeling.py
+++ b/utils/modeling.py
@@ -245,6 +245,14 @@ class ModelingDataset:
     # None for regression labels. When set, the column lives in ``dataset`` and
     # downstream IC computation must use it instead of the binary ``label_col``.
     eval_label_col: str | None = None
+    # The feature list the panel carries, independent of any ``columns`` projection the load
+    # was asked for. ``feature_names`` describes the frame in ``dataset`` and narrows with the
+    # projection; this one describes the artifacts and does not, which is what the recorded
+    # identity has to read so a caller narrowing its own load does not re-key runs it never
+    # touched. Equal to ``feature_names`` whenever nothing was projected. Empty only on a
+    # ``ModelingDataset`` built by hand rather than by ``load_modeling_dataset``, where
+    # ``input_lineage`` falls back to ``feature_names`` and behaves exactly as it did before.
+    panel_feature_names: list[str] = field(default_factory=list)
     # Inputs ``input_lineage`` is derived from: the artifact paths and the
     # universe reduction, which are not otherwise recoverable from this object.
     lineage_inputs: dict[str, Any] = field(default_factory=dict, repr=False)
@@ -269,7 +277,7 @@ class ModelingDataset:
                 )
             self._input_lineage = build_modeling_input_lineage(
                 artifacts=self.lineage_inputs["artifacts"],
-                feature_names=self.feature_names,
+                feature_names=self.panel_feature_names or self.feature_names,
                 splits=self.splits,
                 label_buffer=self.label_buffer,
                 task_type=self.task_type,
@@ -899,6 +907,20 @@ def load_modeling_dataset(
     # literally: without the join keys the frames cannot be joined, without the label there is
     # nothing to model, and without ``fold`` the per-fold substitution has no key to select on.
     # That union is why the parameter belongs here instead of in each caller.
+    #
+    # The projection must not reach the recorded identity. ``feature_names`` below is derived
+    # from the joined frame, and it is hashed twice into every registered run - directly as
+    # ``computation.feature_names`` and again inside ``input_data_spec`` - so narrowing the load
+    # would re-key every run whose caller passed ``columns``, while the artifacts read and the
+    # values retained are identical. ``build_modeling_input_lineage`` already states the rule for
+    # the same event in the other direction, about adding ``feature_dtype``: a change that moves
+    # the fingerprint of a case study whose declaration did not change invalidates every run
+    # registered against it. So the panel's own feature list is recorded here, before the
+    # projection narrows the column lists, and ``panel_feature_names`` below is what the identity
+    # reads. What the caller asked for narrows the load and nothing else.
+    panel_feature_columns = list(feature_columns)
+    panel_temporal_columns = list(temporal_columns)
+
     if columns is not None:
         requested = list(dict.fromkeys(columns))
         known = set(feature_columns) | set(temporal_columns) | set(label_columns)
@@ -1041,6 +1063,46 @@ def load_modeling_dataset(
     # Feature columns = everything except IDs and label
     feature_names = [c for c in dataset.columns if c not in ID_COLS and c != label_col]
 
+    # The same list the unprojected load would have produced, reconstructed from the column
+    # lists captured before the projection. The joins concatenate left columns then the right
+    # frame's non-key columns, in source order, so the unprojected order is the three source
+    # lists in sequence under the same filters applied to ``feature_names`` above.
+    #
+    # The one case this reconstruction cannot express is a name carried by both the financial
+    # and the model-based artifact: polars would suffix the second ``_t`` and the position of
+    # the suffixed name is not recoverable from the source lists. No case study has one -
+    # checked across all eight on 2026-09-11 - so it is refused rather than guessed, and only
+    # when a projection is actually in play, because the unprojected path takes ``feature_names``
+    # itself and is exact by construction.
+    if columns is None:
+        panel_feature_names = list(feature_names)
+    else:
+        collisions = sorted(
+            (set(panel_feature_columns) & set(panel_temporal_columns)) - set(_temporal_keys)
+        )
+        if collisions:
+            raise ValueError(
+                f"{case_study_id}: the financial and model-based artifacts both carry "
+                f"{collisions}, so a projected load cannot reconstruct the panel's feature "
+                "order and would register an identity that differs from the unprojected "
+                "load's. Rename the duplicate column in one artifact, or load without "
+                "`columns`."
+            )
+        ordered = [
+            *panel_feature_columns,
+            *[c for c in panel_temporal_columns if c not in set(_temporal_keys) | {"fold"}],
+            *[c for c in label_columns if c not in set(join_cols)],
+        ]
+        seen: set[str] = set()
+        panel_feature_names = [
+            c
+            for c in ordered
+            if c not in ID_COLS
+            and c not in META_LEAK
+            and c != label_col
+            and not (c in seen or seen.add(c))
+        ]
+
     # CV splits — read buffer from setup.yaml (explicit, handles non-standard labels)
     setup = yaml.safe_load((case_dir / "config" / "setup.yaml").read_text())
     label_buffer = resolve_label_buffer(case_study_id, primary_label, setup)
@@ -1149,6 +1211,7 @@ def load_modeling_dataset(
         feature_names = [
             c for c in dataset.columns if c not in ID_COLS and c not in {label_col, eval_label_col}
         ]
+        panel_feature_names = [c for c in panel_feature_names if c != eval_label_col]
 
     input_artifacts = {
         "financial": features_path,
@@ -1176,6 +1239,7 @@ def load_modeling_dataset(
     return ModelingDataset(
         dataset=dataset,
         feature_names=feature_names,
+        panel_feature_names=panel_feature_names,
         label_col=label_col,
         date_col=date_col,
         entity_cols=entity_cols,


### PR DESCRIPTION
Based on `teaching/ch-12-shap-reduction`, which adds `columns=` to `load_modeling_dataset`. That branch deliberately left `case_studies/utils/causal.py` alone, because it resolves its column list from `setup.yaml` *after* the load, so using the parameter needs the function reordered. This is that change, plus the reason it could not be a one-line wiring.

## The projection re-keys the run

`columns=` pushes a projection into the parquet scans. It changes no rows and no retained value, so it reads as a pure memory optimization. It is not one for any caller that registers a run.

`feature_names` is derived from the joined frame (`utils/modeling.py:1005`), so a projection narrows it, and it is hashed into every registered run twice - as `computation.feature_names` and again inside `computation.input_data_spec` - both reached by `training_hash_from_spec`. Wiring the projection in as-is would have re-keyed **twenty registered `causal_runs` across seven case studies**, for a change that reads the same artifacts, keeps the same values in the columns it retains, and computes the same estimate. The lane doing the wiring is not the lane that pays: `us_equities_panel` holds none of the twenty.

`build_modeling_input_lineage` already ruled on this shape in the other direction, in its note on why `feature_dtype` is written only when it is not the default: a key that moves the fingerprint of a case study whose declaration did not change invalidates every run registered against it, and "any future default must be added the same way, for the same reason". A projection narrowing the recorded list is the same event.

## What changed

- **`ModelingDataset.panel_feature_names`** - the feature list the artifacts carry, independent of what one caller chose to read. `input_lineage` and the causal spec read it; `feature_names` still describes the frame the caller was handed, which is what its other consumers want. Defaults empty, so hand-built `ModelingDataset` objects behave exactly as before.
- It is reconstructed from the column lists captured *before* the projection. The one shape that reconstruction cannot express - a name carried by both the financial and the model-based artifact, which polars would suffix `_t` at a position not recoverable from the source lists - raises rather than guesses. No case study has one; checked across all eight.
- **`resolve_causal_request` moves four lines.** `setup`, `causal`, `treatment` and `confounders` are read before the load rather than after it, still behind `study.activate(tier)` because that resolves the `study.root` they read. Nothing in that block depends on the panel, which is why the reordering is available at all. The loader adds the date, entity and label columns itself, so the request is just the treatment and the confounders.

## Measured

On `us_equities_panel/fwd_ret_1d`, 2026-09-11: the projected load hands back 9,973,233 x 7 at 0.441 GiB for a process peak of **4.93 GiB**. The unprojected join is 74 columns whose numeric block alone is 5.39 GiB - that second figure is arithmetic from the three artifact schemas, **not a measurement**, because there was no headroom to load it beside a running notebook. The full-scale cost this targets is 17.6 GiB on `14_causal_dml`.

## Verification

The identity claim does not rest on the unit tests. Against **four registered production runs** - three `fx_pairs` labels and `us_firm_characteristics`, which has no model-based artifact at all - a projected load reproduces the stored `spec_json`'s `computation.feature_names`, its `input_data_spec.feature_names` and its fingerprint exactly, while narrowing the load to 7 columns of 63 and 57 features respectively. The same check confirms each stored spec rehashes to its registered `causal_hash`, so the comparison is against the registry's own hashing rather than a reimplementation of it.

Six new tests, with the control that matters last: the fingerprint equality would be satisfied by an implementation that never projects, so one test narrows the recorded list by hand and asserts the fingerprint *does* move. Mutation-tested - pointing `input_lineage` back at `feature_names` fails the fingerprint test with the narrowed list in the assertion.

| suite | result |
|---|---|
| projection + identity (new file) | 12 passed |
| causal resolver | 63 passed |
| loader / sidecar / storage-dtype / fold coverage | 58 passed |
| linear resolver | 77 passed |
| folds, CV windows, artifact specs, model planning | 52 passed |

`tests/test_causal_adapter.py` fakes the modeling dataset with three `SimpleNamespace` doubles that did not carry the new field, so the resolver raised `AttributeError` against them. The doubles are fixed rather than the production read defended with `getattr`: a double missing an attribute the code under test reads is the defect, and a default would have made the next missing field silent.

## Merge order

Stacked on `teaching/ch-12-shap-reduction`. CI workflows filter on `base: main`, so this PR will show **zero checks** until its base merges - that is unmergeable rather than pending. Merge the chapter-12 PR first, then this one retargets to `main` and gets a real run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
