### PR TITLE
Ask the input-artifact vintage question before the chain is queued

### DIFF
--- a/case_studies/utils/registry/registration.py
+++ b/case_studies/utils/registry/registration.py
@@ -8,6 +8,7 @@ import os
 import shutil
 import sqlite3
 import uuid
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -197,7 +198,39 @@ def _enforce_input_artifact_vintage(db, spec: dict) -> None:
     incoming = _input_artifact_shas(spec)
     if not incoming or not label:
         return
-    registered = _registered_artifact_shas(db, label=str(label))
+    for conflict in input_artifact_vintage_conflicts(db, label=str(label), incoming=incoming):
+        raise ValueError(conflict.message)
+
+
+@dataclass(frozen=True)
+class ArtifactVintageConflict:
+    """One artifact whose on-disk vintage the population does not carry and nothing retires."""
+
+    artifact_name: str
+    label: str
+    sha256: str
+    undeclared: tuple[str, ...]
+    message: str
+
+
+def input_artifact_vintage_conflicts(
+    db, *, label: str, incoming: dict[str, str]
+) -> list[ArtifactVintageConflict]:
+    """The refusals :func:`_enforce_input_artifact_vintage` would raise, as values.
+
+    Separated from the raise so the same question can be asked BEFORE a chain is queued.
+    The refusal costs a launch rather than a fit - ``register_training_run`` runs ahead of
+    the fit on every path - but it still stops the chain ten seconds in, and until
+    ``scripts/check_input_artifact_vintage.py`` existed the only warning was that stop
+    (ml4t/agent-workspace#1123).
+
+    The pre-flight has to ask THIS function rather than its own version of the comparison.
+    A check that re-implements the rule can disagree with it, and a pre-flight that passes
+    where registration refuses is worse than no pre-flight: it is a green light for a chain
+    that will not run.
+    """
+    conflicts: list[ArtifactVintageConflict] = []
+    registered = _registered_artifact_shas(db, label=label)
     for name, sha in incoming.items():
         known = registered.get(name)
         if not known or sha in known:
@@ -209,16 +242,26 @@ def _enforce_input_artifact_vintage(db, spec: dict) -> None:
         )
         if not undeclared:
             continue
-        raise ValueError(
-            f"input artifact {name!r} on disk hashes {sha}, but every training run "
-            f"registered for label {label!r} was fitted on {undeclared if len(undeclared) > 1 else undeclared[0]}. "
-            f"Registering this run would put two vintages of one artifact in the same "
-            f"population with nothing recording it. If the artifact was regenerated on "
-            f"purpose, declare it: declare_artifact_supersession(case_study, {name!r}, "
-            f"sha256={sha!r}, supersedes_sha256={undeclared[0]!r}). If it was not, the "
-            f"artifact on disk is not the one this population was built from - restore it "
-            f"rather than fitting on it."
+        conflicts.append(
+            ArtifactVintageConflict(
+                artifact_name=name,
+                label=label,
+                sha256=sha,
+                undeclared=tuple(undeclared),
+                message=(
+                    f"input artifact {name!r} on disk hashes {sha}, but every training run "
+                    f"registered for label {label!r} was fitted on "
+                    f"{undeclared if len(undeclared) > 1 else undeclared[0]}. "
+                    f"Registering this run would put two vintages of one artifact in the same "
+                    f"population with nothing recording it. If the artifact was regenerated on "
+                    f"purpose, declare it: declare_artifact_supersession(case_study, {name!r}, "
+                    f"sha256={sha!r}, supersedes_sha256={undeclared[0]!r}). If it was not, the "
+                    f"artifact on disk is not the one this population was built from - restore "
+                    f"it rather than fitting on it."
+                ),
+            )
         )
+    return conflicts
 
 
 def declare_artifact_supersession(

--- a/scripts/check_input_artifact_vintage.py
+++ b/scripts/check_input_artifact_vintage.py
@@ -26,14 +26,22 @@ condition is narrower: the sha on disk differs from what the registry's runs pin
 pre-flight that passes where registration refuses is a green light for a chain that will not
 run.
 
-**An artifact it cannot resolve is reported, not skipped.** The registry pins a sha per
-artifact NAME, and three names address a file this script can locate from the case study's
-own specs: ``financial``, ``model_based`` and ``label``. ``eval_label`` needs the
-classification mapping in ``config/setup.yaml`` and is resolved through the same function the
-loader uses. Anything else - the latent adapter records a ``files`` list rather than an
-``artifacts`` mapping (ml4t/agent-workspace#891) - is counted and named as unchecked, because
-a checker that answers green for what it did not look at is the failure this whole class is
-about.
+**What is NOT checked is reported, because a checker that answers green for what it did not
+look at is the failure this whole class is about.** Two things fall outside.
+
+An artifact NAME it cannot locate: three resolve from the case study's own specs
+(``financial``, ``model_based``, ``label``) and ``eval_label`` through the classification
+mapping the loader uses. Any other name is reported ``unresolved``.
+
+A training run whose spec records its inputs in a shape ``_input_artifact_shas`` does not
+read, reported ``unchecked`` per family. It reads ``computation.input_data_spec.artifacts``,
+and measured across the nine live registries on 2026-09-11 that misses 121 runs: 45
+``latent_factors`` runs record ``input_data_spec.files``, a list of ``{role, sha256}`` with a
+``sha256:`` prefix (ml4t/agent-workspace#891), and 76 ``deep_learning`` runs nest the payload
+one level deeper, at ``input_data_spec.input_data_spec.artifacts``. **Those runs are not
+vintage-checked by registration either**, so this script reports them rather than reading
+them: a pre-flight stricter than the rule it previews would refuse a chain registration would
+accept, which is a different failure and a worse one. The enforcement gap is filed separately.
 
 Usage::
 
@@ -58,6 +66,8 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 from case_studies.utils.registry.registration import (  # noqa: E402
+    _declared_artifact_supersessions,
+    _input_artifact_shas,
     _registered_artifact_shas,
     input_artifact_vintage_conflicts,
 )
@@ -73,7 +83,15 @@ class Finding:
     case_study: str
     label: str
     artifact: str
-    status: str  # "current" | "superseded" | "undeclared" | "unresolved" | "absent"
+    # current            the runs for this label were fitted on the file that is on disk
+    # superseded         the disk vintage is pinned and every other pinned one is retired
+    # mixed              the disk vintage is pinned and another one is not retired
+    # accepted_replacement  the disk vintage is pinned by no run yet and retires every pinned one
+    # undeclared         registration would refuse this run
+    # unresolved         an artifact name this script cannot locate
+    # unchecked          a run whose inputs are recorded in a shape the rule does not read
+    # absent             pinned by a run and not on disk
+    status: str
     on_disk: str | None
     pinned: tuple[str, ...]
     detail: str
@@ -126,6 +144,51 @@ def _artifact_path(case_dir: Path, case_study: str, name: str, label: str) -> Pa
     return None
 
 
+def _unread_input_shapes(con: sqlite3.Connection, case_study: str) -> list[Finding]:
+    """Runs whose recorded inputs ``_input_artifact_shas`` returns nothing for.
+
+    Silence here would be the same defect one level up: the rule reads
+    ``computation.input_data_spec.artifacts``, two producers record somewhere else, and a
+    checker that only walks what the rule returns reports a registry of nothing but those
+    runs as entirely clean.
+    """
+    try:
+        rows = list(con.execute("SELECT family, label, spec_json FROM training_runs"))
+    except sqlite3.DatabaseError:
+        return []
+    unread: dict[tuple[str, str], int] = {}
+    for family, label, spec_json in rows:
+        if _input_artifact_shas(spec_json):
+            continue
+        try:
+            nested = (json.loads(spec_json) or {}).get("computation", {}).get("input_data_spec", {})
+        except (TypeError, ValueError):
+            nested = {}
+        if "files" in nested:
+            shape = "input_data_spec.files"
+        elif isinstance(nested.get("input_data_spec"), dict):
+            shape = "input_data_spec.input_data_spec.artifacts"
+        else:
+            shape = "no artifact shas recorded"
+        unread[(str(family), shape)] = unread.get((str(family), shape), 0) + 1
+    return [
+        Finding(
+            case_study=case_study,
+            label="",
+            artifact=family,
+            status="unchecked",
+            on_disk=None,
+            pinned=(),
+            detail=(
+                f"{count} {family} run(s) record their inputs at {shape}, which the vintage "
+                "rule does not read, so registration does not check their vintage either and "
+                "neither does this"
+            ),
+        )
+        for (family, shape), count in sorted(unread.items())
+    ]
+
+
 def check_case_study(
     case_study: str, *, artifacts_root: Path, digests: dict[Path, str] | None = None
 ) -> list[Finding]:
@@ -163,6 +226,7 @@ def check_case_study(
                     detail=f"registry unreadable: {exc}",
                 )
             ]
+        findings.extend(_unread_input_shapes(con, case_study))
         for label in labels:
             registered = _registered_artifact_shas(con, label=label)
             incoming: dict[str, str] = {}
@@ -220,22 +284,29 @@ def check_case_study(
                             detail=conflicts[name].message,
                         )
                     )
-                elif on_disk in pinned and len(pinned) > 1:
+                    continue
+                # Not a conflict, which leaves three distinguishable states. Lumping them
+                # under "current" claimed runs had been fitted on a file no run had touched,
+                # and --quiet then hid it.
+                retired = _declared_artifact_supersessions(con, artifact_name=name, sha256=on_disk)
+                others = tuple(sha for sha in pinned if sha != on_disk)
+                if on_disk not in pinned:
                     findings.append(
                         Finding(
                             case_study=case_study,
                             label=label,
                             artifact=name,
-                            status="superseded",
+                            status="accepted_replacement",
                             on_disk=on_disk,
                             pinned=pinned,
                             detail=(
-                                f"the registry holds {len(pinned)} vintages and the runs fitted "
-                                "on the others are retired by a declared supersession"
+                                "no run for this label was fitted on the file now on disk; "
+                                f"a declaration retires the {len(pinned)} vintage(s) that were, "
+                                "so registration accepts the next run"
                             ),
                         )
                     )
-                else:
+                elif not others:
                     findings.append(
                         Finding(
                             case_study=case_study,
@@ -245,6 +316,38 @@ def check_case_study(
                             on_disk=on_disk,
                             pinned=pinned,
                             detail="the runs registered for this label were fitted on this file",
+                        )
+                    )
+                elif all(sha in retired for sha in others):
+                    findings.append(
+                        Finding(
+                            case_study=case_study,
+                            label=label,
+                            artifact=name,
+                            status="superseded",
+                            on_disk=on_disk,
+                            pinned=pinned,
+                            detail=(
+                                f"the registry holds {len(pinned)} vintages, and a declaration "
+                                "retires every one the disk vintage replaced"
+                            ),
+                        )
+                    )
+                else:
+                    findings.append(
+                        Finding(
+                            case_study=case_study,
+                            label=label,
+                            artifact=name,
+                            status="mixed",
+                            on_disk=on_disk,
+                            pinned=pinned,
+                            detail=(
+                                f"the registry holds {len(pinned)} vintages and nothing retires "
+                                f"{', '.join(sha[:8] for sha in others if sha not in retired)}. "
+                                "Registration stays silent because the file on disk is one of "
+                                "them, so the mixture is already in the population"
+                            ),
                         )
                     )
     finally:
@@ -297,7 +400,16 @@ def main(argv: list[str] | None = None) -> int:
             print(f"            {finding.detail}")
         counts = {
             status: sum(f.status == status for f in findings)
-            for status in ("current", "superseded", "undeclared", "unresolved", "absent")
+            for status in (
+                "current",
+                "superseded",
+                "mixed",
+                "accepted_replacement",
+                "undeclared",
+                "unresolved",
+                "unchecked",
+                "absent",
+            )
         }
         print(
             f"{len(findings)} artifact/label pair(s): "

--- a/scripts/check_input_artifact_vintage.py
+++ b/scripts/check_input_artifact_vintage.py
@@ -1,0 +1,311 @@
+#!/usr/bin/env python3
+"""Every input artifact on disk is a vintage the registry's runs were fitted on.
+
+A kept-registry case study has four pre-flight resolutions that can refuse a run: input
+artifact vintage, population hash, causal identity, and candidate sets.
+``scripts/check_supersedes_literals.py`` covers the last three. This covers the first, which
+until now had no warning but the run itself stopping (ml4t/agent-workspace#1123).
+
+``_enforce_input_artifact_vintage`` refuses a run that would join a population fitted on a
+different vintage of the same input artifact. Regenerate a stage-03 or stage-04 artifact and
+every later run refuses until ``declare_artifact_supersession`` records which sha the new one
+replaces. On 2026-09-10 ``us_equities_panel/06_linear`` hit exactly that at plan time:
+``model_based.parquet`` on disk hashed ``0e74d15f`` while the registered training runs for
+``fwd_ret_1d`` had been fitted against ``86ece972``.
+
+**What this costs and what it saves, because the two differ from the other three.** This
+refusal fires BEFORE the fit - ``register_training_run`` runs ahead of it on every path - so
+it costs a launch and a queue slot rather than compute. The value is not a loss prevented but
+a chain that can be queued knowing it will not stop ten seconds in.
+
+**The declared supersession is what makes a second vintage legitimate**, so a check that read
+only the disk and the runs would report every deliberate regeneration as a defect. The
+condition is narrower: the sha on disk differs from what the registry's runs pin, *and*
+``artifact_supersessions`` holds no row retiring the pinned one. That is
+``input_artifact_vintage_conflicts``, and this script calls it rather than restating it - a
+pre-flight that passes where registration refuses is a green light for a chain that will not
+run.
+
+**An artifact it cannot resolve is reported, not skipped.** The registry pins a sha per
+artifact NAME, and three names address a file this script can locate from the case study's
+own specs: ``financial``, ``model_based`` and ``label``. ``eval_label`` needs the
+classification mapping in ``config/setup.yaml`` and is resolved through the same function the
+loader uses. Anything else - the latent adapter records a ``files`` list rather than an
+``artifacts`` mapping (ml4t/agent-workspace#891) - is counted and named as unchecked, because
+a checker that answers green for what it did not look at is the failure this whole class is
+about.
+
+Usage::
+
+    python scripts/check_input_artifact_vintage.py                    # every case study
+    python scripts/check_input_artifact_vintage.py --case-study etfs  # one
+    python scripts/check_input_artifact_vintage.py --json
+
+Exits non-zero when any artifact is on an undeclared vintage.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from case_studies.utils.registry.registration import (  # noqa: E402
+    _registered_artifact_shas,
+    input_artifact_vintage_conflicts,
+)
+from utils.artifact_specs import load_feature_spec, load_label_spec  # noqa: E402
+from utils.modeling import (
+    _sha256_file,  # noqa: E402
+    get_classification_eval_label,  # noqa: E402
+)
+
+
+@dataclass(frozen=True)
+class Finding:
+    case_study: str
+    label: str
+    artifact: str
+    status: str  # "current" | "superseded" | "undeclared" | "unresolved" | "absent"
+    on_disk: str | None
+    pinned: tuple[str, ...]
+    detail: str
+
+    @property
+    def is_failure(self) -> bool:
+        return self.status == "undeclared"
+
+
+def _default_artifacts_root() -> Path:
+    return Path.home() / "ml4t" / "artifacts" / "case_studies"
+
+
+def _relative(spec: dict | None, default: str) -> str:
+    """Where the producer was told to write it, defaulting to the canonical layout.
+
+    ``utils.artifact_specs.resolve_storage_path`` joins this to ``get_case_study_dir``, which
+    answers with the WORKTREE's case_studies/<id>. The artifacts are not there - a checkout
+    carries a gitignored ``run_log`` symlink and no features or labels at all - so the
+    relative half is taken from the spec and joined to the artifacts root instead.
+    """
+    if spec is None:
+        return default
+    return str((spec.get("storage") or {}).get("path", default))
+
+
+def _artifact_path(case_dir: Path, case_study: str, name: str, label: str) -> Path | None:
+    if name == "financial":
+        return case_dir / _relative(
+            load_feature_spec(case_study, "financial"), "features/financial.parquet"
+        )
+    if name == "model_based":
+        return case_dir / _relative(
+            load_feature_spec(case_study, "model_based"), "features/model_based.parquet"
+        )
+    if name == "label":
+        return case_dir / _relative(load_label_spec(case_study, label), f"labels/{label}.parquet")
+    if name == "eval_label":
+        try:
+            eval_label = get_classification_eval_label(case_study, label)
+        except (KeyError, ValueError, OSError):
+            # KeyError: the label is a regression target and declares no eval label, which is
+            # the common case. OSError: no setup.yaml, which is every synthetic case study.
+            # Either way the name cannot be located, and the caller reports it as unchecked
+            # rather than passing it.
+            return None
+        return case_dir / _relative(
+            load_label_spec(case_study, eval_label), f"labels/{eval_label}.parquet"
+        )
+    return None
+
+
+def check_case_study(
+    case_study: str, *, artifacts_root: Path, digests: dict[Path, str] | None = None
+) -> list[Finding]:
+    digests = {} if digests is None else digests
+    case_dir = artifacts_root / case_study
+    db_path = case_dir / "run_log" / "registry.db"
+    if not db_path.is_file():
+        return []
+
+    def sha(path: Path) -> str | None:
+        if not path.is_file():
+            return None
+        if path not in digests:
+            digests[path] = _sha256_file(path)
+        return digests[path]
+
+    findings: list[Finding] = []
+    con = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+    try:
+        try:
+            labels = sorted(
+                str(row[0])
+                for row in con.execute("SELECT DISTINCT label FROM training_runs")
+                if row[0]
+            )
+        except sqlite3.DatabaseError as exc:
+            return [
+                Finding(
+                    case_study=case_study,
+                    label="",
+                    artifact="",
+                    status="unresolved",
+                    on_disk=None,
+                    pinned=(),
+                    detail=f"registry unreadable: {exc}",
+                )
+            ]
+        for label in labels:
+            registered = _registered_artifact_shas(con, label=label)
+            incoming: dict[str, str] = {}
+            for name, pinned in sorted(registered.items()):
+                path = _artifact_path(case_dir, case_study, name, label)
+                if path is None:
+                    findings.append(
+                        Finding(
+                            case_study=case_study,
+                            label=label,
+                            artifact=name,
+                            status="unresolved",
+                            on_disk=None,
+                            pinned=tuple(sorted(pinned)),
+                            detail=(
+                                f"{len(pinned)} sha(s) pinned for an artifact name this script "
+                                "cannot locate, so its vintage is unchecked"
+                            ),
+                        )
+                    )
+                    continue
+                on_disk = sha(path)
+                if on_disk is None:
+                    findings.append(
+                        Finding(
+                            case_study=case_study,
+                            label=label,
+                            artifact=name,
+                            status="absent",
+                            on_disk=None,
+                            pinned=tuple(sorted(pinned)),
+                            detail=f"{path} is pinned by {len(pinned)} run(s) and is not on disk",
+                        )
+                    )
+                    continue
+                incoming[name] = on_disk
+
+            conflicts = {
+                conflict.artifact_name: conflict
+                for conflict in input_artifact_vintage_conflicts(
+                    con, label=label, incoming=incoming
+                )
+            }
+            for name, on_disk in incoming.items():
+                pinned = tuple(sorted(registered.get(name, set())))
+                if name in conflicts:
+                    findings.append(
+                        Finding(
+                            case_study=case_study,
+                            label=label,
+                            artifact=name,
+                            status="undeclared",
+                            on_disk=on_disk,
+                            pinned=pinned,
+                            detail=conflicts[name].message,
+                        )
+                    )
+                elif on_disk in pinned and len(pinned) > 1:
+                    findings.append(
+                        Finding(
+                            case_study=case_study,
+                            label=label,
+                            artifact=name,
+                            status="superseded",
+                            on_disk=on_disk,
+                            pinned=pinned,
+                            detail=(
+                                f"the registry holds {len(pinned)} vintages and the runs fitted "
+                                "on the others are retired by a declared supersession"
+                            ),
+                        )
+                    )
+                else:
+                    findings.append(
+                        Finding(
+                            case_study=case_study,
+                            label=label,
+                            artifact=name,
+                            status="current",
+                            on_disk=on_disk,
+                            pinned=pinned,
+                            detail="the runs registered for this label were fitted on this file",
+                        )
+                    )
+    finally:
+        con.close()
+    return findings
+
+
+def check_all(*, artifacts_root: Path, only: str | None = None) -> list[Finding]:
+    if not artifacts_root.is_dir():
+        return []
+    names = (
+        [only]
+        if only
+        else sorted(p.name for p in artifacts_root.iterdir() if (p / "run_log").is_dir())
+    )
+    digests: dict[Path, str] = {}
+    findings: list[Finding] = []
+    for name in names:
+        findings.extend(check_case_study(name, artifacts_root=artifacts_root, digests=digests))
+    return findings
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--case-study", default=None, help="check one instead of all")
+    parser.add_argument(
+        "--artifacts-root",
+        type=Path,
+        default=_default_artifacts_root(),
+        help="where the per-case-study run_log/ directories live",
+    )
+    parser.add_argument("--json", action="store_true", help="emit findings as JSON")
+    parser.add_argument(
+        "--quiet",
+        action="store_true",
+        help="print only the artifacts that are not on a vintage the registry carries",
+    )
+    args = parser.parse_args(argv)
+
+    findings = check_all(artifacts_root=args.artifacts_root, only=args.case_study)
+
+    if args.json:
+        print(json.dumps([asdict(f) for f in findings], indent=1, default=list))
+    else:
+        for finding in findings:
+            if args.quiet and finding.status == "current":
+                continue
+            head = f"{finding.status.upper():<11} {finding.case_study}/{finding.label}"
+            print(f"{head}  {finding.artifact}")
+            print(f"            {finding.detail}")
+        counts = {
+            status: sum(f.status == status for f in findings)
+            for status in ("current", "superseded", "undeclared", "unresolved", "absent")
+        }
+        print(
+            f"{len(findings)} artifact/label pair(s): "
+            + ", ".join(f"{n} {status}" for status, n in counts.items() if n)
+        )
+
+    return 1 if any(f.is_failure for f in findings) else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_input_artifact_vintage_check.py
+++ b/tests/test_input_artifact_vintage_check.py
@@ -1,0 +1,149 @@
+"""The vintage pre-flight reports the state registration would refuse, and only that.
+
+Both outcomes matter and for different reasons. A checker that never reports a conflict is
+the state ml4t/agent-workspace#1123 describes - the run stopping is the only warning. One
+that reports every second vintage is worse than useless on a repository where regenerating an
+artifact is a normal, declared operation: it would be red on `us_equities_panel` today, where
+`model_based` carries two vintages and a declaration retires the older.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from scripts.check_input_artifact_vintage import check_case_study, main
+
+CASE_STUDY = "vintage_fixture"
+LABEL = "fwd_ret_1d"
+
+
+def _sha256_of(path: Path) -> str:
+    digest = hashlib.sha256()
+    digest.update(path.read_bytes())
+    return digest.hexdigest()
+
+
+def _registry(db_path: Path, *, artifact_shas: dict[str, str], supersessions=()) -> None:
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    con = sqlite3.connect(db_path)
+    con.execute("CREATE TABLE training_runs (training_hash TEXT, label TEXT, spec_json TEXT)")
+    con.execute(
+        "CREATE TABLE artifact_supersessions "
+        "(artifact_name TEXT, sha256 TEXT, supersedes_sha256 TEXT)"
+    )
+    spec = {
+        "label": LABEL,
+        "computation": {
+            "input_data_spec": {
+                "artifacts": {
+                    name: {"sha256": sha, "size": 1} for name, sha in artifact_shas.items()
+                }
+            }
+        },
+    }
+    con.execute("INSERT INTO training_runs VALUES (?,?,?)", ("hash-1", LABEL, json.dumps(spec)))
+    for name, sha, supersedes in supersessions:
+        con.execute("INSERT INTO artifact_supersessions VALUES (?,?,?)", (name, sha, supersedes))
+    con.commit()
+    con.close()
+
+
+@pytest.fixture
+def artifacts_root(tmp_path: Path) -> Path:
+    root = tmp_path / "case_studies"
+    features = root / CASE_STUDY / "features"
+    labels = root / CASE_STUDY / "labels"
+    features.mkdir(parents=True)
+    labels.mkdir(parents=True)
+    (features / "financial.parquet").write_bytes(b"financial-v1")
+    (features / "model_based.parquet").write_bytes(b"model-based-v2")
+    (labels / f"{LABEL}.parquet").write_bytes(b"label-v1")
+    return root
+
+
+def _on_disk(root: Path) -> dict[str, str]:
+    base = root / CASE_STUDY
+    return {
+        "financial": _sha256_of(base / "features" / "financial.parquet"),
+        "model_based": _sha256_of(base / "features" / "model_based.parquet"),
+        "label": _sha256_of(base / "labels" / f"{LABEL}.parquet"),
+    }
+
+
+def _statuses(findings) -> dict[str, str]:
+    return {f.artifact: f.status for f in findings}
+
+
+def test_a_registry_fitted_on_what_is_on_disk_reports_current(artifacts_root):
+    db = artifacts_root / CASE_STUDY / "run_log" / "registry.db"
+    _registry(db, artifact_shas=_on_disk(artifacts_root))
+
+    findings = check_case_study(CASE_STUDY, artifacts_root=artifacts_root)
+
+    assert _statuses(findings) == {
+        "financial": "current",
+        "model_based": "current",
+        "label": "current",
+    }
+    assert not any(f.is_failure for f in findings)
+
+
+def test_a_regenerated_artifact_with_no_declaration_is_reported(artifacts_root):
+    """The `us_equities_panel/06_linear` state of 2026-09-10, before the declaration."""
+    shas = _on_disk(artifacts_root) | {"model_based": "0" * 64}
+    db = artifacts_root / CASE_STUDY / "run_log" / "registry.db"
+    _registry(db, artifact_shas=shas)
+
+    findings = check_case_study(CASE_STUDY, artifacts_root=artifacts_root)
+
+    assert _statuses(findings)["model_based"] == "undeclared"
+    failure = next(f for f in findings if f.is_failure)
+    assert failure.pinned == ("0" * 64,)
+    assert failure.on_disk == _on_disk(artifacts_root)["model_based"]
+    assert "declare_artifact_supersession" in failure.detail
+    assert main(["--case-study", CASE_STUDY, "--artifacts-root", str(artifacts_root)]) == 1
+
+
+def test_a_declared_supersession_makes_the_second_vintage_legitimate(artifacts_root):
+    disk = _on_disk(artifacts_root)
+    retired = "0" * 64
+    db = artifacts_root / CASE_STUDY / "run_log" / "registry.db"
+    _registry(
+        db,
+        artifact_shas=disk | {"model_based": retired},
+        supersessions=[("model_based", disk["model_based"], retired)],
+    )
+
+    findings = check_case_study(CASE_STUDY, artifacts_root=artifacts_root)
+
+    # The run pins only the retired sha, so the disk vintage is not among the pinned set and
+    # the declaration is the whole reason this is not a conflict.
+    assert not any(f.is_failure for f in findings)
+    assert main(["--case-study", CASE_STUDY, "--artifacts-root", str(artifacts_root)]) == 0
+
+
+def test_an_artifact_the_registry_pins_and_disk_lacks_is_reported_not_ignored(artifacts_root):
+    shas = _on_disk(artifacts_root) | {"model_based": "0" * 64}
+    (artifacts_root / CASE_STUDY / "features" / "model_based.parquet").unlink()
+    db = artifacts_root / CASE_STUDY / "run_log" / "registry.db"
+    _registry(db, artifact_shas=shas)
+
+    findings = check_case_study(CASE_STUDY, artifacts_root=artifacts_root)
+
+    assert _statuses(findings)["model_based"] == "absent"
+
+
+def test_an_artifact_name_that_cannot_be_located_is_reported_not_skipped(artifacts_root):
+    """A checker that answers green for what it did not look at is this defect class."""
+    db = artifacts_root / CASE_STUDY / "run_log" / "registry.db"
+    _registry(db, artifact_shas=_on_disk(artifacts_root) | {"latent_files": "0" * 64})
+
+    findings = check_case_study(CASE_STUDY, artifacts_root=artifacts_root)
+
+    assert _statuses(findings)["latent_files"] == "unresolved"
+    assert "unchecked" in next(f for f in findings if f.artifact == "latent_files").detail

--- a/tests/test_input_artifact_vintage_check.py
+++ b/tests/test_input_artifact_vintage_check.py
@@ -28,10 +28,15 @@ def _sha256_of(path: Path) -> str:
     return digest.hexdigest()
 
 
-def _registry(db_path: Path, *, artifact_shas: dict[str, str], supersessions=()) -> None:
+def _registry(
+    db_path: Path, *, artifact_shas: dict[str, str], supersessions=(), extra_runs=()
+) -> None:
     db_path.parent.mkdir(parents=True, exist_ok=True)
+    db_path.unlink(missing_ok=True)
     con = sqlite3.connect(db_path)
-    con.execute("CREATE TABLE training_runs (training_hash TEXT, label TEXT, spec_json TEXT)")
+    con.execute(
+        "CREATE TABLE training_runs (training_hash TEXT, family TEXT, label TEXT, spec_json TEXT)"
+    )
     con.execute(
         "CREATE TABLE artifact_supersessions "
         "(artifact_name TEXT, sha256 TEXT, supersedes_sha256 TEXT)"
@@ -46,11 +51,45 @@ def _registry(db_path: Path, *, artifact_shas: dict[str, str], supersessions=())
             }
         },
     }
-    con.execute("INSERT INTO training_runs VALUES (?,?,?)", ("hash-1", LABEL, json.dumps(spec)))
+    con.execute(
+        "INSERT INTO training_runs VALUES (?,?,?,?)", ("hash-1", "gbm", LABEL, json.dumps(spec))
+    )
+    for training_hash, family, run_spec in extra_runs:
+        con.execute(
+            "INSERT INTO training_runs VALUES (?,?,?,?)",
+            (training_hash, family, LABEL, json.dumps(run_spec)),
+        )
     for name, sha, supersedes in supersessions:
         con.execute("INSERT INTO artifact_supersessions VALUES (?,?,?)", (name, sha, supersedes))
     con.commit()
     con.close()
+
+
+# The two shapes the vintage rule does not read, copied from the live registries rather than
+# invented: an etfs latent_factors run and an etfs deep_learning run, 2026-09-11.
+LATENT_SPEC = {
+    "label": LABEL,
+    "computation": {
+        "input_data_spec": {
+            "files": [
+                {"role": "financial", "sha256": "sha256:" + "a" * 64},
+                {"role": "label", "sha256": "sha256:" + "b" * 64},
+            ],
+            "input_digest": "sha256:" + "c" * 64,
+            "version": "v2",
+        }
+    },
+}
+DEEP_LEARNING_SPEC = {
+    "label": LABEL,
+    "computation": {
+        "input_data_spec": {
+            "input_data_spec": {"artifacts": {"financial": {"sha256": "d" * 64, "size": 1}}},
+            "lookback": 60,
+            "max_train_sequences": 0,
+        }
+    },
+}
 
 
 @pytest.fixture
@@ -122,9 +161,69 @@ def test_a_declared_supersession_makes_the_second_vintage_legitimate(artifacts_r
     findings = check_case_study(CASE_STUDY, artifacts_root=artifacts_root)
 
     # The run pins only the retired sha, so the disk vintage is not among the pinned set and
-    # the declaration is the whole reason this is not a conflict.
+    # the declaration is the whole reason this is not a conflict. It is NOT "current": no run
+    # was fitted on the file that is on disk, and saying so hid the replacement under --quiet.
     assert not any(f.is_failure for f in findings)
+    assert _statuses(findings)["model_based"] == "accepted_replacement"
+    detail = next(f for f in findings if f.artifact == "model_based").detail
+    assert "no run for this label was fitted on the file now on disk" in detail
     assert main(["--case-study", CASE_STUDY, "--artifacts-root", str(artifacts_root)]) == 0
+
+
+def test_two_pinned_vintages_are_only_superseded_when_a_declaration_retires_the_other(
+    artifacts_root,
+):
+    """Two shas alone do not establish the retirement, and the rule stays silent either way."""
+    disk = _on_disk(artifacts_root)
+    other = "0" * 64
+    db = artifacts_root / CASE_STUDY / "run_log" / "registry.db"
+    second = {
+        "label": LABEL,
+        "computation": {
+            "input_data_spec": {"artifacts": {"model_based": {"sha256": other, "size": 1}}}
+        },
+    }
+    _registry(db, artifact_shas=disk, extra_runs=[("hash-2", "gbm", second)])
+
+    mixed = check_case_study(CASE_STUDY, artifacts_root=artifacts_root)
+    assert _statuses(mixed)["model_based"] == "mixed"
+    assert not any(f.is_failure for f in mixed)
+
+    _registry(
+        db,
+        artifact_shas=disk,
+        extra_runs=[("hash-2", "gbm", second)],
+        supersessions=[("model_based", disk["model_based"], other)],
+    )
+    retired = check_case_study(CASE_STUDY, artifacts_root=artifacts_root)
+    assert _statuses(retired)["model_based"] == "superseded"
+
+
+def test_runs_recording_inputs_in_a_shape_the_rule_does_not_read_are_reported(artifacts_root):
+    """The rule reads one location; two producers record elsewhere and are checked by nothing.
+
+    A registry holding only those runs would otherwise report zero pairs and exit 0, which is
+    the silence this whole check exists to end.
+    """
+    db = artifacts_root / CASE_STUDY / "run_log" / "registry.db"
+    _registry(
+        db,
+        artifact_shas=_on_disk(artifacts_root),
+        extra_runs=[
+            ("hash-latent", "latent_factors", LATENT_SPEC),
+            ("hash-dl", "deep_learning", DEEP_LEARNING_SPEC),
+        ],
+    )
+
+    findings = check_case_study(CASE_STUDY, artifacts_root=artifacts_root)
+    unchecked = {f.artifact: f.detail for f in findings if f.status == "unchecked"}
+
+    assert set(unchecked) == {"latent_factors", "deep_learning"}
+    assert "input_data_spec.files" in unchecked["latent_factors"]
+    assert "input_data_spec.input_data_spec.artifacts" in unchecked["deep_learning"]
+    # Reported, not fatal: registration accepts these runs, and a pre-flight stricter than the
+    # rule it previews would refuse a chain that would in fact register.
+    assert not any(f.is_failure for f in findings)
 
 
 def test_an_artifact_the_registry_pins_and_disk_lacks_is_reported_not_ignored(artifacts_root):


### PR DESCRIPTION
A kept-registry case study has four pre-flight resolutions that can refuse a run: input
artifact vintage, population hash, causal identity, and candidate sets.
`scripts/check_supersedes_literals.py` covers the last three. The first had no warning but the
run itself stopping.

`_enforce_input_artifact_vintage` refuses a run that would join a population fitted on a
different vintage of the same input artifact. Regenerate a stage-03 or stage-04 artifact and
every later run refuses until `declare_artifact_supersession` records which sha the new one
replaces. On 2026-09-10 `us_equities_panel/06_linear` hit exactly that at plan time:
`model_based.parquet` on disk hashed `0e74d15f` while the registered training runs for
`fwd_ret_1d` had been fitted against `86ece972`.

`scripts/check_input_artifact_vintage.py` asks the same question ahead of the launch. It is
its own script rather than a fifth section of the literals checker because what it costs
differs: this refusal fires *before* the fit, so it costs a launch and a queue slot rather
than compute, and conflating that with resolutions that cost a whole fit loses the
distinction.

The comparison is now `input_artifact_vintage_conflicts`, extracted from the enforcement and
returning values instead of raising. The enforcement raises from it and the script calls it. A
pre-flight that re-implemented the rule could pass where registration refuses, which is a
green light for a chain that will not run.

## What the check has to get right

A declared supersession is what makes a second vintage legitimate, so a check reading only the
disk and the runs would report every deliberate regeneration as a defect, and would be red on
`us_equities_panel` today. The condition is narrower: the sha on disk differs from what the
runs pin **and** `artifact_supersessions` holds no row retiring the pinned one.

What it does not look at, it says. Two things fall outside:

- An artifact name it cannot locate. `financial`, `model_based` and `label` resolve from the case study's own specs, `eval_label` through the classification mapping the loader uses; anything else is reported `unresolved`.
- A run whose inputs are recorded in a shape the rule does not read. Measured across the nine live registries: **121 runs** - 45 `latent_factors` recording `input_data_spec.files` and 76 `deep_learning` nesting the payload at `input_data_spec.input_data_spec.artifacts`. Neither reaches `_input_artifact_shas`, so **registration does not vintage-check them either**. They are reported `unchecked` per family rather than read: a pre-flight stricter than the rule it previews would refuse a chain that would in fact register. That enforcement gap is a separate defect and is filed as one.

The four non-conflict states are distinguished rather than lumped under one label, because
calling a declared replacement `current` claimed runs had been fitted on a file no run had
touched, and `--quiet` then hid it: `current`, `superseded`, `mixed`, `accepted_replacement`.

## Verification

Against the nine live registries: **95 pairs - 83 current, 1 superseded, 11 unchecked, 0
undeclared, 0 unresolved, 0 absent, exit 0.** The superseded pair is
`us_equities_panel/fwd_ret_1d/model_based`, and it is superseded because a declaration retires
`86ece972`, not because two shas are pinned.

Seven tests cover both directions on a constructed registry, with the two unread spec shapes
copied from the live registries rather than invented. 34 tests green across this file,
`tests/test_input_artifact_vintage.py` and `tests/test_artifact_supersession.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
