### PR TITLE
Break the reported winner's tie on a name, not on row order

### DIFF
--- a/case_studies/utils/strategy_analysis.py
+++ b/case_studies/utils/strategy_analysis.py
@@ -2395,6 +2395,31 @@ def classify_holdout_degradation(
     return "degenerate"
 
 
+def rank_one(frame: pl.DataFrame, *, by: str, name: str) -> pl.DataFrame:
+    """The top row of *frame* by *by*, with *name* deciding a tie.
+
+    A one-key ``sort(by, descending=True).head(1)`` hands a tie to whatever order the frame
+    arrived in, so the row it returns is not a function of the data - the defect class
+    ml4t/agent-workspace#333 is about, where a visible precaution (the sort) leaves one
+    dimension of the answer free.
+
+    Exact ties in these quantities are not hypothetical. Measured across the nine live
+    registries on 2026-09-11, 14 (case study, stage) pairs hold at least one exactly repeated
+    Sharpe, with multiplicity up to 6, and crypto_perps_funding's signal stage holds two rows
+    tied at the maximum. Two risk overlays that never trigger book the baseline exactly, which
+    is the mechanism that produces them.
+
+    Breaking on the name costs nothing when there is no tie: the second key is only consulted
+    where the first is equal.
+
+    ``nulls_last`` because polars puts nulls FIRST under ``descending=True``, so a row with no
+    value for *by* would win the ranking and be reported as the best of them. No live registry
+    holds a null Sharpe today, so this changes no current result; it is here because the frame
+    is built by a join and the code reading the result already guards a null ``max_drawdown``.
+    """
+    return frame.sort([by, name], descending=[True, False], nulls_last=True).head(1)
+
+
 def build_all_synthesis(
     case_studies: list[str],
     explorers: dict,
@@ -2580,7 +2605,8 @@ def build_all_synthesis(
         if not alloc_comp.is_empty():
             # compare_allocators sorts by avg_sharpe; the heatmap and prose report
             # the allocator with the highest best_sharpe, so re-rank explicitly.
-            _top = alloc_comp.sort("best_sharpe", descending=True).head(1)
+            #
+            _top = rank_one(alloc_comp, by="best_sharpe", name="allocator")
             alloc_dict["best_allocator"] = _top["allocator"][0]
             alloc_dict["best_sharpe"] = round(float(_top["best_sharpe"][0]), 4)
             for row in alloc_comp.iter_rows(named=True):
@@ -2681,7 +2707,7 @@ def build_all_synthesis(
                 if len(bs) > 0:
                     risk_dict["baseline_sharpe"] = round(float(bs[0]), 4)
 
-            best_risk = risk_df.sort("sharpe", descending=True).head(1)
+            best_risk = rank_one(risk_df, by="sharpe", name="risk_name")
             risk_dict["best_overlay"] = best_risk["risk_name"][0]
             risk_dict["managed_sharpe"] = round(float(best_risk["sharpe"][0]), 4)
             risk_dict["managed_max_dd"] = round(float(best_risk["max_drawdown"][0] or 0), 4)

--- a/tests/test_rank_one_is_order_invariant.py
+++ b/tests/test_rank_one_is_order_invariant.py
@@ -1,0 +1,77 @@
+"""The reported winner is a function of the data, not of how the frame arrived.
+
+`ml4t/agent-workspace#333` is the class where a visible precaution - a seed, a sort - pins one
+dimension of randomness and leaves another free. Here the precaution is `sort(by,
+descending=True)`, and what it leaves free is the tie: `head(1)` then returns whichever tied
+row happened to come first, so the allocator or overlay a case study reports moves between
+runs that computed identical numbers.
+
+Exact ties in these quantities are measured, not hypothetical: across the nine live registries
+on 2026-09-11, 14 (case study, stage) pairs hold at least one exactly repeated Sharpe, with
+multiplicity up to 6, and one stage holds two rows tied at the maximum.
+"""
+
+from __future__ import annotations
+
+import itertools
+
+import polars as pl
+
+from case_studies.utils.strategy_analysis import rank_one
+
+
+def _tied_at_the_top() -> pl.DataFrame:
+    return pl.DataFrame(
+        {
+            "risk_name": ["trailing_stop", "daily_loss", "max_drawdown"],
+            "sharpe": [1.25, 1.25, 0.80],
+        }
+    )
+
+
+def test_a_tie_at_the_top_resolves_the_same_way_from_every_row_order():
+    """Every permutation of a tied frame reports the same winner."""
+    frame = _tied_at_the_top()
+    winners = {
+        rank_one(frame[list(order)], by="sharpe", name="risk_name")["risk_name"][0]
+        for order in itertools.permutations(range(frame.height))
+    }
+    assert winners == {"daily_loss"}
+
+
+def test_the_one_key_sort_this_replaced_does_not_survive_the_same_permutations():
+    """The control: without the named tiebreak the answer moves, which is the defect.
+
+    Asserting the fix alone would pass just as well against a frame that never ties, and the
+    point is that this frame does.
+    """
+    frame = _tied_at_the_top()
+    winners = {
+        frame[list(order)].sort("sharpe", descending=True).head(1)["risk_name"][0]
+        for order in itertools.permutations(range(frame.height))
+    }
+    assert winners == {"trailing_stop", "daily_loss"}
+
+
+def test_an_untied_frame_reports_the_largest_and_the_tiebreak_changes_nothing():
+    frame = pl.DataFrame(
+        {"allocator": ["hrp", "mean_variance", "equal_weight"], "best_sharpe": [0.9, 1.4, 0.3]}
+    )
+    for order in itertools.permutations(range(frame.height)):
+        top = rank_one(frame[list(order)], by="best_sharpe", name="allocator")
+        assert top["allocator"][0] == "mean_variance"
+        assert top["best_sharpe"][0] == 1.4
+
+
+def test_nulls_in_the_ranked_column_do_not_win():
+    """polars sorts nulls FIRST under descending=True, so the default would report one.
+
+    No live registry holds a null Sharpe today, so this is a contract rather than a repair of
+    a current number - the frame is built by a join, and the code reading the result already
+    guards a null max_drawdown.
+    """
+    frame = pl.DataFrame(
+        {"risk_name": ["a", "b", "c"], "sharpe": [None, 0.5, 0.4]},
+        schema={"risk_name": pl.String, "sharpe": pl.Float64},
+    )
+    assert rank_one(frame, by="sharpe", name="risk_name")["risk_name"][0] == "b"


### PR DESCRIPTION
Two rankings in `build_all_synthesis` sort on one key and take `head(1)`, and each reports a
NAME: the best allocator and the best risk overlay. A tie goes to whichever row arrived first,
so the allocator a case study reports is not a function of its data. It is the shape where a
visible precaution - the sort - pins one dimension and leaves another free.

## The tie is measured, not hypothetical

Across the nine live registries on 2026-09-11, **14 (case study, stage) pairs hold at least one
exactly repeated Sharpe**, with multiplicity up to 6, and `crypto_perps_funding`'s signal stage
holds two rows tied *at the maximum*. Three of the pairs are `risk_overlay` stages, which is
the frame the second site ranks. The mechanism is ordinary: two overlays that never trigger
book the baseline exactly.

Both sites now call `rank_one`, which sorts on the value and then the name. The second key is
consulted only where the first is equal, so nothing moves where there is no tie.

`nulls_last=True` came out of writing the test: polars sorts nulls **first** under
`descending=True`, so a row with no Sharpe would have won the ranking and been reported as the
best of them. No live registry holds a null Sharpe today, so this repairs no current number;
the frame is built by a join and the code reading the result already guards a null
`max_drawdown`.

## Verification

Four tests, and the control is the load-bearing one: the same permutations of the same tied
frame run against the one-key sort this replaced, asserting it returns two different winners.
Asserting the fix alone would pass equally against a frame that never ties, and the point is
that this frame does.

12 tests green with `tests/test_holdout_selection_is_single_sourced.py`; 121 passed and 8
skipped across the wider strategy-analysis selection.

The three instances that motivated the issue were re-verified as already fixed before anything
was touched: the seeded `hmmlearn` fit runs inside `threadpool_limits(1)`, the bootstrap
interval sorts its input before `rng.choice`, and the unpinned evidence script is gone. The
rest of the sweep is adjudicated and filed for the bands that own those chapters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
