### PR TITLE
Carrier selection: a ruined candidate carries no Sharpe and must not borrow one

### DIFF
--- a/20_strategy_synthesis/holdout.py
+++ b/20_strategy_synthesis/holdout.py
@@ -169,6 +169,11 @@ def _candidate_from_row(cs_id: str, row: dict) -> dict:
         # field was re-ranked. Reporting the stored value instead would have the two entry
         # points agree on the configuration and print different numbers for it, and chapter
         # 20 measures holdout decay against this.
+        #
+        # The fallback to the stored value is for the field that was never re-ranked, where
+        # it is the only Sharpe there is. It must not be reached for a ruined candidate,
+        # whose `comparison_sharpe` is also None and whose stored Sharpe describes an
+        # account that went to zero; `select_best_models` keeps those out of this pool.
         "val_sharpe": (
             row["comparison_sharpe"] if row["comparison_sharpe"] is not None else row["sharpe"]
         ),
@@ -248,6 +253,15 @@ def select_best_models(
     seen_phashes: set[str] = set()
     candidates: list[dict] = []
     for row in candidates_df:
+        # A candidate the engine stopped at ruin carries no Sharpe over the common support
+        # and is not a strategy anything can be retrained into. It stays on the ranked frame
+        # so it is visibly compared, and the ranking already orders it below every solvent
+        # one - but this pool is the rank-2 and rank-3 the holdout retrain falls back to,
+        # and a field with fewer than `top_n` solvent members would otherwise offer one.
+        # `_candidate_from_row` would then report its registered Sharpe as `val_sharpe`,
+        # which is the bankrupt path comparing as a solvent one.
+        if row.get("comparison_ruined"):
+            continue
         ph = row["prediction_hash"]
         if ph in seen_phashes:
             continue

--- a/case_studies/us_firm_characteristics/15_holdout_predictions.ipynb
+++ b/case_studies/us_firm_characteristics/15_holdout_predictions.ipynb
@@ -2,8 +2,16 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "86c2aea6",
-   "metadata": {},
+   "id": "edb01357",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001356,
+     "end_time": "2026-09-11T18:28:38.042363+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T18:28:38.041007+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "# US Firm Characteristics: Holdout Predictions\n",
     "\n",
@@ -38,9 +46,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "1552e8a1",
-   "metadata": {},
+   "execution_count": 1,
+   "id": "880963cb",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-11T18:28:38.045340Z",
+     "iopub.status.busy": "2026-09-11T18:28:38.045214Z",
+     "iopub.status.idle": "2026-09-11T18:28:42.183503Z",
+     "shell.execute_reply": "2026-09-11T18:28:42.182390Z"
+    },
+    "papermill": {
+     "duration": 4.140967,
+     "end_time": "2026-09-11T18:28:42.184459+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T18:28:38.043492+00:00",
+     "status": "completed"
+    }
+   },
    "outputs": [],
    "source": [
     "\"\"\"US Firm Characteristics: Holdout Predictions.\"\"\"\n",
@@ -66,9 +88,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "ff0a0aac",
+   "execution_count": 2,
+   "id": "c38bbf37",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-11T18:28:42.191486Z",
+     "iopub.status.busy": "2026-09-11T18:28:42.190990Z",
+     "iopub.status.idle": "2026-09-11T18:28:42.195678Z",
+     "shell.execute_reply": "2026-09-11T18:28:42.194791Z"
+    },
+    "papermill": {
+     "duration": 0.00904,
+     "end_time": "2026-09-11T18:28:42.196504+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T18:28:42.187464+00:00",
+     "status": "completed"
+    },
     "tags": [
      "parameters"
     ]
@@ -95,9 +130,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "162a9faf",
-   "metadata": {},
+   "execution_count": 4,
+   "id": "b76c33b4",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-11T18:28:42.210121Z",
+     "iopub.status.busy": "2026-09-11T18:28:42.209930Z",
+     "iopub.status.idle": "2026-09-11T18:28:42.288303Z",
+     "shell.execute_reply": "2026-09-11T18:28:42.287339Z"
+    },
+    "papermill": {
+     "duration": 0.081014,
+     "end_time": "2026-09-11T18:28:42.288825+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T18:28:42.207811+00:00",
+     "status": "completed"
+    }
+   },
    "outputs": [],
    "source": [
     "study = open_study(CASE_STUDY_ID, execution_tier=EXECUTION_TIER, workspace=WORKSPACE or None)\n",
@@ -124,8 +173,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8ee6e20c",
-   "metadata": {},
+   "id": "0d571971",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001735,
+     "end_time": "2026-09-11T18:28:42.292378+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T18:28:42.290643+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "## 1. Which configuration the holdout runs\n",
     "\n",
@@ -141,10 +198,34 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "48ad255e",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 5,
+   "id": "eb6862ca",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-11T18:28:42.296097Z",
+     "iopub.status.busy": "2026-09-11T18:28:42.295980Z",
+     "iopub.status.idle": "2026-09-11T18:28:54.132306Z",
+     "shell.execute_reply": "2026-09-11T18:28:54.130961Z"
+    },
+    "papermill": {
+     "duration": 11.839936,
+     "end_time": "2026-09-11T18:28:54.133815+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T18:28:42.293879+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Selected configuration: f8a96bc86f1c  stage=allocation  family=gbm  config=leaves_31_huber  label=fwd_ret_1m_win\n",
+      "  validation Sharpe 3.682, max drawdown -0.177\n",
+      "  fitted by training run 7bc69205868d\n"
+     ]
+    }
+   ],
    "source": [
     "carrier = resolve_solvent_carrier(CASE_STUDY_ID)\n",
     "print(\n",
@@ -160,8 +241,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cd8ca93a",
-   "metadata": {},
+   "id": "f686dcb4",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002025,
+     "end_time": "2026-09-11T18:28:54.139427+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T18:28:54.137402+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "The checkpoint is part of the configuration. This family publishes a prediction set per boosting\n",
     "iteration on a declared schedule, and the selected configuration's prediction set names one of\n",
@@ -171,10 +260,32 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "e11d494d",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 6,
+   "id": "6d0a11e2",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-11T18:28:54.147022Z",
+     "iopub.status.busy": "2026-09-11T18:28:54.146493Z",
+     "iopub.status.idle": "2026-09-11T18:28:54.152383Z",
+     "shell.execute_reply": "2026-09-11T18:28:54.151543Z"
+    },
+    "papermill": {
+     "duration": 0.01173,
+     "end_time": "2026-09-11T18:28:54.153092+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T18:28:54.141362+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Checkpoint: iteration=500\n"
+     ]
+    }
+   ],
    "source": [
     "validation_prediction = study.results.open(carrier[\"val_prediction_hash\"])\n",
     "prediction_record = validation_prediction.registry_record()\n",
@@ -185,8 +296,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4bcc0f25",
-   "metadata": {},
+   "id": "f973aed6",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001984,
+     "end_time": "2026-09-11T18:28:54.157748+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T18:28:54.155764+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "## 2. The window, and the model that is allowed to see it\n",
     "\n",
@@ -210,10 +329,37 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "2f03a125",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 7,
+   "id": "a54ee36d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-11T18:28:54.164184Z",
+     "iopub.status.busy": "2026-09-11T18:28:54.163730Z",
+     "iopub.status.idle": "2026-09-11T18:28:56.749983Z",
+     "shell.execute_reply": "2026-09-11T18:28:56.749032Z"
+    },
+    "papermill": {
+     "duration": 2.590754,
+     "end_time": "2026-09-11T18:28:56.750830+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T18:28:54.160076+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Holdout fold 10\n",
+      "  trains  1996-12-31 -> 2015-11-30\n",
+      "  predicts 2016-01-01 -> 2016-12-31\n",
+      "  label buffer: 1M\n",
+      "Validation folds: 10, latest evaluation end 2015-12-31 00:00:00\n",
+      "Holdout training ends 2015-11-30, holdout opens 2016-01-01\n"
+     ]
+    }
+   ],
    "source": [
     "observation_timeline = (\n",
     "    pl.read_parquet(study.root / \"labels\" / f\"{carrier['label']}.parquet\")\n",
@@ -247,8 +393,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "34e8b89f",
-   "metadata": {},
+   "id": "ede15a50",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002383,
+     "end_time": "2026-09-11T18:28:56.756113+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T18:28:56.753730+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "## 3. Fit, and register the predictions\n",
     "\n",
@@ -283,10 +437,39 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "9212c7f4",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 8,
+   "id": "edc3c9c1",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-11T18:28:56.764429Z",
+     "iopub.status.busy": "2026-09-11T18:28:56.764018Z",
+     "iopub.status.idle": "2026-09-11T18:28:56.802305Z",
+     "shell.execute_reply": "2026-09-11T18:28:56.801092Z"
+    },
+    "papermill": {
+     "duration": 0.044269,
+     "end_time": "2026-09-11T18:28:56.803881+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T18:28:56.759612+00:00",
+     "status": "completed"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "REPLACING holdout generation 70125d7e8c23 (leaves_63_mse)\n",
+      "  deleted   1 from backtest_metrics\n",
+      "  deleted   2 from backtest_paired_metrics\n",
+      "  deleted   1 from backtest_runs\n",
+      "  deleted   1 from fold_metrics\n",
+      "  deleted   1 from prediction_coverage\n",
+      "  deleted   1 from prediction_metrics\n",
+      "  deleted   1 from prediction_sets\n"
+     ]
+    }
+   ],
    "source": [
     "holdout_training_hash = training_hash_from_spec(holdout_spec)\n",
     "this_generation = (holdout_training_hash, (CHECKPOINT_KIND, CHECKPOINT_VALUE))\n",
@@ -352,14 +535,50 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "7d7ab23d",
+   "execution_count": 9,
+   "id": "da437985",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-11T18:28:56.814430Z",
+     "iopub.status.busy": "2026-09-11T18:28:56.813980Z",
+     "iopub.status.idle": "2026-09-11T18:29:19.507877Z",
+     "shell.execute_reply": "2026-09-11T18:29:19.506341Z"
+    },
+    "papermill": {
+     "duration": 22.701525,
+     "end_time": "2026-09-11T18:29:19.509496+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T18:28:56.807971+00:00",
+     "status": "completed"
+    },
     "tags": [
      "results"
     ]
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      fold 10: training n_train=572,710 n_val=23,648 trees=500 num_leaves=31 obj=huber\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      fold 10: done in 18s\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Holdout training run:  37b83b09fa56\n",
+      "Holdout prediction set: dc47b209c6e4\n"
+     ]
+    }
+   ],
    "source": [
     "request = reconstruct_locked_model_request(\n",
     "    study,\n",
@@ -381,8 +600,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f7799bf4",
-   "metadata": {},
+   "id": "c06a8a1a",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002831,
+     "end_time": "2026-09-11T18:29:19.516496+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T18:29:19.513665+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "What the prediction set covers, read back from the registry rather than from the\n",
     "request. The two agree only if the fit published what it declared, and the count is the\n",
@@ -393,14 +620,37 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "208fb320",
+   "execution_count": 10,
+   "id": "4299d094",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-11T18:29:19.525342Z",
+     "iopub.status.busy": "2026-09-11T18:29:19.524897Z",
+     "iopub.status.idle": "2026-09-11T18:29:19.542820Z",
+     "shell.execute_reply": "2026-09-11T18:29:19.541942Z"
+    },
+    "papermill": {
+     "duration": 0.023918,
+     "end_time": "2026-09-11T18:29:19.543989+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T18:29:19.520071+00:00",
+     "status": "completed"
+    },
     "tags": [
      "results"
     ]
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "split=holdout  checkpoint=iteration=500\n",
+      "rows=23,648  dates=12\n",
+      "  2016-01-29 -> 2016-12-30, 2,098 names\n"
+     ]
+    }
+   ],
    "source": [
     "record = holdout_prediction.registry_record()\n",
     "predictions = holdout_prediction.load()\n",
@@ -416,8 +666,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "78c807b9",
-   "metadata": {},
+   "id": "3b47cd73",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002671,
+     "end_time": "2026-09-11T18:29:19.550164+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T18:29:19.547493+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "The registry now holds more than one holdout prediction set for this case study, and\n",
     "only one of them was fitted on data that ends before the window. The other is the\n",
@@ -428,14 +686,35 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "5522d431",
+   "execution_count": 11,
+   "id": "e58fbff1",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-11T18:29:19.559426Z",
+     "iopub.status.busy": "2026-09-11T18:29:19.559009Z",
+     "iopub.status.idle": "2026-09-11T18:29:19.567697Z",
+     "shell.execute_reply": "2026-09-11T18:29:19.566809Z"
+    },
+    "papermill": {
+     "duration": 0.014907,
+     "end_time": "2026-09-11T18:29:19.568426+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T18:29:19.553519+00:00",
+     "status": "completed"
+    },
     "tags": [
      "results"
     ]
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  dc47b209c6e4  training=37b83b09fa56  leaves_31_huber  refitted for the holdout\n"
+     ]
+    }
+   ],
    "source": [
     "for row in registered_holdout_generations(CASE_DIR):\n",
     "    note = (\n",
@@ -448,8 +727,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d1c01794",
-   "metadata": {},
+   "id": "7fb607e6",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002681,
+     "end_time": "2026-09-11T18:29:19.573830+00:00",
+     "exception": false,
+     "start_time": "2026-09-11T18:29:19.571149+00:00",
+     "status": "completed"
+    }
+   },
    "source": [
     "## What this notebook establishes, and what it does not\n",
     "\n",
@@ -479,6 +766,43 @@
    "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.14.3"
+  },
+  "ml4t_provenance": {
+   "executed_at": "2026-09-11T18:29:29.437509+00:00",
+   "executor": "local-uv",
+   "library_digest": "4ef9f7c67e1db08d0009165619cc654a560a1852e334ff23eaa93376b1f19c62",
+   "outputs_digest": "db2d80be55dc9b3b79634214470660ef0dd80e1831fa732e02dff8b5d242c677",
+   "parameters": {
+    "REPLACE_HOLDOUT": "True"
+   },
+   "production": true,
+   "source_py_blob": "11554dac64b5cb2c8f9344a4bbe31f687f8096f4"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 45.347437,
+   "end_time": "2026-09-11T18:29:22.564558+00:00",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "~/ml4t/public-solvent-carrier/case_studies/us_firm_characteristics/.15_holdout_predictions.build.1647596.ipynb",
+   "output_path": "~/ml4t/public-solvent-carrier/case_studies/us_firm_characteristics/.15_holdout_predictions.papermill.1647596.ipynb",
+   "parameters": {
+    "REPLACE_HOLDOUT": "True"
+   },
+   "start_time": "2026-09-11T18:28:37.217121+00:00",
+   "version": "2.7.0"
   }
  },
  "nbformat": 4,

--- a/case_studies/us_firm_characteristics/16_holdout_backtest.ipynb
+++ b/case_studies/us_firm_characteristics/16_holdout_backtest.ipynb
@@ -2,13 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "6ef44315",
+   "id": "aba3b306",
    "metadata": {
     "papermill": {
-     "duration": 0.001083,
-     "end_time": "2026-09-07T08:28:04.643155+00:00",
+     "duration": 0.002374,
+     "end_time": "2026-09-11T18:29:49.283981+00:00",
      "exception": false,
-     "start_time": "2026-09-07T08:28:04.642072+00:00",
+     "start_time": "2026-09-11T18:29:49.281607+00:00",
      "status": "completed"
     }
    },
@@ -56,19 +56,19 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "fa4e3de9",
+   "id": "25f3ff02",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-07T08:28:04.646736Z",
-     "iopub.status.busy": "2026-09-07T08:28:04.646629Z",
-     "iopub.status.idle": "2026-09-07T08:28:06.847793Z",
-     "shell.execute_reply": "2026-09-07T08:28:06.847181Z"
+     "iopub.execute_input": "2026-09-11T18:29:49.288949Z",
+     "iopub.status.busy": "2026-09-11T18:29:49.288764Z",
+     "iopub.status.idle": "2026-09-11T18:29:54.639622Z",
+     "shell.execute_reply": "2026-09-11T18:29:54.638501Z"
     },
     "papermill": {
-     "duration": 2.203419,
-     "end_time": "2026-09-07T08:28:06.848361+00:00",
+     "duration": 5.354738,
+     "end_time": "2026-09-11T18:29:54.640493+00:00",
      "exception": false,
-     "start_time": "2026-09-07T08:28:04.644942+00:00",
+     "start_time": "2026-09-11T18:29:49.285755+00:00",
      "status": "completed"
     }
    },
@@ -106,19 +106,19 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "da1ea13c",
+   "id": "ce86b687",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-07T08:28:06.850772Z",
-     "iopub.status.busy": "2026-09-07T08:28:06.850620Z",
-     "iopub.status.idle": "2026-09-07T08:28:06.852495Z",
-     "shell.execute_reply": "2026-09-07T08:28:06.852193Z"
+     "iopub.execute_input": "2026-09-11T18:29:54.645624Z",
+     "iopub.status.busy": "2026-09-11T18:29:54.645277Z",
+     "iopub.status.idle": "2026-09-11T18:29:54.648382Z",
+     "shell.execute_reply": "2026-09-11T18:29:54.647686Z"
     },
     "papermill": {
-     "duration": 0.003455,
-     "end_time": "2026-09-07T08:28:06.852804+00:00",
+     "duration": 0.006244,
+     "end_time": "2026-09-11T18:29:54.648994+00:00",
      "exception": false,
-     "start_time": "2026-09-07T08:28:06.849349+00:00",
+     "start_time": "2026-09-11T18:29:54.642750+00:00",
      "status": "completed"
     },
     "tags": [
@@ -139,19 +139,19 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "6b9f8c9c",
+   "id": "7a0d2070",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-07T08:28:06.854720Z",
-     "iopub.status.busy": "2026-09-07T08:28:06.854662Z",
-     "iopub.status.idle": "2026-09-07T08:28:10.688464Z",
-     "shell.execute_reply": "2026-09-07T08:28:10.688032Z"
+     "iopub.execute_input": "2026-09-11T18:29:54.652950Z",
+     "iopub.status.busy": "2026-09-11T18:29:54.652796Z",
+     "iopub.status.idle": "2026-09-11T18:29:55.026257Z",
+     "shell.execute_reply": "2026-09-11T18:29:55.024868Z"
     },
     "papermill": {
-     "duration": 3.835392,
-     "end_time": "2026-09-07T08:28:10.688975+00:00",
+     "duration": 0.377695,
+     "end_time": "2026-09-11T18:29:55.028414+00:00",
      "exception": false,
-     "start_time": "2026-09-07T08:28:06.853583+00:00",
+     "start_time": "2026-09-11T18:29:54.650719+00:00",
      "status": "completed"
     }
    },
@@ -191,13 +191,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "40bf7cc8",
+   "id": "2549c09c",
    "metadata": {
     "papermill": {
-     "duration": 0.001503,
-     "end_time": "2026-09-07T08:28:10.691454+00:00",
+     "duration": 0.002504,
+     "end_time": "2026-09-11T18:29:55.034986+00:00",
      "exception": false,
-     "start_time": "2026-09-07T08:28:10.689951+00:00",
+     "start_time": "2026-09-11T18:29:55.032482+00:00",
      "status": "completed"
     }
    },
@@ -219,19 +219,19 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "3bae14be",
+   "id": "c3e1b838",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-07T08:28:10.693550Z",
-     "iopub.status.busy": "2026-09-07T08:28:10.693468Z",
-     "iopub.status.idle": "2026-09-07T08:28:13.883835Z",
-     "shell.execute_reply": "2026-09-07T08:28:13.883381Z"
+     "iopub.execute_input": "2026-09-11T18:29:55.044112Z",
+     "iopub.status.busy": "2026-09-11T18:29:55.043647Z",
+     "iopub.status.idle": "2026-09-11T18:30:07.537361Z",
+     "shell.execute_reply": "2026-09-11T18:30:07.536279Z"
     },
     "papermill": {
-     "duration": 3.192141,
-     "end_time": "2026-09-07T08:28:13.884334+00:00",
+     "duration": 12.500139,
+     "end_time": "2026-09-11T18:30:07.538098+00:00",
      "exception": false,
-     "start_time": "2026-09-07T08:28:10.692193+00:00",
+     "start_time": "2026-09-11T18:29:55.037959+00:00",
      "status": "completed"
     }
    },
@@ -258,19 +258,19 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "ca96f486",
+   "id": "fcb6539f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-07T08:28:13.887607Z",
-     "iopub.status.busy": "2026-09-07T08:28:13.887511Z",
-     "iopub.status.idle": "2026-09-07T08:28:13.891051Z",
-     "shell.execute_reply": "2026-09-07T08:28:13.890646Z"
+     "iopub.execute_input": "2026-09-11T18:30:07.546835Z",
+     "iopub.status.busy": "2026-09-11T18:30:07.546086Z",
+     "iopub.status.idle": "2026-09-11T18:30:07.557811Z",
+     "shell.execute_reply": "2026-09-11T18:30:07.556715Z"
     },
     "papermill": {
-     "duration": 0.005934,
-     "end_time": "2026-09-07T08:28:13.891327+00:00",
+     "duration": 0.017307,
+     "end_time": "2026-09-11T18:30:07.558732+00:00",
      "exception": false,
-     "start_time": "2026-09-07T08:28:13.885393+00:00",
+     "start_time": "2026-09-11T18:30:07.541425+00:00",
      "status": "completed"
     }
    },
@@ -279,9 +279,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Carrier:            25e0a7c90e87  leaves_63_mse (fwd_ret_1m)\n",
-      "Holdout training:   d1cb02192d29\n",
-      "Holdout prediction: 70125d7e8c23\n"
+      "Carrier:            f8a96bc86f1c  leaves_31_huber (fwd_ret_1m_win)\n",
+      "Holdout training:   37b83b09fa56\n",
+      "Holdout prediction: dc47b209c6e4\n"
      ]
     }
    ],
@@ -316,13 +316,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "113e2130",
+   "id": "8646b27b",
    "metadata": {
     "papermill": {
-     "duration": 0.000701,
-     "end_time": "2026-09-07T08:28:13.892874+00:00",
+     "duration": 0.00088,
+     "end_time": "2026-09-11T18:30:07.561243+00:00",
      "exception": false,
-     "start_time": "2026-09-07T08:28:13.892173+00:00",
+     "start_time": "2026-09-11T18:30:07.560363+00:00",
      "status": "completed"
     }
    },
@@ -389,19 +389,19 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "8516bd78",
+   "id": "9cba6249",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-07T08:28:13.894880Z",
-     "iopub.status.busy": "2026-09-07T08:28:13.894805Z",
-     "iopub.status.idle": "2026-09-07T08:28:13.896879Z",
-     "shell.execute_reply": "2026-09-07T08:28:13.896528Z"
+     "iopub.execute_input": "2026-09-11T18:30:07.566772Z",
+     "iopub.status.busy": "2026-09-11T18:30:07.566339Z",
+     "iopub.status.idle": "2026-09-11T18:30:07.572993Z",
+     "shell.execute_reply": "2026-09-11T18:30:07.571933Z"
     },
     "papermill": {
-     "duration": 0.003448,
-     "end_time": "2026-09-07T08:28:13.897102+00:00",
+     "duration": 0.011526,
+     "end_time": "2026-09-11T18:30:07.574439+00:00",
      "exception": false,
-     "start_time": "2026-09-07T08:28:13.893654+00:00",
+     "start_time": "2026-09-11T18:30:07.562913+00:00",
      "status": "completed"
     },
     "tags": [
@@ -413,7 +413,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Conformal carrier: embargo 0 observation(s), widths written below.\n"
+      "Allocator 'score_weighted' needs no calibration.\n"
      ]
     }
    ],
@@ -429,13 +429,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ca1e770c",
+   "id": "de99e810",
    "metadata": {
     "papermill": {
-     "duration": 0.000711,
-     "end_time": "2026-09-07T08:28:13.898630+00:00",
+     "duration": 0.002714,
+     "end_time": "2026-09-11T18:30:07.580669+00:00",
      "exception": false,
-     "start_time": "2026-09-07T08:28:13.897919+00:00",
+     "start_time": "2026-09-11T18:30:07.577955+00:00",
      "status": "completed"
     }
    },
@@ -487,19 +487,19 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "78834980",
+   "id": "f4ab2558",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-07T08:28:13.900780Z",
-     "iopub.status.busy": "2026-09-07T08:28:13.900715Z",
-     "iopub.status.idle": "2026-09-07T08:28:14.131073Z",
-     "shell.execute_reply": "2026-09-07T08:28:14.130664Z"
+     "iopub.execute_input": "2026-09-11T18:30:07.591430Z",
+     "iopub.status.busy": "2026-09-11T18:30:07.590908Z",
+     "iopub.status.idle": "2026-09-11T18:30:08.227116Z",
+     "shell.execute_reply": "2026-09-11T18:30:08.225825Z"
     },
     "papermill": {
-     "duration": 0.232017,
-     "end_time": "2026-09-07T08:28:14.131458+00:00",
+     "duration": 0.644412,
+     "end_time": "2026-09-11T18:30:08.228592+00:00",
      "exception": false,
-     "start_time": "2026-09-07T08:28:13.899441+00:00",
+     "start_time": "2026-09-11T18:30:07.584180+00:00",
      "status": "completed"
     },
     "tags": [
@@ -512,16 +512,14 @@
      "output_type": "stream",
      "text": [
       "Prices: 23,648 rows, 2,098 assets\n",
-      "Predictions: 23,648 rows, 12 dates\n",
-      "Conformal widths: 23,648 rows over 2,098 names, embargo 0 observation(s)\n",
-      "  calibration_n: median 110\n"
+      "Predictions: 23,648 rows, 12 dates\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Holdout backtest: a2bd03c902a0\n"
+      "Holdout backtest: 0a41057b2daa\n"
      ]
     }
    ],
@@ -628,13 +626,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d539e2f6",
+   "id": "3f00b9f4",
    "metadata": {
     "papermill": {
-     "duration": 0.000949,
-     "end_time": "2026-09-07T08:28:14.133463+00:00",
+     "duration": 0.002684,
+     "end_time": "2026-09-11T18:30:08.234638+00:00",
      "exception": false,
-     "start_time": "2026-09-07T08:28:14.132514+00:00",
+     "start_time": "2026-09-11T18:30:08.231954+00:00",
      "status": "completed"
     }
    },
@@ -670,19 +668,19 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "962336b5",
+   "id": "32f62ade",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-07T08:28:14.135798Z",
-     "iopub.status.busy": "2026-09-07T08:28:14.135712Z",
-     "iopub.status.idle": "2026-09-07T08:28:14.138595Z",
-     "shell.execute_reply": "2026-09-07T08:28:14.138314Z"
+     "iopub.execute_input": "2026-09-11T18:30:08.243773Z",
+     "iopub.status.busy": "2026-09-11T18:30:08.243215Z",
+     "iopub.status.idle": "2026-09-11T18:30:08.252131Z",
+     "shell.execute_reply": "2026-09-11T18:30:08.250813Z"
     },
     "papermill": {
-     "duration": 0.004868,
-     "end_time": "2026-09-07T08:28:14.139182+00:00",
+     "duration": 0.01534,
+     "end_time": "2026-09-11T18:30:08.253118+00:00",
      "exception": false,
-     "start_time": "2026-09-07T08:28:14.134314+00:00",
+     "start_time": "2026-09-11T18:30:08.237778+00:00",
      "status": "completed"
     },
     "tags": [
@@ -694,10 +692,10 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Validation Sharpe over its 109 months:  2.870\n",
-      "  the same run re-ranked on common support: 2.870\n",
-      "Holdout Sharpe over 12 months:        4.281\n",
-      "Holdout: CAGR 250.6%, max drawdown -0.16%, win rate 92%\n"
+      "Validation Sharpe over its 110 months:  3.583\n",
+      "  the same run re-ranked on common support: 3.682\n",
+      "Holdout Sharpe over 12 months:        2.742\n",
+      "Holdout: CAGR 130.7%, max drawdown -16.58%, win rate 83%\n"
      ]
     }
    ],
@@ -733,13 +731,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2c2a45fe",
+   "id": "72c0b7d0",
    "metadata": {
     "papermill": {
-     "duration": 0.001483,
-     "end_time": "2026-09-07T08:28:14.142413+00:00",
+     "duration": 0.002966,
+     "end_time": "2026-09-11T18:30:08.259603+00:00",
      "exception": false,
-     "start_time": "2026-09-07T08:28:14.140930+00:00",
+     "start_time": "2026-09-11T18:30:08.256637+00:00",
      "status": "completed"
     }
    },
@@ -785,25 +783,24 @@
    "version": "3.14.3"
   },
   "ml4t_provenance": {
-   "executed_at": "2026-09-07T08:28:21.145736+00:00",
+   "executed_at": "2026-09-11T18:30:18.340253+00:00",
    "executor": "local-uv",
-   "library_digest": "b2e3eb3974419256993e32a42d428dae9ce0007f682329d43d0c4bc699c62390",
-   "outputs_digest": "a0f107bcf8cbc3a6ed0de7bc229b1a4bccd7de9734985fc7a10d56112ec402bc",
+   "library_digest": "4ef9f7c67e1db08d0009165619cc654a560a1852e334ff23eaa93376b1f19c62",
+   "outputs_digest": "625399891d7b1659cb79fcec416fd6f5cd0dd08e08639feb2ee3db9c64343a06",
    "parameters": {},
    "production": true,
-   "source_py_blob": "084749f1e3329fa445b51527387f47e981294f20",
-   "notes": "prose synced from the .py at 2026-09-09T05:15:44.400433+00:00 without re-executing; every code cell is identical to blob 948caef105c9"
+   "source_py_blob": "084749f1e3329fa445b51527387f47e981294f20"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 11.661234,
-   "end_time": "2026-09-07T08:28:15.661525+00:00",
+   "duration": 23.199258,
+   "end_time": "2026-09-11T18:30:11.664937+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "~/ml4t/public-smoke-etfs-ufc/case_studies/us_firm_characteristics/.16_holdout_backtest.build.2827881.ipynb",
-   "output_path": "~/ml4t/public-smoke-etfs-ufc/case_studies/us_firm_characteristics/.16_holdout_backtest.papermill.2827881.ipynb",
+   "input_path": "~/ml4t/public-solvent-carrier/case_studies/us_firm_characteristics/.16_holdout_backtest.build.1654587.ipynb",
+   "output_path": "~/ml4t/public-solvent-carrier/case_studies/us_firm_characteristics/.16_holdout_backtest.papermill.1654587.ipynb",
    "parameters": {},
-   "start_time": "2026-09-07T08:28:04.000291+00:00",
+   "start_time": "2026-09-11T18:29:48.465679+00:00",
    "version": "2.7.0"
   }
  },

--- a/case_studies/utils/strategy_analysis.py
+++ b/case_studies/utils/strategy_analysis.py
@@ -1037,10 +1037,31 @@ def _rank_on_common_support_where_a_conformal_candidate_is_present(
     name different configurations - and the degeneracy fallback's rank-2 and rank-3 were
     ordered by a criterion the rank-1 was not.
 
-    Each candidate keeps its registered ``sharpe`` and gains ``comparison_sharpe``, which is
-    the Sharpe over the timestamps every candidate prices, or ``None`` where no re-ranking
-    was needed. Callers reporting the selection's Sharpe want ``comparison_sharpe`` where it
-    is set; callers reporting what the registry stored want ``sharpe``.
+    Each candidate keeps its registered ``sharpe`` and gains ``comparison_sharpe``, the
+    Sharpe over the timestamps every candidate prices. Callers reporting the selection's
+    Sharpe want ``comparison_sharpe`` where it is set; callers reporting what the registry
+    stored want ``sharpe``.
+
+    ``comparison_sharpe`` is ``None`` in two different states, and ``comparison_ruined``
+    separates them, because the correct handling is opposite in each:
+
+    ``comparison_ruined is None``
+        No re-ranking ran - there was no conformal candidate in the field - so the
+        registered ``sharpe`` is the only Sharpe there is and is what a caller should read.
+    ``comparison_ruined is True``
+        Re-ranking ran and :func:`rank_returns_on_common_support` found this candidate's
+        path stopped at ruin, so it carries no Sharpe at all. **Falling back to the
+        registered ``sharpe`` here is what the ruin rule exists to prevent**: that number
+        is computed on a balance that no longer exists, and reading it lets a bankrupt
+        path compare as a solvent one. The candidate stays on the frame, ordered below
+        every solvent one, so a caller can see it was compared and not selected.
+
+    Coercing that ``None`` to a float is what this used to do, and it raised ``TypeError:
+    float() argument must be a string or a real number, not 'NoneType'`` on the one case
+    study whose field holds a conformal candidate and ruined candidates at once
+    (``us_firm_characteristics``: 46 of 2,516 candidates carry no Sharpe over the 109
+    monthly periods, 2006-12-29 to 2015-12-31, that every candidate prices). The crash was
+    the honest half of the behaviour; the fallback it hid is the dangerous half.
     """
 
     def _is_conformal(row: dict[str, Any]) -> bool:
@@ -1050,7 +1071,13 @@ def _rank_on_common_support_where_a_conformal_candidate_is_present(
 
     if not any(_is_conformal(row) for row in candidates):
         return [
-            {**row, "comparison_sharpe": None, "comparison_n_periods": None} for row in candidates
+            {
+                **row,
+                "comparison_sharpe": None,
+                "comparison_n_periods": None,
+                "comparison_ruined": None,
+            }
+            for row in candidates
         ]
 
     from case_studies.utils.uncertainty import periods_per_year_from_setup
@@ -1067,16 +1094,22 @@ def _rank_on_common_support_where_a_conformal_candidate_is_present(
     ):
         raise RuntimeError("Common-support ranking produced unequal n_periods")
     by_hash = {row["backtest_hash"]: row for row in candidates}
-    return [
-        {
+
+    def _compared(backtest_hash: str) -> dict[str, Any]:
+        # None is the producer's documented answer for a path stopped at ruin, not a
+        # missing value to fill in. Carried through as None and flagged, so that no caller
+        # can read it as a number and none has to guess which of the two Nones it is.
+        sharpe = rank_rows[backtest_hash]["sharpe"]
+        return {
             **by_hash[backtest_hash],
-            "comparison_sharpe": float(rank_rows[backtest_hash]["sharpe"]),
+            "comparison_sharpe": None if sharpe is None else float(sharpe),
+            "comparison_ruined": sharpe is None,
             "comparison_n_periods": comparison_n_periods,
             "comparison_start": rank_rows[backtest_hash]["start"],
             "comparison_end": rank_rows[backtest_hash]["end"],
         }
-        for backtest_hash in common_ranking["backtest_hash"].to_list()
-    ]
+
+    return [_compared(backtest_hash) for backtest_hash in common_ranking["backtest_hash"].to_list()]
 
 
 def resolve_canonical_rank1_lineage(
@@ -1134,6 +1167,22 @@ def resolve_canonical_rank1_lineage(
     # rank-1 is read rather than recomputed. `comparison_sharpe` is set exactly where that
     # re-ranking ran, and it is the Sharpe over the timestamps every candidate prices - the
     # only one the candidates can be compared on.
+    # A ruined rank-1 has no Sharpe to report and must not borrow the registered one. The
+    # ranking puts nulls last, so this is reachable in exactly two states: every candidate in
+    # the field was stopped at ruin, or a CARRIER_PINS entry narrowed the field to one that
+    # was. Both are a sweep to fix or a pin to re-derive, and neither is a selection this
+    # function can make - so it refuses here rather than returning a configuration whose
+    # reported Sharpe is computed on a balance that no longer exists.
+    if val.get("comparison_ruined"):
+        raise NoSelectableCandidates(
+            f"The rank-1 validation candidate for {case_study} ({val['backtest_hash']}) was "
+            "stopped at ruin, so it carries no Sharpe over the common support and nothing "
+            "measured downstream of it would mean anything. Its registered Sharpe of "
+            f"{float(val['sharpe']):.4f} is computed on a balance that no longer exists. "
+            "Ruined candidates sort below every solvent one, so reaching this means the whole "
+            "field was ruined, or a CARRIER_PINS entry narrowed it to one that was. Fix the "
+            "sweep, or re-derive the pin, rather than selecting a bankrupt path."
+        )
     val_sharpe = (
         float(val["comparison_sharpe"])
         if val["comparison_sharpe"] is not None

--- a/case_studies/utils/strategy_analysis.py
+++ b/case_studies/utils/strategy_analysis.py
@@ -1049,8 +1049,12 @@ def _rank_on_common_support_where_a_conformal_candidate_is_present(
         No re-ranking ran - there was no conformal candidate in the field - so the
         registered ``sharpe`` is the only Sharpe there is and is what a caller should read.
     ``comparison_ruined is True``
-        Re-ranking ran and :func:`rank_returns_on_common_support` found this candidate's
-        path stopped at ruin, so it carries no Sharpe at all. **Falling back to the
+        Re-ranking ran and :func:`rank_returns_on_common_support` returned no Sharpe for
+        this candidate. That producer folds two states into one ``None`` deliberately - a
+        path stopped at ruin, and a degenerate series whose Sharpe is NaN - because the
+        consequence is the same: there is no number to rank on. The name follows the case
+        that occurs; on ``us_firm_characteristics`` all 46 are genuine ruin, equity through
+        zero, read off the return paths rather than off any registry column. **Falling back to the
         registered ``sharpe`` here is what the ruin rule exists to prevent**: that number
         is computed on a balance that no longer exists, and reading it lets a bankrupt
         path compare as a solvent one. The candidate stays on the frame, ordered below

--- a/tests/test_common_support_trigger.py
+++ b/tests/test_common_support_trigger.py
@@ -24,7 +24,11 @@ import pytest
 
 import case_studies.utils.uncertainty as uncertainty
 import utils.paths as paths
-from case_studies.utils.strategy_analysis import resolve_canonical_rank1_lineage
+from case_studies.utils.strategy_analysis import (
+    NoSelectableCandidates,
+    resolve_canonical_rank1_lineage,
+    selectable_validation_candidates,
+)
 
 CASE_STUDY = "fixture_conformal"
 SESSIONS = [dt.datetime(2024, 1, 1) + dt.timedelta(days=i) for i in range(40)]
@@ -162,3 +166,82 @@ def test_a_current_version_candidate_survives_an_older_one_in_the_same_field(
     lineage = resolve_canonical_rank1_lineage(CASE_STUDY)
 
     assert lineage["val_backtest_hash"] == "bt_conformal_v3"
+
+
+# A path that takes its account to zero. `first_ruin_index` reads the equity curve, so a
+# single -100% period is ruin regardless of what follows it, and the engine books the rest
+# as zeros. Its registered Sharpe is high on purpose: the bug this pins is a fallback to
+# that stored number, so a ruined candidate whose stored Sharpe is low would pass a broken
+# implementation for the wrong reason.
+RUINED_RETURNS = [0.05] * 10 + [-1.0] + [0.0] * 19
+
+
+def test_a_ruined_candidate_is_compared_without_a_sharpe(case_dir: Path) -> None:
+    """It stays on the frame, carries no Sharpe, and says which kind of None that is.
+
+    `rank_returns_on_common_support` returns None for a path stopped at ruin, deliberately.
+    Coercing it with `float()` raised TypeError and took the whole resolver down; the
+    ranking is fine either way, because nulls sort last.
+    """
+    _add(case_dir, "bt_plain", _spec(None), sharpe=0.5, values=PLAIN_RETURNS)
+    _add(
+        case_dir,
+        "bt_conformal_v3",
+        _spec("conformal_weighted", "walk_forward_v3"),
+        sharpe=0.6,
+        values=CONFORMAL_RETURNS,
+    )
+    _add(case_dir, "bt_ruined", _spec(None), sharpe=9.0, values=RUINED_RETURNS)
+
+    field = selectable_validation_candidates(CASE_STUDY)
+
+    by_hash = {row["backtest_hash"]: row for row in field}
+    assert set(by_hash) == {"bt_plain", "bt_conformal_v3", "bt_ruined"}
+
+    ruined = by_hash["bt_ruined"]
+    assert ruined["comparison_sharpe"] is None
+    assert ruined["comparison_ruined"] is True
+    # Stored Sharpe 9.0 is the highest in the field and still does not decide the order.
+    assert field[-1]["backtest_hash"] == "bt_ruined"
+    for solvent in ("bt_plain", "bt_conformal_v3"):
+        assert by_hash[solvent]["comparison_ruined"] is False
+        assert by_hash[solvent]["comparison_sharpe"] is not None
+
+
+def test_a_field_that_was_never_re_ranked_reports_a_third_state(case_dir: Path) -> None:
+    """No conformal candidate, so ruin was never assessed - which is not the same as False.
+
+    `comparison_sharpe` is None here too. A caller reading only that field cannot tell this
+    apart from a ruined candidate, and the two want opposite handling: here the registered
+    Sharpe is the only one there is.
+    """
+    _add(case_dir, "bt_plain", _spec(None), sharpe=0.5, values=PLAIN_RETURNS)
+    _add(case_dir, "bt_other", _spec(None), sharpe=0.4, values=CONFORMAL_RETURNS)
+
+    field = selectable_validation_candidates(CASE_STUDY)
+
+    assert [row["comparison_ruined"] for row in field] == [None, None]
+    assert all(row["comparison_sharpe"] is None for row in field)
+    assert resolve_canonical_rank1_lineage(CASE_STUDY)["val_sharpe"] == pytest.approx(0.5)
+
+
+def test_the_resolver_refuses_a_ruined_rank_1_rather_than_borrowing_its_stored_sharpe(
+    case_dir: Path,
+) -> None:
+    """Every candidate ruined is not a selection, and the stored Sharpe must not stand in.
+
+    Nulls sort last, so a ruined rank-1 means the whole field is ruined. Falling back to the
+    registered Sharpe would answer with a configuration whose reported number is computed on
+    a balance that no longer exists.
+    """
+    _add(
+        case_dir,
+        "bt_conformal_v3",
+        _spec("conformal_weighted", "walk_forward_v3"),
+        sharpe=0.6,
+        values=[0.02] * 5 + [-1.0] + [0.0] * 24,
+    )
+    _add(case_dir, "bt_ruined", _spec(None), sharpe=9.0, values=RUINED_RETURNS)
+
+    with pytest.raises(NoSelectableCandidates, match="stopped at ruin"):
+        resolve_canonical_rank1_lineage(CASE_STUDY)


### PR DESCRIPTION
`resolve_solvent_carrier("us_firm_characteristics")` raised `TypeError: float() argument must be a string or a real number, not 'NoneType'`, and the two notebooks that open with it could not be re-executed at all.

## The defect

`rank_returns_on_common_support` returns `sharpe = None` for a path the engine stopped at ruin, deliberately: a ratio of a mean to a dispersion describes a process that continues. The candidate stays on the frame, ordered below every solvent one, so a caller can see it was compared and not selected.

`_rank_on_common_support_where_a_conformal_candidate_is_present` coerced that `None` with `float()` and had no `None` branch, while its own docstring three lines above documented `comparison_sharpe` as nullable.

Only `us_firm_characteristics` reaches it. The branch runs only when a conformal candidate is in the field, and it is the only case study whose field holds a conformal candidate and ruined candidates at once: 46 of 2,516 candidates carry no Sharpe over the 109 monthly periods, 2006-12-29 to 2015-12-31, that every candidate prices. CI never saw it because the case-study jobs run against fixtures.

## The fix, and the worse bug underneath it

`None` is the producer's documented answer, so the resolver decides what it means rather than coercing it. `comparison_sharpe` is carried through as `None`, and a new `comparison_ruined` separates the two states that `None` could mean, because they want opposite handling:

| `comparison_ruined` | meaning | what a caller should read |
|---|---|---|
| `None` | no re-ranking ran | the registered `sharpe`, the only one there is |
| `True` | the path was stopped at ruin | nothing; it has no Sharpe |
| `False` | re-ranked and solvent | `comparison_sharpe` |

The crash was the honest half of the old behaviour. The dangerous half is the fallback it hid: two callers read `comparison_sharpe is None` as "not re-ranked" and substituted the registered Sharpe, which is computed on a balance that no longer exists. That is a bankrupt path comparing as a solvent one. Both are closed:

- `resolve_canonical_rank1_lineage` refuses a ruined rank-1 with `NoSelectableCandidates`, naming the hash and its registered Sharpe. Nulls sort last, so this is reachable only when the whole field was ruined or a `CARRIER_PINS` entry narrowed it to one that was. Both are a sweep to fix or a pin to re-derive.
- `select_best_models` skips ruined rows when building the retrain pool, so the holdout's rank-2/rank-3 fallback cannot land on one.

## Verification

Three regression tests on the existing `fixture_conformal` harness, each confirmed failing on the pre-fix source with the reported `TypeError`: a ruined candidate stays on the frame without a Sharpe and last in the order despite holding the highest stored Sharpe in the field; a never-re-ranked field reports the third state; and the resolver refuses rather than borrowing.

160 tests across the carrier, selection and holdout suites pass.

Against the production registry, all four re-ranking case studies resolve:

| case study | carrier | val Sharpe | candidates | ruined |
|---|---|---|---|---|
| `us_firm_characteristics` | `f8a96bc86f1c` | 3.6821 | 2,516 | 46 |
| `fx_pairs` | `adb648fc0f51` | 0.4121 | 1,378 | 0 |
| `etfs` | `18c7a8419306` | 1.0278 | 1,822 | 0 |
| `cme_futures` | `5075cacaecb2` | 1.1000 | 906 | 0 |

The three controls are unchanged.

## Downstream, not done here

No notebook is re-run in this PR. `us_firm_characteristics/14_costs` already renders this carrier and this Sharpe (`bt_hash=f8a96bc8`, `Sharpe=3.682`), so it re-executes unchanged. `16_holdout_backtest` renders `25e0a7c90e87` on `fwd_ret_1m`, which is not what the resolver now answers, so both its carrier and its label move when it is re-executed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019gBppujoxyVbx5bwVouEnh

---

## Update: the two notebooks, re-executed

`15_holdout_predictions` and `16_holdout_backtest` both open with `resolve_solvent_carrier`, so neither could run while it raised. Their renders on `main` were written before the crash and name a configuration the resolver does not select. Both are now re-executed and re-rendered in this PR.

`16_holdout_backtest`, old -> new -> cause:

| | old | new |
|---|---|---|
| carrier | `25e0a7c90e87` gbm/leaves_63_mse fwd_ret_1m ckpt 50 | `f8a96bc86f1c` gbm/leaves_31_huber fwd_ret_1m_win ckpt 500 |
| validation Sharpe | 2.8699 | 3.5829 stored, 3.6821 common support |
| holdout Sharpe | 4.2811 | **2.7422** |
| holdout maxDD | -0.0016 | -0.1658 |
| holdout backtest | `a2bd03c902a0` | `0a41057b2daa` |
| holdout prediction set | `70125d7e8c23` | `dc47b209c6e4` |

**Cause: the validation sweep was rebuilt**, and the field now holds 129 candidates that beat the one the holdout was spent on. Not the common-support re-ranking and not the ruin fix in this branch. Both rankings independently put `f8a96bc86f1c` at rank 1, and `25e0a7c90e87` ranks 146 of 2,516 on common support and 130 of 2,516 on stored Sharpe. The ruin fix only made the resolver able to report an answer that was already the case; the drift predates it.

**The holdout is re-spent.** A holdout is settled only when the program is declared done, so this needs no ruling, but it should be readable in the record rather than inferred later. Evaluating a configuration ranked 146th was the anomaly; replacing it is the selection rule.

`15_holdout_predictions` ran with `REPLACE_HOLDOUT=True`, which deletes rather than marks, so only one generation is readable afterwards: 8 rows (backtest_metrics 1, backtest_paired_metrics 2, backtest_runs 1, fold_metrics 1, prediction_coverage 1, prediction_metrics 1, prediction_sets 1) and the 316K predictions directory.

The superseded generation was copied first, since `delete_prediction_generation` is not recoverable and nothing else held a copy. It is at `~/ml4t/artifacts/case_studies/us_firm_characteristics/holdout-gen-70125d7e8c23-20260911/` with a full `sqlite3 .backup` of the pre-run registry (24 MB), the prediction artifacts, and a README recording what it held and how to restore it. The copy was verified to read back Sharpe 4.2811 and max drawdown -0.0016 before the replacement ran.

Verified after the run with the resolver's own answer rather than by assuming the holdout became visible: `_resolve_holdout_self_backtest` returns `0a41057b2daa` with `reason=None`, so all three lineage post-conditions pass - identical strategy spec, fitted for the holdout, and a refit of the validation training spec. Registry deltas confirmed against a pre-run baseline rather than read off exit status: backtest_runs 2539 -> 2538 -> 2539, prediction_sets 570 throughout, one holdout prediction set and one holdout backtest at the end.

`14_costs` is not re-run: it already renders this carrier and this Sharpe. No additional backtests were run for prediction sets that have none.

One clarification to `comparison_ruined`: `rank_returns_on_common_support` folds two states into one `None` - a path stopped at ruin, and a degenerate series whose Sharpe is NaN. Folding them is right, since neither gives a number to rank on, and the docstring now says so. On `us_firm_characteristics` all 46 are genuine ruin and none is a NaN Sharpe.