### PR TITLE
deps: move ml4t-data from 0.1.2 to 0.1.6

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -119,6 +119,17 @@ jobs:
               - 'case_studies/config/**'
               - 'data/**'
               - 'pyproject.toml'
+              # And the lock, which is what `uv sync --locked` actually installs.
+              # A `uv lock --upgrade-package <x>` that does not touch
+              # pyproject.toml changes the library version every notebook imports
+              # and, without this line, matches only `image-inputs` - so the whole
+              # chapter and case-study matrix is skipped and the PR reports green
+              # on `test-unit`, which pins nothing about notebook behaviour.
+              # Dependabot opens no PRs against this repo
+              # (.github/dependabot.yml, open-pull-requests-limit: 0), so this
+              # costs a full matrix only on a deliberate bump, which is the case
+              # that needs one.
+              - 'uv.lock'
               - '.github/workflows/test.yml'
               - 'matplotlibrc'
               - 'tests/__init__.py'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,10 +53,13 @@ dependencies = [
     # ===================
     # ML4T Libraries (PyPI)
     # ===================
-    # ml4t-data 0.1.2: HiveStorage.partitions() reports what a write committed, the anomaly
-    # detectors accept a date-typed timestamp column, and get_metadata() no longer lets a
-    # null in the provider block erase the timestamp an update just wrote.
-    "ml4t-data>=0.1.2",
+    # ml4t-data 0.1.6: an empty yf.download frame is no longer read as "symbol not
+    # found". Yahoo returns that one shape for a rate limit, a network error and a
+    # delisted ticker alike, so a throttled reader was told AAPL does not exist. The
+    # empty branch now refetches through Ticker.history(raise_errors=True) and reports
+    # what the vendor said. 0.1.4 also drops the current session's placeholder bar
+    # instead of raising on it, which is the behaviour chapter 2 documents.
+    "ml4t-data>=0.1.6",
     # ml4t-diagnostic 0.1.2: cross_sectional_ic_series() reports an undefined date
     # (all predictions or all returns tied) as null rather than NaN, so a
     # drop_nulls("ic") followed by .mean() can no longer come back nan.

--- a/uv.lock
+++ b/uv.lock
@@ -4325,7 +4325,7 @@ requires-dist = [
     { name = "llama-index-vector-stores-chroma", specifier = ">=0.5.5" },
     { name = "matplotlib", specifier = ">=3.8" },
     { name = "ml4t-backtest", specifier = ">=0.1.3" },
-    { name = "ml4t-data", specifier = ">=0.1.2" },
+    { name = "ml4t-data", specifier = ">=0.1.6" },
     { name = "ml4t-diagnostic", specifier = ">=0.1.4" },
     { name = "ml4t-engineer", specifier = ">=0.1.3" },
     { name = "ml4t-live", specifier = ">=0.1.0" },
@@ -4427,7 +4427,7 @@ wheels = [
 
 [[package]]
 name = "ml4t-data"
-version = "0.1.2"
+version = "0.1.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
@@ -4449,9 +4449,9 @@ dependencies = [
     { name = "structlog" },
     { name = "tenacity" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fa/3a/e49c4512f0ef3f4834959ecfe36de7ee17354c406258cc26b9232043c8b4/ml4t_data-0.1.2.tar.gz", hash = "sha256:f35b134435c61f5a686bf8837225ff83079bcf01106ffd2df19cda8da215d541", size = 770903, upload-time = "2026-08-10T16:41:18.543Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b5/73/d7d855a132f48b3a03994103d574b1c917a0bb5c4acc4d44211644867b73/ml4t_data-0.1.6.tar.gz", hash = "sha256:991e5d772652e785aa7718f90866c8cb7a446c440efa876b186ed8372f021092", size = 778252, upload-time = "2026-09-11T17:17:54.717Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/16/96/15a92fc69ec6ffbeaa470bcf1870ec32576969782725e381c26b84417842/ml4t_data-0.1.2-py3-none-any.whl", hash = "sha256:773dae5b8446e41904c36568d8cc5e6910b0be1a0390918a57e4197b1523aff6", size = 488360, upload-time = "2026-08-10T16:41:16.869Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/93/559c8fa0a60e30a8361231c1ab2b0b14a38fc7797f675c1caa7cf573762b/ml4t_data-0.1.6-py3-none-any.whl", hash = "sha256:473118d21abddd4a04b7402ab822f5c74fe69c45ddf087b20b032f286c2b7958", size = 490512, upload-time = "2026-09-11T17:17:53.014Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
`uv.lock` pinned `ml4t-data` at 0.1.2. `uv sync --locked` is what CI and the
install instructions both use, so four releases of the library every chapter
imports reached neither a CI run nor a reader. `pyproject.toml` already said
`>=0.1.2`, so the constraint was never what held it back - the lock was.

Measured in a fresh worktree built from the repo's own lock:

```
$ uv run python -c "import importlib.metadata as m; print(m.version('ml4t-data'))"
0.1.2
```

## What the four releases carry

Two are chapter-2 defects a reader hits:

- **0.1.4** drops the current session's placeholder bar instead of raising on it.
  A window containing that row alongside real bars now succeeds, which is the
  behaviour `18_data_management` and `19_incremental_updates` document in prose.
- **0.1.6** stops reading an empty `yf.download` frame as "symbol not found".
  Yahoo returns that one shape for a rate limit, a network error and a delisted
  ticker alike, so a throttled reader was told `AAPL` does not exist. The empty
  branch now refetches through `Ticker.history(raise_errors=True)` and reports
  what the vendor actually said.

0.1.3 is an ETF partition rebuild and a set of CI chores; 0.1.5 names the day and
reason in an async Binance download failure.

## Scope

Only `ml4t-data` moves. The lock diff is its four lines - specifier, version,
sdist, wheel - and nothing else resolved differently.

`ml4t-diagnostic`, `ml4t-engineer`, `ml4t-backtest` and `ml4t-live` are also
behind and are deliberately not here. Each needs its own reading of what moved,
and two of them carry behaviour changes that want a measurement before they land.

## Verification

- `uv sync --locked --extra dev` resolves 0.1.6 with no other change.
- `tests/test_env_matches_lock.py` and `tests/test_toolchain_pins.py`: 23 passed.
- Both chapter-2 notebooks that fetch live pass against it: `2 passed in 94.25s`.
  This branch does not carry #982's deterministic-provider override, so that run
  went to Yahoo for real, which is the point of running it here.

Read the `ch*` and `cs-*` jobs on this one rather than the five required checks:
a library behaviour change surfaces in a notebook, not in `test-unit`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
