### PR TITLE
Every file in the CI fixture has a producer, and three of the last six were wrong

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1399,14 +1399,12 @@ jobs:
             cp test-data/intermediates/ch20_synthesis/output/* 20_strategy_synthesis/output/
             echo "Seeded Ch20 synthesis outputs"
           fi
-          # Ch24/11 research_operator: artifacts dir is gitignored in this repo;
-          # source them from test-data into the notebook dir.
-          if [ -d test-data/data/autonomous_agents/operator_artifacts ]; then
-            mkdir -p 24_autonomous_agents/operator_artifacts
-            cp test-data/data/autonomous_agents/operator_artifacts/*.json \
-              24_autonomous_agents/operator_artifacts/
-            echo "Seeded ch24/11 operator artifacts"
-          fi
+          # Ch24/11's two operator traces are not seeded here. They are tracked in
+          # this repo under 24_autonomous_agents/operator_artifacts/ (force-added
+          # past the .gitignore), so the checkout already carries them and CI reads
+          # what a reader reads. The copy that used to stand here overwrote both
+          # with the test-data fixture's unsanitized originals, which carry the
+          # author's absolute home directory in every skill path.
 
       - name: Run chapter notebooks (${{ matrix.name }})
         if: steps.reach.outputs.have_key

--- a/data/equities/firm_characteristics/dataset_card.ipynb
+++ b/data/equities/firm_characteristics/dataset_card.ipynb
@@ -976,8 +976,8 @@
    "end_time": "2026-09-11T18:55:00.052207+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "~/ml4t/public-fixture-d/data/equities/firm_characteristics/.dataset_card.build.1734332.ipynb",
-   "output_path": "~/ml4t/public-fixture-d/data/equities/firm_characteristics/.dataset_card.papermill.1734332.ipynb",
+   "input_path": "data/equities/firm_characteristics/.dataset_card.build.1734332.ipynb",
+   "output_path": "data/equities/firm_characteristics/.dataset_card.papermill.1734332.ipynb",
    "parameters": {},
    "start_time": "2026-09-11T18:54:50.834110+00:00",
    "version": "2.7.0"

--- a/data/equities/firm_characteristics/dataset_card.ipynb
+++ b/data/equities/firm_characteristics/dataset_card.ipynb
@@ -2,13 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "d381d65f",
+   "id": "e60444b1",
    "metadata": {
     "papermill": {
-     "duration": 0.006943,
-     "end_time": "2026-05-03T01:59:03.910766+00:00",
+     "duration": 0.003201,
+     "end_time": "2026-09-11T18:54:51.810924+00:00",
      "exception": false,
-     "start_time": "2026-05-03T01:59:03.903823+00:00",
+     "start_time": "2026-09-11T18:54:51.807723+00:00",
      "status": "completed"
     }
    },
@@ -34,19 +34,19 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "60c4a4bf",
+   "id": "8c0d3755",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-03T01:59:03.914161Z",
-     "iopub.status.busy": "2026-05-03T01:59:03.913985Z",
-     "iopub.status.idle": "2026-05-03T01:59:03.960401Z",
-     "shell.execute_reply": "2026-05-03T01:59:03.959972Z"
+     "iopub.execute_input": "2026-09-11T18:54:51.820273Z",
+     "iopub.status.busy": "2026-09-11T18:54:51.819631Z",
+     "iopub.status.idle": "2026-09-11T18:54:51.931574Z",
+     "shell.execute_reply": "2026-09-11T18:54:51.929843Z"
     },
     "papermill": {
-     "duration": 0.04877,
-     "end_time": "2026-05-03T01:59:03.960834+00:00",
+     "duration": 0.119058,
+     "end_time": "2026-09-11T18:54:51.932601+00:00",
      "exception": false,
-     "start_time": "2026-05-03T01:59:03.912064+00:00",
+     "start_time": "2026-09-11T18:54:51.813543+00:00",
      "status": "completed"
     }
    },
@@ -55,23 +55,19 @@
     "\"\"\"Firm Characteristics - download, explore, and update workflow.\"\"\"\n",
     "\n",
     "import json\n",
-    "import os\n",
-    "import sys\n",
-    "import zipfile\n",
-    "from pathlib import Path\n",
     "\n",
     "import polars as pl"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "b62b55ba",
+   "id": "af25aa7b",
    "metadata": {
     "papermill": {
-     "duration": 0.000991,
-     "end_time": "2026-05-03T01:59:03.963121+00:00",
+     "duration": 0.001305,
+     "end_time": "2026-09-11T18:54:51.935583+00:00",
      "exception": false,
-     "start_time": "2026-05-03T01:59:03.962130+00:00",
+     "start_time": "2026-09-11T18:54:51.934278+00:00",
      "status": "completed"
     }
    },
@@ -92,19 +88,19 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "c3f3f87b",
+   "id": "050ea996",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-03T01:59:03.965736Z",
-     "iopub.status.busy": "2026-05-03T01:59:03.965652Z",
-     "iopub.status.idle": "2026-05-03T01:59:03.967599Z",
-     "shell.execute_reply": "2026-05-03T01:59:03.967377Z"
+     "iopub.execute_input": "2026-09-11T18:54:51.939894Z",
+     "iopub.status.busy": "2026-09-11T18:54:51.939723Z",
+     "iopub.status.idle": "2026-09-11T18:54:51.943930Z",
+     "shell.execute_reply": "2026-09-11T18:54:51.942886Z"
     },
     "papermill": {
-     "duration": 0.003819,
-     "end_time": "2026-05-03T01:59:03.967940+00:00",
+     "duration": 0.007895,
+     "end_time": "2026-09-11T18:54:51.944732+00:00",
      "exception": false,
-     "start_time": "2026-05-03T01:59:03.964121+00:00",
+     "start_time": "2026-09-11T18:54:51.936837+00:00",
      "status": "completed"
     }
    },
@@ -136,13 +132,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5f052859",
+   "id": "4e6ae776",
    "metadata": {
     "papermill": {
-     "duration": 0.000943,
-     "end_time": "2026-05-03T01:59:03.969991+00:00",
+     "duration": 0.002251,
+     "end_time": "2026-09-11T18:54:51.949819+00:00",
      "exception": false,
-     "start_time": "2026-05-03T01:59:03.969048+00:00",
+     "start_time": "2026-09-11T18:54:51.947568+00:00",
      "status": "completed"
     }
    },
@@ -155,19 +151,19 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "890f361e",
+   "id": "51489b47",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-03T01:59:03.972428Z",
-     "iopub.status.busy": "2026-05-03T01:59:03.972357Z",
-     "iopub.status.idle": "2026-05-03T01:59:03.973830Z",
-     "shell.execute_reply": "2026-05-03T01:59:03.973622Z"
+     "iopub.execute_input": "2026-09-11T18:54:51.957840Z",
+     "iopub.status.busy": "2026-09-11T18:54:51.957568Z",
+     "iopub.status.idle": "2026-09-11T18:54:51.960514Z",
+     "shell.execute_reply": "2026-09-11T18:54:51.959989Z"
     },
     "papermill": {
-     "duration": 0.003148,
-     "end_time": "2026-05-03T01:59:03.974169+00:00",
+     "duration": 0.008722,
+     "end_time": "2026-09-11T18:54:51.961125+00:00",
      "exception": false,
-     "start_time": "2026-05-03T01:59:03.971021+00:00",
+     "start_time": "2026-09-11T18:54:51.952403+00:00",
      "status": "completed"
     }
    },
@@ -188,253 +184,58 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d229a4b7",
+   "id": "cb7be1aa",
    "metadata": {
     "papermill": {
-     "duration": 0.000979,
-     "end_time": "2026-05-03T01:59:03.976217+00:00",
+     "duration": 0.001968,
+     "end_time": "2026-09-11T18:54:51.965704+00:00",
      "exception": false,
-     "start_time": "2026-05-03T01:59:03.975238+00:00",
+     "start_time": "2026-09-11T18:54:51.963736+00:00",
      "status": "completed"
     }
    },
    "source": [
     "## 3. Download Data\n",
     "\n",
-    "The dataset is hosted on Google Drive via the GitHub repository.\n",
-    "Download can be automatic (with `gdown`) or manual."
+    "`data/equities/firm_characteristics/download.py` is the only path that produces what\n",
+    "`load_firm_characteristics()` reads. It fetches the archive from the Google Drive folder\n",
+    "the paper's repository links, then converts the published `char/*.npz` tensors - not\n",
+    "`RetChar.csv` - into `equities/firm_characteristics/firm_characteristics_{train,valid,test,all}.parquet`.\n",
+    "\n",
+    "The tensors are what carry firm identity. Each block has a fixed anonymous firm axis whose\n",
+    "positions are persistent within the block, so the converter can emit a `symbol` column; the\n",
+    "CSV drops that axis and can only emit `permno`, which the loader rejects. A split offset keeps\n",
+    "the three blocks' identifier namespaces disjoint, because the archive publishes no mapping\n",
+    "between them.\n",
+    "\n",
+    "```bash\n",
+    "uv run python data/equities/firm_characteristics/download.py           # fetch and convert\n",
+    "uv run python data/equities/firm_characteristics/download.py --check   # verify what is there\n",
+    "uv run python data/equities/firm_characteristics/download.py --convert # convert an existing archive\n",
+    "```\n",
+    "\n",
+    "This card used to carry a second downloader of its own, writing\n",
+    "`firm_characteristics_{all,train,test}.parquet` into an `academic/` directory from\n",
+    "`RetChar.csv`. Nothing read that directory and the loader rejects that schema, so the files\n",
+    "it produced were unreachable whichever way a reader arrived at them."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "a15b9b8d",
+   "id": "14e92ba8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-03T01:59:03.978723Z",
-     "iopub.status.busy": "2026-05-03T01:59:03.978653Z",
-     "iopub.status.idle": "2026-05-03T01:59:03.983851Z",
-     "shell.execute_reply": "2026-05-03T01:59:03.983630Z"
+     "iopub.execute_input": "2026-09-11T18:54:51.970222Z",
+     "iopub.status.busy": "2026-09-11T18:54:51.969994Z",
+     "iopub.status.idle": "2026-09-11T18:54:55.960750Z",
+     "shell.execute_reply": "2026-09-11T18:54:55.958106Z"
     },
     "papermill": {
-     "duration": 0.00696,
-     "end_time": "2026-05-03T01:59:03.984211+00:00",
+     "duration": 3.994381,
+     "end_time": "2026-09-11T18:54:55.961933+00:00",
      "exception": false,
-     "start_time": "2026-05-03T01:59:03.977251+00:00",
-     "status": "completed"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "# Google Drive file ID for the data archive\n",
-    "GDRIVE_FILE_ID = \"1nYHpJ2lNm-qDX5iq18-HaL1H6z7lPGVi\"\n",
-    "GITHUB_REPO = \"https://github.com/jasonzy121/Deep_Learning_Asset_Pricing\"\n",
-    "\n",
-    "\n",
-    "def download_firm_characteristics(dry_run: bool = False, force: bool = False, convert: bool = True):\n",
-    "    \"\"\"Download Chen-Pelger-Zhu firm characteristics dataset.\n",
-    "\n",
-    "    Args:\n",
-    "        dry_run: If True, show what would be downloaded without doing it\n",
-    "        force: If True, re-download even if data exists\n",
-    "        convert: If True, convert CSV to parquet after download\n",
-    "    \"\"\"\n",
-    "    from utils import ML4T_DATA_PATH\n",
-    "\n",
-    "    output_dir = ML4T_DATA_PATH / \"academic\"\n",
-    "    dl_dir = output_dir / \"dl_asset_pricing\"\n",
-    "    parquet_path = output_dir / \"firm_characteristics_all.parquet\"\n",
-    "\n",
-    "    print(\"=== Firm Characteristics Download ===\")\n",
-    "    print(\"Dataset: Chen-Pelger-Zhu (2020)\")\n",
-    "    print(\"Coverage: 1967-1989 (train), 2000-2016 (test)\")\n",
-    "    print(\"Features: 94 firm characteristics + returns\")\n",
-    "    print(\"Estimated size: ~1.5 GB (archive), ~258 MB (parquet)\")\n",
-    "    print(f\"Output: {output_dir}\")\n",
-    "\n",
-    "    if dry_run:\n",
-    "        print(\"\\n[DRY RUN] Would download:\")\n",
-    "        print(\"  - data.zip from Google Drive (~1.5 GB)\")\n",
-    "        print(f\"  - Extract to: {dl_dir}\")\n",
-    "        print(f\"  - Convert to parquet: {parquet_path}\")\n",
-    "        print(\"\\nManual download:\")\n",
-    "        print(f\"  1. Go to: {GITHUB_REPO}\")\n",
-    "        print(\"  2. Download data.zip from Google Drive link\")\n",
-    "        print(f\"  3. Extract to: {dl_dir}\")\n",
-    "        return\n",
-    "\n",
-    "    # Check existing\n",
-    "    if parquet_path.exists() and not force:\n",
-    "        existing = pl.read_parquet(parquet_path)\n",
-    "        print(f\"\\nData already exists ({len(existing):,} rows).\")\n",
-    "        print(\"Use force=True to re-download.\")\n",
-    "        return\n",
-    "\n",
-    "    # Try automatic download with gdown\n",
-    "    try:\n",
-    "        import gdown\n",
-    "    except ImportError:\n",
-    "        print(\"\\nWARNING: gdown not installed for automatic download\")\n",
-    "        print(\"Install with: pip install gdown\")\n",
-    "        print(\"\\nManual download instructions:\")\n",
-    "        print(f\"  1. Go to: {GITHUB_REPO}\")\n",
-    "        print(\"  2. Download data.zip from Google Drive link\")\n",
-    "        print(f\"  3. Extract to: {dl_dir}\")\n",
-    "        print(\"  4. Run: download_firm_characteristics(convert=True)\")\n",
-    "        return\n",
-    "\n",
-    "    dl_dir.mkdir(parents=True, exist_ok=True)\n",
-    "    zip_path = dl_dir / \"data.zip\"\n",
-    "\n",
-    "    print(\"\\nDownloading from Google Drive...\")\n",
-    "    url = f\"https://drive.google.com/uc?id={GDRIVE_FILE_ID}\"\n",
-    "    gdown.download(url, str(zip_path), quiet=False)\n",
-    "\n",
-    "    if not zip_path.exists():\n",
-    "        print(\"ERROR: Download failed\")\n",
-    "        return\n",
-    "\n",
-    "    print(\"\\nExtracting archive...\")\n",
-    "    with zipfile.ZipFile(zip_path, \"r\") as zf:\n",
-    "        zf.extractall(dl_dir)\n",
-    "\n",
-    "    # Cleanup zip\n",
-    "    zip_path.unlink()\n",
-    "\n",
-    "    print(\"Download complete!\")\n",
-    "\n",
-    "    # Convert to parquet\n",
-    "    if convert:\n",
-    "        _convert_to_parquet(output_dir)\n",
-    "\n",
-    "\n",
-    "def _convert_to_parquet(output_dir: Path):\n",
-    "    \"\"\"Convert RetChar.csv to parquet format with train/test splits.\"\"\"\n",
-    "    dl_dir = output_dir / \"dl_asset_pricing\"\n",
-    "    retchar_path = dl_dir / \"RetChar.csv\"\n",
-    "\n",
-    "    if not retchar_path.exists():\n",
-    "        # Try nested path\n",
-    "        nested_path = dl_dir / \"data\" / \"RetChar.csv\"\n",
-    "        if nested_path.exists():\n",
-    "            retchar_path = nested_path\n",
-    "        else:\n",
-    "            print(f\"ERROR: RetChar.csv not found at {retchar_path}\")\n",
-    "            return\n",
-    "\n",
-    "    print(\"\\nConverting to parquet format...\")\n",
-    "\n",
-    "    # Read CSV\n",
-    "    df = pl.read_csv(retchar_path)\n",
-    "    print(f\"  Loaded {len(df):,} rows, {len(df.columns)} columns\")\n",
-    "\n",
-    "    # Date is in YYYYMMDD format (integer)\n",
-    "    df = df.with_columns(\n",
-    "        pl.col(\"Date\").cast(pl.Utf8).str.to_date(\"%Y%m%d\").alias(\"date\"),\n",
-    "        pl.col(\"Date\").cast(pl.Utf8).str.slice(0, 4).cast(pl.Int32).alias(\"year\"),\n",
-    "    )\n",
-    "\n",
-    "    # Rename permno column if it exists differently\n",
-    "    if \"Permno\" in df.columns:\n",
-    "        df = df.rename({\"Permno\": \"permno\"})\n",
-    "    if \"RET\" in df.columns:\n",
-    "        df = df.rename({\"RET\": \"ret\"})\n",
-    "\n",
-    "    # Create splits based on paper\n",
-    "    train_df = df.filter(pl.col(\"year\") < 1990)\n",
-    "    test_df = df.filter(pl.col(\"year\") >= 2000)\n",
-    "\n",
-    "    # Drop helper columns\n",
-    "    train_df = train_df.drop([\"Date\", \"year\"])\n",
-    "    test_df = test_df.drop([\"Date\", \"year\"])\n",
-    "    all_df = df.drop([\"Date\", \"year\"])\n",
-    "\n",
-    "    # Save parquet files\n",
-    "    output_dir.mkdir(parents=True, exist_ok=True)\n",
-    "\n",
-    "    all_df.write_parquet(output_dir / \"firm_characteristics_all.parquet\")\n",
-    "    train_df.write_parquet(output_dir / \"firm_characteristics_train.parquet\")\n",
-    "    test_df.write_parquet(output_dir / \"firm_characteristics_test.parquet\")\n",
-    "\n",
-    "    print(\"  Created:\")\n",
-    "    print(f\"    firm_characteristics_all.parquet: {len(all_df):,} rows\")\n",
-    "    print(f\"    firm_characteristics_train.parquet: {len(train_df):,} rows (1967-1989)\")\n",
-    "    print(f\"    firm_characteristics_test.parquet: {len(test_df):,} rows (2000-2016)\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "11257101",
-   "metadata": {
-    "papermill": {
-     "duration": 0.000989,
-     "end_time": "2026-05-03T01:59:03.986286+00:00",
-     "exception": false,
-     "start_time": "2026-05-03T01:59:03.985297+00:00",
-     "status": "completed"
-    }
-   },
-   "source": [
-    "### Download"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "id": "cc955346",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-05-03T01:59:03.988898Z",
-     "iopub.status.busy": "2026-05-03T01:59:03.988832Z",
-     "iopub.status.idle": "2026-05-03T01:59:03.990199Z",
-     "shell.execute_reply": "2026-05-03T01:59:03.989977Z"
-    },
-    "papermill": {
-     "duration": 0.003065,
-     "end_time": "2026-05-03T01:59:03.990520+00:00",
-     "exception": false,
-     "start_time": "2026-05-03T01:59:03.987455+00:00",
-     "status": "completed"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "# Uncomment to download\n",
-    "# download_firm_characteristics()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "79f41566",
-   "metadata": {
-    "papermill": {
-     "duration": 0.00154,
-     "end_time": "2026-05-03T01:59:03.993439+00:00",
-     "exception": false,
-     "start_time": "2026-05-03T01:59:03.991899+00:00",
-     "status": "completed"
-    }
-   },
-   "source": [
-    "### Dry Run (Preview)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
-   "id": "77cb850d",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-05-03T01:59:03.996076Z",
-     "iopub.status.busy": "2026-05-03T01:59:03.996012Z",
-     "iopub.status.idle": "2026-05-03T01:59:04.669951Z",
-     "shell.execute_reply": "2026-05-03T01:59:04.669460Z"
-    },
-    "papermill": {
-     "duration": 0.675859,
-     "end_time": "2026-05-03T01:59:04.670399+00:00",
-     "exception": false,
-     "start_time": "2026-05-03T01:59:03.994540+00:00",
+     "start_time": "2026-09-11T18:54:51.967552+00:00",
      "status": "completed"
     }
    },
@@ -444,37 +245,34 @@
      "output_type": "stream",
      "text": [
       "=== Firm Characteristics Download ===\n",
-      "Dataset: Chen-Pelger-Zhu (2020)\n",
-      "Coverage: 1967-1989 (train), 2000-2016 (test)\n",
-      "Features: 94 firm characteristics + returns\n",
-      "Estimated size: ~1.5 GB (archive), ~258 MB (parquet)\n",
-      "Output: data/academic\n",
-      "\n",
-      "[DRY RUN] Would download:\n",
-      "  - data.zip from Google Drive (~1.5 GB)\n",
-      "  - Extract to: data/academic/dl_asset_pricing\n",
-      "  - Convert to parquet: data/academic/firm_characteristics_all.parquet\n",
-      "\n",
-      "Manual download:\n",
-      "  1. Go to: https://github.com/jasonzy121/Deep_Learning_Asset_Pricing\n",
-      "  2. Download data.zip from Google Drive link\n",
-      "  3. Extract to: data/academic/dl_asset_pricing\n"
+      "Downloader: data/equities/firm_characteristics/download.py\n",
+      "Writes to:  <ML4T_DATA_PATH>/equities/firm_characteristics\n",
+      "Present:    ['firm_characteristics_all.parquet', 'firm_characteristics_test.parquet', 'firm_characteristics_train.parquet', 'firm_characteristics_valid.parquet']\n"
      ]
     }
    ],
    "source": [
-    "download_firm_characteristics(dry_run=True)"
+    "from utils import ML4T_DATA_PATH\n",
+    "from utils.paths import display_path\n",
+    "\n",
+    "parquet_dir = ML4T_DATA_PATH / \"equities\" / \"firm_characteristics\"\n",
+    "present = sorted(path.name for path in parquet_dir.glob(\"firm_characteristics_*.parquet\"))\n",
+    "\n",
+    "print(\"=== Firm Characteristics Download ===\")\n",
+    "print(\"Downloader: data/equities/firm_characteristics/download.py\")\n",
+    "print(f\"Writes to:  {display_path(parquet_dir)}\")\n",
+    "print(f\"Present:    {present or 'nothing yet - run the downloader'}\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "2ed6899b",
+   "id": "2173c90b",
    "metadata": {
     "papermill": {
-     "duration": 0.001819,
-     "end_time": "2026-05-03T01:59:04.673576+00:00",
+     "duration": 0.005337,
+     "end_time": "2026-09-11T18:54:55.973605+00:00",
      "exception": false,
-     "start_time": "2026-05-03T01:59:04.671757+00:00",
+     "start_time": "2026-09-11T18:54:55.968268+00:00",
      "status": "completed"
     }
    },
@@ -486,20 +284,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
-   "id": "05a2fd89",
+   "execution_count": 5,
+   "id": "66babb2e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-03T01:59:04.677802Z",
-     "iopub.status.busy": "2026-05-03T01:59:04.677674Z",
-     "iopub.status.idle": "2026-05-03T01:59:04.795097Z",
-     "shell.execute_reply": "2026-05-03T01:59:04.794667Z"
+     "iopub.execute_input": "2026-09-11T18:54:55.983758Z",
+     "iopub.status.busy": "2026-09-11T18:54:55.983324Z",
+     "iopub.status.idle": "2026-09-11T18:54:56.386276Z",
+     "shell.execute_reply": "2026-09-11T18:54:56.385458Z"
     },
     "papermill": {
-     "duration": 0.120275,
-     "end_time": "2026-05-03T01:59:04.795669+00:00",
+     "duration": 0.410933,
+     "end_time": "2026-09-11T18:54:56.387480+00:00",
      "exception": false,
-     "start_time": "2026-05-03T01:59:04.675394+00:00",
+     "start_time": "2026-09-11T18:54:55.976547+00:00",
      "status": "completed"
     }
    },
@@ -508,10 +306,10 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Shape: (1218555, 49)\n",
+      "Shape: (1218555, 50)\n",
       "Date range: 1967-01-31 to 2016-12-30\n",
       "Features: 47\n",
-      "Memory: 446.9 MB\n"
+      "Memory: 451.3 MB\n"
      ]
     }
    ],
@@ -532,20 +330,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
-   "id": "26922681",
+   "execution_count": 6,
+   "id": "3b1f4d32",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-03T01:59:04.801540Z",
-     "iopub.status.busy": "2026-05-03T01:59:04.801422Z",
-     "iopub.status.idle": "2026-05-03T01:59:04.805610Z",
-     "shell.execute_reply": "2026-05-03T01:59:04.805250Z"
+     "iopub.execute_input": "2026-09-11T18:54:56.402937Z",
+     "iopub.status.busy": "2026-09-11T18:54:56.399892Z",
+     "iopub.status.idle": "2026-09-11T18:54:56.423523Z",
+     "shell.execute_reply": "2026-09-11T18:54:56.423011Z"
     },
     "papermill": {
-     "duration": 0.007961,
-     "end_time": "2026-05-03T01:59:04.806079+00:00",
+     "duration": 0.034135,
+     "end_time": "2026-09-11T18:54:56.424657+00:00",
      "exception": false,
-     "start_time": "2026-05-03T01:59:04.798118+00:00",
+     "start_time": "2026-09-11T18:54:56.390522+00:00",
      "status": "completed"
     }
    },
@@ -553,7 +351,9 @@
     {
      "data": {
       "text/plain": [
-       "Schema([('ret', Float64),\n",
+       "Schema([('symbol', UInt32),\n",
+       "        ('timestamp', Date),\n",
+       "        ('ret', Float64),\n",
        "        ('A2ME', Float64),\n",
        "        ('AC', Float64),\n",
        "        ('AT', Float64),\n",
@@ -600,11 +400,10 @@
        "        ('ST_REV', Float64),\n",
        "        ('SUV', Float64),\n",
        "        ('Variance', Float64),\n",
-       "        ('timestamp', Date),\n",
        "        ('split', String)])"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -616,20 +415,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
-   "id": "b071912d",
+   "execution_count": 7,
+   "id": "28588d9c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-03T01:59:04.810236Z",
-     "iopub.status.busy": "2026-05-03T01:59:04.810131Z",
-     "iopub.status.idle": "2026-05-03T01:59:04.815186Z",
-     "shell.execute_reply": "2026-05-03T01:59:04.814872Z"
+     "iopub.execute_input": "2026-09-11T18:54:56.432038Z",
+     "iopub.status.busy": "2026-09-11T18:54:56.431853Z",
+     "iopub.status.idle": "2026-09-11T18:54:56.440465Z",
+     "shell.execute_reply": "2026-09-11T18:54:56.439673Z"
     },
     "papermill": {
-     "duration": 0.007659,
-     "end_time": "2026-05-03T01:59:04.815589+00:00",
+     "duration": 0.01295,
+     "end_time": "2026-09-11T18:54:56.440916+00:00",
      "exception": false,
-     "start_time": "2026-05-03T01:59:04.807930+00:00",
+     "start_time": "2026-09-11T18:54:56.427966+00:00",
      "status": "completed"
     }
    },
@@ -644,29 +443,29 @@
        "  white-space: pre-wrap;\n",
        "}\n",
        "</style>\n",
-       "<small>shape: (10, 49)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>ret</th><th>A2ME</th><th>AC</th><th>AT</th><th>ATO</th><th>BEME</th><th>Beta</th><th>C</th><th>CF</th><th>CF2P</th><th>CTO</th><th>D2A</th><th>D2P</th><th>DPI2A</th><th>E2P</th><th>FC2Y</th><th>IdioVol</th><th>Investment</th><th>Lev</th><th>LME</th><th>LT_Rev</th><th>LTurnover</th><th>MktBeta</th><th>NI</th><th>NOA</th><th>OA</th><th>OL</th><th>OP</th><th>PCM</th><th>PM</th><th>PROF</th><th>Q</th><th>r2_1</th><th>r12_2</th><th>r12_7</th><th>r36_13</th><th>Rel2High</th><th>Resid_Var</th><th>RNA</th><th>ROA</th><th>ROE</th><th>S2P</th><th>SGA2S</th><th>Spread</th><th>ST_REV</th><th>SUV</th><th>Variance</th><th>timestamp</th><th>split</th></tr><tr><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>date</td><td>str</td></tr></thead><tbody><tr><td>0.136223</td><td>0.108392</td><td>0.24359</td><td>0.152681</td><td>-0.182984</td><td>0.113054</td><td>0.185315</td><td>0.113054</td><td>-0.271562</td><td>0.404429</td><td>-0.252914</td><td>0.036131</td><td>0.15035</td><td>0.001166</td><td>0.343823</td><td>-0.381119</td><td>-0.155012</td><td>0.073427</td><td>-0.01049</td><td>0.01049</td><td>0.432401</td><td>0.059441</td><td>-0.136364</td><td>-0.390443</td><td>0.134033</td><td>0.259907</td><td>-0.245921</td><td>0.143357</td><td>-0.148019</td><td>0.311189</td><td>-0.283217</td><td>-0.217949</td><td>-0.008159</td><td>-0.043124</td><td>0.250583</td><td>0.106061</td><td>-0.122378</td><td>-0.224942</td><td>0.045455</td><td>0.059441</td><td>0.08042</td><td>-0.015152</td><td>-0.38345</td><td>-0.164336</td><td>-0.241259</td><td>-0.325175</td><td>-0.182984</td><td>1967-01-31</td><td>&quot;train&quot;</td></tr><tr><td>0.317129</td><td>0.455711</td><td>-0.36014</td><td>-0.472028</td><td>0.257576</td><td>0.45338</td><td>0.318182</td><td>0.122378</td><td>0.071096</td><td>0.43007</td><td>0.180653</td><td>-0.194639</td><td>-0.5</td><td>-0.488345</td><td>0.488345</td><td>-0.201632</td><td>0.495338</td><td>-0.467366</td><td>0.17366</td><td>-0.488345</td><td>-0.439394</td><td>0.332168</td><td>-0.145688</td><td>-0.320513</td><td>-0.294872</td><td>-0.334499</td><td>0.355478</td><td>-0.357809</td><td>-0.409091</td><td>-0.392774</td><td>-0.068765</td><td>0.015152</td><td>0.082751</td><td>0.364802</td><td>0.495338</td><td>-0.329837</td><td>-0.490676</td><td>0.483683</td><td>0.038462</td><td>-0.346154</td><td>-0.245921</td><td>0.439394</td><td>-0.175991</td><td>0.439394</td><td>-0.399767</td><td>-0.064103</td><td>0.483683</td><td>1967-01-31</td><td>&quot;train&quot;</td></tr><tr><td>0.101064</td><td>0.050117</td><td>0.050117</td><td>0.206294</td><td>-0.276224</td><td>0.096737</td><td>0.068765</td><td>-0.294872</td><td>-0.325175</td><td>0.374126</td><td>-0.325175</td><td>0.099068</td><td>0.148019</td><td>-0.115385</td><td>0.019814</td><td>-0.029138</td><td>-0.369464</td><td>-0.182984</td><td>0.003497</td><td>0.10373</td><td>-0.05711</td><td>0.138695</td><td>-0.085082</td><td>0.175991</td><td>0.269231</td><td>0.047786</td><td>-0.280886</td><td>-0.110723</td><td>0.124709</td><td>0.203963</td><td>-0.194639</td><td>-0.187646</td><td>-0.334499</td><td>-0.294872</td><td>-0.320513</td><td>-0.047786</td><td>0.206294</td><td>-0.129371</td><td>-0.145688</td><td>-0.136364</td><td>-0.134033</td><td>-0.108392</td><td>0.001166</td><td>0.115385</td><td>0.5</td><td>0.273893</td><td>0.026807</td><td>1967-01-31</td><td>&quot;train&quot;</td></tr><tr><td>0.287367</td><td>-0.031469</td><td>0.019814</td><td>0.416084</td><td>-0.252914</td><td>0.005828</td><td>-0.297203</td><td>-0.493007</td><td>-0.31352</td><td>0.315851</td><td>-0.320513</td><td>0.416084</td><td>-0.208625</td><td>0.213287</td><td>-0.054779</td><td>-0.054779</td><td>-0.413753</td><td>0.024476</td><td>-0.078089</td><td>0.339161</td><td>-0.297203</td><td>0.15035</td><td>-0.33683</td><td>-0.166667</td><td>0.236597</td><td>0.001166</td><td>-0.31352</td><td>0.040793</td><td>0.092075</td><td>0.15035</td><td>-0.236597</td><td>-0.108392</td><td>-0.399767</td><td>-0.341492</td><td>-0.378788</td><td>-0.423077</td><td>-0.271562</td><td>-0.460373</td><td>-0.136364</td><td>-0.059441</td><td>-0.099068</td><td>-0.17366</td><td>-0.178322</td><td>0.024476</td><td>-0.001166</td><td>0.378788</td><td>-0.357809</td><td>1967-01-31</td><td>&quot;train&quot;</td></tr><tr><td>0.143427</td><td>0.371795</td><td>0.497669</td><td>0.280886</td><td>-0.175991</td><td>0.362471</td><td>0.325175</td><td>-0.346154</td><td>-0.08042</td><td>0.148019</td><td>-0.141026</td><td>-0.129371</td><td>-0.168998</td><td>-0.297203</td><td>0.120047</td><td>-0.213287</td><td>0.110723</td><td>-0.085082</td><td>-0.120047</td><td>-0.003497</td><td>0.180653</td><td>0.388112</td><td>0.378788</td><td>-0.318182</td><td>0.24359</td><td>0.483683</td><td>-0.038462</td><td>-0.320513</td><td>-0.332168</td><td>-0.304196</td><td>-0.238928</td><td>-0.385781</td><td>-0.38345</td><td>-0.427739</td><td>-0.162005</td><td>0.374126</td><td>-0.416084</td><td>0.071096</td><td>-0.278555</td><td>-0.392774</td><td>-0.38345</td><td>0.299534</td><td>-0.189977</td><td>0.292541</td><td>0.152681</td><td>-0.304196</td><td>0.248252</td><td>1967-01-31</td><td>&quot;train&quot;</td></tr><tr><td>0.162367</td><td>-0.071096</td><td>-0.472028</td><td>0.283217</td><td>0.012821</td><td>-0.134033</td><td>0.208625</td><td>0.483683</td><td>-0.248252</td><td>0.050117</td><td>-0.304196</td><td>-0.203963</td><td>-0.164336</td><td>0.234266</td><td>0.31352</td><td>-0.2669</td><td>0.192308</td><td>0.399767</td><td>-0.071096</td><td>0.259907</td><td>-0.026807</td><td>-0.075758</td><td>0.113054</td><td>0.178322</td><td>-0.106061</td><td>-0.467366</td><td>-0.332168</td><td>-0.285548</td><td>-0.185315</td><td>0.043124</td><td>-0.374126</td><td>-0.01049</td><td>-0.229604</td><td>-0.017483</td><td>0.168998</td><td>-0.178322</td><td>-0.250583</td><td>0.259907</td><td>0.061772</td><td>0.36014</td><td>0.378788</td><td>-0.276224</td><td>-0.255245</td><td>0.229604</td><td>0.2669</td><td>-0.001166</td><td>0.224942</td><td>1967-01-31</td><td>&quot;train&quot;</td></tr><tr><td>0.157643</td><td>-0.089744</td><td>-0.45338</td><td>0.350816</td><td>-0.308858</td><td>0.026807</td><td>-0.378788</td><td>-0.469697</td><td>0.285548</td><td>-0.224942</td><td>-0.367133</td><td>-0.497669</td><td>-0.187646</td><td>-0.339161</td><td>0.24359</td><td>-0.001166</td><td>-0.131702</td><td>-0.36014</td><td>-0.192308</td><td>0.327506</td><td>-0.357809</td><td>-0.259907</td><td>-0.019814</td><td>-0.388112</td><td>0.378788</td><td>-0.465035</td><td>-0.367133</td><td>-0.038462</td><td>0.2669</td><td>0.462704</td><td>-0.234266</td><td>-0.085082</td><td>-0.343823</td><td>-0.08042</td><td>-0.192308</td><td>-0.003497</td><td>0.0338</td><td>-0.236597</td><td>0.008159</td><td>0.194639</td><td>0.026807</td><td>-0.252914</td><td>0.0338</td><td>-0.17366</td><td>-0.10373</td><td>-0.138695</td><td>-0.283217</td><td>1967-01-31</td><td>&quot;train&quot;</td></tr><tr><td>-0.081223</td><td>-0.141026</td><td>0.129371</td><td>0.061772</td><td>0.148019</td><td>-0.241259</td><td>0.099068</td><td>0.397436</td><td>0.019814</td><td>-0.353147</td><td>0.299534</td><td>-0.250583</td><td>-0.012821</td><td>-0.315851</td><td>-0.287879</td><td>-0.5</td><td>0.369464</td><td>0.215618</td><td>-0.036131</td><td>0.138695</td><td>0.203963</td><td>0.411422</td><td>0.299534</td><td>0.199301</td><td>-0.05711</td><td>0.092075</td><td>0.332168</td><td>0.038462</td><td>-0.493007</td><td>-0.252914</td><td>-0.423077</td><td>0.078089</td><td>0.138695</td><td>0.276224</td><td>0.322844</td><td>0.423077</td><td>0.47669</td><td>0.304196</td><td>0.040793</td><td>-0.108392</td><td>0.008159</td><td>0.106061</td><td>-0.5</td><td>0.038462</td><td>0.437063</td><td>0.064103</td><td>0.271562</td><td>1967-01-31</td><td>&quot;train&quot;</td></tr><tr><td>-0.000577</td><td>0.075758</td><td>0.024476</td><td>0.395105</td><td>-0.166667</td><td>0.138695</td><td>-0.245921</td><td>-0.145688</td><td>0.052448</td><td>0.399767</td><td>-0.138695</td><td>0.245921</td><td>-0.180653</td><td>-0.206294</td><td>0.036131</td><td>-0.24359</td><td>-0.066434</td><td>-0.285548</td><td>-0.134033</td><td>0.301865</td><td>-0.029138</td><td>-0.162005</td><td>-0.455711</td><td>0.094406</td><td>0.122378</td><td>0.026807</td><td>-0.052448</td><td>-0.071096</td><td>-0.187646</td><td>-0.026807</td><td>-0.215618</td><td>-0.234266</td><td>-0.325175</td><td>-0.054779</td><td>0.064103</td><td>-0.099068</td><td>0.087413</td><td>-0.283217</td><td>-0.117716</td><td>-0.164336</td><td>-0.22028</td><td>0.101399</td><td>-0.227273</td><td>-0.22028</td><td>0.061772</td><td>0.155012</td><td>-0.287879</td><td>1967-01-31</td><td>&quot;train&quot;</td></tr><tr><td>0.4157</td><td>0.458042</td><td>-0.444056</td><td>0.227273</td><td>-0.434732</td><td>0.467366</td><td>0.285548</td><td>0.003497</td><td>-0.444056</td><td>0.187646</td><td>0.36014</td><td>-0.115385</td><td>-0.38345</td><td>0.182984</td><td>-0.432401</td><td>-0.092075</td><td>0.402098</td><td>-0.110723</td><td>0.175991</td><td>-0.148019</td><td>-0.45338</td><td>0.385781</td><td>-0.418415</td><td>-0.01049</td><td>-0.374126</td><td>-0.45338</td><td>0.420746</td><td>-0.481352</td><td>-0.437063</td><td>-0.483683</td><td>-0.117716</td><td>-0.122378</td><td>-0.5</td><td>-0.236597</td><td>0.355478</td><td>-0.497669</td><td>-0.488345</td><td>0.45338</td><td>-0.350816</td><td>-0.469697</td><td>-0.47669</td><td>0.462704</td><td>-0.068765</td><td>0.483683</td><td>-0.488345</td><td>0.374126</td><td>0.455711</td><td>1967-01-31</td><td>&quot;train&quot;</td></tr></tbody></table></div>"
+       "<small>shape: (10, 50)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>symbol</th><th>timestamp</th><th>ret</th><th>A2ME</th><th>AC</th><th>AT</th><th>ATO</th><th>BEME</th><th>Beta</th><th>C</th><th>CF</th><th>CF2P</th><th>CTO</th><th>D2A</th><th>D2P</th><th>DPI2A</th><th>E2P</th><th>FC2Y</th><th>IdioVol</th><th>Investment</th><th>Lev</th><th>LME</th><th>LT_Rev</th><th>LTurnover</th><th>MktBeta</th><th>NI</th><th>NOA</th><th>OA</th><th>OL</th><th>OP</th><th>PCM</th><th>PM</th><th>PROF</th><th>Q</th><th>r2_1</th><th>r12_2</th><th>r12_7</th><th>r36_13</th><th>Rel2High</th><th>Resid_Var</th><th>RNA</th><th>ROA</th><th>ROE</th><th>S2P</th><th>SGA2S</th><th>Spread</th><th>ST_REV</th><th>SUV</th><th>Variance</th><th>split</th></tr><tr><td>u32</td><td>date</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>str</td></tr></thead><tbody><tr><td>0</td><td>1967-01-31</td><td>0.136223</td><td>0.108392</td><td>0.24359</td><td>0.152681</td><td>-0.182984</td><td>0.113054</td><td>0.185315</td><td>0.113054</td><td>-0.271562</td><td>0.404429</td><td>-0.252914</td><td>0.036131</td><td>0.15035</td><td>0.001166</td><td>0.343823</td><td>-0.381119</td><td>-0.155012</td><td>0.073427</td><td>-0.01049</td><td>0.01049</td><td>0.432401</td><td>0.059441</td><td>-0.136364</td><td>-0.390443</td><td>0.134033</td><td>0.259907</td><td>-0.245921</td><td>0.143357</td><td>-0.148019</td><td>0.311189</td><td>-0.283217</td><td>-0.217949</td><td>-0.008159</td><td>-0.043124</td><td>0.250583</td><td>0.106061</td><td>-0.122378</td><td>-0.224942</td><td>0.045455</td><td>0.059441</td><td>0.08042</td><td>-0.015152</td><td>-0.38345</td><td>-0.164336</td><td>-0.241259</td><td>-0.325175</td><td>-0.182984</td><td>&quot;train&quot;</td></tr><tr><td>1</td><td>1967-01-31</td><td>0.317129</td><td>0.455711</td><td>-0.36014</td><td>-0.472028</td><td>0.257576</td><td>0.45338</td><td>0.318182</td><td>0.122378</td><td>0.071096</td><td>0.43007</td><td>0.180653</td><td>-0.194639</td><td>-0.5</td><td>-0.488345</td><td>0.488345</td><td>-0.201632</td><td>0.495338</td><td>-0.467366</td><td>0.17366</td><td>-0.488345</td><td>-0.439394</td><td>0.332168</td><td>-0.145688</td><td>-0.320513</td><td>-0.294872</td><td>-0.334499</td><td>0.355478</td><td>-0.357809</td><td>-0.409091</td><td>-0.392774</td><td>-0.068765</td><td>0.015152</td><td>0.082751</td><td>0.364802</td><td>0.495338</td><td>-0.329837</td><td>-0.490676</td><td>0.483683</td><td>0.038462</td><td>-0.346154</td><td>-0.245921</td><td>0.439394</td><td>-0.175991</td><td>0.439394</td><td>-0.399767</td><td>-0.064103</td><td>0.483683</td><td>&quot;train&quot;</td></tr><tr><td>4</td><td>1967-01-31</td><td>0.101064</td><td>0.050117</td><td>0.050117</td><td>0.206294</td><td>-0.276224</td><td>0.096737</td><td>0.068765</td><td>-0.294872</td><td>-0.325175</td><td>0.374126</td><td>-0.325175</td><td>0.099068</td><td>0.148019</td><td>-0.115385</td><td>0.019814</td><td>-0.029138</td><td>-0.369464</td><td>-0.182984</td><td>0.003497</td><td>0.10373</td><td>-0.05711</td><td>0.138695</td><td>-0.085082</td><td>0.175991</td><td>0.269231</td><td>0.047786</td><td>-0.280886</td><td>-0.110723</td><td>0.124709</td><td>0.203963</td><td>-0.194639</td><td>-0.187646</td><td>-0.334499</td><td>-0.294872</td><td>-0.320513</td><td>-0.047786</td><td>0.206294</td><td>-0.129371</td><td>-0.145688</td><td>-0.136364</td><td>-0.134033</td><td>-0.108392</td><td>0.001166</td><td>0.115385</td><td>0.5</td><td>0.273893</td><td>0.026807</td><td>&quot;train&quot;</td></tr><tr><td>5</td><td>1967-01-31</td><td>0.287367</td><td>-0.031469</td><td>0.019814</td><td>0.416084</td><td>-0.252914</td><td>0.005828</td><td>-0.297203</td><td>-0.493007</td><td>-0.31352</td><td>0.315851</td><td>-0.320513</td><td>0.416084</td><td>-0.208625</td><td>0.213287</td><td>-0.054779</td><td>-0.054779</td><td>-0.413753</td><td>0.024476</td><td>-0.078089</td><td>0.339161</td><td>-0.297203</td><td>0.15035</td><td>-0.33683</td><td>-0.166667</td><td>0.236597</td><td>0.001166</td><td>-0.31352</td><td>0.040793</td><td>0.092075</td><td>0.15035</td><td>-0.236597</td><td>-0.108392</td><td>-0.399767</td><td>-0.341492</td><td>-0.378788</td><td>-0.423077</td><td>-0.271562</td><td>-0.460373</td><td>-0.136364</td><td>-0.059441</td><td>-0.099068</td><td>-0.17366</td><td>-0.178322</td><td>0.024476</td><td>-0.001166</td><td>0.378788</td><td>-0.357809</td><td>&quot;train&quot;</td></tr><tr><td>7</td><td>1967-01-31</td><td>0.143427</td><td>0.371795</td><td>0.497669</td><td>0.280886</td><td>-0.175991</td><td>0.362471</td><td>0.325175</td><td>-0.346154</td><td>-0.08042</td><td>0.148019</td><td>-0.141026</td><td>-0.129371</td><td>-0.168998</td><td>-0.297203</td><td>0.120047</td><td>-0.213287</td><td>0.110723</td><td>-0.085082</td><td>-0.120047</td><td>-0.003497</td><td>0.180653</td><td>0.388112</td><td>0.378788</td><td>-0.318182</td><td>0.24359</td><td>0.483683</td><td>-0.038462</td><td>-0.320513</td><td>-0.332168</td><td>-0.304196</td><td>-0.238928</td><td>-0.385781</td><td>-0.38345</td><td>-0.427739</td><td>-0.162005</td><td>0.374126</td><td>-0.416084</td><td>0.071096</td><td>-0.278555</td><td>-0.392774</td><td>-0.38345</td><td>0.299534</td><td>-0.189977</td><td>0.292541</td><td>0.152681</td><td>-0.304196</td><td>0.248252</td><td>&quot;train&quot;</td></tr><tr><td>9</td><td>1967-01-31</td><td>0.162367</td><td>-0.071096</td><td>-0.472028</td><td>0.283217</td><td>0.012821</td><td>-0.134033</td><td>0.208625</td><td>0.483683</td><td>-0.248252</td><td>0.050117</td><td>-0.304196</td><td>-0.203963</td><td>-0.164336</td><td>0.234266</td><td>0.31352</td><td>-0.2669</td><td>0.192308</td><td>0.399767</td><td>-0.071096</td><td>0.259907</td><td>-0.026807</td><td>-0.075758</td><td>0.113054</td><td>0.178322</td><td>-0.106061</td><td>-0.467366</td><td>-0.332168</td><td>-0.285548</td><td>-0.185315</td><td>0.043124</td><td>-0.374126</td><td>-0.01049</td><td>-0.229604</td><td>-0.017483</td><td>0.168998</td><td>-0.178322</td><td>-0.250583</td><td>0.259907</td><td>0.061772</td><td>0.36014</td><td>0.378788</td><td>-0.276224</td><td>-0.255245</td><td>0.229604</td><td>0.2669</td><td>-0.001166</td><td>0.224942</td><td>&quot;train&quot;</td></tr><tr><td>12</td><td>1967-01-31</td><td>0.157643</td><td>-0.089744</td><td>-0.45338</td><td>0.350816</td><td>-0.308858</td><td>0.026807</td><td>-0.378788</td><td>-0.469697</td><td>0.285548</td><td>-0.224942</td><td>-0.367133</td><td>-0.497669</td><td>-0.187646</td><td>-0.339161</td><td>0.24359</td><td>-0.001166</td><td>-0.131702</td><td>-0.36014</td><td>-0.192308</td><td>0.327506</td><td>-0.357809</td><td>-0.259907</td><td>-0.019814</td><td>-0.388112</td><td>0.378788</td><td>-0.465035</td><td>-0.367133</td><td>-0.038462</td><td>0.2669</td><td>0.462704</td><td>-0.234266</td><td>-0.085082</td><td>-0.343823</td><td>-0.08042</td><td>-0.192308</td><td>-0.003497</td><td>0.0338</td><td>-0.236597</td><td>0.008159</td><td>0.194639</td><td>0.026807</td><td>-0.252914</td><td>0.0338</td><td>-0.17366</td><td>-0.10373</td><td>-0.138695</td><td>-0.283217</td><td>&quot;train&quot;</td></tr><tr><td>13</td><td>1967-01-31</td><td>-0.081223</td><td>-0.141026</td><td>0.129371</td><td>0.061772</td><td>0.148019</td><td>-0.241259</td><td>0.099068</td><td>0.397436</td><td>0.019814</td><td>-0.353147</td><td>0.299534</td><td>-0.250583</td><td>-0.012821</td><td>-0.315851</td><td>-0.287879</td><td>-0.5</td><td>0.369464</td><td>0.215618</td><td>-0.036131</td><td>0.138695</td><td>0.203963</td><td>0.411422</td><td>0.299534</td><td>0.199301</td><td>-0.05711</td><td>0.092075</td><td>0.332168</td><td>0.038462</td><td>-0.493007</td><td>-0.252914</td><td>-0.423077</td><td>0.078089</td><td>0.138695</td><td>0.276224</td><td>0.322844</td><td>0.423077</td><td>0.47669</td><td>0.304196</td><td>0.040793</td><td>-0.108392</td><td>0.008159</td><td>0.106061</td><td>-0.5</td><td>0.038462</td><td>0.437063</td><td>0.064103</td><td>0.271562</td><td>&quot;train&quot;</td></tr><tr><td>14</td><td>1967-01-31</td><td>-0.000577</td><td>0.075758</td><td>0.024476</td><td>0.395105</td><td>-0.166667</td><td>0.138695</td><td>-0.245921</td><td>-0.145688</td><td>0.052448</td><td>0.399767</td><td>-0.138695</td><td>0.245921</td><td>-0.180653</td><td>-0.206294</td><td>0.036131</td><td>-0.24359</td><td>-0.066434</td><td>-0.285548</td><td>-0.134033</td><td>0.301865</td><td>-0.029138</td><td>-0.162005</td><td>-0.455711</td><td>0.094406</td><td>0.122378</td><td>0.026807</td><td>-0.052448</td><td>-0.071096</td><td>-0.187646</td><td>-0.026807</td><td>-0.215618</td><td>-0.234266</td><td>-0.325175</td><td>-0.054779</td><td>0.064103</td><td>-0.099068</td><td>0.087413</td><td>-0.283217</td><td>-0.117716</td><td>-0.164336</td><td>-0.22028</td><td>0.101399</td><td>-0.227273</td><td>-0.22028</td><td>0.061772</td><td>0.155012</td><td>-0.287879</td><td>&quot;train&quot;</td></tr><tr><td>17</td><td>1967-01-31</td><td>0.4157</td><td>0.458042</td><td>-0.444056</td><td>0.227273</td><td>-0.434732</td><td>0.467366</td><td>0.285548</td><td>0.003497</td><td>-0.444056</td><td>0.187646</td><td>0.36014</td><td>-0.115385</td><td>-0.38345</td><td>0.182984</td><td>-0.432401</td><td>-0.092075</td><td>0.402098</td><td>-0.110723</td><td>0.175991</td><td>-0.148019</td><td>-0.45338</td><td>0.385781</td><td>-0.418415</td><td>-0.01049</td><td>-0.374126</td><td>-0.45338</td><td>0.420746</td><td>-0.481352</td><td>-0.437063</td><td>-0.483683</td><td>-0.117716</td><td>-0.122378</td><td>-0.5</td><td>-0.236597</td><td>0.355478</td><td>-0.497669</td><td>-0.488345</td><td>0.45338</td><td>-0.350816</td><td>-0.469697</td><td>-0.47669</td><td>0.462704</td><td>-0.068765</td><td>0.483683</td><td>-0.488345</td><td>0.374126</td><td>0.455711</td><td>&quot;train&quot;</td></tr></tbody></table></div>"
       ],
       "text/plain": [
-       "shape: (10, 49)\n",
-       "┌───────────┬───────────┬───────────┬───────────┬───┬───────────┬───────────┬────────────┬───────┐\n",
-       "│ ret       ┆ A2ME      ┆ AC        ┆ AT        ┆ … ┆ SUV       ┆ Variance  ┆ timestamp  ┆ split │\n",
-       "│ ---       ┆ ---       ┆ ---       ┆ ---       ┆   ┆ ---       ┆ ---       ┆ ---        ┆ ---   │\n",
-       "│ f64       ┆ f64       ┆ f64       ┆ f64       ┆   ┆ f64       ┆ f64       ┆ date       ┆ str   │\n",
-       "╞═══════════╪═══════════╪═══════════╪═══════════╪═══╪═══════════╪═══════════╪════════════╪═══════╡\n",
-       "│ 0.136223  ┆ 0.108392  ┆ 0.24359   ┆ 0.152681  ┆ … ┆ -0.325175 ┆ -0.182984 ┆ 1967-01-31 ┆ train │\n",
-       "│ 0.317129  ┆ 0.455711  ┆ -0.36014  ┆ -0.472028 ┆ … ┆ -0.064103 ┆ 0.483683  ┆ 1967-01-31 ┆ train │\n",
-       "│ 0.101064  ┆ 0.050117  ┆ 0.050117  ┆ 0.206294  ┆ … ┆ 0.273893  ┆ 0.026807  ┆ 1967-01-31 ┆ train │\n",
-       "│ 0.287367  ┆ -0.031469 ┆ 0.019814  ┆ 0.416084  ┆ … ┆ 0.378788  ┆ -0.357809 ┆ 1967-01-31 ┆ train │\n",
-       "│ 0.143427  ┆ 0.371795  ┆ 0.497669  ┆ 0.280886  ┆ … ┆ -0.304196 ┆ 0.248252  ┆ 1967-01-31 ┆ train │\n",
-       "│ 0.162367  ┆ -0.071096 ┆ -0.472028 ┆ 0.283217  ┆ … ┆ -0.001166 ┆ 0.224942  ┆ 1967-01-31 ┆ train │\n",
-       "│ 0.157643  ┆ -0.089744 ┆ -0.45338  ┆ 0.350816  ┆ … ┆ -0.138695 ┆ -0.283217 ┆ 1967-01-31 ┆ train │\n",
-       "│ -0.081223 ┆ -0.141026 ┆ 0.129371  ┆ 0.061772  ┆ … ┆ 0.064103  ┆ 0.271562  ┆ 1967-01-31 ┆ train │\n",
-       "│ -0.000577 ┆ 0.075758  ┆ 0.024476  ┆ 0.395105  ┆ … ┆ 0.155012  ┆ -0.287879 ┆ 1967-01-31 ┆ train │\n",
-       "│ 0.4157    ┆ 0.458042  ┆ -0.444056 ┆ 0.227273  ┆ … ┆ 0.374126  ┆ 0.455711  ┆ 1967-01-31 ┆ train │\n",
-       "└───────────┴───────────┴───────────┴───────────┴───┴───────────┴───────────┴────────────┴───────┘"
+       "shape: (10, 50)\n",
+       "┌────────┬────────────┬───────────┬───────────┬───┬───────────┬───────────┬───────────┬───────┐\n",
+       "│ symbol ┆ timestamp  ┆ ret       ┆ A2ME      ┆ … ┆ ST_REV    ┆ SUV       ┆ Variance  ┆ split │\n",
+       "│ ---    ┆ ---        ┆ ---       ┆ ---       ┆   ┆ ---       ┆ ---       ┆ ---       ┆ ---   │\n",
+       "│ u32    ┆ date       ┆ f64       ┆ f64       ┆   ┆ f64       ┆ f64       ┆ f64       ┆ str   │\n",
+       "╞════════╪════════════╪═══════════╪═══════════╪═══╪═══════════╪═══════════╪═══════════╪═══════╡\n",
+       "│ 0      ┆ 1967-01-31 ┆ 0.136223  ┆ 0.108392  ┆ … ┆ -0.241259 ┆ -0.325175 ┆ -0.182984 ┆ train │\n",
+       "│ 1      ┆ 1967-01-31 ┆ 0.317129  ┆ 0.455711  ┆ … ┆ -0.399767 ┆ -0.064103 ┆ 0.483683  ┆ train │\n",
+       "│ 4      ┆ 1967-01-31 ┆ 0.101064  ┆ 0.050117  ┆ … ┆ 0.5       ┆ 0.273893  ┆ 0.026807  ┆ train │\n",
+       "│ 5      ┆ 1967-01-31 ┆ 0.287367  ┆ -0.031469 ┆ … ┆ -0.001166 ┆ 0.378788  ┆ -0.357809 ┆ train │\n",
+       "│ 7      ┆ 1967-01-31 ┆ 0.143427  ┆ 0.371795  ┆ … ┆ 0.152681  ┆ -0.304196 ┆ 0.248252  ┆ train │\n",
+       "│ 9      ┆ 1967-01-31 ┆ 0.162367  ┆ -0.071096 ┆ … ┆ 0.2669    ┆ -0.001166 ┆ 0.224942  ┆ train │\n",
+       "│ 12     ┆ 1967-01-31 ┆ 0.157643  ┆ -0.089744 ┆ … ┆ -0.10373  ┆ -0.138695 ┆ -0.283217 ┆ train │\n",
+       "│ 13     ┆ 1967-01-31 ┆ -0.081223 ┆ -0.141026 ┆ … ┆ 0.437063  ┆ 0.064103  ┆ 0.271562  ┆ train │\n",
+       "│ 14     ┆ 1967-01-31 ┆ -0.000577 ┆ 0.075758  ┆ … ┆ 0.061772  ┆ 0.155012  ┆ -0.287879 ┆ train │\n",
+       "│ 17     ┆ 1967-01-31 ┆ 0.4157    ┆ 0.458042  ┆ … ┆ -0.488345 ┆ 0.374126  ┆ 0.455711  ┆ train │\n",
+       "└────────┴────────────┴───────────┴───────────┴───┴───────────┴───────────┴───────────┴───────┘"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -678,13 +477,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e5ee4b7d",
+   "id": "b0f9ace0",
    "metadata": {
     "papermill": {
-     "duration": 0.001712,
-     "end_time": "2026-05-03T01:59:04.819029+00:00",
+     "duration": 0.001901,
+     "end_time": "2026-09-11T18:54:56.445777+00:00",
      "exception": false,
-     "start_time": "2026-05-03T01:59:04.817317+00:00",
+     "start_time": "2026-09-11T18:54:56.443876+00:00",
      "status": "completed"
     }
    },
@@ -694,20 +493,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
-   "id": "d2b7b379",
+   "execution_count": 8,
+   "id": "02f08bd1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-03T01:59:04.822254Z",
-     "iopub.status.busy": "2026-05-03T01:59:04.822190Z",
-     "iopub.status.idle": "2026-05-03T01:59:04.828197Z",
-     "shell.execute_reply": "2026-05-03T01:59:04.827901Z"
+     "iopub.execute_input": "2026-09-11T18:54:56.455036Z",
+     "iopub.status.busy": "2026-09-11T18:54:56.454849Z",
+     "iopub.status.idle": "2026-09-11T18:54:56.458950Z",
+     "shell.execute_reply": "2026-09-11T18:54:56.458448Z"
     },
     "papermill": {
-     "duration": 0.007974,
-     "end_time": "2026-05-03T01:59:04.828542+00:00",
+     "duration": 0.013098,
+     "end_time": "2026-09-11T18:54:56.464110+00:00",
      "exception": false,
-     "start_time": "2026-05-03T01:59:04.820568+00:00",
+     "start_time": "2026-09-11T18:54:56.451012+00:00",
      "status": "completed"
     }
    },
@@ -756,13 +555,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a5acc6d9",
+   "id": "92112e4d",
    "metadata": {
     "papermill": {
-     "duration": 0.001692,
-     "end_time": "2026-05-03T01:59:04.831871+00:00",
+     "duration": 0.002615,
+     "end_time": "2026-09-11T18:54:56.469721+00:00",
      "exception": false,
-     "start_time": "2026-05-03T01:59:04.830179+00:00",
+     "start_time": "2026-09-11T18:54:56.467106+00:00",
      "status": "completed"
     }
    },
@@ -772,20 +571,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
-   "id": "d463f0c1",
+   "execution_count": 9,
+   "id": "b14d461b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-03T01:59:04.836846Z",
-     "iopub.status.busy": "2026-05-03T01:59:04.836709Z",
-     "iopub.status.idle": "2026-05-03T01:59:04.853486Z",
-     "shell.execute_reply": "2026-05-03T01:59:04.852991Z"
+     "iopub.execute_input": "2026-09-11T18:54:56.474796Z",
+     "iopub.status.busy": "2026-09-11T18:54:56.474583Z",
+     "iopub.status.idle": "2026-09-11T18:54:56.504428Z",
+     "shell.execute_reply": "2026-09-11T18:54:56.503773Z"
     },
     "papermill": {
-     "duration": 0.0202,
-     "end_time": "2026-05-03T01:59:04.854022+00:00",
+     "duration": 0.03694,
+     "end_time": "2026-09-11T18:54:56.508626+00:00",
      "exception": false,
-     "start_time": "2026-05-03T01:59:04.833822+00:00",
+     "start_time": "2026-09-11T18:54:56.471686+00:00",
      "status": "completed"
     }
    },
@@ -830,7 +629,7 @@
        "└──────┴────────────────┘"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -851,13 +650,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6f6c2662",
+   "id": "52350c88",
    "metadata": {
     "papermill": {
-     "duration": 0.002234,
-     "end_time": "2026-05-03T01:59:04.859352+00:00",
+     "duration": 0.004075,
+     "end_time": "2026-09-11T18:54:56.528855+00:00",
      "exception": false,
-     "start_time": "2026-05-03T01:59:04.857118+00:00",
+     "start_time": "2026-09-11T18:54:56.524780+00:00",
      "status": "completed"
     }
    },
@@ -867,20 +666,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
-   "id": "401cee4b",
+   "execution_count": 10,
+   "id": "f6cd61ef",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-03T01:59:04.864124Z",
-     "iopub.status.busy": "2026-05-03T01:59:04.864035Z",
-     "iopub.status.idle": "2026-05-03T01:59:04.866288Z",
-     "shell.execute_reply": "2026-05-03T01:59:04.866017Z"
+     "iopub.execute_input": "2026-09-11T18:54:56.539070Z",
+     "iopub.status.busy": "2026-09-11T18:54:56.538844Z",
+     "iopub.status.idle": "2026-09-11T18:54:56.547595Z",
+     "shell.execute_reply": "2026-09-11T18:54:56.546160Z"
     },
     "papermill": {
-     "duration": 0.00471,
-     "end_time": "2026-05-03T01:59:04.866608+00:00",
+     "duration": 0.01821,
+     "end_time": "2026-09-11T18:54:56.551050+00:00",
      "exception": false,
-     "start_time": "2026-05-03T01:59:04.861898+00:00",
+     "start_time": "2026-09-11T18:54:56.532840+00:00",
      "status": "completed"
     }
    },
@@ -889,7 +688,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Profile not found at data/academic/firm_characteristics_profile.json\n",
+      "Profile not found at <ML4T_DATA_PATH>/equities/firm_characteristics/firm_characteristics_profile.json\n",
       "Generate with: python generate_profiles.py --dataset firm_characteristics\n"
      ]
     }
@@ -898,7 +697,9 @@
     "from utils import ML4T_DATA_PATH\n",
     "\n",
     "# Check for existing profile\n",
-    "profile_path = ML4T_DATA_PATH / \"academic\" / \"firm_characteristics_profile.json\"\n",
+    "profile_path = (\n",
+    "    ML4T_DATA_PATH / \"equities\" / \"firm_characteristics\" / \"firm_characteristics_profile.json\"\n",
+    ")\n",
     "\n",
     "if profile_path.exists():\n",
     "    profile = json.loads(profile_path.read_text())\n",
@@ -907,19 +708,19 @@
     "    print(f\"Columns: {profile['columns']}\")\n",
     "    print(f\"Memory: {profile['memory_mb']:.1f} MB\")\n",
     "else:\n",
-    "    print(f\"Profile not found at {profile_path}\")\n",
+    "    print(f\"Profile not found at {display_path(profile_path)}\")\n",
     "    print(\"Generate with: python generate_profiles.py --dataset firm_characteristics\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "65b16c83",
+   "id": "7fe7066b",
    "metadata": {
     "papermill": {
-     "duration": 0.001306,
-     "end_time": "2026-05-03T01:59:04.869331+00:00",
+     "duration": 0.0036,
+     "end_time": "2026-09-11T18:54:56.558893+00:00",
      "exception": false,
-     "start_time": "2026-05-03T01:59:04.868025+00:00",
+     "start_time": "2026-09-11T18:54:56.555293+00:00",
      "status": "completed"
     }
    },
@@ -931,20 +732,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
-   "id": "2ca1724d",
+   "execution_count": 11,
+   "id": "cae0fd72",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-03T01:59:04.873141Z",
-     "iopub.status.busy": "2026-05-03T01:59:04.873042Z",
-     "iopub.status.idle": "2026-05-03T01:59:04.944892Z",
-     "shell.execute_reply": "2026-05-03T01:59:04.944502Z"
+     "iopub.execute_input": "2026-09-11T18:54:56.568933Z",
+     "iopub.status.busy": "2026-09-11T18:54:56.568697Z",
+     "iopub.status.idle": "2026-09-11T18:54:56.708930Z",
+     "shell.execute_reply": "2026-09-11T18:54:56.708097Z"
     },
     "papermill": {
-     "duration": 0.074451,
-     "end_time": "2026-05-03T01:59:04.945275+00:00",
+     "duration": 0.146079,
+     "end_time": "2026-09-11T18:54:56.709471+00:00",
      "exception": false,
-     "start_time": "2026-05-03T01:59:04.870824+00:00",
+     "start_time": "2026-09-11T18:54:56.563392+00:00",
      "status": "completed"
     }
    },
@@ -953,7 +754,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Train: (414025, 49), 1967-01-31 to 1989-12-29\n"
+      "Train: (336113, 50), 1967-01-31 to 1986-12-31\n"
      ]
     }
    ],
@@ -965,20 +766,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
-   "id": "80a4b22e",
+   "execution_count": 12,
+   "id": "27eefdab",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-03T01:59:04.949581Z",
-     "iopub.status.busy": "2026-05-03T01:59:04.949420Z",
-     "iopub.status.idle": "2026-05-03T01:59:05.017882Z",
-     "shell.execute_reply": "2026-05-03T01:59:05.017345Z"
+     "iopub.execute_input": "2026-09-11T18:54:56.718358Z",
+     "iopub.status.busy": "2026-09-11T18:54:56.718213Z",
+     "iopub.status.idle": "2026-09-11T18:54:56.900641Z",
+     "shell.execute_reply": "2026-09-11T18:54:56.899215Z"
     },
     "papermill": {
-     "duration": 0.070837,
-     "end_time": "2026-05-03T01:59:05.018344+00:00",
+     "duration": 0.189532,
+     "end_time": "2026-09-11T18:54:56.901330+00:00",
      "exception": false,
-     "start_time": "2026-05-03T01:59:04.947507+00:00",
+     "start_time": "2026-09-11T18:54:56.711798+00:00",
      "status": "completed"
     }
    },
@@ -987,7 +788,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Test: (497436, 49), 2000-01-31 to 2016-12-30\n"
+      "Test: (750275, 50), 1992-01-31 to 2016-12-30\n"
      ]
     }
    ],
@@ -999,20 +800,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
-   "id": "8eeada79",
+   "execution_count": 13,
+   "id": "fa07b0af",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-03T01:59:05.021949Z",
-     "iopub.status.busy": "2026-05-03T01:59:05.021873Z",
-     "iopub.status.idle": "2026-05-03T01:59:05.125241Z",
-     "shell.execute_reply": "2026-05-03T01:59:05.124769Z"
+     "iopub.execute_input": "2026-09-11T18:54:56.907411Z",
+     "iopub.status.busy": "2026-09-11T18:54:56.907192Z",
+     "iopub.status.idle": "2026-09-11T18:54:57.234910Z",
+     "shell.execute_reply": "2026-09-11T18:54:57.233973Z"
     },
     "papermill": {
-     "duration": 0.105669,
-     "end_time": "2026-05-03T01:59:05.125643+00:00",
+     "duration": 0.331878,
+     "end_time": "2026-09-11T18:54:57.235616+00:00",
      "exception": false,
-     "start_time": "2026-05-03T01:59:05.019974+00:00",
+     "start_time": "2026-09-11T18:54:56.903738+00:00",
      "status": "completed"
     }
    },
@@ -1021,7 +822,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Full: (1218555, 49)\n"
+      "Full: (1218555, 50)\n"
      ]
     }
    ],
@@ -1033,13 +834,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d4e867fa",
+   "id": "78362216",
    "metadata": {
     "papermill": {
-     "duration": 0.001454,
-     "end_time": "2026-05-03T01:59:05.128834+00:00",
+     "duration": 0.001965,
+     "end_time": "2026-09-11T18:54:57.240204+00:00",
      "exception": false,
-     "start_time": "2026-05-03T01:59:05.127380+00:00",
+     "start_time": "2026-09-11T18:54:57.238239+00:00",
      "status": "completed"
     }
    },
@@ -1082,13 +883,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "974209b7",
+   "id": "f3bed779",
    "metadata": {
     "papermill": {
-     "duration": 0.001637,
-     "end_time": "2026-05-03T01:59:05.131895+00:00",
+     "duration": 0.005169,
+     "end_time": "2026-09-11T18:54:57.248856+00:00",
      "exception": false,
-     "start_time": "2026-05-03T01:59:05.130258+00:00",
+     "start_time": "2026-09-11T18:54:57.243687+00:00",
      "status": "completed"
     }
    },
@@ -1113,13 +914,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b4e1d8ec",
+   "id": "a8d4e4f0",
    "metadata": {
     "papermill": {
-     "duration": 0.001339,
-     "end_time": "2026-05-03T01:59:05.134681+00:00",
+     "duration": 0.002759,
+     "end_time": "2026-09-11T18:54:57.255169+00:00",
      "exception": false,
-     "start_time": "2026-05-03T01:59:05.133342+00:00",
+     "start_time": "2026-09-11T18:54:57.252410+00:00",
      "status": "completed"
     }
    },
@@ -1160,16 +961,25 @@
    "pygments_lexer": "ipython3",
    "version": "3.14.3"
   },
+  "ml4t_provenance": {
+   "executed_at": "2026-09-11T18:55:03.087121+00:00",
+   "executor": "local-uv",
+   "library_digest": "a0b74d85ac5b7af01e5e33bbb5d1b2c2aef64f2e7940dd4708386da163a62f3c",
+   "outputs_digest": "47d5635dc4c853b889cffb4e905c80ec6e8ee637e104f9e29ea982e7be5bd4c1",
+   "parameters": {},
+   "production": true,
+   "source_py_blob": "699bcead4b306bccbdb0092bc6ae3bd8e0b79137"
+  },
   "papermill": {
    "default_parameters": {},
-   "duration": 2.392896,
-   "end_time": "2026-05-03T01:59:05.650626+00:00",
+   "duration": 9.218097,
+   "end_time": "2026-09-11T18:55:00.052207+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "data/equities/firm_characteristics/dataset_card.ipynb",
-   "output_path": "data/equities/firm_characteristics/dataset_card.ipynb",
+   "input_path": "~/ml4t/public-fixture-d/data/equities/firm_characteristics/.dataset_card.build.1734332.ipynb",
+   "output_path": "~/ml4t/public-fixture-d/data/equities/firm_characteristics/.dataset_card.papermill.1734332.ipynb",
    "parameters": {},
-   "start_time": "2026-05-03T01:59:03.257730+00:00",
+   "start_time": "2026-09-11T18:54:50.834110+00:00",
    "version": "2.7.0"
   }
  },

--- a/data/equities/firm_characteristics/dataset_card.py
+++ b/data/equities/firm_characteristics/dataset_card.py
@@ -35,10 +35,6 @@
 """Firm Characteristics - download, explore, and update workflow."""
 
 import json
-import os
-import sys
-import zipfile
-from pathlib import Path
 
 import polars as pl
 
@@ -76,158 +72,39 @@ print("Source: https://github.com/jasonzy121/Deep_Learning_Asset_Pricing")
 # %% [markdown]
 # ## 3. Download Data
 #
-# The dataset is hosted on Google Drive via the GitHub repository.
-# Download can be automatic (with `gdown`) or manual.
+# `data/equities/firm_characteristics/download.py` is the only path that produces what
+# `load_firm_characteristics()` reads. It fetches the archive from the Google Drive folder
+# the paper's repository links, then converts the published `char/*.npz` tensors - not
+# `RetChar.csv` - into `equities/firm_characteristics/firm_characteristics_{train,valid,test,all}.parquet`.
+#
+# The tensors are what carry firm identity. Each block has a fixed anonymous firm axis whose
+# positions are persistent within the block, so the converter can emit a `symbol` column; the
+# CSV drops that axis and can only emit `permno`, which the loader rejects. A split offset keeps
+# the three blocks' identifier namespaces disjoint, because the archive publishes no mapping
+# between them.
+#
+# ```bash
+# uv run python data/equities/firm_characteristics/download.py           # fetch and convert
+# uv run python data/equities/firm_characteristics/download.py --check   # verify what is there
+# uv run python data/equities/firm_characteristics/download.py --convert # convert an existing archive
+# ```
+#
+# This card used to carry a second downloader of its own, writing
+# `firm_characteristics_{all,train,test}.parquet` into an `academic/` directory from
+# `RetChar.csv`. Nothing read that directory and the loader rejects that schema, so the files
+# it produced were unreachable whichever way a reader arrived at them.
 
 # %%
-# Google Drive file ID for the data archive
-GDRIVE_FILE_ID = "1nYHpJ2lNm-qDX5iq18-HaL1H6z7lPGVi"
-GITHUB_REPO = "https://github.com/jasonzy121/Deep_Learning_Asset_Pricing"
+from utils import ML4T_DATA_PATH
+from utils.paths import display_path
 
+parquet_dir = ML4T_DATA_PATH / "equities" / "firm_characteristics"
+present = sorted(path.name for path in parquet_dir.glob("firm_characteristics_*.parquet"))
 
-def download_firm_characteristics(dry_run: bool = False, force: bool = False, convert: bool = True):
-    """Download Chen-Pelger-Zhu firm characteristics dataset.
-
-    Args:
-        dry_run: If True, show what would be downloaded without doing it
-        force: If True, re-download even if data exists
-        convert: If True, convert CSV to parquet after download
-    """
-    from utils import ML4T_DATA_PATH
-
-    output_dir = ML4T_DATA_PATH / "academic"
-    dl_dir = output_dir / "dl_asset_pricing"
-    parquet_path = output_dir / "firm_characteristics_all.parquet"
-
-    print("=== Firm Characteristics Download ===")
-    print("Dataset: Chen-Pelger-Zhu (2020)")
-    print("Coverage: 1967-1989 (train), 2000-2016 (test)")
-    print("Features: 94 firm characteristics + returns")
-    print("Estimated size: ~1.5 GB (archive), ~258 MB (parquet)")
-    print(f"Output: {output_dir}")
-
-    if dry_run:
-        print("\n[DRY RUN] Would download:")
-        print("  - data.zip from Google Drive (~1.5 GB)")
-        print(f"  - Extract to: {dl_dir}")
-        print(f"  - Convert to parquet: {parquet_path}")
-        print("\nManual download:")
-        print(f"  1. Go to: {GITHUB_REPO}")
-        print("  2. Download data.zip from Google Drive link")
-        print(f"  3. Extract to: {dl_dir}")
-        return
-
-    # Check existing
-    if parquet_path.exists() and not force:
-        existing = pl.read_parquet(parquet_path)
-        print(f"\nData already exists ({len(existing):,} rows).")
-        print("Use force=True to re-download.")
-        return
-
-    # Try automatic download with gdown
-    try:
-        import gdown
-    except ImportError:
-        print("\nWARNING: gdown not installed for automatic download")
-        print("Install with: pip install gdown")
-        print("\nManual download instructions:")
-        print(f"  1. Go to: {GITHUB_REPO}")
-        print("  2. Download data.zip from Google Drive link")
-        print(f"  3. Extract to: {dl_dir}")
-        print("  4. Run: download_firm_characteristics(convert=True)")
-        return
-
-    dl_dir.mkdir(parents=True, exist_ok=True)
-    zip_path = dl_dir / "data.zip"
-
-    print("\nDownloading from Google Drive...")
-    url = f"https://drive.google.com/uc?id={GDRIVE_FILE_ID}"
-    gdown.download(url, str(zip_path), quiet=False)
-
-    if not zip_path.exists():
-        print("ERROR: Download failed")
-        return
-
-    print("\nExtracting archive...")
-    with zipfile.ZipFile(zip_path, "r") as zf:
-        zf.extractall(dl_dir)
-
-    # Cleanup zip
-    zip_path.unlink()
-
-    print("Download complete!")
-
-    # Convert to parquet
-    if convert:
-        _convert_to_parquet(output_dir)
-
-
-def _convert_to_parquet(output_dir: Path):
-    """Convert RetChar.csv to parquet format with train/test splits."""
-    dl_dir = output_dir / "dl_asset_pricing"
-    retchar_path = dl_dir / "RetChar.csv"
-
-    if not retchar_path.exists():
-        # Try nested path
-        nested_path = dl_dir / "data" / "RetChar.csv"
-        if nested_path.exists():
-            retchar_path = nested_path
-        else:
-            print(f"ERROR: RetChar.csv not found at {retchar_path}")
-            return
-
-    print("\nConverting to parquet format...")
-
-    # Read CSV
-    df = pl.read_csv(retchar_path)
-    print(f"  Loaded {len(df):,} rows, {len(df.columns)} columns")
-
-    # Date is in YYYYMMDD format (integer)
-    df = df.with_columns(
-        pl.col("Date").cast(pl.Utf8).str.to_date("%Y%m%d").alias("date"),
-        pl.col("Date").cast(pl.Utf8).str.slice(0, 4).cast(pl.Int32).alias("year"),
-    )
-
-    # Rename permno column if it exists differently
-    if "Permno" in df.columns:
-        df = df.rename({"Permno": "permno"})
-    if "RET" in df.columns:
-        df = df.rename({"RET": "ret"})
-
-    # Create splits based on paper
-    train_df = df.filter(pl.col("year") < 1990)
-    test_df = df.filter(pl.col("year") >= 2000)
-
-    # Drop helper columns
-    train_df = train_df.drop(["Date", "year"])
-    test_df = test_df.drop(["Date", "year"])
-    all_df = df.drop(["Date", "year"])
-
-    # Save parquet files
-    output_dir.mkdir(parents=True, exist_ok=True)
-
-    all_df.write_parquet(output_dir / "firm_characteristics_all.parquet")
-    train_df.write_parquet(output_dir / "firm_characteristics_train.parquet")
-    test_df.write_parquet(output_dir / "firm_characteristics_test.parquet")
-
-    print("  Created:")
-    print(f"    firm_characteristics_all.parquet: {len(all_df):,} rows")
-    print(f"    firm_characteristics_train.parquet: {len(train_df):,} rows (1967-1989)")
-    print(f"    firm_characteristics_test.parquet: {len(test_df):,} rows (2000-2016)")
-
-
-# %% [markdown]
-# ### Download
-
-# %%
-# Uncomment to download
-# download_firm_characteristics()
-
-# %% [markdown]
-# ### Dry Run (Preview)
-
-# %%
-download_firm_characteristics(dry_run=True)
+print("=== Firm Characteristics Download ===")
+print("Downloader: data/equities/firm_characteristics/download.py")
+print(f"Writes to:  {display_path(parquet_dir)}")
+print(f"Present:    {present or 'nothing yet - run the downloader'}")
 
 # %% [markdown]
 # ## 4. Load and Explore
@@ -292,7 +169,9 @@ yearly
 from utils import ML4T_DATA_PATH
 
 # Check for existing profile
-profile_path = ML4T_DATA_PATH / "academic" / "firm_characteristics_profile.json"
+profile_path = (
+    ML4T_DATA_PATH / "equities" / "firm_characteristics" / "firm_characteristics_profile.json"
+)
 
 if profile_path.exists():
     profile = json.loads(profile_path.read_text())
@@ -301,7 +180,7 @@ if profile_path.exists():
     print(f"Columns: {profile['columns']}")
     print(f"Memory: {profile['memory_mb']:.1f} MB")
 else:
-    print(f"Profile not found at {profile_path}")
+    print(f"Profile not found at {display_path(profile_path)}")
     print("Generate with: python generate_profiles.py --dataset firm_characteristics")
 
 # %% [markdown]

--- a/tests/create_test_data.py
+++ b/tests/create_test_data.py
@@ -13,13 +13,13 @@ from what was actually generated.
 
 ``tests/test_fixture_manifest_matches_builders.py`` checks each entry of the
 manifest against a declaration and against the data on disk. What it cannot check
-is a file no declaration mentions, and most of the test-data repo is still in that
-state: named neither by a ``Dataset.owns`` nor by ``manifest.json``. Such a fixture
-has no builder, no recorded budget and nothing comparing it to the datasets it has
-to join against - which is how the FNSPID news fixture came to sit entirely past
-the end of its own price panel (ml4t/agent-workspace#1116). Adding a declaration is
-how a fixture leaves that state; ml4t/agent-workspace#1117 carries the running
-count and the remaining groups.
+is a file no declaration mentions. A fixture in that state has no builder, no
+recorded budget and nothing comparing it to the datasets it has to join against -
+which is how the FNSPID news fixture came to sit entirely past the end of its own
+price panel, and how an options panel built from a different universe than its
+loader documents survived a year of green CI. ``UNPRODUCED`` in
+``tests/test_every_fixture_file_has_a_producer.py`` is what is left of that backlog,
+and it only shrinks.
 
 It is also not a from-empty rebuild of the fixture repo: it operates on a checkout
 of ml4t/third-edition-test-data and replaces the datasets it is asked for.

--- a/tests/create_test_data.py
+++ b/tests/create_test_data.py
@@ -89,11 +89,6 @@ class Dataset:
             is the only place the drift shows: the manifest and the
             ``nasdaq100_minute_bars`` builder agreed with each other on six symbols
             while the fixture carried twelve, so comparing the two proved nothing.
-        irreplaceable: The fixture copy is the only copy, so ``--clean`` must not
-            remove it. Set this only for data that no source can regenerate -
-            redistributed samples whose tick files neither production nor this
-            workstation holds. Such a builder verifies what is there rather than
-            deriving it, and says so in its output.
     """
 
     name: str
@@ -102,7 +97,6 @@ class Dataset:
     owns: tuple[Path, ...]
     budget: dict[str, object] = field(default_factory=dict)
     entities: dict[str, tuple[str, int]] = field(default_factory=dict)
-    irreplaceable: bool = False
 
 
 # --- firm characteristics -----------------------------------------------------
@@ -2012,72 +2006,6 @@ def build_polymarket_events(source: Path, output: Path) -> list[Path]:
     return [dst]
 
 
-# --- AlgoSeek NASDAQ 100 TAQ --------------------------------------------------
-#
-# The one fixture with no source to reduce from. AlgoSeek publishes this sample
-# openly and permits its redistribution, and the copy in the test-data repo is the
-# only copy: neither the production tree nor this workstation holds the tick files
-# `data/equities/market/algoseek_convert.py` documents converting.
-#
-# So its declaration cannot be a builder. What it can be is a contract - the
-# schema, symbol, session and row count `03_market_microstructure/12_algoseek_taq_lob_reconstruction`
-# needs - checked against the file that is there, so a change to it is visible even
-# though a rebuild is not available. `irreplaceable` keeps `--clean` off it: for
-# every other dataset, deleting `owns` before the build is how a stale file is
-# prevented, and here it would delete the only copy of something nothing can
-# regenerate.
-
-NASDAQ100_TAQ = Path("equities") / "market" / "microstructure" / "nasdaq100_taq" / "data.parquet"
-NASDAQ100_TAQ_COLUMNS = ("timestamp", "symbol", "event_type", "price", "quantity", "exchange")
-NASDAQ100_TAQ_ROWS = 20_000
-NASDAQ100_TAQ_SYMBOL = "AAPL"
-NASDAQ100_TAQ_SESSION = date(2020, 3, 16)
-
-
-def build_nasdaq100_taq(source: Path, output: Path) -> list[Path]:
-    """Verify the redistributed AlgoSeek sample; copy it only if a source appears."""
-    src = source / NASDAQ100_TAQ
-    dst = output / NASDAQ100_TAQ
-    if src.exists():
-        dst.parent.mkdir(parents=True, exist_ok=True)
-        shutil.copyfile(src, dst)
-        origin = "copied from source"
-    elif dst.exists():
-        origin = "verified in place (no source; redistributed sample)"
-    else:
-        raise FileNotFoundError(
-            f"{NASDAQ100_TAQ} is absent from both {source} and {output}. It is "
-            "redistributed AlgoSeek data with no production copy, so it cannot be "
-            "rebuilt; restore it from the test-data repository's history."
-        )
-
-    frame = pl.read_parquet(dst)
-    if missing := [c for c in NASDAQ100_TAQ_COLUMNS if c not in frame.columns]:
-        raise ValueError(f"{NASDAQ100_TAQ} is missing {missing}; load_nasdaq100_taq reads them.")
-    if frame.height != NASDAQ100_TAQ_ROWS:
-        raise ValueError(
-            f"{NASDAQ100_TAQ} holds {frame.height:,} rows, not the {NASDAQ100_TAQ_ROWS:,} "
-            "recorded for this sample."
-        )
-    symbols = frame["symbol"].unique().to_list()
-    if symbols != [NASDAQ100_TAQ_SYMBOL]:
-        raise ValueError(
-            f"{NASDAQ100_TAQ} carries {symbols}, not [{NASDAQ100_TAQ_SYMBOL!r}]; "
-            "12_algoseek_taq_lob_reconstruction asks for that symbol by name."
-        )
-    sessions = frame.select(pl.col("timestamp").dt.date().unique())["timestamp"].to_list()
-    if sessions != [NASDAQ100_TAQ_SESSION]:
-        raise ValueError(
-            f"{NASDAQ100_TAQ} covers {sessions}, not [{NASDAQ100_TAQ_SESSION}]; "
-            "the notebook reconstructs one session."
-        )
-    print(
-        f"    nasdaq100_taq: {frame.height:,} events, {NASDAQ100_TAQ_SYMBOL} on "
-        f"{NASDAQ100_TAQ_SESSION}, {origin}"
-    )
-    return [dst]
-
-
 DATASETS: tuple[Dataset, ...] = (
     Dataset(
         name="etfs",
@@ -2435,19 +2363,6 @@ DATASETS: tuple[Dataset, ...] = (
         owns=(POLYMARKET,),
         budget={"subsample": "none"},
     ),
-    Dataset(
-        name="nasdaq100_taq",
-        description=(
-            f"{NASDAQ100_TAQ_ROWS:,} AlgoSeek TAQ events for {NASDAQ100_TAQ_SYMBOL} on "
-            f"{NASDAQ100_TAQ_SESSION}, redistributed by permission and verified rather "
-            "than rebuilt: no source exists to reduce from"
-        ),
-        build=build_nasdaq100_taq,
-        owns=(NASDAQ100_TAQ,),
-        budget={"subsample": "unknown - the sample as AlgoSeek published it"},
-        entities={NASDAQ100_TAQ.as_posix(): ("symbol", 1)},
-        irreplaceable=True,
-    ),
 )
 
 DATASETS_BY_NAME = {dataset.name: dataset for dataset in DATASETS}
@@ -2670,9 +2585,7 @@ def main() -> int:
     built: dict[str, list[Path]] = {}
     for dataset in selected:
         print(f"  {dataset.name}: {dataset.description}")
-        if args.clean and dataset.irreplaceable:
-            print("    --clean skipped: the fixture copy is the only copy")
-        elif args.clean:
+        if args.clean:
             for owned in dataset.owns:
                 target = output / owned
                 if target.is_dir():

--- a/tests/create_test_data.py
+++ b/tests/create_test_data.py
@@ -89,6 +89,11 @@ class Dataset:
             is the only place the drift shows: the manifest and the
             ``nasdaq100_minute_bars`` builder agreed with each other on six symbols
             while the fixture carried twelve, so comparing the two proved nothing.
+        irreplaceable: The fixture copy is the only copy, so ``--clean`` must not
+            remove it. Set this only for data that no source can regenerate -
+            redistributed samples whose tick files neither production nor this
+            workstation holds. Such a builder verifies what is there rather than
+            deriving it, and says so in its output.
     """
 
     name: str
@@ -97,6 +102,7 @@ class Dataset:
     owns: tuple[Path, ...]
     budget: dict[str, object] = field(default_factory=dict)
     entities: dict[str, tuple[str, int]] = field(default_factory=dict)
+    irreplaceable: bool = False
 
 
 # --- firm characteristics -----------------------------------------------------
@@ -1662,6 +1668,416 @@ def build_crypto_onchain(source: Path, output: Path) -> list[Path]:
     )
 
 
+# --- S&P 500 options EDA ------------------------------------------------------
+#
+# A separate dataset from `sp500_options` above, at `sp500/options_eda/`, read by
+# `load_sp500_options_eda`. Four notebooks read it: 02/07 for chain structure, the
+# smile and the IV surface, 02/08 for Greeks on AAPL 2020, 02/09 for the
+# constant-maturity straddle series on AAPL 2019, and 08/03 for cross-instrument
+# features on all eight underlyings.
+#
+# The budget below is taken from those notebooks' own declared parameters, because
+# the fixture this replaces was narrower than every one of them and nothing said
+# so. It carried moneyness 0.95-1.05 and nothing past 45 days to maturity, against
+# 02/07's declarations:
+#
+#   CHAIN_BAND = (0.7, 1.3)   the smile's shape       - fixture covered 0.95-1.05
+#   SPREAD_BAND = (0.5, 1.5)  "what happens in the wings is its subject"
+#   WING_BAND = (0.9, 1.1)    splits near-the-money from away-from-the-money
+#   SURFACE_MAX_DAYS = 180    far expirations drawn as their own section
+#
+# So the smile had no smile, the wing analysis had no wings, "away from the money"
+# was empty, and the far-expiration section drew nothing - and the notebook passed,
+# every time, because each of those sections renders an empty frame rather than
+# raising. The symbol list was wrong in the same silent way: the fixture carried
+# AMD, GOOG and INTC and lacked BA, JPM, KO and XOM, so four of the eight symbols
+# `08_financial_features/03_structural_cross_instrument_features` names at its line
+# 73 came back empty.
+#
+# What is still reduced, and the two axes are chosen so that no declared parameter
+# lands outside the data:
+#
+#   - Contracts outside CHAIN_BAND. This clips SPREAD_BAND, which reaches to
+#     (0.5, 1.5); the section keeps real wings either side of WING_BAND, which is
+#     what it needs to have a subject, without the deep wings where quotes are
+#     stale and which are most of the row count.
+#   - Expirations beyond the nearest few. Both the near-dated chain and the far
+#     section are kept, because 02/07 draws them separately and a "nearest N" rule
+#     alone starves the far one: the sixth-nearest expiration is never more than
+#     120 days out.
+#
+# Sessions are never reduced. 02/09 builds a daily series by picking one straddle
+# per day inside a 25-35 day window, so a session stride would thin the series that
+# notebook is about.
+
+SP500_OPTIONS_EDA_DIR = SP500_DIR / "options_eda"
+SP500_OPTIONS_EDA_YEARS = (2019, 2020)
+SP500_OPTIONS_EDA_SYMBOLS = ("AAPL", "AMZN", "BA", "GOOGL", "JPM", "KO", "MSFT", "XOM")
+# 02/07's CHAIN_BAND, SURFACE_MAX_DAYS and WING_BAND, named here so the budget and
+# the notebook move together.
+SP500_OPTIONS_EDA_BAND = (0.7, 1.3)
+SP500_OPTIONS_EDA_FAR_DAYS = 180
+SP500_OPTIONS_EDA_WING_BAND = (0.9, 1.1)
+SP500_OPTIONS_EDA_NEAR_EXPIRATIONS = 6
+SP500_OPTIONS_EDA_FAR_EXPIRATIONS = 2
+# 02/09's DTE_WINDOW, and the symbol and year it demonstrates on. Asserted rather
+# than assumed: the reduction is keyed on expiration, so it is exactly the kind of
+# budget that can starve that notebook's selection while every other consumer still
+# looks healthy.
+SP500_OPTIONS_EDA_DTE_WINDOW = (25, 35)
+SP500_OPTIONS_EDA_DEMO = ("AAPL", 2019)
+
+
+def build_sp500_options_eda(source: Path, output: Path) -> list[Path]:
+    """Reduce the production chains on moneyness and expiration, never on session.
+
+    The ``year`` column production carries is dropped. ``load_sp500_options_eda``
+    scans ``year=*.parquet`` with ``hive_partitioning=True``, so the partition key
+    comes from the path; a column of the same name in the file is a second source
+    for it.
+    """
+    out_dir = output / SP500_OPTIONS_EDA_DIR
+    out_dir.mkdir(parents=True, exist_ok=True)
+    keep = list(SP500_OPTIONS_EDA_SYMBOLS)
+    low, high = SP500_OPTIONS_EDA_BAND
+    written: list[Path] = []
+
+    for year in SP500_OPTIONS_EDA_YEARS:
+        src = source / SP500_OPTIONS_EDA_DIR / f"year={year}.parquet"
+        if not src.exists():
+            raise FileNotFoundError(
+                f"{src} not found. Build it with data/equities/market/sp500/build_options_eda.py."
+            )
+        full = pl.scan_parquet(src).filter(pl.col("symbol").is_in(keep))
+        if absent := sorted(
+            set(keep) - set(full.select("symbol").unique().collect()["symbol"].to_list())
+        ):
+            raise ValueError(
+                f"Production's {year} chain carries no rows for {absent}. The fixture "
+                "declares all eight underlyings and a chapter-8 notebook asks for them "
+                "by name, so a narrower source would reintroduce the gap this builder "
+                "exists to close."
+            )
+        banded = full.filter((pl.col("strike") / pl.col("underlying_price")).is_between(low, high))
+
+        def _nearest(frame: pl.LazyFrame, keep_ranks: int) -> pl.LazyFrame:
+            return (
+                frame.with_columns(
+                    pl.col("expiration").rank("dense").over("symbol", "date").alias("_rank")
+                )
+                .filter(pl.col("_rank") <= keep_ranks)
+                .drop("_rank")
+            )
+
+        near = _nearest(
+            banded.filter(pl.col("days_to_maturity") <= SP500_OPTIONS_EDA_FAR_DAYS),
+            SP500_OPTIONS_EDA_NEAR_EXPIRATIONS,
+        )
+        far = _nearest(
+            banded.filter(pl.col("days_to_maturity") > SP500_OPTIONS_EDA_FAR_DAYS),
+            SP500_OPTIONS_EDA_FAR_EXPIRATIONS,
+        )
+        reduced = (
+            pl.concat([near, far])
+            .collect()
+            .drop("year", strict=False)
+            .sort("date", "symbol", "expiration", "call_put", "strike")
+        )
+        _require_every_declared_band_reaches_data(reduced, year)
+        written.append(_write_options_eda_part(reduced, out_dir, year))
+
+    _require_constant_maturity_window(out_dir)
+    return written
+
+
+def _write_options_eda_part(frame: pl.DataFrame, out_dir: Path, year: int) -> Path:
+    dst = out_dir / f"year={year}.parquet"
+    frame.write_parquet(dst)
+    print(
+        f"    year={year}: {frame.height:,} rows, {frame['symbol'].n_unique()} symbols, "
+        f"{frame['date'].n_unique()} sessions, {frame['expiration'].n_unique()} expirations "
+        f"({dst.stat().st_size / 1e6:.1f} MB)"
+    )
+    return dst
+
+
+def _require_every_declared_band_reaches_data(frame: pl.DataFrame, year: int) -> None:
+    """Each of 02/07's declared bands has to have rows on both of its sides.
+
+    This is the check the previous fixture would have failed. A band that lands
+    entirely inside the data, or entirely outside it, renders an empty frame and
+    the notebook reports a clean run either way.
+    """
+    moneyness = frame["strike"] / frame["underlying_price"]
+    wing_low, wing_high = SP500_OPTIONS_EDA_WING_BAND
+    checks = {
+        f"below the {wing_low} wing": int((moneyness < wing_low).sum()),
+        f"above the {wing_high} wing": int((moneyness > wing_high).sum()),
+        f"beyond {SP500_OPTIONS_EDA_FAR_DAYS} days to maturity": int(
+            (frame["days_to_maturity"] > SP500_OPTIONS_EDA_FAR_DAYS).sum()
+        ),
+    }
+    if empty := sorted(name for name, count in checks.items() if not count):
+        raise ValueError(
+            f"{year}: the reduction leaves nothing {' or '.join(empty)}. "
+            "02_financial_data_universe/07_sp500_options_eda declares WING_BAND and "
+            "SURFACE_MAX_DAYS to separate those regions, and a section with nothing on "
+            "one side of its own boundary renders empty rather than failing."
+        )
+    print(
+        "      declared bands reached: "
+        + ", ".join(f"{name} {count:,}" for name, count in checks.items())
+    )
+
+
+def _require_constant_maturity_window(out_dir: Path) -> None:
+    """Every session of the 02/09 demo must offer a contract inside its DTE window.
+
+    The notebook builds a daily series by picking, each day, the straddle closest to
+    30 days and 50 delta. An expiration cap that leaves some sessions with nothing
+    in the 25-35 day window does not fail the notebook - it silently shortens the
+    series the whole notebook is about.
+    """
+    symbol, year = SP500_OPTIONS_EDA_DEMO
+    low, high = SP500_OPTIONS_EDA_DTE_WINDOW
+    frame = pl.read_parquet(out_dir / f"year={year}.parquet").filter(pl.col("symbol") == symbol)
+    in_window = frame.filter(pl.col("days_to_maturity").is_between(low, high))
+    sessions = frame["date"].n_unique()
+    missing = sessions - in_window["date"].n_unique()
+    if missing:
+        raise ValueError(
+            f"{missing} of {sessions} {symbol} {year} sessions carry no contract with "
+            f"{low}-{high} days to maturity, which is the window "
+            "02_financial_data_universe/09_options_continuous selects in."
+        )
+    print(f"    {symbol} {year}: all {sessions} sessions offer a {low}-{high} DTE contract")
+
+
+# --- 13F bulk holdings --------------------------------------------------------
+#
+# The full-universe quarterly archive, distinct from the curated ten-institution
+# panel above. `04_fundamental_alternative_data/10_institutional_holdings_13f`
+# reads one quarter and ranks managers by reported value, so the reduction has to
+# keep whole filings and has to keep more managers than the notebook ranks.
+#
+# 600 is not a new choice: filtering production to the 600 CIKs with the largest
+# total reported value reproduces the fixture that was already there, row for row
+# (1,327,852 rows, 743 filings, 21,388 securities). The rule had not been written
+# down, which is the whole of what this declaration adds.
+
+_13F_BULK_QUARTER = "2024Q3"
+_13F_BULK_MANAGERS = 600
+_13F_BULK = (
+    Path("equities")
+    / "positioning"
+    / "13f"
+    / "bulk"
+    / _13F_BULK_QUARTER
+    / "institutional_holdings.parquet"
+)
+# The notebook's declared TOP_N and CO_OWNERSHIP_UNIVERSE. Keeping more managers
+# than it ranks is what makes its ranking the true one rather than an artifact of
+# the fixture's size.
+_13F_BULK_NOTEBOOK_TOP_N = 500
+
+
+def build_13f_bulk_holdings(source: Path, output: Path) -> list[Path]:
+    """Keep every position of the 600 managers reporting the most value."""
+    src = source / _13F_BULK
+    if not src.exists():
+        raise FileNotFoundError(
+            f"{_13F_BULK} not found at {src}. Fetch it with "
+            f"data/equities/positioning/13f_download.py --mode bulk --quarters {_13F_BULK_QUARTER}."
+        )
+    full = pl.read_parquet(src)
+    ranked = (
+        full.group_by("cik")
+        .agg(pl.col("value_thousands").sum().alias("reported_value"))
+        .sort(["reported_value", "cik"], descending=[True, False])
+        .head(_13F_BULK_MANAGERS)
+    )
+    if ranked.height < _13F_BULK_MANAGERS:
+        raise ValueError(
+            f"Production's {_13F_BULK_QUARTER} archive carries {ranked.height} managers, "
+            f"fewer than the {_13F_BULK_MANAGERS} this fixture declares."
+        )
+    reduced = full.filter(pl.col("cik").is_in(ranked["cik"].implode()))
+
+    # Two sections of the notebook depend on rows a naive top-N could drop, and
+    # both would render as an empty table rather than an error.
+    repeat_filers = (
+        reduced.group_by("cik")
+        .agg(pl.col("accession_no").n_unique().alias("filings"))
+        .filter(pl.col("filings") > 1)
+    )
+    if not repeat_filers.height:
+        raise ValueError(
+            "No manager in the reduced set filed more than once in the window, so "
+            "the 'one filing per manager' section has nothing to demonstrate."
+        )
+    implied = (
+        reduced.filter(pl.col("shares") > 0)
+        .with_columns((pl.col("value_thousands") / pl.col("shares")).alias("implied_price"))
+        .group_by("accession_no")
+        .agg(pl.col("implied_price").median().alias("median_implied_price"))
+    )
+    unbelievable = implied.filter(~pl.col("median_implied_price").is_between(1.0, 10_000.0))
+    if not unbelievable.height:
+        raise ValueError(
+            "Every filing in the reduced set implies a believable price per share, so "
+            "the screening section screens nothing out."
+        )
+
+    dst = output / _13F_BULK
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    reduced.write_parquet(dst)
+    print(
+        f"    {_13F_BULK_QUARTER}: {reduced.height:,} of {full.height:,} positions, "
+        f"{reduced['cik'].n_unique()} of {full['cik'].n_unique():,} managers "
+        f"(notebook ranks {_13F_BULK_NOTEBOOK_TOP_N}), "
+        f"{reduced['accession_no'].n_unique()} filings, {repeat_filers.height} of them "
+        f"repeat filers, {unbelievable.height} failing the implied-price screen"
+    )
+    return [dst]
+
+
+# --- Financial Phrasebank -----------------------------------------------------
+#
+# `sentences_allagree.parquet` is the subset of Malo et al. (2014) that every
+# annotator labelled the same way. The fixture held 4,846 rows, which is the whole
+# corpus at 50% agreement, under the filename that promises the 2,264 unanimous
+# ones. `10_text_feature_engineering/04_bert_finetuning` fine-tunes on this file,
+# so CI trained on 2,582 sentences the annotators disagreed about, each carrying
+# whatever label the corpus assigned.
+#
+# `load_financial_phrasebank(agreement=...)` looks like it would have caught that
+# and does not: it filters on an `agreement` column, and neither production's file
+# nor the fixture's has one, so the argument has never selected anything. What
+# makes production correct is that its file already holds the unanimous subset.
+# Copying it is therefore the fix, and no reduction applies.
+
+PHRASEBANK_DIR = Path("alternative") / "text" / "financial_phrasebank"
+PHRASEBANK = PHRASEBANK_DIR / "sentences_allagree.parquet"
+PHRASEBANK_ROWS = 2264
+PHRASEBANK_LABELS = 3
+
+
+def build_financial_phrasebank(source: Path, output: Path) -> list[Path]:
+    """Copy the unanimous-agreement subset, verbatim."""
+    dst = _copy_verbatim(
+        source,
+        output,
+        PHRASEBANK,
+        "the download script in data/alternative/text/README.md",
+    )
+    frame = pl.read_parquet(dst)
+    if frame.height != PHRASEBANK_ROWS:
+        raise ValueError(
+            f"Production's {PHRASEBANK.name} holds {frame.height:,} rows, not the "
+            f"{PHRASEBANK_ROWS:,} unanimous sentences the filename promises. The corpus "
+            "at lower agreement levels is a different dataset and belongs in a "
+            "differently named file."
+        )
+    if (labels := frame["label"].n_unique()) != PHRASEBANK_LABELS:
+        raise ValueError(
+            f"{PHRASEBANK.name} carries {labels} distinct labels, not {PHRASEBANK_LABELS}; "
+            "a sentiment fixture missing a class trains and scores on a different task."
+        )
+    print(f"    {PHRASEBANK.name}: {frame.height:,} sentences, {labels} labels, copied verbatim")
+    return [dst]
+
+
+# --- Polymarket events --------------------------------------------------------
+#
+# 22 rows in production and three in the fixture, which is smaller than the panel
+# `13_polymarket_prediction_markets` groups by category. Copied whole instead: the
+# file is 5 KB.
+
+POLYMARKET = Path("prediction_markets") / "polymarket_events.parquet"
+
+
+def build_polymarket_events(source: Path, output: Path) -> list[Path]:
+    """Copy the production Polymarket event panel, verbatim."""
+    dst = _copy_verbatim(
+        source,
+        output,
+        POLYMARKET,
+        "data/prediction_markets/download.py --provider polymarket",
+    )
+    frame = pl.read_parquet(dst)
+    print(
+        f"    {POLYMARKET.name}: {frame.height} events, "
+        f"{frame['symbol'].n_unique()} markets, copied verbatim"
+    )
+    return [dst]
+
+
+# --- AlgoSeek NASDAQ 100 TAQ --------------------------------------------------
+#
+# The one fixture with no source to reduce from. AlgoSeek publishes this sample
+# openly and permits its redistribution, and the copy in the test-data repo is the
+# only copy: neither the production tree nor this workstation holds the tick files
+# `data/equities/market/algoseek_convert.py` documents converting.
+#
+# So its declaration cannot be a builder. What it can be is a contract - the
+# schema, symbol, session and row count `03_market_microstructure/12_algoseek_taq_lob_reconstruction`
+# needs - checked against the file that is there, so a change to it is visible even
+# though a rebuild is not available. `irreplaceable` keeps `--clean` off it: for
+# every other dataset, deleting `owns` before the build is how a stale file is
+# prevented, and here it would delete the only copy of something nothing can
+# regenerate.
+
+NASDAQ100_TAQ = Path("equities") / "market" / "microstructure" / "nasdaq100_taq" / "data.parquet"
+NASDAQ100_TAQ_COLUMNS = ("timestamp", "symbol", "event_type", "price", "quantity", "exchange")
+NASDAQ100_TAQ_ROWS = 20_000
+NASDAQ100_TAQ_SYMBOL = "AAPL"
+NASDAQ100_TAQ_SESSION = date(2020, 3, 16)
+
+
+def build_nasdaq100_taq(source: Path, output: Path) -> list[Path]:
+    """Verify the redistributed AlgoSeek sample; copy it only if a source appears."""
+    src = source / NASDAQ100_TAQ
+    dst = output / NASDAQ100_TAQ
+    if src.exists():
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(src, dst)
+        origin = "copied from source"
+    elif dst.exists():
+        origin = "verified in place (no source; redistributed sample)"
+    else:
+        raise FileNotFoundError(
+            f"{NASDAQ100_TAQ} is absent from both {source} and {output}. It is "
+            "redistributed AlgoSeek data with no production copy, so it cannot be "
+            "rebuilt; restore it from the test-data repository's history."
+        )
+
+    frame = pl.read_parquet(dst)
+    if missing := [c for c in NASDAQ100_TAQ_COLUMNS if c not in frame.columns]:
+        raise ValueError(f"{NASDAQ100_TAQ} is missing {missing}; load_nasdaq100_taq reads them.")
+    if frame.height != NASDAQ100_TAQ_ROWS:
+        raise ValueError(
+            f"{NASDAQ100_TAQ} holds {frame.height:,} rows, not the {NASDAQ100_TAQ_ROWS:,} "
+            "recorded for this sample."
+        )
+    symbols = frame["symbol"].unique().to_list()
+    if symbols != [NASDAQ100_TAQ_SYMBOL]:
+        raise ValueError(
+            f"{NASDAQ100_TAQ} carries {symbols}, not [{NASDAQ100_TAQ_SYMBOL!r}]; "
+            "12_algoseek_taq_lob_reconstruction asks for that symbol by name."
+        )
+    sessions = frame.select(pl.col("timestamp").dt.date().unique())["timestamp"].to_list()
+    if sessions != [NASDAQ100_TAQ_SESSION]:
+        raise ValueError(
+            f"{NASDAQ100_TAQ} covers {sessions}, not [{NASDAQ100_TAQ_SESSION}]; "
+            "the notebook reconstructs one session."
+        )
+    print(
+        f"    nasdaq100_taq: {frame.height:,} events, {NASDAQ100_TAQ_SYMBOL} on "
+        f"{NASDAQ100_TAQ_SESSION}, {origin}"
+    )
+    return [dst]
+
+
 DATASETS: tuple[Dataset, ...] = (
     Dataset(
         name="etfs",
@@ -1951,6 +2367,87 @@ DATASETS: tuple[Dataset, ...] = (
         owns=(ONCHAIN_DIR,),
         budget={"subsample": "none"},
     ),
+    Dataset(
+        name="sp500_options_eda",
+        description=(
+            f"the {len(SP500_OPTIONS_EDA_SYMBOLS)} production underlyings over "
+            f"{SP500_OPTIONS_EDA_YEARS[0]}-{SP500_OPTIONS_EDA_YEARS[-1]}, every session, "
+            f"moneyness {SP500_OPTIONS_EDA_BAND[0]}-{SP500_OPTIONS_EDA_BAND[1]}, the "
+            f"nearest {SP500_OPTIONS_EDA_NEAR_EXPIRATIONS} expirations plus "
+            f"{SP500_OPTIONS_EDA_FAR_EXPIRATIONS} beyond "
+            f"{SP500_OPTIONS_EDA_FAR_DAYS} days"
+        ),
+        build=build_sp500_options_eda,
+        owns=tuple(
+            SP500_OPTIONS_EDA_DIR / f"year={year}.parquet" for year in SP500_OPTIONS_EDA_YEARS
+        ),
+        budget={
+            "symbols": list(SP500_OPTIONS_EDA_SYMBOLS),
+            "sessions": "none - every trading day is kept",
+            "moneyness_band": list(SP500_OPTIONS_EDA_BAND),
+            "near_expirations_per_session": SP500_OPTIONS_EDA_NEAR_EXPIRATIONS,
+            "far_expirations_per_session": SP500_OPTIONS_EDA_FAR_EXPIRATIONS,
+            "far_threshold_days": SP500_OPTIONS_EDA_FAR_DAYS,
+            "dte_window_required": list(SP500_OPTIONS_EDA_DTE_WINDOW),
+            "clips": (
+                "07_sp500_options_eda's SPREAD_BAND (0.5, 1.5) is clipped to the "
+                "moneyness band; the deep wings are stale quotes and most of the rows"
+            ),
+        },
+        entities={
+            (SP500_OPTIONS_EDA_DIR / f"year={year}.parquet").as_posix(): (
+                "symbol",
+                len(SP500_OPTIONS_EDA_SYMBOLS),
+            )
+            for year in SP500_OPTIONS_EDA_YEARS
+        },
+    ),
+    Dataset(
+        name="institutional_holdings_13f_bulk",
+        description=(
+            f"every position of the {_13F_BULK_MANAGERS} managers reporting the most "
+            f"value in the {_13F_BULK_QUARTER} filing window, whole filings only"
+        ),
+        build=build_13f_bulk_holdings,
+        owns=(_13F_BULK,),
+        budget={
+            "quarter": _13F_BULK_QUARTER,
+            "managers": _13F_BULK_MANAGERS,
+            "notebook_ranks": _13F_BULK_NOTEBOOK_TOP_N,
+            "filings": "whole - a manager keeps every position it reported",
+        },
+        entities={_13F_BULK.as_posix(): ("cik", _13F_BULK_MANAGERS)},
+    ),
+    Dataset(
+        name="financial_phrasebank",
+        description=(
+            f"the {PHRASEBANK_ROWS:,} sentences every annotator labelled the same way, "
+            "copied verbatim - which is the whole of what the filename promises"
+        ),
+        build=build_financial_phrasebank,
+        owns=(PHRASEBANK,),
+        budget={"subsample": "none", "agreement": "100% (unanimous)"},
+    ),
+    Dataset(
+        name="polymarket_events",
+        description="the whole production Polymarket event panel, copied verbatim",
+        build=build_polymarket_events,
+        owns=(POLYMARKET,),
+        budget={"subsample": "none"},
+    ),
+    Dataset(
+        name="nasdaq100_taq",
+        description=(
+            f"{NASDAQ100_TAQ_ROWS:,} AlgoSeek TAQ events for {NASDAQ100_TAQ_SYMBOL} on "
+            f"{NASDAQ100_TAQ_SESSION}, redistributed by permission and verified rather "
+            "than rebuilt: no source exists to reduce from"
+        ),
+        build=build_nasdaq100_taq,
+        owns=(NASDAQ100_TAQ,),
+        budget={"subsample": "unknown - the sample as AlgoSeek published it"},
+        entities={NASDAQ100_TAQ.as_posix(): ("symbol", 1)},
+        irreplaceable=True,
+    ),
 )
 
 DATASETS_BY_NAME = {dataset.name: dataset for dataset in DATASETS}
@@ -2173,7 +2670,9 @@ def main() -> int:
     built: dict[str, list[Path]] = {}
     for dataset in selected:
         print(f"  {dataset.name}: {dataset.description}")
-        if args.clean:
+        if args.clean and dataset.irreplaceable:
+            print("    --clean skipped: the fixture copy is the only copy")
+        elif args.clean:
             for owned in dataset.owns:
                 target = output / owned
                 if target.is_dir():

--- a/tests/generate_skip_data.py
+++ b/tests/generate_skip_data.py
@@ -1,31 +1,47 @@
-"""Generate synthetic test data for currently-skipped notebooks.
+"""Generate synthetic intermediates for notebooks that would otherwise have no inputs.
 
-Run once to enrich the test-data repo with minimal synthetic datasets
-that allow the remaining skipped notebooks to execute their code paths.
+Run once to enrich the test-data repo with minimal synthetic artifacts that let
+the remaining skipped notebooks execute their code paths.
 
 Usage:
     uv run python tests/generate_skip_data.py --output ~/ml4t/test-data
 
-This generates data for:
-1. SEC 10-Q MD&A text (Ch10/09)
-2. ADV columns for Kyle lambda (Ch18/03)
-3. Engine divergence predictions (Ch16/07)
-4. Signal quality synthesis data (Ch20/02)
-5. MLOps drift detection features (Ch26/02)
-6. MLOps safe model rollout (Ch26/03)
-7. MLOps MLflow registry (Ch26/06)
+This generates, all of it under ``intermediates/``:
+1. Engine divergence predictions (Ch16/07)
+2. Signal quality synthesis data (Ch20/02)
+3. MLOps registry and stub predictions (Ch26/03, Ch26/06)
 
-The FNSPID news fixture is not here. It is subsampled from production by
+Nothing here writes into ``data/``. Two generators used to, and both wrote where
+nothing reads:
+
+- ``generate_sec_10q_mda`` wrote ``alternative/text/sp500_10q_mda.parquet`` with a
+  pre-canonical ``mda_text`` column, while ``load_sp500_10q_mda`` reads
+  ``equities/fundamentals/10q/sp500/reference/all_10q_filings.parquet``. That file
+  is production-sourced and declared as ``sec_filing_references`` in
+  ``tests/create_test_data.py``, so Ch10/09 has been running against the real
+  schema and the synthetic copy reached no reader.
+- ``enrich_adv_columns`` added ``adv_21d`` to ``etfs/etf_universe.parquet`` and
+  ``equities/us_equities.parquet``. Neither path exists: the fixture carries
+  ``etfs/market/`` and ``equities/market/us_equities/``, so every run printed
+  "SKIP (not found)". No notebook reads ``adv_21d`` from either file.
+
+Keeping this script out of ``data/`` is what makes the fixture's producers
+countable: ``tests/create_test_data.py`` derives from production and
+``tests/generate_test_microstructure.py`` is synthetic, and
+``tests/test_every_fixture_file_has_a_producer.py`` checks the fixture against
+those two.
+
+The FNSPID news fixture is not here either. It is subsampled from production by
 ``tests/create_test_data.py``, whose ``fnspid_news`` dataset bounds it by the
 us_equities panel's date range so 07_news_return_signals' price join has dates to
 land on; the synthetic generator that used to live here wrote 2022-2024, which is
-past the end of that panel - ml4t/agent-workspace#1116.
+past the end of that panel.
 """
 
 import argparse
 import json
 import sqlite3
-from datetime import date, timedelta
+from datetime import date
 from pathlib import Path
 
 import numpy as np
@@ -35,92 +51,6 @@ np.random.seed(42)
 
 SYMBOLS_ETF = ["SPY", "QQQ", "IWM", "TLT", "GLD", "XLF", "XLK", "XLE", "EFA", "VWO"]
 SYMBOLS_EQ = ["AAPL", "MSFT", "GOOGL", "AMZN", "NVDA", "META", "TSLA", "JPM", "V", "JNJ"]
-
-
-def generate_sec_10q_mda(data_dir: Path):
-    """Generate synthetic SEC 10-Q MD&A text data."""
-    out = data_dir / "alternative" / "text"
-    out.mkdir(parents=True, exist_ok=True)
-
-    rows = []
-    for sym in SYMBOLS_EQ[:6]:
-        for year in range(2019, 2024):
-            for quarter in range(1, 5):
-                month = quarter * 3 + 1
-                if month > 12:
-                    month = 1
-                    year_f = year + 1
-                else:
-                    year_f = year
-                filing_date = date(year_f, min(month, 12), 15)
-                period_end = date(year, quarter * 3, 28)
-
-                mda_text = (
-                    f"Management's Discussion and Analysis for {sym}. "
-                    f"During Q{quarter} {year}, revenue increased by {np.random.uniform(2, 15):.1f}% "
-                    f"year-over-year. Operating margins improved to {np.random.uniform(15, 35):.1f}%. "
-                    f"We continue to invest in R&D and expect continued growth. "
-                    f"Key risks include market volatility and regulatory changes."
-                )
-                rows.append(
-                    {
-                        "symbol": sym,
-                        "cik": str(np.random.randint(100000, 999999)),
-                        "accession_no": f"0001234567-{year_f:04d}-{np.random.randint(10000, 99999):05d}",
-                        "filing_date": filing_date,
-                        "period_end": period_end,
-                        "mda_text": mda_text,
-                        "mda_word_count": len(mda_text.split()),
-                        "mda_char_count": len(mda_text),
-                    }
-                )
-
-    df = pl.DataFrame(rows)
-    df.write_parquet(out / "sp500_10q_mda.parquet")
-    print(f"  SEC 10-Q: {len(df)} filings -> {out / 'sp500_10q_mda.parquet'}")
-
-
-def enrich_adv_columns(data_dir: Path):
-    """Add adv_21d (21-day average daily volume) to datasets that need it.
-
-    The Kyle lambda market impact calibration notebook (Ch18/03) reads
-    adv_21d from equity price data. The test data doesn't have this computed.
-    """
-    datasets = [
-        ("etfs", "etf_universe.parquet"),
-        ("equities", "us_equities.parquet"),
-    ]
-    for subdir, filename in datasets:
-        path = data_dir / subdir / filename
-        if not path.exists():
-            print(f"  ADV: SKIP {path} (not found)")
-            continue
-        df = pl.read_parquet(path)
-        if "adv_21d" in df.columns:
-            print(f"  ADV: SKIP {path} (already has adv_21d)")
-            continue
-        if "volume" not in df.columns:
-            print(f"  ADV: SKIP {path} (no volume column)")
-            continue
-
-        # Compute rolling 21-day average volume per symbol
-        sort_cols = ["symbol", "timestamp"] if "symbol" in df.columns else ["timestamp"]
-        group_col = "symbol" if "symbol" in df.columns else None
-
-        if group_col:
-            df = df.sort(sort_cols).with_columns(
-                pl.col("volume")
-                .rolling_mean(window_size=21, min_samples=1)
-                .over(group_col)
-                .alias("adv_21d")
-            )
-        else:
-            df = df.sort("timestamp").with_columns(
-                pl.col("volume").rolling_mean(window_size=21, min_samples=1).alias("adv_21d")
-            )
-
-        df.write_parquet(path)
-        print(f"  ADV: Added adv_21d to {path} ({len(df)} rows)")
 
 
 def generate_engine_divergence_predictions(intermediates_dir: Path):
@@ -202,10 +132,8 @@ def generate_signal_quality_data(intermediates_dir: Path):
     print(f"  Signal quality: IC comparison + synthesis -> {out}")
 
 
-def generate_mlops_data(intermediates_dir: Path, data_dir: Path):
-    """Generate data for Ch26 MLOps notebooks (02, 03, 06)."""
-    # Ch26/02 needs ETFs features with adv_21d — handled by enrich_adv_columns
-
+def generate_mlops_data(intermediates_dir: Path):
+    """Generate the registry and stub predictions Ch26/03 and Ch26/06 read."""
     # Ch26/03 needs a linear/lasso validation run in registry
     out = intermediates_dir / "us_equities_panel" / "run_log"
     out.mkdir(parents=True, exist_ok=True)
@@ -319,32 +247,24 @@ def generate_mlops_data(intermediates_dir: Path, data_dir: Path):
 
 def main():
     parser = argparse.ArgumentParser(
-        description="Generate synthetic test data for skipped notebooks"
+        description="Generate synthetic intermediates for skipped notebooks"
     )
     parser.add_argument("--output", required=True, help="Test data repo root")
     args = parser.parse_args()
 
-    root = Path(args.output)
-    data_dir = root / "data"
-    intermediates_dir = root / "intermediates"
+    intermediates_dir = Path(args.output) / "intermediates"
 
-    print("Generating synthetic test data for skipped notebooks...")
+    print("Generating synthetic intermediates for skipped notebooks...")
     print()
 
-    print("[1/5] SEC 10-Q MD&A text (Ch10/09)...")
-    generate_sec_10q_mda(data_dir)
-
-    print("[2/5] ADV columns for Kyle lambda (Ch18/03)...")
-    enrich_adv_columns(data_dir)
-
-    print("[3/5] Engine divergence predictions (Ch16/07)...")
+    print("[1/3] Engine divergence predictions (Ch16/07)...")
     generate_engine_divergence_predictions(intermediates_dir)
 
-    print("[4/5] Signal quality synthesis data (Ch20/02)...")
+    print("[2/3] Signal quality synthesis data (Ch20/02)...")
     generate_signal_quality_data(intermediates_dir)
 
-    print("[5/5] MLOps registry and predictions (Ch26/02-06)...")
-    generate_mlops_data(intermediates_dir, data_dir)
+    print("[3/3] MLOps registry and predictions (Ch26/03, Ch26/06)...")
+    generate_mlops_data(intermediates_dir)
 
     print()
     print("Done! Now commit changes to the test-data repo and update overrides.yaml.")

--- a/tests/test_every_fixture_file_has_a_producer.py
+++ b/tests/test_every_fixture_file_has_a_producer.py
@@ -9,16 +9,17 @@ able to rebuild it and every test still pass - which is how 149 of 327 files got
 there.
 
 A file with no producer cannot be regenerated when production moves, cannot be
-checked against production, and cannot be explained. The backlog has so far turned
-up three files byte-identical to each other at pre-migration paths that nothing
-reads, one holding the whole FinancialPhraseBank corpus under a filename that
-promises the unanimous subset, and an options panel built from a different universe
-than the one its loader documents, so four of the eight symbols a chapter-8 notebook
-asks for come back empty under CI.
+checked against production, and cannot be explained. The backlog turned up three
+files byte-identical to each other at pre-migration paths that nothing reads, one
+holding the whole FinancialPhraseBank corpus under a filename that promises the
+unanimous subset, an options panel built from a different universe than the one its
+loader documents - so four of the eight symbols a chapter-8 notebook asks for came
+back empty under CI - and a 20,000-row trade-only panel at `nasdaq100_taq/`, which
+no code resolves at all: `load_nasdaq100_taq` reads `trade_and_quotes/symbol=*`.
 
-`UNPRODUCED` is the remaining backlog, and it is a ratchet: a new fixture file with
-no producer fails immediately, and a file that gains one has to leave the list. It
-only shrinks.
+`UNPRODUCED` is down to that last one, and it is the ratchet: a new fixture file with
+no producer fails immediately, an exemption has to be named here, and a file that
+gains a producer has to leave the list. It only shrinks.
 
 Two producers are declared, and two is the whole list. `create_test_data.py` derives
 from production and each `Dataset` names what it owns; `generate_test_microstructure.py`
@@ -43,24 +44,17 @@ import generate_test_microstructure as generator  # noqa: E402
 
 from tests.create_test_data import DATASETS  # noqa: E402
 
-# Fixture files that no declared producer writes. Grouped by top-level directory,
-# which is mechanical; the triage of what each one needs is on the tracker, because
-# it is a judgement that goes stale and a comment here would not be re-checked.
-UNPRODUCED = frozenset(
-    {
-        # Each of these exists in production and the fixture copy is a genuine
-        # reduction of it, so declaring one means writing a builder that performs
-        # that reduction, not a `Dataset` that copies. `nasdaq100_taq` is the
-        # exception: it is AlgoSeek data redistributed by permission, with no
-        # production or workstation copy, so its declaration has to say so.
-        "alternative/text/financial_phrasebank/sentences_allagree.parquet",
-        "equities/market/microstructure/nasdaq100_taq/data.parquet",
-        "equities/market/sp500/options_eda/year=2019.parquet",
-        "equities/market/sp500/options_eda/year=2020.parquet",
-        "equities/positioning/13f/bulk/2024Q3/institutional_holdings.parquet",
-        "prediction_markets/polymarket_events.parquet",
-    }
-)
+# One file is left, and it is a deletion rather than a declaration: no code resolves
+# `nasdaq100_taq/`. `load_nasdaq100_taq` reads `trade_and_quotes/symbol=*`, which
+# `generate_test_microstructure.py` writes, and both chapter-3 TAQ notebooks reach the
+# data through that loader. The file itself is 20,000 rows evenly spaced 117 seconds
+# apart, five symbols over twenty March 2020 sessions, `event_type` "trade" on every
+# row and no quote events at all - so it is neither the AlgoSeek tick sample the
+# `nasdaq100_taq` name promises nor anything the Lee-Ready section could be run on.
+# It stays here for one more change: removing it from this list and deleting it from
+# the fixture cannot be done in one commit, because whichever half lands first turns
+# a test red on every branch that has not merged the other.
+UNPRODUCED = frozenset({"equities/market/microstructure/nasdaq100_taq/data.parquet"})
 
 
 def _owned_by_a_dataset(on_disk: set[str]) -> set[str]:

--- a/tests/test_every_fixture_file_has_a_producer.py
+++ b/tests/test_every_fixture_file_has_a_producer.py
@@ -9,20 +9,22 @@ able to rebuild it and every test still pass - which is how 149 of 327 files got
 there.
 
 A file with no producer cannot be regenerated when production moves, cannot be
-checked against production, and cannot be explained: three of them turned out to be
-byte-identical copies of each other at pre-migration paths that nothing reads, and
-one holds the whole FinancialPhraseBank corpus under a filename that promises the
-unanimous subset.
+checked against production, and cannot be explained. The backlog has so far turned
+up three files byte-identical to each other at pre-migration paths that nothing
+reads, one holding the whole FinancialPhraseBank corpus under a filename that
+promises the unanimous subset, and an options panel built from a different universe
+than the one its loader documents, so four of the eight symbols a chapter-8 notebook
+asks for come back empty under CI.
 
 `UNPRODUCED` is the remaining backlog, and it is a ratchet: a new fixture file with
 no producer fails immediately, and a file that gains one has to leave the list. It
 only shrinks.
 
-Two producers are declared. `create_test_data.py` derives from production and each
-`Dataset` names what it owns; `generate_test_microstructure.py` is synthetic and
-`generate_all` returns what it writes. A third, `generate_skip_data.py`, declares
-nothing at all - its outputs are in `UNPRODUCED` below, and one of them,
-`enrich_adv_columns`, writes back into two files `create_test_data.py` owns.
+Two producers are declared, and two is the whole list. `create_test_data.py` derives
+from production and each `Dataset` names what it owns; `generate_test_microstructure.py`
+is synthetic and `generate_all` returns what it writes. `generate_skip_data.py` used to
+be a third, writing two paths into the fixture and declaring neither; both turned out to
+be paths no loader resolves, so it was cut back to `intermediates/` instead of declared.
 """
 
 from __future__ import annotations
@@ -46,43 +48,17 @@ from tests.create_test_data import DATASETS  # noqa: E402
 # it is a judgement that goes stale and a comment here would not be re-checked.
 UNPRODUCED = frozenset(
     {
-        # academic/ - 3
-        "academic/firm_characteristics_all.parquet",
-        "academic/firm_characteristics_test.parquet",
-        "academic/firm_characteristics_train.parquet",
-        # alternative/ - 4
-        "alternative/institutional/13f_expanded/institutional_holdings.parquet",
-        "alternative/institutional/13f_expanded/stock_features.parquet",
+        # Each of these exists in production and the fixture copy is a genuine
+        # reduction of it, so declaring one means writing a builder that performs
+        # that reduction, not a `Dataset` that copies. `nasdaq100_taq` is the
+        # exception: it is AlgoSeek data redistributed by permission, with no
+        # production or workstation copy, so its declaration has to say so.
         "alternative/text/financial_phrasebank/sentences_allagree.parquet",
-        "alternative/text/sp500_10q_mda.parquet",
-        # autonomous_agents/ - 3
-        "autonomous_agents/operator_artifacts/run_20260504T201005.json",
-        "autonomous_agents/operator_artifacts/run_etfs_20260504T223150.json",
-        "autonomous_agents/operator_artifacts/run_us_firm_characteristics_20260504T225521.json",
-        # crypto/ - 6
-        # equities/ - 9
-        "equities/market/microstructure/iex/deep/parsed/path_signatures/data.parquet",
         "equities/market/microstructure/nasdaq100_taq/data.parquet",
-        "equities/market/microstructure/nasdaq_itch/messages/enriched/C.parquet",
-        "equities/market/microstructure/nasdaq_itch/messages/enriched/E.parquet",
-        "equities/market/microstructure/nasdaq_itch/messages/enriched/X.parquet",
         "equities/market/sp500/options_eda/year=2019.parquet",
         "equities/market/sp500/options_eda/year=2020.parquet",
-        "equities/market/sp500/sp500.csv",
         "equities/positioning/13f/bulk/2024Q3/institutional_holdings.parquet",
-        # factors/ - 38
-        # institutional/ - 1
-        "institutional/13f/institutional_holdings.parquet",
-        # macro/ - 7
-        # prediction_markets/ - 1
         "prediction_markets/polymarket_events.parquet",
-        # sec_filings/ - 6
-        "sec_filings/sp100/10k/AAPL/2023.parquet",
-        "sec_filings/sp100/10k/AAPL/2024.parquet",
-        "sec_filings/sp100/10k/GOOG/2023.parquet",
-        "sec_filings/sp100/10k/GOOG/2024.parquet",
-        "sec_filings/sp100/10k/MSFT/2023.parquet",
-        "sec_filings/sp100/10k/MSFT/2024.parquet",
     }
 )
 


### PR DESCRIPTION
The fixture backlog - files under no `Dataset.owns` and in no manifest entry - closes here. It was 149 of 327 when it was first counted, 27 after the factor/macro/on-chain tranche, and this branch takes the last of it: 21 deletions at paths nothing resolves, five declarations, and one more deletion that only showed itself when its builder was run.

**A fixture with no builder has never been compared to production, and three of the last six turned out to be wrong.** That is the argument for declaring rather than recording. None of the three announced itself, because each rendered an empty frame rather than raising.

- `equities/market/sp500/options_eda/year={2019,2020}.parquet` carried moneyness 0.95-1.05 and nothing past 45 days to maturity, against `02_financial_data_universe/07_sp500_options_eda`'s own declared `CHAIN_BAND` (0.7, 1.3), `SPREAD_BAND` (0.5, 1.5), `WING_BAND` (0.9, 1.1) and `SURFACE_MAX_DAYS` 180. So the smile had no smile, the wing analysis had no wings, "away from the money" was empty and the far-expiration section drew nothing. Its symbol list was wrong the same silent way - AMD, GOOG and INTC where the loader's docstring and `08_financial_features/03_structural_cross_instrument_features` line 73 name BA, JPM, KO and XOM, so four of the eight symbols that notebook asks for by name came back empty.
- `alternative/text/financial_phrasebank/sentences_allagree.parquet` held 4,846 rows - the whole corpus at 50% annotator agreement - under the filename that promises the 2,264 unanimous ones. `10_text_feature_engineering/04_bert_finetuning` fine-tunes on this file, so CI trained on 2,582 sentences the annotators disagreed about, each carrying whatever label the corpus assigned. `load_financial_phrasebank(agreement=...)` looks like it would have caught that and does not: it filters an `agreement` column neither production's file nor the fixture's has, so the argument has never selected anything.
- `prediction_markets/polymarket_events.parquet` held three events against production's 22, which is fewer rows than the panel `13_polymarket_prediction_markets` groups by category.

`institutional_holdings_13f_bulk` was correct already, and its declaration is worth having for a different reason: filtering production to the 600 CIKs with the largest reported value reproduces the fixture row for row - 1,327,852 rows, 743 filings - and that rule had never been written down.

**`nasdaq100_taq` is the one the builder caught.** It was declared as redistributed AlgoSeek tick data with no source to reduce from, and the first run of its own contract refused it: five symbols where the contract asserted one. Measured, it is 20,000 rows, five symbols at exactly 4,000 each over twenty March 2020 sessions, every consecutive gap exactly 117 seconds, `event_type` "trade" on every row and no quote events at all. `load_nasdaq100_taq` reads `equities/market/microstructure/trade_and_quotes/symbol=*`, which `generate_test_microstructure.py` writes and which carries 600 rows on the one session the notebooks name, with TRADE, QUOTE BID and QUOTE ASK events - which is what `12_algoseek_taq_lob_reconstruction`'s Lee-Ready classification needs and what this file has none of. Nothing in the repository resolves `nasdaq100_taq/`. So it is a deletion, and `Dataset.irreplaceable` goes with it: it existed for this one dataset and now has no user.

It leaves the fixture in the next change rather than this one, because removing it from `UNPRODUCED` and deleting it from the test-data repo cannot land together - whichever half arrives first turns a test red on every branch that has not merged the other.

## What this costs

`options_eda` goes 25 MB -> 118 MB, on a 587 MB fixture. Both axes that would cut it are pinned: `02/09` builds a daily straddle series and needs every 2019 session, and `08/03` names all eight underlyings.

**Measured, because the row count creates the wrong intuition: the growth is almost entirely rows these notebooks never plot.** `02/07`'s every plotting path is bounded by one symbol on one session, so on the real `sample_date` (`options["timestamp"].max()`, 2020-12-31) it sees 680 rows in `aapl_day` and 217 in `aapl_calls`, and the `trendline="lowess"` scatter - the one superlinear element in the notebook - is handed **34 points**. The two whole-panel aggregations take 0.21 s and 0.24 s. The entire cost of the forty-fold panel is the load, 0.54 s against about 0.1 s before.

**And the same number states the original defect in cost terms.** Under the old 0.95-1.05 band that lowess call got **6 points** at the earliest session. A trendline through 6 points is not a smile. So the old fixture was not buying speed with its narrowness - it was drawing an empty analysis for free, which is why nothing ever flagged it.

## Pairs with a test-data push

`ml4t/third-edition-test-data` `6dbc3fa0` carries the rebuilt files and the reconciled manifest. It had to go first: `test_the_manifest_subsets_are_exactly_the_declared_ones` compares that manifest against each branch's own `DATASETS`, so until this merges the five new subsets show as undeclared on `main` and on every open branch. The instruction in that window is `git merge origin/main`, never a re-run - a re-run reads the same pre-merge file and fails identically.

## Renders this invalidates

Five notebooks now draw against different data, and none is in any pane's current scope: `02/07_sp500_options_eda`, `02/08_options_greeks_computation`, `02/09_options_continuous`, `08/03_structural_cross_instrument_features` and `10/04_bert_finetuning`. Their committed renders were produced against the fixtures corrected here, and the sections at issue drew empty frames rather than failing - so a reader sees nothing wrong and CI stayed green. Their register rows reading `done` is a dated claim, not a fact, and they need re-opening deliberately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NReuqDy57ft7qkAAKUEtVG
