### PR TITLE
Two rules that could not fail: the input-vintage guard, and an as-of join with no age bound

### DIFF
--- a/case_studies/nasdaq100_microstructure/17_costs.ipynb
+++ b/case_studies/nasdaq100_microstructure/17_costs.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "0fbd07f7",
+   "id": "650d9592",
    "metadata": {},
    "source": [
     "# NASDAQ-100 Microstructure: Costs\n",
@@ -57,7 +57,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "401714d6",
+   "id": "a56eabdb",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -79,6 +79,7 @@
     "    build_backtest_spec,\n",
     "    clone_backtest_spec,\n",
     "    ensure_backtest_spec,\n",
+    "    prediction_age_declaration,\n",
     "    set_backtest_costs_bps,\n",
     "    strategy_view,\n",
     "    traded_universe_declaration,\n",
@@ -100,7 +101,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8667744f",
+   "id": "b359c28f",
    "metadata": {
     "tags": [
      "parameters"
@@ -123,7 +124,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "868ba52c",
+   "id": "bbbf4757",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -146,7 +147,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a4ed062f",
+   "id": "d1e96b70",
    "metadata": {},
    "source": [
     "The study is opened before anything resolves a path or reads the registry. Opening it\n",
@@ -160,7 +161,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7d9b8330",
+   "id": "4d420d2a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -186,7 +187,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6efbb2cb",
+   "id": "c5ae9581",
    "metadata": {},
    "source": [
     "## 1. Load the leading pre-cost runs\n",
@@ -229,7 +230,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6afe2280",
+   "id": "3f6ff505",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -335,7 +336,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8228ac13",
+   "id": "afb3d6de",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -351,7 +352,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "720b952e",
+   "id": "9d6d9d50",
    "metadata": {},
    "source": [
     "## 2. Cost Grid Sweep\n",
@@ -371,7 +372,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d518409f",
+   "id": "b58fba27",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -436,7 +437,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2657aad7",
+   "id": "36a735f2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -453,7 +454,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b770bf9a",
+   "id": "f9032714",
    "metadata": {},
    "source": [
     "## 3. Cost Sensitivity Analysis\n",
@@ -471,7 +472,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "523d8c1b",
+   "id": "949c6c10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -482,7 +483,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "451666ab",
+   "id": "011b232c",
    "metadata": {},
    "source": [
     "**The curve is scoped to the rows this run just registered.** `cost_sensitivity()` unscoped\n",
@@ -497,7 +498,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "79d72ea6",
+   "id": "9aad8eb9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -534,7 +535,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9811bc56",
+   "id": "e402c8a9",
    "metadata": {},
    "source": [
     "## 4. Full Universe vs the Cost-Feasible Screen\n",
@@ -557,7 +558,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f8f4a86f",
+   "id": "bdbacf05",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -593,7 +594,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c9c76d89",
+   "id": "e47f0c91",
    "metadata": {},
    "source": [
     "### Reading the Screen's Effect\n",
@@ -610,7 +611,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b87fc786",
+   "id": "2678c575",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -630,7 +631,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d747d15d",
+   "id": "dd20c21d",
    "metadata": {},
    "source": [
     "## 5. Cadence × Per-Share Cost Analysis\n",
@@ -667,7 +668,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "104cdddd",
+   "id": "55e08060",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -729,20 +730,38 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c8110923",
+   "id": "2129b56a",
    "metadata": {},
    "source": [
     "### Aligning predictions to target bar frequency\n",
     "\n",
-    "The predictions are at 15-minute resolution. When rebalancing at hourly\n",
-    "cadence, we take the **last available prediction** at or before each price\n",
-    "bar timestamp via an asof join. This is realistic: the portfolio manager\n",
-    "uses the most recent signal when the rebalance fires."
+    "The predictions are minute-level. When rebalancing at hourly cadence, we take the\n",
+    "**last available prediction** at or before each price bar timestamp via an asof join.\n",
+    "This is realistic: the portfolio manager uses the most recent signal when the\n",
+    "rebalance fires.\n",
+    "\n",
+    "A backward asof join produces a null only *before* a symbol's series begins, so\n",
+    "dropping nulls trims the leading edge and nothing else. Everything after a symbol's\n",
+    "series *ends* reuses its last score for as long as the panel runs, and the coarser the\n",
+    "cadence the larger a share of the result that is. On this registry's `fwd_dir_15m`\n",
+    "predictions, eleven of 113 symbols stop reporting mid-sample - ten of them together at\n",
+    "the 2020-12-18 fold boundary and `UAL` after a single session - and the oldest match\n",
+    "the join produced was 252 sessions, the whole panel. At 30-minute cadence 19,667 of\n",
+    "303,641 aligned rows carried a prediction more than one session old; at four-hour\n",
+    "cadence, 3,593 of 55,355.\n",
+    "\n",
+    "So the age is bounded, and in sessions rather than minutes: an overnight or weekend\n",
+    "carry is legitimate and is 5,600 minutes wide, while a symbol that has left the\n",
+    "universe is months of *sessions* stale. Measured on the same predictions, age 0 and\n",
+    "age 1 cover every symbol that stays; every row beyond that belongs to one of the\n",
+    "twelve that leave or have a hole. `MAX_PREDICTION_AGE_SESSIONS` is the bound, and the\n",
+    "rows it removes are counted and printed rather than dropped quietly - an alignment\n",
+    "that silently discards a symbol is the same absence this bound exists to end."
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "909f148a",
+   "id": "9e944388",
    "metadata": {},
    "source": [
     "The cadences swept come from `backtest.sweep.cadence_sweep` in `setup.yaml`,\n",
@@ -755,7 +774,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8f797d97",
+   "id": "76f200f5",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -788,10 +807,34 @@
     "cadence_results = []\n",
     "\n",
     "\n",
-    "def align_predictions_to_bars(preds: pl.DataFrame, bar_timestamps: pl.Series) -> pl.DataFrame:\n",
-    "    \"\"\"Align 15-min predictions to coarser bar timestamps via asof join.\"\"\"\n",
-    "    # For each symbol, find the last prediction at or before each bar timestamp\n",
+    "# One session, so a bar may use the session's own prediction or the one before it -\n",
+    "# which is what an overnight or weekend gap produces - and nothing older.\n",
+    "MAX_PREDICTION_AGE_SESSIONS = 1\n",
+    "\n",
+    "\n",
+    "def align_predictions_to_bars(\n",
+    "    preds: pl.DataFrame,\n",
+    "    bar_timestamps: pl.Series,\n",
+    "    *,\n",
+    "    max_age_sessions: int = MAX_PREDICTION_AGE_SESSIONS,\n",
+    "    label: str = \"\",\n",
+    ") -> pl.DataFrame:\n",
+    "    \"\"\"Align minute predictions to coarser bars, refusing a match older than the bound.\n",
+    "\n",
+    "    Sessions come from the prediction panel's own dates, so the bound counts trading days\n",
+    "    rather than calendar time: a Friday prediction matched to a Monday bar is one session\n",
+    "    old, not three days.\n",
+    "\n",
+    "    Returns the aligned frame and, when the bound removed rows, the declaration that has to\n",
+    "    reach `backtest_hash` with them. Without that second value the fix would be invisible to\n",
+    "    the registry: `prediction_hash` and the strategy spec are unchanged by a filter on the\n",
+    "    aligned frame, so a bounded run and an unbounded one hash alike and the later one is\n",
+    "    served the earlier one's result - the same shape as ml4t/agent-workspace#911.\n",
+    "    \"\"\"\n",
     "    bar_df = pl.DataFrame({\"timestamp\": bar_timestamps}).unique().sort(\"timestamp\")\n",
+    "    sessions = preds.select(\n",
+    "        pl.col(\"timestamp\").dt.date().unique().sort().alias(\"session\")\n",
+    "    ).with_row_index(\"session_index\")\n",
     "    symbols = preds[\"symbol\"].unique().sort().to_list()\n",
     "\n",
     "    aligned = []\n",
@@ -799,18 +842,64 @@
     "        sym_preds = preds.filter(pl.col(\"symbol\") == sym).sort(\"timestamp\")\n",
     "        sym_bars = bar_df.with_columns(pl.lit(sym).alias(\"symbol\"))\n",
     "        joined = sym_bars.join_asof(\n",
-    "            sym_preds.drop(\"symbol\"),\n",
+    "            sym_preds.drop(\"symbol\").with_columns(pl.col(\"timestamp\").alias(\"prediction_ts\")),\n",
     "            on=\"timestamp\",\n",
     "            strategy=\"backward\",\n",
     "        )\n",
     "        aligned.append(joined.drop_nulls(\"y_score\"))\n",
     "\n",
-    "    return pl.concat(aligned) if aligned else pl.DataFrame()"
+    "    if not aligned:\n",
+    "        return pl.DataFrame(), None\n",
+    "\n",
+    "    matched = pl.concat(aligned)\n",
+    "    dated = (\n",
+    "        matched.with_columns(pl.col(\"timestamp\").dt.date().alias(\"session\"))\n",
+    "        .join(sessions, on=\"session\", how=\"left\")\n",
+    "        .drop(\"session\")\n",
+    "        .with_columns(pl.col(\"prediction_ts\").dt.date().alias(\"session\"))\n",
+    "        .join(sessions, on=\"session\", how=\"left\", suffix=\"_prediction\")\n",
+    "        .drop(\"session\")\n",
+    "        .with_columns(\n",
+    "            (pl.col(\"session_index\") - pl.col(\"session_index_prediction\")).alias(\"age_sessions\")\n",
+    "        )\n",
+    "    )\n",
+    "    fresh = dated.filter(pl.col(\"age_sessions\") <= max_age_sessions)\n",
+    "    stale = dated.filter(pl.col(\"age_sessions\") > max_age_sessions)\n",
+    "    # Printed on every cadence, including the ones that drop nothing. A line only on the bad\n",
+    "    # case is indistinguishable from the function not having run, which is the shape of the\n",
+    "    # defect this bound closes.\n",
+    "    summary = (\n",
+    "        f\"  {label or 'alignment'}: match age {dated['age_sessions'].median():.0f} session(s) \"\n",
+    "        f\"median, {dated['age_sessions'].max()} max, bound {max_age_sessions}\"\n",
+    "    )\n",
+    "    declaration = None\n",
+    "    if stale.height:\n",
+    "        names = sorted(stale[\"symbol\"].unique().to_list())\n",
+    "        summary += (\n",
+    "            f\" - dropped {stale.height:,} of {dated.height:,} on \"\n",
+    "            f\"{len(names)} of {dated['symbol'].n_unique()} symbols \"\n",
+    "            f\"({', '.join(names[:6])}{' ...' if len(names) > 6 else ''})\"\n",
+    "        )\n",
+    "        # Declared only when it removed something, so a cadence the bound does not touch\n",
+    "        # produces the spec it produced before this existed and keeps its registered identity.\n",
+    "        declaration = prediction_age_declaration(\n",
+    "            max_age_sessions=max_age_sessions,\n",
+    "            dropped=stale.height,\n",
+    "            kept=fresh.height,\n",
+    "            symbols_dropped=len(names),\n",
+    "        )\n",
+    "    else:\n",
+    "        summary += \" - nothing dropped\"\n",
+    "    print(summary)\n",
+    "    aligned = fresh.drop(\n",
+    "        \"session_index\", \"session_index_prediction\", \"age_sessions\", \"prediction_ts\"\n",
+    "    )\n",
+    "    return aligned, declaration"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "491e74f5",
+   "id": "a1c50bc9",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -824,12 +913,12 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f98c9be1",
+   "id": "68db9285",
    "metadata": {},
    "outputs": [],
    "source": [
     "def run_cadence_cost_backtest(\n",
-    "    cadence, cadence_label, cost_ps, cadence_prices, aligned_preds, state\n",
+    "    cadence, cadence_label, cost_ps, cadence_prices, aligned_preds, state, prediction_age=None\n",
     "):\n",
     "    \"\"\"Run one cadence × cost backtest and record results.\"\"\"\n",
     "    state[\"n_done\"] += 1\n",
@@ -849,6 +938,9 @@
     "        # from the panel this spec is being built against, which is the one `run_backtest`\n",
     "        # is handed below. A full run declares nothing and hashes as it did before.\n",
     "        traded_universe=(traded_universe_declaration(cadence_prices) if MAX_SYMBOLS else None),\n",
+    "        # Travels with the spec for the same reason the universe does: it changes what this\n",
+    "        # run is computed from and `prediction_hash` cannot see it.\n",
+    "        prediction_age=prediction_age,\n",
     "        # The universe travels with the spec, not just with the query above. A row registered\n",
     "        # without it reads as full-universe to every later reader - including section 4's\n",
     "        # full-versus-screened query and `derived_tables_off_canonical_universe` - so the\n",
@@ -914,7 +1006,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "426060da",
+   "id": "3f575b2c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -937,9 +1029,14 @@
     "    )\n",
     "    bar_ts = cadence_prices[\"timestamp\"].unique().sort()\n",
     "\n",
-    "    aligned_preds = (\n",
-    "        predictions_15m if freq == \"15m\" else align_predictions_to_bars(predictions_minute, bar_ts)\n",
-    "    )\n",
+    "    if freq == \"15m\":\n",
+    "        # The 15-minute cadence is the prediction grid itself, so no as-of match is made and\n",
+    "        # there is no age to bound.\n",
+    "        aligned_preds, prediction_age = predictions_15m, None\n",
+    "    else:\n",
+    "        aligned_preds, prediction_age = align_predictions_to_bars(\n",
+    "            predictions_minute, bar_ts, label=cadence_label\n",
+    "        )\n",
     "    if aligned_preds.is_empty():\n",
     "        print(f\"  {cadence_label}: no aligned predictions — skipping\")\n",
     "        continue\n",
@@ -949,14 +1046,20 @@
     "    )\n",
     "    for cost_ps in COST_PER_SHARE_GRID:\n",
     "        run_cadence_cost_backtest(\n",
-    "            cadence, cadence_label, cost_ps, cadence_prices, aligned_preds, sweep_state\n",
+    "            cadence,\n",
+    "            cadence_label,\n",
+    "            cost_ps,\n",
+    "            cadence_prices,\n",
+    "            aligned_preds,\n",
+    "            sweep_state,\n",
+    "            prediction_age=prediction_age,\n",
     "        )"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "15446242",
+   "id": "fbcbc004",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -966,7 +1069,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fa9ccb79",
+   "id": "0879af2c",
    "metadata": {},
    "source": [
     "### Cadence × Cost Heatmap\n",
@@ -980,7 +1083,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fe1ad9e0",
+   "id": "5ca45827",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1028,7 +1131,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "259fe3e7",
+   "id": "81c50c4b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1043,7 +1146,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1b2d6f53",
+   "id": "10674497",
    "metadata": {},
    "source": [
     "### Trade Count by Cadence\n",
@@ -1059,7 +1162,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "031a8786",
+   "id": "a46cd8c2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1087,7 +1190,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "46dafefa",
+   "id": "3c8136ce",
    "metadata": {},
    "source": [
     "## Key Takeaways\n",

--- a/case_studies/nasdaq100_microstructure/17_costs.py
+++ b/case_studies/nasdaq100_microstructure/17_costs.py
@@ -81,6 +81,7 @@ from case_studies.utils.backtest_presets import (
     build_backtest_spec,
     clone_backtest_spec,
     ensure_backtest_spec,
+    prediction_age_declaration,
     set_backtest_costs_bps,
     strategy_view,
     traded_universe_declaration,
@@ -603,10 +604,28 @@ else:
 # %% [markdown]
 # ### Aligning predictions to target bar frequency
 #
-# The predictions are at 15-minute resolution. When rebalancing at hourly
-# cadence, we take the **last available prediction** at or before each price
-# bar timestamp via an asof join. This is realistic: the portfolio manager
-# uses the most recent signal when the rebalance fires.
+# The predictions are minute-level. When rebalancing at hourly cadence, we take the
+# **last available prediction** at or before each price bar timestamp via an asof join.
+# This is realistic: the portfolio manager uses the most recent signal when the
+# rebalance fires.
+#
+# A backward asof join produces a null only *before* a symbol's series begins, so
+# dropping nulls trims the leading edge and nothing else. Everything after a symbol's
+# series *ends* reuses its last score for as long as the panel runs, and the coarser the
+# cadence the larger a share of the result that is. On this registry's `fwd_dir_15m`
+# predictions, eleven of 113 symbols stop reporting mid-sample - ten of them together at
+# the 2020-12-18 fold boundary and `UAL` after a single session - and the oldest match
+# the join produced was 252 sessions, the whole panel. At 30-minute cadence 19,667 of
+# 303,641 aligned rows carried a prediction more than one session old; at four-hour
+# cadence, 3,593 of 55,355.
+#
+# So the age is bounded, and in sessions rather than minutes: an overnight or weekend
+# carry is legitimate and is 5,600 minutes wide, while a symbol that has left the
+# universe is months of *sessions* stale. Measured on the same predictions, age 0 and
+# age 1 cover every symbol that stays; every row beyond that belongs to one of the
+# twelve that leave or have a hole. `MAX_PREDICTION_AGE_SESSIONS` is the bound, and the
+# rows it removes are counted and printed rather than dropped quietly - an alignment
+# that silently discards a symbol is the same absence this bound exists to end.
 
 # %% [markdown]
 # The cadences swept come from `backtest.sweep.cadence_sweep` in `setup.yaml`,
@@ -643,10 +662,34 @@ COST_LABELS = [f"{v * 100:g}¢" for v in COST_PER_SHARE_GRID]
 cadence_results = []
 
 
-def align_predictions_to_bars(preds: pl.DataFrame, bar_timestamps: pl.Series) -> pl.DataFrame:
-    """Align 15-min predictions to coarser bar timestamps via asof join."""
-    # For each symbol, find the last prediction at or before each bar timestamp
+# One session, so a bar may use the session's own prediction or the one before it -
+# which is what an overnight or weekend gap produces - and nothing older.
+MAX_PREDICTION_AGE_SESSIONS = 1
+
+
+def align_predictions_to_bars(
+    preds: pl.DataFrame,
+    bar_timestamps: pl.Series,
+    *,
+    max_age_sessions: int = MAX_PREDICTION_AGE_SESSIONS,
+    label: str = "",
+) -> pl.DataFrame:
+    """Align minute predictions to coarser bars, refusing a match older than the bound.
+
+    Sessions come from the prediction panel's own dates, so the bound counts trading days
+    rather than calendar time: a Friday prediction matched to a Monday bar is one session
+    old, not three days.
+
+    Returns the aligned frame and, when the bound removed rows, the declaration that has to
+    reach `backtest_hash` with them. Without that second value the fix would be invisible to
+    the registry: `prediction_hash` and the strategy spec are unchanged by a filter on the
+    aligned frame, so a bounded run and an unbounded one hash alike and the later one is
+    served the earlier one's result - the same shape as ml4t/agent-workspace#911.
+    """
     bar_df = pl.DataFrame({"timestamp": bar_timestamps}).unique().sort("timestamp")
+    sessions = preds.select(
+        pl.col("timestamp").dt.date().unique().sort().alias("session")
+    ).with_row_index("session_index")
     symbols = preds["symbol"].unique().sort().to_list()
 
     aligned = []
@@ -654,13 +697,59 @@ def align_predictions_to_bars(preds: pl.DataFrame, bar_timestamps: pl.Series) ->
         sym_preds = preds.filter(pl.col("symbol") == sym).sort("timestamp")
         sym_bars = bar_df.with_columns(pl.lit(sym).alias("symbol"))
         joined = sym_bars.join_asof(
-            sym_preds.drop("symbol"),
+            sym_preds.drop("symbol").with_columns(pl.col("timestamp").alias("prediction_ts")),
             on="timestamp",
             strategy="backward",
         )
         aligned.append(joined.drop_nulls("y_score"))
 
-    return pl.concat(aligned) if aligned else pl.DataFrame()
+    if not aligned:
+        return pl.DataFrame(), None
+
+    matched = pl.concat(aligned)
+    dated = (
+        matched.with_columns(pl.col("timestamp").dt.date().alias("session"))
+        .join(sessions, on="session", how="left")
+        .drop("session")
+        .with_columns(pl.col("prediction_ts").dt.date().alias("session"))
+        .join(sessions, on="session", how="left", suffix="_prediction")
+        .drop("session")
+        .with_columns(
+            (pl.col("session_index") - pl.col("session_index_prediction")).alias("age_sessions")
+        )
+    )
+    fresh = dated.filter(pl.col("age_sessions") <= max_age_sessions)
+    stale = dated.filter(pl.col("age_sessions") > max_age_sessions)
+    # Printed on every cadence, including the ones that drop nothing. A line only on the bad
+    # case is indistinguishable from the function not having run, which is the shape of the
+    # defect this bound closes.
+    summary = (
+        f"  {label or 'alignment'}: match age {dated['age_sessions'].median():.0f} session(s) "
+        f"median, {dated['age_sessions'].max()} max, bound {max_age_sessions}"
+    )
+    declaration = None
+    if stale.height:
+        names = sorted(stale["symbol"].unique().to_list())
+        summary += (
+            f" - dropped {stale.height:,} of {dated.height:,} on "
+            f"{len(names)} of {dated['symbol'].n_unique()} symbols "
+            f"({', '.join(names[:6])}{' ...' if len(names) > 6 else ''})"
+        )
+        # Declared only when it removed something, so a cadence the bound does not touch
+        # produces the spec it produced before this existed and keeps its registered identity.
+        declaration = prediction_age_declaration(
+            max_age_sessions=max_age_sessions,
+            dropped=stale.height,
+            kept=fresh.height,
+            symbols_dropped=len(names),
+        )
+    else:
+        summary += " - nothing dropped"
+    print(summary)
+    aligned = fresh.drop(
+        "session_index", "session_index_prediction", "age_sessions", "prediction_ts"
+    )
+    return aligned, declaration
 
 
 # %% [markdown]
@@ -672,7 +761,7 @@ def align_predictions_to_bars(preds: pl.DataFrame, bar_timestamps: pl.Series) ->
 
 # %%
 def run_cadence_cost_backtest(
-    cadence, cadence_label, cost_ps, cadence_prices, aligned_preds, state
+    cadence, cadence_label, cost_ps, cadence_prices, aligned_preds, state, prediction_age=None
 ):
     """Run one cadence × cost backtest and record results."""
     state["n_done"] += 1
@@ -692,6 +781,9 @@ def run_cadence_cost_backtest(
         # from the panel this spec is being built against, which is the one `run_backtest`
         # is handed below. A full run declares nothing and hashes as it did before.
         traded_universe=(traded_universe_declaration(cadence_prices) if MAX_SYMBOLS else None),
+        # Travels with the spec for the same reason the universe does: it changes what this
+        # run is computed from and `prediction_hash` cannot see it.
+        prediction_age=prediction_age,
         # The universe travels with the spec, not just with the query above. A row registered
         # without it reads as full-universe to every later reader - including section 4's
         # full-versus-screened query and `derived_tables_off_canonical_universe` - so the
@@ -774,9 +866,14 @@ for cadence in CADENCES if best_pred_hash else []:
     )
     bar_ts = cadence_prices["timestamp"].unique().sort()
 
-    aligned_preds = (
-        predictions_15m if freq == "15m" else align_predictions_to_bars(predictions_minute, bar_ts)
-    )
+    if freq == "15m":
+        # The 15-minute cadence is the prediction grid itself, so no as-of match is made and
+        # there is no age to bound.
+        aligned_preds, prediction_age = predictions_15m, None
+    else:
+        aligned_preds, prediction_age = align_predictions_to_bars(
+            predictions_minute, bar_ts, label=cadence_label
+        )
     if aligned_preds.is_empty():
         print(f"  {cadence_label}: no aligned predictions — skipping")
         continue
@@ -786,7 +883,13 @@ for cadence in CADENCES if best_pred_hash else []:
     )
     for cost_ps in COST_PER_SHARE_GRID:
         run_cadence_cost_backtest(
-            cadence, cadence_label, cost_ps, cadence_prices, aligned_preds, sweep_state
+            cadence,
+            cadence_label,
+            cost_ps,
+            cadence_prices,
+            aligned_preds,
+            sweep_state,
+            prediction_age=prediction_age,
         )
 
 # %%

--- a/case_studies/utils/backtest_presets.py
+++ b/case_studies/utils/backtest_presets.py
@@ -76,6 +76,40 @@ def traded_universe_declaration(prices: pl.DataFrame) -> dict[str, Any]:
     }
 
 
+def prediction_age_declaration(
+    *, max_age_sessions: int, dropped: int, kept: int, symbols_dropped: int
+) -> dict[str, Any]:
+    """Describe a prediction-age bound that removed rows, for the caller to put in its spec.
+
+    The sibling of :func:`traded_universe_declaration`, and the same defect it exists for.
+    Aligning predictions onto a coarser bar with a backward as-of join reuses a symbol's last
+    score for as long as the panel runs after its series ends, and bounding that age changes
+    what the backtest is computed from while ``prediction_hash`` and the strategy spec stay
+    identical - so a run with the bound and a run without it hash alike, and the second is
+    served the first's result. Measured on `nasdaq100_microstructure/17_costs`: the bound
+    removes 19,667 of 303,641 aligned rows at 30-minute cadence.
+
+    Carries the counts and not only the bound, because two runs can declare the same bound
+    and drop different rows: the prediction set behind them moves on every refit, and a run
+    whose universe left earlier is a different portfolio at the same tolerance.
+
+    Declare it only when the bound actually removed something. A caller that drops nothing
+    passes ``None`` and produces byte-identical specs to before this key existed, which is
+    what leaves every registered backtest at the identity it was written under.
+    """
+    if dropped <= 0:
+        raise ValueError(
+            "prediction_age_declaration is for a bound that removed rows; a bound that "
+            "removed none must declare nothing, so the run keeps the identity it had."
+        )
+    return {
+        "max_age_sessions": int(max_age_sessions),
+        "dropped": int(dropped),
+        "kept": int(kept),
+        "symbols_dropped": int(symbols_dropped),
+    }
+
+
 def resolve_execution_mode(fill_timing: str):
     """Map fill_timing string to ExecutionMode enum.
 
@@ -504,6 +538,7 @@ def build_backtest_spec(
     min_trade_value: float | None = None,
     label: str | None = None,
     traded_universe: dict[str, Any] | None = None,
+    prediction_age: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     # A case study that declares per-label cadences must be told which label it is building for.
     # Defaulting to the case-study cadence here would put the spec on the wrong grid and register
@@ -541,6 +576,12 @@ def build_backtest_spec(
     # registered backtest keeps the identity it was written under (ml4t/agent-workspace#911).
     if traded_universe is not None:
         resolved_signal["traded_universe"] = deepcopy(traded_universe)
+    # The prediction-age bound, from `prediction_age_declaration`, on the same terms and in
+    # the same block for the same reason: it changes what the run is computed from without
+    # touching `prediction_hash`, so without this a bounded run and an unbounded one over the
+    # same predictions hash alike and the second is served the first's result.
+    if prediction_age is not None:
+        resolved_signal["prediction_age"] = deepcopy(prediction_age)
 
     strategy_spec: dict[str, Any] = {
         "signal": resolved_signal,

--- a/case_studies/utils/registry/registration.py
+++ b/case_studies/utils/registry/registration.py
@@ -95,13 +95,83 @@ def _sampling_reduced(spec_json: str | None) -> bool:
     return False
 
 
+def _artifacts_mapping(artifacts: object) -> dict[str, str]:
+    """``{name: {"sha256": ...}}`` as a flat mapping, dropping records that pin nothing.
+
+    The ``sha256:`` prefix is stripped here as well as in :func:`_files_mapping`, because a
+    prefixed digest compared against a bare one can never match and the guard would pass such
+    a run in silence. All 3,359 records in the nine live registries are bare, so this changes
+    nothing today - but ``darts_forecasting.py`` already builds a record as
+    ``{"dataset": ..., "sha256": f"sha256:{...}"}``, and ``tests/fixture_registry.py`` has
+    been stripping the prefix on this shape since before it delegated here.
+    """
+    if not isinstance(artifacts, dict):
+        return {}
+    return {
+        str(name): str(record["sha256"]).removeprefix("sha256:")
+        for name, record in sorted(artifacts.items())
+        if isinstance(record, dict) and record.get("sha256")
+    }
+
+
+#: The latent adapter's ``files`` roles that name the same artifact under a different word.
+#: The guard compares per NAME, so ``evaluation_label`` and ``eval_label`` would never be
+#: compared to each other however wide the reader got - the same file pinned twice, checked
+#: never. Measured across the nine live registries before this was added: the only case is
+#: ``us_firm_characteristics/fwd_class_1m``, where the four latent runs pin 04c53aa6a847 as
+#: ``evaluation_label`` and the gbm, linear and tabular_dl runs pin that same sha as
+#: ``eval_label``. Every eval-label sha agrees within its label, so folding the names
+#: together refuses nothing that registers today.
+_FILES_ROLE_ALIASES = {"evaluation_label": "eval_label"}
+
+
+def _files_mapping(files: object) -> dict[str, str]:
+    """A ``files`` list of ``{role, sha256}`` as the same mapping, keyed by role.
+
+    The ``sha256:`` prefix is stripped so a latent run's pin compares against the bare digest
+    every other family records, and a role in ``_FILES_ROLE_ALIASES`` is renamed to the word
+    the other families use. Two records naming one role would be a spec defect rather than a
+    legitimate second vintage, so the later one is not allowed to win silently.
+    """
+    if not isinstance(files, list):
+        return {}
+    mapping: dict[str, str] = {}
+    for record in files:
+        if not isinstance(record, dict):
+            continue
+        role, sha = record.get("role"), record.get("sha256")
+        if not role or not sha:
+            continue
+        digest = str(sha).removeprefix("sha256:")
+        name = _FILES_ROLE_ALIASES.get(str(role), str(role))
+        if mapping.setdefault(name, digest) != digest:
+            raise ValueError(
+                f"input_data_spec.files pins two shas for role {role!r}: "
+                f"{mapping[name]} and {digest}"
+            )
+    return dict(sorted(mapping.items()))
+
+
 def _input_artifact_shas(spec: dict | str | None) -> dict[str, str]:
     """The whole-file sha256 a training spec pins per input artifact.
 
-    ``computation.input_data_spec.artifacts`` is what six of the seven producers build from
-    ``mds.input_lineage``; the latent adapter records a ``files`` list instead
-    (ml4t/agent-workspace#891) and reaches this as an empty mapping, which is a weaker check
-    for that family rather than a wrong one.
+    Three shapes, because the producers write three and reading only one left 119 of the
+    1,156 registered runs vintage-checked by nothing at all (ml4t/agent-workspace#1137):
+
+    - ``computation.input_data_spec.artifacts``, what ``gbm``, ``linear`` and ``tabular_dl``
+      build from ``mds.input_lineage``.
+    - ``computation.input_data_spec.input_data_spec.artifacts``. ``deep_learning`` builds its
+      payload as ``{"input_data_spec": mds.input_lineage, ...}``
+      (``case_studies/utils/deep_learning.py``), so the same mapping ends up one level down.
+      A nesting slip, not a different contract.
+    - ``computation.input_data_spec.files``, a list of ``{role, sha256}`` with a ``sha256:``
+      prefix, which is what the latent adapter records (ml4t/agent-workspace#891).
+
+    Reading all three is what makes ``_enforce_input_artifact_vintage`` cover the population
+    it claims to. Measured across the nine live registries before the widening landed: the
+    119 newly-read runs introduce no conflict the rule would refuse - every (label, artifact)
+    pair they pin already agrees with itself - so this changes what is checked from here on
+    without retroactively refusing anything already registered.
     """
     if isinstance(spec, str):
         try:
@@ -116,14 +186,12 @@ def _input_artifact_shas(spec: dict | str | None) -> dict[str, str]:
     input_data_spec = computation.get("input_data_spec")
     if not isinstance(input_data_spec, dict):
         return {}
-    artifacts = input_data_spec.get("artifacts")
-    if not isinstance(artifacts, dict):
-        return {}
-    return {
-        str(name): str(record["sha256"])
-        for name, record in sorted(artifacts.items())
-        if isinstance(record, dict) and record.get("sha256")
-    }
+    if mapping := _artifacts_mapping(input_data_spec.get("artifacts")):
+        return mapping
+    nested = input_data_spec.get("input_data_spec")
+    if isinstance(nested, dict) and (mapping := _artifacts_mapping(nested.get("artifacts"))):
+        return mapping
+    return _files_mapping(input_data_spec.get("files"))
 
 
 def _registered_artifact_shas(db, *, label: str) -> dict[str, set[str]]:

--- a/scripts/check_input_artifact_vintage.py
+++ b/scripts/check_input_artifact_vintage.py
@@ -34,14 +34,19 @@ An artifact NAME it cannot locate: three resolve from the case study's own specs
 mapping the loader uses. Any other name is reported ``unresolved``.
 
 A training run whose spec records its inputs in a shape ``_input_artifact_shas`` does not
-read, reported ``unchecked`` per family. It reads ``computation.input_data_spec.artifacts``,
-and measured across the nine live registries on 2026-09-11 that misses 121 runs: 45
-``latent_factors`` runs record ``input_data_spec.files``, a list of ``{role, sha256}`` with a
-``sha256:`` prefix (ml4t/agent-workspace#891), and 76 ``deep_learning`` runs nest the payload
-one level deeper, at ``input_data_spec.input_data_spec.artifacts``. **Those runs are not
-vintage-checked by registration either**, so this script reports them rather than reading
-them: a pre-flight stricter than the rule it previews would refuse a chain registration would
-accept, which is a different failure and a worse one. The enforcement gap is filed separately.
+read, reported ``unchecked`` per family. Nothing in the nine live registries is in that state
+as of ml4t/agent-workspace#1137: the rule reads all three recorded shapes now - ``artifacts``,
+the ``deep_learning`` payload nested one level deeper at
+``input_data_spec.input_data_spec.artifacts``, and the ``latent_factors`` ``files`` list of
+``{role, sha256}`` with a ``sha256:`` prefix (ml4t/agent-workspace#891). Before that widening
+the two missed 119 runs, 77 sequence and 42 latent, which neither registration nor this
+script checked.
+
+The category stays, and stays able to fire, because that is the whole shape of this file: a
+checker that walks only what the rule returns would report a registry of nothing but
+unreadable runs as entirely clean. It is still reported rather than fatal - a pre-flight
+stricter than the rule it previews would refuse a chain registration would accept, which is a
+different failure and a worse one.
 
 Usage::
 
@@ -147,10 +152,14 @@ def _artifact_path(case_dir: Path, case_study: str, name: str, label: str) -> Pa
 def _unread_input_shapes(con: sqlite3.Connection, case_study: str) -> list[Finding]:
     """Runs whose recorded inputs ``_input_artifact_shas`` returns nothing for.
 
-    Silence here would be the same defect one level up: the rule reads
-    ``computation.input_data_spec.artifacts``, two producers record somewhere else, and a
-    checker that only walks what the rule returns reports a registry of nothing but those
-    runs as entirely clean.
+    Silence here would be the same defect one level up, and it was: the rule read
+    ``computation.input_data_spec.artifacts`` alone while two producers recorded somewhere
+    else, and a checker that only walks what the rule returns reports a registry of nothing
+    but those runs as entirely clean.
+
+    Written against what the rule RETURNS rather than against a list of shapes, so widening
+    the rule empties this by itself and a producer that invents a fourth shape lands here
+    without anyone editing it.
     """
     try:
         rows = list(con.execute("SELECT family, label, spec_json FROM training_runs"))

--- a/tests/fixture_registry.py
+++ b/tests/fixture_registry.py
@@ -77,33 +77,21 @@ def shipped_artifact_shas(case_dir: Path) -> dict[str, str]:
 def pinned_input_shas(spec_json: str | dict | None) -> dict[str, str]:
     """The ``{artifact name: sha256}`` a training run's spec pins, hex and unprefixed.
 
-    Mirrors ``case_studies/utils/registry/registration.py::_input_artifact_shas``, which
-    is what the vintage guard compares against, and tolerates the same spec shapes it
-    does: a spec that carries no ``computation.input_data_spec.artifacts`` block pins
-    nothing and is never stale.
+    Delegates to ``case_studies.utils.registry.registration._input_artifact_shas`` rather
+    than restating it. It used to restate it, and the two then had to be widened together
+    when the guard learned the ``deep_learning`` and ``latent_factors`` shapes
+    (ml4t/agent-workspace#1137); a mirror that has to be edited in step with its subject is
+    a mirror that will eventually not be. What this module must not do is import from
+    ``conftest`` or pytest - ``generate_intermediates.py`` runs it standalone - and
+    ``registration`` is neither, so the import is inside the function only to keep module
+    import cheap for a caller that never prunes.
+
+    The prefix stripping the ``files`` shape needs now happens there, so this is exactly
+    what the vintage guard compares against, by construction rather than by agreement.
     """
-    spec = spec_json
-    if isinstance(spec, str):
-        try:
-            spec = json.loads(spec)
-        except (TypeError, ValueError):
-            return {}
-    if not isinstance(spec, dict):
-        return {}
-    computation = spec.get("computation")
-    if not isinstance(computation, dict):
-        return {}
-    input_data_spec = computation.get("input_data_spec")
-    if not isinstance(input_data_spec, dict):
-        return {}
-    artifacts = input_data_spec.get("artifacts")
-    if not isinstance(artifacts, dict):
-        return {}
-    return {
-        str(name): str(record["sha256"]).removeprefix("sha256:")
-        for name, record in sorted(artifacts.items())
-        if isinstance(record, dict) and record.get("sha256")
-    }
+    from case_studies.utils.registry.registration import _input_artifact_shas
+
+    return _input_artifact_shas(spec_json)
 
 
 def stale_training_runs(db: sqlite3.Connection, case_dir: Path) -> dict[str, dict[str, str]]:

--- a/tests/test_input_artifact_vintage.py
+++ b/tests/test_input_artifact_vintage.py
@@ -220,19 +220,164 @@ def test_another_label_is_compared_against_its_own_runs(tmp_path: Path) -> None:
     assert _registered(tmp_path) == 2
 
 
-def test_a_run_pinning_no_artifacts_is_not_blocked(tmp_path: Path) -> None:
-    """The latent adapter records a `files` list rather than `artifacts` (#891).
+def _latent_spec(*, model_based: str, config_name: str = "pca_5", prefix: str = "sha256:"):
+    """The shape the latent adapter records: a `files` list of {role, sha256} (#891).
 
-    Reaching this guard with nothing to compare has to be a weaker check for that family
-    rather than a refusal it can never satisfy.
+    The `sha256:` prefix is the adapter's own, and it is what made these look like a
+    different contract rather than the same one written differently.
+    """
+    spec = _spec(model_based=model_based, config_name=config_name)
+    spec["family"] = "latent_factors"
+    spec["computation"]["input_data_spec"] = {
+        "schema_version": 1,
+        "files": [
+            {"role": "financial", "sha256": f"{prefix}{'f' * 64}"},
+            {"role": "label", "sha256": f"{prefix}{'1' * 64}"},
+            {"role": "model_based", "sha256": f"{prefix}{model_based}"},
+        ],
+    }
+    return spec
+
+
+def _sequence_spec(*, model_based: str, config_name: str = "tcn_default"):
+    """The shape `deep_learning` records: `mds.input_lineage` nested one level too deep.
+
+    `case_studies/utils/deep_learning.py` builds the payload as
+    `{"input_data_spec": mds.input_lineage, ...}`, so the artifacts mapping lands at
+    `computation.input_data_spec.input_data_spec.artifacts`. A nesting slip rather than a
+    different contract, and it put 77 runs outside the guard.
+    """
+    spec = _spec(model_based=model_based, config_name=config_name)
+    spec["family"] = "deep_learning"
+    spec["computation"]["input_data_spec"] = {
+        "input_data_spec": spec["computation"]["input_data_spec"],
+        "lookback": 32,
+    }
+    return spec
+
+
+def test_a_latent_run_on_the_registered_vintage_registers(tmp_path: Path) -> None:
+    """The control for the `files` shape: the prefix is stripped, not compared."""
+    register_training_run("etfs", _spec(model_based=SHA_A), case_dir=tmp_path)
+    register_training_run("etfs", _latent_spec(model_based=SHA_A), case_dir=tmp_path)
+    assert _registered(tmp_path) == 2
+
+
+def test_a_latent_run_on_a_regenerated_artifact_is_refused(tmp_path: Path) -> None:
+    """What #1137 changes. This registered silently before: `_input_artifact_shas` read
+    `artifacts` only, returned an empty mapping for a `files` spec, and the guard returns
+    early on an empty mapping - so 42 latent runs were vintage-checked by nothing."""
+    register_training_run("etfs", _spec(model_based=SHA_A), case_dir=tmp_path)
+    with pytest.raises(ValueError, match="model_based"):
+        register_training_run("etfs", _latent_spec(model_based=SHA_B), case_dir=tmp_path)
+    assert _registered(tmp_path) == 1
+
+
+def test_an_unprefixed_files_sha_compares_the_same(tmp_path: Path) -> None:
+    """The prefix is cosmetic, so its absence must not make a run unrefusable."""
+    register_training_run("etfs", _spec(model_based=SHA_A), case_dir=tmp_path)
+    with pytest.raises(ValueError, match="model_based"):
+        register_training_run("etfs", _latent_spec(model_based=SHA_B, prefix=""), case_dir=tmp_path)
+
+
+def test_a_sequence_run_on_the_registered_vintage_registers(tmp_path: Path) -> None:
+    """The control for the nested shape."""
+    register_training_run("etfs", _spec(model_based=SHA_A), case_dir=tmp_path)
+    register_training_run("etfs", _sequence_spec(model_based=SHA_A), case_dir=tmp_path)
+    assert _registered(tmp_path) == 2
+
+
+def test_a_sequence_run_on_a_regenerated_artifact_is_refused(tmp_path: Path) -> None:
+    """The other half of #1137, and the larger one: 77 deep_learning runs."""
+    register_training_run("etfs", _spec(model_based=SHA_A), case_dir=tmp_path)
+    with pytest.raises(ValueError, match="model_based"):
+        register_training_run("etfs", _sequence_spec(model_based=SHA_B), case_dir=tmp_path)
+    assert _registered(tmp_path) == 1
+
+
+def test_a_sequence_run_is_what_a_later_run_is_compared_against(tmp_path: Path) -> None:
+    """Reading a shape is only half of covering it.
+
+    A widened reader that still wrote nothing comparable would leave the population exactly
+    as unchecked, because `_registered_artifact_shas` builds the set every later run is
+    measured against from the same function. So the direction that matters is this one: a
+    sequence run registers FIRST, and an ordinary run on a different vintage is then refused
+    against it.
+    """
+    register_training_run("etfs", _sequence_spec(model_based=SHA_A), case_dir=tmp_path)
+    with pytest.raises(ValueError, match="model_based"):
+        register_training_run("etfs", _spec(model_based=SHA_B), case_dir=tmp_path)
+    assert _registered(tmp_path) == 1
+
+
+def test_the_latent_eval_label_role_is_compared_against_the_other_families(
+    tmp_path: Path,
+) -> None:
+    """Two words for one artifact is checked never, however wide the reader gets.
+
+    The guard compares per NAME. The latent adapter's `files` list calls the evaluation
+    label `evaluation_label` and gbm, linear and tabular_dl call it `eval_label`, so the
+    same file was pinned under two names and a latent run's pin was only ever compared
+    against other latent runs'. Measured before the alias landed, the only live case is
+    `us_firm_characteristics/fwd_class_1m`, where all four families pin 04c53aa6a847 - so
+    folding the names together refuses nothing that registers today and starts comparing
+    what it was not comparing.
+    """
+    ordinary = _spec(model_based=SHA_A)
+    ordinary["computation"]["input_data_spec"]["artifacts"]["eval_label"] = {
+        "sha256": "e" * 64,
+        "size": 14,
+    }
+    register_training_run("etfs", ordinary, case_dir=tmp_path)
+
+    latent = _latent_spec(model_based=SHA_A, config_name="pca_eval")
+    latent["computation"]["input_data_spec"]["files"].append(
+        {"role": "evaluation_label", "sha256": "sha256:" + "9" * 64}
+    )
+    with pytest.raises(ValueError, match="eval_label"):
+        register_training_run("etfs", latent, case_dir=tmp_path)
+    assert _registered(tmp_path) == 1
+
+
+def test_the_alias_does_not_refuse_the_vintage_the_population_holds(tmp_path: Path) -> None:
+    """The other half, and the one that says the alias is safe rather than merely strict."""
+    ordinary = _spec(model_based=SHA_A)
+    ordinary["computation"]["input_data_spec"]["artifacts"]["eval_label"] = {
+        "sha256": "e" * 64,
+        "size": 14,
+    }
+    register_training_run("etfs", ordinary, case_dir=tmp_path)
+
+    latent = _latent_spec(model_based=SHA_A, config_name="pca_eval")
+    latent["computation"]["input_data_spec"]["files"].append(
+        {"role": "evaluation_label", "sha256": "sha256:" + "e" * 64}
+    )
+    register_training_run("etfs", latent, case_dir=tmp_path)
+    assert _registered(tmp_path) == 2
+
+
+def test_a_files_list_pinning_one_role_twice_is_refused(tmp_path: Path) -> None:
+    """A spec defect rather than a second vintage, so the later record must not win quietly."""
+    latent = _latent_spec(model_based=SHA_A)
+    latent["computation"]["input_data_spec"]["files"].append(
+        {"role": "financial", "sha256": "sha256:" + "7" * 64}
+    )
+    with pytest.raises(ValueError, match="two shas for role"):
+        register_training_run("etfs", latent, case_dir=tmp_path)
+
+
+def test_a_run_pinning_no_artifacts_at_all_is_not_blocked(tmp_path: Path) -> None:
+    """A spec carrying none of the three shapes still pins nothing and is not refused.
+
+    The guard returns early on an empty mapping, and that has to stay true: a family whose
+    inputs this cannot see is a weaker check for that family rather than a refusal it can
+    never satisfy. With all three shapes read, nothing in the nine live registries is in
+    this state - but a spec that predates them, or a future producer, can be.
     """
     register_training_run("etfs", _spec(model_based=SHA_A), case_dir=tmp_path)
-    latent = _spec(model_based=SHA_A, config_name="pca_5")
-    latent["family"] = "latent_factors"
-    latent["computation"]["input_data_spec"] = {
-        "files": [{"role": "financial", "sha256": "f" * 64}]
-    }
-    register_training_run("etfs", latent, case_dir=tmp_path)
+    bare = _spec(model_based=SHA_B, config_name="bare")
+    bare["computation"]["input_data_spec"] = {"schema_version": 1, "fingerprint": "none"}
+    register_training_run("etfs", bare, case_dir=tmp_path)
     assert _registered(tmp_path) == 2
 
 

--- a/tests/test_input_artifact_vintage_check.py
+++ b/tests/test_input_artifact_vintage_check.py
@@ -199,11 +199,18 @@ def test_two_pinned_vintages_are_only_superseded_when_a_declaration_retires_the_
     assert _statuses(retired)["model_based"] == "superseded"
 
 
-def test_runs_recording_inputs_in_a_shape_the_rule_does_not_read_are_reported(artifacts_root):
-    """The rule reads one location; two producers record elsewhere and are checked by nothing.
+def test_the_two_shapes_that_used_to_be_unchecked_are_now_checked(artifacts_root):
+    """What ml4t/agent-workspace#1137 changed, from this end.
 
-    A registry holding only those runs would otherwise report zero pairs and exit 0, which is
-    the silence this whole check exists to end.
+    These two specs used to come back `unchecked`, one per family, because
+    `_input_artifact_shas` read `computation.input_data_spec.artifacts` and nothing else -
+    so 119 registered runs across the nine live registries were vintage-checked by neither
+    registration nor this pre-flight. The rule reads all three shapes now, so both specs
+    produce ordinary per-artifact findings and neither family appears as unchecked.
+
+    Asserting the findings rather than only the absence: a widening that made
+    `_input_artifact_shas` return `{}` faster would also empty the unchecked list, and would
+    look identical here.
     """
     db = artifacts_root / CASE_STUDY / "run_log" / "registry.db"
     _registry(
@@ -216,12 +223,43 @@ def test_runs_recording_inputs_in_a_shape_the_rule_does_not_read_are_reported(ar
     )
 
     findings = check_case_study(CASE_STUDY, artifacts_root=artifacts_root)
+
+    assert not [f for f in findings if f.status == "unchecked"]
+    # The latent spec pins `financial` at a...a and `label` at b...b, the sequence spec pins
+    # `financial` at d...d, and none of those is what is on disk. Being reported at all is the
+    # change; the `sha256:` prefix on the latent side being stripped is why its pins compare
+    # against the same digests every other family records.
+    pinned = {sha for f in findings for sha in f.pinned}
+    assert {"a" * 64, "b" * 64, "d" * 64} <= pinned
+
+
+def test_a_spec_carrying_none_of_the_three_shapes_is_still_reported(artifacts_root):
+    """The unchecked category has to stay able to fire.
+
+    With all three shapes read nothing in the live registries reaches it, and a category that
+    cannot fire is the failure this whole check exists to end - it would report a registry of
+    nothing but unreadable runs as entirely clean. So: a spec recording its inputs nowhere the
+    rule looks is still counted and named.
+    """
+    db = artifacts_root / CASE_STUDY / "run_log" / "registry.db"
+    _registry(
+        db,
+        artifact_shas=_on_disk(artifacts_root),
+        extra_runs=[
+            (
+                "hash-opaque",
+                "some_future_family",
+                {"label": LABEL, "computation": {"input_data_spec": {"digest": "x" * 64}}},
+            )
+        ],
+    )
+
+    findings = check_case_study(CASE_STUDY, artifacts_root=artifacts_root)
     unchecked = {f.artifact: f.detail for f in findings if f.status == "unchecked"}
 
-    assert set(unchecked) == {"latent_factors", "deep_learning"}
-    assert "input_data_spec.files" in unchecked["latent_factors"]
-    assert "input_data_spec.input_data_spec.artifacts" in unchecked["deep_learning"]
-    # Reported, not fatal: registration accepts these runs, and a pre-flight stricter than the
+    assert set(unchecked) == {"some_future_family"}
+    assert "no artifact shas recorded" in unchecked["some_future_family"]
+    # Reported, not fatal: registration accepts such a run, and a pre-flight stricter than the
     # rule it previews would refuse a chain that would in fact register.
     assert not any(f.is_failure for f in findings)
 

--- a/tests/test_prediction_age_reaches_the_backtest_identity.py
+++ b/tests/test_prediction_age_reaches_the_backtest_identity.py
@@ -1,0 +1,128 @@
+"""A bound on prediction age changes the result, so it has to change the identity.
+
+ml4t/agent-workspace#1135. `17_costs.py` aligns minute predictions onto coarser bars with a
+backward as-of join. That join produces a null only *before* a symbol's series begins, so
+dropping nulls trims the leading edge and nothing else: every bar after a symbol's series
+*ends* reuses its last score for as long as the panel runs. Measured on this registry's
+`fwd_dir_15m` predictions, eleven of 113 symbols stop mid-sample and the oldest match the
+join produced was 252 sessions - the whole panel.
+
+Bounding that age fixes what the backtest is computed from and touches neither
+`prediction_hash` nor the strategy spec, so without a declaration a bounded run and an
+unbounded one hash alike and the second is served the first's result. That is
+ml4t/agent-workspace#911 exactly, one level over: there the reduction was the price panel,
+here it is the aligned predictions, and in both the caller has to declare what it did before
+it hashes.
+
+`prediction_age_declaration` builds the declaration and
+`build_backtest_spec(prediction_age=...)` puts it in `strategy.signal`, which is hashed
+whole. A caller that declares nothing produces the spec it produced before the parameter
+existed, which is what leaves every registered backtest at the identity it was written
+under - the first two tests hold both halves of that.
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+
+import polars as pl
+import pytest
+
+from case_studies.utils.backtest_loaders import get_backtest_config
+from case_studies.utils.backtest_presets import build_backtest_spec, prediction_age_declaration
+from case_studies.utils.registry.specs import backtest_hash_from_parts
+
+CASE_STUDY = "nasdaq100_microstructure"
+
+
+def _prices() -> pl.DataFrame:
+    timestamps = pl.datetime_range(
+        pl.datetime(2020, 6, 30), pl.datetime(2020, 7, 30), "1d", eager=True
+    )
+    return pl.DataFrame(
+        {"timestamp": timestamps, "symbol": "AAPL", "close": 100.0},
+    )
+
+
+def _spec(**kwargs) -> dict:
+    config = get_backtest_config(CASE_STUDY)
+    base = dict(
+        prices=_prices(),
+        prediction_hash="p" * 12,
+        initial_cash=1_000_000.0,
+        signal={"method": "equal_weight_top_k", "top_k": 5},
+        chapter="ch18",
+        label=config.primary_label,
+    )
+    return build_backtest_spec(CASE_STUDY, config, **deepcopy(base), **kwargs)
+
+
+def _hash(spec: dict) -> str:
+    return backtest_hash_from_parts("p" * 12, spec)
+
+
+def _declaration(*, dropped: int = 19_667, kept: int = 283_974, symbols: int = 12) -> dict:
+    return prediction_age_declaration(
+        max_age_sessions=1, dropped=dropped, kept=kept, symbols_dropped=symbols
+    )
+
+
+def test_a_cadence_that_drops_nothing_hashes_exactly_as_it_did_before() -> None:
+    """The compatibility half, and why the key is emitted only when it is earned."""
+    without = _spec()
+    explicit_none = _spec(prediction_age=None)
+
+    assert "prediction_age" not in without["strategy"]["signal"]
+    assert _hash(without) == _hash(explicit_none)
+
+
+def test_a_bound_that_drops_rows_gets_an_identity_of_its_own() -> None:
+    """The defect. Without this the fix is invisible to a registry that already holds a row.
+
+    `prediction_hash` names the prediction set, not the subset of it this run was computed
+    from, and the strategy spec is untouched by a filter on the aligned frame. So a warm
+    re-run of an already-swept cadence returns the unbounded numbers and nothing says so.
+    """
+    assert _hash(_spec()) != _hash(_spec(prediction_age=_declaration()))
+
+
+def test_two_different_drops_are_two_identities() -> None:
+    """The counts are in the declaration, not only the bound.
+
+    Two runs can declare the same tolerance and be computed from different rows: the
+    prediction set behind them moves on every refit, and a universe that left earlier is a
+    different portfolio at the same bound. A declaration carrying only `max_age_sessions`
+    would collapse those into one identity, which is the failure this whole key exists to
+    prevent rather than a smaller version of it.
+    """
+    thirty_minute = _spec(prediction_age=_declaration(dropped=19_667, kept=283_974))
+    four_hour = _spec(prediction_age=_declaration(dropped=3_593, kept=51_762))
+
+    assert _hash(thirty_minute) != _hash(four_hour)
+
+
+def test_a_bound_that_removed_nothing_cannot_be_declared() -> None:
+    """A declaration for a bound that did nothing would re-key a run for no change in it.
+
+    The refusal is what keeps the compatibility half above true by construction rather than
+    by the caller remembering: there is no way to spell "bounded, dropped zero" in a spec.
+    """
+    with pytest.raises(ValueError, match="removed rows"):
+        prediction_age_declaration(max_age_sessions=1, dropped=0, kept=283_974, symbols_dropped=0)
+
+
+def test_the_declaration_reaches_the_hashed_block_rather_than_sitting_beside_it() -> None:
+    """Where it lands is the whole mechanism, so it is asserted rather than assumed.
+
+    `strategy.signal` is hashed whole. A key written anywhere `_hashable_strategy_spec`
+    strips, or outside `strategy`, would read as a declaration and change no identity - which
+    is indistinguishable from the defect it is meant to close.
+    """
+    spec = _spec(prediction_age=_declaration())
+
+    assert spec["strategy"]["signal"]["prediction_age"] == {
+        "max_age_sessions": 1,
+        "dropped": 19_667,
+        "kept": 283_974,
+        "symbols_dropped": 12,
+    }


### PR DESCRIPTION
Two refusals that were reading less than they claimed. Both are the same shape - an absence presenting as a success - and both are measured rather than argued.

## The vintage guard read one of the three shapes producers write

`_enforce_input_artifact_vintage` refuses a training run that would join a population fitted on a different vintage of the same input artifact. It read `computation.input_data_spec.artifacts`, and two of the five producers do not write there - so across the nine live registries **119 of 1,159 registered runs were vintage-checked by nothing at all**: 77 `deep_learning` and 42 `latent_factors`.

Neither is a different contract. `deep_learning` builds its payload as `{"input_data_spec": mds.input_lineage, ...}`, so the same mapping lands one level deeper; `latent_factors` records a `files` list of `{role, sha256}` with a `sha256:` prefix. `_input_artifact_shas`'s docstring called the latter "a weaker check for that family rather than a wrong one" - it was not a weaker check, it was none, because the guard returns early on an empty mapping.

**Reading a shape is only half of covering it.** `_registered_artifact_shas` builds the set every later run is measured against from the same function, so those 119 runs were also invisible *as a population*: an ordinary run fitted on a vintage only a sequence run had used was compared against nothing. There is a test for that direction specifically.

A third gap the widening exposes rather than creates: the guard compares per **name**, and the latent `files` roles call the evaluation label `evaluation_label` where the other three families call it `eval_label`. One file pinned under two names is compared never, however wide the reader gets.

**Measured before landing, because widening a refusal can refuse runs that register today. It does not.** Every `(label, artifact)` pair the newly read runs pin already agrees with itself; every eval-label sha agrees within its label; the one conflict that exists was already visible and already declared. `scripts/check_input_artifact_vintage.py --quiet` goes from 95 pairs / 83 current / 1 superseded / **11 unchecked** to 84 / 83 / 1 / **0 unchecked, 0 unresolved**.

The `unchecked` category stays and stays able to fire, written against what the rule *returns* rather than a list of shapes - so a producer inventing a fourth lands there with nobody editing it, and there is a test with a spec carrying none of the three. The six new refusal tests were run against the pre-change function and all six fail there.

## An as-of join carried a prediction forward for a year

`align_predictions_to_bars` in `17_costs.py` joins minute predictions backward onto each coarser cadence's bars and drops nulls. A backward as-of join produces a null only *before* a symbol's series begins, so that trims the leading edge and nothing else. Everything after a symbol's series *ends* reuses its last `y_score` for as long as the panel runs.

Measured on the registry's own predictions - 113 symbols, 2020-06-30 to 2021-06-30:

- Eleven symbols stop mid-sample. Ten stop together at the 2020-12-18 fold boundary; `UAL` after a single session, 296 rows. A twelfth, `BIIB`, is present on all 253 sessions with one missing in the middle.
- The oldest match the join produced is **252 sessions - the whole panel**.
- 30-minute cadence: 19,667 of 303,641 aligned rows older than one session. 1h: 10,732 of 165,631. 4h: 3,593 of 55,355.

**The bound is in sessions, and the measurement is what decided that.** In minutes the two populations overlap - a legitimate long-weekend carry is 5,600 minutes wide, so a one-trading-day wall-clock bound flags 24,851 rows on symbols that never left. In sessions they separate exactly: age 0 and age 1 cover every symbol that stays, every row beyond belongs to one of the twelve.

**And the bound reaches `backtest_hash`.** A filter on the aligned frame changes what the run is computed from and touches neither `prediction_hash` - which names the prediction set, not the subset used - nor the strategy spec, so a bounded run and an unbounded one hash alike and a re-run of an already-swept cadence is served the unbounded numbers. A reduction that does not reach the identity is the same defect one level down, where the reduction was the price panel; this is it one level over, and this notebook already carries that lesson for `MAX_SYMBOLS` six lines away. RoboRev blocked the first push of this branch on exactly that, which is the finding of the day.

`prediction_age_declaration` follows `traded_universe`'s terms exactly: emitted into `strategy.signal` only when the bound removed rows, so an untouched cadence produces the spec it produced before the parameter existed. It carries the counts and not only the tolerance, because two runs can declare the same bound and be computed from different rows.

No render is invalidated: `backtest_runs` is empty in this registry, so `17_costs` has never produced the cadence exhibit.

## Verification

- `tests/test_input_artifact_vintage.py`, `test_input_artifact_vintage_check.py`, `test_fixture_registry_prune.py`, `test_artifact_supersession.py`, `test_max_symbols_reduces_a_vectorized_backtest.py` and the new `test_prediction_age_reaches_the_backtest_identity.py`: 92 passed.
- The live pre-flight reports 0 unchecked.
- The notebook's own `align_predictions_to_bars` was lifted out of the file and run against the real prediction set: columns unchanged, declared `kept` equals rows returned, and a bound of 0 drops strictly more (36,621 rows on all 113 symbols), so the filter is live rather than decorative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NReuqDy57ft7qkAAKUEtVG
