### PR TITLE
A supersedes declaration names the lineage, not a generation of it

### DIFF
--- a/case_studies/research/__init__.py
+++ b/case_studies/research/__init__.py
@@ -48,6 +48,7 @@ from .model_planning import (
 )
 from .models import ModelRequest, ModelRun, ResolvedModelRequest
 from .population import (
+    SUPERSEDES_LIVE,
     OfficialPopulation,
     RetirementSplit,
     population_supersedes,
@@ -160,6 +161,7 @@ __all__ = [
     "unfinished_sweep_plans",
     "planned_backtests",
     "upstream_plan_hashes",
+    "SUPERSEDES_LIVE",
     "population_supersedes",
     "research_name",
     "resolved_model_plan",

--- a/case_studies/research/comparison.py
+++ b/case_studies/research/comparison.py
@@ -13,7 +13,7 @@ import polars as pl
 from case_studies.utils.registry.specs import canonical_json, compute_hash
 from case_studies.utils.registry.store import _git_hash, _open_registry, _utc_now
 
-from .population import _refuse_preview_activation
+from .population import SUPERSEDES_LIVE, _refuse_preview_activation
 from .results import Result
 
 if TYPE_CHECKING:
@@ -101,6 +101,13 @@ def candidate_set_supersedes(study: Study, *, name: str, declared: str | None) -
     - **The refit.** The declaration names the tip itself, and offering it publishes the next
       generation over that tip.
 
+    A declaration of :data:`case_studies.research.population.SUPERSEDES_LIVE` resolves to the tip
+    in all three and is the form that does not decay. It matters more here than on the population
+    path: a candidate set's hash is computed from its members and its contract, not from what it
+    supersedes, so an unchanged re-run is answered by the existing name binding and the
+    declaration is never read at all. The only run that reads it is the one whose membership
+    moved, and that run accepts the tip and nothing else.
+
     Anything else is withheld, and ``create`` then refuses and names the hash it requires, which
     is a better answer than this function guessing.
 
@@ -118,6 +125,11 @@ def candidate_set_supersedes(study: Study, *, name: str, declared: str | None) -
         # name resolves to other than exactly one head, `open` raises `KeyError` for a hash the
         # table does not hold, and a clean clone has no `candidate_sets` table for either to read.
         return None
+    if declared == SUPERSEDES_LIVE:
+        # Same branch as `population_supersedes`, for the same reason and with the same reading
+        # of the two cases above it: a clean clone and an unbound name have already returned
+        # None, so there is a generation here to extend. See `SUPERSEDES_LIVE`.
+        return current.hash
     if declared in (current.supersedes, current.hash):
         return declared
     return None

--- a/case_studies/research/population.py
+++ b/case_studies/research/population.py
@@ -81,6 +81,36 @@ def retired_prediction_hashes(connection: sqlite3.Connection) -> set[str]:
     return published - live
 
 
+SUPERSEDES_LIVE = "live"
+"""A declaration that names the lineage's live generation rather than a hash.
+
+A ``SUPERSEDES_*`` hash is a committed constant that has to equal a value the registry moves on
+every publish, and the two sides cannot both be kept. Measured over the committed corpus on
+2026-09-11: of 48 declared literals, 6 named the generation ``create`` would accept, 19 named the
+one it had already replaced, 8 named a generation no lineage holds, and 5 named a hash that
+cannot be placed at all. So the hash pins which generation was replaced in 6 cases out of 48,
+and in the other 19 it is a value ``create`` refuses - at the freeze, after the fit.
+
+``"live"`` states the thing the declaration is actually for: *this run intends to extend the
+lineage published under this name*. That is a property of the run, so it does not go stale, and
+it is the only part of the declaration ``create`` cannot work out for itself - the resolvers are
+already called with ``name=``, and the predecessor's hash is a lookup under that name. The
+record of which generation was replaced is written by ``create`` into
+``official_populations.supersedes_hash`` and ``candidate_set_names.supersedes_hash``, which is
+where a reader looks for a lineage anyway; it was never recoverable from the source.
+
+It does not weaken any refusal. A lineage this run does not name is still refused when its
+membership moves, which is the guard's whole job, and on a clean clone ``"live"`` resolves to
+nothing at all because there is no generation under the name - so a reader still publishes
+generation one. What it removes is the case where the author named the lineage, meant to extend
+it, and was refused for quoting a hash that had moved underneath them.
+
+A hash remains valid and is still the stronger statement where an author genuinely knows which
+generation they are replacing. ``scripts/check_supersedes_literals.py`` reports one that has
+drifted and names ``"live"`` as the repair.
+"""
+
+
 def research_name(case_study_id: str, suffix: str, *, scope: str = "") -> str:
     """Name one published artifact, isolated as a whole chain when a run is narrowed.
 
@@ -372,6 +402,11 @@ def population_supersedes(study: Study, *, name: str, declared: str | None) -> s
     - **The refit.** The declaration names the tip itself, ``current.hash == declared``, and
       offering it publishes the next generation over that tip.
 
+    A declaration of :data:`SUPERSEDES_LIVE` resolves to the tip in every one of those three, and
+    is the form that does not decay: the other two arms are a quotation of a value the registry
+    moves. The clean-clone case is unchanged by it - the lookup above fails and nothing is
+    offered - so the reader still publishes generation one.
+
     Anything else is withheld, and ``create`` then refuses and names the hash it requires - a
     better answer than this function guessing. Note that the two matching conditions are both
     needed: testing only the first withholds the hash from an author holding generation one who
@@ -408,6 +443,12 @@ def population_supersedes(study: Study, *, name: str, declared: str | None) -> s
             # predecessor. Same rule as `_lineage`.
             raise
         return None
+    if declared == SUPERSEDES_LIVE:
+        # The lineage is named, so the predecessor is a lookup rather than a quotation. See
+        # `SUPERSEDES_LIVE`: this is the only branch whose correctness does not decay when the
+        # registry publishes, and it reaches here only after the clean-clone and preview cases
+        # above have already withheld it.
+        return current.hash
     return declared if declared in (current.supersedes, current.hash) else None
 
 
@@ -420,9 +461,11 @@ def supersedes_for_run(
 ) -> str | None:
     """Resolve the ``supersedes`` hash a model-execution run should pass.
 
-    Notebooks declare the hash their published population replaced as a literal in the parameter
-    cell, so that running the committed ``.py`` as it stands recomputes the population on record.
-    Whether that literal may be offered is :func:`population_supersedes`' decision, and this
+    Notebooks declare what their published population replaced as a literal in the parameter
+    cell - either the predecessor's hash, or :data:`SUPERSEDES_LIVE` to name the lineage's live
+    generation without quoting it - so that running the committed ``.py`` as it stands recomputes
+    the population on record. Whether that literal may be offered is
+    :func:`population_supersedes`' decision, and this
     function is the model-execution entry point to it: it adds the one thing that decision cannot
     see, which is the tier the run was planned in.
 

--- a/scripts/check_supersedes_literals.py
+++ b/scripts/check_supersedes_literals.py
@@ -55,6 +55,23 @@ Usage::
     python scripts/check_supersedes_literals.py --json             # machine-readable
     python scripts/check_supersedes_literals.py --case-study etfs --require-declarations
 
+**A literal one generation behind is a refusal, not a pass.** The resolvers offer a declared
+hash when it is the tip OR when it is what the tip replaced, and the second arm made this script
+report "live: names what the tip of X replaced; a re-run resolves to it". That reading is true of
+an unchanged re-run and false of every other run: ``create`` accepts the tip and nothing else,
+so the run whose membership MOVES is refused at the freeze. On 2026-09-11 that was 19 of the 25
+literals this script called live, including the two in ``us_equities_panel/06_linear`` that had
+just cost 78 minutes of cold fitting - reproduced end to end against ``OfficialPopulation.create``
+and ``CandidateSet.create`` in ``tests/test_supersedes_declares_intent.py``. They are reported
+``behind`` and refuse exactly as ``stale`` does.
+
+**The repair this prints is ``"live"``, never the current hash.** Pasting the tip is correct
+until the next publish of whatever freezes that lineage, which is the loop these literals have
+been in since #944. ``SUPERSEDES_LIVE`` names the lineage rather than quoting a generation of it
+and is resolved against the registry at run time, so a declaration that carries it is reported
+``intent`` and has nothing left to go stale - and it is right on a reader's clean clone, where
+there is no generation and the resolvers withhold it.
+
 **What a stale literal does and does not cost, because the difference decides what this
 refuses.** ``OfficialPopulation.create`` reads the declared predecessor only when the member
 list has moved: an unchanged re-run matches on members and returns the published population
@@ -63,8 +80,8 @@ fires on the run whose membership changes, which is the refit a chain is queued 
 which is exactly the run that has already paid for its fit by the time it is refused. That
 is why this refuses rather than warns, and why the refusal is waivable by name.
 
-Exit status is 1 when a literal is dead AND the registry can name the head it should have
-named. `unresolved` - the hash is in no lineage and the notebook's population name cannot be
+Exit status is 1 when a literal is refused at the freeze - dead, or one generation behind -
+AND the registry can name the head it should have named. `unresolved` - the hash is in no lineage and the notebook's population name cannot be
 read without executing it - is reported and never blocks: refusing there would be the check
 asserting knowledge it does not have. A case study with no registry on disk is reported and
 does not fail either; that is a reader's clone. ``--allow-stale-supersedes`` waives the
@@ -84,6 +101,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
+from case_studies.research.population import SUPERSEDES_LIVE  # noqa: E402
 from case_studies.utils.registry.store import current_causal_identities  # noqa: E402
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -147,6 +165,23 @@ def _declared_pairs(value: str | dict[str, str]) -> list[tuple[str | None, str]]
     return [(None, value)] if value else []
 
 
+# Every verdict this script can reach. Named once, because the corpus scan's allowlist was a
+# second copy of it and drifted: `undeclared` was added in #944 and never reached the test, which
+# skips wherever there is no registry - so the drift was invisible in CI by construction and the
+# scan asserted a status set two releases old on the one machine that runs it.
+STATUSES = (
+    "live",  # the declaration names the tip; a refit publishes over it
+    "intent",  # SUPERSEDES_LIVE: the lineage is named and the generation is looked up
+    "behind",  # names the generation the tip replaced; refused on a membership move
+    "stale",  # names no generation of a lineage that has one; refused
+    "superseded",  # causal only: no longer current, which an unchanged re-run is entitled to
+    "undeclared",  # a live generation no declaration in the case study names
+    "unresolved",  # in no lineage, and nothing here can say whether that is dead or first
+    "forked",  # two generations nothing supersedes; no defensible answer
+    "no-registry",  # a reader's clone
+)
+
+
 @dataclass
 class Finding:
     case_study: str
@@ -164,8 +199,36 @@ class Finding:
     label: str | None = None
 
     @property
-    def is_stale(self) -> bool:
-        return self.status == "stale"
+    def refused_at_the_freeze(self) -> bool:
+        """Whether ``create`` refuses this declaration on the run that moves its members.
+
+        Two statuses do, and reading only ``stale`` is how 19 of the corpus's 25 ``live``
+        verdicts were reported green while every one of them was a refusal. ``behind`` is the
+        common one: the literal names the generation the tip replaced, which the resolver offers
+        and ``create`` then rejects because it accepts the tip and nothing else.
+        """
+        return self.status in ("stale", "behind")
+
+
+def _intent_finding(case_study: str, notebook: str, parameter: str, name: str | None) -> Finding:
+    """A declaration that names the live generation instead of quoting a hash.
+
+    Nothing to classify and nothing that can decay. It is reported rather than dropped because
+    a name that appears nowhere in the output reads as a name nobody declared, which is the
+    absence this script exists to make visible.
+    """
+    return Finding(
+        case_study,
+        notebook,
+        SUPERSEDES_LIVE,
+        "intent",
+        f"names the live generation of {name!r} rather than a hash; nothing here goes stale"
+        if name
+        else "names the live generation of whatever lineage this notebook publishes under, "
+        "rather than a hash; nothing here goes stale",
+        parameter,
+        label=name,
+    )
 
 
 _POPULATION_NAME_ASSIGN = re.compile(
@@ -431,6 +494,9 @@ def _check_lineage_literal(
     db = sqlite3.connect(f"file:{registry}?mode=ro", uri=True)
     try:
         for name, declared in pairs:
+            if declared == SUPERSEDES_LIVE:
+                findings.append(_intent_finding(case_study, notebook.name, parameter, name))
+                continue
             owner = _owning_lineage(db, declared)
             if owner is None:
                 # Absent is not evidence on its own - a reset or a reader's empty registry
@@ -472,7 +538,7 @@ def _check_lineage_literal(
                             f"{name!r} is at {tip} (superseding {tip_supersedes}) and this "
                             "hash is in no lineage the registry holds",
                             parameter,
-                            tip,
+                            SUPERSEDES_LIVE,
                             name,
                         )
                     )
@@ -520,16 +586,20 @@ def _check_lineage_literal(
                 )
             elif declared == tip_supersedes:
                 status, detail = (
-                    "live",
-                    f"names what the tip of {owner_name!r} replaced; a re-run resolves to it",
+                    "behind",
+                    f"{owner_name!r} is at {tip} and this names the generation {tip} replaced. "
+                    "An unchanged re-run resolves to the tip and is fine; the run that MOVES "
+                    "its members is refused at the freeze, because create accepts the tip and "
+                    "nothing else",
                 )
+                remedy = SUPERSEDES_LIVE
             else:
                 status, detail = (
                     "stale",
                     f"{owner_name!r} is at {tip} (superseding {tip_supersedes}); this literal "
                     "is neither",
                 )
-                remedy = tip
+                remedy = SUPERSEDES_LIVE
             findings.append(
                 Finding(
                     case_study, notebook.name, declared, status, detail, parameter, remedy, name
@@ -672,7 +742,7 @@ def _undeclared_heads(case_study: str, registry: Path, notebooks: list[Path]) ->
                     f"study names it or its hash; {where}. The next run that moves its "
                     "members is refused at the freeze, after the fit",
                     "SUPERSEDES_SETS",
-                    tip,
+                    SUPERSEDES_LIVE,
                     name,
                 )
             )
@@ -707,6 +777,16 @@ def check_case_study(case_study: str, *, repo_root: Path, artifacts_root: Path) 
 
         declared = declared_by_name.get(_POPULATION_NAME, "")
         if not declared or not isinstance(declared, str):
+            continue
+
+        if declared == SUPERSEDES_LIVE:
+            # The one declaration this script does not have to read a name for. Every other
+            # population verdict needs `_population_name`, which is deliberately partial - a
+            # name built from an f-string or a module constant cannot be read without executing
+            # the notebook, and that is what leaves five of the corpus's literals unresolvable.
+            # The sentinel is resolved at run time against the name the call site already holds,
+            # so there is nothing here to look up and nothing that can drift.
+            findings.append(_intent_finding(case_study, notebook.name, _POPULATION_NAME, None))
             continue
 
         if not registry.exists():
@@ -757,7 +837,7 @@ def check_case_study(case_study: str, *, repo_root: Path, artifacts_root: Path) 
                             f"{statically_named!r} is at {tip} (superseding {tip_supersedes}) "
                             "and this hash is in no lineage the registry holds",
                             _POPULATION_NAME,
-                            tip,
+                            SUPERSEDES_LIVE,
                         )
                     )
                 else:
@@ -801,15 +881,19 @@ def check_case_study(case_study: str, *, repo_root: Path, artifacts_root: Path) 
             status, detail = "live", f"names the tip of {name!r}; a refit publishes over it"
         elif declared == tip_supersedes:
             status, detail = (
-                "live",
-                f"names what the tip of {name!r} replaced; a re-run resolves to it",
+                "behind",
+                f"{name!r} is at {tip} and this names the generation {tip} replaced. An "
+                "unchanged re-run resolves to the tip and is fine; the run that MOVES its "
+                "members is refused at the freeze, because create accepts the tip and nothing "
+                "else",
             )
+            remedy = SUPERSEDES_LIVE
         else:
             status, detail = (
                 "stale",
                 f"{name!r} is at {tip} (superseding {tip_supersedes}); this literal is neither",
             )
-            remedy = tip
+            remedy = SUPERSEDES_LIVE
         findings.append(
             Finding(case_study, notebook.name, declared, status, detail, _POPULATION_NAME, remedy)
         )
@@ -876,18 +960,22 @@ def main(argv: list[str] | None = None) -> int:
         print(json.dumps([asdict(f) for f in findings], indent=1))
     else:
         for finding in findings:
-            mark = "STALE" if finding.is_stale else finding.status.upper()
-            print(f"{mark:<11} {finding.case_study}/{finding.notebook}  {finding.declared}")
+            print(
+                f"{finding.status.upper():<11} {finding.case_study}/{finding.notebook}  "
+                f"{finding.declared}"
+            )
             print(f"            {finding.detail}")
         undeclared_count = sum(f.status == "undeclared" for f in findings)
         checked = len(findings) - undeclared_count
-        stale = sum(f.is_stale for f in findings)
+        refused = sum(f.refused_at_the_freeze for f in findings)
+        behind = sum(f.status == "behind" for f in findings)
         print(
-            f"\n{checked} declared literal(s); {stale} stale; "
+            f"\n{checked} declared literal(s); {refused} refused at the freeze "
+            f"({behind} of them one generation behind); "
             f"{undeclared_count} live generation(s) declared nowhere"
         )
 
-    stale = [f for f in findings if f.is_stale]
+    stale = [f for f in findings if f.refused_at_the_freeze]
     unresolved = [f for f in findings if f.status == "unresolved"]
     undeclared = [f for f in findings if f.status == "undeclared"]
 
@@ -934,7 +1022,7 @@ def main(argv: list[str] | None = None) -> int:
         # sanctioned way to commit that drops its outputs - a live render lost, unless a run
         # is coming anyway. Theirs is.
         print(
-            "\nA stale literal does not make any committed output wrong, and it does not "
+            "\nA refused literal does not make any committed output wrong, and it does not "
             "fail every run: an unchanged re-run returns the published population without "
             "ever reading it. It fails the run whose membership MOVES - which is the refit "
             "you are about to queue - after that run has paid for its fit:\n",
@@ -953,15 +1041,20 @@ def main(argv: list[str] | None = None) -> int:
                 fix = f'set it to "{finding.remedy}"'
             else:
                 fix = "look up the current identity for the label this notebook fits"
+            reading = "is dead" if finding.status == "stale" else "is one generation behind"
             print(
                 f"  case_studies/{finding.case_study}/{finding.notebook}\n"
-                f"      {finding.parameter} = {finding.declared!r} is dead\n"
+                f"      {finding.parameter} = {finding.declared!r} {reading}\n"
                 f"      {finding.detail}\n"
                 f"      fix: {fix}",
                 file=sys.stderr,
             )
         print(
-            "\nFix it now - you are about to pay for the run that re-renders the notebook "
+            '\nPaste "live" rather than the hash. A hash is a quotation of a value the '
+            "registry moves on every publish, so pasting the current one buys you until the "
+            'next run of whatever freezes it; "live" names the lineage instead and is '
+            "resolved against the registry at run time, so it is correct for a clean clone "
+            "too. Fix it now - you are about to pay for the run that re-renders the notebook "
             "you have to clear. If you know this run's membership is unchanged, so the "
             "literal is never read, pass --allow-stale-supersedes.",
             file=sys.stderr,
@@ -969,7 +1062,7 @@ def main(argv: list[str] | None = None) -> int:
         return 1
     if stale:
         print(
-            f"\n{len(stale)} stale literal(s) allowed by --allow-stale-supersedes.",
+            f"\n{len(stale)} refused literal(s) allowed by --allow-stale-supersedes.",
             file=sys.stderr,
         )
     return 0

--- a/scripts/check_supersedes_literals.py
+++ b/scripts/check_supersedes_literals.py
@@ -671,6 +671,15 @@ def _undeclared_heads(case_study: str, registry: Path, notebooks: list[Path]) ->
 
     Coverage is by name OR by hash, because a string-valued declaration names no set and only
     its hash can place it - the same reason this script keys on hashes everywhere else.
+
+    **A scalar ``SUPERSEDES_LIVE`` cannot be placed by either.** It states no name, and it is
+    not a hash, so a set declared through one - ``sp500_options/13_portfolio_management`` uses
+    three scalar parameters rather than a mapping - reads here as declared nowhere. Which of a
+    notebook's scalars covers which of the sets it freezes is decided at the call site, by the
+    ``name=`` each is passed, and no static reader can recover that. So such a head is still
+    reported, because inventing the coverage would let the expensive case through, but the
+    report says a sentinel was found rather than claiming nothing declares it. A mapping entry
+    needs none of this: its key IS the name, so ``{"the-set": "live"}`` covers by name.
     """
     if not registry.exists():
         return []
@@ -698,9 +707,13 @@ def _undeclared_heads(case_study: str, registry: Path, notebooks: list[Path]) ->
         declared_names: set[str] = set()
         declared_hashes: set[str] = set()
         owners: dict[str, list[str]] = {}
+        # Notebooks carrying a scalar sentinel, which states intent without stating a name.
+        sentinel_scalars: dict[str, list[str]] = {}
         for notebook in notebooks:
             source = notebook.read_text(encoding="utf-8", errors="ignore")
-            for value in _declared_literals(source).values():
+            for parameter, value in _declared_literals(source).items():
+                if value == SUPERSEDES_LIVE:
+                    sentinel_scalars.setdefault(notebook.name, []).append(parameter)
                 for lineage_name, declared in _declared_pairs(value):
                     if lineage_name:
                         declared_names.add(lineage_name)
@@ -732,15 +745,32 @@ def _undeclared_heads(case_study: str, registry: Path, notebooks: list[Path]) ->
                     if attributed
                     else "no notebook states this name as a readable template"
                 )
+            scalars = sorted({p for nb in attributed for p in sentinel_scalars.get(nb, [])})
+            if scalars:
+                # A sentinel is present and cannot be placed. Say that rather than "no
+                # declaration names it", which is false, and rather than treating it as
+                # coverage, which would let the case this check exists for through.
+                detail = (
+                    f"{name!r} is live at {tip} and no declaration in this case study names it "
+                    f"or its hash; {where}, and that notebook declares {', '.join(scalars)} = "
+                    f'"{SUPERSEDES_LIVE}" - a scalar sentinel states no name, so which set it '
+                    "covers is decided at the call site and cannot be read here. Confirm it is "
+                    "passed with this set's name; the next run that moves the members of an "
+                    "undeclared set is refused at the freeze, after the fit"
+                )
+            else:
+                detail = (
+                    f"{name!r} is live at {tip} and no SUPERSEDES_* declaration in this case "
+                    f"study names it or its hash; {where}. The next run that moves its "
+                    "members is refused at the freeze, after the fit"
+                )
             findings.append(
                 Finding(
                     case_study,
                     notebook_name,
                     tip,
                     "undeclared",
-                    f"{name!r} is live at {tip} and no SUPERSEDES_* declaration in this case "
-                    f"study names it or its hash; {where}. The next run that moves its "
-                    "members is refused at the freeze, after the fit",
+                    detail,
                     "SUPERSEDES_SETS",
                     SUPERSEDES_LIVE,
                     name,
@@ -1049,12 +1079,29 @@ def main(argv: list[str] | None = None) -> int:
                 f"      fix: {fix}",
                 file=sys.stderr,
             )
+        if any(f.parameter != _CAUSAL_NAME for f in stale):
+            # Addressed only to the lineage declarations. `causal_supersedes` resolves against
+            # `current_causal_identities` and offers the declaration only when it is one of
+            # them, so the sentinel is never a current identity and is always withheld - a
+            # reader who pasted it there would be refused after the DML fit and every placebo
+            # refit, which is the expense this message exists to prevent.
+            print(
+                '\nFor the population and candidate-set declarations, paste "live" rather '
+                "than the hash. A hash is a quotation of a value the registry moves on every "
+                "publish, so pasting the current one buys you until the next run of whatever "
+                'freezes it; "live" names the lineage instead and is resolved against the '
+                "registry at run time, so it is correct for a clean clone too.",
+                file=sys.stderr,
+            )
+        if any(f.parameter == _CAUSAL_NAME for f in stale):
+            print(
+                f"\n{_CAUSAL_NAME} takes no sentinel: `causal_supersedes` offers a declaration "
+                "only when it is a current identity for the label, so paste the hash named "
+                "above.",
+                file=sys.stderr,
+            )
         print(
-            '\nPaste "live" rather than the hash. A hash is a quotation of a value the '
-            "registry moves on every publish, so pasting the current one buys you until the "
-            'next run of whatever freezes it; "live" names the lineage instead and is '
-            "resolved against the registry at run time, so it is correct for a clean clone "
-            "too. Fix it now - you are about to pay for the run that re-renders the notebook "
+            "\nFix it now - you are about to pay for the run that re-renders the notebook "
             "you have to clear. If you know this run's membership is unchanged, so the "
             "literal is never read, pass --allow-stale-supersedes.",
             file=sys.stderr,

--- a/scripts/pre_run_gate.py
+++ b/scripts/pre_run_gate.py
@@ -536,11 +536,19 @@ def check_supersedes_declarations(report: Report, case_study: str, notebook: str
     """Every `SUPERSEDES_*` literal this run may read must still name a generation that exists.
 
     A literal naming a hash the registry no longer holds is withheld by
-    `population_supersedes`, and `create` then refuses the write. That refusal lands at the
-    freeze, *after* the fits are paid for, which is exactly what this gate exists to prevent.
-    It is also invisible until then: an unchanged re-run matches on members and never reads
-    the declaration, so the literal can sit dead through any number of green runs and fail
-    the first one that moves the set's membership - the refit the notebook exists for.
+    `population_supersedes`, and `create` then refuses the write. So is one naming the
+    generation the tip replaced: the resolver offers that hash, and `create` rejects it
+    because it accepts the tip and nothing else. Either refusal lands at the freeze, *after*
+    the fits are paid for, which is exactly what this gate exists to prevent. Both are
+    invisible until then: an unchanged re-run matches on members and never reads the
+    declaration, so the literal sits through any number of green runs and fails the first one
+    that moves the set's membership - the refit the notebook exists for.
+
+    The repair the checker prints is `"live"` rather than the current head, and the difference
+    is the reason this keeps firing. A head is a value the registry moves on every publish, so
+    pasting it buys until the next run of whatever freezes that lineage;
+    `case_studies.research.population.SUPERSEDES_LIVE` names the lineage instead and is
+    resolved at run time.
 
     `scripts/check_supersedes_literals.py` has been able to answer this since #944, and
     nothing called it before a run. It cannot live in CI: the check needs `run_log/`, which
@@ -592,7 +600,13 @@ def check_supersedes_declarations(report: Report, case_study: str, notebook: str
         )
         return
 
-    stale = [f for f in findings if f.is_stale]
+    # `refused_at_the_freeze`, not `is_stale`. Two statuses refuse, and reading only the dead
+    # one is how 19 of the corpus's declarations were reported green: `behind` names the
+    # generation the tip replaced, which `population_supersedes` offers and `create` then
+    # rejects because it accepts the tip and nothing else. That is the state
+    # `us_equities_panel/06_linear` was in when it lost 78 minutes of cold fit on 2026-09-11,
+    # and this gate would have passed it.
+    stale = [f for f in findings if f.refused_at_the_freeze]
     # Scoped to the notebook being run when one is named. A dead literal in a sibling
     # notebook is somebody else's run to fix and must not block this one.
     if notebook is not None:
@@ -603,7 +617,7 @@ def check_supersedes_declarations(report: Report, case_study: str, notebook: str
         report.add(
             "supersedes literals name live generations",
             True,
-            f"no dead declaration in {scope}",
+            f"no refused declaration in {scope}",
             checked=len(findings),
         )
         return
@@ -616,8 +630,8 @@ def check_supersedes_declarations(report: Report, case_study: str, notebook: str
     report.add(
         "supersedes literals name live generations",
         False,
-        f"{len(stale)} dead declaration(s) in {scope}, each of which refuses the write at "
-        f"the freeze once membership moves: " + "; ".join(lines),
+        f"{len(stale)} declaration(s) in {scope} that the registry refuses, each of which "
+        f"refuses the write at the freeze once membership moves: " + "; ".join(lines),
         stale=[asdict(f) for f in stale],
     )
 

--- a/tests/test_pre_run_gate_supersedes.py
+++ b/tests/test_pre_run_gate_supersedes.py
@@ -118,7 +118,34 @@ def test_a_live_literal_in_the_redirected_registry_passes(redirected):
     check = _run()
 
     assert check.passed
-    assert "no dead declaration" in check.detail
+    assert "no refused declaration" in check.detail
+
+
+def test_a_literal_one_generation_behind_the_head_is_refused(redirected):
+    """The verdict this gate used to report green, and the one that cost the fit.
+
+    `population_supersedes` offers a declared hash that equals `current.supersedes`, so a
+    literal one generation back resolves to something - and `create` then rejects it, because
+    it accepts the tip and nothing else. Reading only `is_stale` passed every declaration in
+    this state: 19 of the corpus's 48 on 2026-09-11, including the two in
+    `us_equities_panel/06_linear` that had just cost 78 minutes of cold fitting.
+    """
+    repo, artifacts = redirected
+    _registry(
+        artifacts,
+        [
+            ("gen1", "universe", None),
+            ("gen2", "universe", "gen1"),
+            ("gen3", "universe", "gen2"),
+        ],
+    )
+    _notebook(repo, declared="gen2")
+
+    check = _run()
+
+    assert not check.passed
+    assert "gen2" in check.detail
+    assert "'live'" in check.detail, "the repair has to be the sentinel, not the moving head"
 
 
 def test_no_registry_is_reported_rather_than_passed(redirected):

--- a/tests/test_supersedes_checker_reads_every_declaration.py
+++ b/tests/test_supersedes_checker_reads_every_declaration.py
@@ -36,6 +36,8 @@ checker = importlib.util.module_from_spec(_spec)
 sys.modules["check_supersedes_literals"] = checker
 _spec.loader.exec_module(checker)
 
+SUPERSEDES_LIVE = checker.SUPERSEDES_LIVE
+
 
 def _registry(tmp_path: Path, rows: list[tuple[str, str, str | None]]) -> Path:
     """A registry holding just the candidate-set lineage table the checker reads."""
@@ -99,10 +101,14 @@ def test_a_dict_states_its_own_lineage_names() -> None:
     ("declared", "status"),
     [
         # `candidate_set_supersedes` offers the hash when it is the head or what the head
-        # replaced, and withholds it otherwise (research/comparison.py:121).
+        # replaced (research/comparison.py), but `create` accepts only the head - so the
+        # second of those is `behind`: fine for an unchanged re-run, refused for the run that
+        # moves members. The repair for anything refused is the sentinel, not the head, since
+        # the head moves again at the next publish.
         ("55d6", "live"),
-        ("454f", "live"),
+        ("454f", "behind"),
         ("dead", "stale"),
+        (SUPERSEDES_LIVE, "intent"),
     ],
 )
 def test_a_candidate_set_literal_is_classified_by_the_resolvers_own_rule(
@@ -115,8 +121,10 @@ def test_a_candidate_set_literal_is_classified_by_the_resolvers_own_rule(
         "demo", Path("06_linear.py"), registry, "SUPERSEDES_SETS", [("demo-linear-v1", declared)]
     )
     assert [f.status for f in findings] == [status]
-    if status == "stale":
-        assert findings[0].remedy == "55d6"
+    assert findings[0].refused_at_the_freeze == (status in ("behind", "stale"))
+    if findings[0].refused_at_the_freeze:
+        assert findings[0].remedy == SUPERSEDES_LIVE
+        assert "55d6" in findings[0].detail
 
 
 def test_a_dead_hash_is_answered_with_the_head_because_the_dict_names_the_lineage(
@@ -133,7 +141,8 @@ def test_a_dead_hash_is_answered_with_the_head_because_the_dict_names_the_lineag
         "demo", Path("06_linear.py"), registry, "SUPERSEDES_SETS", [("demo-linear-v1", "gone")]
     )
     assert findings[0].status == "stale"
-    assert findings[0].remedy == "77ab"
+    assert findings[0].remedy == SUPERSEDES_LIVE
+    assert "77ab" in findings[0].detail
 
 
 # --- the missing declaration ----------------------------------------------------------
@@ -149,7 +158,8 @@ def test_a_live_generation_that_nothing_declares_is_reported(tmp_path: Path) -> 
 
     assert [f.status for f in findings] == ["undeclared"]
     assert findings[0].label == "demo-fwd_ret_5d-linear-v1"
-    assert findings[0].remedy == "e7b7"
+    assert findings[0].remedy == SUPERSEDES_LIVE
+    assert "e7b7" in findings[0].detail
     # Attributed through the f-string template, which is the only thing that can name a set
     # the dict does not: the missing entry is by definition not a key.
     assert findings[0].notebook == "06_linear.py"

--- a/tests/test_supersedes_checker_reads_every_declaration.py
+++ b/tests/test_supersedes_checker_reads_every_declaration.py
@@ -165,6 +165,56 @@ def test_a_live_generation_that_nothing_declares_is_reported(tmp_path: Path) -> 
     assert findings[0].notebook == "06_linear.py"
 
 
+SCALAR_SENTINEL_NOTEBOOK = """
+from case_studies.research.comparison import candidate_set_supersedes
+
+SUPERSEDES_BASELINE_CANDIDATES: str = "live"
+
+for label_name in LABELS:
+    full_set_name = f"demo-{label_name}-linear-v1"
+    candidate_set_supersedes(study, name=full_set_name, declared=SUPERSEDES_BASELINE_CANDIDATES)
+"""
+
+
+def test_a_scalar_sentinel_is_reported_as_unplaceable_not_as_absent(tmp_path: Path) -> None:
+    """A scalar `"live"` states intent without stating a name, and both readings are wrong.
+
+    `sp500_options/13_portfolio_management` declares its candidate sets through three scalar
+    parameters rather than a mapping. Such a declaration is neither a name nor a hash, so
+    coverage cannot be resolved from it: which of a notebook's scalars is passed with which
+    set's `name=` is decided at the call site.
+
+    Treating it as coverage would let the case this check exists for through - the expensive
+    one, refused at the freeze after the fit. Reporting "no SUPERSEDES_* declaration in this
+    case study names it or its hash" is simply false when the notebook declares one. So the
+    head is still reported and the report says what was found.
+    """
+    registry = _registry(tmp_path, [("demo-fwd_ret_5d-linear-v1", "e7b7", None)])
+    notebook = tmp_path / "13_portfolio_management.py"
+    notebook.write_text(SCALAR_SENTINEL_NOTEBOOK)
+
+    findings = checker._undeclared_heads("demo", registry, [notebook])
+
+    assert [f.status for f in findings] == ["undeclared"]
+    assert "SUPERSEDES_BASELINE_CANDIDATES" in findings[0].detail
+    assert "cannot be read here" in findings[0].detail
+    assert "no SUPERSEDES_* declaration" not in findings[0].detail
+
+
+def test_a_mapping_entry_naming_the_sentinel_is_coverage(tmp_path: Path) -> None:
+    """The control for the test above: a key IS the name, so nothing has to be inferred."""
+    registry = _registry(tmp_path, [("demo-fwd_ret_5d-linear-v1", "e7b7", None)])
+    notebook = tmp_path / "06_linear.py"
+    notebook.write_text(
+        FREEZING_NOTEBOOK.replace(
+            "SUPERSEDES_SETS: dict = {}",
+            'SUPERSEDES_SETS: dict = {"demo-fwd_ret_5d-linear-v1": "live"}',
+        )
+    )
+
+    assert checker._undeclared_heads("demo", registry, [notebook]) == []
+
+
 def test_a_name_with_no_generation_is_not_reported(tmp_path: Path) -> None:
     """The boundary. Declaring nothing is CORRECT until a generation exists to supersede.
 

--- a/tests/test_supersedes_declares_intent.py
+++ b/tests/test_supersedes_declares_intent.py
@@ -1,0 +1,271 @@
+"""A supersedes declaration says which lineage it extends, not which generation it replaces.
+
+A ``SUPERSEDES_*`` literal is committed source that has to equal a value the registry moves on
+every publish, so it goes stale by construction and every repair is a repair of one instance.
+Measured over the corpus on 2026-09-11: 48 declared literals, of which 6 named a value ``create``
+accepts, 19 named the generation it had already replaced, 8 named a generation no lineage holds,
+and 5 could not be placed at all.
+
+The 19 are the interesting number, because nothing reported them.
+``scripts/check_supersedes_literals.py`` called them ``live`` on the strength of
+``population_supersedes`` offering a hash that equals ``current.supersedes`` - which is true of
+an unchanged re-run and false of the run that pays for a fit. The first two tests here are that
+run, end to end through the real ``create`` on both lineages, because the claim that the
+declaration is a latent fault rather than a certain failure is the whole reason it was left
+alone.
+
+``SUPERSEDES_LIVE`` is what the declaration was for: the author states that this run extends the
+lineage published under this name, and the predecessor is looked up rather than quoted. The rest
+of this file is what must still fail once it exists, because a declaration that cannot refuse
+anything is not a declaration.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import polars as pl
+import pytest
+
+from case_studies.research import CandidateSet, Study
+from case_studies.research.comparison import candidate_set_supersedes
+from case_studies.research.population import (
+    SUPERSEDES_LIVE,
+    OfficialPopulation,
+    population_supersedes,
+)
+from tests.test_research_workspace import _seed_release
+
+NAME = "the-set"
+POPULATION = "cs:the-population"
+
+
+@pytest.fixture
+def study(tmp_path: Path) -> Study:
+    return Study.open(
+        "etfs", workspace=tmp_path / "workspace", release_root=_seed_release(tmp_path)
+    )
+
+
+def _training_spec(alpha: float) -> dict:
+    return {
+        "identity_version": 2,
+        "family": "linear",
+        "label": "fwd_ret_21d",
+        "label_artifact": "label-a",
+        "feature_artifacts": {"financial": "features-a"},
+        "feature_names": ["momentum", "volatility"],
+        "cv": {"folds": [{"fold": 0, "val_start": "2024-01-05"}]},
+        "model": {"class": "Ridge", "params": {"alpha": alpha}},
+        "numerics": {"seed": 42, "precision": "float64"},
+        "execution_tier": "canonical",
+        "seed": 42,
+    }
+
+
+def _member(study: Study, alpha: float):
+    frame = pl.DataFrame(
+        {
+            "symbol": ["A", "B"],
+            "timestamp": ["2024-01-05", "2024-01-05"],
+            "fold_id": [0, 0],
+            "y_true": [0.01, -0.02],
+            "y_score": [0.02, -0.01],
+        }
+    ).with_columns(pl.col("timestamp").str.to_date())
+    training = study.results.register_training(_training_spec(alpha))
+    return study.results.publish_predictions(
+        training,
+        checkpoint_kind="final",
+        checkpoint_value=None,
+        split="validation",
+        predictions=frame,
+        expected_keys=frame.select("symbol", "timestamp", "fold_id"),
+    )
+
+
+class TestTheFailureThatWasReportedAsLive:
+    """Two generations on record, a literal naming the first, and a run that moves members."""
+
+    def test_a_population_literal_one_generation_behind_is_refused_at_the_freeze(
+        self, study: Study
+    ) -> None:
+        first = OfficialPopulation.create(
+            study, name=POPULATION, member_kind="prediction", members=["m1"]
+        )
+        second = OfficialPopulation.create(
+            study,
+            name=POPULATION,
+            member_kind="prediction",
+            members=["m1", "m2"],
+            supersedes=population_supersedes(study, name=POPULATION, declared=first.hash),
+        )
+        assert second.supersedes == first.hash
+
+        # The committed literal still names generation one, and the resolver still offers it -
+        # this is exactly the state 19 of the corpus's declarations were in.
+        offered = population_supersedes(study, name=POPULATION, declared=first.hash)
+        assert offered == first.hash
+
+        with pytest.raises(ValueError, match=f"must explicitly supersedes {second.hash}"):
+            OfficialPopulation.create(
+                study,
+                name=POPULATION,
+                member_kind="prediction",
+                members=["m1", "m2", "m3"],
+                supersedes=offered,
+            )
+
+    def test_a_candidate_set_literal_one_generation_behind_is_refused_at_the_freeze(
+        self, study: Study
+    ) -> None:
+        one, two, three = (_member(study, alpha) for alpha in (1.0, 2.0, 3.0))
+        first = CandidateSet.create(study, NAME, [one])
+        second = CandidateSet.create(
+            study,
+            NAME,
+            [one, two],
+            supersedes=candidate_set_supersedes(study, name=NAME, declared=first.hash),
+        )
+        assert second.supersedes == first.hash
+
+        offered = candidate_set_supersedes(study, name=NAME, declared=first.hash)
+        assert offered == first.hash
+
+        with pytest.raises(ValueError, match=f"must explicitly supersedes {second.hash}"):
+            CandidateSet.create(study, NAME, [one, two, three], supersedes=offered)
+
+
+class TestWhatTheSentinelResolves:
+    def test_it_publishes_over_the_tip_on_the_population_lineage(self, study: Study) -> None:
+        first = OfficialPopulation.create(
+            study, name=POPULATION, member_kind="prediction", members=["m1"]
+        )
+        second = OfficialPopulation.create(
+            study,
+            name=POPULATION,
+            member_kind="prediction",
+            members=["m1", "m2"],
+            supersedes=first.hash,
+        )
+
+        third = OfficialPopulation.create(
+            study,
+            name=POPULATION,
+            member_kind="prediction",
+            members=["m1", "m2", "m3"],
+            supersedes=population_supersedes(study, name=POPULATION, declared=SUPERSEDES_LIVE),
+        )
+
+        assert third.supersedes == second.hash
+
+    def test_it_publishes_over_the_tip_on_the_candidate_set_lineage(self, study: Study) -> None:
+        one, two, three = (_member(study, alpha) for alpha in (1.0, 2.0, 3.0))
+        first = CandidateSet.create(study, NAME, [one])
+        second = CandidateSet.create(study, NAME, [one, two], supersedes=first.hash)
+
+        third = CandidateSet.create(
+            study,
+            NAME,
+            [one, two, three],
+            supersedes=candidate_set_supersedes(study, name=NAME, declared=SUPERSEDES_LIVE),
+        )
+
+        assert third.supersedes == second.hash
+
+    def test_an_unchanged_re_run_still_resolves_to_the_published_generation(
+        self, study: Study
+    ) -> None:
+        """The sentinel must not turn a no-op re-run into a new generation."""
+        first = OfficialPopulation.create(
+            study, name=POPULATION, member_kind="prediction", members=["m1"]
+        )
+        second = OfficialPopulation.create(
+            study,
+            name=POPULATION,
+            member_kind="prediction",
+            members=["m1", "m2"],
+            supersedes=first.hash,
+        )
+
+        again = OfficialPopulation.create(
+            study,
+            name=POPULATION,
+            member_kind="prediction",
+            members=["m1", "m2"],
+            supersedes=population_supersedes(study, name=POPULATION, declared=SUPERSEDES_LIVE),
+        )
+
+        assert again.hash == second.hash
+
+
+class TestWhatMustStillFail:
+    """The negative selftests. A declaration that refuses nothing has stopped being one."""
+
+    def test_a_clean_clone_is_still_handed_nothing(self, study: Study) -> None:
+        """`create` refuses a first generation that claims to replace one, so the reader's run
+        must be handed None rather than a hash - which is the whole reason the declaration is
+        resolved instead of passed straight through."""
+        assert population_supersedes(study, name=POPULATION, declared=SUPERSEDES_LIVE) is None
+        assert candidate_set_supersedes(study, name=NAME, declared=SUPERSEDES_LIVE) is None
+
+    def test_a_first_generation_declaring_the_sentinel_is_still_refused(self, study: Study) -> None:
+        """Resolution returns None on an unbound name; passing the sentinel past it does not."""
+        with pytest.raises(ValueError, match="first population version cannot supersede"):
+            OfficialPopulation.create(
+                study,
+                name=POPULATION,
+                member_kind="prediction",
+                members=["m1"],
+                supersedes=SUPERSEDES_LIVE,
+            )
+
+    def test_a_hash_two_generations_back_is_still_withheld(self, study: Study) -> None:
+        """The sentinel rescues the one-behind case on purpose. It must not rescue this one:
+        a literal this far back names a lineage the author has stopped tracking, and offering
+        the tip anyway would publish over a generation they have never seen."""
+        first = OfficialPopulation.create(
+            study, name=POPULATION, member_kind="prediction", members=["m1"]
+        )
+        second = OfficialPopulation.create(
+            study,
+            name=POPULATION,
+            member_kind="prediction",
+            members=["m1", "m2"],
+            supersedes=first.hash,
+        )
+        OfficialPopulation.create(
+            study,
+            name=POPULATION,
+            member_kind="prediction",
+            members=["m1", "m2", "m3"],
+            supersedes=second.hash,
+        )
+
+        assert population_supersedes(study, name=POPULATION, declared=first.hash) is None
+
+    def test_a_hash_in_no_lineage_is_still_withheld(self, study: Study) -> None:
+        OfficialPopulation.create(study, name=POPULATION, member_kind="prediction", members=["m1"])
+
+        assert population_supersedes(study, name=POPULATION, declared="feedfacefeed") is None
+
+    def test_a_lineage_this_run_does_not_name_is_still_refused(self, study: Study) -> None:
+        """The interlock the sentinel must not weaken. Declaring one name says nothing about
+        another, so a second lineage whose membership moves is refused exactly as before."""
+        one, two = (_member(study, alpha) for alpha in (1.0, 2.0))
+        CandidateSet.create(study, "declared-set", [one])
+        first_other = CandidateSet.create(study, "undeclared-set", [one])
+
+        assert (
+            candidate_set_supersedes(study, name="declared-set", declared=SUPERSEDES_LIVE)
+            == CandidateSet.one(study, name="declared-set").hash
+        )
+        with pytest.raises(ValueError, match=f"must explicitly supersedes {first_other.hash}"):
+            CandidateSet.create(study, "undeclared-set", [one, two])
+
+    def test_a_narrowed_run_under_its_own_name_is_still_handed_nothing(self, study: Study) -> None:
+        """A caller-chosen name has no prior generation, so the sentinel resolves to nothing
+        there too - the isolation a narrowed run depends on is not a property of the hash."""
+        OfficialPopulation.create(study, name=POPULATION, member_kind="prediction", members=["m1"])
+
+        assert population_supersedes(study, name="cs:scratch", declared=SUPERSEDES_LIVE) is None

--- a/tests/test_supersedes_literals.py
+++ b/tests/test_supersedes_literals.py
@@ -556,6 +556,40 @@ def test_a_per_label_causal_remedy_names_that_labels_current_identity(tree):
     assert findings[0].remedy == "bbbb"
 
 
+def test_a_causal_repair_is_never_the_sentinel(capsys, tree):
+    """`causal_supersedes` takes no sentinel, so the advice must not reach a causal finding.
+
+    It offers a declaration only when it is a current identity for the label
+    (`current_causal_identities`), and `"live"` never is - so a reader who followed a blanket
+    "paste live" would be withheld and refused after the DML fit and every placebo refit,
+    which is the expense this message exists to prevent.
+    """
+    repo, artifacts = tree
+    _causal_notebook(repo, "etfs", "12_causal_dml", '{"fwd_ret_21d": "gone"}')
+    _registry(artifacts, "etfs", [])
+    _causal_rows(artifacts, "etfs", [("bbbb", "fwd_ret_21d", None)])
+
+    assert _exit_status(repo, artifacts) == 1
+    message = capsys.readouterr().err
+
+    assert "takes no sentinel" in message
+    assert '"bbbb"' in message
+    assert '"live"' not in message.lower().replace("takes no sentinel", "")
+
+
+def test_a_lineage_repair_still_gets_the_sentinel_advice(capsys, tree):
+    """The control: the advice has to survive being scoped away from the causal path."""
+    repo, artifacts = tree
+    _notebook(repo, "etfs", "07_gbm", "gone", "etfs-gbm-v1")
+    _registry(artifacts, "etfs", [("aaaa", "etfs-gbm-v1", None)])
+
+    assert _exit_status(repo, artifacts) == 1
+    message = capsys.readouterr().err
+
+    assert 'paste "live"' in message.lower()
+    assert "takes no sentinel" not in message
+
+
 def test_a_multi_label_repair_says_which_entry_to_replace(capsys, tree):
     """Following "set it to <hash>" on a mapping would break the run this message saves.
 

--- a/tests/test_supersedes_literals.py
+++ b/tests/test_supersedes_literals.py
@@ -23,8 +23,9 @@ from pathlib import Path
 
 import pytest
 
+from case_studies.research.population import SUPERSEDES_LIVE
 from case_studies.utils.registry.specs import IDENTITY_VERSION
-from scripts.check_supersedes_literals import check_all, check_case_study
+from scripts.check_supersedes_literals import STATUSES, check_all, check_case_study
 
 _SCHEMA = """
 CREATE TABLE causal_runs (
@@ -88,15 +89,39 @@ def test_a_literal_naming_the_tip_is_live(tree):
     assert [f.status for f in findings] == ["live"]
 
 
-def test_a_literal_naming_what_the_tip_replaced_is_live(tree):
-    """The re-run: the generation in force is the one this declaration produced."""
+def test_a_literal_naming_what_the_tip_replaced_refuses_the_freeze(tree):
+    """Reported `live` until 2026-09-11, and it is the state 19 of the corpus's 25 were in.
+
+    `population_supersedes` offers a hash that equals `current.supersedes`, which is why this
+    read as fine: the unchanged re-run resolves to the published generation and nothing fails.
+    Every other run does fail. `create` accepts the tip and nothing else, so the run whose
+    membership moves is refused at the freeze, after the fit - which is the run a chain is
+    queued for. `tests/test_supersedes_declares_intent.py` is that refusal end to end.
+    """
     repo, artifacts = tree
     _notebook(repo, "etfs", "07_gbm", "aaaa", "etfs-gbm-v1")
     _registry(artifacts, "etfs", [("aaaa", "etfs-gbm-v1", None), ("bbbb", "etfs-gbm-v1", "aaaa")])
 
     findings = check_case_study("etfs", repo_root=repo, artifacts_root=artifacts)
 
-    assert [f.status for f in findings] == ["live"]
+    assert [f.status for f in findings] == ["behind"]
+    assert findings[0].refused_at_the_freeze
+    assert "bbbb" in findings[0].detail
+
+
+def test_a_sentinel_declaration_is_reported_and_never_refuses(tree):
+    """`SUPERSEDES_LIVE` names the lineage rather than a generation of it, so there is nothing
+    to classify and nothing that can go stale. It is still printed: a name that appears nowhere
+    in the output reads as a name nobody declared."""
+    repo, artifacts = tree
+    _notebook(repo, "etfs", "07_gbm", SUPERSEDES_LIVE, "etfs-gbm-v1")
+    _registry(artifacts, "etfs", [("aaaa", "etfs-gbm-v1", None), ("bbbb", "etfs-gbm-v1", "aaaa")])
+
+    findings = check_case_study("etfs", repo_root=repo, artifacts_root=artifacts)
+
+    assert [f.status for f in findings] == ["intent"]
+    assert not findings[0].refused_at_the_freeze
+    assert _exit_status(repo, artifacts) == 0
 
 
 def test_a_literal_two_generations_behind_is_stale(tree):
@@ -115,7 +140,7 @@ def test_a_literal_two_generations_behind_is_stale(tree):
 
     findings = check_case_study("etfs", repo_root=repo, artifacts_root=artifacts)
 
-    assert findings[0].is_stale
+    assert findings[0].refused_at_the_freeze
     assert "cccc" in findings[0].detail
 
 
@@ -127,7 +152,7 @@ def test_a_literal_naming_a_hash_the_registry_lost_is_stale(tree):
 
     findings = check_case_study("etfs", repo_root=repo, artifacts_root=artifacts)
 
-    assert findings[0].is_stale
+    assert findings[0].refused_at_the_freeze
     assert "no lineage the registry holds" in findings[0].detail
 
 
@@ -171,7 +196,9 @@ def test_an_empty_registry_does_not_make_every_declaration_stale(tree):
 
     findings = check_case_study("etfs", repo_root=repo, artifacts_root=artifacts)
 
-    assert not any(f.is_stale for f in findings), "an empty registry was read as staleness"
+    assert not any(f.refused_at_the_freeze for f in findings), (
+        "an empty registry was read as staleness"
+    )
     assert findings[0].status == "unresolved"
 
 
@@ -192,7 +219,7 @@ def test_no_registry_is_reported_and_does_not_fail(tree):
     findings = check_case_study("etfs", repo_root=repo, artifacts_root=artifacts)
 
     assert [f.status for f in findings] == ["no-registry"]
-    assert not any(f.is_stale for f in findings)
+    assert not any(f.refused_at_the_freeze for f in findings)
 
 
 def test_a_forked_lineage_is_reported_rather_than_guessed_at(tree):
@@ -206,7 +233,7 @@ def test_a_forked_lineage_is_reported_rather_than_guessed_at(tree):
     assert [f.status for f in findings] == ["forked"]
 
 
-def test_exit_status_is_one_when_anything_is_stale(tree):
+def test_exit_status_is_one_when_anything_is_refused_at_the_freeze(tree):
     """The gate's contract: a queueing step reads the status, not the prose."""
     from scripts.check_supersedes_literals import main
 
@@ -229,9 +256,10 @@ def test_exit_status_is_one_when_anything_is_stale(tree):
 def test_the_scan_reads_the_real_corpus_without_falling_over():
     """The scanner against real registries, which the synthetic fixtures cannot stand in for.
 
-    It deliberately does NOT assert the corpus is clean. Six literals are stale as this is
-    written, and leaving them is the decision rather than an oversight: editing one makes the
-    paired `.ipynb` stale, and the only sanctioned way to commit that drops its outputs. That
+    It deliberately does NOT assert the corpus is clean. 27 literals are refused at the freeze
+    as this is written - 8 dead and 19 one generation behind - and leaving them is the decision
+    rather than an oversight: editing one makes the paired `.ipynb` stale, and the only
+    sanctioned way to commit that drops its outputs. That
     costs a live render in a `done` case study for a fault that bites nothing until those
     notebooks next execute - at which point the run restores the render for free. So the
     corpus is corrected by `scripts/check_supersedes_literals.py` refusing the chain at
@@ -250,19 +278,12 @@ def test_the_scan_reads_the_real_corpus_without_falling_over():
     if not any(f.status != "no-registry" for f in findings):
         pytest.skip("registries present but none holds an official_populations table")
 
-    # `undeclared` joined the set when `_undeclared_heads` did: a live generation that no
-    # declaration names at all, which `main()` reports separately and exits non-zero on under
-    # `--require-declarations`. It is a status the checker declares, not one it invented.
-    known = {
-        "live",
-        "stale",
-        "superseded",
-        "unresolved",
-        "forked",
-        "no-registry",
-        "undeclared",
-    }
-    unclassified = [f for f in findings if f.status not in known]
+    # Asked of the script rather than restated here. The literal set that used to sit at this
+    # line went stale once already: `undeclared` joined the checker when `_undeclared_heads`
+    # did and reached this allowlist only in #983, months later. It could only go stale
+    # unnoticed - this test skips wherever `run_log/` is absent, which is every CI run, so a
+    # second copy of the status list is checked on one machine and nowhere else.
+    unclassified = [f for f in findings if f.status not in STATUSES]
     assert not unclassified, f"unrecognised status: {unclassified}"
     assert all(f.detail for f in findings), "a finding with no explanation is not usable"
 
@@ -339,7 +360,9 @@ def test_a_retired_causal_identity_is_reported_but_does_not_fail(tree):
     findings = check_case_study("etfs", repo_root=repo, artifacts_root=artifacts)
 
     assert findings[0].status == "superseded"
-    assert not findings[0].is_stale, "an unchanged re-run must not be reported as a failure"
+    assert not findings[0].refused_at_the_freeze, (
+        "an unchanged re-run must not be reported as a failure"
+    )
 
 
 def test_a_bare_causal_hash_the_registry_lost_is_unresolved(tree):
@@ -357,7 +380,7 @@ def test_a_bare_causal_hash_the_registry_lost_is_unresolved(tree):
     findings = check_case_study("etfs", repo_root=repo, artifacts_root=artifacts)
 
     assert findings[0].status == "unresolved"
-    assert not findings[0].is_stale
+    assert not findings[0].refused_at_the_freeze
 
 
 def test_a_per_label_causal_hash_is_stale_when_that_label_already_resolves(tree):
@@ -369,7 +392,7 @@ def test_a_per_label_causal_hash_is_stale_when_that_label_already_resolves(tree)
 
     findings = check_case_study("etfs", repo_root=repo, artifacts_root=artifacts)
 
-    assert findings[0].is_stale
+    assert findings[0].refused_at_the_freeze
     assert "placebo refit" in findings[0].detail
     assert findings[0].label == "fwd_ret_21d"
     assert findings[0].remedy == "aaaa"
@@ -440,7 +463,7 @@ def test_an_annotation_of_str_or_none_is_read(tree):
     findings = check_case_study("cme_futures", repo_root=repo, artifacts_root=artifacts)
 
     assert len(findings) == 1, "a `str | None` annotation was skipped"
-    assert findings[0].is_stale
+    assert findings[0].refused_at_the_freeze
 
 
 def test_a_parenthesised_multiline_declaration_is_read(tree):
@@ -503,15 +526,21 @@ def test_an_unresolved_declaration_never_blocks(tree):
     assert _exit_status(repo, artifacts) == 0
 
 
-def test_a_stale_finding_carries_the_hash_to_paste(tree):
-    """The message has to say what the fix is, not only that something is wrong."""
+def test_a_refused_finding_is_repaired_with_the_sentinel_not_the_current_hash(tree):
+    """The message has to say what the fix is, and the fix has to survive the next publish.
+
+    Pasting `aaaa` is correct until whatever freezes this lineage runs again, which is the loop
+    these literals have been in. The head still appears in `detail`, so a reader who wants to
+    know which generation they are replacing can see it.
+    """
     repo, artifacts = tree
     _notebook(repo, "etfs", "07_gbm", "gone", "etfs-gbm-v1")
     _registry(artifacts, "etfs", [("aaaa", "etfs-gbm-v1", None)])
 
     findings = check_case_study("etfs", repo_root=repo, artifacts_root=artifacts)
 
-    assert findings[0].remedy == "aaaa"
+    assert findings[0].remedy == SUPERSEDES_LIVE
+    assert "aaaa" in findings[0].detail
 
 
 def test_a_per_label_causal_remedy_names_that_labels_current_identity(tree):
@@ -523,7 +552,7 @@ def test_a_per_label_causal_remedy_names_that_labels_current_identity(tree):
 
     findings = check_case_study("etfs", repo_root=repo, artifacts_root=artifacts)
 
-    assert findings[0].is_stale
+    assert findings[0].refused_at_the_freeze
     assert findings[0].remedy == "bbbb"
 
 


### PR DESCRIPTION
A `SUPERSEDES_*` literal is a committed constant that has to equal a value the registry moves on every publish. Measured over the corpus today: 48 declared literals, of which **6** name a value `create` accepts, **19** name the generation it has already replaced, **8** name a generation no lineage holds, and **5** cannot be placed at all.

## The 19, which nothing reported

`population_supersedes` offers a declared hash when it equals `current.supersedes`, and `scripts/check_supersedes_literals.py` read that as `live: names what the tip replaced; a re-run resolves to it`. That is true of an unchanged re-run and false of every other run. `create` accepts the tip and nothing else, so the run whose membership **moves** is refused - and that is the refit a chain is queued for.

`tests/test_supersedes_declares_intent.py` is the reproduction, end to end through the real `create` on both lineages:

```
gen1: 62ece7eb073f
gen2: bfa25aff19e1 supersedes 62ece7eb073f
candidate_set_supersedes(declared=gen1) -> 62ece7eb073f      # the resolver offers it
CandidateSet.create(members=[m1, m2, m3], supersedes=62ece7eb073f)
  -> ValueError: a changed candidate set named 'the-set' must explicitly supersedes bfa25aff19e1
```

Identical on the population path. Those declarations are now reported `behind` and refuse exactly as `stale` does: 8 refusals across the corpus became 27.

The two refusals do not cost the same, and the difference is measured rather than assumed. `run_official_models` writes the population snapshot before the first fit, so a population refusal lands during planning; a candidate set is frozen in the last cell, after every fold is fitted. Split of the 27: **5 behind + 4 stale on the candidate-set lineage**, refused after the fit; **14 behind + 4 stale on the population lineage**, refused during planning.

#983 wired the checker into `scripts/pre_run_gate.py` and keyed it on `is_stale`, which is `status == "stale"` exactly - so the gate ran, saw 19 real refusals, and reported `no dead declaration`. Fixed here, with a test on the three-generation chain that PR's own fixture already builds.

## `SUPERSEDES_LIVE`

Both resolvers are already called with `name=`. The predecessor is therefore a lookup under a name the call site holds, not something the source has to quote, and the record of which generation was replaced is written by `create` into `supersedes_hash` - where a reader looks for a lineage anyway. It was never recoverable from source.

A declaration of `"live"` resolves to the tip at run time and is reported `intent`. It is additive: every existing hash resolves exactly as before, so no notebook has to change to stay correct. What changes is the repair the checker prints - `"live"` rather than the current head, since pasting a head is correct only until the next publish of whatever freezes that lineage.

It weakens no refusal, and each of these is a test:

- a lineage this run does not name is still refused when its membership moves;
- a hash two or more generations back is still withheld;
- a hash in no lineage is still withheld;
- a clean clone is handed nothing, so a reader still publishes generation one;
- a narrowed run under its own name is handed nothing;
- passing the sentinel to `create` past the resolver is still refused as a first version.

Verified as a negative control: with the two resolver branches commented out, three tests fail and the other eight pass, which is what makes them selftests of the sentinel rather than of the surrounding code.

## Also

The corpus scan's status allowlist is now asked of the script instead of restated in the test. That second copy went stale once already - `undeclared` reached it only in #983, long after the checker declared it - and it can only go stale unnoticed, because the test skips wherever `run_log/` is absent, which is every CI run.

## Not in this PR

Nine declarations in `fx_pairs` and `sp500_equity_option_analytics` that no checker can classify - the hash is in no lineage AND the name is built at run time, so nothing can say whether the literal is dead or waiting for a first publication. They are swept and verified against the live registries (the corpus then holds zero unresolvable), but a parameters-cell value is a code cell, so five paired `.ipynb` files go stale and the provenance gate refuses the commit. Three of the five last exited 1, so a re-run restores nothing until those failures are diagnosed. Held as a patch for the case-study owners, who own the re-render-versus-clear call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GwvExyYgecwyTLrW2F4Juw
