### PR TITLE
An agreement level has to select a file, not filter a column no file carries

### DIFF
--- a/data/alternative/loader.py
+++ b/data/alternative/loader.py
@@ -129,6 +129,16 @@ def load_bloomberg_news(
     return data
 
 
+# Which file holds each agreement level. The corpus ships one file per level rather than
+# one file with a level column, which is what the old filter assumed.
+_PHRASEBANK_FILES: dict[str, str] = {
+    "100": "sentences_allagree.parquet",
+    "75": "sentences_75agree.parquet",
+    "66": "sentences_66agree.parquet",
+    "50": "sentences_50agree.parquet",
+}
+
+
 def load_financial_phrasebank(
     agreement: Literal["all", "50", "66", "75", "100"] = "100",
 ) -> pl.DataFrame:
@@ -139,39 +149,61 @@ def load_financial_phrasebank(
     sentiment analysis.
 
     Args:
-        agreement: Minimum annotator agreement level:
-            - "100": All annotators agree (most reliable, ~2,264 sentences)
-            - "75": 75%+ agreement (~3,453 sentences)
-            - "66": 66%+ agreement (~4,217 sentences)
-            - "50": 50%+ agreement (~4,846 sentences)
-            - "all": Load all agreement levels combined
+        agreement: Annotator agreement level, selecting one distributed file:
+            - "100": all annotators agree (most reliable, 2,264 sentences)
+            - "75": 75%+ agreement (3,453 sentences)
+            - "66": 66%+ agreement (4,217 sentences)
+            - "50": 50%+ agreement (4,846 sentences)
+            - "all": every level present on disk, tagged with `agreement_level`
 
     Returns:
-        DataFrame with columns: sentence, sentiment/label, agreement_level (if 'all')
+        DataFrame with columns: sentence, label, and `agreement_level` when
+        `agreement="all"`.
+
+    The levels nest - the 50% file contains every sentence the 100% file does - so
+    `agreement="all"` repeats sentences across levels by construction. It exists to
+    show which level a sentence survives at, not as a larger corpus.
 
     Source: Malo et al. (2014) "Good debt or bad debt: Detecting semantic
             orientations in economic texts"
-    Coverage: ~4,800 sentences from financial news articles
     """
     base_path = ML4T_DATA_PATH / "alternative" / "text" / "financial_phrasebank"
-    parquet_files = list(base_path.glob("*.parquet")) if base_path.exists() else []
 
-    if not parquet_files:
-        raise DataNotFoundError(
+    def _missing(wanted: str) -> DataNotFoundError:
+        return DataNotFoundError(
             dataset_name="Financial Phrasebank",
-            path=base_path,
+            path=base_path / wanted if wanted else base_path,
             readme="data/alternative/text/README.md",
             instructions=(
                 "Download from HuggingFace (takala/financial_phrasebank) and save as\n"
-                f"  {base_path}/sentences_{{agreement}}.parquet\n\n"
+                f"  {base_path}/sentences_{{allagree,75agree,66agree,50agree}}.parquet\n\n"
                 "See data/alternative/text/README.md for the download script."
             ),
         )
 
-    data = pl.read_parquet(parquet_files)
+    if agreement == "all":
+        present = [
+            (level, base_path / name)
+            for level, name in _PHRASEBANK_FILES.items()
+            if (base_path / name).exists()
+        ]
+        if not present:
+            raise _missing("")
+        return pl.concat(
+            [
+                pl.read_parquet(path).with_columns(pl.lit(level).alias("agreement_level"))
+                for level, path in present
+            ],
+            how="vertical_relaxed",
+        )
 
-    if agreement != "all" and "agreement" in data.columns:
-        min_agreement = int(agreement) / 100
-        data = data.filter(pl.col("agreement") >= min_agreement)
+    # One file per level, so the level is chosen by which file is read. The previous
+    # implementation globbed every parquet in the directory and filtered an `agreement`
+    # column, which no distributed file carries - so the argument selected nothing and a
+    # second file in the directory would have been concatenated into the result.
+    name = _PHRASEBANK_FILES[agreement]
+    path = base_path / name
+    if not path.exists():
+        raise _missing(name)
 
-    return data
+    return pl.read_parquet(path)

--- a/tests/create_test_data.py
+++ b/tests/create_test_data.py
@@ -1944,11 +1944,12 @@ def build_13f_bulk_holdings(source: Path, output: Path) -> list[Path]:
 # so CI trained on 2,582 sentences the annotators disagreed about, each carrying
 # whatever label the corpus assigned.
 #
-# `load_financial_phrasebank(agreement=...)` looks like it would have caught that
-# and does not: it filters on an `agreement` column, and neither production's file
-# nor the fixture's has one, so the argument has never selected anything. What
-# makes production correct is that its file already holds the unanimous subset.
-# Copying it is therefore the fix, and no reduction applies.
+# `load_financial_phrasebank(agreement=...)` looked like it would have caught that
+# and did not: it filtered on an `agreement` column, and no distributed file has
+# one, so the argument selected nothing. It now selects the file for the requested
+# level and refuses a level that was never downloaded. What makes production
+# correct is that its file already holds the unanimous subset, so copying it is the
+# fix here and no reduction applies.
 
 PHRASEBANK_DIR = Path("alternative") / "text" / "financial_phrasebank"
 PHRASEBANK = PHRASEBANK_DIR / "sentences_allagree.parquet"

--- a/tests/test_financial_phrasebank_agreement_selects.py
+++ b/tests/test_financial_phrasebank_agreement_selects.py
@@ -1,0 +1,103 @@
+"""`agreement` has to choose a corpus, and it was filtering a column no file carries.
+
+`load_financial_phrasebank(agreement=...)` documented five agreement levels and implemented
+them as `data.filter(pl.col("agreement") >= ...)` guarded by `"agreement" in data.columns`.
+No distributed file carries that column - the corpus ships one file per level
+(`sentences_allagree.parquet`, `sentences_75agree.parquet`, ...) - so the guard was always
+false and the argument selected nothing.
+
+It went unnoticed because the data directory holds exactly one of the five files, which made
+"read every parquet here" and "read the 100% file" the same answer. The failure needs a second
+file present, which is why these tests construct one: with two on disk the old loader
+concatenated both and returned a corpus that is neither level, for every value of `agreement`.
+
+Found while giving the CI fixture a builder: the fixture's `sentences_allagree.parquet` held
+the 4,846-row 50% corpus under the 100% filename, and this argument is what should have
+caught it.
+"""
+
+from __future__ import annotations
+
+import polars as pl
+import pytest
+
+from data.alternative import loader
+from data.exceptions import DataNotFoundError
+
+
+def _write(root, name: str, sentences: list[str]) -> None:
+    target = root / "alternative" / "text" / "financial_phrasebank" / name
+    target.parent.mkdir(parents=True, exist_ok=True)
+    pl.DataFrame(
+        {"sentence": sentences, "label": [1] * len(sentences)},
+    ).write_parquet(target)
+
+
+@pytest.fixture
+def two_levels(tmp_path, monkeypatch):
+    """The 100% and 50% files side by side, as a full download leaves them."""
+    _write(tmp_path, "sentences_allagree.parquet", ["unanimous one", "unanimous two"])
+    _write(
+        tmp_path,
+        "sentences_50agree.parquet",
+        ["unanimous one", "unanimous two", "contested three"],
+    )
+    monkeypatch.setattr(loader, "ML4T_DATA_PATH", tmp_path)
+    return tmp_path
+
+
+def test_each_level_reads_its_own_file(two_levels) -> None:
+    """The defect. The old loader answered both calls with all five rows concatenated."""
+    assert loader.load_financial_phrasebank(agreement="100")["sentence"].to_list() == [
+        "unanimous one",
+        "unanimous two",
+    ]
+    assert loader.load_financial_phrasebank(agreement="50")["sentence"].to_list() == [
+        "unanimous one",
+        "unanimous two",
+        "contested three",
+    ]
+
+
+def test_a_neighbouring_file_does_not_reach_the_result(two_levels) -> None:
+    """Selecting a level is what keeps the other levels out, not a filter afterwards.
+
+    Stated separately from the case above because it is the half that silently corrupts a
+    result rather than merely widening it: a duplicated sentence in a fine-tuning corpus is
+    not visible in a row count anyone checks.
+    """
+    unanimous = loader.load_financial_phrasebank(agreement="100")
+
+    assert unanimous.height == unanimous["sentence"].n_unique()
+    assert "contested three" not in unanimous["sentence"].to_list()
+
+
+def test_a_level_that_was_never_downloaded_refuses(two_levels) -> None:
+    """Returning a different level's corpus is the failure this argument exists to prevent.
+
+    The old loader returned the concatenation of whatever happened to be present, so asking
+    for a level absent from disk produced a full DataFrame and no signal at all.
+    """
+    with pytest.raises(DataNotFoundError, match="Financial Phrasebank"):
+        loader.load_financial_phrasebank(agreement="66")
+
+
+def test_all_tags_each_level_rather_than_merging_them(two_levels) -> None:
+    """`agreement="all"` promised an `agreement_level` column and never produced one.
+
+    The levels nest, so the concatenation repeats sentences by construction. That is the
+    point of the column: without it the result is an unlabelled corpus with duplicates,
+    which is what the old loader returned for every argument value.
+    """
+    combined = loader.load_financial_phrasebank(agreement="all")
+
+    assert combined["agreement_level"].to_list() == ["100", "100", "50", "50", "50"]
+
+
+def test_an_empty_directory_still_refuses(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(loader, "ML4T_DATA_PATH", tmp_path)
+
+    with pytest.raises(DataNotFoundError):
+        loader.load_financial_phrasebank()
+    with pytest.raises(DataNotFoundError):
+        loader.load_financial_phrasebank(agreement="all")


### PR DESCRIPTION
`load_financial_phrasebank(agreement=...)` documented five annotator-agreement levels and implemented them as `data.filter(pl.col("agreement") >= ...)`, guarded by `"agreement" in data.columns`. **No distributed file carries that column** - the corpus ships one file per level (`sentences_allagree.parquet`, `sentences_75agree.parquet`, ...). The guard was always false, so the argument selected nothing and every call returned `pl.read_parquet(base_path.glob("*.parquet"))`: whatever happened to be in the directory, concatenated.

## Why it stayed invisible

The data root holds exactly one of the five files, which makes "read every parquet here" and "read the 100% file" the same answer. The defect needs a second level on disk to show, and then it shows in the two worst ways:

- A fine-tuning corpus silently gains duplicated sentences carrying a lower agreement level's labels. That is not visible in any row count anyone checks.
- Asking for a level that was never downloaded returns a different level's corpus instead of refusing.

## The fix

Each level maps to its filename; the loader reads that one file and raises `DataNotFoundError` naming it when it is absent. `agreement="all"` returns every level present, tagged with the `agreement_level` column the docstring already promised and never produced - and the docstring now says the levels nest, so that result repeats sentences by construction rather than being a larger corpus.

## Verification

- `uv run pytest tests/test_financial_phrasebank_agreement_selects.py -q` - 5 passed. **Four of the five fail against the previous implementation**, checked by restoring `origin/main`'s loader and re-running.
- `uv run pytest tests/test_alternative_loaders.py tests/test_list_loaders.py tests/test_every_fixture_file_has_a_producer.py -q` - 20 passed with the above.
- **No committed render moves.** On the current data root the default still returns 2,264 rows with columns `['sentence', 'label']`, identical to before. The three notebooks that call this loader (`10/01`, `10/03`, `10/04`) all want the unanimous corpus and all get the same frame they got before.

Found while giving the CI fixture a builder in #989, where the fixture's `sentences_allagree.parquet` held the 4,846-row 50% corpus under the 100% filename. This argument is what should have caught that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NReuqDy57ft7qkAAKUEtVG
