### PR TITLE
The launch gate refuses on the declarations the run reads, not on its siblings'

### DIFF
--- a/scripts/check_supersedes_literals.py
+++ b/scripts/check_supersedes_literals.py
@@ -955,6 +955,17 @@ def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
     parser.add_argument("--case-study", default=None, help="check one instead of all")
     parser.add_argument(
+        "--notebook",
+        default=None,
+        help=(
+            "the stem of the notebook being launched. Every finding is still reported; only "
+            "this notebook's decide the exit status. A run reads its own SUPERSEDES_* values "
+            "and no others, so a sibling's refused literal cannot refuse it - and the waiver "
+            "that clears the false refusal also switches off the true one. Requires "
+            "--case-study."
+        ),
+    )
+    parser.add_argument(
         "--artifacts-root",
         type=Path,
         default=_default_artifacts_root(),
@@ -982,9 +993,20 @@ def main(argv: list[str] | None = None) -> int:
     )
     args = parser.parse_args(argv)
 
+    if args.notebook and not args.case_study:
+        parser.error("--notebook scopes within one case study; pass --case-study too")
+
     findings = check_all(
         repo_root=REPO_ROOT, artifacts_root=args.artifacts_root, only=args.case_study
     )
+
+    if args.notebook:
+        # Refuse a stem the case study does not hold rather than scoping to nothing. A typo
+        # would otherwise leave every finding non-fatal and report the green it did not earn,
+        # which is the shape of defect this checker exists to catch.
+        directory = REPO_ROOT / "case_studies" / args.case_study
+        if not (directory / f"{args.notebook}.py").is_file():
+            parser.error(f"no case_studies/{args.case_study}/{args.notebook}.py to scope to")
 
     if args.json:
         print(json.dumps([asdict(f) for f in findings], indent=1))
@@ -1005,9 +1027,28 @@ def main(argv: list[str] | None = None) -> int:
             f"{undeclared_count} live generation(s) declared nowhere"
         )
 
-    stale = [f for f in findings if f.refused_at_the_freeze]
+    refused = [f for f in findings if f.refused_at_the_freeze]
+    if args.notebook:
+        # Reported either way; only the exit status narrows. A sibling's refused literal is
+        # real - it fails the run that freezes ITS members - and the person queueing a chain
+        # is the one for whom fixing it is free, so saying nothing would waste the only cheap
+        # moment. It just does not fail this notebook.
+        stale = [f for f in refused if f.notebook == f"{args.notebook}.py"]
+        siblings = [f for f in refused if f not in stale]
+    else:
+        stale, siblings = refused, []
     unresolved = [f for f in findings if f.status == "unresolved"]
     undeclared = [f for f in findings if f.status == "undeclared"]
+
+    if siblings:
+        print(
+            f"\n{len(siblings)} refused literal(s) elsewhere in {args.case_study}. This run "
+            f"reads only {args.notebook}'s own declarations, so this does not block this run - "
+            "it blocks the run that freezes each of these, after that run's fit:\n",
+            file=sys.stderr,
+        )
+        for finding in siblings:
+            print(f"  {finding.notebook}  {finding.declared}  ({finding.status})", file=sys.stderr)
 
     if undeclared:
         # The expensive one. A stale literal at least tells the reader a lineage exists; an

--- a/tests/test_supersedes_gate_scopes_to_the_notebook.py
+++ b/tests/test_supersedes_gate_scopes_to_the_notebook.py
@@ -1,0 +1,132 @@
+"""The launch gate must refuse on the declarations the run reads, not on its siblings'.
+
+`nb-run.sh` calls this checker with `--case-study` alone, so every literal the case study
+commits decided the exit status of every notebook's launch. On 2026-09-11 that refused
+`fx_pairs/13_backtest` - whose own two declarations had just been swept to the sentinel and
+which reads nothing else - by naming eight refused literals in seven sibling notebooks it
+never touches. The only way through was `NB_RUN_ALLOW_STALE_SUPERSEDES=1`, which also
+switches off the check on the notebook's OWN declarations. A gate whose false refusals are
+cleared by a flag that disables the true ones teaches the flag, and the flag is then
+load-bearing for every run of that case study.
+
+A sibling's stale literal is still worth saying out loud - it refuses the run that freezes
+it, and the operator queueing a chain is the one person for whom fixing it is free - so it
+is reported, and only the exit status is scoped.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from scripts import check_supersedes_literals as checker
+
+_SCHEMA = """
+CREATE TABLE official_populations (
+    population_hash TEXT PRIMARY KEY,
+    name TEXT,
+    member_kind TEXT,
+    snapshot_json TEXT,
+    supersedes_hash TEXT,
+    created_at TEXT
+);
+"""
+
+CASE_STUDY = "scoped_case_study"
+
+
+@pytest.fixture
+def corpus(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> tuple[Path, Path]:
+    """One case study, one live lineage two generations deep, and two notebooks."""
+    repo, artifacts = tmp_path / "repo", tmp_path / "artifacts"
+    directory = repo / "case_studies" / CASE_STUDY
+    directory.mkdir(parents=True)
+    run_log = artifacts / CASE_STUDY / "run_log"
+    run_log.mkdir(parents=True)
+
+    db = sqlite3.connect(run_log / "registry.db")
+    db.executescript(_SCHEMA)
+    db.executemany(
+        "INSERT INTO official_populations VALUES (?, ?, 'prediction', '{}', ?, '2026-01-01')",
+        [("gen1", "universe", None), ("gen2", "universe", "gen1")],
+    )
+    db.commit()
+    db.close()
+
+    monkeypatch.setattr(checker, "REPO_ROOT", repo)
+    return repo, artifacts
+
+
+def _notebook(repo: Path, stem: str, declared: str) -> None:
+    (repo / "case_studies" / CASE_STUDY / f"{stem}.py").write_text(
+        '# %% tags=["parameters"]\n'
+        f'SUPERSEDES_POPULATION: str = "{declared}"\n'
+        "\n# %%\n"
+        'population_name = POPULATION_NAME or "universe"\n'
+    )
+
+
+def _run(artifacts: Path, *extra: str) -> int:
+    return checker.main(["--case-study", CASE_STUDY, "--artifacts-root", str(artifacts), *extra])
+
+
+def test_a_siblings_stale_literal_does_not_refuse_this_notebook(corpus, capsys):
+    """The reproduction. `06_clean` names the head; `07_stale` names the generation it
+    replaced. Launching `06_clean` must not be refused for `07_stale`'s declaration, which
+    `06_clean` never reads."""
+    repo, artifacts = corpus
+    _notebook(repo, "06_clean", declared="live")
+    _notebook(repo, "07_stale", declared="gen1")
+
+    assert _run(artifacts, "--notebook", "06_clean") == 0
+
+    err = capsys.readouterr().err
+    assert "07_stale" in err, "the sibling is still reported, just not fatal"
+    assert "does not block this run" in err
+
+
+def test_the_notebooks_own_stale_literal_still_refuses(corpus):
+    """The negative selftest. Scoping must not make the gate unable to refuse: the same
+    literal, in the notebook being launched, still exits non-zero."""
+    repo, artifacts = corpus
+    _notebook(repo, "06_clean", declared="live")
+    _notebook(repo, "07_stale", declared="gen1")
+
+    assert _run(artifacts, "--notebook", "07_stale") == 1
+
+
+def test_without_the_flag_every_notebook_still_decides(corpus):
+    """The control for the control. `--case-study` alone keeps the corpus-wide behaviour the
+    scan and CI depend on, so scoping is something the launch path asks for rather than a
+    change to what the checker means."""
+    repo, artifacts = corpus
+    _notebook(repo, "06_clean", declared="live")
+    _notebook(repo, "07_stale", declared="gen1")
+
+    assert _run(artifacts) == 1
+
+
+def test_a_clean_case_study_passes_either_way(corpus):
+    """No refusal anywhere: scoped and unscoped must agree, or the scoping is doing something
+    besides narrowing."""
+    repo, artifacts = corpus
+    _notebook(repo, "06_clean", declared="live")
+    _notebook(repo, "07_also_clean", declared="live")
+
+    assert _run(artifacts) == 0
+    assert _run(artifacts, "--notebook", "06_clean") == 0
+
+
+def test_an_unknown_notebook_refuses_rather_than_passing_vacuously(corpus):
+    """A typo'd stem must not read as "nothing to check". Scoping to a notebook the case study
+    does not hold leaves every finding non-fatal, which is the shape of the defect this whole
+    checker exists to catch: a check that silently applies to nothing."""
+    repo, artifacts = corpus
+    _notebook(repo, "06_clean", declared="live")
+    _notebook(repo, "07_stale", declared="gen1")
+
+    with pytest.raises(SystemExit) as exit_info:
+        _run(artifacts, "--notebook", "99_not_here")
+    assert exit_info.value.code == 2


### PR DESCRIPTION
A defect in the gate #991 landed this afternoon, found by the first person to hit it.

## What went wrong

`nb-run.sh` calls this checker with `--case-study` alone, so every `SUPERSEDES_*` literal a case study commits decided the exit status of every notebook's launch. A run reads its own declarations and no others, so that is wrong in the direction that costs the most: it refuses runs that were never going to fail.

Measured today. `fx_pairs/13_backtest`, whose own two declarations had just been swept to the sentinel in #995, was refused by eight literals in seven sibling notebooks it never touches:

```
06_linear.py         d1b0c5a302f8  (stale)
07_gbm.py            23abc9ef1009  (stale)
09_dl_tcn.py         3cf95f3b150d  (behind)
10_dl_nlinear.py     ddf6c474f3d8  (behind)
10a_dl_lstm.py       2f5810edd6cd  (behind)
15_risk_management.py  d966caa61faf, fde7af05fff6, ff269dc95622  (behind)
```

The only way through was `NB_RUN_ALLOW_STALE_SUPERSEDES=1` - which also switches off the check on the notebook's own declarations. A false refusal cleared by a flag that disables the true one teaches the flag, and the flag is then load-bearing for every run of that case study. Fixing the seven instead means re-rendering seven finished notebooks, three of them deep learning, to launch one.

## The change

`--notebook STEM` narrows the exit status to that notebook's findings. `--case-study` alone is unchanged, so the corpus scan and CI see exactly what they saw before.

Siblings are still printed, under a line saying they do not block this run and naming the run each of them does block. Dropping them would waste the only moment when fixing them is free, which is the argument for having the gate at all.

Scoping to a stem the case study does not hold is a usage error, not a vacuous pass. A typo would otherwise leave every finding non-fatal and report a green it did not earn, which is the shape of defect this checker exists to catch.

## Verification

- Five new tests in `tests/test_supersedes_gate_scopes_to_the_notebook.py`, including the negative selftest: the notebook's *own* stale literal still refuses.
- Negative control run: with the scoping line replaced by the unscoped list, the sibling test fails and the other four pass, so it tests the scoping rather than the surrounding code.
- Against the live `fx_pairs` registry: `--case-study fx_pairs` exits 1, `--case-study fx_pairs --notebook 13_backtest` exits 0 and prints the eight siblings.
- 65 passed across the five supersedes test files.

The `nb-run.sh` half is in the agents repo and lands separately. It probes by behaviour rather than by version: an older checker answers `--notebook` with argparse's exit 2, which this checker never uses for a refusal, so the runner reads 2 as "cannot be scoped" and re-checks case-study-wide. That fallback is covered by the runner's own harness, now 25 cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GwvExyYgecwyTLrW2F4Juw
