### PR TITLE
fx_pairs 15_risk_management: declare the lineage, and let the run that moved its members publish

### DIFF
--- a/case_studies/fx_pairs/15_risk_management.ipynb
+++ b/case_studies/fx_pairs/15_risk_management.ipynb
@@ -2,13 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "87bb1540",
+   "id": "c295bea0",
    "metadata": {
     "papermill": {
-     "duration": 0.001029,
-     "end_time": "2026-09-09T06:22:52.071069+00:00",
+     "duration": 0.003778,
+     "end_time": "2026-09-12T01:24:54.211684+00:00",
      "exception": false,
-     "start_time": "2026-09-09T06:22:52.070040+00:00",
+     "start_time": "2026-09-12T01:24:54.207906+00:00",
      "status": "completed"
     }
    },
@@ -48,19 +48,19 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "b019dd9d",
+   "id": "51658155",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T06:22:52.084266Z",
-     "iopub.status.busy": "2026-09-09T06:22:52.084158Z",
-     "iopub.status.idle": "2026-09-09T06:22:54.463721Z",
-     "shell.execute_reply": "2026-09-09T06:22:54.463185Z"
+     "iopub.execute_input": "2026-09-12T01:24:54.218045Z",
+     "iopub.status.busy": "2026-09-12T01:24:54.217795Z",
+     "iopub.status.idle": "2026-09-12T01:24:59.470586Z",
+     "shell.execute_reply": "2026-09-12T01:24:59.469728Z"
     },
     "papermill": {
-     "duration": 2.381808,
-     "end_time": "2026-09-09T06:22:54.464307+00:00",
+     "duration": 5.256825,
+     "end_time": "2026-09-12T01:24:59.471238+00:00",
      "exception": false,
-     "start_time": "2026-09-09T06:22:52.082499+00:00",
+     "start_time": "2026-09-12T01:24:54.214413+00:00",
      "status": "completed"
     }
    },
@@ -103,19 +103,19 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "366cae80",
+   "id": "b665df23",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T06:22:54.467960Z",
-     "iopub.status.busy": "2026-09-09T06:22:54.467601Z",
-     "iopub.status.idle": "2026-09-09T06:22:54.470657Z",
-     "shell.execute_reply": "2026-09-09T06:22:54.470187Z"
+     "iopub.execute_input": "2026-09-12T01:24:59.477413Z",
+     "iopub.status.busy": "2026-09-12T01:24:59.476435Z",
+     "iopub.status.idle": "2026-09-12T01:24:59.483053Z",
+     "shell.execute_reply": "2026-09-12T01:24:59.482274Z"
     },
     "papermill": {
-     "duration": 0.005623,
-     "end_time": "2026-09-09T06:22:54.470917+00:00",
+     "duration": 0.010384,
+     "end_time": "2026-09-12T01:24:59.484064+00:00",
      "exception": false,
-     "start_time": "2026-09-09T06:22:54.465294+00:00",
+     "start_time": "2026-09-12T01:24:59.473680+00:00",
      "status": "completed"
     },
     "tags": [
@@ -136,30 +136,42 @@
     "RUN_SWEEP = True\n",
     "FORCE_REBACKTEST = False\n",
     "POPULATION_NAME = \"\"\n",
-    "SUPERSEDES_RISK_BACKTESTS: str = \"df20d72ab319\"\n",
+    "# `df20d72ab319` was the tip of `fx_pairs:risk-overlay-backtests` when it was written, and\n",
+    "# `create` accepts the tip and nothing else, so the literal was correct exactly until this\n",
+    "# notebook next published. `\"live\"` names the lineage and is resolved against it at run time.\n",
+    "SUPERSEDES_RISK_BACKTESTS: str = \"live\"\n",
     "# A candidate set is immutable under its name, exactly as a population is, so a rebuilt upstream\n",
     "# generation has to name the set it replaces. Keyed by the full set name because that is what the\n",
     "# refusal prints: pasting back the name it names is the obvious thing to try, and it has to work.\n",
     "# Resolved through `candidate_set_supersedes` rather than passed straight to `create`, because a\n",
     "# reader's clean clone has no generation to supersede and `create` refuses a first version that\n",
     "# claims to replace one.\n",
+    "#\n",
+    "# `\"live\"` names the lineage rather than a generation of it, which is what stops these going\n",
+    "# stale again. Three of the four hashes it replaces were already dead: the three\n",
+    "# `pre-risk-strategies` sets moved on 2026-09-09 (`d966caa61faf` -> `669d50f0f525`,\n",
+    "# `fde7af05fff6` -> `93b56a9dfb42`, `ff269dc95622` -> `f70630285818`), so each named the\n",
+    "# generation its own successor had replaced and the next membership move here would have been\n",
+    "# refused at the freeze, after the fit. `bf21ae4c9070` was still the head of\n",
+    "# `fx_pairs:holdout-candidates` and would have gone the same way on the next publish.\n",
+    "# See `case_studies.research.population.SUPERSEDES_LIVE`.\n",
     "SUPERSEDES_CANDIDATE_SETS: dict[str, str] = {\n",
-    "    \"fx_pairs:fwd_ret_1d:pre-risk-strategies\": \"d966caa61faf\",\n",
-    "    \"fx_pairs:fwd_ret_5d:pre-risk-strategies\": \"fde7af05fff6\",\n",
-    "    \"fx_pairs:fwd_ret_21d:pre-risk-strategies\": \"ff269dc95622\",\n",
-    "    \"fx_pairs:holdout-candidates\": \"bf21ae4c9070\",\n",
+    "    \"fx_pairs:fwd_ret_1d:pre-risk-strategies\": \"live\",\n",
+    "    \"fx_pairs:fwd_ret_5d:pre-risk-strategies\": \"live\",\n",
+    "    \"fx_pairs:fwd_ret_21d:pre-risk-strategies\": \"live\",\n",
+    "    \"fx_pairs:holdout-candidates\": \"live\",\n",
     "}"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "7b5abf1b",
+   "id": "1a97309a",
    "metadata": {
     "papermill": {
-     "duration": 0.000677,
-     "end_time": "2026-09-09T06:22:54.472521+00:00",
+     "duration": 0.00397,
+     "end_time": "2026-09-12T01:24:59.491059+00:00",
      "exception": false,
-     "start_time": "2026-09-09T06:22:54.471844+00:00",
+     "start_time": "2026-09-12T01:24:59.487089+00:00",
      "status": "completed"
     }
    },
@@ -190,19 +202,19 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "2c486a81",
+   "id": "b686aeb8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T06:22:54.474594Z",
-     "iopub.status.busy": "2026-09-09T06:22:54.474513Z",
-     "iopub.status.idle": "2026-09-09T06:23:33.656374Z",
-     "shell.execute_reply": "2026-09-09T06:23:33.655750Z"
+     "iopub.execute_input": "2026-09-12T01:24:59.500865Z",
+     "iopub.status.busy": "2026-09-12T01:24:59.500511Z",
+     "iopub.status.idle": "2026-09-12T01:26:18.787963Z",
+     "shell.execute_reply": "2026-09-12T01:26:18.786932Z"
     },
     "papermill": {
-     "duration": 39.183707,
-     "end_time": "2026-09-09T06:23:33.656943+00:00",
+     "duration": 79.294817,
+     "end_time": "2026-09-12T01:26:18.789643+00:00",
      "exception": false,
-     "start_time": "2026-09-09T06:22:54.473236+00:00",
+     "start_time": "2026-09-12T01:24:59.494826+00:00",
      "status": "completed"
     },
     "tags": [
@@ -220,7 +232,7 @@
        "  white-space: pre-wrap;\n",
        "}\n",
        "</style>\n",
-       "<small>shape: (3, 4)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>label</th><th>backtest_hash</th><th>prediction_hash</th><th>stage</th></tr><tr><td>str</td><td>str</td><td>str</td><td>str</td></tr></thead><tbody><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;042f2cee8082&quot;</td><td>&quot;439d342a6bdb&quot;</td><td>&quot;signal&quot;</td></tr><tr><td>&quot;fwd_ret_21d&quot;</td><td>&quot;747e7e47abaa&quot;</td><td>&quot;a9b0e4416d41&quot;</td><td>&quot;allocation&quot;</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;28d3ceeea1c5&quot;</td><td>&quot;7db90b5518e1&quot;</td><td>&quot;signal&quot;</td></tr></tbody></table></div>"
+       "<small>shape: (3, 4)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>label</th><th>backtest_hash</th><th>prediction_hash</th><th>stage</th></tr><tr><td>str</td><td>str</td><td>str</td><td>str</td></tr></thead><tbody><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;02df24286767&quot;</td><td>&quot;0eb73fea6afa&quot;</td><td>&quot;signal&quot;</td></tr><tr><td>&quot;fwd_ret_21d&quot;</td><td>&quot;0c8d095371b6&quot;</td><td>&quot;b839846c1759&quot;</td><td>&quot;allocation&quot;</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;fc2c1d73880f&quot;</td><td>&quot;93c502488088&quot;</td><td>&quot;signal&quot;</td></tr></tbody></table></div>"
       ],
       "text/plain": [
        "shape: (3, 4)\n",
@@ -229,9 +241,9 @@
        "│ ---         ┆ ---           ┆ ---             ┆ ---        │\n",
        "│ str         ┆ str           ┆ str             ┆ str        │\n",
        "╞═════════════╪═══════════════╪═════════════════╪════════════╡\n",
-       "│ fwd_ret_1d  ┆ 042f2cee8082  ┆ 439d342a6bdb    ┆ signal     │\n",
-       "│ fwd_ret_21d ┆ 747e7e47abaa  ┆ a9b0e4416d41    ┆ allocation │\n",
-       "│ fwd_ret_5d  ┆ 28d3ceeea1c5  ┆ 7db90b5518e1    ┆ signal     │\n",
+       "│ fwd_ret_1d  ┆ 02df24286767  ┆ 0eb73fea6afa    ┆ signal     │\n",
+       "│ fwd_ret_21d ┆ 0c8d095371b6  ┆ b839846c1759    ┆ allocation │\n",
+       "│ fwd_ret_5d  ┆ fc2c1d73880f  ┆ 93c502488088    ┆ signal     │\n",
        "└─────────────┴───────────────┴─────────────────┴────────────┘"
       ]
      },
@@ -286,10 +298,11 @@
     "# replaced in the registry, complete and current, so this filter alone would carry a retired\n",
     "# prediction set into the sweep. `superseded_members` reads the lineage instead - see\n",
     "# `13_backtest`, which drops the same set before it freezes the baseline population.\n",
-    "# `SUPERSEDES_RISK_BACKTESTS` names the snapshot this run replaces under the name it publishes,\n",
-    "# offered through `population_supersedes` on the same rule. It is empty until that name has a\n",
-    "# first generation; after that, an upstream refit changes this population's member list and\n",
-    "# the registry refuses the write without it. `13_backtest` states the reasoning once.\n",
+    "# `SUPERSEDES_RISK_BACKTESTS` is the sentinel `\"live\"`, so it names the lineage this run\n",
+    "# publishes under and `population_supersedes` resolves the generation in force at write time.\n",
+    "# It resolves to nothing until that name has a first generation, which is also what a reader's\n",
+    "# clean clone sees; after that, an upstream refit changes this population's member list and the\n",
+    "# registry refuses the write without the tip. `13_backtest` states the reasoning once.\n",
     "retired = superseded_members(study, member_kind=\"prediction\")\n",
     "if retired:\n",
     "    catalog = catalog.filter(~pl.col(\"prediction_hash\").is_in(list(retired)))\n",
@@ -462,13 +475,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0133a6c0",
+   "id": "45ba5433",
    "metadata": {
     "papermill": {
-     "duration": 0.000732,
-     "end_time": "2026-09-09T06:23:33.658545+00:00",
+     "duration": 0.000953,
+     "end_time": "2026-09-12T01:26:18.791845+00:00",
      "exception": false,
-     "start_time": "2026-09-09T06:23:33.657813+00:00",
+     "start_time": "2026-09-12T01:26:18.790892+00:00",
      "status": "completed"
     }
    },
@@ -499,19 +512,19 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "9185b887",
+   "id": "4f009c8a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T06:23:33.660834Z",
-     "iopub.status.busy": "2026-09-09T06:23:33.660751Z",
-     "iopub.status.idle": "2026-09-09T06:24:18.438778Z",
-     "shell.execute_reply": "2026-09-09T06:24:18.438027Z"
+     "iopub.execute_input": "2026-09-12T01:26:18.795030Z",
+     "iopub.status.busy": "2026-09-12T01:26:18.794814Z",
+     "iopub.status.idle": "2026-09-12T01:27:37.778359Z",
+     "shell.execute_reply": "2026-09-12T01:27:37.776863Z"
     },
     "papermill": {
-     "duration": 44.779932,
-     "end_time": "2026-09-09T06:24:18.439251+00:00",
+     "duration": 78.991286,
+     "end_time": "2026-09-12T01:27:37.784100+00:00",
      "exception": false,
-     "start_time": "2026-09-09T06:23:33.659319+00:00",
+     "start_time": "2026-09-12T01:26:18.792814+00:00",
      "status": "completed"
     },
     "tags": [
@@ -523,7 +536,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Frozen expected risk population: df20d72ab319\n"
+      "Frozen expected risk population: 9774f18e7c54\n"
      ]
     }
    ],
@@ -625,13 +638,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dcf3dd5e",
+   "id": "55016f1c",
    "metadata": {
     "papermill": {
-     "duration": 0.000743,
-     "end_time": "2026-09-09T06:24:18.441063+00:00",
+     "duration": 0.002783,
+     "end_time": "2026-09-12T01:27:37.790428+00:00",
      "exception": false,
-     "start_time": "2026-09-09T06:24:18.440320+00:00",
+     "start_time": "2026-09-12T01:27:37.787645+00:00",
      "status": "completed"
     }
    },
@@ -646,19 +659,19 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "2d5a5b01",
+   "id": "bdd60428",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T06:24:18.443336Z",
-     "iopub.status.busy": "2026-09-09T06:24:18.443245Z",
-     "iopub.status.idle": "2026-09-09T06:26:43.190236Z",
-     "shell.execute_reply": "2026-09-09T06:26:43.189872Z"
+     "iopub.execute_input": "2026-09-12T01:27:37.799224Z",
+     "iopub.status.busy": "2026-09-12T01:27:37.798719Z",
+     "iopub.status.idle": "2026-09-12T01:34:08.229034Z",
+     "shell.execute_reply": "2026-09-12T01:34:08.228372Z"
     },
     "papermill": {
-     "duration": 144.749279,
-     "end_time": "2026-09-09T06:26:43.191172+00:00",
+     "duration": 390.439131,
+     "end_time": "2026-09-12T01:34:08.232553+00:00",
      "exception": false,
-     "start_time": "2026-09-09T06:24:18.441893+00:00",
+     "start_time": "2026-09-12T01:27:37.793422+00:00",
      "status": "completed"
     },
     "tags": [
@@ -670,8 +683,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Risk overlays: reused all 42 from the registry, computed by an earlier run, 42 in the population\n",
-      "Official risk population: df20d72ab319\n"
+      "Risk overlays: computed all 42, 42 in the population\n",
+      "Official risk population: 9774f18e7c54\n"
      ]
     },
     {
@@ -684,7 +697,7 @@
        "  white-space: pre-wrap;\n",
        "}\n",
        "</style>\n",
-       "<small>shape: (42, 4)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>label</th><th>risk_name</th><th>backtest_hash</th><th>prediction_hash</th></tr><tr><td>str</td><td>str</td><td>str</td><td>str</td></tr></thead><tbody><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;stop_loss_10pct&quot;</td><td>&quot;728dc3b9a8fb&quot;</td><td>&quot;439d342a6bdb&quot;</td></tr><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;stop_loss_15pct&quot;</td><td>&quot;9e544a5cf3ef&quot;</td><td>&quot;439d342a6bdb&quot;</td></tr><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;stop_loss_3pct&quot;</td><td>&quot;eaa94b25aa1c&quot;</td><td>&quot;439d342a6bdb&quot;</td></tr><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;stop_loss_5pct&quot;</td><td>&quot;037421cf0ed0&quot;</td><td>&quot;439d342a6bdb&quot;</td></tr><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;time_exit_10&quot;</td><td>&quot;d419a2c93e92&quot;</td><td>&quot;439d342a6bdb&quot;</td></tr><tr><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;trailing_1pct&quot;</td><td>&quot;8956745c83fa&quot;</td><td>&quot;7db90b5518e1&quot;</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;trailing_20pct&quot;</td><td>&quot;83f414834353&quot;</td><td>&quot;7db90b5518e1&quot;</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;trailing_2pct&quot;</td><td>&quot;ebf617a2107c&quot;</td><td>&quot;7db90b5518e1&quot;</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;trailing_3pct&quot;</td><td>&quot;d54779b8e4d1&quot;</td><td>&quot;7db90b5518e1&quot;</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;trailing_5pct&quot;</td><td>&quot;d68582f97828&quot;</td><td>&quot;7db90b5518e1&quot;</td></tr></tbody></table></div>"
+       "<small>shape: (42, 4)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>label</th><th>risk_name</th><th>backtest_hash</th><th>prediction_hash</th></tr><tr><td>str</td><td>str</td><td>str</td><td>str</td></tr></thead><tbody><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;stop_loss_10pct&quot;</td><td>&quot;114fcd5c942a&quot;</td><td>&quot;0eb73fea6afa&quot;</td></tr><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;stop_loss_15pct&quot;</td><td>&quot;2a9ca43f2292&quot;</td><td>&quot;0eb73fea6afa&quot;</td></tr><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;stop_loss_3pct&quot;</td><td>&quot;8331c4e849ff&quot;</td><td>&quot;0eb73fea6afa&quot;</td></tr><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;stop_loss_5pct&quot;</td><td>&quot;180b2a05a56a&quot;</td><td>&quot;0eb73fea6afa&quot;</td></tr><tr><td>&quot;fwd_ret_1d&quot;</td><td>&quot;time_exit_10&quot;</td><td>&quot;84ec7d832dd3&quot;</td><td>&quot;0eb73fea6afa&quot;</td></tr><tr><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;trailing_1pct&quot;</td><td>&quot;bc75435dd927&quot;</td><td>&quot;93c502488088&quot;</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;trailing_20pct&quot;</td><td>&quot;396feb7f1571&quot;</td><td>&quot;93c502488088&quot;</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;trailing_2pct&quot;</td><td>&quot;1bac3c7c0d25&quot;</td><td>&quot;93c502488088&quot;</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;trailing_3pct&quot;</td><td>&quot;9bb3d1bcad7a&quot;</td><td>&quot;93c502488088&quot;</td></tr><tr><td>&quot;fwd_ret_5d&quot;</td><td>&quot;trailing_5pct&quot;</td><td>&quot;c521156a2842&quot;</td><td>&quot;93c502488088&quot;</td></tr></tbody></table></div>"
       ],
       "text/plain": [
        "shape: (42, 4)\n",
@@ -693,17 +706,17 @@
        "│ ---        ┆ ---             ┆ ---           ┆ ---             │\n",
        "│ str        ┆ str             ┆ str           ┆ str             │\n",
        "╞════════════╪═════════════════╪═══════════════╪═════════════════╡\n",
-       "│ fwd_ret_1d ┆ stop_loss_10pct ┆ 728dc3b9a8fb  ┆ 439d342a6bdb    │\n",
-       "│ fwd_ret_1d ┆ stop_loss_15pct ┆ 9e544a5cf3ef  ┆ 439d342a6bdb    │\n",
-       "│ fwd_ret_1d ┆ stop_loss_3pct  ┆ eaa94b25aa1c  ┆ 439d342a6bdb    │\n",
-       "│ fwd_ret_1d ┆ stop_loss_5pct  ┆ 037421cf0ed0  ┆ 439d342a6bdb    │\n",
-       "│ fwd_ret_1d ┆ time_exit_10    ┆ d419a2c93e92  ┆ 439d342a6bdb    │\n",
+       "│ fwd_ret_1d ┆ stop_loss_10pct ┆ 114fcd5c942a  ┆ 0eb73fea6afa    │\n",
+       "│ fwd_ret_1d ┆ stop_loss_15pct ┆ 2a9ca43f2292  ┆ 0eb73fea6afa    │\n",
+       "│ fwd_ret_1d ┆ stop_loss_3pct  ┆ 8331c4e849ff  ┆ 0eb73fea6afa    │\n",
+       "│ fwd_ret_1d ┆ stop_loss_5pct  ┆ 180b2a05a56a  ┆ 0eb73fea6afa    │\n",
+       "│ fwd_ret_1d ┆ time_exit_10    ┆ 84ec7d832dd3  ┆ 0eb73fea6afa    │\n",
        "│ …          ┆ …               ┆ …             ┆ …               │\n",
-       "│ fwd_ret_5d ┆ trailing_1pct   ┆ 8956745c83fa  ┆ 7db90b5518e1    │\n",
-       "│ fwd_ret_5d ┆ trailing_20pct  ┆ 83f414834353  ┆ 7db90b5518e1    │\n",
-       "│ fwd_ret_5d ┆ trailing_2pct   ┆ ebf617a2107c  ┆ 7db90b5518e1    │\n",
-       "│ fwd_ret_5d ┆ trailing_3pct   ┆ d54779b8e4d1  ┆ 7db90b5518e1    │\n",
-       "│ fwd_ret_5d ┆ trailing_5pct   ┆ d68582f97828  ┆ 7db90b5518e1    │\n",
+       "│ fwd_ret_5d ┆ trailing_1pct   ┆ bc75435dd927  ┆ 93c502488088    │\n",
+       "│ fwd_ret_5d ┆ trailing_20pct  ┆ 396feb7f1571  ┆ 93c502488088    │\n",
+       "│ fwd_ret_5d ┆ trailing_2pct   ┆ 1bac3c7c0d25  ┆ 93c502488088    │\n",
+       "│ fwd_ret_5d ┆ trailing_3pct   ┆ 9bb3d1bcad7a  ┆ 93c502488088    │\n",
+       "│ fwd_ret_5d ┆ trailing_5pct   ┆ c521156a2842  ┆ 93c502488088    │\n",
        "└────────────┴─────────────────┴───────────────┴─────────────────┘"
       ]
      },
@@ -775,13 +788,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bca6f9a0",
+   "id": "b2d813c9",
    "metadata": {
     "papermill": {
-     "duration": 0.000842,
-     "end_time": "2026-09-09T06:26:43.193001+00:00",
+     "duration": 0.00205,
+     "end_time": "2026-09-12T01:34:08.236950+00:00",
      "exception": false,
-     "start_time": "2026-09-09T06:26:43.192159+00:00",
+     "start_time": "2026-09-12T01:34:08.234900+00:00",
      "status": "completed"
     }
    },
@@ -812,19 +825,19 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "2155556b",
+   "id": "e58b80e9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-09T06:26:43.195371Z",
-     "iopub.status.busy": "2026-09-09T06:26:43.195291Z",
-     "iopub.status.idle": "2026-09-09T06:27:00.534549Z",
-     "shell.execute_reply": "2026-09-09T06:27:00.534019Z"
+     "iopub.execute_input": "2026-09-12T01:34:08.242212Z",
+     "iopub.status.busy": "2026-09-12T01:34:08.242078Z",
+     "iopub.status.idle": "2026-09-12T01:34:39.567553Z",
+     "shell.execute_reply": "2026-09-12T01:34:39.566926Z"
     },
     "papermill": {
-     "duration": 17.341199,
-     "end_time": "2026-09-09T06:27:00.535091+00:00",
+     "duration": 31.330815,
+     "end_time": "2026-09-12T01:34:39.570013+00:00",
      "exception": false,
-     "start_time": "2026-09-09T06:26:43.193892+00:00",
+     "start_time": "2026-09-12T01:34:08.239198+00:00",
      "status": "completed"
     }
    },
@@ -833,8 +846,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Frozen holdout candidate set: bf21ae4c9070\n",
-      "Validation-selected backtest: adb648fc0f51\n"
+      "Frozen holdout candidate set: 07d118635d4d\n",
+      "Validation-selected backtest: 0c8d095371b6\n"
      ]
     }
    ],
@@ -861,13 +874,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "918695aa",
+   "id": "72b9026d",
    "metadata": {
     "papermill": {
-     "duration": 0.001606,
-     "end_time": "2026-09-09T06:27:00.537871+00:00",
+     "duration": 0.0021,
+     "end_time": "2026-09-12T01:34:39.574506+00:00",
      "exception": false,
-     "start_time": "2026-09-09T06:27:00.536265+00:00",
+     "start_time": "2026-09-12T01:34:39.572406+00:00",
      "status": "completed"
     }
    },
@@ -914,24 +927,24 @@
    "version": "3.14.3"
   },
   "ml4t_provenance": {
-   "executed_at": "2026-09-09T06:27:08.950720+00:00",
+   "executed_at": "2026-09-12T01:34:45.985145+00:00",
    "executor": "local-uv",
-   "library_digest": "3b7b30e57da3ad3e44f5212436762e111267644e79445ec6a5a5868f75bd5a93",
-   "outputs_digest": "e74ec1c0c80920fe9bbe00bf3d3b38f6402db3255290e0e8de7e5fcee4530f17",
+   "library_digest": "52dd7834407db6990d726fab8a47e33208e5132642f5d869211faa8d91ba22aa",
+   "outputs_digest": "69d44aa1c85658ce0b08812a1451326e86c8c4f2057164a4926f5500c5017821",
    "parameters": {},
    "production": true,
-   "source_py_blob": "621b3e0d4c473d1baf977d669a7de097a9a65e32"
+   "source_py_blob": "6d3575c8145cea348510bc5ce402e437357dcc29"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 250.636452,
-   "end_time": "2026-09-09T06:27:02.055482+00:00",
+   "duration": 589.620169,
+   "end_time": "2026-09-12T01:34:42.545678+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "case_studies/fx_pairs/.15_risk_management.build.920959.ipynb",
-   "output_path": "case_studies/fx_pairs/.15_risk_management.papermill.920959.ipynb",
+   "input_path": "case_studies/fx_pairs/.15_risk_management.build.3039751.ipynb",
+   "output_path": "case_studies/fx_pairs/.15_risk_management.papermill.3039751.ipynb",
    "parameters": {},
-   "start_time": "2026-09-09T06:22:51.419030+00:00",
+   "start_time": "2026-09-12T01:24:52.925509+00:00",
    "version": "2.7.0"
   }
  },

--- a/case_studies/fx_pairs/15_risk_management.py
+++ b/case_studies/fx_pairs/15_risk_management.py
@@ -92,18 +92,30 @@ SEED = 42
 RUN_SWEEP = True
 FORCE_REBACKTEST = False
 POPULATION_NAME = ""
-SUPERSEDES_RISK_BACKTESTS: str = "df20d72ab319"
+# `df20d72ab319` was the tip of `fx_pairs:risk-overlay-backtests` when it was written, and
+# `create` accepts the tip and nothing else, so the literal was correct exactly until this
+# notebook next published. `"live"` names the lineage and is resolved against it at run time.
+SUPERSEDES_RISK_BACKTESTS: str = "live"
 # A candidate set is immutable under its name, exactly as a population is, so a rebuilt upstream
 # generation has to name the set it replaces. Keyed by the full set name because that is what the
 # refusal prints: pasting back the name it names is the obvious thing to try, and it has to work.
 # Resolved through `candidate_set_supersedes` rather than passed straight to `create`, because a
 # reader's clean clone has no generation to supersede and `create` refuses a first version that
 # claims to replace one.
+#
+# `"live"` names the lineage rather than a generation of it, which is what stops these going
+# stale again. Three of the four hashes it replaces were already dead: the three
+# `pre-risk-strategies` sets moved on 2026-09-09 (`d966caa61faf` -> `669d50f0f525`,
+# `fde7af05fff6` -> `93b56a9dfb42`, `ff269dc95622` -> `f70630285818`), so each named the
+# generation its own successor had replaced and the next membership move here would have been
+# refused at the freeze, after the fit. `bf21ae4c9070` was still the head of
+# `fx_pairs:holdout-candidates` and would have gone the same way on the next publish.
+# See `case_studies.research.population.SUPERSEDES_LIVE`.
 SUPERSEDES_CANDIDATE_SETS: dict[str, str] = {
-    "fx_pairs:fwd_ret_1d:pre-risk-strategies": "d966caa61faf",
-    "fx_pairs:fwd_ret_5d:pre-risk-strategies": "fde7af05fff6",
-    "fx_pairs:fwd_ret_21d:pre-risk-strategies": "ff269dc95622",
-    "fx_pairs:holdout-candidates": "bf21ae4c9070",
+    "fx_pairs:fwd_ret_1d:pre-risk-strategies": "live",
+    "fx_pairs:fwd_ret_5d:pre-risk-strategies": "live",
+    "fx_pairs:fwd_ret_21d:pre-risk-strategies": "live",
+    "fx_pairs:holdout-candidates": "live",
 }
 
 # %% [markdown]
@@ -175,10 +187,11 @@ catalog = study.predictions.table(include_preview=include_preview).filter(
 # replaced in the registry, complete and current, so this filter alone would carry a retired
 # prediction set into the sweep. `superseded_members` reads the lineage instead - see
 # `13_backtest`, which drops the same set before it freezes the baseline population.
-# `SUPERSEDES_RISK_BACKTESTS` names the snapshot this run replaces under the name it publishes,
-# offered through `population_supersedes` on the same rule. It is empty until that name has a
-# first generation; after that, an upstream refit changes this population's member list and
-# the registry refuses the write without it. `13_backtest` states the reasoning once.
+# `SUPERSEDES_RISK_BACKTESTS` is the sentinel `"live"`, so it names the lineage this run
+# publishes under and `population_supersedes` resolves the generation in force at write time.
+# It resolves to nothing until that name has a first generation, which is also what a reader's
+# clean clone sees; after that, an upstream refit changes this population's member list and the
+# registry refuses the write without the tip. `13_backtest` states the reasoning once.
 retired = superseded_members(study, member_kind="prediction")
 if retired:
     catalog = catalog.filter(~pl.col("prediction_hash").is_in(list(retired)))


### PR DESCRIPTION
The three `SUPERSEDES_CANDIDATE_SETS` entries for `pre-risk-strategies` each named the generation their own successor had replaced. The registry records the move on 09-09, in `candidate_set_names`, which is the lineage table:

```
d966caa61faf -> 669d50f0f525   fwd_ret_1d:pre-risk-strategies
fde7af05fff6 -> 93b56a9dfb42   fwd_ret_5d:pre-risk-strategies
ff269dc95622 -> f70630285818   fwd_ret_21d:pre-risk-strategies
```

The other two declarations, `SUPERSEDES_RISK_BACKTESTS` and `holdout-candidates`, named current tips. That is the same defect one publish earlier: `create` accepts the tip and nothing else, and the tip moves on every publish.

## This was not preventive

The re-run moved all four member lists, so the writers consulted every declaration rather than taking the `same_list` path. The old literals would have been refused at the freeze, after the fit. With the sentinel they resolved to the tips and published successors, each recording the generation it replaced:

```
2dca935a02d2  supersedes 669d50f0f525   fwd_ret_1d:pre-risk-strategies
5bc279a6d55e  supersedes 93b56a9dfb42   fwd_ret_5d:pre-risk-strategies
ffba58c1ae6b  supersedes f70630285818   fwd_ret_21d:pre-risk-strategies
07d118635d4d  supersedes bf21ae4c9070   holdout-candidates
```

## Verification

- Re-run through `nb-run.sh`: exit 0, 1.4 GB largest single process.
- `notebook_provenance.py check`: sync OK, no library drift.
- `check_supersedes_literals.py --case-study fx_pairs --notebook 15_risk_management`: exit 0, all five declarations reading INTENT. fx_pairs drops from eight refused literals to five.
- `16_costs`' four declarations are undisturbed and still name their own tips.
- 20 tests pass across the three supersedes test files.

One measurement note for anyone checking this: a lineage question has to be asked of `candidate_set_names`, not `candidate_sets`. The latter is `PRIMARY KEY (set_hash)` over a content-addressed hash with a single name column, so two names holding identical membership collapse onto one row carrying whichever registered first. Here `pre-cost-strategies` registered these three hashes at 04:09 and `pre-risk-strategies` registered the identical membership at 04:23, so a query against `candidate_sets` filtered on the pre-risk name returns only the 09-06 generation with `supersedes_hash` NULL and the lineage reads as one generation deep. `CandidateSet.one` plus `candidate_set_supersedes` is the decidable test, because it is the pair `create` itself uses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GwvExyYgecwyTLrW2F4Juw