### PR TITLE
The pre-fit causal check no longer guards against a file hash

### DIFF
--- a/case_studies/utils/causal.py
+++ b/case_studies/utils/causal.py
@@ -1948,10 +1948,20 @@ def run_resolved_causal_request(
         return cached
 
     # Before the fit, not after it. The registry can already hold a current identity for
-    # this label that this run does not retire - the ordinary state whenever this module
-    # has been edited, since the spec carries a hash of the whole file - and the write
-    # refuses that. Asking now costs one read and names the hash to declare; asking at
-    # the write costs the fit and every placebo refit first. See #953.
+    # this label that this run does not retire, and the write refuses that. Asking now
+    # costs one read and names the hash to declare; asking at the write costs the fit and
+    # every placebo refit first - an hour on a panel of this size, spent to be told
+    # something the registry could have said before the first fold.
+    #
+    # The reason the state arises has changed, and the old wording here said the wrong
+    # one: it read "whenever this module has been edited, since the spec carries a hash of
+    # the whole file". `_causal_source_identity` no longer hashes the module - it returns
+    # the declared `CAUSAL_RUNNER_VERSION` - so an edit to this file moves no identity at
+    # all. What moves them is that integer being raised by hand, and then every
+    # resolver-based fit in every case study moves at once, which makes the pre-fit check
+    # matter more rather than less. `tests/test_causal_prefit_supersedes_check.py` pins it
+    # against the write-time rule, which it calls rather than restates.
+    # See ml4t/agent-workspace#953.
     check_causal_supersedes(
         study.case_study,
         causal_hash,


### PR DESCRIPTION
`_causal_source_identity` stopped hashing `case_studies/utils/causal.py` some time ago and now returns the declared `CAUSAL_RUNNER_VERSION`. The comment explaining why the supersedes check runs before the DML fit was never updated with it, and still says the state it catches is "the ordinary state whenever this module has been edited, since the spec carries a hash of the whole file".

Both halves of that are false now. Editing this file moves no causal identity, and nothing in the resolved spec hashes it - `grep -n 'read_bytes()\|Path(__file__)' case_studies/utils/causal.py` returns nothing.

The check itself is unchanged and its placement is still right. What differs is how the state arises: a declared integer raised by hand moves every resolver-based fit in every case study at once, rather than one file edit moving them incrementally. That concentrates the failure the pre-fit check prevents rather than removing it, so the comment now argues for the check instead of describing a mechanism that is gone. It also points at `tests/test_causal_prefit_supersedes_check.py`, which pins the pre-fit answer against the write-time rule by calling it rather than restating it.

The tracker reference in that comment gains its full owner-and-repo form. A bare number there reads as a pull request in this repository, which is not what it names.

Comment only - no executable change, no identity moves, nothing re-executes.

`tests/test_causal_prefit_supersedes_check.py` 10 passed, `tests/test_model_source_identity_versions.py` 14 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NReuqDy57ft7qkAAKUEtVG
