### PR TITLE
Panel DML sizes its folds in decision times, so refuse a panel too short for them

### DIFF
--- a/case_studies/utils/causal.py
+++ b/case_studies/utils/causal.py
@@ -387,6 +387,10 @@ def _walk_forward_indices(
     """Build expanding-window folds in rows or complete decision-time groups."""
     if groups is None:
         fold_size = n_rows // (n_folds + 1)
+        if fold_size == 0:
+            raise ValueError(
+                f"{n_folds}-fold walk-forward needs at least {n_folds + 1} rows, got {n_rows}."
+            )
         folds = []
         for fold in range(n_folds):
             train_end = (fold + 1) * fold_size
@@ -405,7 +409,24 @@ def _walk_forward_indices(
     ):
         raise ValueError("groups must be sorted and contiguous")
 
+    # A fold is `len(ordered_groups) // (n_folds + 1)` decision times wide, and integer
+    # division makes that 0 whenever the panel holds fewer complete decision times than
+    # folds. Every train and test slice is then empty, every fold is skipped downstream,
+    # and the estimate comes back NaN over zero observations with nothing raised - the
+    # caller's guard counts ROWS (`(n_folds + 1) * 50 + n_folds * embargo`), which a wide
+    # panel clears on a handful of dates. Measured on a 10,000-row cap of
+    # us_firm_characteristics/09_causal_dml: 8,180 rows, 4 complete decision months,
+    # 5 folds, `4 // 6 == 0`, full summary printed, DML effect nan.
+    #
+    # The count that has to clear the geometry is decision times, so it is checked here,
+    # at the one place the geometry is built, rather than in each caller.
     fold_size = len(ordered_groups) // (n_folds + 1)
+    if fold_size == 0:
+        raise ValueError(
+            f"{n_folds}-fold walk-forward needs at least {n_folds + 1} complete decision "
+            f"times, got {len(ordered_groups)}. On a panel the fold geometry is sized in "
+            f"decision times, not rows, so a row-count minimum does not constrain it."
+        )
     folds = []
     for fold in range(n_folds):
         train_end = (fold + 1) * fold_size

--- a/tests/test_causal_panel_splits.py
+++ b/tests/test_causal_panel_splits.py
@@ -572,3 +572,42 @@ def test_entity_sorted_groups_are_refused_rather_than_split() -> None:
 
     with pytest.raises(ValueError, match="sorted and contiguous"):
         _walk_forward_indices(n_rows=len(entity_major), n_folds=2, embargo=1, groups=entity_major)
+
+
+def test_panel_walk_forward_rejects_fewer_decision_times_than_folds() -> None:
+    """A panel too short for its fold count must raise, not return empty folds.
+
+    `fold_size = len(ordered_groups) // (n_folds + 1)` is 0 whenever the panel holds
+    fewer complete decision times than folds, and every train and test slice is then
+    empty. Downstream that is indistinguishable from small folds: each one is skipped,
+    the estimate is NaN over zero observations, and a full summary prints. Measured on
+    a 10,000-row cap of `us_firm_characteristics/09_causal_dml` - 8,180 rows, 4 decision
+    months, 5 folds, `4 // 6 == 0`.
+
+    The caller's minimum counts rows, and 8,180 clears `(5 + 1) * 50` comfortably, so
+    it cannot be what catches this. The width of a panel is why: a handful of decision
+    times carries thousands of rows.
+    """
+    dates = np.repeat(np.arange(4), 2045)
+
+    with pytest.raises(ValueError, match="complete decision times"):
+        _walk_forward_indices(n_rows=len(dates), n_folds=5, embargo=0, groups=dates)
+
+
+def test_panel_walk_forward_accepts_exactly_enough_decision_times() -> None:
+    """The negative direction: n_folds + 1 decision times is the boundary and passes.
+
+    Without this, the guard above is satisfied by any rule that rejects everything.
+    """
+    dates = np.repeat(np.arange(6), 10)
+
+    folds = _walk_forward_indices(n_rows=len(dates), n_folds=5, embargo=0, groups=dates)
+
+    assert len(folds) == 5
+    assert all(len(test_idx) > 0 for _, test_idx in folds)
+
+
+def test_row_walk_forward_rejects_fewer_rows_than_folds() -> None:
+    """Same degeneracy on the ungrouped path, which has no panel guard in front of it."""
+    with pytest.raises(ValueError, match="at least 6 rows"):
+        _walk_forward_indices(n_rows=4, n_folds=5, embargo=0, groups=None)


### PR DESCRIPTION
A panel DML run whose sample holds fewer complete decision times than folds returned a NaN effect over zero observations, printed a full summary, and raised nothing.

## The defect

`_walk_forward_indices` sizes a fold as `len(ordered_groups) // (n_folds + 1)`. Integer division makes that `0` whenever the panel is shorter than its fold count, so every train and test slice is empty and every fold is skipped downstream.

The guard in front of it counts rows:

```python
min_rows = (n_folds + 1) * 50 + n_folds * embargo
```

On a panel that is the wrong quantity. A wide panel carries thousands of rows on a handful of dates, so the row minimum is cleared comfortably while the fold geometry is degenerate. Measured on a 10,000-row cap of `case_studies/us_firm_characteristics/09_causal_dml`: 8,180 rows against a 305-row minimum, 4 complete decision months, 5 folds, `4 // 6 == 0`, `DML effect: nan`. The failure surfaced two cells later and only because that notebook happens to carry a `placebo_effects.size < 10` check of its own.

## The fix

The check goes where the geometry is built rather than in each caller, so it covers `manual_dml_timeseries` and `run_dml_analysis` together. The ungrouped path gets the same guard, since it is constrained by the row minimum only when reached through `run_dml_analysis`.

## No result moves and nothing is re-run

Production runs carry hundreds of decision times - `us_firm_characteristics` has 311 eligible months - so this raises only where the old code silently returned NaN. It bites the reduced-scale preview path, which is exactly where a silent NaN makes a smoke run useless as a gate.

## Verification

Three tests in `tests/test_causal_panel_splits.py`, including the negative direction: exactly `n_folds + 1` decision times is the boundary and must still build five usable folds, so the guard cannot be satisfied by a rule that rejects everything.

- Both refusal tests fail against the unpatched file (`DID NOT RAISE <class 'ValueError'>`); the boundary test passes either way.
- `tests/test_causal_panel_splits.py` is 31 passed.
- The wider `-k "causal or dml"` selection is 385 passed, 11 skipped, 2 failed. The two failures are `test_docker_notebooks.py::test_docker_notebook` for `15_causal_estimation/05_momentum_causal_trading` and `06_fed_announcement_bsts`, which fail identically on clean `main` with `Cell 21 (ValueError): No walk-forward splits available for training period`. Pre-existing and filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UPDj1nioTuD4xATMVyhZxB