### PR TITLE
A holdout refit is compared on the fields it keeps, not the ones it must recompute

### DIFF
--- a/case_studies/research/holdout.py
+++ b/case_studies/research/holdout.py
@@ -369,7 +369,19 @@ def build_holdout_training_spec(
 # `holdout_start`/`holdout_end`, but `resolve()` passes them to `generate_cv_splits` as boundaries
 # to seal VALIDATION against, so it selects validation folds and cannot emit a holdout fold. That
 # is why the fold is derived here.
-_FOLD_DERIVED_FIELDS = (
+#
+# Public because `utils/strategy_analysis._refit_comparable` reads it. That function decides
+# whether a holdout run is a refit of the validation run, so it must skip exactly the fields
+# named here and no others. Kept as one declaration because it was two: the exemption list was
+# written out by hand and matched two of these three, so `macro_context.resolved_fold_digest`
+# was required to change here and required not to have changed there. cme_futures' holdout
+# `723a305604bb` was rejected by its own lineage check for that reason and no other, with its
+# feature artifacts, feature names and label artifact all identical to the validation run's
+# (ml4t/agent-workspace#1147).
+#
+# Each entry is (container, field). "computation" means the computation mapping itself; any
+# other value names a mapping inside it.
+FOLD_DERIVED_FIELDS = (
     ("computation", "expected_prediction_keys"),
     ("model", "effective_params_by_fold"),
     ("macro_context", "resolved_fold_digest"),

--- a/case_studies/utils/strategy_analysis.py
+++ b/case_studies/utils/strategy_analysis.py
@@ -402,22 +402,45 @@ def holdout_generations_to_retire(
 # This is a denylist rather than an allowlist on purpose: a field added to the specification
 # later is compared by default, so the check tightens as the spec grows instead of silently
 # ignoring the new field.
-_REFIT_MAY_CHANGE = frozenset(
-    {"cv", "expected_prediction_keys", "input_data_spec", "runtime_identity", "source_identity"}
-)
+# Fields a refit may differ in for reasons that are not the fold set: the CV specification it
+# was asked for, where its inputs came from, and the two identity stamps. The fold-derived
+# fields are NOT listed here - they come from `FOLD_DERIVED_FIELDS`, which is the declaration
+# of what a holdout refit is required to recompute.
+_REFIT_MAY_CHANGE = frozenset({"cv", "input_data_spec", "runtime_identity", "source_identity"})
 
 
 def _refit_comparable(training_spec_json: str | None) -> dict | None:
-    """A training specification reduced to what a refit must preserve."""
+    """A training specification reduced to what a refit must preserve.
+
+    The fold-derived fields are skipped by reading the same tuple the holdout deriver writes
+    them from, rather than by a list kept in step with it by hand. The hand-kept list matched
+    two of the three and compared `macro_context.resolved_fold_digest`, which
+    `_resolved_macro_digest` computes over `case.splits` - so it differs whenever a refit is
+    correct, and the one holdout that reached this check was rejected for changing a field it
+    was required to change (ml4t/agent-workspace#1147).
+
+    Scoped to the named subfield, never to its container: the other five entries under
+    `macro_context` are the macro *configuration* - `series`, `policy`, `alignment`,
+    `availability_lag_days`, `version` - and a run that differs in any of them is not a refit
+    of this specification at all.
+    """
     if not training_spec_json:
         return None
+    # Imported in the function because `case_studies.research` pulls in the workspace on import
+    # and this module is reached from notebooks that open no study.
+    from case_studies.research.holdout import FOLD_DERIVED_FIELDS
+
     computation = dict(json.loads(training_spec_json).get("computation") or {})
     for key in _REFIT_MAY_CHANGE:
         computation.pop(key, None)
-    model = dict(computation.get("model") or {})
-    if model:
-        model.pop("effective_params_by_fold", None)
-        computation["model"] = model
+    for container, field in FOLD_DERIVED_FIELDS:
+        if container == "computation":
+            computation.pop(field, None)
+            continue
+        nested = dict(computation.get(container) or {})
+        if nested:
+            nested.pop(field, None)
+            computation[container] = nested
     return computation
 
 

--- a/tests/test_holdout_anchor_selection.py
+++ b/tests/test_holdout_anchor_selection.py
@@ -485,6 +485,37 @@ CURRENT = "aaaa" * 16
 SUPERSEDED = "bbbb" * 16
 
 
+def _macro_spec(
+    *,
+    split: str = "holdout",
+    series: tuple[str, ...] = ("DGS10", "VIXCLS"),
+    fold_digest: str = "sha256:" + "cccc" * 16,
+) -> str:
+    """A spec carrying a macro context, which only `latent_factors/sdf` does.
+
+    Two of its six fields are what this exercises. `resolved_fold_digest` is computed over the
+    fold set by `_resolved_macro_digest`, so a correct refit always moves it. `series` is the
+    macro configuration and a refit that moved it would be a different specification.
+    """
+    return json.dumps(
+        {
+            "computation": {
+                "cv": {"split": split, "folds": [{"fold": 1}]},
+                "feature_artifacts": {"model_based": {"sha256": CURRENT}},
+                "feature_names": ["ret_5d", "vol_21d"],
+                "macro_context": {
+                    "version": 2,
+                    "series": list(series),
+                    "policy": "as_of",
+                    "alignment": "daily",
+                    "availability_lag_days": 1,
+                    "resolved_fold_digest": fold_digest,
+                },
+            }
+        }
+    )
+
+
 def test_a_refit_differs_from_its_validation_run_only_in_the_fold_geometry() -> None:
     """The positive case, or the check would be satisfied by rejecting everything."""
     from case_studies.utils.strategy_analysis import is_refit_of
@@ -548,3 +579,74 @@ def test_the_pinned_carrier_rejects_a_stale_generation_sharing_its_name(
     # 9.9 is the higher Sharpe. Nothing may reach it, and it must not raise as ambiguity
     # either - it is not a candidate at all.
     assert resolved["backtest_hash"] != "b2"
+
+
+# ---------------------------------------------------------------------------------------
+# The macro context, where two of the three fold-derived fields were exempt and one was not.
+#
+# `_resolved_macro_digest` hashes the macro values each fold saw, walking `case.splits`. A
+# holdout refit fits a different fold set by definition, so the digest differs whenever the
+# refit is correct - and comparing it made `is_refit_of` unsatisfiable for every
+# `latent_factors/sdf` holdout. cme_futures' `723a305604bb` was the first to reach the check
+# and was rejected on that field alone, with its feature artifacts, feature names and label
+# artifact identical to the validation run's (ml4t/agent-workspace#1147).
+#
+# Both directions are asserted here. A one-sided test passes just as well against an exemption
+# written one level too wide, as `macro_context` rather than the subfield, which would stop
+# checking the macro configuration entirely and say nothing about it.
+# ---------------------------------------------------------------------------------------
+
+
+def test_a_refit_may_move_the_resolved_fold_digest() -> None:
+    """The field the holdout deriver is required to recompute."""
+    from case_studies.utils.strategy_analysis import is_refit_of
+
+    assert is_refit_of(
+        _macro_spec(fold_digest="sha256:" + "dddd" * 16),
+        _macro_spec(split="validation"),
+    )
+
+
+def test_a_refit_may_not_move_the_macro_series() -> None:
+    """The negative half, and what keeps the exemption at the subfield.
+
+    Same shape as the test above and one field further out. If the exemption is ever widened
+    to `macro_context`, this is what goes red rather than a holdout fitted against a different
+    macro panel being accepted as the carrier's.
+    """
+    from case_studies.utils.strategy_analysis import is_refit_of
+
+    assert not is_refit_of(
+        _macro_spec(series=("DGS10", "VIXCLS", "T10Y2Y")),
+        _macro_spec(split="validation"),
+    )
+
+
+def test_every_declared_fold_derived_field_is_exempt() -> None:
+    """The declaration and the exemption are one thing, so they cannot drift apart again.
+
+    The defect was two lists: `FOLD_DERIVED_FIELDS` named three fields a holdout refit must
+    recompute, and the comparison skipped two of them. This walks the declaration itself, so a
+    fourth entry added to it is covered on the day it is added, and reverting the comparison to
+    a hand-kept list fails here rather than at whichever holdout reaches the check first.
+    """
+    from case_studies.research.holdout import FOLD_DERIVED_FIELDS
+    from case_studies.utils.strategy_analysis import is_refit_of
+
+    for container, field in FOLD_DERIVED_FIELDS:
+        base = {
+            "cv": {"split": "validation", "folds": [{"fold": 1}]},
+            "feature_names": ["ret_5d"],
+            "model": {"class": "lightgbm.Booster"},
+            "macro_context": {"series": ["DGS10"]},
+        }
+        moved = json.loads(json.dumps(base))
+        if container == "computation":
+            base[field] = "validation-value"
+            moved[field] = "holdout-value"
+        else:
+            base[container][field] = "validation-value"
+            moved[container][field] = "holdout-value"
+        assert is_refit_of(json.dumps({"computation": moved}), json.dumps({"computation": base})), (
+            f"{container}.{field} is declared fold-derived but is still compared"
+        )


### PR DESCRIPTION
## What

Two modules disagreed about one field, and the disagreement made a correct holdout unusable.

`research/holdout.py` declares the three fields a holdout refit has to recompute for its own fold:

```python
FOLD_DERIVED_FIELDS = (
    ("computation", "expected_prediction_keys"),
    ("model", "effective_params_by_fold"),
    ("macro_context", "resolved_fold_digest"),
)
```

`utils/strategy_analysis._refit_comparable`, which decides whether a holdout run is a refit of the validation run, skipped the first through `_REFIT_MAY_CHANGE` and the second by an explicit `pop`, and **compared the third**. So the same run was required to change a field in one module and required not to have changed it in the other.

## Why the field can never match

`_resolved_macro_digest` walks `case.splits` and hashes the macro values each fold actually saw. A holdout refit fits a different fold set by definition, so the digest differs whenever the refit is correct. `latent_factors/holdout.py:41` already says this: it "resolves from the macro panel restricted to the fold being fitted, so the validation folds' digest describes a different panel slice."

`is_refit_of` was therefore unsatisfiable for every `latent_factors/sdf` holdout, which is the only family carrying a macro context.

## Measured

cme_futures' registered holdout is the first to reach the check. Evaluating the three post-conditions separately against its production registry:

```
strategy spec identical:              True
training_run_fitted_for_the_holdout:  True   (status: refit)
is_refit_of:                          False
```

`_refit_comparable` compares ten keys. Exactly one differs, and inside it exactly one subfield of six:

```
feature_artifacts:    equal
feature_names:        equal
label_artifact:       equal
macro_context.{alignment, availability_lag_days, policy, series, version}:  equal
macro_context.resolved_fold_digest:   validation ca6067164a23...  holdout e9248c281387...
```

So no re-run could have fixed it: a refit reproduces the same difference by construction. After this change, `resolve_holdout_self_backtest` on that registry returns the registered holdout where it returned `None`.

Eleven training runs across four case studies carry a macro context - etfs, cme_futures, sp500_equity_option_analytics and us_firm_characteristics, all `latent_factors/sdf`. One is at `refit` status and ten are validation runs that have not reached the holdout stage, so three of the four were exposed without having hit it yet.

## The change

The exemption is derived from the declaration instead of restated beside it, so a fourth entry added to `FOLD_DERIVED_FIELDS` is covered on the day it is added. The constant loses its underscore because it now has a reader in another package, and `expected_prediction_keys` comes out of `_REFIT_MAY_CHANGE`, which is left holding only the fields that may differ for reasons other than the fold set.

**Scoped to the named subfield and never its container.** The other five fields under `macro_context` are the macro *configuration*, and a run differing in any of them is not a refit of this specification at all.

## Verification

Three tests, asserting both directions, because a one-sided test passes just as well against an exemption written one level too wide:

- a refit may move `resolved_fold_digest`
- a refit may **not** move `macro_context.series`
- every entry in `FOLD_DERIVED_FIELDS` is exempt, walked from the declaration itself, so reverting to a hand-kept list fails here rather than at whichever holdout reaches the check first

Verified by reverting the change twice rather than by reading it. Dropping the exemption fails the two tests that assert it and leaves the `series` one green. Widening it to the whole container fails the `series` test and the hyperparameter test that was already in the file.

105 passed across the nine carrier and holdout suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GwvExyYgecwyTLrW2F4Juw