### PR TITLE
The docker notebook runner honours a skip whose blocker still holds

### DIFF
--- a/tests/pm_helpers.py
+++ b/tests/pm_helpers.py
@@ -1093,9 +1093,19 @@ def check_kernel_routing(overrides: dict) -> KernelRouting:
     )
 
     if not (Path(kernel_python).is_file() and os.access(kernel_python, os.X_OK)):
+        # Which filesystem was looked at decides who is at fault, and the two read alike
+        # otherwise: run this file from the host venv and a correct image is reported as
+        # needing a rebuild. /.dockerenv is written by the runtime, not by our images.
+        where = (
+            f"inside this container. {rebuild}"
+            if Path("/.dockerenv").exists()
+            else "on this host. That path lives inside the "
+            f"{image or 'notebook'} image, where this test is meant to execute, so nothing "
+            "here says the image is stale. Run it through the docker job instead."
+        )
         return KernelRouting(
             f"overrides.yaml routes this notebook to {kernel_python}, "
-            f"which is not an executable file here. {rebuild}"
+            f"which is not an executable file {where}"
         )
 
     launcher_path = REPO_ROOT / launcher if launcher else None

--- a/tests/test_docker_notebooks.py
+++ b/tests/test_docker_notebooks.py
@@ -1,12 +1,22 @@
 """Test notebooks that require Docker environments (py312, neo4j, benchmark).
 
-Same as test_chapter_notebooks.py but IGNORES skip flags from overrides.yaml.
-These notebooks are skipped in uv-native runs (missing modules like signatory,
-gensim, esig, tfcausalimpact, or Neo4j) but CAN run inside their respective
-Docker images.
+Same as test_chapter_notebooks.py, and it honours the same skip declarations.
 
-The skip flag stays in overrides.yaml so the uv-native runner still skips them.
-This file runs them in Docker where the dependencies are available.
+It used to ignore them. The reason it gave was that a skip meant a missing module
+(signatory, gensim, esig, tfcausalimpact, Neo4j) and the image supplies it, so
+running anyway was how those notebooks got covered at all. That premise has
+expired: a notebook whose dependency lives in an image now carries ``docker_env``
+and ``requires_import`` with no ``skip``, and every remaining ``skip: true`` in
+overrides.yaml declares a ``skip_blocker`` naming a fixture, registry or external
+condition. An image does not grow the fixture a shortfall names, register a
+candidate set, or attach a CUDA device, so ignoring the skip did not run those
+notebooks under a cured condition - it ran them under a condition still true and
+collected the failure the declaration predicted.
+
+Honouring the skip is not a coverage loss, because ``honoured_skip_reason``
+honours it only while its blocker still holds. A fixture that grows the file or an
+image that gains the module retires the skip with no edit here, and
+``tests/test_skip_blockers.py`` fails the build on a declaration that has expired.
 
 Usage:
     # Py312 notebooks (signatory, gensim, esig, tfcausalimpact, torch CUDA bug)
@@ -32,6 +42,7 @@ from tests.pm_helpers import (
     gpu_skip_reason,
     run_notebook,
 )
+from tests.skip_blockers import honoured_skip_reason
 
 REPO_ROOT = Path(__file__).parent.parent
 
@@ -66,8 +77,11 @@ def test_docker_notebook(notebook_path, populated_data_dir, seeded_output_dir):
     if nb_tier != run_tier:
         pytest.skip(f"Tier {nb_tier} — current run tier is {run_tier}")
 
-    # NOTE: We intentionally do NOT check overrides.get("skip") here.
-    # That's the whole point of this file — Docker provides the missing deps.
+    # Honoured only while the blocker its reason rests on still holds, so this cannot
+    # hide a notebook whose condition has lifted - that one runs here as before. See the
+    # module docstring for why ignoring the skip stopped being the right default.
+    if reason := honoured_skip_reason(overrides):
+        pytest.skip(f"Skipped: {reason}")
 
     # GPU requirement still applies (CI runners have no GPU)
     reason = gpu_skip_reason(overrides)

--- a/tests/test_skip_blockers.py
+++ b/tests/test_skip_blockers.py
@@ -213,3 +213,83 @@ def test_every_decidable_kind_is_exercised_by_the_declarations():
         "these kinds are implemented but no row declares one, so nothing exercises them "
         f"against the fixture: {', '.join(unused)}"
     )
+
+
+def _run_docker_runner(monkeypatch, overrides, tmp_path):
+    """Drive ``test_docker_notebook`` with one declaration and report what it did.
+
+    Returns ``("skipped", reason)`` or ``("executed", None)``. ``run_notebook`` is replaced by
+    a sentinel so a regression reports itself instead of executing a notebook inside the unit
+    suite; every decision the runner makes before that point is the real one.
+    """
+    from tests import test_docker_notebooks as runner
+
+    monkeypatch.setattr(runner, "get_overrides", lambda _: overrides)
+    monkeypatch.setattr(runner, "get_tier", lambda _: runner.current_test_tier())
+    executed = []
+    monkeypatch.setattr(
+        runner, "run_notebook", lambda **kwargs: executed.append(kwargs) or {"status": "ok"}
+    )
+    notebook = tmp_path / "15_causal_estimation" / "05_stand_in.py"
+    notebook.parent.mkdir(parents=True, exist_ok=True)
+    notebook.write_text("# %%\n")
+    monkeypatch.setattr(runner, "REPO_ROOT", tmp_path)
+    try:
+        runner.test_docker_notebook(notebook, tmp_path, tmp_path)
+    except pytest.skip.Exception as exc:
+        # Skipped derives from BaseException, not Exception. Catching Exception here lets the
+        # skip escape and marks THIS test skipped, which reads as a pass in the summary and
+        # asserts nothing - the first version of this helper did exactly that.
+        return "skipped", str(exc)
+    return ("executed", None) if executed else ("returned without executing", None)
+
+
+def test_the_docker_runner_honours_a_skip_whose_blocker_still_holds(monkeypatch, tmp_path):
+    """The defect this replaced: the runner ignored ``skip`` and executed the notebook anyway.
+
+    ``15_causal_estimation/05_momentum_causal_trading`` declared a ``fixture_shortfall`` naming
+    the exact ValueError it raises, and the docker runner ran it regardless and collected that
+    failure. An image supplies a module; it does not widen the fixture window, so there was
+    never a cured condition here to run under.
+    """
+    outcome, reason = _run_docker_runner(
+        monkeypatch,
+        {
+            "skip": True,
+            "skip_reason": "Walk-forward CV needs more bars than the test-data window provides",
+            "skip_blocker": {"fixture_shortfall": {"note": "...", "verified": "2026-09-11"}},
+        },
+        tmp_path,
+    )
+    assert outcome == "skipped", (
+        "the docker runner executed a notebook whose blocker still holds; a skip it ignores "
+        "is a declaration that costs nothing and a failure nobody can act on"
+    )
+    assert "more bars than the test-data window" in reason
+
+
+def test_the_docker_runner_still_executes_once_the_blocker_expires(monkeypatch, tmp_path):
+    """The negative half: honouring a skip must not become skipping unconditionally.
+
+    Without this, deleting the blocker check entirely - or honouring ``skip`` without asking
+    whether its condition still holds - passes the test above while silently dropping every
+    docker notebook from CI.
+    """
+    fixture_root = tmp_path / "fixture"
+    (fixture_root / "futures").mkdir(parents=True)
+    (fixture_root / "futures" / "continuous.parquet").touch()
+    monkeypatch.setattr("tests.skip_blockers._fixture_root", lambda: fixture_root)
+
+    outcome, _ = _run_docker_runner(
+        monkeypatch,
+        {
+            "skip": True,
+            "skip_reason": "the fixture carries no continuous futures",
+            "skip_blocker": {"absent_fixture_path": "futures/continuous.parquet"},
+        },
+        tmp_path,
+    )
+    assert outcome == "executed", (
+        "the blocker names a file the fixture now carries, so the skip has expired and the "
+        "notebook must run again with no edit to overrides.yaml"
+    )


### PR DESCRIPTION
`tests/test_docker_notebooks.py` ignored the `skip` key on purpose:

```python
# NOTE: We intentionally do NOT check overrides.get("skip") here.
# That's the whole point of this file — Docker provides the missing deps.
```

That was true when a skip meant a missing module. It is not true now.

## The premise expired

All 40 `skip: true` entries in `tests/overrides.yaml` carry a `skip_blocker`, and **not one
names a module**:

| blocker kind | rows |
|---|---:|
| `no_canonical_selection` | 16 |
| `external` | 9 |
| `fixture_shortfall` | 6 |
| `absent_candidate_set` | 4 |
| `absent_fixture_path` | 3 |
| `absent_population` | 2 |

An image does not grow a fixture, register a candidate set, or attach a CUDA device. Exactly one
skipped notebook even has a `docker_env` (`23_knowledge_graphs/07_dynamic_kg_temporal`), and its
blocker is `external: CUDA device`, which a container does not supply either and which this file
already honours through `gpu_skip_reason`.

Notebooks whose dependency lives in an image are now expressed as `docker_env` plus
`requires_import` with no `skip`, so ignoring `skip` no longer reaches the case it was written
for. It only overrides declarations that are still true.

## What it cost

`15_causal_estimation/05_momentum_causal_trading` declares

```yaml
skip_blocker:
  fixture_shortfall:
    note: "Cell 21 raises ValueError: No walk-forward splits available for training period. ..."
    verified: 2026-09-11
```

and this runner executed it anyway and failed on exactly that. The notebook is not broken and
neither is the library: the CI fixture window is shorter than one walk-forward split, which is
what the declaration says. Nothing here widens a training period to make the symptom go away.

It has been invisible because `.github/ci/unit-test-quarantine.txt` routes this file to
`test-py312`, `test-neo4j` and `test-benchmark`, none of which is a required check.

## The change

The runner calls `honoured_skip_reason()`, the same blocker-aware path
`test_chapter_notebooks.py` uses. No coverage is lost: a skip is honoured only while its
condition holds, so a fixture that grows the file retires it with no edit here, and
`tests/test_skip_blockers.py` still fails the build on a declaration that has expired.

Two tests, because honouring a skip and skipping unconditionally satisfy the same happy-path
assertion. The second lets the blocker expire and requires the notebook to run. Reverting the
production change turns the first red (`assert 'executed' == 'skipped'`) and leaves the second
green.

Also in here: `check_kernel_routing` reported a correct image as needing a rebuild when the suite
ran from the host venv, since it tests the interpreter path against whatever filesystem the
process is on. It now names the filesystem it looked at and stops implicating the image when that
is the host.

## Verification

- `tests/test_skip_blockers.py`: 77 passed, plus 4 failures that are **pre-existing and
  environmental**. A control run with all three changed files reverted to `main` reproduces the
  same 4 identically. They are `absent_fixture_path` rows evaluated against a workstation
  `ML4T_DATA_PATH` that holds production data rather than the CI fixture, which is the hazard
  `tests/skip_blockers.py` documents.
- `ruff check` and `ruff format` clean on all three files.
