### PR TITLE
The quarantine says why no job runs test_model_notebook, not that none does

### DIFF
--- a/.github/ci/unit-test-quarantine.txt
+++ b/.github/ci/unit-test-quarantine.txt
@@ -146,17 +146,38 @@ tests/test_model_catalog_columns.py
 #
 # The first three collect nothing but notebook executions, so the whole file
 # goes. `test_model_registry.py` does not: only `test_model_notebook` runs a
-# notebook, and its other ten tests are pure config assertions that finish in
-# 0.07s. Excluding the file threw those away, which is the same
+# notebook, and its siblings are pure config assertions that finish in 0.14s.
+# Excluding the file threw those away, which is the same
 # exclude-more-than-you-meant defect the subtraction below exists to fix.
-# Eleven, not nine: `test_registering_stage_maps_to_its_actual_entry_point` is
-# parametrized over five stages, so counting `def test_` undercounts what the
-# deselect leaves behind. Measured 2026-09-03: 105 collected, 94 deselected.
+# Count the deselect, not `def test_`: parametrization makes the two disagree,
+# and `test_registering_stage_maps_to_its_actual_entry_point` alone contributes
+# five. Measured 2026-09-12: 110 collected, 98 deselected, 12 left running
+# (2026-09-03 it was 105 / 94 / 11, so this number moves and is not a pin).
+#
+# `test_model_notebook` is the one exception to "each line names the job that
+# does run it", because no CI job CAN run it. It skips at
+# `tests/test_model_registry.py:532` when `case_studies/<case study>/features`
+# or `labels` is absent, and both are absent on every runner: `.gitignore:152`
+# and `:154` exclude them, nothing tracks them, and a maintainer worktree
+# reaches them through a symlink into `~/ml4t/artifacts`. Every parametrization
+# would skip, so wiring it into a job buys a green that executed nothing - which
+# is the failure this file's subtraction exists to prevent, arriving by the
+# other door. It is deselected here so the file's twelve siblings still run,
+# not because a job is missing.
+#
+# The residual gap, stated rather than implied: the end-to-end path - a notebook
+# runs, registers, and the `entry_point` it recorded names the notebook that
+# wrote it - executes nowhere in CI. `test_model_notebook` is the only test that
+# walks it, and a maintainer worktree is the only place it can. PR #1006's
+# `tests/test_entry_point_names_the_notebook.py` pins the resolver that chooses
+# the value, which is the half that runs without stage 01-05 inputs; nothing
+# observes what a real registration writes. That is why a stale `dl_tsmixer`
+# literal in this file's own query survived from the initial release commit.
 # ---------------------------------------------------------------------------
 tests/test_case_studies.py                       # cs-<case-study> (test-case-studies)
 tests/test_chapter_notebooks.py                  # chNN (test-chapters)
 tests/test_docker_notebooks.py                   # test-py312, test-neo4j, test-benchmark
-tests/test_model_registry.py::test_model_notebook  # nothing runs it; the file's other eleven tests run here
+tests/test_model_registry.py::test_model_notebook  # no job can run it (see above); its siblings run here
 
 # ---------------------------------------------------------------------------
 # Needs the reader's Docker image. It walks every declared third-party import

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -694,11 +694,13 @@ def test_model_notebook(case_study, stage, notebook_path, isolated_model_output)
             # before the migration; the notebook now declares `entry_point="10_dl_tsmixer"` to
             # `open_study`, which is the stem every registering notebook records per
             # `test_a_registering_stage_is_recognised_by_its_suffix` above. The literal survived
-            # the mapping's removal unchanged, and nothing caught it because this test runs in no
-            # job: `.github/ci/unit-test-quarantine.txt` deselects `test_model_notebook` and says
-            # so. Measured 2026-09-12 against the etfs production registry - 2 rows at
-            # `10_dl_tsmixer`, 0 at `dl_tsmixer` - so the query returned the empty set and the
-            # `issubset` below could only have failed, on the first machine that ever ran it.
+            # the mapping's removal unchanged, and nothing caught it because this test runs in
+            # no job and cannot: it skips above without the stage 01-05 inputs no runner has,
+            # so `.github/ci/unit-test-quarantine.txt` deselects it rather than leaving every
+            # parametrization to skip. Measured 2026-09-12 against the etfs production
+            # registry - 2 rows at `10_dl_tsmixer`, 0 at `dl_tsmixer` - so the query returned
+            # the empty set and the `issubset` below could only have failed, on the first
+            # machine that ever ran it.
             if case_study == "etfs" and notebook_path.stem == "10_dl_tsmixer":
                 db = sqlite3.connect(str(registry_db))
                 try:


### PR DESCRIPTION
`.github/ci/unit-test-quarantine.txt` deselected `tests/test_model_registry.py::test_model_notebook` with the reason "nothing runs it", sitting under a section header that promises each line names the job that does run it. That reads as an oversight waiting to be corrected.

It is not one. The test cannot run in CI at all:

- It skips at `tests/test_model_registry.py:532` when `case_studies/<case study>/features` or `labels` is absent.
- Both are absent on every runner. `.gitignore:152` and `:154` exclude them, `git ls-files` finds nothing tracked, and a maintainer worktree reaches them through a symlink into `~/ml4t/artifacts`.

So every parametrization would skip, and wiring it into a job buys a green that executed nothing - the failure this file's subtraction exists to prevent, arriving through the other door. The entry now says that, and the same correction goes to the cross-reference inside `test_model_registry.py` that repeated the old wording.

## The residual gap is now stated rather than implied

The end-to-end path - a notebook runs, registers, and the `entry_point` it recorded names the notebook that wrote it - executes nowhere in CI, and a maintainer worktree is the only place it can. #1006's `tests/test_entry_point_names_the_notebook.py` pins the resolver that chooses the value, which is the half that runs without stage 01-05 inputs. Nothing observes what a real registration writes.

That is not a hypothetical: it is why a stale `dl_tsmixer` literal in this file's own query survived from the initial release commit until it was found by hand.

## Drifted counts

The paragraph explaining why to count the deselect rather than `def test_` carried figures from 2026-09-03. Measured today: 110 collected, 98 deselected, 12 running, against 105 / 94 / 11 then. Replaced with today's figures and a note that the number moves, since a count stated as though fixed is what went stale.

## Verification

- `tests/test_quarantine_list.py` 69 passed.
- `tests/test_model_registry.py` 12 passed with `test_model_notebook` deselected, as CI deselects it.
- The workflow's own parser loop (`.github/workflows/test.yml:917-926`) replayed over the edited file yields the same 60 arguments, with `--deselect=tests/test_model_registry.py::test_model_notebook` intact.

Comment-only. No executable change, nothing re-executes, no register row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NReuqDy57ft7qkAAKUEtVG
