### PR TITLE
Sequence batches are gathered once, on the card, instead of built window by window

### DIFF
--- a/.github/ci/unit-test-quarantine.txt
+++ b/.github/ci/unit-test-quarantine.txt
@@ -17,7 +17,7 @@
 
 # ---------------------------------------------------------------------------
 # Needs the modelling environment - run by test-unit-image, in ml4t/ml4t:latest.
-# 45 files. The 26 that existed on 2026-08-24 measured 392 tests, 3m21s.
+# 47 files. The 26 that existed on 2026-08-24 measured 392 tests, 3m21s.
 #
 # `case_studies/utils/gbm.py` imports torch at module scope, so the LightGBM
 # files are behind this boundary too even though LightGBM itself is a small
@@ -84,6 +84,10 @@ tests/test_lightning_announcement_silence.py
 tests/test_family_hook_dispatch.py
 tests/test_model_analysis_selection.py
 tests/test_model_source_identity_versions.py
+# The gather this file tests is the torch one: it builds a FoldSequenceDataset and
+# runs a DataLoader over it, so it imports torch directly rather than reaching it
+# through the module under test.
+tests/test_sequence_batch_gather.py
 # `test_prediction_sequence_cap` tests the same module as `test_sequence_dataset`
 # below. `case_studies/utils/sequence_dataset.py` imports torch at :10 for the
 # Dataset subclass; these cases exercise the index builders, which never touch it.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1115,7 +1115,7 @@ jobs:
           print(f"{len(cases)} tests ran against the test-data checkout, none skipped")
           PY
   # ---------------------------------------------------------------------------
-  # The 35 test files that need the modelling environment.
+  # The 47 test files that need the modelling environment.
   #
   # These ran in NO job. .github/ci/unit-test-quarantine.txt excluded them from
   # test-unit's sweep for needing torch, and said they "belong in a job that runs
@@ -1194,7 +1194,7 @@ jobs:
     # outcome this job must never have.
     if: always()
     runs-on: ubuntu-latest
-    # The 26 files measured on 2026-08-24 ran in 3m21s; the list now contains 36.
+    # The 26 files measured on 2026-08-24 ran in 3m21s; the list now contains 47.
     # --timeout=900 bounds a hung test but not a hung
     # import, collection or image pull, which would otherwise fall through to
     # GitHub's six-hour default.
@@ -1300,6 +1300,7 @@ jobs:
             tests/test_sae_batch_size.py \
             tests/test_sdf_checkpoint_numbering.py \
             tests/test_sdf_macro_context.py \
+            tests/test_sequence_batch_gather.py \
             tests/test_sequence_dataset.py \
             tests/test_sequence_identity_roundtrip.py \
             tests/test_sequence_holdout_rekey.py \

--- a/case_studies/utils/deep_learning.py
+++ b/case_studies/utils/deep_learning.py
@@ -66,6 +66,7 @@ from case_studies.utils.sequence_dataset import (
     GAP_MASK_FEATURES,
     GAP_POLICY_ID,
     FoldSequenceDataset,
+    collate_sequences,
     collate_with_metadata,
     materialize_store_metadata,
     prepare_fold_sequence_stores,
@@ -1903,7 +1904,7 @@ def _train_one_config(
                     y_batch_dev = y_batch.to(device, non_blocking=True)
                     pred_batch = model(X_batch)
                     pred_parts.append(pred_batch.cpu().numpy())
-                    y_parts.append(y_batch.numpy())
+                    y_parts.append(y_batch.cpu().numpy())
                     date_parts.append(timestamps)
                     entity_parts.append(entities)
                     val_loss += criterion(pred_batch, y_batch_dev).item()
@@ -2505,8 +2506,8 @@ def run_dl_cv(
         )
         print("    creating datasets...")
 
-        train_ds = FoldSequenceDataset(train_store)
-        val_ds = FoldSequenceDataset(val_store, include_metadata=True)
+        train_ds = FoldSequenceDataset(train_store, device=torch_device)
+        val_ds = FoldSequenceDataset(val_store, include_metadata=True, device=torch_device)
 
         # The architecture's input width is a property of what the loader
         # actually produced, not of what the caller declared. The store appends
@@ -2544,19 +2545,26 @@ def run_dl_cv(
             t0 = time.perf_counter()
             print(f"    {config_name}:")
 
+            # num_workers stays 0 and the sampler and seed stay exactly as they were:
+            # both decide which sequences land in which batch, and already-registered
+            # results were produced under them. What changed is how a batch is gathered,
+            # which the dataset's __getitems__ does in one indexing operation.
+            # Pinning is for a host tensor awaiting a copy to the card. When the dataset
+            # gathers on the card there is no such copy and nothing to pin.
             train_loader = DataLoader(
                 train_ds,
                 batch_size=cfg_batch_size,
                 shuffle=True,
                 num_workers=0,
-                pin_memory=torch_device.type == "cuda",
+                pin_memory=torch_device.type == "cuda" and not train_ds.returns_device_tensors,
+                collate_fn=collate_sequences,
             )
             val_loader = DataLoader(
                 val_ds,
                 batch_size=cfg_batch_size,
                 shuffle=False,
                 num_workers=0,
-                pin_memory=torch_device.type == "cuda",
+                pin_memory=torch_device.type == "cuda" and not val_ds.returns_device_tensors,
                 collate_fn=collate_with_metadata,
             )
 
@@ -2705,9 +2713,13 @@ def run_dl_cv(
                 f"({elapsed:.1f}s, {len(checkpoint_ics)} checkpoints)"
             )
 
-        # Free this fold's data before creating next fold's sequences
+        # Free this fold's data before creating next fold's sequences. The datasets may
+        # hold the fold's features on the card, so release those blocks to the rest of the
+        # machine rather than leaving them reserved until the process exits.
         del train_ds, val_ds, train_store, val_store
         gc.collect()
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
 
     if n_valid_folds == 0:
         raise ValueError("No valid folds created. Check data size vs lookback.")

--- a/case_studies/utils/sequence_dataset.py
+++ b/case_studies/utils/sequence_dataset.py
@@ -8,7 +8,7 @@ import numpy as np
 import pandas as pd
 import polars as pl
 import torch
-from torch.utils.data import Dataset
+from torch.utils.data import Dataset, default_collate
 
 from utils.modeling import RANDOM_SEED
 
@@ -63,12 +63,162 @@ class SequenceStore:
         return int(len(self.entities))
 
 
-class FoldSequenceDataset(Dataset):
-    """Lazy map-style dataset yielding lookback windows on demand."""
+# The share of the card's free memory a fold's feature store may take. Training also
+# needs the model, its gradients and a batch of activations, and the card is shared with
+# whatever else this machine is running, so the store - the one allocation here big
+# enough to decide whether a fold fits - gets a minority of what is free, and the host
+# gather takes the fold when it does not fit.
+DEVICE_STORE_MAX_FREE_FRACTION = 0.4
 
-    def __init__(self, store: SequenceStore, *, include_metadata: bool = False) -> None:
+
+@dataclass(slots=True)
+class GatheredBatch:
+    """A batch ``FoldSequenceDataset.__getitems__`` assembled in one gather.
+
+    torch's map-style fetcher passes whatever ``__getitems__`` returns straight to
+    ``collate_fn``, so the assembled batch travels in this wrapper and the collate
+    functions below hand ``payload`` back untouched. Returning a list of per-sequence
+    samples is the documented shape, and it puts back into the collate step the
+    per-sequence Python work that the batch gather exists to remove.
+    """
+
+    payload: tuple
+
+
+def _device_available_bytes(device: torch.device) -> int:
+    """Bytes this process can still allocate on ``device``.
+
+    ``mem_get_info`` reports what the driver has free, which excludes the blocks torch's
+    caching allocator already holds for this process. Those are reusable, so a fold that
+    has just released its predecessor's store would otherwise read the card as fuller
+    than it is and fall back to the host for the rest of the run.
+    """
+
+    free, _total = torch.cuda.mem_get_info(device)
+    reusable = torch.cuda.memory_reserved(device) - torch.cuda.memory_allocated(device)
+    return int(free) + int(reusable)
+
+
+def _resolve_gather_device(store: SequenceStore, device: torch.device | str | None) -> torch.device:
+    """Decide where this fold's flat store lives, by measuring it against the card."""
+
+    if device is None:
+        return torch.device("cpu")
+    device = torch.device(device)
+    if device.type != "cuda" or not torch.cuda.is_available():
+        return torch.device("cpu")
+    if not store.features:
+        return device
+    rows = sum(len(feats) for feats in store.features)
+    sample = store.features[0]
+    # The target column is float32 whatever the features are, because __getitem__ casts it.
+    needed = rows * (int(sample.shape[1]) * sample.dtype.itemsize + 4)
+    if needed > DEVICE_STORE_MAX_FREE_FRACTION * _device_available_bytes(device):
+        return torch.device("cpu")
+    return device
+
+
+def _flatten_store(store: SequenceStore, device: torch.device) -> tuple[torch.Tensor, torch.Tensor]:
+    """Concatenate the per-symbol arrays into one feature and one target tensor.
+
+    On a CUDA device each symbol is copied straight to the card, so the host never holds
+    a second copy of the fold. The host path concatenates, which does hold one: that is
+    what the fallback's vectorized gather costs.
+    """
+
+    if not store.features:
+        return (
+            torch.zeros((0, 0), dtype=torch.float32, device=device),
+            torch.zeros(0, dtype=torch.float32, device=device),
+        )
+
+    if device.type == "cpu":
+        features = torch.from_numpy(np.concatenate(store.features))
+        targets = torch.from_numpy(np.concatenate(store.targets)).to(torch.float32)
+        return features, targets
+
+    total = int(sum(len(feats) for feats in store.features))
+    width = int(store.features[0].shape[1])
+    features = torch.empty(
+        (total, width), dtype=torch.from_numpy(store.features[0][:0]).dtype, device=device
+    )
+    targets = torch.empty(total, dtype=torch.float32, device=device)
+    start = 0
+    for feats, tgts in zip(store.features, store.targets, strict=True):
+        stop = start + len(feats)
+        features[start:stop] = torch.from_numpy(feats)
+        targets[start:stop] = torch.from_numpy(tgts).to(torch.float32)
+        start = stop
+    return features, targets
+
+
+class FoldSequenceDataset(Dataset):
+    """Map-style dataset gathering lookback windows one batch at a time.
+
+    ``__getitems__`` (note the plural) is the method that carries the work. torch's
+    map-style fetcher calls it with the whole index list the sampler chose and hands
+    whatever it returns straight to ``collate_fn``, so one strided gather replaces one
+    Python call per sequence. The sampler still decides which indices land in which
+    batch and in what order, so the batches are the ones ``__getitem__`` would have
+    produced, in the same order and with the same values.
+
+    The fold's features are held as one flat ``(total_rows, n_features)`` tensor with a
+    row offset per symbol, which makes a window a contiguous row range and a batch of
+    windows a single index. ``device`` decides where that tensor lives. On a CUDA device
+    the gather runs on the card and the batch is already there when the model reads it;
+    otherwise it runs on the host, which still removes the per-sequence Python call. The
+    choice is made here, at fold setup, by measuring the store against what the card has
+    free - not by attempting the allocation and catching the failure, which would leave
+    the fold half set up and the card fragmented.
+
+    ``__getitem__`` is unchanged and still reads the store's per-symbol arrays. It is the
+    reference the batch gather is tested against.
+    """
+
+    def __init__(
+        self,
+        store: SequenceStore,
+        *,
+        include_metadata: bool = False,
+        device: torch.device | str | None = None,
+    ) -> None:
         self.store = store
         self.include_metadata = include_metadata
+
+        self._symbol_idx = np.asarray(store.symbol_idx, dtype=np.int64)
+        self._end_idx = np.asarray(store.end_idx, dtype=np.int64)
+        lengths = np.asarray([len(feats) for feats in store.features], dtype=np.int64)
+        self._row_offset = np.concatenate(([0], np.cumsum(lengths)[:-1])).astype(np.int64)
+        # The flat row holding each sequence's target. Its window is the ``lookback``
+        # rows before it, which is the slice [end - lookback, end) that __getitem__ takes.
+        self._target_row = self._row_offset[self._symbol_idx] + self._end_idx
+
+        gather_device = _resolve_gather_device(store, device)
+        self._features, self._targets = _flatten_store(store, gather_device)
+        self._target_row_t = torch.as_tensor(self._target_row, device=gather_device)
+        self._window_offsets = torch.arange(
+            -store.lookback, 0, dtype=torch.long, device=gather_device
+        )
+        # Only the evaluation dataset emits these, and a fold's timestamp column is tens
+        # of megabytes, so the training dataset does not build a flat copy it never reads.
+        self._entities = np.asarray(store.entities, dtype="U64") if include_metadata else None
+        self._timestamps = (
+            np.concatenate(store.timestamps)
+            if include_metadata and store.timestamps
+            else np.zeros(0, dtype="datetime64[ns]")
+        )
+
+    @property
+    def gather_device(self) -> torch.device:
+        """Where a gathered batch is produced, and so where it already lives."""
+
+        return self._features.device
+
+    @property
+    def returns_device_tensors(self) -> bool:
+        """Whether batches arrive off the host. This is what decides ``pin_memory``."""
+
+        return self._features.device.type != "cpu"
 
     def __len__(self) -> int:
         return self.store.n_sequences
@@ -85,10 +235,32 @@ class FoldSequenceDataset(Dataset):
         entity = self.store.entities[symbol_id]
         return window, target, timestamp, entity
 
+    def __getitems__(self, indices) -> GatheredBatch:
+        device = self._features.device
+        rows = self._target_row_t[torch.as_tensor(indices, dtype=torch.long, device=device)]
+        X = self._features[rows.unsqueeze(1) + self._window_offsets]
+        y = self._targets[rows]
+        if not self.include_metadata:
+            return GatheredBatch((X, y))
+        host_idx = np.asarray(indices, dtype=np.int64)
+        timestamps = self._timestamps[self._target_row[host_idx]]
+        entities = self._entities[self._symbol_idx[host_idx]]
+        return GatheredBatch((X, y, timestamps, entities))
+
+
+def collate_sequences(batch):
+    """Collate training batches, handing a pre-gathered batch straight back."""
+
+    if isinstance(batch, GatheredBatch):
+        return batch.payload
+    return default_collate(batch)
+
 
 def collate_with_metadata(batch):
     """Collate evaluation batches while preserving timestamps/entities."""
 
+    if isinstance(batch, GatheredBatch):
+        return batch.payload
     X = torch.stack([item[0] for item in batch])
     y = torch.stack([item[1] for item in batch])
     timestamps = np.asarray([item[2] for item in batch])

--- a/tests/test_sequence_batch_gather.py
+++ b/tests/test_sequence_batch_gather.py
@@ -147,10 +147,15 @@ def test_a_gathered_batch_needs_no_copy_to_reach_the_model() -> None:
     assert X.to(torch.device("cuda"), non_blocking=True) is X
 
 
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="needs a CUDA device")
 def test_a_store_too_big_for_the_card_is_gathered_on_the_host(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """The fallback is chosen by measuring, before anything is allocated."""
+    """The fallback is chosen by measuring, before anything is allocated.
+
+    Without a card `_resolve_gather_device` returns the host before it measures
+    anything, so this case passes on a CPU-only runner whatever the measurement does.
+    """
 
     store = _synthetic_store()
     monkeypatch.setattr(

--- a/tests/test_sequence_batch_gather.py
+++ b/tests/test_sequence_batch_gather.py
@@ -1,0 +1,171 @@
+"""The batch gather must emit the batches the per-sequence path emitted.
+
+``FoldSequenceDataset.__getitems__`` replaced one Python call per sequence with one
+strided gather. Sequence runs already registered under the old path stay valid only if
+the change is invisible to the model: the same sequences in the same batches in the same
+order, with the same bits in every window. That is what these tests assert, by running
+the same sampler over the gather and over a view of the dataset that hides
+``__getitems__`` and so takes the path the loader took before.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import torch
+from torch.utils.data import DataLoader, Dataset
+
+from case_studies.utils.sequence_dataset import (
+    FoldSequenceDataset,
+    SequenceStore,
+    _device_available_bytes,
+    _resolve_gather_device,
+    collate_sequences,
+    collate_with_metadata,
+)
+
+LOOKBACK = 6
+SYMBOL_LENGTHS = (20, 35, 12, 28)
+N_FEATURES = 5
+
+
+class _PerItemView(Dataset):
+    """The dataset without ``__getitems__``, which is the path the loader took before."""
+
+    def __init__(self, dataset: FoldSequenceDataset) -> None:
+        self._dataset = dataset
+
+    def __len__(self) -> int:
+        return len(self._dataset)
+
+    def __getitem__(self, idx: int):
+        return self._dataset[idx]
+
+
+def _synthetic_store() -> SequenceStore:
+    """A store with uneven symbols and missing cells, which is the shape folds have."""
+
+    rng = np.random.default_rng(11)
+    features, targets, timestamps, entities = [], [], [], []
+    symbol_idx, end_idx = [], []
+    for symbol, length in enumerate(SYMBOL_LENGTHS):
+        feats = rng.standard_normal((length, N_FEATURES)).astype(np.float32)
+        # Unobserved cells reach the gather as NaN, so they have to survive it bit for bit.
+        feats[rng.random(feats.shape) < 0.1] = np.nan
+        features.append(feats)
+        targets.append(rng.standard_normal(length).astype(np.float32))
+        timestamps.append(np.datetime64("2024-01-01") + np.arange(length, dtype="timedelta64[D]"))
+        entities.append(f"SYM{symbol}")
+        for end in range(LOOKBACK, length):
+            symbol_idx.append(symbol)
+            end_idx.append(end)
+
+    return SequenceStore(
+        features=features,
+        targets=targets,
+        timestamps=timestamps,
+        entities=entities,
+        symbol_idx=np.asarray(symbol_idx, dtype=np.int64),
+        end_idx=np.asarray(end_idx, dtype=np.int64),
+        lookback=LOOKBACK,
+    )
+
+
+def _assert_bit_identical(gathered: torch.Tensor, per_item: torch.Tensor) -> None:
+    """Compare the raw bits, so a NaN counts as equal to itself and to nothing else."""
+
+    assert gathered.dtype == per_item.dtype
+    assert gathered.shape == per_item.shape
+    left = np.ascontiguousarray(gathered.cpu().numpy())
+    right = np.ascontiguousarray(per_item.cpu().numpy())
+    np.testing.assert_array_equal(left.view(np.uint8), right.view(np.uint8))
+
+
+def _loaders(dataset: FoldSequenceDataset, collate, *, batch_size: int, shuffle: bool):
+    """The same sampler over the gather and over the per-sequence path."""
+
+    def build(source, seed: int = 1234):
+        return DataLoader(
+            source,
+            batch_size=batch_size,
+            shuffle=shuffle,
+            num_workers=0,
+            collate_fn=collate,
+            generator=torch.Generator().manual_seed(seed),
+        )
+
+    return build(dataset), build(_PerItemView(dataset))
+
+
+def _devices() -> list[str]:
+    return ["cpu", "cuda"] if torch.cuda.is_available() else ["cpu"]
+
+
+@pytest.mark.parametrize("device", _devices())
+def test_the_gathered_training_batches_are_the_per_sequence_batches(device: str) -> None:
+    dataset = FoldSequenceDataset(_synthetic_store(), device=device)
+    gathered_loader, per_item_loader = _loaders(
+        dataset, collate_sequences, batch_size=7, shuffle=True
+    )
+
+    batches = 0
+    for (X, y), (X_ref, y_ref) in zip(gathered_loader, per_item_loader, strict=True):
+        _assert_bit_identical(X, X_ref)
+        _assert_bit_identical(y, y_ref)
+        batches += 1
+    assert batches > 1
+
+
+@pytest.mark.parametrize("device", _devices())
+def test_the_gathered_evaluation_batches_keep_their_timestamps_and_entities(
+    device: str,
+) -> None:
+    dataset = FoldSequenceDataset(_synthetic_store(), include_metadata=True, device=device)
+    gathered_loader, per_item_loader = _loaders(
+        dataset, collate_with_metadata, batch_size=7, shuffle=False
+    )
+
+    for gathered, reference in zip(gathered_loader, per_item_loader, strict=True):
+        X, y, timestamps, entities = gathered
+        X_ref, y_ref, timestamps_ref, entities_ref = reference
+        _assert_bit_identical(X, X_ref)
+        _assert_bit_identical(y, y_ref)
+        np.testing.assert_array_equal(timestamps, timestamps_ref)
+        np.testing.assert_array_equal(entities, entities_ref)
+        assert timestamps.dtype == timestamps_ref.dtype
+        assert entities.dtype == entities_ref.dtype
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="needs a CUDA device")
+def test_a_gathered_batch_needs_no_copy_to_reach_the_model() -> None:
+    """The training loop's ``.to(device)`` must be a no-op, not a second transfer."""
+
+    dataset = FoldSequenceDataset(_synthetic_store(), device="cuda")
+    assert dataset.returns_device_tensors
+    X, _y = dataset.__getitems__(list(range(16))).payload
+    assert X.device.type == "cuda"
+    assert X.to(torch.device("cuda"), non_blocking=True) is X
+
+
+def test_a_store_too_big_for_the_card_is_gathered_on_the_host(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The fallback is chosen by measuring, before anything is allocated."""
+
+    store = _synthetic_store()
+    monkeypatch.setattr(
+        "case_studies.utils.sequence_dataset._device_available_bytes", lambda device: 1
+    )
+    assert _resolve_gather_device(store, "cuda").type == "cpu"
+
+    dataset = FoldSequenceDataset(store, device="cuda")
+    assert not dataset.returns_device_tensors
+    assert dataset.gather_device.type == "cpu"
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="needs a CUDA device")
+def test_the_fit_measurement_counts_what_this_process_can_reuse() -> None:
+    """A released fold's blocks are still this process's to allocate."""
+
+    device = torch.device("cuda")
+    assert _device_available_bytes(device) >= torch.cuda.mem_get_info(device)[0]


### PR DESCRIPTION
## What was wrong

`FoldSequenceDataset.__getitem__` built one lookback window per call, and the DataLoader ran
with `num_workers=0`, so a batch of 2,048 sequences cost 2,048 Python calls on the training
thread. A `us_equities_panel` nlinear run sits in that loop: it holds 432 MiB of card memory
while the card waits on the host.

## The change

The dataset implements `__getitems__` (plural). torch's map-style fetcher calls it with the
whole index list the sampler chose and hands what it returns straight to `collate_fn`, so one
strided gather replaces the per-sequence calls. The fold's features become one flat
`(total_rows, n_features)` tensor with a row offset per symbol, which makes a window a
contiguous row range and a batch of windows a single index. It is built once per fold and
reused by every config trained on it.

## Measured

Synthetic fold shaped like uep's: 2,000 symbols, 2,100 rows, 25 features, lookback 60, batch
2,048, 2.2M sequences, a 0.43 GB store. Three runs, sharing the machine with two live
case-study runs, so the spread is contention:

| path | ms/batch |
|---|---|
| per-sequence assembly, then the copy to the card | 18.2 - 21.1 |
| vectorized gather on the host, then the copy | 3.4 - 5.4 |
| gather on the card | 2.6 - 2.8 |

19.4 s saved per epoch on a fold of 2.2M sequences, and the epoch count multiplies it.

## Why the batches are the same batches

Results already registered under the old path have to stay valid, and that constraint decides
the shape of this. `num_workers` stays 0, and the sampler, `shuffle` and the seed are
untouched: they decide which sequences land in which batch and in what order. Only the gather
changed.

`tests/test_sequence_batch_gather.py` runs the same sampler over the gather and over a view of
the dataset that hides `__getitems__`, then compares the **raw bytes** of every batch, so a NaN
counts as equal to itself and to nothing else. Shifting the window by one period reds four of
its seven tests, which is the control I ran before trusting it.

## Three things the batch living on the card decides

- `pin_memory` is for a host tensor awaiting a copy to the card. There is no such copy now, so
  both loaders take it from the dataset rather than from the device alone.
- The validation loop called `y_batch.numpy()`, which raises on a CUDA tensor. It now calls
  `.cpu().numpy()` - what the two other prediction sites in this file already spell, and a
  no-op when the tensor is already on the host.
- `X_batch.to(device, non_blocking=True)` in the training loop needed no change, because `.to()`
  returns the same object when the device already matches. The test asserts that rather than
  assuming it.

## The fallback

`modeling.dl.device` can be CPU, and a reader may have a smaller card or none, so the host
vectorized gather is the fallback. It is chosen at fold setup by measuring the store against
what the card has free, not attempted and caught - a failed allocation would leave the fold
half set up. The measurement counts the blocks torch's caching allocator holds for this
process as available, because they are, and the fold teardown now returns the store to the
rest of the machine.

## Training identity

No identity field moves and no registered run is invalidated, so nothing has to be refitted
because of this. Verified against the base commit `e0ea7054` rather than argued:

- `sequence_identity_params` hashes `device`, `sequence_preparation`, `batch_size`,
  `input_data_spec`, `lookback`, `max_train_sequences`, `train_sequence_stride` when it is
  declared, and the caller's own `identity_params`. Both it and `_sequence_source_identity`
  are AST-identical to the base.
- `SEQUENCE_RUNNER_VERSION`, `SEQUENCE_PREPARATION_VERSION` and `SEQUENCE_STATE_VERSION` are
  unchanged at 1, 3 and 1. They are declared integers: the sequence identity stopped hashing
  source files, so editing `sequence_dataset.py` cannot move a hash by itself, and a bump is a
  decision someone writes down. The decision here is not to bump, because the fits see the same
  bits in the same batches in the same order.
- `input_data_spec` is the same value. The whole diff of `sequence_dataset.py` removes three
  lines - the import, one docstring line and the `__init__` signature - and the store builders
  (`prepare_fold_sequence_stores`, `sequence_validation_keys`, `materialize_store_metadata`)
  are untouched.
- The `device` the identity hashes is the notebook's declared device, unchanged. The dataset's
  new `device` keyword decides where a batch is gathered and never reaches the identity.

## Verification

- `tests/test_sequence_batch_gather.py`: 7 passed, on CPU and CUDA. Negative control above.
- `tests/test_sequence_dataset.py`, `test_dl_device_contract.py`, `test_sequence_identity_roundtrip.py`,
  `test_prediction_sequence_cap.py`, `test_sequence_holdout_rekey.py`, `test_deep_learning_state.py`,
  `test_deep_learning_adapter.py`, `test_deep_model_state.py`, `test_dl_force_retrain_identity.py`,
  `test_sequence_lookup_reaches_registration.py`: 110 passed, 1 skipped in one run.
- An end-to-end pass through `_train_one_config` on both devices: two epochs, checkpoint
  callback fires with the right row count and the right timestamp and entity dtypes.
- `ruff check` clean across the repo, `ruff format` clean on the three files.
- The new test file imports torch, so it is quarantined out of `test-unit`'s sweep and named
  in `test-unit-image`, which runs in the modelling image. `tests/test_quarantine_list.py`
  holds the two lists to each other.

No notebook is re-run for this. A running kernel keeps the module it imported, so this changes
nothing underneath the case-study runs in flight.


