### PR TITLE
sp500_options carries three cost fields it never applies

### DIFF
--- a/case_studies/sp500_options/config/backtest/base.yaml
+++ b/case_studies/sp500_options/config/backtest/base.yaml
@@ -1,3 +1,18 @@
+# Three fields below are inert on the path this case study runs: `execution.execution_price`,
+# `commission.rate` and `slippage.rate`. Every registered backtest here is `ret_to_expiry`,
+# which `case_studies/utils/backtest_runner.py` routes to `_run_htm_daily_mtm`, and that call
+# is not passed `cost_spec` - the only thing that carries these rates into a run. The
+# `quote_side` fill is read by the event-driven broker, which a `rebalance.mode: vectorized`
+# case study never constructs. They still reach the registered `backtest_config` and so the
+# hashed identity, which is why they stay: removing them would re-key 879 backtests to delete
+# values nothing reads.
+#
+# The costs this case study actually pays come from `_htm_backtest.py`, which reads
+# `config/setup.yaml::costs.components` directly - per-leg entry spread from the real option
+# quotes, `hedge_spread.estimate_bps_of_notional` on every hedge rebalance,
+# `commission.option_per_contract` and `commission.equity_per_share`, plus an exit spread on
+# liquidation. Verified 2026-09-12; `total_slippage` is NULL on all 879 rows because the
+# vectorized path records no cost totals, not because nothing was charged.
 account:
   allow_short_selling: true
 execution:

--- a/case_studies/sp500_options/config/setup.yaml
+++ b/case_studies/sp500_options/config/setup.yaml
@@ -65,6 +65,9 @@ mapping:
   # per concurrent cohort. The specialized path does not target a fixed vega.
   sizing: equal_premium_capital_with_fixed_cohort_fraction
 
+# These components are what charges this case study. `_htm_backtest.py` reads this block
+# directly; the `commission.rate` and `slippage.rate` in `config/backtest/base.yaml` are inert
+# on this case study's path and are documented there.
 costs:
   class: dominant
   components:


### PR DESCRIPTION
Reading `slippage.rate: 0.0002` beside `execution_price: quote_side` in this preset suggests
sp500_options takes the quoted side of an option spread and then charges two basis points on
top of it. It charges neither. This adds a comment saying so, at both places a reader looks.

Comments only. No value changes, no re-run, nothing re-keyed.

## The trace

| field | why it never applies |
|---|---|
| `execution.execution_price: quote_side` | read by the event-driven broker; a case study running `rebalance.mode: vectorized` never constructs one |
| `commission.rate: 0.0005` | reaches a run only via `cost_spec` |
| `slippage.rate: 0.0002` | same |

`backtest_runner.py` builds `cost_spec` before the dispatch and passes it to `_run_vectorized`
alone. All 879 registered backtests in this case study are `ret_to_expiry`, which routes to
`_run_htm_daily_mtm`, and that call is not passed it.

What charges this case study is `case_studies/sp500_options/_htm_backtest.py:95`, reading
`config/setup.yaml::costs.components` directly: the per-leg entry spread taken from the real
option quotes and scaled by `option_spread_fraction`,
`hedge_spread.estimate_bps_of_notional` on every hedge rebalance,
`commission.option_per_contract`, `commission.equity_per_share`, and an exit spread on
liquidation. Quoted spreads rather than a flat rate, which is a stronger cost model than the
one the dead fields describe.

## Why the fields stay

They are in the registered `backtest_config` and therefore in the hashed identity. Removing
them would re-key 879 backtests to delete values nothing reads. A comment costs nothing and
answers the question where it gets asked.

The pointer in `setup.yaml` runs the other way: the block that does the charging is the one
with no `model:` key, which is itself easy to misread as inert.

## Verified to re-key nothing, rather than assumed

`notebook_provenance.py check` captured over the whole repo before and after: both reports
454 lines, byte-identical. 0 stale, 0 outputs-changed, 389 library-drift. `register.sh check`
likewise, 226 lines identical, including two pre-existing `UNMERGED` rows for
`23_knowledge_graphs` that have nothing to do with this change and are the reason to compare
rather than read the after-state alone.

Both files still parse to the same values: `execution_price: quote_side`,
`slippage.rate: 0.0002`, `commission.rate: 0.0005`, and the four `costs.components` keys.

The mechanism behind that result: every `setup.yaml` read in the tree is
`yaml.safe_load(read_text())`, so a comment dies at the parse; `library_digest` hashes only
files reached through the AST import graph in `repo_local_sources`, which is Python modules;
and `backtest_hash` is built from parsed values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NReuqDy57ft7qkAAKUEtVG
