### PR TITLE
A holdout figure title says what it plots instead of naming the Sharpe it plots

### DIFF
--- a/case_studies/sp500_equity_option_analytics/19_holdout_backtest.ipynb
+++ b/case_studies/sp500_equity_option_analytics/19_holdout_backtest.ipynb
@@ -724,8 +724,8 @@
     "ax_dd.set_ylabel(\"Drawdown\")\n",
     "add_message_title(\n",
     "    ax_equity,\n",
-    "    f\"The selected strategy on the 2021 holdout: Sharpe {_holdout['sharpe']:.2f}\",\n",
-    "    f\"Peak-to-trough {_holdout['max_drawdown']:.1%} over {curve.height} sessions\",\n",
+    "    \"Selected strategy on the 2021 holdout: equity curve and drawdown\",\n",
+    "    \"Growth of 1 above, peak-to-trough drawdown below, daily\",\n",
     ")\n",
     "fig.show()"
    ]

--- a/case_studies/sp500_equity_option_analytics/19_holdout_backtest.py
+++ b/case_studies/sp500_equity_option_analytics/19_holdout_backtest.py
@@ -591,8 +591,8 @@ ax_dd.fill_between(curve["timestamp"], curve["drawdown"], 0.0, color=COLORS["neg
 ax_dd.set_ylabel("Drawdown")
 add_message_title(
     ax_equity,
-    f"The selected strategy on the 2021 holdout: Sharpe {_holdout['sharpe']:.2f}",
-    f"Peak-to-trough {_holdout['max_drawdown']:.1%} over {curve.height} sessions",
+    "Selected strategy on the 2021 holdout: equity curve and drawdown",
+    "Growth of 1 above, peak-to-trough drawdown below, daily",
 )
 fig.show()
 


### PR DESCRIPTION
The title read `The selected strategy on the 2021 holdout: Sharpe {sharpe:.2f}` and the subtitle carried the max drawdown and the session count. A title may not name a value the notebook's own code produced: a re-run moves it, and the figure already shows it. The same Sharpe, its 95% interval and the session count print four cells above, and the drawdown panel is the max drawdown.

The notebook carries no provenance stamp and no executed outputs, so this changes no render.

## Why only one

The figure-title census this comes from was measured on `main` at `73507cc4` and counted 399 findings across 24 chapters and all nine case studies. Re-run against current `main`, the widened check reports **five**: the lanes have swept the rest over the six weeks since.

| | |
|---|---|
| `case_studies/sp500_equity_option_analytics/19_holdout_backtest` | fixed here - unstamped, no outputs |
| `case_studies/etfs/09_dl_lstm:496` | title 106 chars; stamped 2026-09-08, owes a cell re-run |
| `23_knowledge_graphs/02_supply_chain_kg_construction:955` | subtitle interpolates `len(filings_df)`; stamped 2026-09-10 |
| `23_knowledge_graphs/05_institutional_holdings_kg:986` | subtitle interpolates `len(data_stocks)` and `len(data_institutions)`; stamped 2026-09-10 |

The other four sit in notebooks with executed outputs, where a title is drawn into the image and the edit is not free. They are left for whoever re-runs those notebooks next; the check reports them, so nothing is lost by waiting.

The check itself was verified in both directions rather than trusted: planting one interpolated `set_title`, one over-long `suptitle` and one interpolated `update_layout(title=)` into a scratch copy reports all three, so the near-zero count is a real zero and not a broken detector.
