### PR TITLE
Four figure descriptions match the figure their cell draws

### DIFF
--- a/23_knowledge_graphs/02_supply_chain_kg_construction.ipynb
+++ b/23_knowledge_graphs/02_supply_chain_kg_construction.ipynb
@@ -2,13 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "cc52b9ca",
+   "id": "fd1603fc",
    "metadata": {
     "papermill": {
-     "duration": 0.005503,
-     "end_time": "2026-09-10T22:11:22.827646+00:00",
+     "duration": 0.018257,
+     "end_time": "2026-09-13T00:30:25.625204+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:22.822143+00:00",
+     "start_time": "2026-09-13T00:30:25.606947+00:00",
      "status": "completed"
     }
    },
@@ -48,19 +48,19 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "ba6d591f",
+   "id": "b6119936",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T22:11:22.838810Z",
-     "iopub.status.busy": "2026-09-10T22:11:22.838675Z",
-     "iopub.status.idle": "2026-09-10T22:11:26.414784Z",
-     "shell.execute_reply": "2026-09-10T22:11:26.413849Z"
+     "iopub.execute_input": "2026-09-13T00:30:25.655884Z",
+     "iopub.status.busy": "2026-09-13T00:30:25.655397Z",
+     "iopub.status.idle": "2026-09-13T00:30:37.277751Z",
+     "shell.execute_reply": "2026-09-13T00:30:37.276551Z"
     },
     "papermill": {
-     "duration": 3.583639,
-     "end_time": "2026-09-10T22:11:26.416112+00:00",
+     "duration": 11.64082,
+     "end_time": "2026-09-13T00:30:37.279775+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:22.832473+00:00",
+     "start_time": "2026-09-13T00:30:25.638955+00:00",
      "status": "completed"
     }
    },
@@ -96,19 +96,19 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "79b59f27",
+   "id": "d7eb11bd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T22:11:26.435302Z",
-     "iopub.status.busy": "2026-09-10T22:11:26.434947Z",
-     "iopub.status.idle": "2026-09-10T22:11:26.440888Z",
-     "shell.execute_reply": "2026-09-10T22:11:26.438587Z"
+     "iopub.execute_input": "2026-09-13T00:30:37.310579Z",
+     "iopub.status.busy": "2026-09-13T00:30:37.309761Z",
+     "iopub.status.idle": "2026-09-13T00:30:37.326229Z",
+     "shell.execute_reply": "2026-09-13T00:30:37.323074Z"
     },
     "papermill": {
-     "duration": 0.020802,
-     "end_time": "2026-09-10T22:11:26.444679+00:00",
+     "duration": 0.039422,
+     "end_time": "2026-09-13T00:30:37.327424+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:26.423877+00:00",
+     "start_time": "2026-09-13T00:30:37.288002+00:00",
      "status": "completed"
     },
     "tags": [
@@ -140,19 +140,19 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "1194a7f8",
+   "id": "3ece740c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T22:11:26.467958Z",
-     "iopub.status.busy": "2026-09-10T22:11:26.467776Z",
-     "iopub.status.idle": "2026-09-10T22:11:26.488930Z",
-     "shell.execute_reply": "2026-09-10T22:11:26.487082Z"
+     "iopub.execute_input": "2026-09-13T00:30:37.353542Z",
+     "iopub.status.busy": "2026-09-13T00:30:37.353231Z",
+     "iopub.status.idle": "2026-09-13T00:30:37.386021Z",
+     "shell.execute_reply": "2026-09-13T00:30:37.384725Z"
     },
     "papermill": {
-     "duration": 0.034112,
-     "end_time": "2026-09-10T22:11:26.490420+00:00",
+     "duration": 0.047816,
+     "end_time": "2026-09-13T00:30:37.387382+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:26.456308+00:00",
+     "start_time": "2026-09-13T00:30:37.339566+00:00",
      "status": "completed"
     }
    },
@@ -163,13 +163,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "22fc57c1",
+   "id": "ea03a193",
    "metadata": {
     "papermill": {
-     "duration": 0.01107,
-     "end_time": "2026-09-10T22:11:26.510157+00:00",
+     "duration": 0.011925,
+     "end_time": "2026-09-13T00:30:37.410996+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:26.499087+00:00",
+     "start_time": "2026-09-13T00:30:37.399071+00:00",
      "status": "completed"
     }
    },
@@ -182,19 +182,19 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "9d6391d8",
+   "id": "7bb8ee9a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T22:11:26.526552Z",
-     "iopub.status.busy": "2026-09-10T22:11:26.526038Z",
-     "iopub.status.idle": "2026-09-10T22:11:27.622782Z",
-     "shell.execute_reply": "2026-09-10T22:11:27.622173Z"
+     "iopub.execute_input": "2026-09-13T00:30:37.441689Z",
+     "iopub.status.busy": "2026-09-13T00:30:37.440881Z",
+     "iopub.status.idle": "2026-09-13T00:30:40.401392Z",
+     "shell.execute_reply": "2026-09-13T00:30:40.398795Z"
     },
     "papermill": {
-     "duration": 1.104667,
-     "end_time": "2026-09-10T22:11:27.623192+00:00",
+     "duration": 2.980217,
+     "end_time": "2026-09-13T00:30:40.403889+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:26.518525+00:00",
+     "start_time": "2026-09-13T00:30:37.423672+00:00",
      "status": "completed"
     }
    },
@@ -235,13 +235,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0eb62e7d",
+   "id": "d1d2d0e0",
    "metadata": {
     "papermill": {
-     "duration": 0.007144,
-     "end_time": "2026-09-10T22:11:27.637925+00:00",
+     "duration": 0.014091,
+     "end_time": "2026-09-13T00:30:40.436931+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:27.630781+00:00",
+     "start_time": "2026-09-13T00:30:40.422840+00:00",
      "status": "completed"
     }
    },
@@ -255,19 +255,19 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "61eecce1",
+   "id": "f119e8ff",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T22:11:27.651606Z",
-     "iopub.status.busy": "2026-09-10T22:11:27.651106Z",
-     "iopub.status.idle": "2026-09-10T22:11:27.656660Z",
-     "shell.execute_reply": "2026-09-10T22:11:27.656022Z"
+     "iopub.execute_input": "2026-09-13T00:30:40.468420Z",
+     "iopub.status.busy": "2026-09-13T00:30:40.467556Z",
+     "iopub.status.idle": "2026-09-13T00:30:40.481318Z",
+     "shell.execute_reply": "2026-09-13T00:30:40.479586Z"
     },
     "papermill": {
-     "duration": 0.012825,
-     "end_time": "2026-09-10T22:11:27.657028+00:00",
+     "duration": 0.031412,
+     "end_time": "2026-09-13T00:30:40.482995+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:27.644203+00:00",
+     "start_time": "2026-09-13T00:30:40.451583+00:00",
      "status": "completed"
     }
    },
@@ -315,13 +315,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bbbf199a",
+   "id": "dcbe962e",
    "metadata": {
     "papermill": {
-     "duration": 0.005245,
-     "end_time": "2026-09-10T22:11:27.667966+00:00",
+     "duration": 0.012706,
+     "end_time": "2026-09-13T00:30:40.510703+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:27.662721+00:00",
+     "start_time": "2026-09-13T00:30:40.497997+00:00",
      "status": "completed"
     }
    },
@@ -335,19 +335,19 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "0aa19c0b",
+   "id": "df62b1e8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T22:11:27.681204Z",
-     "iopub.status.busy": "2026-09-10T22:11:27.680922Z",
-     "iopub.status.idle": "2026-09-10T22:11:27.692609Z",
-     "shell.execute_reply": "2026-09-10T22:11:27.691871Z"
+     "iopub.execute_input": "2026-09-13T00:30:40.542711Z",
+     "iopub.status.busy": "2026-09-13T00:30:40.541230Z",
+     "iopub.status.idle": "2026-09-13T00:30:40.588290Z",
+     "shell.execute_reply": "2026-09-13T00:30:40.583505Z"
     },
     "papermill": {
-     "duration": 0.019232,
-     "end_time": "2026-09-10T22:11:27.693425+00:00",
+     "duration": 0.066957,
+     "end_time": "2026-09-13T00:30:40.591568+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:27.674193+00:00",
+     "start_time": "2026-09-13T00:30:40.524611+00:00",
      "status": "completed"
     }
    },
@@ -359,19 +359,19 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "b9142317",
+   "id": "cd1ee034",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T22:11:27.706604Z",
-     "iopub.status.busy": "2026-09-10T22:11:27.706401Z",
-     "iopub.status.idle": "2026-09-10T22:11:27.733723Z",
-     "shell.execute_reply": "2026-09-10T22:11:27.733066Z"
+     "iopub.execute_input": "2026-09-13T00:30:40.627192Z",
+     "iopub.status.busy": "2026-09-13T00:30:40.626535Z",
+     "iopub.status.idle": "2026-09-13T00:30:40.861741Z",
+     "shell.execute_reply": "2026-09-13T00:30:40.860160Z"
     },
     "papermill": {
-     "duration": 0.034438,
-     "end_time": "2026-09-10T22:11:27.734310+00:00",
+     "duration": 0.255408,
+     "end_time": "2026-09-13T00:30:40.863714+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:27.699872+00:00",
+     "start_time": "2026-09-13T00:30:40.608306+00:00",
      "status": "completed"
     }
    },
@@ -434,13 +434,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1cac4233",
+   "id": "a8d84bc2",
    "metadata": {
     "papermill": {
-     "duration": 0.004905,
-     "end_time": "2026-09-10T22:11:27.745247+00:00",
+     "duration": 0.012255,
+     "end_time": "2026-09-13T00:30:40.890898+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:27.740342+00:00",
+     "start_time": "2026-09-13T00:30:40.878643+00:00",
      "status": "completed"
     }
    },
@@ -453,14 +453,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "41645cff",
+   "id": "cd7dbd78",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.004827,
-     "end_time": "2026-09-10T22:11:27.757112+00:00",
+     "duration": 0.009247,
+     "end_time": "2026-09-13T00:30:40.924525+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:27.752285+00:00",
+     "start_time": "2026-09-13T00:30:40.915278+00:00",
      "status": "completed"
     }
    },
@@ -474,19 +474,19 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "758e496d",
+   "id": "5c7317d2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T22:11:27.773217Z",
-     "iopub.status.busy": "2026-09-10T22:11:27.773033Z",
-     "iopub.status.idle": "2026-09-10T22:11:27.775991Z",
-     "shell.execute_reply": "2026-09-10T22:11:27.775539Z"
+     "iopub.execute_input": "2026-09-13T00:30:40.952551Z",
+     "iopub.status.busy": "2026-09-13T00:30:40.952154Z",
+     "iopub.status.idle": "2026-09-13T00:30:40.959554Z",
+     "shell.execute_reply": "2026-09-13T00:30:40.958046Z"
     },
     "papermill": {
-     "duration": 0.010561,
-     "end_time": "2026-09-10T22:11:27.776291+00:00",
+     "duration": 0.025757,
+     "end_time": "2026-09-13T00:30:40.960837+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:27.765730+00:00",
+     "start_time": "2026-09-13T00:30:40.935080+00:00",
      "status": "completed"
     }
    },
@@ -507,19 +507,19 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "0cb9dbf3",
+   "id": "679c8db8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T22:11:27.788921Z",
-     "iopub.status.busy": "2026-09-10T22:11:27.788665Z",
-     "iopub.status.idle": "2026-09-10T22:11:27.791718Z",
-     "shell.execute_reply": "2026-09-10T22:11:27.791223Z"
+     "iopub.execute_input": "2026-09-13T00:30:40.991279Z",
+     "iopub.status.busy": "2026-09-13T00:30:40.990887Z",
+     "iopub.status.idle": "2026-09-13T00:30:40.999405Z",
+     "shell.execute_reply": "2026-09-13T00:30:40.996680Z"
     },
     "papermill": {
-     "duration": 0.010449,
-     "end_time": "2026-09-10T22:11:27.792101+00:00",
+     "duration": 0.02593,
+     "end_time": "2026-09-13T00:30:41.000768+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:27.781652+00:00",
+     "start_time": "2026-09-13T00:30:40.974838+00:00",
      "status": "completed"
     }
    },
@@ -551,13 +551,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "85da75cd",
+   "id": "599b5a34",
    "metadata": {
     "papermill": {
-     "duration": 0.006068,
-     "end_time": "2026-09-10T22:11:27.807903+00:00",
+     "duration": 0.013524,
+     "end_time": "2026-09-13T00:30:41.030592+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:27.801835+00:00",
+     "start_time": "2026-09-13T00:30:41.017068+00:00",
      "status": "completed"
     }
    },
@@ -571,13 +571,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "90a6b0d7",
+   "id": "102882e7",
    "metadata": {
     "papermill": {
-     "duration": 0.00526,
-     "end_time": "2026-09-10T22:11:27.819641+00:00",
+     "duration": 0.013045,
+     "end_time": "2026-09-13T00:30:41.058671+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:27.814381+00:00",
+     "start_time": "2026-09-13T00:30:41.045626+00:00",
      "status": "completed"
     }
    },
@@ -590,14 +590,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d3932902",
+   "id": "540ff2be",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.005536,
-     "end_time": "2026-09-10T22:11:27.830776+00:00",
+     "duration": 0.013867,
+     "end_time": "2026-09-13T00:30:41.086778+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:27.825240+00:00",
+     "start_time": "2026-09-13T00:30:41.072911+00:00",
      "status": "completed"
     }
    },
@@ -611,20 +611,20 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "b2c4b9c1",
+   "id": "9d9228a7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T22:11:27.844986Z",
-     "iopub.status.busy": "2026-09-10T22:11:27.844785Z",
-     "iopub.status.idle": "2026-09-10T22:11:27.848794Z",
-     "shell.execute_reply": "2026-09-10T22:11:27.848066Z"
+     "iopub.execute_input": "2026-09-13T00:30:41.121329Z",
+     "iopub.status.busy": "2026-09-13T00:30:41.120833Z",
+     "iopub.status.idle": "2026-09-13T00:30:41.126884Z",
+     "shell.execute_reply": "2026-09-13T00:30:41.125863Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.011723,
-     "end_time": "2026-09-10T22:11:27.849233+00:00",
+     "duration": 0.02509,
+     "end_time": "2026-09-13T00:30:41.127855+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:27.837510+00:00",
+     "start_time": "2026-09-13T00:30:41.102765+00:00",
      "status": "completed"
     }
    },
@@ -653,14 +653,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b9192497",
+   "id": "ed7b5c5d",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.005296,
-     "end_time": "2026-09-10T22:11:27.861793+00:00",
+     "duration": 0.007375,
+     "end_time": "2026-09-13T00:30:41.145999+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:27.856497+00:00",
+     "start_time": "2026-09-13T00:30:41.138624+00:00",
      "status": "completed"
     }
    },
@@ -674,20 +674,20 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "266f711e",
+   "id": "60cfea8b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T22:11:27.873172Z",
-     "iopub.status.busy": "2026-09-10T22:11:27.872937Z",
-     "iopub.status.idle": "2026-09-10T22:11:27.881343Z",
-     "shell.execute_reply": "2026-09-10T22:11:27.880645Z"
+     "iopub.execute_input": "2026-09-13T00:30:41.160594Z",
+     "iopub.status.busy": "2026-09-13T00:30:41.160377Z",
+     "iopub.status.idle": "2026-09-13T00:30:41.165291Z",
+     "shell.execute_reply": "2026-09-13T00:30:41.164563Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.014671,
-     "end_time": "2026-09-10T22:11:27.881748+00:00",
+     "duration": 0.01318,
+     "end_time": "2026-09-13T00:30:41.165744+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:27.867077+00:00",
+     "start_time": "2026-09-13T00:30:41.152564+00:00",
      "status": "completed"
     }
    },
@@ -742,14 +742,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3d4267cc",
+   "id": "dd49b15d",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.005125,
-     "end_time": "2026-09-10T22:11:27.893011+00:00",
+     "duration": 0.005825,
+     "end_time": "2026-09-13T00:30:41.178455+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:27.887886+00:00",
+     "start_time": "2026-09-13T00:30:41.172630+00:00",
      "status": "completed"
     }
    },
@@ -763,20 +763,20 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "f0e9606d",
+   "id": "6379eeab",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T22:11:27.904559Z",
-     "iopub.status.busy": "2026-09-10T22:11:27.904399Z",
-     "iopub.status.idle": "2026-09-10T22:11:27.908233Z",
-     "shell.execute_reply": "2026-09-10T22:11:27.907502Z"
+     "iopub.execute_input": "2026-09-13T00:30:41.230783Z",
+     "iopub.status.busy": "2026-09-13T00:30:41.229950Z",
+     "iopub.status.idle": "2026-09-13T00:30:41.245033Z",
+     "shell.execute_reply": "2026-09-13T00:30:41.243389Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.010632,
-     "end_time": "2026-09-10T22:11:27.908749+00:00",
+     "duration": 0.049341,
+     "end_time": "2026-09-13T00:30:41.246419+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:27.898117+00:00",
+     "start_time": "2026-09-13T00:30:41.197078+00:00",
      "status": "completed"
     }
    },
@@ -808,14 +808,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c6a8d130",
+   "id": "280bdd24",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.005201,
-     "end_time": "2026-09-10T22:11:27.921039+00:00",
+     "duration": 0.014942,
+     "end_time": "2026-09-13T00:30:41.273385+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:27.915838+00:00",
+     "start_time": "2026-09-13T00:30:41.258443+00:00",
      "status": "completed"
     }
    },
@@ -828,19 +828,19 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "82c293ac",
+   "id": "ae8a8b47",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T22:11:27.934181Z",
-     "iopub.status.busy": "2026-09-10T22:11:27.933969Z",
-     "iopub.status.idle": "2026-09-10T22:11:27.937583Z",
-     "shell.execute_reply": "2026-09-10T22:11:27.936882Z"
+     "iopub.execute_input": "2026-09-13T00:30:41.303239Z",
+     "iopub.status.busy": "2026-09-13T00:30:41.302939Z",
+     "iopub.status.idle": "2026-09-13T00:30:41.307145Z",
+     "shell.execute_reply": "2026-09-13T00:30:41.306437Z"
     },
     "papermill": {
-     "duration": 0.011346,
-     "end_time": "2026-09-10T22:11:27.938159+00:00",
+     "duration": 0.020418,
+     "end_time": "2026-09-13T00:30:41.308058+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:27.926813+00:00",
+     "start_time": "2026-09-13T00:30:41.287640+00:00",
      "status": "completed"
     }
    },
@@ -855,13 +855,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ab1aafea",
+   "id": "3b5972f9",
    "metadata": {
     "papermill": {
-     "duration": 0.007634,
-     "end_time": "2026-09-10T22:11:27.953691+00:00",
+     "duration": 0.012608,
+     "end_time": "2026-09-13T00:30:41.332957+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:27.946057+00:00",
+     "start_time": "2026-09-13T00:30:41.320349+00:00",
      "status": "completed"
     }
    },
@@ -891,20 +891,20 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "id": "8f1ec29c",
+   "id": "cd76cd05",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T22:11:27.968408Z",
-     "iopub.status.busy": "2026-09-10T22:11:27.968190Z",
-     "iopub.status.idle": "2026-09-10T22:11:27.971577Z",
-     "shell.execute_reply": "2026-09-10T22:11:27.970932Z"
+     "iopub.execute_input": "2026-09-13T00:30:41.357675Z",
+     "iopub.status.busy": "2026-09-13T00:30:41.357302Z",
+     "iopub.status.idle": "2026-09-13T00:30:41.361595Z",
+     "shell.execute_reply": "2026-09-13T00:30:41.361056Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.011029,
-     "end_time": "2026-09-10T22:11:27.972239+00:00",
+     "duration": 0.018354,
+     "end_time": "2026-09-13T00:30:41.362440+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:27.961210+00:00",
+     "start_time": "2026-09-13T00:30:41.344086+00:00",
      "status": "completed"
     }
    },
@@ -921,14 +921,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "45301068",
+   "id": "a69aa485",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.005731,
-     "end_time": "2026-09-10T22:11:27.984532+00:00",
+     "duration": 0.005489,
+     "end_time": "2026-09-13T00:30:41.378302+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:27.978801+00:00",
+     "start_time": "2026-09-13T00:30:41.372813+00:00",
      "status": "completed"
     }
    },
@@ -941,20 +941,20 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "id": "d78ef527",
+   "id": "f84282f7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T22:11:27.999506Z",
-     "iopub.status.busy": "2026-09-10T22:11:27.999224Z",
-     "iopub.status.idle": "2026-09-10T22:11:28.004078Z",
-     "shell.execute_reply": "2026-09-10T22:11:28.003313Z"
+     "iopub.execute_input": "2026-09-13T00:30:41.392636Z",
+     "iopub.status.busy": "2026-09-13T00:30:41.392398Z",
+     "iopub.status.idle": "2026-09-13T00:30:41.404450Z",
+     "shell.execute_reply": "2026-09-13T00:30:41.398043Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.013004,
-     "end_time": "2026-09-10T22:11:28.005434+00:00",
+     "duration": 0.022393,
+     "end_time": "2026-09-13T00:30:41.406776+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:27.992430+00:00",
+     "start_time": "2026-09-13T00:30:41.384383+00:00",
      "status": "completed"
     }
    },
@@ -994,14 +994,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "41b07cbb",
+   "id": "24d962da",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.005295,
-     "end_time": "2026-09-10T22:11:28.020035+00:00",
+     "duration": 0.016919,
+     "end_time": "2026-09-13T00:30:41.442266+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:28.014740+00:00",
+     "start_time": "2026-09-13T00:30:41.425347+00:00",
      "status": "completed"
     }
    },
@@ -1014,20 +1014,20 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "id": "b1a51b7b",
+   "id": "9d5ff541",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T22:11:28.039068Z",
-     "iopub.status.busy": "2026-09-10T22:11:28.038819Z",
-     "iopub.status.idle": "2026-09-10T22:11:28.042922Z",
-     "shell.execute_reply": "2026-09-10T22:11:28.042098Z"
+     "iopub.execute_input": "2026-09-13T00:30:41.478261Z",
+     "iopub.status.busy": "2026-09-13T00:30:41.477560Z",
+     "iopub.status.idle": "2026-09-13T00:30:41.489431Z",
+     "shell.execute_reply": "2026-09-13T00:30:41.487307Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.013525,
-     "end_time": "2026-09-10T22:11:28.043569+00:00",
+     "duration": 0.033731,
+     "end_time": "2026-09-13T00:30:41.492078+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:28.030044+00:00",
+     "start_time": "2026-09-13T00:30:41.458347+00:00",
      "status": "completed"
     }
    },
@@ -1047,14 +1047,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3e593cfa",
+   "id": "a4385f17",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.005642,
-     "end_time": "2026-09-10T22:11:28.055352+00:00",
+     "duration": 0.015114,
+     "end_time": "2026-09-13T00:30:41.524040+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:28.049710+00:00",
+     "start_time": "2026-09-13T00:30:41.508926+00:00",
      "status": "completed"
     }
    },
@@ -1067,19 +1067,19 @@
   {
    "cell_type": "code",
    "execution_count": 17,
-   "id": "80a7e30f",
+   "id": "2733f52c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T22:11:28.068054Z",
-     "iopub.status.busy": "2026-09-10T22:11:28.067391Z",
-     "iopub.status.idle": "2026-09-10T22:11:28.074965Z",
-     "shell.execute_reply": "2026-09-10T22:11:28.074361Z"
+     "iopub.execute_input": "2026-09-13T00:30:41.562499Z",
+     "iopub.status.busy": "2026-09-13T00:30:41.561366Z",
+     "iopub.status.idle": "2026-09-13T00:30:41.581345Z",
+     "shell.execute_reply": "2026-09-13T00:30:41.577416Z"
     },
     "papermill": {
-     "duration": 0.014813,
-     "end_time": "2026-09-10T22:11:28.075717+00:00",
+     "duration": 0.041586,
+     "end_time": "2026-09-13T00:30:41.583094+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:28.060904+00:00",
+     "start_time": "2026-09-13T00:30:41.541508+00:00",
      "status": "completed"
     }
    },
@@ -1112,19 +1112,19 @@
   {
    "cell_type": "code",
    "execution_count": 18,
-   "id": "d1914f96",
+   "id": "08b5e297",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T22:11:28.095506Z",
-     "iopub.status.busy": "2026-09-10T22:11:28.095229Z",
-     "iopub.status.idle": "2026-09-10T22:11:28.119070Z",
-     "shell.execute_reply": "2026-09-10T22:11:28.118117Z"
+     "iopub.execute_input": "2026-09-13T00:30:41.619534Z",
+     "iopub.status.busy": "2026-09-13T00:30:41.618862Z",
+     "iopub.status.idle": "2026-09-13T00:30:41.729754Z",
+     "shell.execute_reply": "2026-09-13T00:30:41.727947Z"
     },
     "papermill": {
-     "duration": 0.033709,
-     "end_time": "2026-09-10T22:11:28.119606+00:00",
+     "duration": 0.129765,
+     "end_time": "2026-09-13T00:30:41.730796+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:28.085897+00:00",
+     "start_time": "2026-09-13T00:30:41.601031+00:00",
      "status": "completed"
     }
    },
@@ -1180,13 +1180,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "59064c73",
+   "id": "9bf4d7c4",
    "metadata": {
     "papermill": {
-     "duration": 0.010882,
-     "end_time": "2026-09-10T22:11:28.137145+00:00",
+     "duration": 0.017344,
+     "end_time": "2026-09-13T00:30:41.770324+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:28.126263+00:00",
+     "start_time": "2026-09-13T00:30:41.752980+00:00",
      "status": "completed"
     }
    },
@@ -1210,13 +1210,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1b17c335",
+   "id": "a0e5f567",
    "metadata": {
     "papermill": {
-     "duration": 0.010187,
-     "end_time": "2026-09-10T22:11:28.157743+00:00",
+     "duration": 0.013559,
+     "end_time": "2026-09-13T00:30:41.799412+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:28.147556+00:00",
+     "start_time": "2026-09-13T00:30:41.785853+00:00",
      "status": "completed"
     }
    },
@@ -1232,19 +1232,19 @@
   {
    "cell_type": "code",
    "execution_count": 19,
-   "id": "7e594bae",
+   "id": "1973ad08",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T22:11:28.180036Z",
-     "iopub.status.busy": "2026-09-10T22:11:28.179695Z",
-     "iopub.status.idle": "2026-09-10T22:11:28.185290Z",
-     "shell.execute_reply": "2026-09-10T22:11:28.184591Z"
+     "iopub.execute_input": "2026-09-13T00:30:41.837583Z",
+     "iopub.status.busy": "2026-09-13T00:30:41.836764Z",
+     "iopub.status.idle": "2026-09-13T00:30:41.851707Z",
+     "shell.execute_reply": "2026-09-13T00:30:41.850012Z"
     },
     "papermill": {
-     "duration": 0.017791,
-     "end_time": "2026-09-10T22:11:28.185909+00:00",
+     "duration": 0.041192,
+     "end_time": "2026-09-13T00:30:41.856162+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:28.168118+00:00",
+     "start_time": "2026-09-13T00:30:41.814970+00:00",
      "status": "completed"
     }
    },
@@ -1293,13 +1293,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6dba7ed7",
+   "id": "a7eade43",
    "metadata": {
     "papermill": {
-     "duration": 0.01008,
-     "end_time": "2026-09-10T22:11:28.207356+00:00",
+     "duration": 0.020017,
+     "end_time": "2026-09-13T00:30:41.893676+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:28.197276+00:00",
+     "start_time": "2026-09-13T00:30:41.873659+00:00",
      "status": "completed"
     }
    },
@@ -1314,19 +1314,19 @@
   {
    "cell_type": "code",
    "execution_count": 20,
-   "id": "8665ba2a",
+   "id": "3c55369a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T22:11:28.229626Z",
-     "iopub.status.busy": "2026-09-10T22:11:28.229348Z",
-     "iopub.status.idle": "2026-09-10T22:11:28.237039Z",
-     "shell.execute_reply": "2026-09-10T22:11:28.236489Z"
+     "iopub.execute_input": "2026-09-13T00:30:41.928154Z",
+     "iopub.status.busy": "2026-09-13T00:30:41.927429Z",
+     "iopub.status.idle": "2026-09-13T00:30:41.940274Z",
+     "shell.execute_reply": "2026-09-13T00:30:41.938967Z"
     },
     "papermill": {
-     "duration": 0.019425,
-     "end_time": "2026-09-10T22:11:28.237633+00:00",
+     "duration": 0.032906,
+     "end_time": "2026-09-13T00:30:41.942877+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:28.218208+00:00",
+     "start_time": "2026-09-13T00:30:41.909971+00:00",
      "status": "completed"
     }
    },
@@ -1351,13 +1351,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2db2103a",
+   "id": "6ffbef52",
    "metadata": {
     "papermill": {
-     "duration": 0.010965,
-     "end_time": "2026-09-10T22:11:28.255747+00:00",
+     "duration": 0.014431,
+     "end_time": "2026-09-13T00:30:41.975709+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:28.244782+00:00",
+     "start_time": "2026-09-13T00:30:41.961278+00:00",
      "status": "completed"
     }
    },
@@ -1373,19 +1373,19 @@
   {
    "cell_type": "code",
    "execution_count": 21,
-   "id": "ff76ebb7",
+   "id": "4c992003",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T22:11:28.280206Z",
-     "iopub.status.busy": "2026-09-10T22:11:28.280006Z",
-     "iopub.status.idle": "2026-09-10T22:11:28.283513Z",
-     "shell.execute_reply": "2026-09-10T22:11:28.282831Z"
+     "iopub.execute_input": "2026-09-13T00:30:42.011957Z",
+     "iopub.status.busy": "2026-09-13T00:30:42.011047Z",
+     "iopub.status.idle": "2026-09-13T00:30:42.023046Z",
+     "shell.execute_reply": "2026-09-13T00:30:42.020483Z"
     },
     "papermill": {
-     "duration": 0.015968,
-     "end_time": "2026-09-10T22:11:28.283943+00:00",
+     "duration": 0.032569,
+     "end_time": "2026-09-13T00:30:42.025028+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:28.267975+00:00",
+     "start_time": "2026-09-13T00:30:41.992459+00:00",
      "status": "completed"
     }
    },
@@ -1409,13 +1409,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5f657205",
+   "id": "289a5a08",
    "metadata": {
     "papermill": {
-     "duration": 0.009435,
-     "end_time": "2026-09-10T22:11:28.302132+00:00",
+     "duration": 0.016183,
+     "end_time": "2026-09-13T00:30:42.059585+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:28.292697+00:00",
+     "start_time": "2026-09-13T00:30:42.043402+00:00",
      "status": "completed"
     }
    },
@@ -1430,19 +1430,19 @@
   {
    "cell_type": "code",
    "execution_count": 22,
-   "id": "e0cd3185",
+   "id": "fff99c6f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T22:11:28.323850Z",
-     "iopub.status.busy": "2026-09-10T22:11:28.323675Z",
-     "iopub.status.idle": "2026-09-10T22:11:28.327399Z",
-     "shell.execute_reply": "2026-09-10T22:11:28.326902Z"
+     "iopub.execute_input": "2026-09-13T00:30:42.102672Z",
+     "iopub.status.busy": "2026-09-13T00:30:42.100752Z",
+     "iopub.status.idle": "2026-09-13T00:30:42.125895Z",
+     "shell.execute_reply": "2026-09-13T00:30:42.123722Z"
     },
     "papermill": {
-     "duration": 0.014432,
-     "end_time": "2026-09-10T22:11:28.327937+00:00",
+     "duration": 0.050071,
+     "end_time": "2026-09-13T00:30:42.128681+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:28.313505+00:00",
+     "start_time": "2026-09-13T00:30:42.078610+00:00",
      "status": "completed"
     }
    },
@@ -1476,20 +1476,20 @@
   {
    "cell_type": "code",
    "execution_count": 23,
-   "id": "f7af2331",
+   "id": "0afc40ab",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T22:11:28.344588Z",
-     "iopub.status.busy": "2026-09-10T22:11:28.343855Z",
-     "iopub.status.idle": "2026-09-10T22:11:28.350068Z",
-     "shell.execute_reply": "2026-09-10T22:11:28.349524Z"
+     "iopub.execute_input": "2026-09-13T00:30:42.173636Z",
+     "iopub.status.busy": "2026-09-13T00:30:42.173127Z",
+     "iopub.status.idle": "2026-09-13T00:30:42.180199Z",
+     "shell.execute_reply": "2026-09-13T00:30:42.179037Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.014667,
-     "end_time": "2026-09-10T22:11:28.350421+00:00",
+     "duration": 0.029945,
+     "end_time": "2026-09-13T00:30:42.181413+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:28.335754+00:00",
+     "start_time": "2026-09-13T00:30:42.151468+00:00",
      "status": "completed"
     }
    },
@@ -1507,14 +1507,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "91338a72",
+   "id": "f8ccd288",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.007931,
-     "end_time": "2026-09-10T22:11:28.366190+00:00",
+     "duration": 0.007596,
+     "end_time": "2026-09-13T00:30:42.199814+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:28.358259+00:00",
+     "start_time": "2026-09-13T00:30:42.192218+00:00",
      "status": "completed"
     }
    },
@@ -1530,19 +1530,19 @@
   {
    "cell_type": "code",
    "execution_count": 24,
-   "id": "c07d73ce",
+   "id": "81440aaf",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T22:11:28.385681Z",
-     "iopub.status.busy": "2026-09-10T22:11:28.385520Z",
-     "iopub.status.idle": "2026-09-10T22:11:28.393938Z",
-     "shell.execute_reply": "2026-09-10T22:11:28.393172Z"
+     "iopub.execute_input": "2026-09-13T00:30:42.255390Z",
+     "iopub.status.busy": "2026-09-13T00:30:42.254551Z",
+     "iopub.status.idle": "2026-09-13T00:30:42.272366Z",
+     "shell.execute_reply": "2026-09-13T00:30:42.270647Z"
     },
     "papermill": {
-     "duration": 0.015349,
-     "end_time": "2026-09-10T22:11:28.394320+00:00",
+     "duration": 0.065676,
+     "end_time": "2026-09-13T00:30:42.274202+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:28.378971+00:00",
+     "start_time": "2026-09-13T00:30:42.208526+00:00",
      "status": "completed"
     }
    },
@@ -1584,19 +1584,19 @@
   {
    "cell_type": "code",
    "execution_count": 25,
-   "id": "90e66a93",
+   "id": "d9abc954",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T22:11:28.408342Z",
-     "iopub.status.busy": "2026-09-10T22:11:28.408165Z",
-     "iopub.status.idle": "2026-09-10T22:11:28.437018Z",
-     "shell.execute_reply": "2026-09-10T22:11:28.436256Z"
+     "iopub.execute_input": "2026-09-13T00:30:42.299018Z",
+     "iopub.status.busy": "2026-09-13T00:30:42.298554Z",
+     "iopub.status.idle": "2026-09-13T00:30:42.332634Z",
+     "shell.execute_reply": "2026-09-13T00:30:42.331576Z"
     },
     "papermill": {
-     "duration": 0.035999,
-     "end_time": "2026-09-10T22:11:28.437623+00:00",
+     "duration": 0.047023,
+     "end_time": "2026-09-13T00:30:42.333439+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:28.401624+00:00",
+     "start_time": "2026-09-13T00:30:42.286416+00:00",
      "status": "completed"
     }
    },
@@ -1631,13 +1631,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b274e28e",
+   "id": "294eaa9c",
    "metadata": {
     "papermill": {
-     "duration": 0.00714,
-     "end_time": "2026-09-10T22:11:28.454737+00:00",
+     "duration": 0.006954,
+     "end_time": "2026-09-13T00:30:42.347907+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:28.447597+00:00",
+     "start_time": "2026-09-13T00:30:42.340953+00:00",
      "status": "completed"
     }
    },
@@ -1652,19 +1652,19 @@
   {
    "cell_type": "code",
    "execution_count": 26,
-   "id": "211fd552",
+   "id": "44752d62",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T22:11:28.471263Z",
-     "iopub.status.busy": "2026-09-10T22:11:28.470962Z",
-     "iopub.status.idle": "2026-09-10T22:11:28.479550Z",
-     "shell.execute_reply": "2026-09-10T22:11:28.478962Z"
+     "iopub.execute_input": "2026-09-13T00:30:42.374854Z",
+     "iopub.status.busy": "2026-09-13T00:30:42.374523Z",
+     "iopub.status.idle": "2026-09-13T00:30:42.386218Z",
+     "shell.execute_reply": "2026-09-13T00:30:42.385406Z"
     },
     "papermill": {
-     "duration": 0.016635,
-     "end_time": "2026-09-10T22:11:28.479855+00:00",
+     "duration": 0.024436,
+     "end_time": "2026-09-13T00:30:42.387066+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:28.463220+00:00",
+     "start_time": "2026-09-13T00:30:42.362630+00:00",
      "status": "completed"
     }
    },
@@ -1715,13 +1715,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "63267806",
+   "id": "9637153c",
    "metadata": {
     "papermill": {
-     "duration": 0.005449,
-     "end_time": "2026-09-10T22:11:28.491190+00:00",
+     "duration": 0.009207,
+     "end_time": "2026-09-13T00:30:42.403797+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:28.485741+00:00",
+     "start_time": "2026-09-13T00:30:42.394590+00:00",
      "status": "completed"
     }
    },
@@ -1738,19 +1738,19 @@
   {
    "cell_type": "code",
    "execution_count": 27,
-   "id": "6419aa49",
+   "id": "9547aca3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T22:11:28.505999Z",
-     "iopub.status.busy": "2026-09-10T22:11:28.505829Z",
-     "iopub.status.idle": "2026-09-10T22:11:28.510470Z",
-     "shell.execute_reply": "2026-09-10T22:11:28.509933Z"
+     "iopub.execute_input": "2026-09-13T00:30:42.573348Z",
+     "iopub.status.busy": "2026-09-13T00:30:42.573024Z",
+     "iopub.status.idle": "2026-09-13T00:30:42.580578Z",
+     "shell.execute_reply": "2026-09-13T00:30:42.579679Z"
     },
     "papermill": {
-     "duration": 0.011846,
-     "end_time": "2026-09-10T22:11:28.511202+00:00",
+     "duration": 0.102798,
+     "end_time": "2026-09-13T00:30:42.581418+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:28.499356+00:00",
+     "start_time": "2026-09-13T00:30:42.478620+00:00",
      "status": "completed"
     }
    },
@@ -1792,13 +1792,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4e7f4562",
+   "id": "1730ca5d",
    "metadata": {
     "papermill": {
-     "duration": 0.006912,
-     "end_time": "2026-09-10T22:11:28.527186+00:00",
+     "duration": 0.013733,
+     "end_time": "2026-09-13T00:30:42.614815+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:28.520274+00:00",
+     "start_time": "2026-09-13T00:30:42.601082+00:00",
      "status": "completed"
     }
    },
@@ -1812,19 +1812,19 @@
   {
    "cell_type": "code",
    "execution_count": 28,
-   "id": "20a58cd4",
+   "id": "0e278503",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T22:11:28.543905Z",
-     "iopub.status.busy": "2026-09-10T22:11:28.543675Z",
-     "iopub.status.idle": "2026-09-10T22:11:28.547891Z",
-     "shell.execute_reply": "2026-09-10T22:11:28.547419Z"
+     "iopub.execute_input": "2026-09-13T00:30:42.655774Z",
+     "iopub.status.busy": "2026-09-13T00:30:42.655083Z",
+     "iopub.status.idle": "2026-09-13T00:30:42.669324Z",
+     "shell.execute_reply": "2026-09-13T00:30:42.666379Z"
     },
     "papermill": {
-     "duration": 0.01437,
-     "end_time": "2026-09-10T22:11:28.548253+00:00",
+     "duration": 0.038275,
+     "end_time": "2026-09-13T00:30:42.671640+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:28.533883+00:00",
+     "start_time": "2026-09-13T00:30:42.633365+00:00",
      "status": "completed"
     }
    },
@@ -1849,19 +1849,19 @@
   {
    "cell_type": "code",
    "execution_count": 29,
-   "id": "1a01dc45",
+   "id": "aa70f457",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T22:11:28.564588Z",
-     "iopub.status.busy": "2026-09-10T22:11:28.564431Z",
-     "iopub.status.idle": "2026-09-10T22:11:28.572057Z",
-     "shell.execute_reply": "2026-09-10T22:11:28.571493Z"
+     "iopub.execute_input": "2026-09-13T00:30:42.708700Z",
+     "iopub.status.busy": "2026-09-13T00:30:42.708144Z",
+     "iopub.status.idle": "2026-09-13T00:30:42.716678Z",
+     "shell.execute_reply": "2026-09-13T00:30:42.715208Z"
     },
     "papermill": {
-     "duration": 0.016789,
-     "end_time": "2026-09-10T22:11:28.572529+00:00",
+     "duration": 0.027013,
+     "end_time": "2026-09-13T00:30:42.718381+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:28.555740+00:00",
+     "start_time": "2026-09-13T00:30:42.691368+00:00",
      "status": "completed"
     }
    },
@@ -1885,19 +1885,19 @@
   {
    "cell_type": "code",
    "execution_count": 30,
-   "id": "fe41b9ba",
+   "id": "38486ab8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T22:11:28.587676Z",
-     "iopub.status.busy": "2026-09-10T22:11:28.587485Z",
-     "iopub.status.idle": "2026-09-10T22:11:28.593793Z",
-     "shell.execute_reply": "2026-09-10T22:11:28.593175Z"
+     "iopub.execute_input": "2026-09-13T00:30:42.740260Z",
+     "iopub.status.busy": "2026-09-13T00:30:42.739933Z",
+     "iopub.status.idle": "2026-09-13T00:30:42.753329Z",
+     "shell.execute_reply": "2026-09-13T00:30:42.751886Z"
     },
     "papermill": {
-     "duration": 0.013579,
-     "end_time": "2026-09-10T22:11:28.594375+00:00",
+     "duration": 0.025091,
+     "end_time": "2026-09-13T00:30:42.755112+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:28.580796+00:00",
+     "start_time": "2026-09-13T00:30:42.730021+00:00",
      "status": "completed"
     }
    },
@@ -1955,13 +1955,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0ebf1f5e",
+   "id": "20fec14b",
    "metadata": {
     "papermill": {
-     "duration": 0.008362,
-     "end_time": "2026-09-10T22:11:28.609096+00:00",
+     "duration": 0.020006,
+     "end_time": "2026-09-13T00:30:42.796723+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:28.600734+00:00",
+     "start_time": "2026-09-13T00:30:42.776717+00:00",
      "status": "completed"
     }
    },
@@ -1978,13 +1978,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dd859813",
+   "id": "7988e9cf",
    "metadata": {
     "papermill": {
-     "duration": 0.008414,
-     "end_time": "2026-09-10T22:11:28.932411+00:00",
+     "duration": 0.014047,
+     "end_time": "2026-09-13T00:30:43.389454+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:28.923997+00:00",
+     "start_time": "2026-09-13T00:30:43.375407+00:00",
      "status": "completed"
     }
    },
@@ -1999,26 +1999,26 @@
   {
    "cell_type": "code",
    "execution_count": 31,
-   "id": "06213e62",
+   "id": "063c633d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T22:11:28.946843Z",
-     "iopub.status.busy": "2026-09-10T22:11:28.946636Z",
-     "iopub.status.idle": "2026-09-10T22:11:29.271300Z",
-     "shell.execute_reply": "2026-09-10T22:11:29.270364Z"
+     "iopub.execute_input": "2026-09-13T00:30:43.419766Z",
+     "iopub.status.busy": "2026-09-13T00:30:43.419279Z",
+     "iopub.status.idle": "2026-09-13T00:30:43.770075Z",
+     "shell.execute_reply": "2026-09-13T00:30:43.769125Z"
     },
     "papermill": {
-     "duration": 0.332464,
-     "end_time": "2026-09-10T22:11:29.272111+00:00",
+     "duration": 0.368583,
+     "end_time": "2026-09-13T00:30:43.770786+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:28.939647+00:00",
+     "start_time": "2026-09-13T00:30:43.402203+00:00",
      "status": "completed"
     }
    },
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAkgAAAH1CAYAAAANogGZAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjksIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvJkbTWQAAAAlwSFlzAAAPYQAAD2EBqD+naQAApK1JREFUeJzs3XV0VEcfxvHvJiGKhASCh0ASCO7u7k5pabGihVKkWIu1FLfiFHcpxUqRIsW1uLsHC4EQLLKRff8I7EuWBCmLlD6fczhkr8zMvXvv7m9n5s4YjMZwEyIiIiJiZvO+CyAiIiLyoVGAJCIiImJBAZKIiIiIBQVIIiIiIhYUIMlL5ShcBde0uWjbuc87yWfwyF+skt4V/+u4ps2Fa9pcbN+1zyppvq5q9Vu80rmz9rG/yPZd+8zn5Yr/9bee38di8MhfzOftn7D2eX/b18y/4TqZ/9uKD76ML2L5Hv4bzvl/iQKkJ55+kcX1b9XaTa+czvv+Un6XX7QfiqdfXDkKV4m13MHenvx5cpA/Tw4SJUr4nkr3anJmy0z+PDlIkyrF+y6KvKG2nfvgmjYX1eq3eKv56Jr5+CRKlND8meVgb/++i/OfZ/e+C/ChsbdPQM5sfrGWJXVN8tbyMxojsLdP8NbSf9/e5/GlTJGcv1bOey95v67500e/7yLIv8yrXjMf8mfMh1y29yF3jixW/czS+X0zqkGykMIj5kv12X/FCucjMjKSstU+xzVtLmp+2gqAqKgoylX/Ate0uaj+SQvm/rqcXEWqmtOq0aBlrF+ST2upWnfoSZ/+P+OTqzT5S9UEYMLUuRSv2ACvbCVI5pUP75yladSyM+cvXo5VvgsXr9Dy6+/IlKcsyTPkI2v+CvTuP9Jcc+V/7QYAQ0dNeq45YP/Bo3zS+Gs8sxYnhXcBSlb+lBWrNsRK/+q1G9T5vA0pvAuQr0QNVv658ZXO27NVw7+vWk/Zap+TPEM+Fv++BoCz5y/RtE1XvHOWJnmGfBQsXZvpc357YZqhoWF83qITOYtUIbVvITwy5idv8RoMHD4BozHCfE6HjpoEgP+1G+YyzP9tRby1ebv3HqTuF1/hmaUYHhnzU7B0bcb+MouoqCjzNk9r4n4YOIpuvQaRIXtJfHKVpkffoURGRpq3W7hkJcUrNiBt5iKkzVyEgqVr07pDz+eOxWQyMXLcNPzylSd9tuK0/uZ7Hj56/Fx+cVW1r1m/hSp1m5HCuwB5ilV/7j2Ly6EjJ2jYvCMZspfEI2N+chWtyrjJs+PdfvO23VSp2wyfXDHvTzq/olSp24wNm3bE2m7c5NkUKFWLVD6F8MxSjGIVPqFP/5/N69dv3E6Fmo3xzFqcVD6FyFOsOl+27UZw8APzNhs27aBqveakzVyElN4FqVK3Gdt27n2tfOLy46DRFC5bB8+sxUnmlQ+/fOX5qlNvbgUEmrd5trbx91XrKVCqFql9C1Gl3pecu3DZvJ3JZGLAsPFkyF4Sz6zF6dZ7MBERES/MH2Lex4WL/wBg55798dYmnz13iRoNWpLSuyAFStVi7V9bY69/hfvlRddMXPegpYDbd2jV/nsy5y2HR8b8ZMpTlhoNWrJ+4/bntn1Rea/fCOCTxl+TrUBFUnoXJKV3QYqUq8vEafMwmf4/zN7T8vbp/zNfd+mLZ9bi1P3iKwDCw40MGjGRvMVrkDxDPnxylebrLn25G3QvVjkmz1hAlnzlSe1biFbtv+fBg0cvfD+e2nfgKDU/bUWG7CVJ4V2AHIWr8HmLTly67A/EXQsdV3PXs7WDU2f9SvZClUnhXYD6jdpx7cYt875PP+vbdOzFoBETyZSnLKl9C9G8XXeC7z8gPvE1sb3snnn2s27OgmXU/LQVKbwLMHLcNKKioug3eAy5ilYlhXcBvLKVoHTVhoz9ZdYrnbv/MgVIr8jOzo4p4wbh7OTItp17mT1/KROmzOXA4eMkSZKIX0YPwCO5OzmyZTbvk9k3I/nz5MAvU8ZYaf2+aj2TZszHI5k7iRLGNP3s3HOAS5evksIjGZm8vQi+/4BVazdR69PWhIWFA3Dx0lXK1viCJSv+5G5QMBm9PImKjmbL9r/NzUlPfy2kTulhrqoF2LPvEFXqfcmGzTtwcnTAM21qjh4/TdOvurJwyUog5kuhSesubN62h4iISOzs7GjToSe3A++81rlq3aEnN27dJn26NBgMBi5cvEL5mo1ZsXoD0dHR+Gb04tyFy3TpOdAc3MQl3GhkzbrNhIWF450xPcnd3bh4+SrDx0yh/9BxAPhlykjqlB5ATO3f02NO5p40zjS379pHjQat2LR1NzY2NqRLk4qz5y/Rd+AoOn834LntJ06bx5IVa3FydODO3XtMnrGA+YtWAHDs5Bnade7D8ZNn8EieDM+0qblxM4Dflq1+Lp0VqzYwesIMHBzsuX//Ib8tX8PoCTNe6Xx+2bYbgXeCcLC359IVf75s150jx0/Fu/3f+w9TqU5T/ly/hcchIXhn8OThw8fs3nso3n1Onb3A/kPHSJjQhSyZfTCZTOzee4iGzTty7OQZANas30Kf/j9z7sJl0numJmWK5Fy8dJXfV8cEbHfuBtGoVWf2HTxK4kQJyZjBk6DgYJavXM/9hw8BWPbHWho0bc+uvw+QNKkrKVIkY/feQ9T5/CvzB/7L8onPX1t2ceNWIGlTpSCjVzoCbt/h1yUr+bx5x+e2vXnrNq2++R6DwUBoWDi7/z5I+y4/mNdPmbmQEWOnci/4PolcnPl91Xomz1jwwvwhptnL3S3m2kuU0CXeJt4mrbtw42YABoOBcxcu06r999y7dx/gH98vz7K8B+PSpedAFv++hsePQ8iS2Qf7BAnYsXs/Bw4ff27bF5X37r17bNgcE0hn8s1AokQunDpzgZ4/Dmfa7EXPpTV55gKWrVhH2tQpcXJ0BKBxq28ZNnoyV/yvk8knI0ZjBPMXraBa/eaEhoYB8OeGLfToO5SbAYE4Ozuxe+9BBgwb99JzER0dzafNvmHbzr0kSGBHJp8MhIaGsmbd5lhBzevYf+gofQeMwsXZiYiISP7aspMvWnSKFRDCk8/66fNJkjgRIaFhLPtjXazr7FW8yj3zrK69B3H85FkypE+Lra0NU2f9yqgJM7h2/RY+Gb1wS+rKydPnWBdHICwWjMZwk/6FmyrUbGRy9vCL89+z202aPtfk7OFnSumd3+Tumdvk7OFnmr9ouXn9uQsXzftt3LIjzjxc0+YwHTh81GQ0hptCQ0NMRmO46ejxk6bHjx+Zt12/cas5nQ2btpmMxnBTq296mJw9/ExJ0mQ3bd/1t3nbfQcPm//OnLesydnDz9Rv8OhYeVesFZN3tfrNTCEhj01GY7ipS88BJmcPP5NvrlImozHctGHTNnOek6bPfW5Zi6+7x3v+Nm7ZYd6uaetvTWFhoebja9m+u8nZw8+Uv0R1U/D9YJPRGG4aM3GGydnDz+Tumdt0NygozrI/fvzIdPT4yVj5NPuqS6wyG43hpn6DR5ucPfxMmfOWjbVtXO9F+RpfmLe9HRhoMhrDTd9+39/k7OFnckmRxXT23IVYZcmSv5wp8M4d04MHD0zeOUqYnD38TI1adjQZjeGmxctXm5w9/Ew5C1eKdbybt+167j1PkTGf6fKVq6awsFBT0fJ1Tc4efqaSlT6J93179nz26jfMZDSGm/yvXTel8i0Qqwxx/atUu7HJ2cPPlMq3gOnk6TMmozHcFBYWar7mnk373IWLJqMx3HT+4iXz+TAaw023bweaUmTMZ3L28DP1HTjSZDSGm0aOm2Jy9vAzVa3XzLzdw4cPzdfi3v2HzMd6//59k9EYbgoPDzPt2XvAdC/4nsloDDf55Ys5ztbffGcKDw8zhYeHmRo0aWdy9vAzlave8JXyie/foSPHze+D0RhumjZrofk4z5w9H+tacfbwM61Yvc5kNIabuvYaYF72tNy+uUqZyxQS8tgUfD/YlKtI5Tg/Eyz/tfg65nqvULNRvPdIt94DTUZjuOn3VevMy9as22QyGsP/8f3yonswrnLmL1Hd5OzhZ5r36zLzsqv+10zHT55+rfIG3rljvo6eXmtP77On7+mz5U3nV8R08fIVc9k2bd1pTvPpvXPV/5r583Xa7IUmozHcVK56Q5Ozh58pW4EKpqB790yhoSHmz7Vnr2XLf7cCAszbXL5y1bz8yLETpus3bsT7GRLXffL0vU2cOrvpyLETJqMx3DR5xrznzsnT+z6VbwGT/7XrJqMx3NSr3zDzdk/P8Yvew6d5vso98+xnXYWajUwPHjwwn9+O3X80OXv4mb7q2NN8bEH37pn27D3wwutY/8JN6oNkIa4+SM9q3rgBf67fav7FVLdmJT6pUzXe7eNSokgBcmSNqWmytbUFwP/aTTr1+IkTp87x6HFIrF8iN2/dBuDAoWMAFCucn0L5c5vX58qe5aV5Hnzyq3Dztj0k88oXa931mwHcuBnAqTPnzctqVi0PQKnihUjqmoR7wfdf+fhaf9kQGxsb8/E9zfvkmfOk9i0ca9vQsDBOnDpL4QJ5nkvHxsaG35atZsXqDfhfv2luVgO4+Uyzyes4dOQEABXLFsc1SWIAPqldhUnT52MymTh87CRe6dOat69SoTRJEicCIL1nGm4GBHI78C4AhQvkxjVJYs5fvEKGHCXxyZCeHNky80mdas/lW6JYQVI/6UybyduLw0dPcvvO3Vcqc71aMdX+KTySUaJIAVat3cTJ0+fi3f7pdVKragV8MnoBMefy6TUXF6PRSLtv+7J3/2GC7t0nOjravO7WrZhzXa5UUfoPHceW7XvwzlkaX+/05MqRlS8+rQWAXyZvvNKn5fKVa/jmLkPGDJ5k9fOlZtXy5M2dnTt3g7jqH9MEPG/R78xb9HusMux/Uu6X5ROfYydO0+7bPpy/cJnHIaGx1t0MCCSDVzrz68SJE1GlQumYcvt6m5cH3g3CNUlirt8MAGLefzs7O+zs7KhYrkSsZrg38Wm96k/y/n/t8tPr4Z/eL8+yvAfjUrlCKU6eOU/bzn0YPPIXMvl4Uaxwfpo1qv9a5bWzs2XsL7NYt3E7twICYzVBx3Wf1qxajrSpU5rLdvCZGqtq9Zs/t/3+g8do0rAup85cAKBc6aIkdHEGoEaVcuzYvf8FZwLckrpSMF8u9h44Qt7iNcjolY4sfj5ULFvitT+7n8rq50OWzD5AzP35tPb55OlzlC9TzLxdiSIFSOGRzLzdqCe1xidPnyOTT4aX5vOq98yzmjeuj6OjAxBzfiuXL8m02YuYs3AZGzZtxztjevLnyUHTz+u95lH/9yhAsvC0D1J8jMYIbt3+/01/1f8GUVFR8X4IxSV5cvdYry9fucYXLTthNEaQKKELuXNmJTIykmMnYpo2op75snpTqVN6mL+onxX5TP+bN5U8uVucy93dkpLhmeDjKVubuM/dqAkz+Hn8dADSpU1NiuTu3LgZwI1bt2N9gb9NT4MjAFvbmNvlaeyawiMZezYtY9HSVRw+dpKTp88za/5S5ixczvrfZ5M/b86407GLnc6HoEGTb7h4+Sp2dnZk9fPF0cGeoydOYzRGmK+/rH6+7Nm4jMW/r+Ho8dMcP3WWPfsWMHfhMv7e8jvp0qRiy5qFLFq6igOHjnH63EUWLV3Fr0tWMmvScIoXyW/Ozyt9WpK5Pd8MajRGvFI+lnbvPUjbzn0wmUy4JXUls29GHoeEcubcRYBY/cvA8v34//Vn2UTytjzN/0V5v+798qz47sFn9enxDYUK5Gbjll2cOnOeXX8fZN3G7ezYvZ/f5ox/5fJ+/8Nw5ixcBoB3Bk+Suibh0pVr3A26R1TU8/dp8mTuzy176mmXgGd5eMS//ata8esUFv++hr/3H+bM2YusWP0XS1esJeD2HTq0bWZuhox+5jp58PDV+je9Ky+6Z55leX7LlS7G1rW/smLVBo6fPMPR46fZsXs/Cxb/wcEdq8zBpjxPAdJrGjh8PMdOnCFNqhSEhRvZf+gYI8ZOpUfnmM6Gzk6O5m1DQkPjTMOyT8CR46fNF/nS+b9QMF8ulq74kxZffxdru3x5cnD67EV27tnP/oNHzV/Ax06eMdcOPM0/xOIXdJ5c2dm5Zz/p0qbm94WTcXqy3fUbARw+dhLPtKnNv4gAVv25iWaN6rNt597Xqj2K6/jy5MrO6bMXSZwoIYvnTCBp0pinAu8G3WPrjr8pkC9nXMmw7+BRAHwypmf/tj+Iioqi4ZcdufGkRu2pp8ccGhqKyWSKt89FTFmysevvA6zftIPg+w9wTZKYJSvWmsudO0fWVz7Om7duczcomI7tvjQvK1i6NmfPX2L3vkOxAqQ3sXzlOrJnzUTgnbvmX8tZ/Xzj3T5fnhxs37WPP9b8Rad2X5Ixgycmk4kTp86RPWum57YPuhfMxctXAejZtR3ftm/BFf/rFCxdO9Z2Fy5ewcbGxnytG40R+OQqzYOHjzh4+ARJEifi7PlLtP6yIYbmnwNQ74u2bNy6i517DlC7ekXSpU2N/7Ub5MqehekThmD3JFg8f/Ey/tduYm+f4KX5xBUg7T90zPyFveuvJaRMkZxR46fTb8jY1znVACROlJA0qVJw/WYAf/61lXatGmGMiHiuw3p8zPdgPPf/y/zT++VZL7oHntqz7xDFCuenUrmSAObPnF1/H3it8u5/cp+WLVWEZfMnERYWTvmajZ/rYB1f2fLkymb+u3P7FlSrVAaAyMhItmz/G18fLwCyZPZm995DbNq6m8chITg6OLzSECwmk4m9B47wRYNaNGlYNyaf7/ozc94Sdv59gA5tm5E8WUxAGXg3iPsPHpIkcSJWvKDP28nT5zlz7iKZfTOy/I915uWW9+WO3fu5HXgXj+TuLF/5/+2e/ax9kWTubq90zzzL8vweP3mWZG5J6dPjGyCmc37mvOW4HXiX8xcukzvnq3/m/dcoQLIQcDuQ8jUaxVrWrlUj6taszM49Bxg3eQ4AY4b9wIOHD2nergfDx0ylYtkS5MmVjWTubrgldSXoXjBtOvTCO4MnDepWo82TL4y4ZMnsja2tLVFRUdRv1I60qVMSEPh880uX9i1ZtXYT9+8/pFKdZvh6p+f+/Ye4u7uxY33MEy6+3l6cOXeRyTMXsGPPfrJk9mbiz/3p2bUdtT5rzd/7D5M5X3nSp0vN3bv3uBkQSNFC+ahWqQwlixUkZ3Y/jh4/zbc9BzJpxnwuX7lOggR2REREPleeV/Vt+xasXruJS1f8yVawIt4Z03Mv+AE3b90mdaoU1K1ZOc79smfJxLq/tnH+4hVyFqlCZEQkoU86rD/L90lV9Z2798hfsiZJXZMwbfwQDDbPf0l836UtdT7/Cv9rN8hdtBrubq5cuBQTHDT+rE6s5rWXOXPuIrUbtiGZe1JSpvDg4aNHXLka8+RJthcEMK9r0vT5/LHmLwIC7/LgwUNsbGzo0PbLeLfv3b09NRq0JPj+AwqXq4tPhvQEBN6lUIHcLIjj0fCkrknMAcHgkRNZsnwNN27dxs7WlmfP9s49B+jQvR8pUyTHI7k7gYF3efDwEba2tvhlysidO0FUrNUE1ySJSZ0qBREREeYmqexZYgKzvj2+odU337Ni9QZ27tlPqpQeBNy+w+3AuzT8pCZlShZ5aT5xeZo+QNHy9UnmnpTAO0Gvfa6fat+mKd//OIzdfx8kV5GqRERGcv/Bw1fa19fbC4hpzi1arh7Ozk6s/G3aK+f9T++X19Vv8BgOHjlBmlQpSZw4IWfPXQIgW5bng+gXyZYlEyfPnGfT1t3kL1mTe8EPXquGt0TRApQrVZSNW3fxRYtO+Hp7YWtrg/+1mzwOCWXlb9NIny4N7ds0ZffeQ1y8fJXcRavh4OBA4Cs0U0dFRVHrs9YkSuhCmtQpsDHYcPpJzeLT66ZE0QLY2NhgNEZQsvKnJHVNwtHjp+NN08E+AaWrNCS9Z2rOnr8MQI5smSlXumis7SIiIshfsiYpPJKZ74WqlcqQ2Tfu6zgur3LPvMjvq9Yzctw00qRKgbt7Uq5dj+mY7uzk+Fqfd/9FeorNgtEYwf5Dx2L9u3X7Dg8ePuKrTr2Jjo6m0ae1KV+mGHVrVqZ29YpERkbSukNPQkPDMBgMjBnWl4xenjx89JgDh4/jf/3mC/PM5JOB8SP7kd4zDUZjBG5urkyfMOS57TJm8GTTyvnUr1UFt6RJzF/spYoXNG/Tu3t7CuTNiY3BhkNHTnDydEy/omKF87Fm6QwqlCmOwRDz5W6XwI6aVcvzzVdNgJhfHnOn/kyp4oWws7MlNCyccSN+JGUKjzc6p77eXqxfMYfa1Svi5OTE6bMXMEVHU750UXp1bRfvft9+04KGn9QkSZJEPHz4mLq1KtOiaYPntqtcviRNP6+HW9KYYGf/oWPx/novUbQAK3+bSpmShYmOjubqtRtk8slAv56dGDWk92sdl5dnWurVqkyihAm5cPEKd+/eI3vWzIwZ2peypYq+PIFXNHvySJIncyc8PByv9GmZPmEIuXPE3++sUP7crFs+m8oVSuHi7My5i5dxcXGiSDz9VgwGA3OmjCRvrmzY2tgSFR3N1HGDcbOozs+Z3Y/qlcuSIEECzpy7yOPQMArkzcmsScPJ7JsRt6SufN6gJh7J3bnqf53rN26RyScDfb/rQJPPY365f1KnKotmj6NY4fyEhYVz/sIVErq48Fn9GjRpWOeV8olLmZJF6NezE6lSJCcsLAxfby9+Htzrn5xuANo0b0jnr5vjmiQxDx4+olK5knz1gh85z2r0WR1qVi1P4sSJOHnmPPsPHXutZvJ/er+8rjo1KpEnZzYePnrEydPnSJIkEfVqVWZaHJ89LzLwh65UrVSGhC7OPHocQoevmlK5QqnXSmP+9NF079QG7wyeXL56jYDbd8nkm5GuHVuR1S+mtqVapTIM+rEbKTyS8ehRCHlyZqV3t/YvTdvW1pbmjT/BM10abtwK5OJlfzzTpeabNk3p3qkNEPMZPHpoHzzTpSYg4A7uSV0ZOej54Tqeyp0zG0N/6sHjkDASJLCjbKkizJ8++rnam5rVKtChbTPuP3iIk6MjtatXZMKIfq91bl7lnnmRooXyUr50MaKjozl15jwmk4mSxQqyeO5Ecz9MiZvBaAz/gHpCiAg8HY6gJQBHdq8hfbo077lEItK2cx8WLv6DYoXzs3rJ9Hi3q1a/BTv37KfhJzX5ZVT/d1hCsSbVIImIiIhYUIAkIiIiYkEBksgHqETRAgRfO0LwtSMfTfPauk07adXp9fpfvI4VazZTveHXlK3VgjNPOs6KvKl7wQ9o330Q5eq0JKl7chbNmUjqtJ7m9XWadGLrrpinS59e46uXTCf42hE1r/3L6Sm2Z+w9eJwZ85Zx9sKVJwPr+fLVlw3I/OQx03ftyImzjBg3i7mTBn1Q5bt67SYTpv/K8VPnMRojyJA+DV+3bEiubPE//VKkUiMcHOyxedKJMU2qFObjisvnrXpw6/b/pziJjIoiQQI7Ni6PeRqo/4jJrN+8iwRPHnl1S5qEz+pWoX7NCvGmOW3uUs5duMrQHzu/1vFa6j9iMgldnOnctvEbpfMi7boNoGSR/HxW1zpPLFkqUqkRsycOJJN3+reS/sEjJ+nRbzQblk0xL6tUthiVyhZ7wV7/XGRkJD//Mocxg3qQO0f8A72+bUZjBJNmLWb95p2EhISRKmVyRvTrQqqUyYH/39P+N27hmSYl3b75khxZY554vHP3HkPHzuD02UvcCQp+6fsTGRXF1NlLWL9lN/fvP8TZ2ZHMPhn46fuvcXF2AuDCZX+GjJ7Bxcv+JHRx5rO6lWlYL/bgiM/eSzY2NnimTcVXzT6hYL7nxySKiIjkhyETOHXuErcC7jDkh06UKpo/1jYvOsZXWf+sVzknW3ftZ/zUhQTevUdmHy++79QSL8/U8Z63Ok060emrRuZynzxzgS59RtC4QQ0+r//8wJG/r9mEjY0NG5ZOMQ++Gd91/DavcXn3FCA9sX33AX4YMpGObRoxckA3oqKiWb56I+26DmDiiN7vJUjauecgxYvk+eDK9/BRCEUK5OK7ji1InCghq9ZtpUvv4SyZ9TOuSRLFu9+UUT+88hfygqlDY73u2nckydxcYy2rW728OUg5eeYC7bsPihl1+QWB2rsSGRWF3WsMHvqhiYyMNI+38m9wN+g+RmME3hnSxbneZDIRHW3C1vbtVpoPGDmFcKORmeMHkMzNlSv+N0mYMGYgvvsPHtGt7wi+btGQKuWL8+dfO+jadyRLZo0kUUIXbGxsKJw/J80a1qZlx5fP1zV30Ur2HjzOhGE9SZ3Sg6Dg++z8+3CsbUaMm0Umn/T8MrI3jx+HcuXJqMyWnt5LkVFR/LZ8Hd/9NJoV88eSKKHLc9vmzJaZBrUr8cOQic+te9kxvmy9pZedkyv+N/hxyC/079meAnmzMXvhH/To9zPzpwx9pftv36Hj9Ow/lo5tvqB6pbifvLtxK5AM6dOYgyP57/j3fAK+RSaTiVG/zKPxpzWoVbWMeXnTz2py7UYA46cuZNzQ75m7aCVnL1yhf8+YR0ubfd0bOztbpo2JaTb4/qcx5Mjqy+f1qxIZGcmM+b+zfvMuHj4KIWc2X7p3aE7yJ5OoFqnUiG7ffMnSPzZwK/AOeXNm4YfubWONarpjzyF6d239wZUvm5832fz+Pz1DraplmDD9V85fukr+3P8f9M1aAu/eY8++I0we1TfebbJm9sbLMw2Xrlx75QDpRcdoNEYwbNxMduw5SGRkFCmSu9OrSyuOnzrPuk27MBhg5dotpPRIxoKpQ2nXbQBZM3tz7sIVjp44x089v2bh0jWxaoHOXrhC03a92L0uZqT2iIhIZi6IeQ/uBT8gZYpk9O3ahnWbdnHk+BmOnzrPlNmLyZU9M6MGdn+u/CGhYUycvogdew5iNEZQKH9OunzdhIQuzoybuoCTZy4yYVhPbGxs2LR9LyMnzGbupEF07TMSgNad+2FjMNDks5pUKlOUuk070+vbVsxauIKQ0DDWLJrI+GkL2bh1Dw8ePsYjuRstG9ejXMlC5jKcPneJ8VMXcvbCFWxtbShfqjAtG9elc+/hGI0RlK3VAoCfB3Tj+s3bLFq+ljm/xNQcBt27z8gJszl49BQO9vZULleMlk3qYWdra66B+qZVQ6bPW05YuJEalUvRvmXD587DmfOX+erbmKaMWl90wC1pEpbM+pk6TTpRu2pZtu8+wLmLV5k+9icc7BMwcsJsTp65SOJELtSvWdH8/qxev41Fy9dSvHBelq36C1tbWzp/1Zjkyd0YNmYGAYF3KVOiIN93ahHnl+XFy9fYvvsgK+aPJXGimC/7Z2sytu7aT3J3N/M9XKtqGRYtX8vWnfupXqkUbkmTUK9G/DWglo6fOk+JInnNkzW7uSahhsWXvK2tLak8kmFna0uSxAnJ+ZJ7w87WltrVyjJu6gKu37yNn2/s6TASJLAzny+bOILNlx3jy9Zbetk5WbtpJ3lzZaF44Zgfks2/qM2SP9Zz5NgZ8uV+8QCIW3buY8CIKfTu0prSxQvEuU3PAWPZtuuA+X7v1LYxtjY2sa7jZz29hp6uq9OkE/Wql2fLzn1cunKdTD5e/Ni9LSmejA5+8fI1Bo2ayqUr1/HzzUCWzBk5eeYCE4f3xmQyMXH6Itb8tZ2w8HDck7rSofUX5mOVt08BEjFNRjcDAqlY5vmxayqWKULnXsMJNxrJmysrvy6PGXX5wcPHBN69R2RkFI9DQnF2cuTg0VM0+zxmvqhJsxZz+twlJo3sQ5LEifhl5m/0HTSeX0b2Mae9advfjBv2PQns7GjfYxC/LvuTlo1j5se5fvM2Dx89JkumjB9k+Z51/pI/IaFhZPB8cV+ZLr2HExkVhXeGdHzVrAHZs7zaaLJrNmzHK30asvnFvb3JZOL4qfNcvXaT7PFsE5/4jnHNX9s5f/Eqi2eOJKGLM/7Xb+Fgb0+D2pU4c/5ynE1sa9ZvZ/hPXciaOSPhxggWLl3zwrwnzviVw8fOMGpgd9KmTsHVazext7enQ5svOH3+0kub2AaOnIKtrS1zJw3Czs6WwaOmMXLCbH7o3pavmjWgded+zFywgqoVSjBk9HT692yPm2sSZoz7iSKVGsWq0bv5ZL617XsOMnN8f3PTpW9GTz6vX5UkiRKxafvf/DRsElkyZSB1Sg9u3wmiffdBtG3egJEDumKKNnH63CWSJE7EqAHdnmtiu34z9gjofYdMwD2pK0tnj+L+g0d06T0cR0cHmjWMuUZDQkO5dPU6v80cwc1bgXzZvi9FC+Qib67YX3yZfbxYMGUIdZt2fq7WY82GbQz78VvSpk4ZM4bZV99Tokhehv7YGf9rt+jcaxhJXRNTqWzMvXXx8jWqVyrFql8nsGbDdoaMmU6hfDmYOKIXxohImrbrxbZdB+L8Qj107BSpUiRj8uzFbNr2NwldnKlVpQyNGsTMY3bh0lV8vT1j7ePrnZ7zl/xfcJXEL2e2TPz2+zqcnZzIlT0Tvt7pn6s1yZU9M9PmLcPXOz2F4mgysxQZGcmyVX/h7OxIutTPT0n0Mi87RmufgwsX/WPVStvZ2eHlmYbzl66+MEBat2kX+w4eZ1CfjhTMmz3e7Qb17vBck/rq9dteq4xrN+1k2I+dcXdz5fufxjBlzhL6dG1DZGQk3X/8mSrli/PLiD6cvXCZLn1GkNErZvDGvQePs37zLmZNGEBy96Tcun3nuWlF5O1SnSEQ/CBmzp1k7q7PrUvunpSoqCgePHyMn28GwsONXLpynYNHT5I7e2ZyZPXlyPEznL1wBYBM3ukxmUwsW/kXHVt/QTL3pCRIYEebZvU5evIsAbf/P/LrF59Uw801CYkSulCmWEFOn7tsXrd990GKFcqDwWD4IMv31MNHj+k7aDxNP6uJu0UT2LPGD+3J0tmjWDZnFEUL5KZjzyGx+hjFx2QysWrd1ud+GQMsX72RCnVbU7ZWS1p37kfVCiXibWKJT3zHaGdrS0hoGJev3sBkMuGZNpX5V198KpQpQjY/bwwGA44O9i89rt9Xb6ZDmy9IlyYlBoOB9OlSkypFslcq973gB2zZuY+u7ZuRKKELTo6OtGpSn7+27iEqKpoECez46fuvWbT8T7r0Hk6NyqVe6QuyRaO6JEroYp7sslLZYri5JsHW1oYKpYuQPl0qjp2MmSh33cad+PlmoF6NCjjY2+Po6PDK/X9u3wniwOGTdGzzBc5OjqRKkYymDWuxZsP2Z84RtGn6CQ729nh5piFHVt84r8EXqVMtZtR4W1sbTp69yN2gYHOaPhk9qVezAms2/P8Lz9U1EQ1qV8LO1paKpYvwOCSUGpVjJixO7p6UPDn84u0A/uDhYy5dvY6zoyO/zxvD0B86s+j3dfz5V8wUJSGh4SR0id2MlDCh8z+ekqRxg+q0aVqfHX8f5OtuA6nySVsmTv/VPP/Z5u17+WvrHkYN7M6AEZPNHYkBytVuyeWr/29ue3ov1fy8Azv3HGJ4vy64/IM5ul52jNY+ByFhYc/NJZYooTMhoWEv3O/vA0fJkD7NS2vUrKFu9fKkTumBg709lcoW5fSTEcuPnzrP/QePaNqwFgkS2JHNz4dypf4/ObGdrS3GiAguXb5GZGQkKT2S4Zn2+Wl25O1RDRLgmjghAHfuBpMmVexRowPv3sNgMOCaOBG2tjbkyp6ZA0dOcsX/BvlyZcUYEcmBIydxT+pK3pxZMBgM3At+QGhYOG27Dog1sqqdnR0BgXfNX7TPBhSOjg6xPiR2/H2Qz+pU+WDLB/DocQideg4jZ/ZMtGxc94Xn+P+/5hLwef2q/LV1D7v2HqFu9XJ07jWMI8djJuZt8llNcw0CwKGjp7gdGETlcs93fKxTrZz5V93tO0H8OHQiv8z8jXbNP2XomBms27QTiPmS79Hx+VnCX3SMlcsX505QMMPGziQg8C4liuTlm1afv7CPVcrXmFTz3v0HhIWH/6Nf6RAzS3p0tIl6TWN3OLcx2HD3XjAeydxIlyYleXJmYeffhxlfP/5RgZ+VwmIi5YXL/mTln1u4fScIg8FAaGgYwfdjpty4dfsOadP8s/IH3gnC3j4Bbk/mGQNIkyqmVuopF2cnc6AG4BTHNfgyz74ngYFB5h8Ez+b59DqBmGaqp57m/WwZY66RuL98nRwdsbWxoVWTetjbJyCjV1qqVyrJjj0HqVK+OM5ODjx4+DjWPo8fh/zj0YxtbGyoWaUMNauUITIqir0HjvHDkImkTuVB7aplWbD0Tz6vV5U8OfwY8VMXOvUaRliYEa90qUiU0CVW89+z99KbeNkxWvscODs68igkJNayR49DzfPhPW3ihZhm3qcB/Ldtm7B05V906zuS4T91eekPmjfh7hb39XPnbjDubq6xav1SJnfn0pVrQMxnZsvGdZkyZwmXr96gQJ7sfNO6oblJVd4+BUiAZ9pUpEyRjA2bd5uboJ7asGU3ObL6mj9U8+XKysEjJ7l89Qb1a1YgIiKSgT9PxS1pYgrnzwVAksQJcXRwYNqYfi98miI+Dx895sy5yxTIm+2DLB88DY6GkiF9Gnp0aP5Kk2M+y+aZedLi6l/z1B9rt1CyaL5Ys6/HxSOZG2WKF+T3NZto1/xTenRsHm9Q9CrsbG1p1rAWzRrWIujeffoOnsD0ecvo8nXTeI/VYIhdIevk6EhY+P9nM7sbFGz+O2mSxDg6OHDtRgDJ3J+fodvG8OLK3RTJ3bGxMbBywbhYQcSzNm3fy4nT5ylWMDcjxs9iUJ+Oz5Q17mN49n05cvwM0+cuY/ywnmTyTo+NjQ1N2vbk6aTzKT2S8ffBY3GmY3hJh9bkydwwGiMIunffHIDcDAjEI9nLZ6F/Hc/Ox5c8uRt37t6L1QHdmnn6ZoxpOorv3Hpn8GTRkybwp85duMpn9aq8cd52trYULZib/LmzceFJc1VUVCTGiJgmmcy+GRjxU1c69xpKUtfEz32OWMvLjtHa58A7YzrOXbhqfh0ZGcmlK9fxbhJTk7xpRdyjXSdM6MzYId/RqedQuvYZwYifusR7H70tydxj5ux89oGOWxZzcNarUYF6NSrw6HEIw8bO5OeJcxnxU5d3Ws7/MjWxEfOB1rHNF8xZ9Ad/rN1CSGgYDx89Zu6ilazbuIs2Teubt82XKwt/HzzGo5AQ0qdLjXeGdNy+E8Sho6fNHZRtbGyoU60s46bONzdZ3X/wkL+27Hml8uzZf5Q8OfxwsLf/IMv3+HEInXsNI12aVPTs3PKlwdGFy/6cPneJyMhIwo1Gfvt9HZeuXKdw/hc3+Tx89JjNO/bF2bxmKSj4Plt27MPb6/Wa2OKz//AJzl64QmRUFI6ODtjbJ8D2yYeYW9Ik3Lh12zx7fHwy+3ixded+Hj0OISj4PvN+W2VeZzAYqFmlNGOnLMD/+i1MJhNX/G9wM+DOkzwSc/1mQLxpu7u5UrJIfkZMmG2u0bkbFMyWnfuAmNqdoWNm0KfrV/Tt1oazF67w+5r/z3zuljQx12/Enz7A45BQbGxscE2SiGiTiZXrtnLx8jXz+kpli3LqzEWWrdqI0RhBWFg4h4/FTPDp5pqYkNBQgoLvx5m2RzI38uXKyripCwgNC+PW7TvMWriCquVLvLBMbyJb5oy4JU3ClDlLMRojuHDZn8UrNlC1gnXyzJ3Dj7RpUjJ93jIiIyO54n+DNeu3U7JoPgBKFc1P4J0g/li7hYiISP5Yu4U7QcGxHpMPNxoJNxqBmE784UZjvBO/Llz2J3sPHickNAyTycSRE2c5ePSU+ZH5imWKMWfRSo6eOEt0dDRJEifEO4MnV6/dwsnR8R8fp9EYEVNGk4nIyCjCjUZzs97LjvFVzoGlF52TymWLceDwSXbtPYzRGMGshStwTZLolZp6E7o4M2ZQD8KNEXzbZzihYS9ulrO27Fl8SOjiwpxf/yAyMpKTZy6wadvf5vUnz1zg6ImzRERE4mBvj5Ojg/kpzJu3AilSqZG576C8HapBeqJ0sQI49XVk5vzljP5lLqFh4SRNkpgR/bvE6hTq650eWxtb8uaMmSzUYDCQJ4cfh4+fJkP6/3dSbtv8U+YtXkX7HoMIunefxIkTkj93NsqXLvxc3pZ27DlE8SJ5P9jybdm1n+OnznP+oj9bn3whA/To2Nw8BkjZWi3MVdrBwQ8ZPn4WAbfvYm+fAO8Mafl5YPeXVhWv37wL96SuFIinE+WyVX+xcu0WAJycHCmYNwedvvripeV/FUH37jNi/GxuB97FwcGeAnmy0aJRzMSQNSuXpvfAcVSq3waP5O7MmzQ4zjQ+q1uFsxeuUKtRB1ImT0a9mhU4ePSUef3XLT5j2rxldPh+CA8ePCJVyuT06dqGVCmS8WmdyvQfMYUKdVuTM1smRvbv+lz6vbu2ZtrcpTT/pi/3Hz7EzTUJ5UsVpkThfPw4ZCLVKpY09zvq993XdOo5lNzZM+PlmYbWTerz8y9zGTx6Go0aVKdCqednBC+cPydlSxSkUZvvsU+QgMrlipHjmT4bHsndGTvke8ZPXcAvMxaRwM6OCmUKkzuHH+nTpaZGpdJ83qoHUVHRcf7q7fddO0ZOmE2dxp3M/TMaNaj2em/Ua7Czs2PET10YOWE21Rt+TaKELjSsWyXOhx/+CVtbG4b3+5ahY2ZQoW4bkrompkHtSuZ7IknihAzv14Xh42cxcsJsPNOkYni/b81PvAGUrvH/Ws+nj7VPGNbzuY7pENPkOGnmb1y9FjMZdvJkSWn+RW3z8XxapxIGAwz8eQq3A+/h7paEGpVL0+iTavQeOJ6kSRLFOdbRy3zashu3ngTyvQeOi/m/S2uqVSz50mN8lXNg6UXnJH261PzQ4ytG/TKX23eCyOzjxbAfv33lITZcXJwZPag73/Yezre9hjNyQDdz89zbZmdnx7AfOzN49HTm/baKLJkyUqlsMS5fvQ7E/EAZNyXmaUJbW1tyZPWh2zdfAjE1TSlTJCN5sudrn8V6NFltPC5duU67bgPo9FWjdzrwV2RUFNU/+5oFU4bG6vvwoZRPRETejiFjpmOKNvF955Yv3G76vGW4JU1CnWrl3lHJ/pvUxBaPDOnTMLJ/V27euvNOq14fPHxEi0Z1Xxgcwfsrn4iIWMfhY6cJuH2X6Oho9h06zvpNuyj7zDhj8WnRqK6Co3dANUgiIiLvweoN25g0czEPHz3GI5kbn9SqyCe1Kr7vYskTCpBERERELKiJTURERMSCAiQRERERC3rM/wmjMYKRE2az79AJ7j94SDL3pDRqUN08Bs/jxyEMHTuTnXsP4WBvT/2aFWj+Rcxj30HB9xkzaT6Hjp3icUgoaVKloFXjupQoks+cfuDdewweNY1DR0+TJHFCvvy8dqyJZy3NX7yaPzfu4GZAIC7OTpQvVYS2XzaINQrw9HnLWLryL8KNRooXykuPjs3Nj6iOm7qAHXsOcuduMEkSJ6JW1TI0/aymed/+IyazfvMu85xbAGMGf2ceQ0VEROS/TAHSE1HRUbi7uTJ2yHekSeXBidMX+Lb3MDySuVEoXw5GTpzDg4eP+H3uGO4FP6DDd0NI6ZGMqhVKEBoaTibv9Hzd4lOSuSdl597D9B00gRnjfjKPPdR38ATSpPJgzW8TuHj5Gp16DiNd2pTm8YosRUdH07NzSzJ5pyfo3n169BvNtLlLadv8UwBWrdvKyrVbmTSyD0ldE9Nn0Hh+njiH3l1aA2Bvn4DBfTqRPl1q/K/fonPvYSRJnJDaVcua86hbvbxVphcQERH52KiJ7QknR0daN61P2tQpMBgMZM/iQ95cWTly/AxhYeH8tXUPbZp9QqKELnimTUX9WhVYuW4rEDOf0xefVMMjuTs2NjaUKJwXz3QpOX76PADXbgRw9MQZ2jX/FCdHR7L5+VCxbFFWPdk/Lo0/rUHWzN7Y2dnhkdydKuWLc/TEWfP6Veu28kmtinimjZlXqXXT+mzYspuw8JgRZ9s0/YSMXmmxtbXByzM1pYvl58jxs/FlJyIiIs9QgBSPcKORk2cu4JPRkyvXbhIREYmvd3rz+kwZ03Ph0tU49w0Kvs/lqzfweTKz/PlLV3F3c401tlGmjOk5/2TOpFdx6OhpvDN4ml+fv+Qfuzze6TEaI/B/Mqrus0wmE4ePnTGX56k//9pBxXpt+LxVDxYsWRPvlAYiIiL/NWpii4PJZGLwqGmkS52S0sXyc/TEWZwcHWINX58woTMhIc8P0BgREUnfQRMoV7IQWTJlBCA0NJxELrGH0o/Z/9VmJl+xZjNHT55l9oQB5mWhYWEkSuhsfm1nZ4ejQ9wzjU+etZiw8HDq1vj/wGINalWkfcuGJE6UkFNnL9J74DgMNgYa1n3ziTNFRET+7VSDZMFkMjF83CyuXrvJ0B87Y2Njg5OTI2HhRiKjoszbPXocirNz7Dl7IiIi6TlgDA4O9nzf6f9DxTs5OfDocUisbR8/DsHZ2QmAoWNmULZWC8rWasHQMTNibbdu004mz17MmEE9Ys367uToGCvNyKgowsLDn5tHaM6iP/hr6x7GDOoRa4LKzL4ZSOqaGFtbG7Jn8aHxp9XZuPXVJqsVERH52KkG6Rkmk4kR42dx4sx5xg3pSUKXmBqa9GlTYWdny/mLV/HzzQDAuQtXYs0cHxERSa8BY4mIiGTYj9/GetrMJ4Mnd4LuERR8HzfXmGa2sxeumvfv0bE5PTr+f0LGp9Zt2snoSfMYPagHPhk9Y63zyZCOcxeuUiBPdnN57BMkIF3aVOZt5iz6g+WrNzFxeG88kru/8NgNBsXKIiIiT+lb8RkjJszm6IlzjB38XazZpR0dHShXsjBTZi/h0eMQ/K/fYskf66lRuTQAkZGR9B44jtCwcIb+2Bl7+wSx0k2bOgU5s2Zi0szfCAsL58TpC6zfvJMalUvFW5b1m3fx88S5/DygG5l9vJ5bX61SKRavWIf/9Vs8ehzC1DlLqVCmCI4O9gDM+20Vy1ZuZMKwnqRKkey5/f/auofHj0MwmUycOnuRub+tpHTxAv/grImIiHx8NNXIEzcD7lC3SSfsEyTA1vb/cWOlssXo0bH5k3GQZrDz78M42NtTr2YFWjSKGQfp4NFTfN1tIPb2CbC1+f++TT6rSbOGtQC4fSeIwaOmcfjYGRIncqH5F3VeOA5S3SaduX0nCPtnaqJSeiRjwdSh5tfT5i5l2cqNhBuNFCuUhx4dm+PypNmuSKVG2NnZxhrnKFf2zIwa2B2Atl36c/6SP1FRUSRPlpQalUrzef2q2NgoZhYREVGAJCIiImJB1QUiIiIiFhQgiYiIiFhQgCQiIiJiQQGSiIiIiAUFSCIiIiIW/vMBkslkIjIyEpNJD/OJiIhIjP/8SNpRUVGUqNaM7atnYWf3nz8dIh+di5ev0bxDX8LDjbglTcLqXydgNEbQpc8ILlz25+GjxyR0ccY3Y3paNq5LzmyZgJjBWn9fs4kr/jd5+Ogx7m6ulCySj9ZN6uHi4vySXEXk304RgYh8tMLCjfQZNJ7IyKhYy6Oio7gTdI9C+XLg5OjIvkPH2XfoOCfPXGDt4l+ws7Pj7wPHuHrtJnly+GEwGNi8Yx+//b6Oe8H3+en79u/piETkXVGAJCIfrdGT5nIr8A6NG1Rn1sIV5uVOjo4snDrM/Pr0uUt82b4Pj0NCuXf/Icndk9KgVkW+79TCXLM8ZfYSZi74nV17j7zz4xCRd08Bkoh8lDZt38uKNZv5sUc7IiMj49xm+rzl3A0KZt+h4wDUqFyK5O5JAcj8ZGLqpyIiYtJInizpWyy1iHwoFCCJyEfn5q1AhoyeRrWKJalUtiir12+Lc7tV67dyK+AOAMncXCmQJ3uc2+09cIxFv6/F1taWTl81fmvlFpEPx3/+KTYR+fhs232Ah49CuBVwhy59RrBo+VoAHj0KoUufEQQF3wdg+ZzRbP5jBoP7diQo+D59B0/gzLlLsdJauW4rXfqOwMbGhsF9O1IoX453fjwi8u6pBklEPjpPR+04cORkrOXGiAh27T1M0L0HuLkmAcDRwZ4iBXLh6OhASEgY5y/7k9k3AyaTiUkzf2POopW4uyVh6A/fks3P+10fioi8JwajMfw/PQBQZGSkHvMX+citXr+NASOnmB/z/3XZWpb8sZ7sWXxwcnTk8PHTXL56A3v7BCyYMpQ0qTyYPHsxsxbEdOwuVSw/KZK7m9Pr3FbNbCIfO0UEIvKfk9ErLa5JErFr72HCwo24JklEmRIFafRJNdKk8gDgdmCQefutO/fH2l8BksjHTzVIqkGS/7Czy+q+7yLIByZT3WXvuwgiHwR10hYRERGxoABJRERExIICJBERERELCpBERERELChAEhEREbGgAElERETEglUDpFkLVnD6yTD9B4+cpELd1lRp0JZDx05bMxsRERGRt8qqAdLy1RtJlzoFAFPnLKVVk3p83eIzxk1ZYM1sRERERN4qqwZIj0JCcHFx5nFIKOcv+VOvRgWqVyqF//Vb/yi9Veu2UqRSI7buihnFNij4Pp16DuWTL7vwRevvYtVMvWidiIiIyOuwaoDkntSVIyfO8teWPeTM5outrQ0hoWEYDIbXTuvmrUBW/LmF7Fl8zMsmTl9E9iw+LJ45kl5dWvHDkAlERka+dJ2IiIjI67BqgNSiUR3adx/ImMnz+LxeNQD2HTqOb0bP10onOjqaQaOm0eXrJiRI8P/pPzZt+5s61coBkDWzN8ncknLw6OmXrhMRERF5HVadfKxS2WKUKpofAEdHBwByZPUlu5/Pi3Z7zsKlf5IzWyb8fDOYl91/8JDIqCjc3VzNy1KlSEZA4N0XrhMRERF5XVafnTUqKoodfx8m8G4Qyd3dKFYoNwldnF95/wuX/dmycx+/jOht7aKZLfljA0tXbgDAZPpPz9UrIiIicbBqgHTkxFm6//AzbkkTk9IjGQG37/LzxDkM6/ctubJlerU0jp3hZkAgnzTvCkBQ0H2GXplBy8Z1sbWx5W5QsLmm6GbAHVIkdydJ4kTxrotL/ZoVqF+zAgCRkZGUqNbsjY5bREREPi5WDZBGjp/FV19+Yu4LBLBizWZGjJvF3EmDXimNujXKU7dGefPrdt0G8GmdypQqmp8TZy6wfPVGWjaux8kzFwi8e4+8Of0AKFuyYLzrRERERF6HVTtpX795m1pVysRaVr1SKW7cum2V9L9u8RnHTp7jky+7MGDEFH7s3hY7O7uXrhMRERF5HVaNIPLnycae/UcpWjC3edneg8cokDf7P05z4vD/90VyS5qEMYO/i3O7F60TEREReR1WDZASJ0pIzwFjyZcrKylTJONWwB0OHDlJxTJFGDN5nnm7jm0aWTNbEREREauyaoBkio6mfMlCAISHhZM0SSLKlyxEdFQ0Dx8+tmZWIiIiIm+NVQOk3l3bWDM5ERERkffijQOkxyGhuDg7xfz9OCTe7VxeYywkERERkffpjQOkml98w8bl0wCoUK8NltOumUxgMMDOP+e+aVYiIiIi78QbB0gLJg81/7109qg3TU5ERETkvXvjACmFx/9Hq06VItmbJiciIiLy3lm1k/bjkFB+XbaWM+cuERIaFmvd+GE9rZmViIiIyFtj1QDpp2GTCAi8S+niBXBydLBm0iIiIiLvjFUDpINHT/H73NF6Yk1ERET+1aw6F5tHcjcio6KsmaSIiIjIO/fGNUjnL141/12/ZgV6DxxP4wbVcUuaJNZ2Phk93zQrERERkXfijQOkJu16YTDEjHf01IEjJ2Nto3GQRERE5N/kjQOkXWsV+IiIiMjHxap9kCydOX+Z85f832YWIiIiIlZn1QCp+w8/c+T4GQCW/LGB1p370brTjyxbtdGa2YiIiIi8VVYNkI6fOk82P28Alq7cwNgh3zN1zI8sXLrGmtmIiIiIvFVWHQfJGBGBnZ0dt+8E8eDhY3JlywRAUPB9a2YjIiIi8lZZNUDKkD4Ns3/9g1sBdyiULwcQExxpVG0RERH5N7FqE1vX9s3Y+fchrly7QcvGdQH4e/8xCubNYc1sRERERN4qq9YgZfbxYsqoH2Itq1K+OFXKF7dmNiIiIiJvlVUDJIAbt25z9sIVQkLCYi2vWqGEtbMSEREReSusGiAtWr6W8dMWkipFchyf6XdkMChAEhERkX8PqwZIc39byZjB35E3ZxZrJisiIiLyTlm1k3Z0tIlc2TJbM0kRERGRd86qAdIntSqyeMV6ayYpIiIi8s5ZtYlt8459XLpyjflLVuOWNHGsdbMnDLRmViIiIiJvjVUDpE/rVLJmciIiIh+dIaOnc+zUOQJu38VkMpEuTUo+r1+VimWKmrf5+8AxZsxfzoVL/hgMBgrly0HHrxqR3D0pAAePnOTr7oOeS7tG5VL07NzqnR3Lx8yqAVK1CiWtmZyIiMhHZ8Wfm8ns40XZkgU5f9GfU2cv8sOQiSRK6EKRArk4cfoCXfqMwGSKplzJwtwLfsDGbX9z9fotZk8YgMFgMKfl5Zk61mDMObL4vo9D+ihZfRykDVt2s3r9NgLv3CN5sqRUq1iSCqWLWDsbERGRf6VpY34km58PAJFRUXzavCs3bgWyZ/8RihTIxeYde4mKiqJQvhz89P3XREdHU6VBO85duMK23QcoVTS/Oa2smb3p3Lbx+zqUj5rVx0Gat3g19WtWIE1KD24E3Gbc1AXcDbrPZ3UrWzMrERGRf6WnwdFTxohIAJK7uwFgnyABADcDArkX/ICg4PuEhsUMvnz2/JVYAdLm7Xv5a8seEidOSP7c2WjX4lNzM5y8GasGSEv+2MCogd3xyZDOvKxYoTz0+HHUawdIHb8fwt1797ExGHB2cqRzuyZk9vHC//otfho+mfsPHpLQxYneXdqQ0SstwAvXiYiIfEiio6MZNnYGd+7eI2P6tNSpXg6A2lXL8MfazVy9douqn7aLtc/de8ExfxgMeHmmxs83I3Z2tmzffYC1G3dw8Yo/M8f1x8bGqg+p/ydZNUB68PAxXulSxVrmmSYVDx4+fu20BvT6hkQJXQDYsnMfA0ZMYe6kQQwdM4PaVctQrWJJNm3fy4CRk5kxrj/AC9eJiIh8KELDwvhh8ES27zlIJp/0jBrYHRdnJwA8kruzcOowNmzeTUDgXbw807Bmw3b2Hz5BUteYJ8Tz5PBj4dRh5vTOXahIk3a9OHv+Clev3cLLM/V7Oa6PiVVDzCyZMjBlzlIio6IAiIqKZvq8ZWTNnPG103oaHAE8fhyKwQBBwfc5de4ilcoVA6BM8QIEBAbhf/3WC9eJiIh8KALv3qNtlwFs33OQ4oXz8MuIPri5Jom1jZOjA3VrlKdt80/JmjkjR0+cBTB3yL52I4Do6Gjz9qZn9jVGRLz1Y/gvsGoNUtf2zejadyS/r95IMrek3Am6R1LXJIz4qcs/Sq/fsEkcPHISgJEDunE7MIhkbq7Y2doCYDAYSJHcnYDAuyQMcY53Xbo0Ka1zgCIiIm+oZYcfuH0nCBdnJ1KlSM7kWYuBmA7XlcoWJTIqilqNOlIgTzYMBht27DmIMSKC0sUKkCeHHwCzFq7g4NFT5Mjii4ODPdt3HwDAN6NnrG4u8s9ZNUBKmzoF8ycP4fjp8wTeCcIjmRtZ/bzNQcvr+qH7VwCs3rCNidN/pXXT+lYp55I/NrB05QYATCbTS7YWERGxntt3ggB4HBIaa/aJqhVKUKlsUWwMBrzSpWbX3sOEhIaT0sOdz+pWpulnNc3bliyaj4DAu+w7dJyQkDCSubtSqWxRvvy8jvofWYnVH/O3tbUhV7ZMVk2zWoWSDBs7E49kbtwJCiYyKgo7W1tMJhMBgXdJkdwdFxeneNdZql+zAvVrVgAgMjKSEtWaWbW8IiIi8dm9bt4L19vY2DBheK8XblOqaP5YT7OJ9b1xgPTDkIn0+y6ml32PfqNiDWD1rCF9O71ymg8fPSYs3Gh+VHHrrv0kSZyQpK6JyezjxbqNO6lWsSSbd+zDI5mbuQntRetEROTf42Cvoi/fSP5z8g7c9c7yeuMA6dnH6DN5p3/T5AB49DiUXgPGEm40YmOwwTVJIkb81BWDwUCPDs0ZMHIKs3/9AxdnJ3p1aW3e70Xr5O14lSHzIaZZc/nqjVy7HoCDgz0Z06dhQK9vSOaelJDQMCZOX8TOvw8SdO8BTk4O+PlmoFWT+mTz835PRyYiIv9lBqMx3GqdcG4H3sUjjiat+JZ/CJ42sW1fPQs7O6u3OH70ilRqRGYfLzL5pDcPmQ/w84BuFCmQC4BxUxewYMkaXJydKF44D/b2CTh99hL9e7YnfbrUDB8/i2Ur/yKhizPlShbixOkLnL90lSSJE7L614nY2qo9/W05u6zu+y6CfGAy1V32vosAqAZJ4vavqkF6VsPWPdi4fNpzyxt91ZP1SydbMyv5QLxsyPybtwL5ddmfJEhgx/Sx/Uif7vmxOa49GYqhRqVSdGjzBSdOX6Blxx+4/+ARj0NCSZzI5bl9RERE3ibrVpnEURcVbjTG2y9J/v1eNmT+vkPHiY424eaakCGjp3P63GWSubvySa2KNKhdCYAGtStx+PgZVq7bSkhoGCdOX8DGxkDjBjUUHImIyHthlQCpSbteGAwQboyg6dexe97fDQomd47M1shGPmDxDZkfFPwAgDtBwbi7uVKmRAE2bNnNqF/mkjiRC5XLFSdrZm8K5s3Ojj2HWPHnZgDSp0tNwbzZ39vxiIjIf5tVAqRP61QCEwwbN9NcKwBgY7DBLWkS8uXOao1s5AP1oiHz3ZL+f3TYnwd2w801CTY2Nqxev42tOw9QuVxxho2dyY49hyhboiC9u7bm7/3H+L7/GLr0Gcnv80aTJHGi93VoIiLyH2WVAKlahZIA+Hqnt9qTbPLvEHj3Ht36juTM+csUL5yHft99jbOTo3m9b0bPePd1cnIA4Oq1mwBk8vHCydGR7Flimu3CwsO5GXBHAZKIiLxzVu2DlMk7PaFhYZy/6E/wg4fwzCjVJYrks2ZW8oF42ZD5WTJlpHD+nOzZf5Rvew3HO0M61m/ehY2NgeoVYwLr3Dn9uHjlGnMXreTGzducPn8JgKRJEuPlmea9HZuIiPx3WTVAOnjkJD0HjCU62kRISCjOzk6EhoXhkcxNAdJH6mVD5gP0++5rxk1dwPbdB7h67SaZvL1o/kVt8uaKaXr9pmVDHOzt2bpzH2s37sTF2YkiBXLRptknODrYv/uDEhGR/zyrBkjjpy2kyac1YwYKrNea9UsnM33ecpwcHayZzb+Oa9pc77sI79ypE8cYOXpinOsOHtjP0mW/v3D/Xbt2MmPWi4fj/zcLvnbkfRdBRERewKoj8F29dotP61QG/t+61rhBdRYtX2vNbERERETeKqsGSE5OjoQbjQAkdU3MtRsBhIUbeRQSYs1sRERERN4qqzax5c+dlc079lKtQknKlihIp55DsbOzo2CeHNbMRkREROStsmqA9EP3tua/2zT7BC/P1ISEhFG1QglrZiMiIiLyVr212VkNBgOVyxV/W8mLiIiIvDVvHCCNmfxqTxp1bNPoTbMSEREReSfeOEB6+PCxNcohIiIi8sF44wCpd9c21iiHiIiIyAfD6n2Q/K/fYuPWv7kTFEzX9k254n+DiIhIfF4wJ5eIiIjIh8Sq4yBt33OQ5t/05bL/df7cuB2Ah49CGDd1gTWzEREREXmrrBogTZr5GyP7d+XHHu2wtYlJOpN3es5duGrNbERERETeKqsGSIF3gsiZLdOTVwYA7OxsiYqOtmY2IiIiIm+VVQOkdGlScfDoqVjLDh87jZdnamtmIyIiIvJWWbWTdptmn/Bdv9FUr1iSiIhIfpmxiNUbtvHTd19bMxsRERGRt8qqNUgF82Zn4vBeGCMiyZsrCw8fhfDzgO7kzZXVmtmIiIiIvFVWf8zfJ6MnXds3jbVs0/a9lC1R0NpZiYiIiLwVVguQ/K/f4vzFq6RLmwqfDOmAmMf+p8xawp2gewqQRERE5F/DKgHSuk27GDByMolcXHjw8BFd2jflwOGTHDlxloZ1q1CnellrZCMiIiLyTlglQJr720oG9upAyaL52Ljtb/oN+4Uq5YqzeOZIHB3srZGFiIiIyDtjlU7aAbfvUrJoPgDKFC+AyWSic7smCo5ERETkX8kqAVK06f8DQdrY2ODk6KjgSERERP61rNLEFh4ewXc/jTa/Dg0Li/UaYEjfTtbISkREROSts0qA9OXntWK99s3oaY1kRURERN4LqwRILRrVtUYyZuFGI30HTeDS1es42NuT1DUx3b5pRro0KQkKvs9PwyZx/eZt7BMkoOs3zciTww/ghetEREREXpVVR9K2plpVy7Bo+nDmThpEiSJ5GTx6GgATpy8iexYfFs8cSa8urfhhyAQiIyNfuk5ERETkVX2QAZKDvT1FC+bGYDAAkD2LDzcD7gCwadvf1KlWDoCsmb1J5paUg0dPv3SdiIiIyKv6IAMkS7/9vo6SRfJy/8FDIqOicHdzNa9LlSIZAYF3X7hORERE5HW8cR+kxSvW80mtikDMdCPp0qR840I9a9bCFVy7EcC4Id8TbjRaJc0lf2xg6coNAJhMJqukKSIiIh+PN65BmjxrsfnvZu17v2lyscxfvJqtO/fz84BuODo6kCRxImxtbLkbFGze5mbAHVIkd3/hOkv1a1Zg4dRhLJw6jHmTBlu1zCIiIvLv98Y1SB7J3Ji1cAXeXmmJiopm+56DEEetTIki+V4r3YVL17Bhy27GDvmeRAldzMvLlizI8tUbadm4HifPXCDw7j3y5vR76ToRERGRV/XGAVKvLq2YPGsJq9ZtJTIiklET5z63jcHwegHS7cC7jJ2ygDSpPGjffSAACRIkYPrYfnzd4jP6DfuFT77sQgI7O37s3hY7u5jDeNE6ERERkVdlMBrDrdYJp3rDr1m1cIK1knsnIiMjKVGtGdtXz3prwZRr2lxvJV359wq+duR9FwGAs8usO4aZ/PtlqrvsfRcBgIO9ir7vIsgHKO/AXe8sL6s+xfZscBR8/6E1kxYRERF5Z6xaZRIWbmT0pLn8+dcOIiMjSZAgAVXKFadDm89xcnS0ZlYiIiIib41Va5DGTp6P/7VbjB/ak5ULxjN+aE/8b9xi3JSF1sxGRERE5K2yaoC0fc9BBvXpSI6svrglTUL2LD4M7PUN23cfsGY2IiIiIm+VdUfSNpmwsTHEWmQw2GBCgzGKiIjIv4dVA6RihfLQs/9YTp29yL3gB5w8c4E+g8ZRvFBea2YjIiIi8lZZtZN2hzZf8PPEOXz1bX8ioyKxs7OjQukifNP6c2tmIyIiIvJWWTVAcnZypHeX1vT6thX37j8gaZLEGAyGl+8oIiIi8gF5KyMjGgwG3FyTvI2kRURERN4663bSFhEREfkIKEASERERsWC1ACk6OpqLl68RGRVlrSRFRERE3gurBUg2Nja06PADtjaqlBIREZF/N6tGMz4Z03HtRoA1kxQRERF556z6FFuJInnp9sPP1KtRHo/kbtg884h/iSL5rJmViIiIyFtj1QDp99WbAVi49M9Yyw0GBUgiIiLy72HVAGnZnFHWTE5ERETkvbB6j+rIqCiOnDjLX1v2ABAaFkZoWJi1sxERERF5a6xag3T56g26/TCScKORR49CKF+6MPsPnWDDlt389H17a2YlIiIi8tZYtQZpxPhZNKhdiT/mj8POzhaAvDmzcOT4WWtmIyIiIvJWWTVAOnvhCvVqlH/yKuYJNhcXZ0JC1cQmIiIi/x5WDZDckibhZsCdWMuuXruJRzI3a2YjIiIi8lZZNUCqW70c3/cfw/Y9B4mOjubvA8foN2wS9WpWsGY2IiIiIm+VVTtpN6hdCVtbGybN+I3o6GhGT5pL3erlqVu9nDWzEREREXmrrBogAdSrUYF6NVRjJCIiIv9eVg+Qbty6zfrNuwm8e4/k7kmpULoIaVJ5WDsbERERkbfGqn2Qtu7aT8NWPTh64iymaBPHTp7lizbfsWXnPmtmIyIiIvJWWbUGaeL0XxnYqwPFC+cxL9v59yHGTJ5P6WIFrJmViIiIyFtj1Rqku0H3KVowV6xlhfPnIujefWtmIyIiIvJWWTVAKluyIKvWbY21bPWGbZQrWcia2YiIiIi8VW/cxNaj3ygMhphRsyMjoxg2bhaLlq8jZQp3bgXc5er1mxTOn/ONCyoiIiLyrrxxgJTJO32s11kyZTD/nTWz9z9K8+eJc9i+5yC3Au4we+JAcx7+12/x0/DJ3H/wkIQuTvTu0oaMXmlfuk5ERETkdbxxgNSiUV1rlCOWMiUK0uiTarTp0j/W8qFjZlC7ahmqVSzJpu17GTByMjPG9X/pOhEREZHXYdU+SAD3gh+w//AJtu8+EOvf68iTww+P5O6xlgUF3+fUuYtUKlcMgDLFCxAQGIT/9VsvXCciIiLyuqz6mP+ylX8xZvJ8XFyccHRwMC83GKBEkXxvlPbtwCCSubliZ2v7JE0DKZK7ExB4l4QhzvGuS5cm5XNpLfljA0tXbgDAZDK9UblERETk42PVAGnavGWMHNCV/LmzWTNZq6tfswL1n0ygGxkZSYlqzd5vgUREROSDYtUAKYGdHblz+FkzSTOP5G7cCQomMioKO1tbTCYTAYF3SZHcHRcXp3jXiYiIiLwuq/ZB+vKL2kyZtZiIiEhrJguAm2sSMvt4sW7jTgA279iHRzI30qVJ+cJ1IiIiIq/LqjVIObNmYt5vq1iw9E+cnRxjrVu/dPIrpzNkzHR27T1MUNB9OvUcirOTI0tm/UyPDs0ZMHIKs3/9AxdnJ3p1aW3e50XrRERERF6HVQOkPoPHkzt7ZsqVKoyDg/0/Tue7ji3iXJ4+XWqmjv7xtdeJiIiIvA6rBki3Au4w95dB2NhYffQAERERkXfGqpFMofw5OXnmojWTFBEREXnnrFqDlNDFic69hlG0YG7ckiaOta5jm0bWzEpERETkrbFqgBQdFU2pojEDQj58+NiaSYuIiIi8M1YNkHp3bWPN5ERERETeC+t20r59J951KT2SWTMrERERkbfGqgFS3SadMRjg6fRmBsP/1+38c641sxIRERF5a6waIFkOBnnn7j1mzF9OsUJ5rJmNiIiIyFtl1cf8E7o4x/rn5ZmGHh1bMG3uMmtmIyIiIvJWvfURHcPCwgm+//BtZyMiIiJiNVZtYhszeV6s12FhRv4+cIySTx79FxEREfk3sGqAZDn2kZOTI82/qE3lcsWsmY2IiIjIW6VxkEREREQsWCVAetH4R09pHCQRERH5t7BKgGQ5/tFTT8dBMmBgx59zrJGViIiIyFtnlQDJcvwjgKioaNb8tZ05v/5B2tQprJGNiIiIyDthlQApoYtzrNfbdx9g0szFRJui6dGhOaWLF7BGNiIiIiLvhFU7aR85foYJ03/l1u07tPiiLjUql8LG5q0PtSQiIiJiVVYJkC5c9ueXGb9x9MRZGjeoToM6lXCwt7dG0iIiIiLvnFUCpKZte5E4UUIa1K6Ig4M9K9Zsfm6bBrUrWSMrERERkbfOKgFSzuyZMGDg0NHTca43GAwKkERERORfwyoB0sThva2RjIiIiMgHQT2oRURERCwoQBIRERGxoABJRERExIICJBERERELCpBERERELChAEhEREbGgAElERETEggIkEREREQsKkEREREQsWGUk7Q+J//Vb/DR8MvcfPCShixO9u7Qho1fa910sERER+Rf56GqQho6ZQe2qZfhtxggaNajBgJGT33eRRERE5F/mo6pBCgq+z6lzFxk9uAcAZYoXYOSE2fhfv0W6NCnj3MdkMgEQGRn5zsop8qFcb5FR77sE8qH5UK7NqOj3XQL5EL3t69PW1haDwQB8ZAHS7cAgkrm5YmdrC4DBYCBFcncCAu/GCpCW/LGBpSs3ABAdHXMXlqnV8q2VK0u2HG8tbfl3KlGt2fsuwhPO77sA8qGZ1ux9l+CJjO+7APIhesufndtXz8LOLiY0+qgCpFdVv2YF6tesAMQESEajMVbUKG9Po6++Z96kwe+7GCLP0bUpHypdm++O7ZMKFvjIAiSP5G7cCQomMioKO1tbTCYTAYF3SZHcPd59bGxscHR0fIel/G8zGAzm6FzkQ6JrUz5Uujbfj4+qk7abaxIy+3ixbuNOADbv2IdHMrd4+x+JiIiIxOWjC0l7dGjOgJFTmP3rH7g4O9GrS+v3XSR5Rr0aFd53EUTipGtTPlS6Nt8Pg9EYbnrfhRARERH5kHxUTWwiIiIi1qAASURERMSCAiQRERERCx9dJ22xji079jFr4Qqio6MJN0aQ3D0pY4d8h42N9WPqdt0G8GmdypQqmp8ps5eQPl0qKpUtZvV85N8hMiqK2QtXsH7zbuxsbbG1tSFrZm++bvkZiRK6vLdyrV6/jWx+Pnh5pgZg++4DHDhyik5fNeLmrUB27z9K3erl3lv55N2z5rV69sIVrvjfoELpIm+ptPK6FCDJc+7cvceQMdOZOX4AqVIkA+DMuUvvZCDN1k3rv/Y+T8e9ko/DoJ+n8uDhY6aO/pHEiVwwmUxs2r6XBw8fv98AacM2EiZ0NgdIJYrko0SRfADcDAjk99Ub/1GApOv338ua1+q5C1fYtuvAewuQns4q8TZ+BP9bKUCS5wQFP8DGxobEif5/g2f2zQBAnSadGPpDZzJ5pwfgy/Z9+KZVQ/Lmykq7bgPw9krHidPnefDwMSWL5OOb1p9jMBheuO5Z/UdMxjdjej6rW5nIyEimzF7C/sMniYyMJF2alPTo2ILEiVzoP2IyBoOB6zcCCAp+wKLpw9/dCZK3xv/6LTZt38vvc8eYrz+DwUC5koUAmLd4FWvWb8dgY8AngyfdvmlGQhdnps1dyqUr1wk3RnD12k3SpUlJuxafMm7KAm7cCsTP14sfe7TDxsbGfO1c8b/J/QcPyZ7Fh+4dmuPoYM/jkFDGTp7PuYtXMUZEkN3Phy5fN+XPv7Zz+uwlxkyaz/S5y/jqywbcC37Atl0HGPpjZ4aOncmt23do0rYnKTzcGd6vC6fOXuTniXMJDQvDPkECOn7ViFzZMnHzViBN2vWidtWy7D10jCrlSvBZ3crv87TLP/Cia/XgkZN8/9No5vwyCIALl/3p2ncky+eM5l7wA34cOpE7QcEYDAb8fLxo1/Izps5ZyqPHITRp25Nsfj706NicPfuP8svMRURFRZMooQvdv/mSDOnTcPDISUZOmEOu7Jk5evIsJpOJfj3asXDZn5w+dwlHBwcG9+2IRzI3AOYvXs3GbX8TFR1F0iSJ6dGxBalSJGPa3KVcuHSN0LAwAgLvMmbwd+Z9RAGSxMEnQzpyZctMncadyJPTjxxZfalYpugr3TiXrl5nyqgfiIyMom3XAazfvJtKZYu+dF1c5i1ejaOjAzPG/QTAjPnLmTx7Md3aNwPgzLnLTPq5Dy7OTm9+0PJBOHP+MulSp8Q1SaLn1u3ed4RV67YxdfQPJErowpDR05k4fRHdO3wJwOlzl5g5fgCJEjrTrttABo+axpjB3+HgYE/z9n3Yve8IxQrlAeDk6QtMHfMjjg4O9Og3il+X/UmzhrUYN2UBubJn5vvOLTGZTAwePY1Fv6+l0SfVWbtpp7kpGGKa3J7q0eFLRk+aZ/5CjIiI5PufxvBdpxYUzp+TI8fP0LP/GBbPHAnAo8chZEifhq9bfvZWz6e8PS+6Vl9k7aadpEqZnDGDvwPg/oNHJEmckFZN6pkDboiZfP2HIROZMLwXPhnSsW7TTnoOGMOCKUMBuOJ/gz7d2tC9w5dMnr2Y9j0GMWlkX7w8UzN8/CwWLV/LN60+Z92mXVy9dpOpo3/E1taGP//awYjxMxnZvxsAx0+dY/bEgbglTWLFs/NxUIAkz7GxsWFw345cvnqDQ8dOsWffUWYv/MMcqLxIlfLFsbOzw87Ojkpli7Hv0HFzEPSidXHZtusAj0NC2LJjHwARkZGkSpHcvL5syYIKjv5D9h08TvlShcxNF3Wql6PXgLHm9QXz5jD/ks/s44V9Ajvz9ZHJOz3+1wPM25YrVci8rkblUiz+fT3NGtZi264DHDt1jl+X/QlAuNH4j5ocrly7icHGQOH8OQHIlT0zbq5JOHfhCh7J3LCzs6VyOfWz+y/K7ufDomVrGTt5Prlz+JmvEUsnTl/AO0NafDKkA6BS2WKMGD+bwDtBAKRJnQK/JzX7WXwzsi/1cXPzb9bMGdm28wAA23bt59TZS3zZvjcAUU+a0p4qUjCXgqN4KECSeHl5psbLMzV1qpWjU8+h7NhzEFsbG3NbNYDRGPHCNF7Ub+nlfZpMfNuuKYXy5YhzrZPm0PvoZPbxwv/GLe4/eEiSxC/+ZW55/djbJzD/bWNjE/u1rQ1RUVEvSCzmPxMmBvfpiGfaVK9f+Jd4triODg7q6/Ev96Jr1dbWNlYg8uznZI6svsyeOJB9h46zZec+psxZwuwJA187f4cXXO+2NjZEPrneTUCTz2pQu2rZONPR52j8dIfKc27fCeLIibPm1w8ePuZmQCBpUqUgbeoUnDh9Hoj5hXPl2s1Y+67buIvIyEjCwo2s37yLAnmyvdK6uJQskp9fl/1JWFg4AGFh4Vy8fM1ahykfoHRpUlKmeAEG/TyNh48eA2Aymdi8fS+pU3mwcdvfPH4cAsDvqzfFGzy/zKbtewkJDSMqKprV67ZRIE92AEoWycfc31aZv1wePHyM//VbALg4O/HoSd6WYtaFml+nT5sKU7SJvQeOAXD0xFnu3ruP75O+e/Lv96Jr1WAwcOv2He4FPwBg7cYd5v1u3LqNs5Mj5UsVpku7Jvhfu0VoWNhz11d2Px8uXLrGhcv+AGzYspvk7klJ/pp9hEoVzcfy1Ru5/+ARAJGRkZw5f/lNDv0/QzVI8pyoqGhmzl/OjVuBODrYExUVTZXyJShZNB/JkyWl//DJ/L56M9mz+JAxfZpY+3p5pqZ155948PARJYvki/VExovWxaXRp9UxzougRccfzLUFjRtUJ6NXWusftHwwen3bipkLVtCy4w/Y2tgSbTKRO0dmvm7xGWHh4bTq1C9WJ+1/IkumjHTqOZTg+zGdtD+tE9NJuuNXjZg4fRFN2/bCYGPA1taGr1s0JF2alNSqUpZxU+ezaNlavvqyQaz0vDN6kiF9Gr5o/R2pUyVneL8uDO7bkZ8nzmXs1AXYJ0jAoN4dcHZy5P79h296iuQD8aJrtdEn1WnR4QfckiamSIFc5n0OHjnFwmV/YmtjQ1RUNO1bNSShizP582Rj/pI1NPrqe3Jk8aVHx+b82KMtPw2fZO6kPbB3h9d+mrhS2WLcf/CI9t1j+sdFRUVRvVIpMvt4WfNUfJQ0F5tYzbPjGb3OOpF36dknJUVE4qMmNhERERELqkESERERsaAaJBERERELCpBERERELChAEhEREbGgAElERETEggIkEREREQsKkEREREQsKEASERERsaAASURERMSCAqQP0LS5S2nStqf5df8Rk+nx46j3WKJ/h5edp9Xrt1Ghbut3WKIPW5FKjdi6a//7LoaIyAdJk9U+cS/4AVPnLGXX3sMEBd8nUUIXfDN68uUXdciVLdN7LVvnto0xmTTgufwz0+YuZduuA8z5ZdD7LoqIyL+GAqQnevYfQ0RkJH26tiF1Kg+C7t1n/+ETPHjw/mfeTuji/Eb7m0wmoqKjsbO1tVKJ5H2IiIgkQQLdsiIi74I+bYGHjx5z+PgZJgzvRd6cWQBIlSIZ2fy8zdvcvBVI3aadmT1xIJm805v3q1ivDROG9SRvrqwcPHKSr7sPYsRPXfhl5m/4X7uFr7cn33duibdXOiCmmWf0pHn07tqa8VMXcjswiDw5/fi+U0tSeLjHWb7+Iybz6FEIQ3/sDEB0dDRzf1vFijWbuXsvGM80qfjyi9qULVEQwFyOnwd0Y/KsxVy47M+YQT1IlNCF0ZPmcfrcJTBAutQp6dGxOVkyZYwz3yKVGvF9pxbs3HuYvw8cI7l7Ujq0/pwSRfIBEBUVzZAx0zlw+CR37wWT0sOdutXL82md/8+S/rTsWTJn5Lff1xEREclndavQtGFNfpmxiJVrt+LoaE/rJvWpXqmUeb+A23cZO2U+ew8ex2AwkDt7Zjq3bUyqlMnNeY+ftoBV67ZhY2NDjcqlXrmWbeuu/XGe+5u3AqnX7Fumj+0X65z8umwti5b/ydLZo7Cxeb5Vuk6TTtSsXJqr126xdec+kiROyLftmpA9iy+DR01j/+ETpE7lQa9vW8VKd/P2vUyds5RrNwNwd3Plk5oV+bx+1Vjp1qhUCv/rAWzbvZ/SxQrQp2sbjhw/wy8zFnHq3CVcEyeiVLH8tG3eACdHx+fKtnr9NqbPW25+PwF6d2lNtYolAbh//yE9+o164/c3Z7ZMLFy2hoiIKMqXLkznrxphZxf/x8uylX+xYOkaAgLvkjplcpo1rE2V8sXN61927QFcuOzP+KkLOXL8DI6ODhTKl4OObRrhmiRRvPkeOXGWybN+4+SZi9gnsCNrZm9++r49iRO5YDRGMH7aQv7asofHIaH4ZcpAxzZfkDVzzOfA0/tq1MDuTJyxiCv+N8iRxZefen7NmXOXGTN5PoF3gyhWMA89O7fE0dEBgHbdBpAxfcz9v3bjDuzsbKlTvRytm9THYDAA8OdfO/jt93VcvXYTR0cH8uXKSqe2jXBzTRIr77FDvmPi9EVcunod34zp6d2lFenTpf7H166IxE93DODk5IizkyPbdh3AaIx44/TGT1tIh1afM33cT7gmSUy3vj8TGRlpXh8WHs7shSvo2+0rJo/qy8NHIfQZPP6V05/z60r+/GsH3Tt8yYIpQ/msbmX6Df2Fg0dPxdpu4vRFtGv+KQunDsM7gyc/Dv0Fj+RuTB/7E7PGD6DxpzVeWqs0fd5yypUsxNxfBlG0YC5+HPoL9x88AsBkisYjmRsDe3/DwqlDaf5FHSbNXMxfW/fESmP/kRPcuRvMLyN606HNF0ybu5SufUaQKKEL08f2o061cgwdO4PbgXcBiIyMpFOvoTg7O/HLyD5MGdUXJydHOvUaRkREzHlcuHQNq9dvp9e3rZj8cx8ePHz0Sv1pXnTuU6VMToE82Vi1flusfVav30bVCiVf+AXz67K15Mzmy+yJAylaMDf9hk3ip+GTqFSuGLMmDCBNKg9+Gj7JHMSdPneJ3oPGUb50YeZNGkzLRnWZMmcJqy3yXrBkDb4ZPZk9YSBffl6bazcC6NxrGKWLF2TepMH079meIyfOMHL87DjLVa5UYRrWq0rG9GlZtXA8qxaOp1ypwlZ9fw8cOcn1m7cZP7QXfbq2Yc367axevz3ec7Vl5z5GTZpLw3pVmD95CLWrlmXgyCkcOHwy1nYvKtvDR4/5pvtgMnmnZ8a4/owa2J2ge/fpPXBcvPmevXCFDj0Gk8EzDVNH/cCkkX0pVigP0dHRAEyYvpDNO/bRp1sbZk0YQNrUKejUc5g5z/+Xaxldvm7KlFE/EBB4l94Dx7Fo+Vr6fdeOkT91Ze/BYyxesT7WPn/+tR1bWxumj+1H57aN+XXpWv74c4t5fWRUFK2b1mfOL4MY+kNnbgbcYcCIKc8dw+RZi/mm9efMHNcfO1sbBv48FXiza1dE4qa7BrCztaV3l9as2bCdCvVa07pzP36ZsYjzF6/+o/RafFGXgvly4JMhHX26tiEo+D5bdv7/yzsyMoouXzclR1Zf/Hwz0KdrG46dPMeJ0xdemrbRGMHsX/+g17etKJw/J2lSeVCtYkkqlSvK76s3xdq2VZN6FMyXg7SpU5AkcUJuBd4hf55seHmmJl2alJQrWQjfJ7Vh8alasQQVyxQlXZqUfPVlA0JCwzh5JqacdnZ2tGpSjyyZMpI6pQeVyhajWsWSbNr2d6w0EidKyLftGpM+XWpqVCqFZ9pUhIcbadawFunSpKTJpzVJYGfHkRNnAfhr6x6io0307NwSnwzp8PJMQ+8urQkIvGsOAhctX0uTz2pQungBvDzT0L1DcxI6v7wp8mXnvkbl0mzYvNscKJ85d4kLl/2p/qTGJT5FC+aiTrVypEuTkuZf1OFxSChZMmWkXMlCeKZNReMGNbh89QZB9+4DsHDpn+TPnY3mX9TBM20qqlUsSf2aFZi/eHWsdPPlzsrn9auSNnUK0qZOwZxFf1CxbFE+q1uZdGlSkjNbJr5t24Q/N+4g3Gh8rlyODvY4Ozlga2uDu5sr7m6uODrYW/X9TZTIhS5fN8XLMzXFC+ehaMFc7D98It5ztWDJGqpVKEm9GhXwTJuKhvWqUqpYfhYsjX3sLyrbkj82kMknPW2bf4qXZ2oy+3jR69tWHDhykqvXbsaZ77zfVuGXKQPdvvkSX+/0ZPRKyye1KuKaJBGhYWEsW7WR9i0bUqRALjKkT8P3nVrg4GDPynVbYqXTuml9cmXLRGYfL2pULsWho6fp9s2XZPbxIncOP8oUL8iBI7GDPY/kbnT6qhHp06WmUtlifFKrAr8u/9O8vkalUhQpkIs0qTzInsWHb9s1Zve+I4SEhsVKp02zT8ibMwsZ0qeh8ac1OHbynPl9/6fXrojETU1sT5QpUZCihXJz5NgZjp8+z+59R5m/eDXfd25pbo54Vdmz+pj/TpI4IZ5pU3HF/4Z5ma2tbaxqcC/P1CRK6Mxl/+uxmvXicu1GAGHh4XT8fkis5RGRkWTy9oq1zC9ThlivG9atwuBR01n7104K5M1G2RKFSJs6xQvz88ngaf7bydERF2cn7gU/MC9b8scGVq3bSkDgXcLDjURERuKbMXbQlTF9mli/YN2SJiGjV1rza1tbG5IkTmhO99zFq1y/EUC52i1jpWM0RnD9RgCP/Ly5ExRMNr//n2c7W9uY431JK9vLzn2povkZOWE2W3ftp0LpIqzesJ28ubKYm/bi450hXazje35ZYiDmYQB3N1cu+1+n5DPNRQA5s2Zi0fK1REVFY2sbc76y+MZu/jx/8SrnL/mzftMu8zKTCaKjTdy8FYiXZ5oXnwAL1np/n5YXIJm7KxcuXYs3z8tXb1CraplYy3Jmy8Rvv6975bKdu3iVA0dOUrZWi+fSv37zNp5pUz23/NzFK5QtUSjOMl2/cZvIyChyPvNAhp2dHVkzZ+Ty1Ruxtn22XG6uSXB0cCBNKo//L0uahJNnY//YyebnY25OA8iexZcFS/80v9enz11i2txlnL94lYePHhMdHXMhB9y+S4b0/39Pn83b3c0ViLmmUnok+8fXrojETQHSMxzs7SmYLwcF8+Wg+Rd1GDRqKtPmLqVaxZIYbGI+3J7t5xIZGfXOyxgaFvOLckT/riR3TxprnX2CBLFeOz3pA/FUy8b1qFimKDv3HmbPviNMm7uMn77/mtLFCsSbn51d7CY4g8FgPgcbtuxm3NQFdGj9Odmz+OLs5Mj8Jas5aVETZmdrZ5EGzzftGQzmL4XQ0HAy+2bgxx5tnytPUtfE8ZbVGhIksKNKueKsXr+N0sUKsH7zLjq3bfzS/Z49xqdfhM+eOwMxy6Jf82lER4v3MCQ0nNpVy/JJrYrPbZvSI9lrpW1ZRrDO+wsGok3Rr12W1ylbaGgYxQvlpV2LT5/bL5m7a5zpOdjbx7n8TcplMBjiKCeYol/9fQ4NC6NTz6EUypeTH3u0xTVJYgIC79Kp51Ainmmajytv+H9e//TaFZG4qYntBTJ4piE0LBwA1yQxX8x3g4LN689duBLnfsdPnTf//eDhY/yv3SJ9utTmZVFRUZw6e8n8+or/DR4+CsEr3ct//Xt5psE+QQICbt8lXZqUsf7F18n7WZ5pU9GwbhXGDP6O0sXyP9fn5XUcPXGWHFl9qVejApl9vEiXJiXXb9z+x+k9ldnHC//rt3BzTfzcMSZ0cSahizPJ3Fw5cfr/5zkyKooz5y6/NO1XOfc1q5Rm36HjLF35F1FR0ZR6QQD5T3mlS8PRJ02KTx09eRbPNKli1cZYyuzjxaUr1587L+nSpIz3CTc7Ozuiol8/YHlb76+XZ2qOnTj3XF6vU/uV2ceLi1eukSpl8ufOQ1yd1QF8MqSLt+kvTWoPEiSwi/WeREZGcursRTK8Zq1cXCyDyuOnz5MuTQpsbW244n+T+w8e0a75p+TO4YeXZ2ruBd//R/m8i2tX5L9CARJw/8FD2ncfxNqNOzh/8So3bt1m47a/mbd4tfmpGUcHe7Jn8WHuopVcvnqdg0dPMXn2kjjTmzn/d/YdOs6Fy/4MGDEZ1yQJKVU0v3m9nZ0tP0+cw4nT5zl97hIDRk4hexaflzavAbg4O/F5/aqMmTyP1Ru2ce1GAGfOXWLxivWs3hB/sBMWbmTE+NkcPHKSmwF3OHLiLCfPXHyloCw+6dKk5PTZS+zZf5Sr124yefZiTp29+I/Te6pS2aK4JklE9x9HcfjYaW7cus3BIyf5eeIcc0fuBrUrMXfRKrbu2s/lqzcYMW4WDx8/fmnar3LuvTzTkM3Ph4kzfqVC6SKx+uxYy+f1qrD/8AlmzF/O1Ws3Wb1hG0v+2BDrKba4NG5QnWOnzjFi/GzOXriC//VbbNt1gBHxdNIGSJUiOTdvBXL2whWC7z985QcR3tb7+8Un1Vi9YRvLVv6F//VbLFy6hq079/PFS479WfVqVuDhw8f0HTyBk2cucO1GAHv2H2XAiMlERcUdDDb5rCanzl5k+LiZnL94lctXb7Bs5V8E33+Ik6MjdaqVY/y0hezed4RLV64zePR0wsKM1Khc+o2POSDwLmMmz+OK/w3Wb97FkhXraVC7EgApkruTIIEdi/9Yz/Wbt9m++wAzF/z+j/J5F9euyH+FmtiI6d+Q1c+bX5et5frNmL4IHsndqFmlNE0/q2Xerte3rRj48zSate+DZ9pUtG/xGR17Dn0uvbbNP2X0L/Pwv3EL34zpGd6vS6xf944ODjRuUJ0fhkwk8M49cmXPTM9vWz6XTnxaN62Pa5JEzPl1JTduTSeRiwuZfNLTtGGtePextbHhwcOH/DR8MkHB90mSOBGli+WnZZO6r5yvpdpVy3L2/GX6DBqPwQAVShehbo3y7Nl35B+nCTHNSr+M6M2E6b/yff8xhISEkTxZUvLnzoaLsxMADetX5U5QMP2HT8bGxkD1iqUoVTQ/jx+HvjjtVzz3NSqX5tjJc1Sv9HY6uGb2zcCAnt8wdc5SZi74nWRurrRqXO+l/d18MnoycXgvJs9aTNsu/TGZTKRJlYJypeLuWwNQpngBtu7cR/vuA3n4KCTWY/4v8rbe31JF89P5q8YsWLqGUZPmkjplcnp1aU3eXFlfOY3k7kmZPKovE6b/SqeeQzFGRJLSIxmF8+fExsYQ5z6eaVMxelAPJs38jRYdfsDBIQFZM3tToUwRANq1+BSTycRPwycREhKGX6YMjB7UncSJXN7oeAEqly9OeHgELTr8gI2NDQ1qV6J21bJATLNx7y6tmTRzMYt/X08mHy/at/qc7j/8/I/yetvXrsh/hcFoDNcQzVbydKyS9Usnkyhh3B+qT8dB2rDs+Ud45cMxY/5yNm3fy7xJg993UeRfrl23AfhmTP/O+gPp2hWxDjWxiTwjJDSMC5f9WfLHBj6p+XxHaJEPla5dEetSE5vIM0ZOmM2GLbspWSRfrJG9RT50unZFrEtNbCIiIiIW1MQmIiIiYkEBkoiIiIiF/3yAZDKZiIyMfOWZ4EVEROTj958PkKKioihRrRlRUe9+2hARERH5MP3nAyQRERERSwqQRERERCwoQBIRERGxoABJRERExIICJBERERELCpBERERELChAEhEREbGgyWqfOLu8AXa277sUIiIiYilT3WXvPE/VIImIiIhYUIAkIiIiYkEBkoiIiIgFBUgiIiIiFhQgiYiIiFhQgCQiIiJiQQGSiIiIiAUFSCIiIiIWFCCJiIiIWFCAJCIiImJBAZKIiIiIBQVIIiIiIhYUIImIiIhYUIAkIiIiYkEBkoiIiIgFBUgiIiIiFhQgiYiIiFhQgCQiIiJiQQGSiIiIiAUFSCIiIiIW7N5VRk3a9gQgIjKSq9du4u2VDgDPtKkY0Osbps9bzqZtf2NjY4MxIoLihfPwTavPAShSqRG+GT2Z88sgc3qr1m1l4M9T6dimEZ/VrQzA6XOXmDTzN/yv3yJxooQkSGDHF59Uo1TR/O/qMEVEROQj8M4CpKfBzc1bgTRp1ytWsLNp+1727D/C9HE/4ehgT2RUFJcuX4u1v62tLafPXcLPNwMQEyBlyZTBvP7i5Wt06jmUXl1aU6JwXgAC795j78Fjb/vQRERE5CPzQTSx3Q4MInEiFxzsEwBgZ2uLr3f6WNtUq1iSleu2AnD12k0io6LIkD6tef3c31ZSvVIpc3AEkNw9KdUqlHwHRyAiIiIfk3dWg/QiFUoXZsWfm6jX9FtyZc9M3lxZqFC6CI4O9uZtShfLz4Ilawg3Glm1bivVKpbk+Knz5vWnz12iTbNPXim/JX9sYOnKDQCYTCbrHoyIiIj8630QAZK7myvzJg3hxOnzHD15lmUr/2LxivVMH9OPBAliiujgYE+hfDnYtG0vm7bvZfaEAbECpNdRv2YF6tesAEBkZCQlqjWz1qGIiIjIR+CDaGIDsLW1IWe2TDT6pDqTf+7LzVuBXLzsH2ub6pVKMnbKfHJk9cXFxTnWOj/fDP84YBIRERF51gcRIJ06e5FrNwLMr6/43yAyMgqP5O6xtsvm50OzhrVo8mnN59L44pPqrFq3lZ1/HzIvuxsUzOoN295ewUVEROSj9EE0sd1/8IiRE2bz8FEIDg722NrY0O+7diR1Tfzctp/WqRxnGj4Z0vHzgG5MnrWYnyfOwdHRAWcnJ5p8Wv1tF19EREQ+MgajMfw/3Uv5aR+k6S1DsLN936URERERS5nqLnvneX4QTWwiIiIiHxIFSCIiIiIWFCCJiIiIWFCAJCIiImJBAZKIiIiIBQVIIiIiIhYUIImIiIhYUIAkIiIiYkEBkoiIiIgFBUgiIiIiFhQgiYiIiFhQgCQiIiJiQQGSiIiIiAUFSCIiIiIWFCCJiIiIWFCAJCIiImJBAZKIiIiIBbv3XYAPRaY6v2Fnp9MhIiIiqkESEREReY4CJBERERELCpBERERELChAEhEREbGgAElERETEggIkEREREQsKkEREREQsKEASERERsaAASURERMSCAiQRERERCwqQRERERCxo8rEnzi5vgJ3t+y6FiHxsMtVd9r6LICL/gGqQRERERCwoQBIRERGxoABJRERExIICJBERERELCpBERERELChAEhEREbGgAElERETEggIkEREREQsKkEREREQsKEASERERsaAASURERMSCAiQRERERCwqQRERERCwoQBIRERGxoABJRERExIICJBERERELCpBERERELChAEhEREbGgAElERETEgt3r7lCnSSfsE9jhYG8PgF+mDPTs3MrqBRMRERF5X147QALo3/MbMnmnt3ZZRERERD4I/yhAsrRn/1F+mbmIqKhoEiV0ofs3X5I+XSq+7T2cAnmy88Un1bh2I4B23QYwbsj3pE+XmlXrtvLb7+swmcDOzpZBvTuQKmVy/vxrB/OXrAYgRXI3enRsgUcyN1av38bajTtJ6pqIC5evYZ8gAQN6fUOaVB4cPHKSkRPmkDtHZo6eOEdUVBR9urUhS6aM1jg8ERER+Y/5RwFSn0HjzE1sTT6tyfDxs5gwvBc+GdKxbtNOeg4Yw4IpQ/mxRzuaf9OXLJkyMHbKAtq3bEj6dKk5eOQkM+b/zpRRfUnmnpSwsHAALlz2Z/y0hcwc3x+PZG7MWrCCwaOmMWpgdwBOnb3InF8GkjqlBxOn/8rc31byXccWAFzxv0HPb1vS7ZsvWbZqI5NnLWb0oB7WOEciIiLyH/PGTWzb9xzEO0NafDKkA6BS2WKMGD+bwDtBeCR354cebWnffSDVKpSkYpmiAOzce5jK5YqRzD0pAI6ODgAcPHKKwvlz4pHMDYC6NcozY8FyoqKiAciexYfUKT2e/O3L4hXrzWVKkzoF2fx8AMiRxYcFT2qh4rLkjw0sXbkBAJPJ9E9OgYiIiHzErNLE9iJnz18mSeKEBN4NwmQyYTAYXnlfy02f1loB2NjYEBUd9cy6BP9fZ2tDVHR0vOnWr1mB+jUrABAZGUmJas1euUwiIiLy8Xvjx/yz+/lw4dI1Llz2B2DDlt0kd09K8mRunDl3iQVL1zB7wkAA5v22CoDihfOybtNO7ty9B0BYWDhhYeHkzZWFPfuPEvhk+fLVG8mfOxu2thqNQERERN6dN65BSuqamB97tOWn4ZPMnbQH9u5ASEgofQZPoNe3rXB3c6Vvt69o0eEHcmbPTJ4cfjRvVIdOvYZhwECCBLYM7N0Rb690tG/ZkM69hgExnbS/69TijQ9SRERE5HUYjMbw/3QnnKdNbNNbhmBn+75LIyIfm0x1l73vIojIP6C2KxERERELCpBERERELChAEhEREbGgAElERETEggIkEREREQsKkEREREQsKEASERERsaAASURERMSCAiQRERERCwqQRERERCwoQBIRERGxoABJRERExIICJBERERELCpBERERELChAEhEREbGgAElERETEggIkEREREQsKkEREREQs2L3vAnwoMtX5DTs7nQ4RERFRDZKIiIjIcxQgiYiIiFhQgCQiIiJiQQGSiIiIiAUFSCIiIiIWFCCJiIiIWFCAJCIiImJBAZKIiIiIBQVIIiIiIhYUIImIiIhYUIAkIiIiYkGTjz1xdnkD7GzfdylE5FVkqrvsfRdBRD5yqkESERERsaAASURERMSCAiQRERERCwqQRERERCwoQBIRERGxoABJRERExIICJBERERELCpBERERELChAEhEREbGgAElERETEggIkEREREQsKkEREREQsKEASERERsaAASURERMSCAiQRERERCwqQRERERCwoQBIRERGxoABJRERExIICJBERERELdi9auWXHPmYtXEF0dDThxgiSuydl7JDvsLFRXCUiIiIfr3gDpDt37zFkzHRmjh9AqhTJADhz7hIGg+GdFU5ERETkfYg3QAoKfoCNjQ2JE7mYl2X2zQDA2CkLOHzsFJGRUbg4O/FdpxakT5cagCKVGtGm6Sds33OQoOD7dPqqEZev3mDLjn08ehzC951akDdXVu4FP+DHoRO5ExSMwWDAz8eL3l3bsHr9NrbtOsDQHzsDsGPPIRYsXc3E4b05eOQkIyfMIXeOzBw9cY6oqCj6dGtDlkwZAVi+eiMLl/6Jk5MDpYrmZ+qcpexeN++tnTwRERH5OMUbIPlkSEeubJmp07gTeXL6kSOrLxXLFMUjmRuNG1SnQ+vPAdiwZTejfpnL6EE9zPs6OTkwfWw/9h06To8fR9Hl66bMHN+fjdv+Zvy0hcwY15+1m3aSKmVyxgz+DoD7Dx69UoGv+N+g57ct6fbNlyxbtZHJsxYzelAPLlz2Z/q8ZcyeMBB3N1emzlkabxpL/tjA0pUbADCZTK+Ur4iIiPx3xBsg2djYMLhvRy5fvcGhY6fYs+8osxf+wYxxP3HyzEWW/LGekJAwok3RPHj4ONa+5UsVBiBLpoyEhoVTvnTM66yZvfG/HgBAdj8fFi1by9jJ88mdw4/C+XO+UoHTpE5BNj8fAHJk8WHBktUAHDh8ksL5cuLu5gpArSqlmTF/eZxp1K9Zgfo1KwAQGRlJiWrNXilvERER+W94YSdtAC/P1Hh5pqZOtXJ06jmU9Zt3s2j5WmaM+4m0qVNw/uJV2nYdEGsfe/sEAObO3A729gDY2hiIiooCIEdWX2ZPHMi+Q8fZsnMfU+YsYfaEgdja2hAVHW1OyxgREStthydpA9hYbBuL+kqJiLxzPw6bxoZte7l+M5DVC34mW+YM5nXFqrfGwT4BDg4x3wntvqxHjYrFAWjc7kcC7wZjsDGQ0NmJH7q1JLtfxtfK+4r/Tdr1GIEJE80+q0aDmuXM6x6HhPJVt2EcP3WByKgojm2db17nf+M2pWq1JbOPp3nZpGHdSZ8uFQDXbwbSd+gULl29gY2NDY3qV6bZZ9Ve/+TEYff+44QbjZQumtcq6Vkj3TPnr9C800B2rppi1TK9rk9b96Z5wxpUKlOIn39ZQMb0aaj9v/buMj6q42vg+G8l7kooUNy9SAmhaCBICgQLUtzdoRSnSPAAxaUQtLgV1xYo0iLFW4rHiStJdvd5EdjGgRD+eSjn+2p379y5c2fvJ3syd+6cpnX+Z8fPNEAKehGKf+ALKpYtAUBkVAz+gcE4V6uIWq3C3tYanU7Hzv3Hs3Vgv4AgHOxsca1TA+eqFWjqOZC4+Hjyf+bEP4+eEv8yAbVaxbHTF96qvi8qlmHjTwcIDY/A1tqKA0fOZqtdQgghsq+JqzN9u7akTc/vMty+ZNaoVEHTaz/MHo3VqzmvR05dZNSUJRzZtvCdjn3o5G9UKFuMWeP7p9umVqvp39UDKysL2veZkG67makxh7emP55Op6PvKC/6d2tFs4YuAASHhL9Tu7Jy8Y9bREbFZBrIJCVpUKtVOV7vx2ZE/47vvE92++61TAMkjUbLj5v34BcQjLGRIRqNliauX+Hp0Ri/gCA69vkWK0tzateskq0DX71xl627D6NSKtFotAzq3QFzM1PKlS6Gc7VKfNP3W+xsralQpgS37z94Y33FChegW8cW9B0+DVNTY2pUqYC5mWm22iaEECJ7vvyibLb2s0rxQFBUdGymNwFiYuOYMncNN27/DUBTVxeG9fFk18HTrN1yAK1Gy/Vbf7F4xgiKFymg38/I0ICa1SvwzC/ondp1/vKfGBoa6IMjAAc76wzLBr0IY+rcNTz3DyI+PoGGdaszakAnLl29zegpS9i/cS7WVhZMmr2KhIREOrdryuZdR9FqtFz84xaN69WglXs9mnYYTsfWbpy7eINW7nUpVawg85Zt5mVCIomJSfTq1BzPlq5A8uDFjIXruXbrPkqlivKli9CtvXu6eof28eTshWssWbOd+JcJqFRKxg7uQs1q5QFYuHIb+w7/grmZCXVdMg+qtu05zprN+zEwUKPVaPGaOJDK5Uvg4t6HVfPH6YPfr78ZxXfDuuFctRyefSZQqlhBrt38i4jIaBrWqc744d1QKBRZbktp5OTFlClZmJ4dvyYxMYn5y7fw2+83SUhMosjnnzFzfH+sLM0ZOXkxSqWCJ88CeBEawaEt8xk5ZQn3HzxBrVbjYGvFxmVT3uq7zzRAypvHPtXE65SG9+/C8P5d9O+7d2ypf53yqTFTE+NU7x0d7Di1by0A7m51cHfLeKhszJDuGX7+RcUy+CyfqX9ftFAB9vh46983blCL1l8nzy36ac8RypUulsnZCSGEyA0jJy1Cp9NRsVxxxg7ujJ2NlX7biEmL+O33mwD8uGhihvsvXrODhIQkjmzzJv5lAm16fkfRQvlo7V6Pp76BREbFMHlUz3duV1zcS5p3Ho1Go6VR3eoM6tkGlUrF3w+fYWtjyaBx83n4xJf8eR2ZMLwbn+d3Sn9ukxczsEdralQpR1KShh7DZvDz8fM0a+iCZ8uGjJqyhJZN6nDl+l32rJ+NsZEhnVq7pWrzM78goqJjKVGkAOOGJP/ORkRGs3PtTFQqFeERUTTrOJLazpXIm8eeafPXYWxkyJFt3iiVSkLCIrCzsUpX79PnAXiv2obPD5OxMDfl8TN/2vYcz7mDKzl/6QaHTlzgwKZ5mJuZMHyid6b9NGPhek7uWoKjgy2JiUnppsFk5u+Hz9i1bhZJSRra9R7P/iO/0qJJ7Tduy8iqjXsxNTFmn89cABav3s68ZZv5/tu+ANy8+5Cda2dibmbCkVMXiYyK4cTOJQCER0S9VXvhLeYgfUyWrfuJm7f/IilJg72dDWOH9sjtJgkhhHhl++oZ5MvrQGJiEvOWb2Hk5MWsX/xvILRg2lAAdh44hdcSn1TbXjt/6Qbjh3dHqVRiamJMq2Z1OXfxhn4uU3Y42ttw8cga7G2tCY+IYtC4+azetJ9+XT3QaDT8duUme9bPpkTRz9m08wgDv53HgU3zUtURGxfPhSt/8iI0/N/PYuN5+MQPgAHdW9F18PeMm7GMfT5zMH41DysjBmo1Hinm2oRFRDFm2g88euqHSqUiLCKK+/88JW8ee079+jt7N8zWz/lNGXCmdPbCNZ48C6Bd7/H6z5RKBX4BwZy/8ifNGrpgYZ5816VjazeuXL+bYT01q5dn+KRFNPiqKnVdvqBIwXxZ9Oy/WjWri4GBGgMDNS2b1uHc5Rv6ICirbRk5duYSUdGxHD71GwCJiUnk/8xRv72Za03MzUwAKFOiEP88es6EWSv5skpZ6rm8/V2v/1SANHpQt9xughBCiEzky+sAgIGBmp4d3KnXamCG5dp8XZ/xs1YSFh6JjbVllnXmxOLFRoYGGL16AtrayoK2zRuw/8gv9OvqwWdODpQtWYQSRZMncLdqVpeJXqtITEzCwODfn9DXS8a8HhlKKzomjme+AZiaGBMaFpllYGFsbJgqY8X4mSuo5/IFK+aORaFQ0KzjSF6+fLuRG3370FHry4osnjnijWWz6tEVc8dy8+4/XPz9Ft2HTGfkgI40d/sKtUqFNsVDUy8TErI+Rhbf25u+U50OpozuTW3nShluNzU11r/+PL8Tx3cu5sKVm5y/9Cdei3w4tHUBVpbmWR4DJBebEEKI/4HYuHgiUiwJs//or5QtmfyUWkRUDIHBofptR09fwsbKAmsri3T1uHxZke37TqDT6YiNi2fPz2f4qkal92rbi9BwEhOTAHiZkMjRU7/p59LUdfkC/6AQAoJCADh97g+KFc6fKjgCMDM1wblqeZav363/LDA4+WEngLHTfqBFkzos9RrF8EmLCAuPBMDCzISo6Ngs2xcRGU2+vI4oFAouXb3N3b8f67e51qnGqo379MFJSFhEhvXWdq7M+cs3Uu17/dZfANSqXpFDJ84THROHTqdj656MH75KStLw5HkAFcoUo0+XljRp4KyfC1awQF6u3/xLX+/Dx36p9t17+BcSE5OIj3/J/iO/4FK94ltty0ijutVZu2U/cXEvgeTbo3/98zTDsv6BL1AoFDSsU53vhndFp9Ph9+o7eZP/1AiSEEKI3DVuxnJOn/uD4JAwug6aipmpCWf3LedFSDj9xsxBq9Gi0+kokD8P81/dUouKjmHg2LnExyegUCqxs7Fkrff4DEcShvRqy5S5a3DzTN63qasL7o1c0pXLSGPPYYSERRIdE0eNJr1wrlqOhd8P4/frd1mwYitKpQqNRkPNauUZ2LMtkDyXdsa4fnQfOh2dDizNTVkyc2SG9XtPH8b0BT/SqN0QFCgwMTFm5vh+HDtzmfDIaIb0avtqmQA3RkxazLpF43GrV4Pdh87SpMNw/STttMYO7sxEr1UsXrOdMiUKU6lccf22iSN68P2Cdbh5DkOtVlGxTDG8Jg5MV+/QPp4smjGC72YsJy4+gcTERMqWLMLimSOoV6sK12//jXunkVlO0tZotYyZ+gPhkVGoVCrsbKyYO3kQAKMGdGTk5MVs3n2MLyqUoHjRAqn2LVYoP216jiM8InkidnO3Wm+1LSP9urYiIeEnWnYdo79G+nX10I/ypXTvwRPm/LAJnQ40Gg0ezepQunihLOt/TZGQ8PKTXkr69UKRa3vF8h5PAwoh/odKtNr95kJCiP8XUq5n9C7bcpvcYhNCCCGESENusQkhhBDig/lp1fRsbcttMoIkhBBCCJGGBEhCCCE+WTMWrmfhym0ZbitUxSPVk3fi4+Di3ofb9x+9dz0SIAkhhHgvSUma3G6CEDlO5iAJIYTI0NDxC3n4xJfExCTy5rFn9qSBONrb8MwvKF2+sK8b1cowD1laO/afYu/hs9jaWPLXg6cYGhqw1GsUn+d3IuhFGEO+W0B0TCwvExJxrlqOKaN7oVQqU+1396/HWFqYMXviQOYu3cw/j5/zWR57Vswbi5mpSZa5uoKCQxk5ZQn+gS/I42CLjbUlRQtlvmjj6o17OXXuD+Li4hna25OWTeuwymcvj576MWvCACB5Hae6Lfpzes/SdGs3/XnnAVPmriE2Nh4jIwMmjuhB1Uql9X3YvYM7p379najoWKaM7kW9WskrPd+4/Tdei32IjolDo9UysHvrVPngXssoF9vcyYMzzVkHyU+OlS9VlD/vPOC5XxCt3evxRYWSLF23E/+gELq3b0avb1oAyaMxzVxrcuHKTaKiY+nYuhF9u3gAyaNvl67eJjEpCQszU2ZNGKDvy0JVPBg9sBPHzlwiJCySIb3b0a55Aw6duMDW3cf0+dA0Gg21m/dn/ZKJqXLnATx+5s/4mSsICY1AoVQwrE97/dNumdWftu+HTfDm5K4l+uUAWnX/lsG92r7VitoSIAkhhMjQpFE99Kkrlv24C+9V25j5XX+AdPnCOg+cmmkesrT+vP2AQ1sXUCBfHrwW+7B8wx5mje+PpYUZa72/w8zUBI1GQ+8Rszh4/DzN3b7S73fkJ2/y5XVg+ERveg6bwa4fvXCws6bH0OnsOniaLu2aZpmra8rcNVQqW5yNSycTEBRC0w4jsgyQFCg4tGUBT58H8HXn0VSpVBpPj4bU9xjAt0O7YmVhxo79J2lYt3q64CghMZF+o2Yza8IA6tSszJVrd+g3Zg5n9y7T92Hp4oUY0a8DZy5cZdq8tdSrVYWIqBjGzVjO+kUTcHSwJTQsEvdOI6lSsRROjnapjpFRLjbIPGfd65QsvgHBbF05jeiYOGq59yUiKpoda2cSGBxK/VaDaNvCVZ9A+EVoBAc2zSMsPAr3TiOpWrE0VSqWol83D8YP7wYkL/w5dd5afH6YpG+boYEB+3zm8uDRc1p0GU2rpnVxq/clM7zX889jX4oWysfxs1coWMApXXAEyQF6uxYN6NTajUdP/fDoNpaypQqTP69jpvWrU6zXU6FMMWysLfj14g1qO1fi1r2HhIZFUrdm5sl4U5IASQghRIb2Hf6FPYfO8jIhgZcvE1Ol/UiZL+xNecjSqlyhJAXy5QHgiwol2fDTIQB0Wh1ei324cv0e6HS8CIugRNHP9QFS5Qol9elKypcuSmKSBgc7awAqlC3Oo6f+QNa5us5fucl3r37UnRztcK1TLcs+8PRwBZJTVlSvXIbLV2/T2r0eTRrUZMe+E/Ts1JzNO4+wZNaodPs+fOyHQqmgTs3KAFSrXAZ7W2vu3H+EUx57jIwMaVy/RnI/lC/Jk+cBAFy9cY9nzwPpOuT7NPX5pguQMsvF9qacdU0aOKNSqbCyNKdA/jzU/6oqCoUCJ0c7bG0see4XhNWr1cTbtWiAQqHA1sYSt/o1OHfpBlUqluLcxRus/+lnYmLj0Gp1hEdGp2rb63xqxQrnR6VSERwSRt489nRu24SN2w8zZUwvNu44TJd2TdP1XXRMHLfvPcRz3SwACn/+GVUrlebKtTv6ACmz+lPq3t4dn+2HqO1ciY3bD/NN28ZvnZ5GAiQhhBDpXLl2h/Xbfmb3ei/sba05fvYyC1Zs1W9PmS/sTXnI0jIyNNC/VimVJGmS5zCt2byfkNAI9m5Iruf7Bet4mZCY8X4qVbp6NK/qeVOurpQUWWYey6D8qx/Xbu2b0XvETIoWzo+tjRXlShV5y/3/fW1ooNbXp1Ip0Wi0r9qvo3jRAuz+0eud2vY27X7NyPDf70mlVKZ7/7ovM6vL1z+YSXNWs99nDgUL5OXu349p12t8qnJGRqnrTHp1fh08GuLaZgit3Ovy+Jk/Dd8QpOqPm+a7yqz+lBrXr8GsxRu4de8hJ365rA+O34ZM0hZCCJFORFQMZmYm2FhZkJCYyJZdxzIt+6Y8ZG99zMhoHOxtMDYyJOhFGIdOXMhW27PK1VWregW27zsJQFBwKCd+uZxlXTv2nwLgmV8QV67foVrlMkDyqEWBfE58N2N5hiMgAEUKfYZOq+PXi9cB+OPGPYJDwinzamQmM1UqluKZbxDnLt3Qf3b7/iMSEtMnqM0sF1tO5qzbeeA0AOERURw7fQmX6hWIio7FQK3C0d4WnU6Hz6tRwLdhZWlOw7rV6DvKi46t3FCp0qexMDczoWypIuzYn/xdPX7mz+/X71K9ctl3artaraJTazd6j5hJo3o19LcN32rfdzqSEEKIT0Id58rsOXSW+q0GYW1lQa0vKxAQHJJp+czykKW95ZGV7h3cGTB2Dg3bDiGPg+0bk5ZmJqtcXZNH9WTklCW4thmMk6MdztUqZFmXVqOlaccRxMXFM2VULwq8ulUHySMhk2avpmkD5wz3NTQwYMW8sUyZu4YZC9djZGTA8tmjMTM1ITQ8KtNjWlma8+Oi8czwXs/0hetJSkriMycHVs3/Nl3ZzHKxvU/OurTsbCxx7zSSqOhYung2oUrFUgC4N6pFw3ZDsLGyoFHdd0sV0sGjETsPnKaDR8NMyyyaMZzxM1ewYfthFArwmjhQf4v1XXi2dGXu0s10zSSQzYzkYpNcbEJ8dCQXm/j/YNLsVdjbWjOkd7vcbsoH4+Leh1Xzx1H2DaNe72qVz14ePH7OnEmDcrTejBw6cYFNO4+wZcW0d9pPRpCEEEKIdxAYHEqHvpOwtjLH54fJud2cj07DtkNQKGDDkklvLvyeugyaxqOnfqycN/ad95URpFcjSL/+vB61WuJFIYQQQsgkbSGEEEKIdCRAEkIIIYRIQwIkIYQQQog0JEASQgghhEhDAiQhhBBCiDQkQBJCCCGESOOTf679dQ6hpKSkXG6JEEIIIXKTSqXSr77+yQdIrxPy1WvRK5dbIoQQQojclHJNxE8+QDI0NOTz/E5sWjErXbZjkTO+6TeOTStm5XYz/pOkbz8s6d8PR/r2w5L+zZ6UiXM/+QBJqVSiVCoxMDDI7ab8ZykUClml/AORvv2wpH8/HOnbD0v69/3JJG0hhBBCiDQkQAJaf90wt5vwnyb9++FI335Y0r8fjvTthyX9+/4++WS1QgghhBBpyQiSEEIIIUQaEiAJIYQQQqQhAZIQQgghRBqf/DOAz3wDmDZ3JRGRUZibmTBhZF+KFMqf2836KC1Y5sOvF68SEPiCDctmUKJoQUD6OCe8TEhg0sylPHrqi5GhITbWlowe3I0C+ZwIDY9g2pwV+PoHYWhgwKjB3ahcvlRuN/mjM3ScFyFhESgVCkxNjBk+oAslixWS6zcHHTx6lhkLVuM1eRh1alaVazeHeHQZhqGBGiNDQwC6eDbHtW4NuXbf0yc/SXvQmJk0ca1Fs0a1OfXrZTZtP8C6Jd/ndrM+Stdu3iOfkwN9R37P7MnD9QGS9PH7e5mQwB/X7+BcrSIKhYId+45x+txlls2dwPT5q3BytKNX59bcuf8P307zZveGhbIGyjuKio7BwtwMgDPnr7B24x42rpgp128O8Q8IZpLXMkDHN+3cqVOzqly7OcSjy7BUf3Nfk2v3/XzSt9hCwyO4+/dD3Bq4AFCvVjUCg0N55huQyy37OFUuXwpHB7tUn0kf5wwjQ0NqVq+kX+29XOli+Ae+AODUL5fwaNYAgDIli2Jva8PVP+/lWls/Vq+DI4CYmDgUCrl+c4pWq2XmwjWMHNgFA4N/gx+5dj8cuXbf3ycdpgcFh2Jva4361dLiCoWCPA52BAaHUCCfUy637r9B+vjD2L73KLWdvyAiMookjQY7W2v9trx57AkMDsm9xn3Eps5ZwdUbdwCYP320XL85ZOuuw1QoW4JSxQvrP5NrN2dNm7sCnU5HmZJFGdDDU67dHPBJjyAJ8TFav3Ufz/0C6d/dM7eb8p8zeUw/9m1eTJ9ubVi2dltuN+c/4Z/Hzzhz/grdO7bI7ab8Zy2fN4FNK2axYel0rC0t+H7eytxu0n/CJx0gOTrY8iI0nCSNBgCdTkdgcAh50twmEtknfZyzNu/4mbPnf2fB9NEYGxthZWmBSqkiJDRcX8Y/8IX073tq1rA2f9y4g6O9XL/v68bN+/gHBtO2xyg8ugzj9t1/mO29jpNnL8m1m0OcHO0BUKvVeHq4cePWffnbmwM+6QDJ1tqKksUKcfTkeQBOn7uCo72tDD/mIOnjnLN11yGOn/mNRbO+TTVfpn7t6uz5+SQAd+7/Q3BIGF9UkCeB3kVUdAzBIWH692cv/I6VpTk21pZy/b6nVl+7cnDrUvb4eLPHx5uypYsydlgPWn3tKtduDoiLjycqOkb//viZ3yhRtKD87c0Bn/xTbE+e+TF9/ioiIqMxMzVh/Mg+FCtcILeb9VHyWrSWC5evExoagaWlOaYmxuxcv0D6OAcEBYfQ4puh5MvriKmJMQAGBgasXTyV0LAIps5Zjl9AMAZqNSMHdqVKpTK53OKPi3/gC8ZPX8zLhASUCiXWVhYM7tOREkULyvWbwwaMno6nR+Pkx/zl2n1vvv5BjPt+EVqtFp1ORz4nR4b370xeJwe5dt/TJx8gCSGEEEKk9UnfYhNCCCGEyIgESEIIIYQQaUiAJIQQQgiRhgRIQgghhBBpSIAkhBBCCJGGBEhCCCGEEGlIgCSEEEIIkYYESEKIHNGx91jOXbyW2814L0dPnaf3sKn/s+P5BwTj7PZNqpWQU7p+8x7NOw3+n7XnfaU9n9mL1rF0jeS0Ex8nWShSiFx049Z91m/dx+17D9DpknMqudWviadHYwwM1LndPJHDnN2+YcOyGZQoWhBIDihadR3OsV0rU6WP+Vj9185HfNrkL7AQueTcxWtM9lpK7y5tmDymP9ZWFjx+6sfG7Qd4ERpO3jz2ud1EIXJNUlISarX8RIncI1efELlAp9OxcLkP37Rzp32rxvrPC33+GRNH9dW/v/vXQxYu38ijJ77Y21nTvWNLGtWrCcCajbu4+9cjHOxtOHHmIpYW5kwY2ZuomFiWrNpCZFQ0rdxd6de9HQA/H/uFn/YcwblaRfYeOo2JsRGdPd1p/XVDAO4/eMyCZT48euKLSqWkWuWyjBzYFStLCyA5h1a50sX568Fjbt75m/z58jBxVD99biePLsMY1u8b6tSsCsDlq7dY8eN2nvkG4GBnQ/8e7fjKuUrytj9usnj1FvwDgjEyMqSuSzXGDOmerp9ej0hMGt2PtZt2ExEZTe2aVRg3rCdqtZrYuHimeC3j1t0HJCQmUrzI54wY0IXir0ZosttHPstn6s+ptbsrZ85f4dETX0oUK8SUMf3J45icEf3h4+fMXLiaR098KVW8MKVLFuHO/X9YNndCunPpMXgSAH2GT0WpUNClfXPcXn2X5y5ey/D8rt64w9ip3hzfvQpIvgW4ZuNuQsMiMDU1waNZfXp08kh3rIjIaGYuXM21P++i00G+vI7MmjSMvHns031PZy/8jveKTezx8dafc4vG9Th9/jLP/QIpX7o440f2wcHOBkgeBRvW7xt2HzxBaFgkX1Ypz7fDemJuZpquHd/PW4m5mSnD+3cG4LlfIN4rNnH73gOMjQxp3qQeXds3R6lU6vv+K+cq7D10igplSjBr0tB0dQrxvyJzkITIBc98A/ALCKZhXedMy0RFxzB8/Bwa1nXm8PZljB7cHS/vtdy4/Ze+zOWrN6lRpQJHd66kcQMXpsxZzq8X/mDjipmsXDCZrbsOc//vR/ryDx8/R6FQcHDrD3z/3SCWrfuJazfvAaBUKBjQw5NDPy1l80ovgl+EsWztT6nadOTkOQb2bM/RXSspXbwIC5ZtyLDtDx4+ZcKMxQzo6cnRnSsYO7QHU+es4MkzPyD5h7NTm2ac3LuGXRsW0LiBS5b99duVG2xYNoMtq2fz+7XbHD11AQCdVkujejXZ5bOAn39aSoliBZkwcwk63b8zB961j9I6cuo808YN5ND2ZZgYG7HKZyeQPMIxZsoCnKtV5MiOFQzo6cnBo2czrWfdkmkArFo4mVP71tKtQ4s3nl9KcfHxfD9vFd+N6M3JvWvYssqLGlUrZHisLTt/RqPRsn/zEo7sWMF3I3rrkxy/jf1HzjB17EB+3roUWxsrps5enrpPTp7nhznj2e2zkKjoGLyXb3xjnfHxLxn87SyqVirL/s1LWD5/IifOXOTgsV/0ZR4+fo5KpWTvxkVMHtPvrdsrxIcgAZIQuSAsIgoAB3ubTMtcuHwdaytL2rZohFqt5osKpWlUryaHj/+qL1OqeGHq1qqGSqWkYV1ngl+E0dnza0yMjSlcMB9FCxfg/oPH+vLGxkb06twKAwM15csUx62eC4dPJNdXvGhBKpYriVqtxtbGivatm3D1z7up2tS4vgvFixZErVLRpOFX3P/7MRnZc+gUTRvWpmqlsiiVSiqWK4nLl5U5+cslANRqFc/9AgkLj8TE2JgKZUtk2V89OnlgZmqCg50NNapW4N6rgMbMzBTXujUwMTbGyNCQXp1b8/R5AMEhYdnuo7RaubvymZMjRoaGuNWvqT/2rbsPiIiMpmuHFhgYqClbqhgN6tTI8jze9fzSUqtVPH7qS0xMLBbmZpQpWTSTcmoiIqN55huASqWkRNGCWFmav3V7Wrk3oNDnn2FsbMSgXh3448YdgoJD9Ns7tW2Gg50NFuZm9OnahmNnfkOr1WZZ5/nL17EwN6N9q+T5dU6O9rRr6cax0/8Gg2ZmpnR71Z/GxkZv3V4hPgS5xSZELrB+9WMV/CKM/J/lybBMUHBounlIn+V14PrN+/r3ttZW+tfGRobJn9mk+MzYkNi4l/r39nY2qeZ1OOWx49qfySNIz3wDWLJqC3f/ekhsfDw6rQ61WpXq+LY21vrXJsZGxMbFZ9j2gMBgfr9+h59TjA5oNBrMTGsB4DVpGOu37sez52ic8tjTxfNrXLMILuxsU56TEdExsQDEv0xgyarNXLhyg8ioaJSK5P/5IiKicLS3zVYfvenYr8/5RUg4drbWqFX/9pGTgx2PnjzPtK53Pb+UTIyNmTt1BFt3HWbpmm0ULVyAPl3aUKVSmXRlO7VtRkJCIhNmLiE6Jg7XOl/Sv0d7/fm/iZPjv9edrY0VhgYGBIeE4eiQfGsx5XXp5GhPYmIS4a+C/sz4Bwbz8PFzGrbqo/9Mq9OSx95O/97B3galUv5vF/8/SIAkRC74PH9e8uZx4MSZi3Tr2CLDMo4OtvgHvkj1mX/AC/0Pf3a8CAlLNfk1MChEP4o1Z/GPfJ7fiYmjZ2NhbsbZC78zfd6qbB3H0d4Oz5ZuDOjZPsPtJYsXZtakoWi1Wn658AcTZizhiwqlUwUub2PrrkPc+/sxK+dPxNHBjqjoGBq17sv/4tFceztrQsPCSdJo9EFSQIpRlowoFIr3Oma1yuWoVrkcSUlJ7DpwgrFTF3Js18p0QYWpiTEDe7VnYK/2+AUEMXrSAnYfOEHHNk0xNTYmPj5BXzYkJDzdcQKC/r3uQsMjSEhM1M9BAvAPfEHZUsVelQ3BwECNtZUFgUGZn38eBztKFS/EmkWZL6OgfM/+ESInSaguRC5QKBSMGNCFjdsPsGPfMSIik//7fvrcnxkLVuMf+ALnapUIC49k14HjJGk0XL95j2OnL9DEtVa2jxsf/5J1m/eSmJjE7XsPOHrqAm71kuf/xMTGYWpigpmpCYFBIWze8XO2j9OyWX0OHvuFP67fQaPRkpCQyM07f/P4qS+JiUkcPnGOyKgYlEol5ubJk3tVqnf/cxQTG4ehoQEWFmbExsWz4sft2W7zuypXuhjmZmb4bNtPUlISd+7/w6lXtxAzY2tjia9fYLaOFxoWwZnzV4iJjUOlUmFmaoJKpcqw7LmL13j63B+tVptcTq3S92+JYoU4fuY3XiYk4OsfxK4DJ9Ltv/fQKZ488yP+ZQLL1myjUvlS+tEjSJ7jFBwSRlR0DKt9duJap8YbR35cvqxMaFjy9fwyIQGNRsuTZ35cvXEnW/0hxIcmI0hC5JJaNSqzYPpoftyyl1Ubkif+5nG0o3EDF+xtrTEwULNg+mi8V2xi+brt2NvZMHpwNyqWK5ntYxYplB+NRoN7h0EYGxnSt1tb/S2aoX07MXvROnYdOE6B/E40ru/Coye+2TpOyWKFmDZuICs37ODxUz+USgXFixRkcJ+OABw7fQHvFZtISkoij4MdU74doH9a7l10aNWEyV7LaOY5ECsrC/p0acPugyez1eZ3pVarmTNlOLO817Jp+0FKlyiCW30XHj/NvM/6dGnDguUbmeW9hm/audOwTuaT9NPSarVs33uUGfNXo9Vp+TxfXmZOGJJhYPLcL5CFy30IDYvExMSIerWq0crdFYC+3dowxWsZTdsNoHDBfDRxrcWug6mDJPdGdZjktZTnfoGUK1WMqWP7p9ruVt+FQWNmEBIaQfUq5fVPqWXF1MSYxV7fsnTNNtZt3ktCQiL58jrSqW2zt+4DIf6XZKFIIT4RaR9hFznPa9FadFod44b3yu2mZFvaZQDSSrvYpRD/VXKLTQghsun6zXsEBoWg1Wq5cu0Wx05doH7tL3O7WUKIHCC32IQQIpt8A4KYOGspUdExONrb0r+HJ19WKZ/bzRJC5AC5xSaEEEIIkYbcYhNCCCGESEMCJCGEEEKINCRAEkIIIYRI4/8A5uzXCR0511AAAAAASUVORK5CYII=",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAkgAAAH1CAYAAAANogGZAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjksIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvJkbTWQAAAAlwSFlzAAAPYQAAD2EBqD+naQAApH9JREFUeJzs3XV4FMcfx/H3JSGKhABBEwIkENzdnaJFCqXFihYp8gNKi7W0SKFocS1OKa5Fimtxdw8WQkIgELnI/f4IXMmRIOWQ0s/reXjI7ezOzO7t3n1vZnbWYDRGmBARERERM5t3XQERERGR940CJBERERELCpBERERELChAEhEREbGgAEleKHexj3DNkJf23fq9lXKGjJholfyu+t3ANUNeXDPkZcfu/VbJ81XVaNDqpY6dtff9eXbs3m8+Llf9brzx8j4UQ0ZMNB+3f8Lax/1NnzP/hvNk3u8r3vs6Po/le/hvOOb/JQqQHnvyRRbfv9XrNr90Pu/6S/ltftG+L558ceUu9lGc5Q729hTKn5tC+XOTJEnid1S7l5MnZzYK5c9N+rSp33VV5DW179YP1wx5qdGg1RstR+fMhydJksTmzywHe/t3XZ3/PLt3XYH3jb19IvLk9I2zLLlrsjdWntEYib19ojeW/7v2LvcvTepU/Llq7jsp+1XNmz76XVdB/mVe9px5nz9j3ue6vQv5cme36meWju/rUQuShdTusV+qT/8rWawgUVFRVKjxGa4Z8lK7URsAoqOjqVjzc1wz5KXmJ62Y89sy8havbs6rVsPWcX5JPmmlatu5N/1+HIl33nIUKlsbgPFT51CqSkO8cpYmpVdBsuQpR5PW3bhw6Uqc+l28dJXWHb8ha/4KpMpUkByFKtP3xxHmliu/6zcBGDpq0jPdAQcOHeOTph3xzFGK1FkKU6ZaI1as3hgn/2vXb1L3s3akzlKYgqVrseqPTS913J5uGl6+egMVanxGqkwFWbR8LQDnLlymebseZMlTjlSZClKk3MdMn/37c/MMCwvns1ZdyVP8I9L5FMU9cyEKlKrFoJ/HYzRGmo/p0FGTAPC7ftNch3m/r0iwNW/PvkPU+/xLPLOXxD1zIYqU+5hfJs4kOjravM6TlrjvBo2iZ5/BZMpVBu+85ejVfyhRUVHm9RYsXkWpKg3JkK04GbIVp0i5j2nbufcz+2IymRgxdhq+BSuRMWcp2n71LSEPHz1TXnxN7Ws3bOWjei1InaUw+UvWfOY9i8/hoydp3LILmXKVwT1zIfKWqM7YybMSXH/L9j18VK8F3nlj3x8P3xJ8VK8FGzfvjLPe2MmzKFy2Dmm9i+KZvSQlK39Cvx9HmtM3bNpB5dpN8cxRirTeRclfsiZftO9JcPAD8zobN++kev2WZMhWnDRZivBRvRZs37XvlcqJz/eDR1OsQl08c5QipVdBfAtW4suufbntH2Be5+nWxuWrN1C4bB3S+RTlo/pfcP7iFfN6JpOJgcPGkSlXGTxzlKJn3yFERkY+t3yIfR8XLFoJwK69BxJsTT53/jK1GrYmTZYiFC5bh3V/boub/hLXy/POmfiuQUv+d+7SptO3ZCtQEffMhciavwK1GrZmw6Ydz6z7vPreuOnPJ007krNwFdJkKUKaLEUoXrEeE6bNxWT6e5q9J/Xt9+NIOnbvj2eOUtT7/EsAIiKMDB4+gQKlapEqU0G885ajY/f+BAbdi1OPyTPmk71gJdL5FKVNp2958ODhc9+PJ/YfPEbtRm3IlKsMqbMUJnexj/isVVcuX/ED4m+Fjq+76+nWwakzfyNX0WqkzlKYBk06cP3mbfO2Tz7r23Xpw+DhE8iavwLpfIrSssPXBN9/QEIS6mJ70TXz9Gfd7PlLqd2oDamzFGbE2GlER0czYMgY8paoTuoshfHKWZpy1Rvzy8SZL3Xs/ssUIL0kOzs7powdjLOTI9t37WPWvCWMnzKHg0dOkCxZEiaOHoh7qhTkzpnNvE02n8wUyp8b36yZ4+S1fPUGJs2Yh3vKFCRJHNv1s2vvQS5fuUZq95RkzeJF8P0HrF63mTqN2hIeHgHApcvXqFDrcxav+IPAoGAye3kSHRPD1h1/mbuTnvxaSJfG3dxUC7B3/2E+qv8FG7fsxMnRAc8M6Th24gzNv+zBgsWrgNgvhWZtu7Nl+14iI6Ows7OjXefe3Am4+0rHqm3n3ty8fYeMHukxGAxcvHSVSrWbsmLNRmJiYvDJ7MX5i1fo3nuQObiJT4TRyNr1WwgPjyBL5oykSuHGpSvX+HnMFH4cOhYA36yZSZfGHYht/XuyzylTJI83zx2791OrYRs2b9uDjY0NHunTcu7CZfoPGkW3bwY+s/6EaXNZvGIdTo4O3A28x+QZ85m3cAUAx0+dpUO3fpw4dRb3VCnxzJCOm7f8+X3pmmfyWbF6I6PHz8DBwZ7790P4fdlaRo+f8VLH84v2PQm4G4SDvT2Xr/rxRYevOXridILr/3XgCFXrNuePDVt5FBpKlkyehIQ8Ys++wwluc/rcRQ4cPk7ixC5kz+aNyWRiz77DNG7ZheOnzgKwdsNW+v04kvMXr5DRMx1pUqfi0uVrLF8TG7DdDQyiSZtu7D90jKRJEpM5kydBwcEsW7WB+yEhACxduY6GzTux+6+DJE/uSurUKdmz7zB1P/vS/IH/onIS8ufW3dy8HUCGtKnJ7OWB/527/LZ4FZ+17PLMurdu36HNV99iMBgIC49gz1+H6NT9O3P6lF8XMPyXqdwLvk8SF2eWr97A5Bnzn1s+xHZ7pXCLPfeSJHZJsIu3Wdvu3Lzlj8Fg4PzFK7Tp9C337t0H+MfXy9Msr8H4dO89iEXL1/LoUSjZs3ljnygRO/cc4OCRE8+s+7z6Bt67x8YtsYF0Vp9MJEniwumzF+n9/c9Mm7Xwmbwm/zqfpSvWkyFdGpwcHQFo2uZ/DBs9mat+N8jqnRmjMZJ5C1dQo0FLwsLCAfhj41Z69R/KLf8AnJ2d2LPvEAOHjX3hsYiJiaFRi6/YvmsfiRLZkdU7E2FhYaxdvyVOUPMqDhw+Rv+Bo3BxdiIyMoo/t+7i81Zd4wSE8Pizfvo8kiVNQmhYOEtXro9znr2Ml7lmntaj72BOnDpHpowZsLW1YerM3xg1fgbXb9zGO7MXbsldOXXmPOvjCYTFgtEYYdK/CFPl2k1Mzu6+8f57er1J0+eYnN19TWmyFDKl8Mxncnb3Nc1buMycfv7iJfN2m7bujLcM1wy5TQePHDMZjRGmsLBQk9EYYTp24pTp0aOH5nU3bNpmzmfj5u0mozHC1OarXiZnd19TsvS5TDt2/2Ved/+hI+a/sxWoYHJ29zUNGDI6TtlV6sSWXaNBC1No6COT0Rhh6t57oMnZ3dfkk7esyWiMMG3cvN1c5qTpc55Z1qrj1wkev01bd5rXa972f6bw8DDz/rXu9LXJ2d3XVKh0TVPw/WCT0RhhGjNhhsnZ3deUwjOfKTAoKN66P3r00HTsxKk45bT4snucOhuNEaYBQ0abnN19TdkKVIizbnzvRaVan5vXvRMQYDIaI0z/+/ZHk7O7r8kldXbTufMX49Qle6GKpoC7d00PHjwwZcld2uTs7mtq0rqLyWiMMC1atsbk7O5rylOsapz93bJ99zPveerMBU1Xrl4zhYeHmUpUqmdydvc1lan6SYLv29PHs8+AYSajMcLkd/2GKa1P4Th1iO9f1Y+bmpzdfU1pfQqbTp05azIaI0zh4WHmc+7pvM9fvGQyGiNMFy5dNh8PozHCdOdOgCl15oImZ3dfU/9BI0xGY4RpxNgpJmd3X1P1+i3M64WEhJjPxX0HDpv39f79+yajMcIUERFu2rvvoOle8D2T0Rhh8i0Yu59tv/rGFBERboqICDc1bNbB5Ozua6pYs/FLlZPQv8NHT5jfB6MxwjRt5gLzfp49dyHOueLs7mtasWa9yWiMMPXoM9C87Em9ffKWNdcpNPSRKfh+sClv8WrxfiZY/mvVMfZ8r1y7SYLXSM++g0xGY4Rp+er15mVr1282GY0R//h6ed41GF89C5WuaXJ29zXN/W2pedk1v+umE6fOvFJ9A+7eNZ9HT861J9fZk/f06fp6+BY3Xbpy1Vy3zdt2mfN8cu1c87tu/nydNmuByWiMMFWs2djk7O5rylm4sino3j1TWFio+XPt6XPZ8t9tf3/zOleuXjMvP3r8pOnGzZsJfobEd508eW+TpstlOnr8pMlojDBNnjH3mWPy5LpP61PY5Hf9hslojDD1GTDMvN6TY/y89/BJmS9zzTz9WVe5dhPTgwcPzMe3y9ffm5zdfU1fdult3rege/dMe/cdfO55rH8RJo1BshDfGKSntWzakD82bDP/YqpXuyqf1K2e4PrxKV28MLlzxLY02draAuB3/RZde/3AydPnefgoNM4vkVu37wBw8PBxAEoWK0TRQvnM6XlzZX9hmYce/yrcsn0vKb0Kxkm7ccufm7f8OX32gnlZ7eqVAChbqijJXZNxL/j+S+9f2y8aY2NjY96/J2WfOnuBdD7F4qwbFh7OydPnKFY4/zP52NjY8PvSNaxYsxG/G7fM3WoAt57qNnkVh4+eBKBKhVK4JksKwCcff8Sk6fMwmUwcOX4Kr4wZzOt/VLkcyZImASCjZ3pu+QdwJyAQgGKF8+GaLCkXLl0lU+4yeGfKSO6c2fikbo1nyi1dsgjpHg+mzZrFiyPHTnHnbuBL1bl+ndhm/9TuKSldvDCr123m1JnzCa7/5DypU70y3pm9gNhj+eSci4/RaKTD//qz78ARgu7dJyYmxpx2+3bssa5YtgQ/Dh3L1h17yZKnHD5ZMpI3dw4+b1QHAN+sWfDKmIErV6/jk688mTN5ksPXh9rVK1EgXy7uBgZxzS+2C3juwuXMXbg8Th0OPK73i8pJyPGTZ+jwv35cuHiFR6FhcdJu+QeQycvD/Dpp0iR8VLlcbL19spiXBwQG4ZosKTdu+QOx77+dnR12dnZUqVg6Tjfc62hUv+bjsv9uXX5yPvzT6+VpltdgfKpVLsupsxdo360fQ0ZMJKu3FyWLFaJFkwavVF87O1t+mTiT9Zt2cNs/IE4XdHzXae3qFcmQLo25boeearGq0aDlM+sfOHScZo3rcfrsRQAqlitBYhdnAGp9VJGdew4850iAW3JXihTMy76DRylQqhaZvTzI7utNlQqlX/mz+4kcvt5kz+YNxF6fT1qfT505T6XyJc3rlS5emNTuKc3rjXrcanzqzHmyemd6YTkve808rWXTBjg6OgCxx7dapTJMm7WQ2QuWsnHzDrJkzkih/Llp/ln9V9zr/x4FSBaejEFKiNEYye07f1/01/xuEh0dneCHUHxSpUoR5/WVq9f5vHVXjMZIkiR2IV+eHERFRXH8ZGzXRvRTX1avK10ad/MX9dOinhp/87pSpXKLd3kKt+Rkeir4eMLWJv5jN2r8DEaOmw6AR4Z0pE6Vgpu3/Ll5+06cL/A36UlwBGBrG3u5PIldU7unZO/mpSxcspojx09x6swFZs5bwuwFy9iwfBaFCuSJPx+7uPm8Dxo2+4pLV65hZ2dHDl8fHB3sOXbyDEZjpPn8y+Hrw95NS1m0fC3HTpzhxOlz7N0/nzkLlvLX1uV4pE/L1rULWLhkNQcPH+fM+UssXLKa3xavYuaknylVvJC5PK+MGUjp9mw3qNEY+VLlWNqz7xDtu/XDZDLhltyVbD6ZeRQaxtnzlwDijC8Dy/fj7/PPsovkTXlS/vPKftXr5WkJXYNP69frK4oWzsemrbs5ffYCu/86xPpNO9i55wC/zx730vX99rufmb1gKQBZMnmS3DUZl69eJzDoHtHRz16nqVKmeGbZE0+GBDzN3T3h9V/Wit+msGj5Wv46cISz5y6xYs2fLFmxDv87d+ncvoW5GzLmqfPkQcjLjW96W553zTzN8vhWLFeSbet+Y8XqjZw4dZZjJ86wc88B5i9ayaGdq83BpjxLAdIrGvTzOI6fPEv6tKkJjzBy4PBxhv8ylV7dYgcbOjs5mtcNDQuLNw/LMQFHT5wxn+RL5k2kSMG8LFnxB606fhNnvYL5c3Pm3CV27T3AgUPHzF/Ax0+dNbcOPCk/1OIXdP68udi19wAeGdKxfMFknB6vd+OmP0eOn8IzQzrzLyKA1X9spkWTBmzfte+VWo/i27/8eXNx5twlkiZJzKLZ40mePPauwMCge2zb+ReFC+aJLxv2HzoGgHfmjBzYvpLo6Ggaf9GFm49b1J54ss9hYWGYTKYEx1zE1iUnu/86yIbNOwm+/wDXZElZvGKdud75cud46f28dfsOgUHBdOnwhXlZkXIfc+7CZfbsPxwnQHody1atJ1eOrATcDTT/Ws7h65Pg+gXz52bH7v2sXPsnXTt8QeZMnphMJk6ePk+uHFmfWT/oXjCXrlwDoHePDvyvUyuu+t2gSLmP46x38dJVbGxszOe60RiJd95yPAh5yKEjJ0mWNAnnLlym7ReNMbT8DID6n7dn07bd7Np7kI9rVsEjQzr8rt8kb67sTB//E3aPg8ULl67gd/0W9vaJXlhOfAHSgcPHzV/Yu/9cTJrUqRg1bjoDfvrlVQ41AEmTJCZ92tTcuOXPH39uo0ObJhgjI58ZsJ4Q8zWYwPX/Iv/0enna866BJ/buP0zJYoWoWrEMgPkzZ/dfB1+pvgceX6cVyhZn6bxJhIdHUKl202cGWCdUt/x5c5r/7tapFTWqlgcgKiqKrTv+wsfbC4Ds2bKwZ99hNm/bw6PQUBwdHF5qChaTycS+g0f5vGEdmjWuF1vONz/y69zF7PrrIJ3btyBVytiAMiAwiPsPQkiWNAkrnjPm7dSZC5w9f4lsPplZtnK9ebnldblzzwHuBATinioFy1b9vd7Tn7XPkzKF20tdM0+zPL4nTp0jpVty+vX6CogdnJ+tQEXuBARy4eIV8uV5+c+8/xoFSBb87wRQqVaTOMs6tGlCvdrV2LX3IGMnzwZgzLDveBASQssOvfh5zFSqVChN/rw5SZnCDbfkrgTdC6Zd5z5kyeRJw3o1aPf4CyM+2bNlwdbWlujoaBo06UCGdGnwD3i2+6V7p9asXreZ+/dDqFq3BT5ZMnL/fggpUrixc0PsHS4+Wbw4e/4Sk3+dz869B8ieLQsTRv5I7x4dqPNpW/46cIRsBSuR0SMdgYH3uOUfQImiBalRtTxlShYhTy5fjp04w/96D2LSjHlcuXqDRInsiIyMeqY+L+t/nVqxZt1mLl/1I2eRKmTJnJF7wQ+4dfsO6dKmpl7tavFulyt7Vtb/uZ0Ll66Sp/hHREVGEfZ4wPrTfB43Vd8NvEehMrVJ7pqMaeN+wmDz7JfEt93bU/ezL/G7fpN8JWqQws2Vi5djg4Omn9aN0732ImfPX+Ljxu1ImSI5aVK7E/LwIVevxd55kvM5AcyrmjR9HivX/ol/QCAPHoRgY2ND5/ZfJLh+3687Uatha4LvP6BYxXp4Z8qIf0AgRQvnY348t4Ynd01mDgiGjJjA4mVruXn7Dna2tjx9tHftPUjnrweQJnUq3FOlICAgkAchD7G1tcU3a2bu3g2iSp1muCZLSrq0qYmMjDR3SeXKHhuY9e/1FW2++pYVazaya+8B0qZxx//OXe4EBNL4k9qUL1P8heXE50n+ACUqNSBliuQE3A165WP9RKd2zfn2+2Hs+esQeYtXJzIqivsPQl5qW58sXkBsd26JivVxdnZi1e/TXrrsf3q9vKoBQ8Zw6OhJ0qdNQ9KkiTl3/jIAObM/G0Q/T87sWTl19gKbt+2hUJna3At+8EotvKVLFKZi2RJs2rabz1t1xSeLF7a2Nvhdv8Wj0DBW/T6NjB7p6dSuOXv2HebSlWvkK1EDBwcHAl6imzo6Opo6n7YlSWIX0qdLjY3BhjOPWxafnDelSxTGxsYGozGSMtUakdw1GcdOnEkwTwf7RJT7qDEZPdNx7sIVAHLnzEbFciXirBcZGUmhMrVJ7Z7SfC1Ur1qebD7xn8fxeZlr5nmWr97AiLHTSJ82NSlSJOf6jdiB6c5Ojq/0efdfpLvYLBiNkRw4fDzOv9t37vIg5CFfdu1LTEwMTRp9TKXyJalXuxof16xCVFQUbTv3JiwsHIPBwJhh/cns5UnIw0ccPHICvxu3nltmVu9MjBsxgIye6TEaI3Fzc2X6+J+eWS9zJk82r5pHgzof4ZY8mfmLvWypIuZ1+n7dicIF8mBjsOHw0ZOcOhM7rqhksYKsXTKDyuVLYTDEfrnbJbKjdvVKfPVlMyD2l8ecqSMpW6oodna2hIVHMHb496RJ7f5ax9QnixcbVszm45pVcHJy4sy5i5hiYqhUrgR9enRIcLv/fdWKxp/UJlmyJISEPKJenWq0at7wmfWqVSpD88/q45Y8Ntg5cPh4gr/eS5cozKrfp1K+TDFiYmK4dv0mWb0zMaB3V0b91PeV9svLMwP161QjSeLEXLx0lcDAe+TKkY0xQ/tToWyJF2fwkmZNHkGqlCmIiIjAK2MGpo//iXy5Ex53VrRQPtYvm0W1ymVxcXbm/KUruLg4UTyBcSsGg4HZU0ZQIG9ObG1siY6JYerYIbhZNOfnyeVLzWoVSJQoEWfPX+JRWDiFC+Rh5qSfyeaTGbfkrnzWsDbuqVJwze8GN27eJqt3Jvp/05lmn8X+cv+kbnUWzhpLyWKFCA+P4MLFqyR2ceHTBrVo1rjuS5UTn/JlijOgd1fSpk5FeHg4Plm8GDmkzz853AC0a9mYbh1b4posKQ9CHlK1Yhm+fM6PnKc1+bQutatXImnSJJw6e4EDh4+/Ujf5P71eXlXdWlXJnycnIQ8fcurMeZIlS0L9OtWYFs9nz/MM+q4H1auWJ7GLMw8fhdL5y+ZUq1z2lfKYN300X3dtR5ZMnly5dh3/O4Fk9clMjy5tyOEb29pSo2p5Bn/fk9TuKXn4MJT8eXLQt2enF+Zta2tLy6af4OmRnpu3A7h0xQ9Pj3R81a45X3dtB8R+Bo8e2g9Pj3T4+98lRXJXRgx+drqOJ/LlycnQH3rxKDScRInsqFC2OPOmj36m9aZ2jcp0bt+C+w9CcHJ05OOaVRg/fMArHZuXuWaep0TRAlQqV5KYmBhOn72AyWSiTMkiLJozwTwOU+JnMBoj3qORECICT6YjaA3A0T1ryeiR/h3XSETad+vHgkUrKVmsEGsWT09wvRoNWrFr7wEaf1KbiaN+fIs1FGtSC5KIiIiIBQVIIiIiIhbUxSYib8X6zbtYvPJPpo5+tZmEX9aKtVuYOmcxoaHhTBzRj2yP7356l9Zs2M7CZeuYPXHwu66KvIITpy8waOQU7gQE0a7FJ1y+eoPELs50bP0pt24HUK95NzYsmUySxC4MHTPDnCYfFt3F9pR9h04wY+5Szl28+nhiPR++/KLhO/ugPXryHMPHzmTOpMHvVf2uXb/F+Om/ceL0BYzGSDJlTE/H1o3JmzPhu1+KV22Cg4M9No8HMaZPm9q8X/H5rE0vbt/5+xEnUdHRJEpkx6ZlsXcD/Th8Mhu27CbR41te3ZIn49N6H9GgduUE85w2ZwnnL15j6PfdXml/Lf04fDKJXZzp1r7pa+XzPB16DqRM8UJ8Ws86dyxZKl61CbMmDCJrloxvJP9DR0/Ra8BoNi6dYl5WtUJJqlYo+Zyt/rmoqChGTpzNmMG9yJc74Yle36T49tna7gbe45cp8zl49BTh4RG4JktC6eIF6frl33febt6xj4kzFhJ07z7uqdz4X4dmFM6fK04+dZt1JejefWxtbLC3T0Su7D50/bIJGdI9O0faxSt+jJ0ynzPnL3P/wUNzYPC0ZWs2MWvBSu4/eEiBvL5827V1nMf9vCj9aQePnGLGvGWcvXAFg8EQ7/GcPncpS1b9SYTRSKmiBejVpWWcKVaeZhnQQGwwPX76An7q35UCeZ+9zX3yzEVULleclp+/eBB0ry7PTm4pHwZ1sT22Y89Bvhkwio8qlWbVgnEsnT2afLl96dBjIGcf38b5tu3ae4hSxfO/d/ULeRhK8cJ5mTtpCOsWTaJG5TJ07/szwfeffxv0lFHfsXnFdDavmP7c4Ahg/tSh5nU3r5hOkQK5qVw27u2s9WpWMqf/8G1HJkz/jaMnz732/lmDNSfefBeeng353yAw6D5GYyRZMnnEm24ymeKdtPDfZsCwSdjbJ+K3acPYuHQKY4Z8g08WT3N6eISRAUMn0qZZfTYtn8bwH3qQKoFA5IdvO7J5xXSWzByJo4M9P/wc/3Pe7GxtqVCmKH27t4s3/cCRk0yYvpBBfb9i7e/jSe6ajO+HTnzpdEuOjg7UrFqWzu0+jzd99fptrFq3jUkj+rF8zhjuPwhh5ITZCeZnac7CVUyeuYhffvo23uAIYmcAT+hckv8OtSAR++E5auJcmjaqRZ3q5c3Lm39am+s3/Rk3dQFjh37LnIWrOHfxKj/2jr21tEXHvtjZ2TJtTOxtm9/+MIbcOXz4rEF1oqKimDFvORu27CbkYSh5cvrwdeeW5g+r4lWb0POrL1iyciO3A+5SIE92vvu6fZxZTXfuPUzfHm3fu/rl9M1CTt+/H89Qp3p5xk//jQuXr1Eo39+TvllLQOA99u4/yuRR/RNcJ0e2LHh5pufy1evPbcl62vP20WiMZNjYX9m59xBRUdGkTpWCPt3bcOL0BdZv3o3BAKvWbSWNe0rmTx1Kh54DyZEtC+cvXuXYyfP80LsjC5asjdMKdO7iVZp36MOe9bEztUdGRvHr/Nj34F7wA9KkTkn/Hu1Yv3k3R0+c5cTpC0yZtYi8ubIxatDXz9Q/NCycCdMXsnPvIYzGSIoWykP3js1I7OLM2KnzOXX2EuOH9cbGxobNO/YxYvws5kwaTI9+IwBo220ANgYDzT6tTdXyJajXvBt9/teGmQtWEBoWztqFExg3bQGbtu3lQcgj3FO50bppfSqWKWquw5nzlxk3dQHnLl7F1taGSmWL0bppPbr1/RmjMZIKdVoBMHJgT27cuhOnuyno3n1GjJ/FoWOncbC3p1rFkrRuVh87W1tza8xXbRozfe4ywiOM1KpWlk6tGz9zHM5euMKX/4u9U6jO551xS56MxTNHUrdZVz6uXoEdew5y/tI1pv/yAw72iRgxfhanzl4iaRIXGtSuYn5/nnSHlSpWgKWr/8TW1pZuXzYlVSo3ho2ZgX9AIOVLF+Hbrq3Mj/F44v6DkHj3+YkZ85axeMVGMECzRrXjtAxu3LqHWb+txP9OIB7pU9P1y6bkSeAcPnnmAq2a1DW3hGRIl/qZVh8bGxvSP54tP33aF0/R4eLiTLWKpfjup/Hxpmf0SEdGj3Tcuh3/433WbNhO1Qolyfn4dvwOLRtR67NO3Lh1h/Rp3V+YbunJ58uho6fiLW/1+m18UqcKnhliJwxt27wB7XsMpEenFjg62D93X8dP+40NW3YzYXhfvDzTxbtOjU87ci/4Af2HjMfWxoaZ4wcy67eVCbYaP92i/KS1qn/PL5k+dyn3HzykTImCfNu1lXmCx8079jFh+m8E3w+hYpmi3A0KJnvWTLRuWp/7Dx4yeNRUDh87jckU+/4N6d+VtKlTPne/5M1QCxKxXUa3/AOoUv7ZuWuqlC/O4eNniDAaKZA3B4eOxT5F/UHIIwIC7+F3w59HobEzOB86dpqC+WJ/kUyauYhjp84xaUQ/Vi8Yh0f6tPQfHHf6/s3b/2LssG9ZPmcMd+4G8dvSP8xpN27dIeThI7Jnzfxe1u9pFy77ERoWTibP59+K3r3vz3zUsD2deg3mxOkLz133aWs37sArY3rzB6wlk8nE8VPnuXb9FrkSWCchCe3j2j93cOHSNRb9OoKNS6cwpH8XUiR3peHHValaoYS59Wr+1KF/13PDDto2/4TNK6Y906URnwkzfmPP/qOMGvQ1fy6byuC+nUmaNAmd231O3lzZ6NDyUzavmB5vcAQwaMQUHoQ8ZM6kwSyZPZLo6ChGjJ8FwJctGhIeHsGv81dwy/8uP42eTv+eX+LmmowZY38A/m7Ra9H472ec7dh7iF/H/cjSWaMA8MnsyfSxP7BhyRRafl6XH4ZNMs9kfuduEJ2+Hkz50oVZtWAsy2aPpmKZoiRLmoRRA3uS2MXZ3MIXX7dX/5/GY2dnx5JZo5g4oh/bdx9k7u+rzemhYWFcvnaD338dzuSR/Viy8s94vzSzeXsxf0rs3D0r5v3C4pkj/35PNm6nX492bF4+nYwZ0tKj/wi8M3uyasFYfurflXmLVrN+827z+peuXMc1WRJW/zaedi0+4acx0/l92TomDO/DgmnD2PXXYbbvfnam6eft86WrN3B0cGDl/F8Y2LsT46Yt4PrN2Ge97d53hLFT59Ove1vWL55Es0a16fndyAQnpcyTMyujJ81l7cYdXLv+7Pxqdna25Myehf5DxnHL/248OTwr5OEj/vhzB1n/YVf9hUt+ZH2qFcstebLHc5L5vVT6K5d32Q+fp7qGs2bJiNEYiV88x+Npw375lW27DzB5VP8EgyOANb+NJ7V7CnML25NA7FXs2X+UWRMGMX/qUA4cPmk+x65dv8WAYRPp3rE56xZPIke2LPx18O/nqc1fvIbo6BhWzhvLukWT6P2/Ngl2HcqbpwAJCH4Q+8ydlClcn0lLlSI50dHRPAh5hK9PJiIijFy+eoNDx06RL1c2cufw4eiJs5y7eBWIvVhNJhNLV/1Jl7afkzJFchIlsqNdiwYcO3UO/zt/z/z6+Sc1cHNNRpLELpQvWYQz56+Y03bsOUTJovkxGAzvZf2eCHn4iP6Dx9H809qkcHu2fk+MG9qbJbNGsXT2KEoUzkeX3j/FGWOUEJPJxOr126hV9dmJ55at2UTlem2pUKc1bbsNoHrl0q/cLJ7QPtrZ2hIaFs6VazcxmUx4ZkhL6hc8E6py+eLk9M2CwWB44S9Zk8nE8jVb6NzuczzSp8FgMJDRI91L/1K8F/yArbv206NTC5IkdsHJ0ZE2zRrw57a9REfHkCiRHT9825GFy/6ge9+fqVWtLEULPvucK0utmtQjSWIX88Muq1YoiZtrMmxtbahcrjgZPdJy/FTsg3LXb9qFr08m6teqjIO9PY6ODi89/ufO3SAOHjlFl3af4+zkSNrUKWneuA5rN+546hhBu+af4GBvj5dnenLn8In3HHyeujViZ423tbXh1LlLBAYFm/P0zuxJ/dqVWbtxu3l9V9ckNPy4Kna2tlQpV5xHoWHUqhb7wOJUKZKTP7fvK3dpuyZLzGcNqmNnZ0eBvDlImzol5x9fj0tWbeTzBjXI5pMJGxsbypUqTEaPtOzedzTevAb1+YpSxfKzcPk6Pmv7DXWbdokT4I2ZNBc316S0bFKXDj0HmoOo0+cuUbNxxzh5ff/TRKrUb8tnbb/BZDLRv+eXr7RfT4SFh5PYYkxSEhdn82StL0r/J+UlSfx3S7udnR2ODg6EhoU/d7vd+49Qsmg+0ri/+daYlp/XxcXZiVQpklOsUB7OPJ6l/M9teymULyfFC+fFztaWOtXL45k+jXk7Ozs77j94iN+N29ja2pA1S0aSJU38xusr8VMXG+D6+AS8Gxj8TJNvQOA9DAYDrkmTYGtrQ95c2Th49BRX/W5SMG8OjJFRHDx6ihTJXSmQJzsGg4F7wQ8IC4+gfY+BcWZWtbOzwz8g0PxF+3RA4ejoEOcDY+dfh/i07kfvbf0AHj4KpWvvYeTJlZXWTes99xg/abmCRHzWoDp/btvL7n1HqVezIt36DOPoidgH8zb7tHacFo3Dx05zJyCIahWfHdxbt0ZFc5P3nbtBfD90AhN//Z0OLRsxdMwM1m/eBcR+ySc0kDKhfaxWqRR3g4IZ9suv+AcEUrp4Ab5q8xmuyZLEmw9Amld4qOa9+w8Ij4jAI55BsS/jln8AMTEm6jePO+DcxmBD4L1g3FO64ZE+DfnzZGfXX0cY1yDhWYGfltriQcoLlv7Bqj+2cuduEAaDgbCwcPNYs9t37pIh/T+rf8DdIOztE+H2+DljENudcOepx4O4ODuZAzUAp3jOwRd5+j0JCAgy/yB4uswn5wmAm+vf9XlS9tN1jD1Hnv9FbOnpPOHJfsTmcev2XSb9uohpc5aa06OiogkIjP8xKS4uzrRuWp/WTesTGhbO8jWb+fHnSWTzzkhq9xQsW7OZBVOH4pE+DdHRMXToOZDRg7/hyPEzz7Rqfv9Ne8qWKBRvOa/CydGRh49C4yx7GBqKs5PTS6W/bnlR0dGER0Tg7OTIkeNn+F/fn81pm1f8PZnjzwO602fgLzjY2/PlF8/OyG9NKdzinjNP6ns3MPiZa+zpH16ff1IDozGSvoPH8vBRGJXKFqV9y09f+INL3gwFSIBnhrSkSZ2SjVv20OKzOnHSNm7dQ+4cPuYP1YJ5c3Do6CmuXLtJg9qViYyMYtDIqbglT0qxQnkBSJY0MY4ODkwbM+C5TbkJCXn4iLPnr1C4QM73sn7wJDgaSqaM6enVueVLPRzzaTZPPSctoS4kgJXrtlKmRME4T1+Pj3tKN8qXKsLytZvp0LIRvbq0fK27S+xsbWnRuA4tGtch6N59+g8Zz/S5S+nesXmC+2owxG2QdXJ0JDzi76eZBQYFm/9Oniwpjg4OXL/pH+/dPDaG5zfupk6VAhsbA6vmj40TRDxt8459nDxzgZJF8jF83EwG9+vyVF3j34en35ejJ84yfc5Sxg3rTdYsGbGxsaFZ+948eeh8GveU/HXoeLz5GGyeX/9UKd0wGiMJunffHIDc8g/APeWLn0L/Kp5+Hl+qVG7cDbxHVFSUeTyINct80T7Hxz2VGw3qVKFezYqvvK2zkyOfNajOrN9WcvnqDdxTpSAmJgZjZOyDr2tXK0dUZBSdvh6Eg709Iwf1fEGO/4x3Zg9zixhAUPB9AoOCza25L0p/5fIyeXD+4jVzwHf+4lXsEyXCI0NaHB3s4wRFT/PJ7MnYob3p3GsIMTExdGj19m/LT5nClZNnLsZZ5n8n0Dym09nJkY6tP6Vj60+5efsOPfuPZOmqP/msQfW3XldRFxsQ+2XRpd3nzF64kpXrthIaFk7Iw0fMWbiK9Zt20655A/O6BfNm569Dx3kYGkpGj3RkyeTBnbtBHD52xjxA2cbGhro1KjB26jxzl9X9ByH8uXXvS9Vn74Fj5M/ti4O9/XtZv0ePQunWZxge6dPSu1vrFwZHF6/4ceb8ZaKioogwGvl9+XouX71BsULP7/IJefiILTv3x9u9Ziko+D5bd+4ni5d17jw5cOQk5y5eJSo6GkdHB+ztE2FrawvEtijcvH3H/PT4hGTz9mLbrgM8fBRKUPD9OONrDAYDtT8qxy9T5uN34zYmk4mrfjfN40bckiflxi3/BPNO4eZKmeKFGD5+lrlFJzAomK279gOxrTtDx8ygX48v6d+zHecuXmX52r+ffO6WPCk3biacP8Cj0DBsbGxwTZaEGJOJVeu3cenKdXN61QolOH32EktXb8JojCQ8PIIjx2Mf8OnmmpTQsDCCgu/Hm7d7SjcK5s3B2KnzCQsP5/adu8xcsILqlUo/t06vI2e2zLglT8aU2UswGiO5eMWPRSs2Ur2ydcp80T7Hp37tysxfvIYz5y9jMpkID49g36ET3InnYdUAY6fO59zFq0RGRhEZGcXKP7YQHh6Br08mnJ0cKV2sAMPHzeLW7QCio2PIktmTRHZ2hIaFY/sPAjiI7Q6OMBrNgVdkZOx1/OT8r1GlDOs37+LkmYuEh0cw6dffyZ87u7m1+0XplmJiYogwGomMir0TNMJoJMJoNKfXqFqWRSvW43fjNg8fhTJ19hIqly/+Uq0s3pk8GDesN6s3bGfctAX/6Hi8joplinLg8En+OnicqOhoVq3fxrXHD4+F2Btzrl2/RUxMDC7OTtja2WJrG/u+rdmwnbrNur71Ov+XqQXpsXIlC+PU35Ff5y1j9MQ5hIVHkDxZUob/2D3OraA+WTJia2NLgTyxDws1GAzkz+3LkRNnyJTx70HK7Vs2Yu6i1XTqNZige/dJmjQxhfLlpFK5Yi+sy869hylVvMB7W7+tuw9w4vQFLlzyY9vjL2SInQ/kyTw3Feq0YuTAnuTL7UtwcAg/j5uJ/51A7O0TkSVTBkYO+pp0aZ5/h82GLbtJkdyVwgXiH/C8dPWfrFq3FQAnJ0eKFMhN1y/jvzX4VQXdu8/wcbO4ExCIg4M9hfPnpFWT2DlRalcrR99BY6naoB3uqVIwd9KQePP4tN5HnLt4lTpNOpMmVUrq165sHkQP0LHVp0ybu5TO3/7EgwcPSZsmFf16tCNt6pQ0qluNH4dPoXK9tuTJmZURP/Z4Jv++Pdoybc4SWn7Vn/shIbi5JqNS2WKULlaQ73+aQI0qZczjjgZ805GuvYeSL1c2vDzT07ZZA0ZOnMOQ0dNo0rDmM1MoABQrlIcKpYvQpN232CdKRLWKJcn91N1V7qlS8MtP3zJu6nwmzlhIIjs7KpcvRr7cvmT0SEetquX4rE0voqNjGP5D92fyH/BNB0aMn0Xdpl1xsLenaoUSNGlY49XeqFdgZ2fH8B+6M2L8LGo27kiSxC40rvdRvDc//BMvs8+WShcrgNEYyZDR07h5K4BEiezIkS0LPTo1j3f9yMgo+g0ex93Ae9ja2uLlmY6h33cjbZpUAPTr2Y7JMxfRrvsPhISEkiljOrp1aMbFy3507T2MKaP6457q5buCAW7736XeU125NT6NHcu0dNYo0qZJRaF8Ofnyi0Z8++NoQkJCyZ/Hl+97tTev/6J0S0eOn6Hj139PA1KuVmxL8JO7P2tVLYv/nbu06/YDEUYjJYvmf6U5yTJ7ZWDCz33o1GswMdExCU4n8CZk9EhHvx7t+Hnsr+a72Arly0GiRIkAuH7Tn1ETZxN07wFOTg6UL1WYejUrAXD7TiB5crzcHbpiHZpJOwGXr96gQ8+BdP2yyRub3C4+UdHR1Py0I/OnDI0z9uF9qZ+IiFhPo1Y9aPl53Rd+jnfqNZgeHZvj9YK7hcV61MWWgEwZ0zPixx7cun2XsPBXG5T5Oh6EPKRVk3rPDY7g3dVPRET+uR17D/EoNAyjMZL5i9dyNyiYYoXyvHC7cUN7Kzh6y9SCJCIi8pYMHzeLDVt2Ex0djWeGtHzVpnGCM3rLu6UASURERMSCuthERERELChAEhEREbGg2/wfMxojGTF+FvsPn+T+gxBSpkhOk4Y1zXPwPHoUytBffmXXvsM42NvToHZlWn4ee9t3UPB9xkyax+Hjp3kUGkb6tKlp07QepYsXNOcfEHiPIaOmcfjYGZIlTcwXn30c58GzluYtWsMfm3Zyyz8AF2cnKpUtTvsvGsaZBXj63KUsWfUnEUYjpYoWoFeXlubn9oydOp+dew9xNzCYZEmTUKd6eZp/Wtu87Y/DJ7Nhy24S2f2d35gh35A7h491DqiIiMi/mAKkx6Jjoknh5sovP31D+rTunDxzkf/1HYZ7SjeKFszNiAmzeRDykOVzxnAv+AGdv/mJNO4pqV65NGFhEWTNkpGOrRqRMkVydu07Qv/B45kx9gfz3EP9h4wnfVp31v4+nktXrtO19zA8MqQxz1dkKSYmht7dWpM1S0aC7t2n14DRTJuzhPYtGwGxT7RetW4bk0b0I7lrUvoNHsfICbPp270tAPb2iRjSrysZPdLhd+M23foOI1nSxHxcvYK5jHo1K73S/CEiIiL/Fepie8zJ0ZG2zRuQIV1qDAYDubJ7UyBvDo6eOEt4eAR/bttLuxafkCSxC54Z0tKgTmVWrd8GxD7P6fNPauCeKgU2NjaULlYAT480nDgT+8T66zf9OXbyLB1aNsLJ0ZGcvt5UqVCC1Y+3j0/TRrXIkS0LdnZ2uKdKwUeVSnHs5Dlz+ur12/ikThU8M6QlSWIX2jZvwMatewiPiJ1xtl3zT8jslQFbWxu8PNNRrmQhjp44l1BxIiIi8hQFSAmIMBo5dfYi3pk9uXr9FpGRUfhkyWhOz5o5IxcvX4t326Dg+1y5dhPvx88aunD5GincXOPMbZQ1c0YuXPZ76focPnaGLJk8za8vXPaLW58sGTEaI/F7/PTup5lMJo4cP2uuzxN//LmTKvXb8VmbXsxfvJaYmJiXro+IiMiHTF1s8TCZTAwZNQ2PdGkoV7IQx06ew8nRAbvHz+ICSJzYmdDQZydojIyMov/g8VQsU5TsWTMDEBYWQRIXlzjrxW7/ck8mX7F2C8dOnWPW+IHmZWHh4SRJ7Gx+bWdnh6ND/E8anzxzEeEREdSr9fcDMRvWqUKn1o1JmiQxp89dou+gsRhsDDSu99FL1UlERORDphYkCyaTiZ/HzuTa9VsM/b4bNjY2ODk5Eh5hJCo62rzew0dhODs7xtk2MjKK3gPH4OBgz7ddW5uXOzk58PBRaJx1Hz0KxdnZCYChY2ZQoU4rKtRpxdAxM+Kst37zLibPWsSYwb3iPPXdydExTp5R0dGER0SYB2k/MXvhSv7ctpcxg3vh5Ph3WjafTCR3TYqtrQ25snvTtFFNNm17uYfVioiIfOjUgvQUk8nE8HEzOXn2AmN/6k1il9gWmowZ0mJnZ8uFS9fw9ckEwPmLV+M8OT4yMoo+A38hMjKKYd//L87dZt6ZPLkbdI+g4Pu4ucZ2s527eM28fa8uLenVpeUz9Vm/eRejJ81l9OBeeGf2jJPmncmD8xevUTh/LnN97BMlwiNDWvM6sxeuZNmazUz4ue8LH1BpMChWFhEReULfik8ZPn4Wx06e55ch35A0yd9dYo6ODlQsU4wpsxbz8FEofjdus3jlBmpVKwdAVFQUfQeNJSw8gqHfd8PePlGcfDOkS02eHFmZ9OvvhIdHcPLMRTZs2UWtamUTrMuGLbsZOWEOIwf2JJu31zPpNaqWZdGK9fjduM3DR6FMnb2EyuWL4+hgD8Dc31ezdNUmxg/rTdrUKZ/Z/s9te3n0KBSTycTpc5eY8/sqypUq/A+OmoiIyIdHjxp57Jb/Xeo164p9okTY2v4dN1atUJJeXVo+ngdpBrv+OoKDvT31a1emVZPYeZAOHTtNx56DsLdPhK3N39s2+7Q2LRrXAeDO3SCGjJrGkeNnSZrEhZaf133uPEj1mnXjzt0g7J9qiUrjnpL5U4eaX0+bs4SlqzYRYTRSsmh+enVpicvjbrviVZtgZ2cbZ56jvLmyMWrQ1wC07/4jFy77ER0dTaqUyalVtRyfNaiOjY1iZhEREQVIIiIiIhbUXCAiIiJiQQGSiIiIiAUFSCIiIiIWFCCJiIiIWFCAJCIiImLhPx8gmUwmoqKiMJl0M5+IiIjE+s/PpB0dHU3pGi3YsWYmdnb/+cMh8sG5dOU6LTv3JyLCiFvyZKz5bTxGYyTd+w3n4hU/Qh4+IrGLMz6ZM9K6aT3y5MwKxE7WunztZq763SLk4SNSuLlSpnhB2jarj4uL8wtKFZF/O0UEIvLBCo8w0m/wOKKiouMsj46J5m7QPYoWzI2ToyP7D59g/+ETnDp7kXWLJmJnZ8dfB49z7fot8uf2xWAwsGXnfn5fvp57wff54dtO72iPRORtUYAkIh+s0ZPmcDvgLk0b1mTmghXm5U6OjiyYOsz8+sz5y3zRqR+PQsO4dz+EVCmS07BOFb7t2srcsjxl1mJ+nb+c3fuOvvX9EJG3TwGSiHyQNu/Yx4q1W/i+VweioqLiXWf63GUEBgWz//AJAGpVK0uqFMkByPb4wdRPREbG5pEqZfI3WGsReV8oQBKRD86t2wH8NHoaNaqUoWqFEqzZsD3e9VZv2MZt/7sApHRzpXD+XPGut+/gcRYuX4etrS1dv2z6xuotIu+P//xdbCLy4dm+5yAhD0O57X+X7v2Gs3DZOgAePgyle7/hBAXfB2DZ7NFsWTmDIf27EBR8n/5DxnP2/OU4ea1av43u/YdjY2PDkP5dKFow91vfHxF5+9SCJCIfnCezdhw8eirOcmNkJLv3HSHo3gPcXJMB4OhgT/HCeXF0dCA0NJwLV/zI5pMJk8nEpF9/Z/bCVaRwS8bQ7/5HTt8sb3tXROQdMRiNEf/pCYCioqJ0m7/IB27Nhu0MHDHFfJv/b0vXsXjlBnJl98bJ0ZEjJ85w5dpN7O0TMX/KUNKndWfyrEXMnB87sLtsyUKkTpXCnF+39upmE/nQKSIQkf+czF4ZcE2WhN37jhAeYcQ1WRLKly5Ck09qkD6tOwB3AoLM62/bdSDO9gqQRD58akFSC5L8h51bWu9dV0HeM1nrLX3XVRB5L2iQtoiIiIgFBUgiIiIiFhQgiYiIiFhQgCQiIiJiQQGSiIiIiAUFSCIiIiIWrBogzZy/gjOPp+k/dPQUleu15aOG7Tl8/Iw1ixERERF5o6waIC1bswmPdKkBmDp7CW2a1adjq08ZO2W+NYsREREReaOsGiA9DA3FxcWZR6FhXLjsR/1alalZtSx+N27/o/xWr99G8apN2LY7dhbboOD7dO09lE++6M7nbb+J0zL1vDQRERGRV2HVAClFcleOnjzHn1v3kienD7a2NoSGhWMwGF45r1u3A1jxx1ZyZfc2L5swfSG5snuz6NcR9Onehu9+Gk9UVNQL00RERERehVUDpFZN6tLp60GMmTyXz+rXAGD/4RP4ZPZ8pXxiYmIYPGoa3Ts2I1Givx//sXn7X9StURGAHNmykNItOYeOnXlhmoiIiMirsOrDx6pWKEnZEoUAcHR0ACB3Dh9y+Xo/b7NnLFjyB3lyZsXXJ5N52f0HIURFR5PCzdW8LG3qlPgHBD43TURERORVWf3prNHR0ez86wgBgUGkSuFGyaL5SOzi/NLbX7zix9Zd+5k4vK+1q2a2eOVGlqzaCIDJ9J9+Vq+IiIjEw6oB0tGT5/j6u5G4JU9KGveU+N8JZOSE2Qwb8D/y5sz6cnkcP8st/wA+adkDgKCg+wy9OoPWTetha2NLYFCwuaXolv9dUqdKQbKkSRJMi0+D2pVpULsyAFFRUZSu0eK19ltEREQ+LFYNkEaMm8mXX3xiHgsEsGLtFoaPncmcSYNfKo96tSpRr1Yl8+sOPQfSqG41ypYoxMmzF1m2ZhOtm9bn1NmLBATeo0AeXwAqlCmSYJqIiIjIq7DqIO0bt+5Q56PycZbVrFqWm7fvWCX/jq0+5fip83zyRXcGDp/C91+3x87O7oVpIiIiIq/CqhFEofw52XvgGCWK5DMv23foOIUL5PrHeU74+e+xSG7JkzFmyDfxrve8NBEREZFXYdUAKWmSxPQe+AsF8+YgTeqU3Pa/y8Gjp6hSvjhjJs81r9elXRNrFisiIiJiVVYNkEwxMVQqUxSAiPAIkidLQqUyRYmJjiEk5JE1ixIRERF5Y6waIPXt0c6a2YmIiIi8E68dID0KDcPF2Sn270ehCa7n8gpzIYmIiIi8S68dINX+/Cs2LZsGQOX67bB87JrJBAYD7PpjzusWJSIiIvJWvHaANH/yUPPfS2aNet3sRERERN651w6QUrv/PVt12tQpXzc7ERERkXfOqoO0H4WG8dvSdZw9f5nQsPA4aeOG9bZmUSIiIiJvjFUDpB+GTcI/IJBypQrj5OhgzaxFRERE3hqrBkiHjp1m+ZzRumNNRERE/tWs+iw291RuREVHWzNLERERkbfutVuQLly6Zv67Qe3K9B00jqYNa+KWPFmc9bwze75uUSIiIiJvxWsHSM069MFgiJ3v6ImDR0/FWUfzIImIiMi/yWsHSLvXKfARERGRD4tVxyBZOnvhChcu+73JIkRERESszqoB0tffjeToibMALF65kbbdBtC26/csXb3JmsWIiIiIvFFWDZBOnL5ATt8sACxZtZFffvqWqWO+Z8GStdYsRkREROSNsuo8SMbISOzs7LhzN4gHIY/ImzMrAEHB961ZjIiIiMgbZdUAKVPG9Mz6bSW3/e9StGBuIDY40qzaIiIi8m9i1S62Hp1asOuvw1y9fpPWTesB8NeB4xQpkNuaxYiIiIi8UVZtQcrm7cWUUd/FWfZRpVJ8VKmUNYsREREReaOsGiAB3Lx9h3MXrxIaGh5nefXKpa1dlIiIiMgbYdUAaeGydYybtoC0qVPh+NS4I4NBAZKIiIj8e1g1QJrz+yrGDPmGAnmyWzNbERERkbfKqoO0Y2JM5M2ZzZpZioiIiLx1Vg2QPqlThUUrNlgzSxEREZG3zqpdbFt27ufy1evMW7wGt+RJ46TNGj/ImkWJiIiIvDFWDZAa1a1qzexEREQ+OD+Nns7x0+fxvxOIyWTCI30aPmtQnSrlS5jX+evgcWbMW8bFy34YDAaKFsxNly+bkCpFcgAOHT1Fx68HP5N3rWpl6d2tzVvblw+ZVQOkGpXLWDM7ERGRD86KP7aQzduLCmWKcOGSH6fPXeK7nyaQJLELxQvn5eSZi3TvNxyTKYaKZYpxL/gBm7b/xbUbt5k1fiAGg8Gcl5dnujiTMefO7vMudumDZPV5kDZu3cOaDdsJuHuPVCmTU6NKGSqXK27tYkRERP6Vpo35npy+3gBERUfTqGUPbt4OYO+BoxQvnJctO/cRHR1N0YK5+eHbjsTExPBRww6cv3iV7XsOUrZEIXNeObJloVv7pu9qVz5oVp8Hae6iNTSoXZn0ady56X+HsVPnExh0n0/rVbNmUSIiIv9KT4KjJ4yRUQCkSuEGgH2iRADc8g/gXvADgoLvExYeO/nyuQtX4wRIW3bs48+te0maNDGF8uWkQ6tG5m44eT1WDZAWr9zIqEFf453Jw7ysZNH89Pp+1CsHSF2+/YnAe/exMRhwdnKkW4dmZPP2wu/GbX74eTL3H4SQ2MWJvt3bkdkrA8Bz00RERN4nMTExDPtlBncD75E5Ywbq1qwIwMfVy7Ny3RauXb9N9UYd4mwTeC849g+DAS/PdPj6ZMbOzpYdew6ybtNOLl3149exP2JjY9Wb1P+TrBogPQh5hJdH2jjLPNOn5UHIo1fOa2Cfr0iS2AWArbv2M3D4FOZMGszQMTP4uHp5alQpw+Yd+xg4YjIzxv4I8Nw0ERGR90VYeDjfDZnAjr2HyOqdkVGDvsbF2QkA91QpWDB1GBu37ME/IBAvz/Ss3biDA0dOktw19g7x/Ll9WTB1mDm/8xer0KxDH85duMq167fx8kz3TvbrQ2LVEDN71kxMmb2EqOhoAKKjY5g+dyk5smV+5byeBEcAjx6FYTBAUPB9Tp+/RNWKJQEoX6ow/gFB+N24/dw0ERGR90VA4D3adx/Ijr2HKFUsPxOH98PNNVmcdZwcHahXqxLtWzYiR7bMHDt5DsA8IPv6TX9iYmLM65ue2tYYGfnG9+G/wKotSD06taBH/xEsX7OJlG7JuRt0j+SuyRj+Q/d/lN+AYZM4dPQUACMG9uROQBAp3Vyxs7UFwGAwkDpVCvwDAkkc6pxgmkf6NNbZQRERkdfUuvN33LkbhIuzE2lTp2LyzEVA7IDrqhVKEBUdTZ0mXSicPycGgw079x7CGBlJuZKFyZ/bF4CZC1Zw6Nhpcmf3wcHBnh17DgLgk9kzzjAX+eesGiBlSJeaeZN/4sSZCwTcDcI9pRs5fLOYg5ZX9d3XXwKwZuN2Jkz/jbbNG1ilnotXbmTJqo0AmEymF6wtIiJiPXfuBgHwKDQsztMnqlcuTdUKJbAxGPDySMfufUcIDYsgjXsKPq1Xjeaf1javW6ZEQfwDAtl/+AShoeGkTOFK1Qol+OKzuhp/ZCVWv83f1taGvDmzWjXPGpXLMOyXX3FP6cbdoGCioqOxs7XFZDLhHxBI6lQpcHFxSjDNUoPalWlQuzIAUVFRlK7Rwqr1FRERScie9XOfm25jY8P4n/s8d52yJQrFuZtNrO+1A6TvfprAgG9iR9n3GjAqzgRWT/upf9eXzjPk4SPCI4zmWxW37T5AsqSJSe6alGzeXqzftIsaVcqwZed+3FO6mbvQnpcmIiL/Hof6lHjxSvKfU2DQ7rdW1msHSE/fRp81S8bXzQ6Ah4/C6DPwFyKMRmwMNrgmS8LwH3pgMBjo1bklA0dMYdZvK3FxdqJP97bm7Z6XJm/Gy0yZD7HdmsvWbOL6DX8cHOzJnDE9A/t8RcoUyQkNC2fC9IXs+usQQfce4OTkgK9PJto0a0BO3yzvaM9EROS/zGA0RlhtEM6dgEDc4+nSSmj5++BJF9uONTOxs7N6j+MHr3jVJmTz9iKrd0bzlPkAIwf2pHjhvACMnTqf+YvX4uLsRKli+bG3T8SZc5f5sXcnMnqk4+dxM1m66k8SuzhTsUxRTp65yIXL10iWNDFrfpuAra3609+Uc0vrvesqyHsma72l77oKgFqQJH7/qhakpzVu24tNy6Y9s7zJl73ZsGSyNYuS98SLpsy/dTuA35b+QaJEdkz/ZQAZPZ6dm+P646kYalUtS+d2n3PyzEVad/mO+w8e8ig0jKRJXJ7ZRkRE5E2ybpNJPG1REUZjguOS5N/vRVPm7z98gpgYE26uiflp9HTOnL9CyhSufFKnCg0/rgpAw4+rcuTEWVat30ZoWDgnz1zExsZA04a1FByJiMg7YZUAqVmHPhgMEGGMpHnHuCPvA4OCyZc7mzWKkfdYQlPmBwU/AOBuUDAp3FwpX7owG7fuYdTEOSRN4kK1iqXIkS0LRQrkYufew6z4YwsAGT3SUaRArne2PyIi8t9mlQCpUd2qYIJhY381twoA2BhscEuejIL5clijGHlPPW/KfLfkf88OO3JQT9xck2FjY8OaDdvZtusg1SqWYtgvv7Jz72EqlC5C3x5t+evAcb79cQzd+41g+dzRJEua5F3tmoiI/EdZJUCqUbkMAD5ZMlrtTjb5dwgIvEfP/iM4e+EKpYrlZ8A3HXF2cjSn+2T2THBbJycHAK5dvwVAVm8vnBwdyZU9ttsuPCKCW/53FSCJiMhbZ9UxSFmzZCQsPJwLl/wIfhACT81SXbp4QWsWJe+JF02Znz1rZooVysPeA8f4X5+fyZLJgw1bdmNjY6BmldjAOl8eXy5dvc6chau4eesOZy5cBiB5sqR4eaZ/Z/smIiL/XVYNkA4dPUXvgb8QE2MiNDQMZ2cnwsLDcU/ppgDpA/WiKfMBBnzTkbFT57Njz0GuXb9F1ixetPz8Ywrkje16/ap1Yxzs7dm2az/rNu3CxdmJ4oXz0q7FJzg62L/9nRIRkf88qwZI46YtoFmj2rETBdZvy4Ylk5k+dxlOjg7WLOZfxzVD3nddhbfu9MnjjBg9Id60QwcPsGTp8uduv3v3LmbMfP50/P9mwdePvusqiIjIc1h1Br5r12/TqG414O/etaYNa7Jw2TprFiMiIiLyRlk1QHJyciTCaAQguWtSrt/0JzzCyMPQUGsWIyIiIvJGWbWLrVC+HGzZuY8alctQoXQRuvYeip2dHUXy57ZmMSIiIiJvlFUDpO++bm/+u12LT/DyTEdoaDjVK5e2ZjEiIiIib9QbezqrwWCgWsVSbyp7ERERkTfmtQOkMZNf7k6jLu2avG5RIiIiIm/FawdIISGPrFEPERERkffGawdIfXu0s0Y9RERERN4bVh+D5HfjNpu2/cXdoGB6dGrOVb+bREZG4f2cZ3KJiIiIvE+sOg/Sjr2HaPlVf6743eCPTTsACHkYytip861ZjIiIiMgbZdUAadKvvzPixx5836sDtjaxWWfNkpHzF69ZsxgRERGRN8qqAVLA3SDy5Mz6+JUBADs7W6JjYqxZjIiIiMgbZdUAySN9Wg4dOx1n2ZHjZ/DyTGfNYkRERETeKKsO0m7X4hO+GTCamlXKEBkZxcQZC1mzcTs/fNPRmsWIiIiIvFFWbUEqUiAXE37ugzEyigJ5sxPyMJSRA7+mQN4c1ixGRERE5I2y+m3+3pk96dGpeZxlm3fso0LpItYuSkREROSNsFqA5HfjNhcuXcMjQ1q8M3kAsbf9T5m5mLtB9xQgiYiIyL+GVQKk9Zt3M3DEZJK4uPAg5CHdOzXn4JFTHD15jsb1PqJuzQrWKEZERETkrbBKgDTn91UM6tOZMiUKsmn7XwwYNpGPKpZi0a8jcHSwt0YRIiIiIm+NVQZp+98JpEyJggCUL1UYk8lEtw7NFByJiIjIv5JVAqQY098TQdrY2ODk6KjgSERERP61rNLFFhERyTc/jDa/DgsPj/Ma4Kf+Xa1RlIiIiMgbZ5UA6YvP6sR57ZPZ0xrZioiIiLwTVgmQWjWpZ41szCKMRvoPHs/lazdwsLcnuWtSen7VAo/0aQgKvs8PwyZx49Yd7BMlosdXLcif2xfguWkiIiIiL8uqM2lbU53q5Vk4/WfmTBpM6eIFGDJ6GgATpi8kV3ZvFv06gj7d2/DdT+OJiop6YZqIiIjIy3ovAyQHe3tKFMmHwWAAIFd2b2753wVg8/a/qFujIgA5smUhpVtyDh0788I0ERERkZf1XgZIln5fvp4yxQtw/0EIUdHRpHBzNaelTZ0S/4DA56aJiIiIvIrXHoO0aMUGPqlTBYh93IhH+jSvXamnzVywgus3/Rn707dEGI1WyXPxyo0sWbURAJPJZJU8RURE5MPx2i1Ik2cuMv/dolPf180ujnmL1rBt1wFGDuyJo6MDyZImwdbGlsCgYPM6t/zvkjpViuemWWpQuzILpg5jwdRhzJ00xKp1FhERkX+/125Bck/pxswFK8jilYHo6Bh27D0E8bTKlC5e8JXyXbBkLRu37uGXn74lSWIX8/IKZYqwbM0mWjetz6mzFwkIvEeBPL4vTBMRERF5Wa8dIPXp3obJMxezev02oiKjGDVhzjPrGAyvFiDdCQjklynzSZ/WnU5fDwIgUaJETP9lAB1bfcqAYRP55IvuJLKz4/uv22NnF7sbz0sTEREReVkGozHCaoNwajbuyOoF462V3VsRFRVF6Rot2LFm5hsLplwz5H0j+cq/V/D1o++6CgCcW2rdOczk3y9rvaXvugoAHOpT4l1XQd5DBQbtfmtlWfUutqeDo+D7IdbMWkREROStsWqTSXiEkdGT5vDHnzuJiooiUaJEfFSxFJ3bfYaTo6M1ixIRERF5Y6zagvTL5Hn4Xb/NuKG9WTV/HOOG9sbv5m3GTllgzWJERERE3iirBkg79h5icL8u5M7hg1vyZOTK7s2gPl+xY89BaxYjIiIi8kZZdyZtkwkbG0OcRQaDDSY0GaOIiIj8e1g1QCpZND+9f/yF0+cucS/4AafOXqTf4LGUKlrAmsWIiIiIvFFWHaTdud3njJwwmy//9yNR0VHY2dlRuVxxvmr7mTWLEREREXmjrBogOTs50rd7W/r8rw337j8gebKkGAyGF28oIiIi8h55IzMjGgwG3FyTvYmsRURERN446w7SFhEREfkAKEASERERsWC1ACkmJoZLV64TFR1trSxFRERE3gmrBUg2Nja06vwdtjZqlBIREZF/N6tGM96ZPbh+09+aWYqIiIi8dVa9i6108QL0/G4k9WtVwj2VGzZP3eJfunhBaxYlIiIi8sZYNUBavmYLAAuW/BFnucGgAElERET+PawaIC2dPcqa2YmIiIi8E1YfUR0VHc3Rk+f4c+teAMLCwwkLD7d2MSIiIiJvjFVbkK5cu0nP70YQYTTy8GEolcoV48Dhk2zcuocfvu1kzaJERERE3hirtiANHzeThh9XZeW8sdjZ2QJQIE92jp44Z81iRERERN4oqwZI5y5epX6tSo9fxd7B5uLiTGiYuthERETk38OqAZJb8mTc8r8bZ9m167dwT+lmzWJERERE3iirBkj1albk2x/HsGPvIWJiYvjr4HEGDJtE/dqVrVmMiIiIyBtl1UHaDT+uiq2tDZNm/E5MTAyjJ82hXs1K1KtZ0ZrFiIiIiLxRVg2QAOrXqkz9WmoxEhERkX8vqwdIN2/fYcOWPQQE3iNViuRULlec9GndrV2MiIiIyBtj1TFI23YfoHGbXhw7eQ5TjInjp87xebtv2LprvzWLEREREXmjrNqCNGH6bwzq05lSxfKbl+366zBjJs+jXMnC1ixKRERE5I2xagtSYNB9ShTJG2dZsUJ5Cbp335rFiIiIiLxRVg2QKpQpwur12+IsW7NxOxXLFLVmMSIiIiJv1Gt3sfUaMAqDIXbW7KioaIaNncnCZetJkzoFt/0DuXbjFsUK5XntioqIiIi8La8dIGXNkjHO6+xZM5n/zpEtyz/Kc+SE2ezYe4jb/neZNWGQuQy/G7f54efJ3H8QQmIXJ/p2b0dmrwwvTBMRERF5Fa8dILVqUs8a9YijfOkiNPmkBu26/xhn+dAxM/i4enlqVCnD5h37GDhiMjPG/vjCNBEREZFXYdUxSAD3gh9w4MhJduw5GOffq8if2xf3VCniLAsKvs/p85eoWrEkAOVLFcY/IAi/G7efmyYiIiLyqqx6m//SVX8yZvI8XFyccHRwMC83GKB08YKvlfedgCBSurliZ2v7OE8DqVOlwD8gkMShzgmmeaRP80xei1duZMmqjQCYTKbXqpeIiIh8eKwaIE2bu5QRA3tQKF9Oa2ZrdQ1qV6bB4wfoRkVFUbpGi3dbIREREXmvWDVASmRnR77cvtbM0sw9lRt3g4KJio7GztYWk8mEf0AgqVOlwMXFKcE0ERERkVdl1TFIX3z+MVNmLiIyMsqa2QLg5pqMbN5erN+0C4AtO/fjntINj/RpnpsmIiIi8qqs2oKUJ0dW5v6+mvlL/sDZyTFO2oYlk186n5/GTGf3viMEBd2na++hODs5snjmSHp1bsnAEVOY9dtKXJyd6NO9rXmb56WJiIiIvAqrBkj9howjX65sVCxbDAcH+3+czzddWsW7PKNHOqaO/v6V00RERERehVUDpNv+d5kzcTA2NlafPUBERETkrbFqJFO0UB5Onb1kzSxFRERE3jqrtiAldnGiW59hlCiSD7fkSeOkdWnXxJpFiYiIiLwxVg2QYqJjKFsidkLIkJBH1sxaRERE5K2xaoDUt0c7a2YnIiIi8k5Yd5D2nbsJpqVxT2nNokRERETeGKsGSPWadcNggCePNzMY/k7b9cccaxYlIiIi8sZYNUCynAzybuA9ZsxbRsmi+a1ZjIiIiMgbZdXb/BO7OMf55+WZnl5dWjFtzlJrFiMiIiLyRr3xGR3DwyMIvh/yposRERERsRqrdrGNmTw3zuvwcCN/HTxOmce3/ouIiIj8G1g1QLKc+8jJyZGWn39MtYolrVmMiIiIyBuleZBERERELFglQHre/EdPaB4kERER+bewSoBkOf/RE0/mQTJgYOcfs61RlIiIiMgbZ5UAyXL+I4Do6BjW/rmD2b+tJEO61NYoRkREROStsEqAlNjFOc7rHXsOMunXRcSYYujVuSXlShW2RjEiIiIib4VVB2kfPXGW8dN/4/adu7T6vB61qpXFxuaNT7UkIiIiYlVWCZAuXvFj4ozfOXbyHE0b1qRh3ao42NtbI2sRERGRt84qAVLz9n1ImiQxDT+ugoODPSvWbnlmnYYfV7VGUSIiIiJvnFUCpDy5smLAwOFjZ+JNNxgMCpBERETkX8MqAdKEn/taIxsRERGR94JGUIuIiIhYUIAkIiIiYkEBkoiIiIgFBUgiIiIiFhQgiYiIiFhQgCQiIiJiQQGSiIiIiAUFSCIiIiIWFCCJiIiIWLDKTNrvE78bt/nh58ncfxBCYhcn+nZvR2avDO+6WiIiIvIv8sG1IA0dM4OPq5fn9xnDadKwFgNHTH7XVRIREZF/mQ+qBSko+D6nz19i9JBeAJQvVZgR42fhd+M2HunTxLuNyWQCICoq6q3VU+R9Od+iot91DeR9876cm9Ex77oG8j560+enra0tBoMB+MACpDsBQaR0c8XO1hYAg8FA6lQp8A8IjBMgLV65kSWrNgIQExN7FZav0/qN1St7ztxvLG/5dypdo8W7rsJjzu+6AvK+mdbiXdfgsczvugLyPnrDn5071szEzi42NPqgAqSX1aB2ZRrUrgzEBkhGozFO1ChvTpMvv2XupCHvuhoiz9C5Ke8rnZtvj+3jBhb4wAIk91Ru3A0KJio6GjtbW0wmE/4BgaROlSLBbWxsbHB0dHyLtfxvMxgM5uhc5H2ic1PeVzo3340PapC2m2sysnl7sX7TLgC27NyPe0q3BMcfiYiIiMTngwtJe3VuycARU5j120pcnJ3o073tu66SPKV+rcrvugoi8dK5Ke8rnZvvhsFojDC960qIiIiIvE8+qC42EREREWtQgCQiIiJiQQGSiIiIiIUPbpC2WMfWnfuZuWAFMTExRBgjSZUiOb/89A02NtaPqTv0HEijutUoW6IQU2YtJqNHWqpWKGn1cuTfISo6mlkLVrBhyx7sbG2xtbUhR7YsdGz9KUkSu7yzeq3ZsJ2cvt54eaYDYMeegxw8epquXzbh1u0A9hw4Rr2aFd9Z/eTts+a5eu7iVa763aRyueJvqLbyqhQgyTPuBt7jpzHT+XXcQNKmTgnA2fOX38pEmm2bN3jlbZ7MeyUfhsEjp/Ig5BFTR39P0iQumEwmNu/Yx4OQR+82QNq4ncSJnc0BUuniBSldvCAAt/wDWL5m0z8KkHT+/ntZ81w9f/Eq23cffGcB0pOnSryJH8H/VgqQ5BlBwQ+wsbEhaZK/L/BsPpkAqNusK0O/60bWLBkB+KJTP75q05gCeXPQoedAsnh5cPLMBR6EPKJM8YJ81fYzDAbDc9Oe9uPwyfhkzsin9aoRFRXFlFmLOXDkFFFRUXikT0OvLq1ImsSFH4dPxmAwcOOmP0HBD1g4/ee3d4DkjfG7cZvNO/axfM4Y8/lnMBioWKYoAHMXrWbthh0YbAx4Z/Kk51ctSOzizLQ5S7h89QYRxkiuXb+FR/o0dGjViLFT5nPzdgC+Pl5836sDNjY25nPnqt8t7j8IIVd2b77u3BJHB3sehYbxy+R5nL90DWNkJLl8venesTl//LmDM+cuM2bSPKbPWcqXXzTkXvADtu8+yNDvuzH0l1+5fecuzdr3JrV7Cn4e0J3T5y4xcsIcwsLDsU+UiC5fNiFvzqzcuh1Asw59+Lh6BfYdPs5HFUvzab1q7/Kwyz/wvHP10NFTfPvDaGZPHAzAxSt+9Og/gmWzR3Mv+AHfD53A3aBgDAYDvt5edGj9KVNnL+Hho1Cate9NTl9venVpyd4Dx5j460Kio2NIktiFr7/6gkwZ03Po6ClGjJ9N3lzZOHbqHCaTiQG9OrBg6R+cOX8ZRwcHhvTvgntKNwDmLVrDpu1/ER0TTfJkSenVpRVpU6dk2pwlXLx8nbDwcPwDAhkz5BvzNqIASeLhncmDvDmzUbdpV/Ln8SV3Dh+qlC/xUhfO5Ws3mDLqO6KiomnfYyAbtuyhaoUSL0yLz9xFa3B0dGDG2B8AmDFvGZNnLaJnpxYAnD1/hUkj++Hi7PT6Oy3vhbMXruCRLg2uyZI8k7Zn/1FWr9/O1NHfkSSxCz+Nns6E6Qv5uvMXAJw5f5lfxw0kSWJnOvQcxJBR0xgz5BscHOxp2akfe/YfpWTR/ACcOnORqWO+x9HBgV4DRvHb0j9o0bgOY6fMJ2+ubHzbrTUmk4kho6excPk6mnxSk3Wbd5m7giG2y+2JXp2/YPSkueYvxMjIKL79YQzfdG1FsUJ5OHriLL1/HMOiX0cA8PBRKJkypqdj60/f6PGUN+d55+rzrNu8i7RpUjFmyDcA3H/wkGRJE9OmWX1zwA2xD1//7qcJjP+5D96ZPFi/eRe9B45h/pShAFz1u0m/nu34uvMXTJ61iE69BjNpRH+8PNPx87iZLFy2jq/afMb6zbu5dv0WU0d/j62tDX/8uZPh435lxI89AThx+jyzJgzCLXkyKx6dD4MCJHmGjY0NQ/p34cq1mxw+fpq9+48xa8FKc6DyPB9VKoWdnR12dnZUrVCS/YdPmIOg56XFZ/vugzwKDWXrzv0AREZFkTZ1KnN6hTJFFBz9h+w/dIJKZYuauy7q1qxIn4G/mNOLFMht/iWfzdsL+0R25vMja5aM+N3wN69bsWxRc1qtamVZtHwDLRrXYfvugxw/fZ7flv4BQITR+I+6HK5ev4XBxkCxQnkAyJsrG26uyTh/8SruKd2ws7OlWkWNs/svyuXrzcKl6/hl8jzy5fY1nyOWTp65SJZMGfDO5AFA1QolGT5uFgF3gwBIny41vo9b9rP7ZGZ/uhPm7t8c2TKzfddBALbvPsDpc5f5olNfAKIfd6U9UbxIXgVHCVCAJAny8kyHl2c66taoSNfeQ9m59xC2NjbmvmoAozHyuXk8b9zSi8c0mfhfh+YULZg73lQnPUPvg5PN2wu/m7e5/yCEZEmf/8vc8vyxt09k/tvGxibua1sboqOjn5NZ7H8mTAzp1wXPDGlfvfIv8HR1HR0cNNbjX+5556qtrW2cQOTpz8ncOXyYNWEQ+w+fYOuu/UyZvZhZ4we9cvkOzznfbW1siHp8vpuAZp/W4uPqFeLNR5+jCdMVKs+4czeIoyfPmV8/CHnELf8A0qdNTYZ0qTl55gIQ+wvn6vVbcbZdv2k3UVFRhEcY2bBlN4Xz53yptPiUKV6I35b+QXh4BADh4RFcunLdWrsp7yGP9GkoX6owg0dOI+ThIwBMJhNbduwjXVp3Nm3/i0ePQgFYvmZzgsHzi2zesY/QsHCio2NYs347hfPnAqBM8YLM+X21+cvlQcgj/G7cBsDF2YmHj8u2FJsWZn6dMUNaTDEm9h08DsCxk+cIvHcfn8dj9+Tf73nnqsFg4Padu9wLfgDAuk07zdvdvH0HZydHKpUtRvcOzfC7fpuw8PBnzq9cvt5cvHydi1f8ANi4dQ+pUiQn1SuOESpboiDL1mzi/oOHAERFRXH2wpXX2fX/DLUgyTOio2P4dd4ybt4OwNHBnujoGD6qVJoyJQqSKmVyfvx5MsvXbCFXdm8yZ0wfZ1svz3S07fYDD0IeUqZ4wTh3ZDwvLT5NGtXEODeSVl2+M7cWNG1Yk8xeGay/0/Le6PO/Nvw6fwWtu3yHrY0tMSYT+XJno2OrTwmPiKBN1wFxBmn/E9mzZqZr76EE348dpN2obuwg6S5fNmHC9IU0b98Hg40BW1sbOrZqjEf6NNT5qAJjp85j4dJ1fPlFwzj5ZcnsSaaM6fm87TekS5uKnwd0Z0j/LoycMIdfps7HPlEiBvftjLOTI/fvh7zuIZL3xPPO1Saf1KRV5+9wS56U4oXzmrc5dPQ0C5b+ga2NDdHRMXRq05jELs4Uyp+TeYvX0uTLb8md3YdeXVryfa/2/PDzJPMg7UF9O7/y3cRVK5Tk/oOHdPo6dnxcdHQ0NauWJZu3lzUPxQdJz2ITq3l6PqNXSRN5m56+U1JEJCHqYhMRERGxoBYkEREREQtqQRIRERGxoABJRERExIICJBERERELCpBERERELChAEhEREbGgAElERETEggIkEREREQsKkEREREQsKEB6D02bs4Rm7XubX/84fDK9vh/1Dmv07/Ci47Rmw3Yq12v7Fmv0fitetQnbdh9419UQEXkv6WG1j90LfsDU2UvYve8IQcH3SZLYBZ/MnnzxeV3y5sz6TuvWrX1TTCZNeC7/zLQ5S9i++yCzJw5+11UREfnXUID0WO8fxxAZFUW/Hu1Il9adoHv3OXDkJA8evPsnbyd2cX6t7U0mE9ExMdjZ2lqpRvIuREZGkSiRLlkRkbdBn7ZAyMNHHDlxlvE/96FAnuwApE2dkpy+Wczr3LodQL3m3Zg1YRBZs2Q0b1elfjvGD+tNgbw5OHT0FB2/HszwH7oz8dff8bt+G58snnzbrTVZvDyA2G6e0ZPm0rdHW8ZNXcCdgCDy5/Hl266tSe2eIt76/Th8Mg8fhjL0+24AxMTEMOf31axYu4XAe8F4pk/LF59/TIXSRQDM9Rg5sCeTZy7i4hU/xgzuRZLELoyeNJcz5y+DATzSpaFXl5Zkz5o53nKLV23Ct11bsWvfEf46eJxUKZLTue1nlC5eEIDo6Bh+GjOdg0dOEXgvmDTuKahXsxKN6v79lPQndc+eLTO/L19PZGQUn9b7iOaNazNxxkJWrduGo6M9bZs1oGbVsubt/O8E8suUeew7dAKDwUC+XNno1r4padOkMpc9btp8Vq/fjo2NDbWqlX3pVrZtuw/Ee+xv3Q6gfov/Mf2XAXGOyW9L17Fw2R8smTUKG5tne6XrNutK7WrluHb9Ntt27SdZ0sT8r0MzcmX3YcioaRw4cpJ0ad3p8782cfLdsmMfU2cv4fotf1K4ufJJ7Sp81qB6nHxrVS2L3w1/tu85QLmShenXox1HT5xl4oyFnD5/GdekSShbshDtWzbEydHxmbqt2bCd6XOXmd9PgL7d21KjShkA7t8PodeAUa/9/ubJmZUFS9cSGRlNpXLF6PZlE+zsEv54WbrqT+YvWYt/QCDp0qSiReOP+ahSKXP6i849gItX/Bg3dQFHT5zF0dGBogVz06VdE1yTJUmw3KMnzzF55u+cOnsJ+0R25MiWhR++7UTSJC4YjZGMm7aAP7fu5VFoGL5ZM9Gl3efkyBb7OfDkuho16GsmzFjIVb+b5M7uww+9O3L2/BXGTJ5HQGAQJYvkp3e31jg6OgDQoedAMmeMvf7XbdqJnZ0tdWtWpG2zBhgMBgD++HMnvy9fz7Xrt3B0dKBg3hx0bd8EN9dkccr+5advmDB9IZev3cAnc0b6dm9DRo90//jcFZGE6YoBnJwccXZyZPvugxiNka+d37hpC+jc5jOmj/0B12RJ6dl/JFFRUeb08IgIZi1YQf+eXzJ5VH9CHobSb8i4l85/9m+r+OPPnXzd+QvmTxnKp/WqMWDoRA4dOx1nvQnTF9KhZSMWTB1GlkyefD90Iu6p3Jj+yw/MHDeQpo1qvbBVafrcZVQsU5Q5EwdTokhevh86kfsPHgJgMsXgntKNQX2/YsHUobT8vC6Tfl3En9v2xsnjwNGT3A0MZuLwvnRu9znT5iyhR7/hJEnswvRfBlC3RkWG/jKDOwGBAERFRdG1z1CcnZ2YOKIfU0b1x8nJka59hhEZGXscFyxZy5oNO+jzvzZMHtmPByEPX2o8zfOOfdo0qSicPyerN2yPs82aDdupXrnMc79gflu6jjw5fZg1YRAliuRjwLBJ/PDzJKpWLMnM8QNJn9adH36eZA7izpy/TN/BY6lUrhhzJw2hdZN6TJm9mDUWZc9fvBafzJ7MGj+ILz77mOs3/enWZxjlShVh7qQh/Ni7E0dPnmXEuFnx1qti2WI0rl+dzBkzsHrBOFYvGEfFssWs+v4ePHqKG7fuMG5oH/r1aMfaDTtYs2FHgsdq6679jJo0h8b1P2Le5J/4uHoFBo2YwsEjp+Ks97y6hTx8xFdfDyFrlozMGPsjowZ9TdC9+/QdNDbBcs9dvErnXkPI5JmeqaO+Y9KI/pQsmp+YmBgAxk9fwJad++nXsx0zxw8kQ7rUdO09zFzm3/VaSveOzZky6jv8AwLpO2gsC5etY8A3HRjxQw/2HTrOohUb4mzzx587sLW1YfovA+jWvim/LVnHyj+2mtOjoqNp27wBsycOZuh33bjlf5eBw6c8sw+TZy7iq7af8evYH7GztWHQyKnA6527IhI/XTWAna0tfbu3Ze3GHVSu35a23QYwccZCLly69o/ya/V5PYoUzI13Jg/69WhHUPB9tu76+8s7Kiqa7h2bkzuHD74+mejXox3HT53n5JmLL8zbaIxk1m8r6fO/NhQrlIf0ad2pUaUMVSuWYPmazXHWbdOsPkUK5iZDutQkS5qY2wF3KZQ/J16e6fBIn4aKZYri87g1LCHVq5SmSvkSeKRPw5dfNCQ0LJxTZ2PraWdnR5tm9cmeNTPp0rhTtUJJalQpw+btf8XJI2mSxPyvQ1MyeqSjVtWyeGZIS0SEkRaN6+CRPg3NGtUmkZ0dR0+eA+DPbXuJiTHRu1trvDN54OWZnr7d2+IfEGgOAhcuW0ezT2tRrlRhvDzT83XnliR2fnFX5IuOfa1q5di4ZY85UD57/jIXr/hR83GLS0JKFMlL3RoV8Uifhpaf1+VRaBjZs2amYpmieGZIS9OGtbhy7SZB9+4DsGDJHxTKl5OWn9fFM0NaalQpQ4PalZm3aE2cfAvmy8FnDaqTIV1qMqRLzeyFK6lSoQSf1quGR/o05MmZlf+1b8Yfm3YSYTQ+Uy9HB3ucnRywtbUhhZsrKdxccXSwt+r7mySJC907NsfLMx2liuWnRJG8HDhyMsFjNX/xWmpULkP9WpXxzJCWxvWrU7ZkIeYvibvvz6vb4pUbyeqdkfYtG+HlmY5s3l70+V8bDh49xbXrt+Itd+7vq/HNmomeX32BT5aMZPbKwCd1quCaLAlh4eEsXb2JTq0bU7xwXjJlTM+3XVvh4GDPqvVb4+TTtnkD8ubMSjZvL2pVK8vhY2fo+dUXZPP2Il9uX8qXKsLBo3GDPfdUbnT9sgkZPdJRtUJJPqlTmd+W/WFOr1W1LMUL5yV9WndyZffmfx2asmf/UULDwuPk067FJxTIk51MGdPTtFEtjp86b37f/+m5KyLxUxfbY+VLF6FE0XwcPX6WE2cusGf/MeYtWsO33VqbuyNeVq4c3ua/kyVNjGeGtFz1u2leZmtrG6cZ3MszHUkSO3PF70acbr34XL/pT3hEBF2+/SnO8sioKLJm8YqzzDdrpjivG9f7iCGjprPuz10ULpCTCqWLkiFd6ueW553J0/y3k6MjLs5O3At+YF62eOVGVq/fhn9AIBERRiKjovDJHDfoypwxfZxfsG7Jk5HZK4P5ta2tDcmSJjbne/7SNW7c9Kfix63j5GM0RnLjpj8PfbNwNyiYnL5/H2c7W9vY/X1BL9uLjn3ZEoUYMX4W23YfoHK54qzZuIMCebObu/YSkiWTR5z9e3ZZUiD2ZoAUbq5c8btBmae6iwDy5MjKwmXriI6OwdY29nhl94nb/Xnh0jUuXPZjw+bd5mUmE8TEmLh1OwAvz/TPPwAWrPX+PqkvQMoUrly8fD3BMq9cu0md6uXjLMuTMyu/L1//0nU7f+kaB4+eokKdVs/kf+PWHTwzpH1m+flLV6lQumi8dbpx8w5RUdHkeeqGDDs7O3Jky8yVazfjrPt0vdxck+Ho4ED6tO5/L0uejFPn4v7Yyenrbe5OA8iV3Yf5S/4wv9dnzl9m2pylXLh0jZCHj4iJiT2R/e8Ekinj3+/p02WncHMFYs+pNO4p//G5KyLxU4D0FAd7e4oUzE2Rgrlp+XldBo+ayrQ5S6hRpQwGm9gPt6fHuURFRb/1OoaFx/6iHP5jD1KlSB4nzT5RojivnR6PgXiiddP6VClfgl37jrB3/1GmzVnKD992pFzJwgmWZ2cXtwvOYDCYj8HGrXsYO3U+ndt+Rq7sPjg7OTJv8RpOWbSE2dnaWeTBs117BoP5SyEsLIJsPpn4vlf7Z+qT3DVpgnW1hkSJ7PioYinWbNhOuZKF2bBlN93aN33hdk/v45MvwqePnYHYZTGveDeio8V7GBoWwcfVK/BJnSrPrJvGPeUr5W1ZR7DO+wsGYkwxr1yXV6lbWFg4pYoWoEOrRs9slzKFa7z5Odjbx7v8deplMBjiqSeYYl7+fQ4LD6dr76EULZiH73u1xzVZUvwDAunaeyiRT3XNx1c2/F3WPz13RSR+6mJ7jkye6QkLjwDANVnsF3NgULA5/fzFq/Fud+L0BfPfD0Ie4Xf9Nhk90pmXRUdHc/rcZfPrq343CXkYipfHi3/9e3mmxz5RIvzvBOKRPk2cfwkN8n6aZ4a0NK73EWOGfEO5koWeGfPyKo6dPEfuHD7Ur1WZbN5eeKRPw42bd/5xfk9k8/bC78Zt3FyTPrOPiV2cSeziTEo3V06e+fs4R0VHc/b8lRfm/TLHvvZH5dh/+ARLVv1JdHQMZZ8TQP5TXh7pOfa4S/GJY6fO4Zk+bZzWGEvZvL24fPXGM8fFI32aBO9ws7OzIzrm1QOWN/X+enmm4/jJ88+U9SqtX9m8vbh09Tpp06R65jjEN1gdwDuTR4Jdf+nTuZMokV2c9yQqKorT5y6R6RVb5eJjGVSeOHMBj/SpsbW14arfLe4/eEiHlo3Il9sXL8903Au+/4/KeRvnrsh/hQIk4P6DEDp9PZh1m3Zy4dI1bt6+w6btfzF30RrzXTOODvbkyu7NnIWruHLtBoeOnWbyrMXx5vfrvOXsP3yCi1f8GDh8Mq7JElO2RCFzup2dLSMnzObkmQucOX+ZgSOmkCu79wu71wBcnJ34rEF1xkyey5qN27l+05+z5y+zaMUG1mxMONgJjzAyfNwsDh09xS3/uxw9eY5TZy+9VFCWEI/0aThz7jJ7Dxzj2vVbTJ61iNPnLv3j/J6oWqEErsmS8PX3ozhy/Aw3b9/h0NFTjJww2zyQu+HHVZmzcDXbdh/gyrWbDB87k5BHj16Y98scey/P9OT09WbCjN+oXK54nDE71vJZ/Y84cOQkM+Yt49r1W6zZuJ3FKzfGuYstPk0b1uT46fMMHzeLcxev4nfjNtt3H2R4AoO0AdKmTsWt2wGcu3iV4PshL30jwpt6fz//pAZrNm5n6ao/8btxmwVL1rJt1wE+f8G+P61+7cqEhDyi/5DxnDp7kes3/dl74BgDh08mOjr+YLDZp7U5fe4SP4/9lQuXrnHl2k2WrvqT4PshODk6UrdGRcZNW8Ce/Ue5fPUGQ0ZPJzzcSK1q5V57n/0DAhkzeS5X/W6yYctuFq/YQMOPqwKQOlUKEiWyY9HKDdy4dYcdew7y6/zl/6ict3HuivxXqIuN2PENOXyz8NvSddy4FTsWwT2VG7U/KkfzT+uY1+vzvzYMGjmNFp364ZkhLZ1afUqX3kOfya99y0aMnjgXv5u38cmckZ8HdI/z697RwYGmDWvy3U8TCLh7j7y5stH7f62fySchbZs3wDVZEmb/toqbt6eTxMWFrN4Zad64ToLb2NrY8CAkhB9+nkxQ8H2SJU1CuZKFaN2s3kuXa+nj6hU4d+EK/QaPw2CAyuWKU69WJfbuP/qP84TYbqWJw/syfvpvfPvjGEJDw0mVMjmF8uXExdkJgMYNqnM3KJgff56MjY2BmlXKUrZEIR49Cnt+3i957GtVK8fxU+epWfXNDHDN5pOJgb2/YursJfw6fzkp3Vxp07T+C8e7eWf2ZMLPfZg8cxHtu/+IyWQifdrUVCwb/9gagPKlCrNt1346fT2IkIehcW7zf5439f6WLVGIbl82Zf6StYyaNId0aVLRp3tbCuTN8dJ5pEqRnMmj+jN++m907T0UY2QUadxTUqxQHmxsDPFu45khLaMH92LSr7/TqvN3ODgkIke2LFQuXxyADq0aYTKZ+OHnSYSGhuObNROjB39N0iQur7W/ANUqlSIiIpJWnb/DxsaGhh9X5ePqFYDYbuO+3dsy6ddFLFq+gazeXnRq8xlffzfyH5X1ps9dkf8Kg9EYoSmareTJXCUblkwmSeL4P1SfzIO0cemzt/DK+2PGvGVs3rGPuZOGvOuqyL9ch54D8cmc8a2NB9K5K2Id6mITeUpoWDgXr/ixeOVGPqn97EBokfeVzl0R61IXm8hTRoyfxcateyhTvGCcmb1F3nc6d0WsS11sIiIiIhbUxSYiIiJiQQGSiIiIiIX/fIBkMpmIiop66SfBi4iIyIfvPx8gRUdHU7pGC6Kj3/5jQ0REROT99J8PkEREREQsKUASERERsaAASURERMSCAiQRERERCwqQRERERCwoQBIRERGxoABJRERExIIeVvvYuWUNsbN917UQERERS1nrLX3rZaoFSURERMSCAiQRERERCwqQRERERCwoQBIRERGxoABJRERExIICJBERERELCpBERERELChAEhEREbGgAElERETEggIkEREREQsKkEREREQsKEASERERsaAASURERMSCAiQRERERCwqQRERERCwoQBIRERGxoABJRERExIICJBERERELCpBERERELChAEhEREbFg97YKata+NwCRUVFcu36LLF4eAHhmSMvAPl8xfe4yNm//CxsbG4yRkZQqlp+v2nwGQPGqTfDJ7MnsiYPN+a1ev41BI6fSpV0TPq1XDYAz5y8z6dff8btxm6RJEpMokR2ff1KDsiUKva3dFBERkQ/AWwuQngQ3t24H0KxDnzjBzuYd+9h74CjTx/6Ao4M9UdHRXL5yPc72tra2nDl/GV+fTEBsgJQ9ayZz+qUr1+naeyh9ureldLECAAQE3mPfoeNvetdERETkA/NedLHdCQgiaRIXHOwTAWBna4tPloxx1qlRpQyr1m8D4Nr1W0RFR5MpYwZz+pzfV1GzallzcASQKkVyalQu8xb2QERERD4kb60F6XkqlyvGij82U7/5/8ibKxsF8mancrniODrYm9cpV7IQ8xevJcJoZPX6bdSoUoYTpy+Y08+cv0y7Fp+8VHmLV25kyaqNAJhMJuvujIiIiPzrvRcBUgo3V+ZO+omTZy5w7NQ5lq76k0UrNjB9zAASJYqtooODPUUL5mbz9n1s3rGPWeMHxgmQXkWD2pVpULsyAFFRUZSu0cJauyIiIiIfgPeiiw3A1taGPDmz0uSTmkwe2Z9btwO4dMUvzjo1q5bhlynzyJ3DBxcX5zhpvj6Z/nHAJCIiIvK09yJAOn3uEtdv+ptfX/W7SVRUNO6pUsRZL6evNy0a16FZo9rP5PH5JzVZvX4bu/46bF4WGBTMmo3b31zFRURE5IP0XnSx3X/wkBHjZxHyMBQHB3tsbWwY8E0HkrsmfWbdRnWrxZuHdyYPRg7syeSZixg5YTaOjg44OznRrFHNN119ERER+cAYjMaI//Qo5SdjkKa3DsXO9l3XRkRERCxlrbf0rZf5XnSxiYiIiLxPFCCJiIiIWFCAJCIiImJBAZKIiIiIBQVIIiIiIhYUIImIiIhYUIAkIiIiYkEBkoiIiIgFBUgiIiIiFhQgiYiIiFhQgCQiIiJiQQGSiIiIiAUFSCIiIiIWFCCJiIiIWFCAJCIiImJBAZKIiIiIBQVIIiIiIhbs3nUF3hdZ6/6OnZ0Oh4iIiKgFSUREROQZCpBERERELChAEhEREbGgAElERETEggIkEREREQsKkEREREQsKEASERERsaAASURERMSCAiQRERERCwqQRERERCwoQBIRERGxoIePPXZuWUPsbN91LUTkQ5O13tJ3XQUR+QfUgiQiIiJiQQGSiIiIiAUFSCIiIiIWFCCJiIiIWFCAJCIiImJBAZKIiIiIBQVIIiIiIhYUIImIiIhYUIAkIiIiYkEBkoiIiIgFBUgiIiIiFhQgiYiIiFhQgCQiIiJiQQGSiIiIiAUFSCIiIiIWFCCJiIiIWFCAJCIiImJBAZKIiIiIBQVIIiIiIhbsXnWDus26Yp/IDgd7ewB8s2aid7c2Vq+YiIiIyLvyygESwI+9vyJrlozWrouIiIjIe+EfBUiW9h44xsRfFxIdHUOSxC58/dUXZPRIy//6/kzh/Ln4/JMaXL/pT4eeAxn707dk9EjH6vXb+H35ekwmsLOzZXDfzqRNk4o//tzJvMVrAEidyo1eXVrhntKNNRu2s27TLpK7JuHilevYJ0rEwD5fkT6tO4eOnmLE+Nnky52NYyfPEx0dTb+e7cieNbM1dk9ERET+Y/5RgNRv8FhzF1uzRrX5edxMxv/cB+9MHqzfvIveA8cwf8pQvu/VgZZf9Sd71kz8MmU+nVo3JqNHOg4dPcWMecuZMqo/KVMkJzw8AoCLV/wYN20Bv477EfeUbsycv4Iho6YxatDXAJw+d4nZEweRLo07E6b/xpzfV/FNl1YAXPW7Se//tabnV1+wdPUmJs9cxOjBvaxxjEREROQ/5rW72HbsPUSWTBnwzuQBQNUKJRk+bhYBd4NwT5WC73q1p9PXg6hRuQxVypcAYNe+I1SrWJKUKZID4OjoAMCho6cpVigP7indAKhXqxIz5i8jOjoGgFzZvUmXxv3x3z4sWrHBXKf06VKT09cbgNzZvZn/uBUqPotXbmTJqo0AmEymf3IIRERE5ANmlS625zl34QrJkiYmIDAIk8mEwWB46W0tV33SagVgY2NDdEz0U2mJ/k6ztSE6JibBfBvUrkyD2pUBiIqKonSNFi9dJxEREfnwvfZt/rl8vbl4+ToXr/gBsHHrHlKlSE6qlG6cPX+Z+UvWMmv8IADm/r4agFLFCrB+8y7uBt4DIDw8gvDwCArkzc7eA8cIeLx82ZpNFMqXE1tbzUYgIiIib89rtyAld03K973a88PPk8yDtAf17UxoaBj9hoynz//akMLNlf49v6RV5+/Ikysb+XP70rJJXbr2GYYBA4kS2TKobxeyeHnQqXVjuvUZBsQO0v6ma6vX3kkRERGRV2EwGiP+04NwnnSxTW8dip3tu66NiHxostZb+q6rICL/gPquRERERCwoQBIRERGxoABJRERExIICJBERERELCpBERERELChAEhEREbGgAElERETEggIkEREREQsKkEREREQsKEASERERsaAASURERMSCAiQRERERCwqQRERERCwoQBIRERGxoABJRERExIICJBERERELCpBERERELChAEhEREbFg964r8L7IWvd37Ox0OEREREQtSCIiIiLPUIAkIiIiYkEBkoiIiIgFBUgiIiIiFhQgiYiIiFhQgCQiIiJiQQGSiIiIiAUFSCIiIiIWFCCJiIiIWFCAJCIiImJBAZKIiIiIBT187LFzyxpiZ/uuayEiLyNrvaXvugoi8oFTC5KIiIiIBQVIIiIiIhYUIImIiIhYUIAkIiIiYkEBkoiIiIgFBUgiIiIiFhQgiYiIiFhQgCQiIiJiQQGSiIiIiAUFSCIiIiIWFCCJiIiIWFCAJCIiImJBAZKIiIiIBQVIIiIiIhYUIImIiIhYUIAkIiIiYkEBkoiIiIgFBUgiIiIiFhQgiYiIiFiwe17i1p37mblgBTExMUQYI0mVIjm//PQNNjaKq0REROTDlWCAdDfwHj+Nmc6v4waSNnVKAM6ev4zBYHhrlRMRERF5FxIMkIKCH2BjY0PSJC7mZdl8MgHwy5T5HDl+mqioaFycnfimaysyeqQDoHjVJrRr/gk79h4iKPg+Xb9swpVrN9m6cz8PH4XybddWFMibg3vBD/h+6ATuBgVjMBjw9faib492rNmwne27DzL0+24A7Nx7mPlL1jDh574cOnqKEeNnky93No6dPE90dDT9erYje9bMACxbs4kFS/7AycmBsiUKMXX2Evasn/vGDp6IiIh8mBIMkLwzeZA3ZzbqNu1K/jy+5M7hQ5XyJXBP6UbThjXp3PYzADZu3cOoiXMYPbiXeVsnJwem/zKA/YdP0Ov7UXTv2Jxfx/3Ipu1/MW7aAmaM/ZF1m3eRNk0qxgz5BoD7Dx6+VIWv+t2k9/9a0/OrL1i6ehOTZy5i9OBeXLzix/S5S5k1fhAp3FyZOntJgnksXrmRJas2AmAymV6qXBEREfnvSDBAsrGxYUj/Lly5dpPDx0+zd/8xZi1YyYyxP3Dq7CUWr9xAaGg4MaYYHoQ8irNtpbLFAMieNTNh4RFUKhf7Oke2LPjd8Acgl683C5eu45fJ88iX25dihfK8VIXTp0tNTl9vAHJn92b+4jUAHDxyimIF85DCzRWAOh+VY8a8ZfHm0aB2ZRrUrgxAVFQUpWu0eKmyRURE5L/huYO0Abw80+HlmY66NSrStfdQNmzZw8Jl65gx9gcypEvNhUvXaN9jYJxt7O0TAZgHczvY2wNga2MgOjoagNw5fJg1YRD7D59g6679TJm9mFnjB2Fra0N0TIw5L2NkZJy8HR7nDWBjsW4cGislIvLWfT9sGhu37+PGrQDWzB9JzmyZzGkla7bFwT4RDg6x3wkdvqhPrSqlAGja4XsCAoMx2BhI7OzEdz1bk8s38yuVfdXvFh16DceEiRaf1qBh7YrmtEehYXzZcxgnTl8kKjqa49vmmdP8bt6hbJ32ZPP2NC+bNOxrMnqkBeDGrQD6D53C5Ws3sbGxoUmDarT4tMarH5x47DlwggijkXIlClglP2vke/bCVVp2HcSu1VOsWqdX1ahtX1o2rkXV8kUZOXE+mTOm/397dxkf1fE1cPy3EncPBYq7FykhFA0ESYEECVLc3aEUp0jwAAWCFoIWt+LaAkVapHhLceLuJNns8yKwJQqE8M9DOd9Xu3vnzp07ez/Zk7lz59CqWd3/2fGzDJCCQsLwDwyhUrmSAERFx+IfGIxT9Uqo1SpsrS3RarXs2HcsRwf2CwjCzsYal7o1capWkWaeA4lPSKDAZ4788/AJCS8SUatVHD11/q3q+6JSWTb8tJ+wiEisLS3Yf/hMjtolhBAi55q6ONG3ayva9Pwu0+1LZo1KEzS98sPs0Vi8nPN6+OQFRk1ZwuGtC9/p2AdP/EbFcsWZNb5/hm1qtZr+Xd2xsDCjfZ8JGbabGBtyaEvG42m1WvqO8qJ/Nw+aN3IGIDg04p3alZ0Lf9wkKjo2y0AmOVmDWq3K9Xo/NiP6d3znfXLad69kGSBpNCn8uGk3fgHBGBroo9Gk0NTlKzzdm+AXEETHPt9iYW5KnVpVc3TgK9fvsGXXIVRKJRpNCoN6d8DUxJjyZYrjVL0y3/T9FhtrSyqWLcmte/ffWF/xIgXp1rElfYdPw9jYkJpVK2JqYpyjtgkhhMiZL78ol6P9LF57ICg6Ji7LmwCxcfFMmbua67f+BqCZizPD+niy88Ap1mzeT4omhWs3/2LxjBGUKFpQt5+Bvh61alTkqV/QO7Xr3KU/0dfX0wVHAHY2lpmWDQoJZ+rc1TzzDyIhIZFG9WowakAnLl65xegpS9i3YS6WFmZMmr2SxMQkOrdrxqadR0jRpHDhj5s0qV8TD7f6NOswnI6tXTl74ToebvUoXbwQ85Zt4kViEklJyfTq1ALPVi5A6uDFjIXruHrzHkqligplitKtvVuGeof28eTM+assWb2NhBeJqFRKxg7uQq3qFQBYuGIrew/9gqmJEfWcsw6qtu4+xupN+9DTU5OiScFr4kCqVCiJs1sfVs4fpwt+v/5mFN8N64ZTtfJ49plA6eKFuHrjLyKjYmhUtwbjh3dDoVBku+11IycvpmypIvTs+DVJScnMX76Z336/QWJSMkU//4yZ4/tjYW7KyMmLUSoVPH4aQEhYJAc3z2fklCXcu/8YtVqNnbUFG5ZNeavvPssAKZ+DbZqJ168b3r8Lw/t30b3v3rGV7vXrT40ZGxmmeW9vZ8PJvWsAcHOti5tr5kNlY4Z0z/TzLyqVxXf5TN37YoULstvXW/e+ScPatP46dW7RT7sPU75M8SzOTgghRF4YOWkRWq2WSuVLMHZwZ2ysLHTbRkxaxG+/3wDgx0UTM91/8ertJCYmc3irNwkvEmnT8zuKFc5Pa7f6PHkeSFR0LJNH9XzndsXHv6BF59FoNCk0rleDQT3boFKp+PvBU6ytzBk0bj4PHj+nQD57JgzvxucFHDOe2+TFDOzRmppVy5OcrKHHsBn8fOwczRs549mqEaOmLKFV07pcvnaH3etmY2igT6fWrmna/NQviOiYOEoWLci4Iam/s5FRMexYMxOVSkVEZDTNO46kjlNl8jnYMm3+WgwN9Dm81RulUkloeCQ2VhYZ6n3yLADvlVvx/WEyZqbGPHrqT9ue4zl7YAXnLl7n4PHz7N84D1MTI4ZP9M6yn2YsXMeJnUuwt7MmKSk5wzSYrPz94Ck7184iOVlDu97j2Xf4V1o2rfPGbZlZuWEPxkaG7PWdC8DiVduYt2wT33/bF4Abdx6wY81MTE2MOHzyAlHRsRzfsQSAiMjot2ovvMUcpI/JsrU/cePWXyQna7C1sWLs0B553SQhhBAvbVs1g/z57EhKSmbe8s2MnLyYdYv/DYQWTBsKwI79J/Fa4ptm2yvnLl5n/PDuKJVKjI0M8Whej7MXruvmMuWEva0VFw6vxtbakojIaAaNm8+qjfvo19UdjUbDb5dvsHvdbEoW+5yNOw4z8Nt57N84L00dcfEJnL/8JyFhEf9+FpfAg8d+AAzo7kHXwd8zbsYy9vrOwfDlPKzM6KnVuL821yY8Mpox037g4RM/VCoV4ZHR3PvnCfkcbDn56+/sWT9bN+f39YDzdWfOX+Xx0wDa9R6v+0ypVOAXEMy5y3/SvJEzZqapd106tnbl8rU7mdZTq0YFhk9aRMOvqlHP+QuKFsqfTc/+y6N5PfT01OjpqWnVrC5nL13XBUHZbcvM0dMXiY6J49DJ3wBISkqmwGf2uu3NXWphamIEQNmShfnn4TMmzFrBl1XLUd/57e96/acCpNGDuuV1E4QQQmQhfz47APT01PTs4EZ9j4GZlmvzdQPGz1pBeEQUVpbm2daZG4sXG+jrYfDyCWhLCzPatmjIvsO/0K+rO5852lGuVFFKFkudwO3RvB4TvVaSlJSMnt6/P6Gvlox5NTKUXkxsPE+fB2BsZEhYeFS2gYWhoX6ajBXjZ/pQ3/kLfOaORaFQ0LzjSF68eLuRG1370FL7y0osnjnijWWz61GfuWO5cecfLvx+k+5DpjNyQEdauH6FWqUi5bWHpl4kJmZ/jGy+tzd9p1otTBndmzpOlTPdbmxsqHv9eQFHju1YzPnLNzh38U+8FvlycMsCLMxNsz0GSC42IYQQ/wNx8QlEvrYkzL4jv1KuVOpTapHRsQQGh+m2HTl1ESsLMywtzDLU4/xlJbbtPY5WqyUuPoHdP5/mq5qV36ttIWERJCUlA/AiMYkjJ3/TzaWp5/wF/kGhBASFAnDq7B8UL1IgTXAEYGJshFO1Cixft0v3WWBw6sNOAGOn/UDLpnVZ6jWK4ZMWER4RBYCZiRHRMXHZti8yKob8+exRKBRcvHKLO38/0m1zqVudlRv26oKT0PDITOut41SFc5eup9n32s2/AKhdoxIHj58jJjYerVbLlt2ZP3yVnKzh8bMAKpYtTp8urWja0Ek3F6xQwXxcu/GXrt4Hj/zS7Lvn0C8kJSWTkPCCfYd/wblGpbfalpnG9WqwZvM+4uNfAKm3R//650mmZf0DQ1AoFDSqW4PvhndFq9Xi9/I7eZP/1AiSEEKIvDVuxnJOnf2D4NBwug6aiomxEWf2LickNIJ+Y+aQoklBq9VSsIAD81/eUouOiWXg2LkkJCSiUCqxsTJnjff4TEcShvRqy5S5q3H1TN23mYszbo2dM5TLTBPPYYSGRxETG0/Npr1wqlaehd8P4/drd1jgswWlUoVGo6FW9QoM7NkWSJ1LO2NcP7oPnY5WC+amxiyZOTLT+r2nD2P6gh9p3G4IChQYGRkyc3w/jp6+RERUDEN6tX25TIArIyYtZu2i8bjWr8mug2do2mG4bpJ2emMHd2ai10oWr95G2ZJFqFy+hG7bxBE9+H7BWlw9h6FWq6hUtjheEwdmqHdoH08WzRjBdzOWE5+QSFJSEuVKFWXxzBHUr12Va7f+xq3TyGwnaWtSUhgz9QcioqJRqVTYWFkwd/IgAEYN6MjIyYvZtOsoX1QsSYliBdPsW7xwAdr0HEdEZOpE7Bautd9qW2b6dfUgMfEnWnUdo7tG+nV1143yve7u/cfM+WEjWi1oNBrcm9elTInC2db/iiIx8cUnvZT0q4Ui1/SK4z2eBhRC/A+V9Nj15kJCiP8XXl/P6F225TW5xSaEEEIIkY7cYhNCCCHEB/PTyuk52pbXZARJCCGEECIdCZCEEEJ8smYsXMfCFVsz3Va4qnuaJ+/Ex8HZrQ+37j1873okQBJCCPFekpM1ed0EIXKdzEESQgiRqaHjF/Lg8XOSkpLJ52DL7EkDsbe14qlfUIZ8YV83rp1pHrL0tu87yZ5DZ7C2Muev+0/Q19djqdcoPi/gSFBIOEO+W0BMbBwvEpNwqlaeKaN7oVQq0+x3569HmJuZMHviQOYu3cQ/j57xmYMtPvPGYmJslG2urqDgMEZOWYJ/YAgOdtZYWZpTrHDWizau2rCHk2f/ID4+gaG9PWnVrC4rfffw8IkfsyYMAFLXcarXsj+ndi/NsHbTn7fvM2XuauLiEjAw0GPiiB5Uq1xG14fdO7hx8tffiY6JY8roXtSvnbrS8/Vbf+O12JeY2Hg0KSkM7N46TT64VzLLxTZ38uAsc9ZB6pNjFUoX48/b93nmF0Rrt/p8UbEUS9fuwD8olO7tm9Prm5ZA6mhMc5danL98g+iYODq2bkzfLu5A6ujbxSu3SEpOxszEmFkTBuj6snBVd0YP7MTR0xcJDY9iSO92tGvRkIPHz7Nl11FdPjSNRkOdFv1Zt2Rimtx5AI+e+jN+pg+hYZEolAqG9Wmve9otq/rT9/2wCd6c2LlEtxyAR/dvGdyr7VutqC0BkhBCiExNGtVDl7pi2Y878V65lZnf9QfIkC+s88CpWeYhS+/PW/c5uGUBBfM74LXYl+XrdzNrfH/MzUxY4/0dJsZGaDQaeo+YxYFj52jh+pVuv8M/eZM/nx3DJ3rTc9gMdv7ohZ2NJT2GTmfngVN0adcs21xdU+aupnK5EmxYOpmAoFCadRiRbYCkQMHBzQt48iyArzuPpmrlMni6N6KB+wC+HdoVCzMTtu87QaN6NTIER4lJSfQbNZtZEwZQt1YVLl+9Tb8xczizZ5muD8uUKMyIfh04ff4K0+atoX7tqkRGxzJuxnLWLZqAvZ01YeFRuHUaSdVKpXG0t0lzjMxysUHWOetepWR5HhDMlhXTiImNp7ZbXyKjY9i+ZiaBwWE08BhE25YuugTCIWGR7N84j/CIaNw6jaRapTJUrVSaft3cGT+8G5C68OfUeWvw/WGSrm36enrs9Z3L/YfPaNllNB7N6uFa/0tmeK/jn0fPKVY4P8fOXKZQQccMwRGkBujtWjakU2tXHj7xw73bWMqVLkKBfPZZ1q9+bb2eimWLY2Vpxq8XrlPHqTI37z4gLDyKerWyTsb7OgmQhBBCZGrvoV/YffAMLxITefEiKU3aj9fzhb0pD1l6VSqWomB+BwC+qFiK9T8dBECbosVrsS+Xr90FrZaQ8EhKFvtcFyBVqVhKl66kQpliJCVrsLOxBKBiuRI8fOIPZJ+r69zlG3z38kfd0d4Gl7rVs+0DT3cXIDVlRY0qZbl05Rat3erTtGEttu89Ts9OLdi04zBLZo3KsO+DR34olArq1qoCQPUqZbG1tuT2vYc4OthiYKBPkwY1U/uhQikePwsA4Mr1uzx9FkjXId+nq+95hgApq1xsb8pZ17ShEyqVCgtzUwoWcKDBV9VQKBQ42ttgbWXOM78gLF6uJt6uZUMUCgXWVua4NqjJ2YvXqVqpNGcvXGfdTz8TGxdPSoqWiKiYNG17lU+teJECqFQqgkPDyedgS+e2Tdmw7RBTxvRiw/ZDdGnXLEPfxcTGc+vuAzzXzgKgyOefUa1yGS5fva0LkLKq/3Xd27vhu+0gdZwqs2HbIb5p2+St09NIgCSEECKDy1dvs27rz+xa54WttSXHzlxigc8W3fbX84W9KQ9Zegb6errXKqWSZE3qHKbVm/YRGhbJnvWp9Xy/YC0vEpMy30+lylCP5mU9b8rV9TpFtpnHMin/8se1W/vm9B4xk2JFCmBtZUH50kXfcv9/X+vrqXX1qVRKNJqUl+3XUqJYQXb96PVObXubdr9ioP/v96RSKjO8f9WXWdX13D+YSXNWsc93DoUK5uPO349o12t8mnIGBmnrTH55fh3cG+HSZggebvV49NSfRm8IUnXHTfddZVX/65o0qMmsxeu5efcBx3+5pAuO34ZM0hZCCJFBZHQsJiZGWFmYkZiUxOadR7Ms+6Y8ZG99zKgY7GytMDTQJygknIPHz+eo7dnl6qpdoyLb9p4AICg4jOO/XMq2ru37TgLw1C+Iy9duU71KWSB11KJgfke+m7E80xEQgKKFP0ObouXXC9cA+OP6XYJDIyj7cmQmK1Urlebp8yDOXryu++zWvYckJmVMUJtVLrbczFm3Y/8pACIiozl66iLONSoSHROHnlqFva01Wq0W35ejgG/DwtyURvWq03eUFx09XFGpMqaxMDUxolzpomzfl/pdPXrqz+/X7lCjSrl3artaraJTa1d6j5hJ4/o1dbcN32rfdzqSEEKIT0JdpyrsPniGBh6DsLQwo/aXFQkIDs2yfFZ5yNLf8shO9w5uDBg7h0Zth+BgZ/3GpKVZyS5X1+RRPRk5ZQkubQbjaG+DU/WK2daVokmhWccRxMcnMGVULwq+vFUHqSMhk2avollDp0z31dfTw2feWKbMXc2MheswMNBj+ezRmBgbERYRneUxLcxN+XHReGZ4r2P6wnUkJyfzmaMdK+d/m6FsVrnY3idnXXo2Vua4dRpJdEwcXTybUrVSaQDcGtemUbshWFmY0bjeu6UK6eDemB37T9HBvVGWZRbNGM74mT6s33YIhQK8Jg7U3WJ9F56tXJi7dBNdswhksyK52CQXmxAfHcnFJv4/mDR7JbbWlgzp3S6vm/LBOLv1YeX8cZR7w6jXu1rpu4f7j54xZ9KgXK03MwePn2fjjsNs9pn2TvvJCJIQQgjxDgKDw+jQdxKWFqb4/jA5r5vz0WnUdggKBaxfMunNhd9Tl0HTePjEjxXzxr7zvjKC9HIE6def16FWS7wohBBCCJmkLYQQQgiRgQRIQgghhBDpSIAkhBBCCJGOBEhCCCGEEOlIgCSEEEIIkY4ESEIIIYQQ6Xzyz7W/yiGUnJycxy0RQgghRF5SqVS61dc/+QDpVUK++i175XFLhBBCCJGXXl8T8ZMPkPT19fm8gCMbfWZlyHYscsc3/cax0WdWXjfjP0n69sOS/v1wpG8/LOnfnHk9ce4nHyAplUqUSiV6enp53ZT/LIVCIauUfyDStx+W9O+HI337YUn/vj+ZpC2EEEIIkY4ESEDrrxvldRP+06R/Pxzp2w9L+vfDkb79sKR/398nn6xWCCGEECI9GUESQgghhEhHAiQhhBBCiHQkQBJCCCGESOeTfwbw6fMAps1dQWRUNKYmRkwY2ZeihQvkdbM+SguW+fLrhSsEBIawftkMShYrBEgf54YXiYlMmrmUh0+eY6Cvj5WlOaMHd6NgfkfCIiKZNseH5/5B6OvpMWpwN6pUKJ3XTf7oDB3nRWh4JEqFAmMjQ4YP6EKp4oXl+s1FB46cYcaCVXhNHkbdWtXk2s0l7l2Goa+nxkBfH4Auni1wqVdTrt339MlP0h40ZiZNXWrTvHEdTv56iY3b9rN2yfd53ayP0tUbd8nvaEffkd8ze/JwXYAkffz+XiQm8se12zhVr4RCoWD73qOcOnuJZXMnMH3+ShztbejVuTW37/3Dt9O82bV+oayB8o6iY2IxMzUB4PS5y6zZsJsNPjPl+s0l/gHBTPJaBmj5pp0bdWtVk2s3l7h3GZbmb+4rcu2+n0/6FltYRCR3/n6Aa0NnAOrXrk5gcBhPnwfkccs+TlUqlMbezibNZ9LHucNAX59aNSrrVnsvX6Y4/oEhAJz85SLuzRsCULZUMWytrbjy5908a+vH6lVwBBAbG49CIddvbklJSWHmwtWMHNgFPb1/gx+5dj8cuXbf3ycdpgcFh2FrbYn65dLiCoUCBzsbAoNDKZjfMY9b998gffxhbNtzhDpOXxAZFU2yRoONtaVuWz4HWwKDQ/OucR+xqXN8uHL9NgDzp4+W6zeXbNl5iIrlSlK6RBHdZ3Lt5q5pc33QarWULVWMAT085drNBZ/0CJIQH6N1W/byzC+Q/t0987op/zmTx/Rj76bF9OnWhmVrtuZ1c/4T/nn0lNPnLtO9Y8u8bsp/1vJ5E9joM4v1S6djaW7G9/NW5HWT/hM+6QDJ3s6akLAIkjUaALRaLYHBoTiku00kck76OHdt2v4zZ879zoLpozE0NMDC3AyVUkVoWISujH9giPTve2reqA5/XL+Nva1cv+/r+o17+AcG07bHKNy7DOPWnX+Y7b2WE2cuyrWbSxztbQFQq9V4urty/eY9+dubCz7pAMna0oJSxQtz5MQ5AE6dvYy9rbUMP+Yi6ePcs2XnQY6d/o1Fs75NM1+mQZ0a7P75BAC37/1DcGg4X1SUJ4HeRXRMLMGh4br3Z87/joW5KVaW5nL9viePr104sGUpu3292e3rTbkyxRg7rAceX7vItZsL4hMSiI6J1b0/dvo3ShYrJH97c8En/xTb46d+TJ+/ksioGEyMjRg/sg/FixTM62Z9lLwWreH8pWuEhUVibm6KsZEhO9YtkD7OBUHBobT8Zij589ljbGQIgJ6eHmsWTyUsPJKpc5bjFxCMnlrNyIFdqVq5bB63+OPiHxjC+OmLeZGYiFKhxNLCjMF9OlKyWCG5fnPZgNHT8XRvkvqYv1y77+25fxDjvl9ESkoKWq2W/I72DO/fmXyOdnLtvqdPPkASQgghhEjvk77FJoQQQgiRGQmQhBBCCCHSkQBJCCGEECIdCZCEEEIIIdKRAEkIIYQQIh0JkIQQQggh0pEASQghhBAiHQmQhBC5omPvsZy9cDWvm/Fejpw8R+9hU/9nx/MPCMbJ9Zs0KyG/7tqNu7ToNPh/1p73lf58Zi9ay9LVktNOfJxkoUgh8tD1m/dYt2Uvt+7eR6tNzank2qAWnu5N0NNT53XzRC5zcv2G9ctmULJYISA1oPDoOpyjO1ekSR/zsfqvnY/4tMlfYCHyyNkLV5nstZTeXdoweUx/LC3MePTEjw3b9hMSFkE+B9u8bqIQeSY5ORm1Wn6iRN6Rq0+IPKDValm43Jdv2rnR3qOJ7vPCn3/GxFF9de/v/PWAhcs38PDxc2xtLOnesRWN69cCYPWGndz56yF2tlYcP30BczNTJozsTXRsHEtWbiYqOgYPNxf6dW8HwM9Hf+Gn3Ydxql6JPQdPYWRoQGdPN1p/3QiAe/cfsWCZLw8fP0elUlK9SjlGDuyKhbkZkJpDq3yZEvx1/xE3bv9NgfwOTBzVT5fbyb3LMIb1+4a6taoBcOnKTXx+3MbT5wHY2VjRv0c7vnKqmrrtjxssXrUZ/4BgDAz0qedcnTFDumfop1cjEpNG92PNxl1ERsVQp1ZVxg3riVqtJi4+gSley7h55z6JSUmUKPo5IwZ0ocTLEZqc9pHv8pm6c2rt5sLpc5d5+Pg5JYsXZsqY/jjYp2ZEf/DoGTMXruLh4+eULlGEMqWKcvvePyybOyHDufQYPAmAPsOnolQo6NK+Ba4vv8uzF65men5Xrt9m7FRvju1aCaTeAly9YRdh4ZEYGxvh3rwBPTq5ZzhWZFQMMxeu4uqfd9BqIX8+e2ZNGkY+B9sM39OZ87/j7bOR3b7eunNu2aQ+p85d4plfIBXKlGD8yD7Y2VgBqaNgw/p9w64DxwkLj+LLqhX4dlhPTE2MM7Tj+3krMDUxZnj/zgA88wvE22cjt+7ex9BAnxZN69O1fQuUSqWu779yqsqegyepWLYksyYNzVCnEP8rMgdJiDzw9HkAfgHBNKrnlGWZ6JhYho+fQ6N6ThzatozRg7vj5b2G67f+0pW5dOUGNatW5MiOFTRp6MyUOcv59fwfbPCZyYoFk9my8xD3/n6oK//g0TMUCgUHtvzA998NYtnan7h64y4ASoWCAT08OfjTUjat8CI4JJxla35K06bDJ84ysGd7juxcQZkSRVmwbH2mbb//4AkTZixmQE9PjuzwYezQHkyd48Pjp35A6g9npzbNObFnNTvXL6BJQ+ds++u3y9dZv2wGm1fN5vertzhy8jwA2pQUGtevxU7fBfz801JKFi/EhJlL0Gr/nTnwrn2U3uGT55g2biAHty3DyNCAlb47gNQRjjFTFuBUvRKHt/swoKcnB46cybKetUumAbBy4WRO7l1Dtw4t33h+r4tPSOD7eSv5bkRvTuxZzeaVXtSsVjHTY23e8TMaTQr7Ni3h8HYfvhvRW5fk+G3sO3yaqWMH8vOWpVhbWTB19vK0fXLiHD/MGc8u34VEx8TivXzDG+tMSHjB4G9nUa1yOfZtWsLy+RM5fvoCB47+oivz4NEzVColezYsYvKYfm/dXiE+BAmQhMgD4ZHRANjZWmVZ5vyla1hamNO2ZWPUajVfVCxD4/q1OHTsV12Z0iWKUK92dVQqJY3qOREcEk5nz68xMjSkSKH8FCtSkHv3H+nKGxoa0KuzB3p6aiqULYFrfWcOHU+tr0SxQlQqXwq1Wo21lQXtWzflyp930rSpSQNnShQrhFqlommjr7j39yMys/vgSZo1qkO1yuVQKpVUKl8K5y+rcOKXiwCo1Sqe+QUSHhGFkaEhFcuVzLa/enRyx8TYCDsbK2pWq8jdlwGNiYkxLvVqYmRoiIG+Pr06t+bJswCCQ8Nz3Efpebi58JmjPQb6+rg2qKU79s0794mMiqFrh5bo6akpV7o4DevWzPY83vX80lOrVTx68pzY2DjMTE0oW6pYFuXUREbF8PR5ACqVkpLFCmFhbvrW7fFwa0jhzz/D0NCAQb068Mf12wQFh+q2d2rbHDsbK8xMTejTtQ1HT/9GSkpKtnWeu3QNM1MT2nukzq9ztLelXStXjp76Nxg0MTGm28v+NDQ0eOv2CvEhyC02IfKA5csfq+CQcAp85pBpmaDgsAzzkD7LZ8e1G/d0760tLXSvDQ30Uz+zeu0zQ33i4l/o3tvaWKWZ1+HoYMPVP1NHkJ4+D2DJys3c+esBcQkJaFO0qNWqNMe3trLUvTYyNCAuPiHTtgcEBvP7tdv8/NrogEajwcS4NgBek4axbss+PHuOxtHBli6eX+OSTXBhY/36ORkQExsHQMKLRJas3MT5y9eJio5BqUj9ny8yMhp7W+sc9dGbjv3qnENCI7CxtkSt+rePHO1sePj4WZZ1vev5vc7I0JC5U0ewZechlq7eSrEiBenTpQ1VK5fNULZT2+YkJiYxYeYSYmLjcan7Jf17tNed/5s42v973VlbWaCvp0dwaDj2dqm3Fl+/Lh3tbUlKSibiZdCfFf/AYB48ekYjjz66z1K0KTjY2uje29laoVTK/+3i/wcJkITIA58XyEc+BzuOn75At44tMy1jb2eNf2BIms/8A0J0P/w5ERIanmbya2BQqG4Ua87iH/m8gCMTR8/GzNSEM+d/Z/q8lTk6jr2tDZ6tXBnQs32m20uVKMKsSUNJSUnhl/N/MGHGEr6oWCZN4PI2tuw8yN2/H7Fi/kTs7WyIjomlceu+/C8ezbW1sSQsPIJkjUYXJAW8NsqSGYVC8V7HrF6lPNWrlCc5OZmd+48zdupCju5ckSGoMDYyZGCv9gzs1R6/gCBGT1rArv3H6dimGcaGhiQkJOrKhoZGZDhOQNC/111YRCSJSUm6OUgA/oEhlCtd/GXZUPT01FhamBEYlPX5O9jZULpEYVYvynoZBeV79o8QuUlCdSHygEKhYMSALmzYtp/te48SGZX63/eTZ/7MWLAK/8AQnKpXJjwiip37j5Gs0XDtxl2OnjpPU5faOT5uQsIL1m7aQ1JSMrfu3ufIyfO41k+d/xMbF4+xkREmxkYEBoWyafvPOT5Oq+YNOHD0F/64dhuNJoXExCRu3P6bR0+ek5SUzKHjZ4mKjkWpVGJqmjq5V6V69z9HsXHx6OvrYWZmQlx8Aj4/bstxm99V+TLFMTUxwXfrPpKTk7l97x9OvryFmBVrK3Oe+wXm6Hhh4ZGcPneZ2Lh4VCoVJsZGqFSqTMuevXCVJ8/8SUlJSS2nVun6t2Txwhw7/RsvEhN57h/Ezv3HM+y/5+BJHj/1I+FFIstWb6VyhdK60SNIneMUHBpOdEwsq3x34FK35htHfpy/rEJYeOr1/CIxEY0mhcdP/bhy/XaO+kOID01GkITII7VrVmHB9NH8uHkPK9enTvx1sLehSUNnbK0t0dNTs2D6aLx9NrJ87TZsbawYPbgblcqXyvExixYugEajwa3DIAwN9Onbra3uFs3Qvp2YvWgtO/cfo2ABR5o0cObh4+c5Ok6p4oWZNm4gK9Zv59ETP5RKBSWKFmJwn44AHD11Hm+fjSQnJ+NgZ8OUbwfonpZ7Fx08mjLZaxnNPQdiYWFGny5t2HXgRI7a/K7UajVzpgxnlvcaNm47QJmSRXFt4MyjJ1n3WZ8ubViwfAOzvFfzTTs3GtXNepJ+eikpKWzbc4QZ81eRok3h8/z5mDlhSKaByTO/QBYu9yUsPAojIwPq166Oh5sLAH27tWGK1zKatRtAkUL5aepSm50H0gZJbo3rMslrKc/8AilfujhTx/ZPs921gTODxswgNCySGlUr6J5Sy46xkSGLvb5l6eqtrN20h8TEJPLns6dT2+Zv3QdC/C/JQpFCfCLSP8Iucp/XojVoU7SMG94rr5uSY+mXAUgv/WKXQvxXyS02IYTIoWs37hIYFEpKSgqXr97k6MnzNKjzZV43SwiRC+QWmxBC5NDzgCAmzlpKdEws9rbW9O/hyZdVK+R1s4QQuUBusQkhhBBCpCO32IQQQggh0pEASQghhBAiHQmQhBBCCCHS+T/V/rpAptBCeAAAAABJRU5ErkJggg==",
       "text/plain": [
        "<Figure size 583.3x500 with 2 Axes>"
       ]
@@ -2086,8 +2086,7 @@
     "    axes[0],\n",
     "    \"Extracted relationship classes and their shared suppliers\",\n",
     "    subtitle=(\n",
-    "        f\"{EXTRACTOR_NAME} extraction from {len(filings_df)} S&P 100 10-K filings, \"\n",
-    "        f\"{min(years)}-{max(years)}\"\n",
+    "        f\"{EXTRACTOR_NAME} extraction from the S&P 100 10-K filings, {min(years)}-{max(years)}\"\n",
     "    ),\n",
     ")\n",
     "show_with_alt(fig, RELATIONSHIP_FIGURE_ALT)"
@@ -2095,13 +2094,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "df5425ea",
+   "id": "be883065",
    "metadata": {
     "papermill": {
-     "duration": 0.011532,
-     "end_time": "2026-09-10T22:11:29.295954+00:00",
+     "duration": 0.01418,
+     "end_time": "2026-09-13T00:30:43.817097+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:29.284422+00:00",
+     "start_time": "2026-09-13T00:30:43.802917+00:00",
      "status": "completed"
     }
    },
@@ -2115,13 +2114,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b5115c89",
+   "id": "74e117ed",
    "metadata": {
     "papermill": {
-     "duration": 0.012043,
-     "end_time": "2026-09-10T22:11:29.319833+00:00",
+     "duration": 0.020951,
+     "end_time": "2026-09-13T00:30:43.858321+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:29.307790+00:00",
+     "start_time": "2026-09-13T00:30:43.837370+00:00",
      "status": "completed"
     }
    },
@@ -2135,14 +2134,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c90cffa0",
+   "id": "c0671889",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.010842,
-     "end_time": "2026-09-10T22:11:29.343240+00:00",
+     "duration": 0.026517,
+     "end_time": "2026-09-13T00:30:43.914105+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:29.332398+00:00",
+     "start_time": "2026-09-13T00:30:43.887588+00:00",
      "status": "completed"
     }
    },
@@ -2156,20 +2155,20 @@
   {
    "cell_type": "code",
    "execution_count": 32,
-   "id": "243dc930",
+   "id": "8062c335",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T22:11:29.367246Z",
-     "iopub.status.busy": "2026-09-10T22:11:29.366842Z",
-     "iopub.status.idle": "2026-09-10T22:11:29.377004Z",
-     "shell.execute_reply": "2026-09-10T22:11:29.376057Z"
+     "iopub.execute_input": "2026-09-13T00:30:43.967260Z",
+     "iopub.status.busy": "2026-09-13T00:30:43.966525Z",
+     "iopub.status.idle": "2026-09-13T00:30:43.977685Z",
+     "shell.execute_reply": "2026-09-13T00:30:43.975261Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.024162,
-     "end_time": "2026-09-10T22:11:29.378413+00:00",
+     "duration": 0.04061,
+     "end_time": "2026-09-13T00:30:43.980520+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:29.354251+00:00",
+     "start_time": "2026-09-13T00:30:43.939910+00:00",
      "status": "completed"
     }
    },
@@ -2184,14 +2183,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0d091fe8",
+   "id": "d43ddf85",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.012925,
-     "end_time": "2026-09-10T22:11:29.405343+00:00",
+     "duration": 0.018784,
+     "end_time": "2026-09-13T00:30:44.029592+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:29.392418+00:00",
+     "start_time": "2026-09-13T00:30:44.010808+00:00",
      "status": "completed"
     }
    },
@@ -2208,20 +2207,20 @@
   {
    "cell_type": "code",
    "execution_count": 33,
-   "id": "ddb80d84",
+   "id": "8818cda5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T22:11:29.436916Z",
-     "iopub.status.busy": "2026-09-10T22:11:29.436333Z",
-     "iopub.status.idle": "2026-09-10T22:11:29.442433Z",
-     "shell.execute_reply": "2026-09-10T22:11:29.441337Z"
+     "iopub.execute_input": "2026-09-13T00:30:44.080983Z",
+     "iopub.status.busy": "2026-09-13T00:30:44.080103Z",
+     "iopub.status.idle": "2026-09-13T00:30:44.092087Z",
+     "shell.execute_reply": "2026-09-13T00:30:44.088804Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.024374,
-     "end_time": "2026-09-10T22:11:29.443416+00:00",
+     "duration": 0.041226,
+     "end_time": "2026-09-13T00:30:44.093890+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:29.419042+00:00",
+     "start_time": "2026-09-13T00:30:44.052664+00:00",
      "status": "completed"
     }
    },
@@ -2257,14 +2256,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "41630c76",
+   "id": "ebb3a8c1",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.018218,
-     "end_time": "2026-09-10T22:11:29.476844+00:00",
+     "duration": 0.009309,
+     "end_time": "2026-09-13T00:30:44.114332+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:29.458626+00:00",
+     "start_time": "2026-09-13T00:30:44.105023+00:00",
      "status": "completed"
     }
    },
@@ -2277,20 +2276,20 @@
   {
    "cell_type": "code",
    "execution_count": 34,
-   "id": "f82d5903",
+   "id": "c3ee7078",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T22:11:29.505508Z",
-     "iopub.status.busy": "2026-09-10T22:11:29.505230Z",
-     "iopub.status.idle": "2026-09-10T22:11:29.511273Z",
-     "shell.execute_reply": "2026-09-10T22:11:29.509914Z"
+     "iopub.execute_input": "2026-09-13T00:30:44.135746Z",
+     "iopub.status.busy": "2026-09-13T00:30:44.135467Z",
+     "iopub.status.idle": "2026-09-13T00:30:44.145927Z",
+     "shell.execute_reply": "2026-09-13T00:30:44.140287Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.021696,
-     "end_time": "2026-09-10T22:11:29.512303+00:00",
+     "duration": 0.025201,
+     "end_time": "2026-09-13T00:30:44.149367+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:29.490607+00:00",
+     "start_time": "2026-09-13T00:30:44.124166+00:00",
      "status": "completed"
     }
    },
@@ -2307,14 +2306,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ba741941",
+   "id": "69fdf1e3",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.012491,
-     "end_time": "2026-09-10T22:11:29.539920+00:00",
+     "duration": 0.005915,
+     "end_time": "2026-09-13T00:30:44.164885+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:29.527429+00:00",
+     "start_time": "2026-09-13T00:30:44.158970+00:00",
      "status": "completed"
     }
    },
@@ -2340,20 +2339,20 @@
   {
    "cell_type": "code",
    "execution_count": 35,
-   "id": "9a8e7696",
+   "id": "718dc8ff",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T22:11:29.568835Z",
-     "iopub.status.busy": "2026-09-10T22:11:29.568474Z",
-     "iopub.status.idle": "2026-09-10T22:11:29.573102Z",
-     "shell.execute_reply": "2026-09-10T22:11:29.572079Z"
+     "iopub.execute_input": "2026-09-13T00:30:44.179162Z",
+     "iopub.status.busy": "2026-09-13T00:30:44.178894Z",
+     "iopub.status.idle": "2026-09-13T00:30:44.182156Z",
+     "shell.execute_reply": "2026-09-13T00:30:44.181572Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.020192,
-     "end_time": "2026-09-10T22:11:29.573787+00:00",
+     "duration": 0.01111,
+     "end_time": "2026-09-13T00:30:44.182540+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:29.553595+00:00",
+     "start_time": "2026-09-13T00:30:44.171430+00:00",
      "status": "completed"
     }
    },
@@ -2377,14 +2376,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "eb9c66db",
+   "id": "4eef3bdb",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.011722,
-     "end_time": "2026-09-10T22:11:29.597990+00:00",
+     "duration": 0.006915,
+     "end_time": "2026-09-13T00:30:44.196767+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:29.586268+00:00",
+     "start_time": "2026-09-13T00:30:44.189852+00:00",
      "status": "completed"
     }
    },
@@ -2397,19 +2396,19 @@
   {
    "cell_type": "code",
    "execution_count": 36,
-   "id": "8ba93395",
+   "id": "a8a61d76",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T22:11:29.627625Z",
-     "iopub.status.busy": "2026-09-10T22:11:29.627059Z",
-     "iopub.status.idle": "2026-09-10T22:11:30.571471Z",
-     "shell.execute_reply": "2026-09-10T22:11:30.569935Z"
+     "iopub.execute_input": "2026-09-13T00:30:44.212836Z",
+     "iopub.status.busy": "2026-09-13T00:30:44.212582Z",
+     "iopub.status.idle": "2026-09-13T00:30:51.467545Z",
+     "shell.execute_reply": "2026-09-13T00:30:51.465351Z"
     },
     "papermill": {
-     "duration": 0.961862,
-     "end_time": "2026-09-10T22:11:30.574729+00:00",
+     "duration": 7.267187,
+     "end_time": "2026-09-13T00:30:51.471410+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:29.612867+00:00",
+     "start_time": "2026-09-13T00:30:44.204223+00:00",
      "status": "completed"
     }
    },
@@ -2428,8 +2427,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Loaded 995 triples to Neo4j (batch size: 500)\n",
-      "Loading completed in 0.93s\n",
+      "Loaded 995 triples to Neo4j (batch size: 500)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Loading completed in 7.24s\n",
       "Entity nodes on supply-chain edges: 817, edges: 995\n"
      ]
     }
@@ -2487,13 +2492,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ab1cab17",
+   "id": "2722835a",
    "metadata": {
     "papermill": {
-     "duration": 0.008273,
-     "end_time": "2026-09-10T22:11:30.596692+00:00",
+     "duration": 0.027988,
+     "end_time": "2026-09-13T00:30:51.525434+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:30.588419+00:00",
+     "start_time": "2026-09-13T00:30:51.497446+00:00",
      "status": "completed"
     }
    },
@@ -2512,19 +2517,19 @@
   {
    "cell_type": "code",
    "execution_count": 37,
-   "id": "f82ac067",
+   "id": "ff2df0fe",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T22:11:30.617017Z",
-     "iopub.status.busy": "2026-09-10T22:11:30.616808Z",
-     "iopub.status.idle": "2026-09-10T22:11:30.807633Z",
-     "shell.execute_reply": "2026-09-10T22:11:30.806397Z"
+     "iopub.execute_input": "2026-09-13T00:30:51.557793Z",
+     "iopub.status.busy": "2026-09-13T00:30:51.556426Z",
+     "iopub.status.idle": "2026-09-13T00:30:52.992423Z",
+     "shell.execute_reply": "2026-09-13T00:30:52.990062Z"
     },
     "papermill": {
-     "duration": 0.202877,
-     "end_time": "2026-09-10T22:11:30.808395+00:00",
+     "duration": 1.451283,
+     "end_time": "2026-09-13T00:30:52.993954+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:30.605518+00:00",
+     "start_time": "2026-09-13T00:30:51.542671+00:00",
      "status": "completed"
     }
    },
@@ -2596,13 +2601,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0337e9ef",
+   "id": "b21da685",
    "metadata": {
     "papermill": {
-     "duration": 0.006736,
-     "end_time": "2026-09-10T22:11:30.823679+00:00",
+     "duration": 0.021162,
+     "end_time": "2026-09-13T00:30:53.045436+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:30.816943+00:00",
+     "start_time": "2026-09-13T00:30:53.024274+00:00",
      "status": "completed"
     }
    },
@@ -2615,19 +2620,19 @@
   {
    "cell_type": "code",
    "execution_count": 38,
-   "id": "2f1ffe13",
+   "id": "5e03d8e7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T22:11:30.848996Z",
-     "iopub.status.busy": "2026-09-10T22:11:30.848720Z",
-     "iopub.status.idle": "2026-09-10T22:11:30.853373Z",
-     "shell.execute_reply": "2026-09-10T22:11:30.852692Z"
+     "iopub.execute_input": "2026-09-13T00:30:53.092532Z",
+     "iopub.status.busy": "2026-09-13T00:30:53.091817Z",
+     "iopub.status.idle": "2026-09-13T00:30:53.103726Z",
+     "shell.execute_reply": "2026-09-13T00:30:53.102039Z"
     },
     "papermill": {
-     "duration": 0.020611,
-     "end_time": "2026-09-10T22:11:30.853949+00:00",
+     "duration": 0.037928,
+     "end_time": "2026-09-13T00:30:53.105080+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:30.833338+00:00",
+     "start_time": "2026-09-13T00:30:53.067152+00:00",
      "status": "completed"
     }
    },
@@ -2704,13 +2709,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5f87f8f8",
+   "id": "6b588d63",
    "metadata": {
     "papermill": {
-     "duration": 0.007615,
-     "end_time": "2026-09-10T22:11:30.870438+00:00",
+     "duration": 0.017275,
+     "end_time": "2026-09-13T00:30:53.146272+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:30.862823+00:00",
+     "start_time": "2026-09-13T00:30:53.128997+00:00",
      "status": "completed"
     }
    },
@@ -2720,13 +2725,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2687ffcb",
+   "id": "a7e33685",
    "metadata": {
     "papermill": {
-     "duration": 0.008094,
-     "end_time": "2026-09-10T22:11:30.886064+00:00",
+     "duration": 0.016907,
+     "end_time": "2026-09-13T00:30:53.181573+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:30.877970+00:00",
+     "start_time": "2026-09-13T00:30:53.164666+00:00",
      "status": "completed"
     }
    },
@@ -2739,19 +2744,19 @@
   {
    "cell_type": "code",
    "execution_count": 39,
-   "id": "5f32ad8f",
+   "id": "76bbcaf9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T22:11:30.905418Z",
-     "iopub.status.busy": "2026-09-10T22:11:30.905208Z",
-     "iopub.status.idle": "2026-09-10T22:11:30.911996Z",
-     "shell.execute_reply": "2026-09-10T22:11:30.911256Z"
+     "iopub.execute_input": "2026-09-13T00:30:53.219210Z",
+     "iopub.status.busy": "2026-09-13T00:30:53.218539Z",
+     "iopub.status.idle": "2026-09-13T00:30:53.246355Z",
+     "shell.execute_reply": "2026-09-13T00:30:53.244486Z"
     },
     "papermill": {
-     "duration": 0.019049,
-     "end_time": "2026-09-10T22:11:30.913176+00:00",
+     "duration": 0.050189,
+     "end_time": "2026-09-13T00:30:53.248932+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:30.894127+00:00",
+     "start_time": "2026-09-13T00:30:53.198743+00:00",
      "status": "completed"
     }
    },
@@ -2781,8 +2786,8 @@
       "│ Suppliers named by 2+ companies ┆ 3                │\n",
       "│ Suppliers named by 3+ companies ┆ 3                │\n",
       "│ Extraction time (s)             ┆ not run (cached) │\n",
-      "│ Neo4j load time (s)             ┆ 0.9              │\n",
-      "│ Neo4j edges per second          ┆ 1067             │\n",
+      "│ Neo4j load time (s)             ┆ 7.2              │\n",
+      "│ Neo4j edges per second          ┆ 137              │\n",
       "└─────────────────────────────────┴──────────────────┘\n"
      ]
     }
@@ -2830,13 +2835,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "14dd4e8f",
+   "id": "d15694ed",
    "metadata": {
     "papermill": {
-     "duration": 0.010537,
-     "end_time": "2026-09-10T22:11:30.935031+00:00",
+     "duration": 0.018474,
+     "end_time": "2026-09-13T00:30:53.283057+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:30.924494+00:00",
+     "start_time": "2026-09-13T00:30:53.264583+00:00",
      "status": "completed"
     }
    },
@@ -2857,19 +2862,19 @@
   {
    "cell_type": "code",
    "execution_count": 40,
-   "id": "edd07791",
+   "id": "929167fa",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T22:11:30.959267Z",
-     "iopub.status.busy": "2026-09-10T22:11:30.958998Z",
-     "iopub.status.idle": "2026-09-10T22:11:31.193120Z",
-     "shell.execute_reply": "2026-09-10T22:11:31.192427Z"
+     "iopub.execute_input": "2026-09-13T00:30:53.315208Z",
+     "iopub.status.busy": "2026-09-13T00:30:53.314747Z",
+     "iopub.status.idle": "2026-09-13T00:30:53.725984Z",
+     "shell.execute_reply": "2026-09-13T00:30:53.725070Z"
     },
     "papermill": {
-     "duration": 0.245873,
-     "end_time": "2026-09-10T22:11:31.194225+00:00",
+     "duration": 0.429491,
+     "end_time": "2026-09-13T00:30:53.727713+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:30.948352+00:00",
+     "start_time": "2026-09-13T00:30:53.298222+00:00",
      "status": "completed"
     }
    },
@@ -2880,14 +2885,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9f0b44c8",
+   "id": "6cbee83b",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.011469,
-     "end_time": "2026-09-10T22:11:31.219962+00:00",
+     "duration": 0.013077,
+     "end_time": "2026-09-13T00:30:53.756377+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:31.208493+00:00",
+     "start_time": "2026-09-13T00:30:53.743300+00:00",
      "status": "completed"
     }
    },
@@ -2902,19 +2907,19 @@
   {
    "cell_type": "code",
    "execution_count": 41,
-   "id": "cdfabc49",
+   "id": "bbf435b7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T22:11:31.239424Z",
-     "iopub.status.busy": "2026-09-10T22:11:31.238945Z",
-     "iopub.status.idle": "2026-09-10T22:11:31.246069Z",
-     "shell.execute_reply": "2026-09-10T22:11:31.245206Z"
+     "iopub.execute_input": "2026-09-13T00:30:53.788981Z",
+     "iopub.status.busy": "2026-09-13T00:30:53.788327Z",
+     "iopub.status.idle": "2026-09-13T00:30:53.794618Z",
+     "shell.execute_reply": "2026-09-13T00:30:53.793826Z"
     },
     "papermill": {
-     "duration": 0.01534,
-     "end_time": "2026-09-10T22:11:31.246620+00:00",
+     "duration": 0.028137,
+     "end_time": "2026-09-13T00:30:53.798619+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:31.231280+00:00",
+     "start_time": "2026-09-13T00:30:53.770482+00:00",
      "status": "completed"
     }
    },
@@ -2946,19 +2951,19 @@
   {
    "cell_type": "code",
    "execution_count": 42,
-   "id": "c1d42d98",
+   "id": "eba51d7b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T22:11:31.262811Z",
-     "iopub.status.busy": "2026-09-10T22:11:31.262617Z",
-     "iopub.status.idle": "2026-09-10T22:11:31.267450Z",
-     "shell.execute_reply": "2026-09-10T22:11:31.266576Z"
+     "iopub.execute_input": "2026-09-13T00:30:53.828362Z",
+     "iopub.status.busy": "2026-09-13T00:30:53.828067Z",
+     "iopub.status.idle": "2026-09-13T00:30:53.834739Z",
+     "shell.execute_reply": "2026-09-13T00:30:53.833926Z"
     },
     "papermill": {
-     "duration": 0.013167,
-     "end_time": "2026-09-10T22:11:31.268156+00:00",
+     "duration": 0.021266,
+     "end_time": "2026-09-13T00:30:53.835486+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:31.254989+00:00",
+     "start_time": "2026-09-13T00:30:53.814220+00:00",
      "status": "completed"
     }
    },
@@ -2990,13 +2995,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "93ef0e9e",
+   "id": "30f25b67",
    "metadata": {
     "papermill": {
-     "duration": 0.009074,
-     "end_time": "2026-09-10T22:11:31.284259+00:00",
+     "duration": 0.014623,
+     "end_time": "2026-09-13T00:30:53.863640+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:31.275185+00:00",
+     "start_time": "2026-09-13T00:30:53.849017+00:00",
      "status": "completed"
     }
    },
@@ -3011,19 +3016,19 @@
   {
    "cell_type": "code",
    "execution_count": 43,
-   "id": "beee1f48",
+   "id": "7ba3c309",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T22:11:31.300144Z",
-     "iopub.status.busy": "2026-09-10T22:11:31.300006Z",
-     "iopub.status.idle": "2026-09-10T22:11:31.302628Z",
-     "shell.execute_reply": "2026-09-10T22:11:31.301852Z"
+     "iopub.execute_input": "2026-09-13T00:30:53.897547Z",
+     "iopub.status.busy": "2026-09-13T00:30:53.897131Z",
+     "iopub.status.idle": "2026-09-13T00:30:53.902345Z",
+     "shell.execute_reply": "2026-09-13T00:30:53.900971Z"
     },
     "papermill": {
-     "duration": 0.010589,
-     "end_time": "2026-09-10T22:11:31.303063+00:00",
+     "duration": 0.023473,
+     "end_time": "2026-09-13T00:30:53.903691+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:31.292474+00:00",
+     "start_time": "2026-09-13T00:30:53.880218+00:00",
      "status": "completed"
     }
    },
@@ -3038,13 +3043,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8ee31729",
+   "id": "c87f1e37",
    "metadata": {
     "papermill": {
-     "duration": 0.006474,
-     "end_time": "2026-09-10T22:11:31.319622+00:00",
+     "duration": 0.014794,
+     "end_time": "2026-09-13T00:30:53.934303+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:31.313148+00:00",
+     "start_time": "2026-09-13T00:30:53.919509+00:00",
      "status": "completed"
     }
    },
@@ -3058,14 +3063,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0b1b9850",
+   "id": "caebc7d0",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.010133,
-     "end_time": "2026-09-10T22:11:31.341347+00:00",
+     "duration": 0.012286,
+     "end_time": "2026-09-13T00:30:53.958048+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:31.331214+00:00",
+     "start_time": "2026-09-13T00:30:53.945762+00:00",
      "status": "completed"
     }
    },
@@ -3078,20 +3083,20 @@
   {
    "cell_type": "code",
    "execution_count": 44,
-   "id": "4dbf7d50",
+   "id": "feb16b2f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T22:11:31.363402Z",
-     "iopub.status.busy": "2026-09-10T22:11:31.363120Z",
-     "iopub.status.idle": "2026-09-10T22:11:31.372798Z",
-     "shell.execute_reply": "2026-09-10T22:11:31.370067Z"
+     "iopub.execute_input": "2026-09-13T00:30:53.991326Z",
+     "iopub.status.busy": "2026-09-13T00:30:53.990521Z",
+     "iopub.status.idle": "2026-09-13T00:30:53.997442Z",
+     "shell.execute_reply": "2026-09-13T00:30:53.996657Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.021207,
-     "end_time": "2026-09-10T22:11:31.373861+00:00",
+     "duration": 0.026698,
+     "end_time": "2026-09-13T00:30:53.999299+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:31.352654+00:00",
+     "start_time": "2026-09-13T00:30:53.972601+00:00",
      "status": "completed"
     }
    },
@@ -3116,13 +3121,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "00954acd",
+   "id": "81f49478",
    "metadata": {
     "papermill": {
-     "duration": 0.010935,
-     "end_time": "2026-09-10T22:11:31.397180+00:00",
+     "duration": 0.016662,
+     "end_time": "2026-09-13T00:30:54.036263+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:31.386245+00:00",
+     "start_time": "2026-09-13T00:30:54.019601+00:00",
      "status": "completed"
     }
    },
@@ -3135,14 +3140,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "09de9c26",
+   "id": "a41a72db",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.011152,
-     "end_time": "2026-09-10T22:11:31.419541+00:00",
+     "duration": 0.019985,
+     "end_time": "2026-09-13T00:30:54.071927+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:31.408389+00:00",
+     "start_time": "2026-09-13T00:30:54.051942+00:00",
      "status": "completed"
     }
    },
@@ -3156,19 +3161,19 @@
   {
    "cell_type": "code",
    "execution_count": 45,
-   "id": "64b203ea",
+   "id": "5784b667",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T22:11:31.443204Z",
-     "iopub.status.busy": "2026-09-10T22:11:31.442827Z",
-     "iopub.status.idle": "2026-09-10T22:11:31.448820Z",
-     "shell.execute_reply": "2026-09-10T22:11:31.447543Z"
+     "iopub.execute_input": "2026-09-13T00:30:54.107892Z",
+     "iopub.status.busy": "2026-09-13T00:30:54.107549Z",
+     "iopub.status.idle": "2026-09-13T00:30:54.113238Z",
+     "shell.execute_reply": "2026-09-13T00:30:54.112649Z"
     },
     "papermill": {
-     "duration": 0.019771,
-     "end_time": "2026-09-10T22:11:31.450151+00:00",
+     "duration": 0.025651,
+     "end_time": "2026-09-13T00:30:54.114543+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:31.430380+00:00",
+     "start_time": "2026-09-13T00:30:54.088892+00:00",
      "status": "completed"
     }
    },
@@ -3195,13 +3200,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a1ac7e57",
+   "id": "277e06d1",
    "metadata": {
     "papermill": {
-     "duration": 0.012519,
-     "end_time": "2026-09-10T22:11:31.470508+00:00",
+     "duration": 0.015079,
+     "end_time": "2026-09-13T00:30:54.147316+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:31.457989+00:00",
+     "start_time": "2026-09-13T00:30:54.132237+00:00",
      "status": "completed"
     }
    },
@@ -3214,19 +3219,19 @@
   {
    "cell_type": "code",
    "execution_count": 46,
-   "id": "e7479afd",
+   "id": "90a5c22b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T22:11:31.494916Z",
-     "iopub.status.busy": "2026-09-10T22:11:31.494686Z",
-     "iopub.status.idle": "2026-09-10T22:11:31.499531Z",
-     "shell.execute_reply": "2026-09-10T22:11:31.498408Z"
+     "iopub.execute_input": "2026-09-13T00:30:54.185712Z",
+     "iopub.status.busy": "2026-09-13T00:30:54.184840Z",
+     "iopub.status.idle": "2026-09-13T00:30:54.195851Z",
+     "shell.execute_reply": "2026-09-13T00:30:54.194897Z"
     },
     "papermill": {
-     "duration": 0.017909,
-     "end_time": "2026-09-10T22:11:31.500182+00:00",
+     "duration": 0.033762,
+     "end_time": "2026-09-13T00:30:54.199008+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:31.482273+00:00",
+     "start_time": "2026-09-13T00:30:54.165246+00:00",
      "status": "completed"
     }
    },
@@ -3256,14 +3261,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dcd35ab0",
+   "id": "1c69ea55",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.012578,
-     "end_time": "2026-09-10T22:11:31.525314+00:00",
+     "duration": 0.015542,
+     "end_time": "2026-09-13T00:30:54.231943+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:31.512736+00:00",
+     "start_time": "2026-09-13T00:30:54.216401+00:00",
      "status": "completed"
     }
    },
@@ -3276,20 +3281,20 @@
   {
    "cell_type": "code",
    "execution_count": 47,
-   "id": "0a10c92d",
+   "id": "a0eebc7b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T22:11:31.542076Z",
-     "iopub.status.busy": "2026-09-10T22:11:31.541907Z",
-     "iopub.status.idle": "2026-09-10T22:11:31.544541Z",
-     "shell.execute_reply": "2026-09-10T22:11:31.544005Z"
+     "iopub.execute_input": "2026-09-13T00:30:54.267233Z",
+     "iopub.status.busy": "2026-09-13T00:30:54.266673Z",
+     "iopub.status.idle": "2026-09-13T00:30:54.273245Z",
+     "shell.execute_reply": "2026-09-13T00:30:54.272226Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.009228,
-     "end_time": "2026-09-10T22:11:31.545014+00:00",
+     "duration": 0.030307,
+     "end_time": "2026-09-13T00:30:54.278571+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:31.535786+00:00",
+     "start_time": "2026-09-13T00:30:54.248264+00:00",
      "status": "completed"
     }
    },
@@ -3312,14 +3317,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c94cb584",
+   "id": "11f98eb4",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.006343,
-     "end_time": "2026-09-10T22:11:31.559352+00:00",
+     "duration": 0.016094,
+     "end_time": "2026-09-13T00:30:54.310865+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:31.553009+00:00",
+     "start_time": "2026-09-13T00:30:54.294771+00:00",
      "status": "completed"
     }
    },
@@ -3332,20 +3337,20 @@
   {
    "cell_type": "code",
    "execution_count": 48,
-   "id": "ef73a226",
+   "id": "ab0c35c3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T22:11:31.583531Z",
-     "iopub.status.busy": "2026-09-10T22:11:31.583401Z",
-     "iopub.status.idle": "2026-09-10T22:11:31.586660Z",
-     "shell.execute_reply": "2026-09-10T22:11:31.585811Z"
+     "iopub.execute_input": "2026-09-13T00:30:54.346857Z",
+     "iopub.status.busy": "2026-09-13T00:30:54.345809Z",
+     "iopub.status.idle": "2026-09-13T00:30:54.353312Z",
+     "shell.execute_reply": "2026-09-13T00:30:54.352282Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.01591,
-     "end_time": "2026-09-10T22:11:31.587724+00:00",
+     "duration": 0.028176,
+     "end_time": "2026-09-13T00:30:54.355796+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:31.571814+00:00",
+     "start_time": "2026-09-13T00:30:54.327620+00:00",
      "status": "completed"
     }
    },
@@ -3373,14 +3378,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "86196853",
+   "id": "80b65dab",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.012426,
-     "end_time": "2026-09-10T22:11:31.612242+00:00",
+     "duration": 0.014661,
+     "end_time": "2026-09-13T00:30:54.386940+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:31.599816+00:00",
+     "start_time": "2026-09-13T00:30:54.372279+00:00",
      "status": "completed"
     }
    },
@@ -3394,19 +3399,19 @@
   {
    "cell_type": "code",
    "execution_count": 49,
-   "id": "99fc071c",
+   "id": "395e6bde",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T22:11:31.637355Z",
-     "iopub.status.busy": "2026-09-10T22:11:31.636837Z",
-     "iopub.status.idle": "2026-09-10T22:11:31.643472Z",
-     "shell.execute_reply": "2026-09-10T22:11:31.642675Z"
+     "iopub.execute_input": "2026-09-13T00:30:54.428359Z",
+     "iopub.status.busy": "2026-09-13T00:30:54.427771Z",
+     "iopub.status.idle": "2026-09-13T00:30:54.436789Z",
+     "shell.execute_reply": "2026-09-13T00:30:54.435647Z"
     },
     "papermill": {
-     "duration": 0.021329,
-     "end_time": "2026-09-10T22:11:31.644318+00:00",
+     "duration": 0.029593,
+     "end_time": "2026-09-13T00:30:54.437589+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:31.622989+00:00",
+     "start_time": "2026-09-13T00:30:54.407996+00:00",
      "status": "completed"
     }
    },
@@ -3447,19 +3452,19 @@
   {
    "cell_type": "code",
    "execution_count": 50,
-   "id": "6790cf11",
+   "id": "15957947",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T22:11:31.665662Z",
-     "iopub.status.busy": "2026-09-10T22:11:31.665538Z",
-     "iopub.status.idle": "2026-09-10T22:11:31.817052Z",
-     "shell.execute_reply": "2026-09-10T22:11:31.816098Z"
+     "iopub.execute_input": "2026-09-13T00:30:54.473704Z",
+     "iopub.status.busy": "2026-09-13T00:30:54.473087Z",
+     "iopub.status.idle": "2026-09-13T00:30:54.762856Z",
+     "shell.execute_reply": "2026-09-13T00:30:54.761112Z"
     },
     "papermill": {
-     "duration": 0.16065,
-     "end_time": "2026-09-10T22:11:31.817549+00:00",
+     "duration": 0.310981,
+     "end_time": "2026-09-13T00:30:54.764976+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:31.656899+00:00",
+     "start_time": "2026-09-13T00:30:54.453995+00:00",
      "status": "completed"
     }
    },
@@ -3501,13 +3506,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a7a80fc2",
+   "id": "8b6a47cd",
    "metadata": {
     "papermill": {
-     "duration": 0.008932,
-     "end_time": "2026-09-10T22:11:31.833948+00:00",
+     "duration": 0.015244,
+     "end_time": "2026-09-13T00:30:54.799053+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:31.825016+00:00",
+     "start_time": "2026-09-13T00:30:54.783809+00:00",
      "status": "completed"
     }
    },
@@ -3522,13 +3527,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "26629db7",
+   "id": "b22d91d8",
    "metadata": {
     "papermill": {
-     "duration": 0.009301,
-     "end_time": "2026-09-10T22:11:31.850755+00:00",
+     "duration": 0.016564,
+     "end_time": "2026-09-13T00:30:54.833320+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:31.841454+00:00",
+     "start_time": "2026-09-13T00:30:54.816756+00:00",
      "status": "completed"
     }
    },
@@ -3542,19 +3547,19 @@
   {
    "cell_type": "code",
    "execution_count": 51,
-   "id": "d5264e14",
+   "id": "becb49f7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T22:11:31.874832Z",
-     "iopub.status.busy": "2026-09-10T22:11:31.874577Z",
-     "iopub.status.idle": "2026-09-10T22:11:31.960399Z",
-     "shell.execute_reply": "2026-09-10T22:11:31.959479Z"
+     "iopub.execute_input": "2026-09-13T00:30:54.869337Z",
+     "iopub.status.busy": "2026-09-13T00:30:54.868793Z",
+     "iopub.status.idle": "2026-09-13T00:30:55.035751Z",
+     "shell.execute_reply": "2026-09-13T00:30:55.034472Z"
     },
     "papermill": {
-     "duration": 0.098909,
-     "end_time": "2026-09-10T22:11:31.961472+00:00",
+     "duration": 0.186921,
+     "end_time": "2026-09-13T00:30:55.037120+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:31.862563+00:00",
+     "start_time": "2026-09-13T00:30:54.850199+00:00",
      "status": "completed"
     }
    },
@@ -3565,13 +3570,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6823e16c",
+   "id": "ef134018",
    "metadata": {
     "papermill": {
-     "duration": 0.013011,
-     "end_time": "2026-09-10T22:11:31.987117+00:00",
+     "duration": 0.008442,
+     "end_time": "2026-09-13T00:30:55.058611+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:31.974106+00:00",
+     "start_time": "2026-09-13T00:30:55.050169+00:00",
      "status": "completed"
     }
    },
@@ -3584,14 +3589,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "74c3355b",
+   "id": "4f8cee07",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.010127,
-     "end_time": "2026-09-10T22:11:32.005509+00:00",
+     "duration": 0.02511,
+     "end_time": "2026-09-13T00:30:55.109494+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:31.995382+00:00",
+     "start_time": "2026-09-13T00:30:55.084384+00:00",
      "status": "completed"
     }
    },
@@ -3604,13 +3609,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "07a61c7c",
+   "id": "0c37960d",
    "metadata": {
     "papermill": {
-     "duration": 0.007567,
-     "end_time": "2026-09-10T22:11:32.026427+00:00",
+     "duration": 0.014963,
+     "end_time": "2026-09-13T00:30:55.142683+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:32.018860+00:00",
+     "start_time": "2026-09-13T00:30:55.127720+00:00",
      "status": "completed"
     }
    },
@@ -3623,20 +3628,20 @@
   {
    "cell_type": "code",
    "execution_count": 52,
-   "id": "1c1cda54",
+   "id": "7e25cdde",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T22:11:32.046845Z",
-     "iopub.status.busy": "2026-09-10T22:11:32.045770Z",
-     "iopub.status.idle": "2026-09-10T22:11:32.051370Z",
-     "shell.execute_reply": "2026-09-10T22:11:32.050559Z"
+     "iopub.execute_input": "2026-09-13T00:30:55.188735Z",
+     "iopub.status.busy": "2026-09-13T00:30:55.187810Z",
+     "iopub.status.idle": "2026-09-13T00:30:55.197239Z",
+     "shell.execute_reply": "2026-09-13T00:30:55.194427Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.016822,
-     "end_time": "2026-09-10T22:11:32.052178+00:00",
+     "duration": 0.036703,
+     "end_time": "2026-09-13T00:30:55.198627+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:32.035356+00:00",
+     "start_time": "2026-09-13T00:30:55.161924+00:00",
      "status": "completed"
     }
    },
@@ -3657,13 +3662,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6a89ce13",
+   "id": "79a3e029",
    "metadata": {
     "papermill": {
-     "duration": 0.012969,
-     "end_time": "2026-09-10T22:11:32.078354+00:00",
+     "duration": 0.158306,
+     "end_time": "2026-09-13T00:30:55.374285+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:32.065385+00:00",
+     "start_time": "2026-09-13T00:30:55.215979+00:00",
      "status": "completed"
     }
    },
@@ -3676,14 +3681,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9af6610f",
+   "id": "b000f3a3",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.009499,
-     "end_time": "2026-09-10T22:11:32.100766+00:00",
+     "duration": 0.018061,
+     "end_time": "2026-09-13T00:30:55.556483+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:32.091267+00:00",
+     "start_time": "2026-09-13T00:30:55.538422+00:00",
      "status": "completed"
     }
    },
@@ -3696,20 +3701,20 @@
   {
    "cell_type": "code",
    "execution_count": 53,
-   "id": "d0e9a7f1",
+   "id": "e3f9138d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T22:11:32.141826Z",
-     "iopub.status.busy": "2026-09-10T22:11:32.141416Z",
-     "iopub.status.idle": "2026-09-10T22:11:32.151120Z",
-     "shell.execute_reply": "2026-09-10T22:11:32.149432Z"
+     "iopub.execute_input": "2026-09-13T00:30:55.598756Z",
+     "iopub.status.busy": "2026-09-13T00:30:55.598038Z",
+     "iopub.status.idle": "2026-09-13T00:30:55.607164Z",
+     "shell.execute_reply": "2026-09-13T00:30:55.605582Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.030504,
-     "end_time": "2026-09-10T22:11:32.152246+00:00",
+     "duration": 0.031204,
+     "end_time": "2026-09-13T00:30:55.607980+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:32.121742+00:00",
+     "start_time": "2026-09-13T00:30:55.576776+00:00",
      "status": "completed"
     }
    },
@@ -3733,14 +3738,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5a0dcbaa",
+   "id": "de139dbc",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.008216,
-     "end_time": "2026-09-10T22:11:32.175286+00:00",
+     "duration": 0.017313,
+     "end_time": "2026-09-13T00:30:55.649885+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:32.167070+00:00",
+     "start_time": "2026-09-13T00:30:55.632572+00:00",
      "status": "completed"
     }
    },
@@ -3753,20 +3758,20 @@
   {
    "cell_type": "code",
    "execution_count": 54,
-   "id": "20d1e0cf",
+   "id": "a316ac03",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T22:11:32.206505Z",
-     "iopub.status.busy": "2026-09-10T22:11:32.206006Z",
-     "iopub.status.idle": "2026-09-10T22:11:32.211188Z",
-     "shell.execute_reply": "2026-09-10T22:11:32.210464Z"
+     "iopub.execute_input": "2026-09-13T00:30:55.690489Z",
+     "iopub.status.busy": "2026-09-13T00:30:55.689315Z",
+     "iopub.status.idle": "2026-09-13T00:30:55.701319Z",
+     "shell.execute_reply": "2026-09-13T00:30:55.698363Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.025816,
-     "end_time": "2026-09-10T22:11:32.212741+00:00",
+     "duration": 0.035608,
+     "end_time": "2026-09-13T00:30:55.704520+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:32.186925+00:00",
+     "start_time": "2026-09-13T00:30:55.668912+00:00",
      "status": "completed"
     }
    },
@@ -3780,14 +3785,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "eac20f1c",
+   "id": "4f158c03",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.011929,
-     "end_time": "2026-09-10T22:11:32.246966+00:00",
+     "duration": 0.017006,
+     "end_time": "2026-09-13T00:30:55.743360+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:32.235037+00:00",
+     "start_time": "2026-09-13T00:30:55.726354+00:00",
      "status": "completed"
     }
    },
@@ -3801,19 +3806,19 @@
   {
    "cell_type": "code",
    "execution_count": 55,
-   "id": "de32532c",
+   "id": "d36063d4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T22:11:32.275481Z",
-     "iopub.status.busy": "2026-09-10T22:11:32.275114Z",
-     "iopub.status.idle": "2026-09-10T22:11:32.308637Z",
-     "shell.execute_reply": "2026-09-10T22:11:32.307670Z"
+     "iopub.execute_input": "2026-09-13T00:30:55.783499Z",
+     "iopub.status.busy": "2026-09-13T00:30:55.783005Z",
+     "iopub.status.idle": "2026-09-13T00:30:55.827353Z",
+     "shell.execute_reply": "2026-09-13T00:30:55.823527Z"
     },
     "papermill": {
-     "duration": 0.048878,
-     "end_time": "2026-09-10T22:11:32.309718+00:00",
+     "duration": 0.070692,
+     "end_time": "2026-09-13T00:30:55.832494+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:32.260840+00:00",
+     "start_time": "2026-09-13T00:30:55.761802+00:00",
      "status": "completed"
     }
    },
@@ -3864,13 +3869,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c3aa6769",
+   "id": "afbd012d",
    "metadata": {
     "papermill": {
-     "duration": 0.013751,
-     "end_time": "2026-09-10T22:11:32.338259+00:00",
+     "duration": 0.018342,
+     "end_time": "2026-09-13T00:30:55.870297+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:32.324508+00:00",
+     "start_time": "2026-09-13T00:30:55.851955+00:00",
      "status": "completed"
     }
    },
@@ -3883,13 +3888,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e54a4661",
+   "id": "1cbbae69",
    "metadata": {
     "papermill": {
-     "duration": 0.011335,
-     "end_time": "2026-09-10T22:11:32.364717+00:00",
+     "duration": 0.017019,
+     "end_time": "2026-09-13T00:30:55.902634+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:32.353382+00:00",
+     "start_time": "2026-09-13T00:30:55.885615+00:00",
      "status": "completed"
     }
    },
@@ -3902,14 +3907,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "01e4dbf7",
+   "id": "59b1fc82",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.012931,
-     "end_time": "2026-09-10T22:11:32.390822+00:00",
+     "duration": 0.039421,
+     "end_time": "2026-09-13T00:30:55.955794+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:32.377891+00:00",
+     "start_time": "2026-09-13T00:30:55.916373+00:00",
      "status": "completed"
     }
    },
@@ -3922,20 +3927,20 @@
   {
    "cell_type": "code",
    "execution_count": 56,
-   "id": "e24c9e3a",
+   "id": "346866b4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T22:11:32.410763Z",
-     "iopub.status.busy": "2026-09-10T22:11:32.410482Z",
-     "iopub.status.idle": "2026-09-10T22:11:32.414808Z",
-     "shell.execute_reply": "2026-09-10T22:11:32.414246Z"
+     "iopub.execute_input": "2026-09-13T00:30:55.988038Z",
+     "iopub.status.busy": "2026-09-13T00:30:55.987760Z",
+     "iopub.status.idle": "2026-09-13T00:30:55.996403Z",
+     "shell.execute_reply": "2026-09-13T00:30:55.994550Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.013235,
-     "end_time": "2026-09-10T22:11:32.415322+00:00",
+     "duration": 0.027047,
+     "end_time": "2026-09-13T00:30:55.998819+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:32.402087+00:00",
+     "start_time": "2026-09-13T00:30:55.971772+00:00",
      "status": "completed"
     }
    },
@@ -3967,14 +3972,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "68c80655",
+   "id": "860fe930",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.011248,
-     "end_time": "2026-09-10T22:11:32.439676+00:00",
+     "duration": 0.021977,
+     "end_time": "2026-09-13T00:30:56.040790+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:32.428428+00:00",
+     "start_time": "2026-09-13T00:30:56.018813+00:00",
      "status": "completed"
     }
    },
@@ -3988,20 +3993,20 @@
   {
    "cell_type": "code",
    "execution_count": 57,
-   "id": "3c5f2d4b",
+   "id": "ced8e247",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T22:11:32.458873Z",
-     "iopub.status.busy": "2026-09-10T22:11:32.458678Z",
-     "iopub.status.idle": "2026-09-10T22:11:32.462747Z",
-     "shell.execute_reply": "2026-09-10T22:11:32.462110Z"
+     "iopub.execute_input": "2026-09-13T00:30:56.081419Z",
+     "iopub.status.busy": "2026-09-13T00:30:56.079474Z",
+     "iopub.status.idle": "2026-09-13T00:30:56.090311Z",
+     "shell.execute_reply": "2026-09-13T00:30:56.088517Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.016608,
-     "end_time": "2026-09-10T22:11:32.463368+00:00",
+     "duration": 0.032883,
+     "end_time": "2026-09-13T00:30:56.092032+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:32.446760+00:00",
+     "start_time": "2026-09-13T00:30:56.059149+00:00",
      "status": "completed"
     }
    },
@@ -4024,14 +4029,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b2f9c81d",
+   "id": "2dd21fbf",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.013208,
-     "end_time": "2026-09-10T22:11:32.488972+00:00",
+     "duration": 0.012326,
+     "end_time": "2026-09-13T00:30:56.118874+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:32.475764+00:00",
+     "start_time": "2026-09-13T00:30:56.106548+00:00",
      "status": "completed"
     }
    },
@@ -4044,20 +4049,20 @@
   {
    "cell_type": "code",
    "execution_count": 58,
-   "id": "085a66f9",
+   "id": "956e0fd9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T22:11:32.510263Z",
-     "iopub.status.busy": "2026-09-10T22:11:32.510022Z",
-     "iopub.status.idle": "2026-09-10T22:11:32.514199Z",
-     "shell.execute_reply": "2026-09-10T22:11:32.513636Z"
+     "iopub.execute_input": "2026-09-13T00:30:56.152208Z",
+     "iopub.status.busy": "2026-09-13T00:30:56.151616Z",
+     "iopub.status.idle": "2026-09-13T00:30:56.161195Z",
+     "shell.execute_reply": "2026-09-13T00:30:56.160179Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.014394,
-     "end_time": "2026-09-10T22:11:32.515680+00:00",
+     "duration": 0.032032,
+     "end_time": "2026-09-13T00:30:56.165698+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:32.501286+00:00",
+     "start_time": "2026-09-13T00:30:56.133666+00:00",
      "status": "completed"
     }
    },
@@ -4081,14 +4086,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5c934252",
+   "id": "608abae2",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.006651,
-     "end_time": "2026-09-10T22:11:32.531477+00:00",
+     "duration": 0.014995,
+     "end_time": "2026-09-13T00:30:56.195756+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:32.524826+00:00",
+     "start_time": "2026-09-13T00:30:56.180761+00:00",
      "status": "completed"
     }
    },
@@ -4102,19 +4107,19 @@
   {
    "cell_type": "code",
    "execution_count": 59,
-   "id": "df5b6a16",
+   "id": "aa2b5702",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T22:11:32.545992Z",
-     "iopub.status.busy": "2026-09-10T22:11:32.545804Z",
-     "iopub.status.idle": "2026-09-10T22:11:32.553856Z",
-     "shell.execute_reply": "2026-09-10T22:11:32.551659Z"
+     "iopub.execute_input": "2026-09-13T00:30:56.231356Z",
+     "iopub.status.busy": "2026-09-13T00:30:56.230321Z",
+     "iopub.status.idle": "2026-09-13T00:30:56.254000Z",
+     "shell.execute_reply": "2026-09-13T00:30:56.249253Z"
     },
     "papermill": {
-     "duration": 0.016966,
-     "end_time": "2026-09-10T22:11:32.555120+00:00",
+     "duration": 0.045566,
+     "end_time": "2026-09-13T00:30:56.256945+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:32.538154+00:00",
+     "start_time": "2026-09-13T00:30:56.211379+00:00",
      "status": "completed"
     }
    },
@@ -4124,7 +4129,7 @@
      "output_type": "stream",
      "text": [
       "Saved D3 JSON to supply_chain_d3.json\n",
-      "D3 export: {'total_companies': 56, 'total_suppliers': 3, 'total_relationships': 115, 'high_risk_threshold': 10, 'high_risk_suppliers': 3, 'generated': '2026-09-10 22:11:32'}\n"
+      "D3 export: {'total_companies': 56, 'total_suppliers': 3, 'total_relationships': 115, 'high_risk_threshold': 10, 'high_risk_suppliers': 3, 'generated': '2026-09-13 00:30:56'}\n"
      ]
     }
    ],
@@ -4147,13 +4152,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2b0731e9",
+   "id": "331c8225",
    "metadata": {
     "papermill": {
-     "duration": 0.009203,
-     "end_time": "2026-09-10T22:11:32.577109+00:00",
+     "duration": 0.016921,
+     "end_time": "2026-09-13T00:30:56.292743+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:32.567906+00:00",
+     "start_time": "2026-09-13T00:30:56.275822+00:00",
      "status": "completed"
     }
    },
@@ -4168,19 +4173,19 @@
   {
    "cell_type": "code",
    "execution_count": 60,
-   "id": "e001a140",
+   "id": "1073e3aa",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T22:11:32.607368Z",
-     "iopub.status.busy": "2026-09-10T22:11:32.607122Z",
-     "iopub.status.idle": "2026-09-10T22:11:32.610827Z",
-     "shell.execute_reply": "2026-09-10T22:11:32.609860Z"
+     "iopub.execute_input": "2026-09-13T00:30:56.332830Z",
+     "iopub.status.busy": "2026-09-13T00:30:56.332204Z",
+     "iopub.status.idle": "2026-09-13T00:30:56.341216Z",
+     "shell.execute_reply": "2026-09-13T00:30:56.338726Z"
     },
     "papermill": {
-     "duration": 0.021811,
-     "end_time": "2026-09-10T22:11:32.611654+00:00",
+     "duration": 0.032856,
+     "end_time": "2026-09-13T00:30:56.343619+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:32.589843+00:00",
+     "start_time": "2026-09-13T00:30:56.310763+00:00",
      "status": "completed"
     }
    },
@@ -4216,19 +4221,19 @@
   {
    "cell_type": "code",
    "execution_count": 61,
-   "id": "dec168ed",
+   "id": "c72fca65",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T22:11:32.646528Z",
-     "iopub.status.busy": "2026-09-10T22:11:32.646022Z",
-     "iopub.status.idle": "2026-09-10T22:11:32.650320Z",
-     "shell.execute_reply": "2026-09-10T22:11:32.649484Z"
+     "iopub.execute_input": "2026-09-13T00:30:56.381283Z",
+     "iopub.status.busy": "2026-09-13T00:30:56.380874Z",
+     "iopub.status.idle": "2026-09-13T00:30:56.385660Z",
+     "shell.execute_reply": "2026-09-13T00:30:56.384423Z"
     },
     "papermill": {
-     "duration": 0.023071,
-     "end_time": "2026-09-10T22:11:32.651024+00:00",
+     "duration": 0.025089,
+     "end_time": "2026-09-13T00:30:56.386523+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:32.627953+00:00",
+     "start_time": "2026-09-13T00:30:56.361434+00:00",
      "status": "completed"
     }
    },
@@ -4258,19 +4263,19 @@
   {
    "cell_type": "code",
    "execution_count": 62,
-   "id": "9d553f06",
+   "id": "efde49c2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T22:11:32.671063Z",
-     "iopub.status.busy": "2026-09-10T22:11:32.670722Z",
-     "iopub.status.idle": "2026-09-10T22:11:32.674218Z",
-     "shell.execute_reply": "2026-09-10T22:11:32.673552Z"
+     "iopub.execute_input": "2026-09-13T00:30:56.425432Z",
+     "iopub.status.busy": "2026-09-13T00:30:56.421122Z",
+     "iopub.status.idle": "2026-09-13T00:30:56.439411Z",
+     "shell.execute_reply": "2026-09-13T00:30:56.436830Z"
     },
     "papermill": {
-     "duration": 0.0151,
-     "end_time": "2026-09-10T22:11:32.674851+00:00",
+     "duration": 0.039561,
+     "end_time": "2026-09-13T00:30:56.442152+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:32.659751+00:00",
+     "start_time": "2026-09-13T00:30:56.402591+00:00",
      "status": "completed"
     }
    },
@@ -4307,19 +4312,19 @@
   {
    "cell_type": "code",
    "execution_count": 63,
-   "id": "e1533fcb",
+   "id": "133375a9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T22:11:32.700565Z",
-     "iopub.status.busy": "2026-09-10T22:11:32.699796Z",
-     "iopub.status.idle": "2026-09-10T22:11:32.704964Z",
-     "shell.execute_reply": "2026-09-10T22:11:32.704101Z"
+     "iopub.execute_input": "2026-09-13T00:30:56.481041Z",
+     "iopub.status.busy": "2026-09-13T00:30:56.480203Z",
+     "iopub.status.idle": "2026-09-13T00:30:56.489465Z",
+     "shell.execute_reply": "2026-09-13T00:30:56.487525Z"
     },
     "papermill": {
-     "duration": 0.021784,
-     "end_time": "2026-09-10T22:11:32.705858+00:00",
+     "duration": 0.030314,
+     "end_time": "2026-09-13T00:30:56.490545+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:32.684074+00:00",
+     "start_time": "2026-09-13T00:30:56.460231+00:00",
      "status": "completed"
     }
    },
@@ -4347,19 +4352,19 @@
   {
    "cell_type": "code",
    "execution_count": 64,
-   "id": "0a1dc50a",
+   "id": "fa486b72",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T22:11:32.728373Z",
-     "iopub.status.busy": "2026-09-10T22:11:32.728082Z",
-     "iopub.status.idle": "2026-09-10T22:11:32.732502Z",
-     "shell.execute_reply": "2026-09-10T22:11:32.731546Z"
+     "iopub.execute_input": "2026-09-13T00:30:56.530403Z",
+     "iopub.status.busy": "2026-09-13T00:30:56.528796Z",
+     "iopub.status.idle": "2026-09-13T00:30:56.538695Z",
+     "shell.execute_reply": "2026-09-13T00:30:56.536522Z"
     },
     "papermill": {
-     "duration": 0.016279,
-     "end_time": "2026-09-10T22:11:32.733300+00:00",
+     "duration": 0.032359,
+     "end_time": "2026-09-13T00:30:56.541471+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:32.717021+00:00",
+     "start_time": "2026-09-13T00:30:56.509112+00:00",
      "status": "completed"
     }
    },
@@ -4392,19 +4397,19 @@
   {
    "cell_type": "code",
    "execution_count": 65,
-   "id": "8f863dce",
+   "id": "859e15d2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T22:11:32.754514Z",
-     "iopub.status.busy": "2026-09-10T22:11:32.753936Z",
-     "iopub.status.idle": "2026-09-10T22:11:32.760226Z",
-     "shell.execute_reply": "2026-09-10T22:11:32.758797Z"
+     "iopub.execute_input": "2026-09-13T00:30:56.581859Z",
+     "iopub.status.busy": "2026-09-13T00:30:56.581033Z",
+     "iopub.status.idle": "2026-09-13T00:30:56.590751Z",
+     "shell.execute_reply": "2026-09-13T00:30:56.589014Z"
     },
     "papermill": {
-     "duration": 0.019583,
-     "end_time": "2026-09-10T22:11:32.762694+00:00",
+     "duration": 0.032501,
+     "end_time": "2026-09-13T00:30:56.593754+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:32.743111+00:00",
+     "start_time": "2026-09-13T00:30:56.561253+00:00",
      "status": "completed"
     }
    },
@@ -4431,19 +4436,19 @@
   {
    "cell_type": "code",
    "execution_count": 66,
-   "id": "72a4edee",
+   "id": "2199e4bf",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T22:11:32.789312Z",
-     "iopub.status.busy": "2026-09-10T22:11:32.788936Z",
-     "iopub.status.idle": "2026-09-10T22:11:32.793273Z",
-     "shell.execute_reply": "2026-09-10T22:11:32.792298Z"
+     "iopub.execute_input": "2026-09-13T00:30:56.631231Z",
+     "iopub.status.busy": "2026-09-13T00:30:56.630579Z",
+     "iopub.status.idle": "2026-09-13T00:30:56.642727Z",
+     "shell.execute_reply": "2026-09-13T00:30:56.639237Z"
     },
     "papermill": {
-     "duration": 0.017676,
-     "end_time": "2026-09-10T22:11:32.793889+00:00",
+     "duration": 0.048569,
+     "end_time": "2026-09-13T00:30:56.659651+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:32.776213+00:00",
+     "start_time": "2026-09-13T00:30:56.611082+00:00",
      "status": "completed"
     }
    },
@@ -4479,19 +4484,19 @@
   {
    "cell_type": "code",
    "execution_count": 67,
-   "id": "3e1287c0",
+   "id": "013b3580",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T22:11:32.821721Z",
-     "iopub.status.busy": "2026-09-10T22:11:32.821438Z",
-     "iopub.status.idle": "2026-09-10T22:11:32.825556Z",
-     "shell.execute_reply": "2026-09-10T22:11:32.824604Z"
+     "iopub.execute_input": "2026-09-13T00:30:56.697344Z",
+     "iopub.status.busy": "2026-09-13T00:30:56.696726Z",
+     "iopub.status.idle": "2026-09-13T00:30:56.703678Z",
+     "shell.execute_reply": "2026-09-13T00:30:56.702626Z"
     },
     "papermill": {
-     "duration": 0.020671,
-     "end_time": "2026-09-10T22:11:32.826528+00:00",
+     "duration": 0.029787,
+     "end_time": "2026-09-13T00:30:56.706881+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:32.805857+00:00",
+     "start_time": "2026-09-13T00:30:56.677094+00:00",
      "status": "completed"
     }
    },
@@ -4514,19 +4519,19 @@
   {
    "cell_type": "code",
    "execution_count": 68,
-   "id": "6ae19e42",
+   "id": "91b6bc49",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T22:11:32.854664Z",
-     "iopub.status.busy": "2026-09-10T22:11:32.854196Z",
-     "iopub.status.idle": "2026-09-10T22:11:32.859115Z",
-     "shell.execute_reply": "2026-09-10T22:11:32.858195Z"
+     "iopub.execute_input": "2026-09-13T00:30:56.746413Z",
+     "iopub.status.busy": "2026-09-13T00:30:56.745817Z",
+     "iopub.status.idle": "2026-09-13T00:30:56.755615Z",
+     "shell.execute_reply": "2026-09-13T00:30:56.754240Z"
     },
     "papermill": {
-     "duration": 0.020992,
-     "end_time": "2026-09-10T22:11:32.860204+00:00",
+     "duration": 0.03387,
+     "end_time": "2026-09-13T00:30:56.758777+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:32.839212+00:00",
+     "start_time": "2026-09-13T00:30:56.724907+00:00",
      "status": "completed"
     }
    },
@@ -4572,19 +4577,19 @@
   {
    "cell_type": "code",
    "execution_count": 69,
-   "id": "3eb753ba",
+   "id": "c3895d3a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T22:11:32.887921Z",
-     "iopub.status.busy": "2026-09-10T22:11:32.887651Z",
-     "iopub.status.idle": "2026-09-10T22:11:32.891777Z",
-     "shell.execute_reply": "2026-09-10T22:11:32.890681Z"
+     "iopub.execute_input": "2026-09-13T00:30:56.803986Z",
+     "iopub.status.busy": "2026-09-13T00:30:56.803248Z",
+     "iopub.status.idle": "2026-09-13T00:30:56.811407Z",
+     "shell.execute_reply": "2026-09-13T00:30:56.809940Z"
     },
     "papermill": {
-     "duration": 0.019743,
-     "end_time": "2026-09-10T22:11:32.892987+00:00",
+     "duration": 0.037366,
+     "end_time": "2026-09-13T00:30:56.815997+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:32.873244+00:00",
+     "start_time": "2026-09-13T00:30:56.778631+00:00",
      "status": "completed"
     }
    },
@@ -4606,19 +4611,19 @@
   {
    "cell_type": "code",
    "execution_count": 70,
-   "id": "39567bfe",
+   "id": "2bbb84fc",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T22:11:32.925005Z",
-     "iopub.status.busy": "2026-09-10T22:11:32.924672Z",
-     "iopub.status.idle": "2026-09-10T22:11:32.929223Z",
-     "shell.execute_reply": "2026-09-10T22:11:32.928271Z"
+     "iopub.execute_input": "2026-09-13T00:30:56.861912Z",
+     "iopub.status.busy": "2026-09-13T00:30:56.861257Z",
+     "iopub.status.idle": "2026-09-13T00:30:56.868401Z",
+     "shell.execute_reply": "2026-09-13T00:30:56.866979Z"
     },
     "papermill": {
-     "duration": 0.021909,
-     "end_time": "2026-09-10T22:11:32.929901+00:00",
+     "duration": 0.030912,
+     "end_time": "2026-09-13T00:30:56.869724+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:32.907992+00:00",
+     "start_time": "2026-09-13T00:30:56.838812+00:00",
      "status": "completed"
     }
    },
@@ -4641,19 +4646,19 @@
   {
    "cell_type": "code",
    "execution_count": 71,
-   "id": "9852dc53",
+   "id": "cf1608b0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T22:11:32.966036Z",
-     "iopub.status.busy": "2026-09-10T22:11:32.965544Z",
-     "iopub.status.idle": "2026-09-10T22:11:32.972220Z",
-     "shell.execute_reply": "2026-09-10T22:11:32.971299Z"
+     "iopub.execute_input": "2026-09-13T00:30:56.894775Z",
+     "iopub.status.busy": "2026-09-13T00:30:56.894450Z",
+     "iopub.status.idle": "2026-09-13T00:30:56.901684Z",
+     "shell.execute_reply": "2026-09-13T00:30:56.900708Z"
     },
     "papermill": {
-     "duration": 0.027359,
-     "end_time": "2026-09-10T22:11:32.973257+00:00",
+     "duration": 0.023889,
+     "end_time": "2026-09-13T00:30:56.905906+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:32.945898+00:00",
+     "start_time": "2026-09-13T00:30:56.882017+00:00",
      "status": "completed"
     }
    },
@@ -4677,13 +4682,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "45e7eee4",
+   "id": "78355b80",
    "metadata": {
     "papermill": {
-     "duration": 0.014753,
-     "end_time": "2026-09-10T22:11:33.007362+00:00",
+     "duration": 0.010958,
+     "end_time": "2026-09-13T00:30:56.937430+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:32.992609+00:00",
+     "start_time": "2026-09-13T00:30:56.926472+00:00",
      "status": "completed"
     }
    },
@@ -4694,19 +4699,19 @@
   {
    "cell_type": "code",
    "execution_count": 72,
-   "id": "91347b34",
+   "id": "7d155abc",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T22:11:33.042036Z",
-     "iopub.status.busy": "2026-09-10T22:11:33.041728Z",
-     "iopub.status.idle": "2026-09-10T22:11:33.048966Z",
-     "shell.execute_reply": "2026-09-10T22:11:33.046957Z"
+     "iopub.execute_input": "2026-09-13T00:30:56.959483Z",
+     "iopub.status.busy": "2026-09-13T00:30:56.959192Z",
+     "iopub.status.idle": "2026-09-13T00:30:56.966568Z",
+     "shell.execute_reply": "2026-09-13T00:30:56.964495Z"
     },
     "papermill": {
-     "duration": 0.027539,
-     "end_time": "2026-09-10T22:11:33.052082+00:00",
+     "duration": 0.020847,
+     "end_time": "2026-09-13T00:30:56.968624+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:33.024543+00:00",
+     "start_time": "2026-09-13T00:30:56.947777+00:00",
      "status": "completed"
     }
    },
@@ -4752,13 +4757,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b4cf193a",
+   "id": "1b914a72",
    "metadata": {
     "papermill": {
-     "duration": 0.014547,
-     "end_time": "2026-09-10T22:11:33.081859+00:00",
+     "duration": 0.016721,
+     "end_time": "2026-09-13T00:30:57.005783+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:33.067312+00:00",
+     "start_time": "2026-09-13T00:30:56.989062+00:00",
      "status": "completed"
     }
    },
@@ -4803,19 +4808,19 @@
   {
    "cell_type": "code",
    "execution_count": 73,
-   "id": "4cdf929e",
+   "id": "bd2e6313",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T22:11:33.106696Z",
-     "iopub.status.busy": "2026-09-10T22:11:33.106429Z",
-     "iopub.status.idle": "2026-09-10T22:11:33.118564Z",
-     "shell.execute_reply": "2026-09-10T22:11:33.117368Z"
+     "iopub.execute_input": "2026-09-13T00:30:57.028275Z",
+     "iopub.status.busy": "2026-09-13T00:30:57.027920Z",
+     "iopub.status.idle": "2026-09-13T00:30:57.033482Z",
+     "shell.execute_reply": "2026-09-13T00:30:57.032618Z"
     },
     "papermill": {
-     "duration": 0.025038,
-     "end_time": "2026-09-10T22:11:33.119314+00:00",
+     "duration": 0.017091,
+     "end_time": "2026-09-13T00:30:57.034060+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:11:33.094276+00:00",
+     "start_time": "2026-09-13T00:30:57.016969+00:00",
      "status": "completed"
     }
    },
@@ -4876,24 +4881,24 @@
    "version": "3.14.7"
   },
   "ml4t_provenance": {
-   "executed_at": "2026-09-10T22:11:47.807842+00:00",
+   "executed_at": "2026-09-13T00:31:09.287558+00:00",
    "executor": "ml4t-neo4j",
-   "library_digest": "971331d685439acf1ad4447debf6e5a73ad0c5bf5e93cde94ff457c84a7d3551",
-   "outputs_digest": "c720c9c4cbb89c5d9afd70f9c27c5e6c45363d3f65e3409cb203e774662d7af0",
+   "library_digest": "eb2e3dcfbea4c0f357acec38e6d64e89a42426ef175928f7e8f58e5ffbb389f8",
+   "outputs_digest": "fee1ab0bd6059ba7e59b3cd5cb1e5a22aa2af715dd0951ce6a4c05f82523d127",
    "parameters": {},
    "production": true,
-   "source_py_blob": "045c3e8240c30bc6d67045ef39cc28644460e807"
+   "source_py_blob": "486dca769ebd74932473271467742e0594f80856"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 15.777449,
-   "end_time": "2026-09-10T22:11:36.094766+00:00",
+   "duration": 42.323237,
+   "end_time": "2026-09-13T00:31:00.405827+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "23_knowledge_graphs/.02_supply_chain_kg_construction.build.3785121.ipynb",
-   "output_path": "23_knowledge_graphs/.02_supply_chain_kg_construction.papermill.3785121.ipynb",
+   "input_path": "23_knowledge_graphs/.02_supply_chain_kg_construction.build.2224663.ipynb",
+   "output_path": "23_knowledge_graphs/.02_supply_chain_kg_construction.papermill.2224663.ipynb",
    "parameters": {},
-   "start_time": "2026-09-10T22:11:20.317317+00:00",
+   "start_time": "2026-09-13T00:30:18.082590+00:00",
    "version": "2.7.0"
   }
  },

--- a/23_knowledge_graphs/02_supply_chain_kg_construction.py
+++ b/23_knowledge_graphs/02_supply_chain_kg_construction.py
@@ -952,8 +952,7 @@ add_message_title(
     axes[0],
     "Extracted relationship classes and their shared suppliers",
     subtitle=(
-        f"{EXTRACTOR_NAME} extraction from {len(filings_df)} S&P 100 10-K filings, "
-        f"{min(years)}-{max(years)}"
+        f"{EXTRACTOR_NAME} extraction from the S&P 100 10-K filings, {min(years)}-{max(years)}"
     ),
 )
 show_with_alt(fig, RELATIONSHIP_FIGURE_ALT)

--- a/23_knowledge_graphs/05_institutional_holdings_kg.ipynb
+++ b/23_knowledge_graphs/05_institutional_holdings_kg.ipynb
@@ -2213,7 +2213,7 @@
     "The top panel describes holder overlap inside a fixed ten-institution cohort;\n",
     "it does not measure the price impact of an unwind. The bottom panel describes\n",
     "the name screen, not the market: \"Other\" is where an issuer whose name nobody\n",
-    "wrote into `SECTOR_TERMS` lands, so its height is a property of the term list."
+    "wrote into `SECTOR_TERMS` lands, so its length is a property of the term list."
    ]
   },
   {
@@ -3174,8 +3174,8 @@
    "outputs_digest": "c124d532cae55503b5242756cfa5fa2c6ebd4b08ccaed677b2b8fd4a3ce77ece",
    "parameters": {},
    "production": true,
-   "source_py_blob": "df33dc3f50914da310c63492cb00213b50c14103",
-   "notes": "alt text synced from the .py at 2026-09-10T22:19:09.267628+00:00 without re-executing; every code cell is identical to blob efb92c8789ba once alt literals are blanked, and 1 output alt(s) were rewritten to match"
+   "source_py_blob": "b7ee0bd3dc3256ca38da2c8914c164b6d48e85f1",
+   "notes": "prose synced from the .py at 2026-09-13T00:21:53.982695+00:00 without re-executing; every code cell is identical to blob df33dc3f5091"
   },
   "papermill": {
    "default_parameters": {},

--- a/23_knowledge_graphs/05_institutional_holdings_kg.ipynb
+++ b/23_knowledge_graphs/05_institutional_holdings_kg.ipynb
@@ -2,13 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "a02a4409",
+   "id": "54367718",
    "metadata": {
     "papermill": {
-     "duration": 0.007327,
-     "end_time": "2026-09-10T22:10:28.642048+00:00",
+     "duration": 0.009897,
+     "end_time": "2026-09-13T00:31:32.117335+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:10:28.634721+00:00",
+     "start_time": "2026-09-13T00:31:32.107438+00:00",
      "status": "completed"
     }
    },
@@ -48,19 +48,19 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "ede6e205",
+   "id": "68d09e03",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T22:10:28.655739Z",
-     "iopub.status.busy": "2026-09-10T22:10:28.655464Z",
-     "iopub.status.idle": "2026-09-10T22:10:34.126787Z",
-     "shell.execute_reply": "2026-09-10T22:10:34.125235Z"
+     "iopub.execute_input": "2026-09-13T00:31:32.134417Z",
+     "iopub.status.busy": "2026-09-13T00:31:32.133999Z",
+     "iopub.status.idle": "2026-09-13T00:31:41.620569Z",
+     "shell.execute_reply": "2026-09-13T00:31:41.614530Z"
     },
     "papermill": {
-     "duration": 5.482384,
-     "end_time": "2026-09-10T22:10:34.130851+00:00",
+     "duration": 9.497785,
+     "end_time": "2026-09-13T00:31:41.623382+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:10:28.648467+00:00",
+     "start_time": "2026-09-13T00:31:32.125597+00:00",
      "status": "completed"
     }
    },
@@ -92,19 +92,19 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "08d31450",
+   "id": "8e597171",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T22:10:34.145683Z",
-     "iopub.status.busy": "2026-09-10T22:10:34.145286Z",
-     "iopub.status.idle": "2026-09-10T22:10:34.153477Z",
-     "shell.execute_reply": "2026-09-10T22:10:34.149568Z"
+     "iopub.execute_input": "2026-09-13T00:31:42.045984Z",
+     "iopub.status.busy": "2026-09-13T00:31:42.045332Z",
+     "iopub.status.idle": "2026-09-13T00:31:42.052049Z",
+     "shell.execute_reply": "2026-09-13T00:31:42.050846Z"
     },
     "papermill": {
-     "duration": 0.018144,
-     "end_time": "2026-09-10T22:10:34.155477+00:00",
+     "duration": 0.022462,
+     "end_time": "2026-09-13T00:31:42.052871+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:10:34.137333+00:00",
+     "start_time": "2026-09-13T00:31:42.030409+00:00",
      "status": "completed"
     },
     "tags": [
@@ -123,13 +123,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bb02279d",
+   "id": "39cc905b",
    "metadata": {
     "papermill": {
-     "duration": 0.007021,
-     "end_time": "2026-09-10T22:10:34.171836+00:00",
+     "duration": 0.009318,
+     "end_time": "2026-09-13T00:31:42.071668+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:10:34.164815+00:00",
+     "start_time": "2026-09-13T00:31:42.062350+00:00",
      "status": "completed"
     }
    },
@@ -142,19 +142,19 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "9e6bc43b",
+   "id": "258e3ddf",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T22:10:34.188104Z",
-     "iopub.status.busy": "2026-09-10T22:10:34.187794Z",
-     "iopub.status.idle": "2026-09-10T22:10:35.355761Z",
-     "shell.execute_reply": "2026-09-10T22:10:35.355131Z"
+     "iopub.execute_input": "2026-09-13T00:31:42.094246Z",
+     "iopub.status.busy": "2026-09-13T00:31:42.093636Z",
+     "iopub.status.idle": "2026-09-13T00:31:44.369398Z",
+     "shell.execute_reply": "2026-09-13T00:31:44.366790Z"
     },
     "papermill": {
-     "duration": 1.178304,
-     "end_time": "2026-09-10T22:10:35.356827+00:00",
+     "duration": 2.291351,
+     "end_time": "2026-09-13T00:31:44.372826+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:10:34.178523+00:00",
+     "start_time": "2026-09-13T00:31:42.081475+00:00",
      "status": "completed"
     }
    },
@@ -186,13 +186,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7a19d27f",
+   "id": "5a0b0d9f",
    "metadata": {
     "papermill": {
-     "duration": 0.005763,
-     "end_time": "2026-09-10T22:10:35.368421+00:00",
+     "duration": 0.01256,
+     "end_time": "2026-09-13T00:31:44.398710+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:10:35.362658+00:00",
+     "start_time": "2026-09-13T00:31:44.386150+00:00",
      "status": "completed"
     }
    },
@@ -214,19 +214,19 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "90f32231",
+   "id": "8e6d973c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T22:10:35.381013Z",
-     "iopub.status.busy": "2026-09-10T22:10:35.380510Z",
-     "iopub.status.idle": "2026-09-10T22:10:35.386638Z",
-     "shell.execute_reply": "2026-09-10T22:10:35.385706Z"
+     "iopub.execute_input": "2026-09-13T00:31:44.426152Z",
+     "iopub.status.busy": "2026-09-13T00:31:44.425173Z",
+     "iopub.status.idle": "2026-09-13T00:31:44.437152Z",
+     "shell.execute_reply": "2026-09-13T00:31:44.435003Z"
     },
     "papermill": {
-     "duration": 0.013311,
-     "end_time": "2026-09-10T22:10:35.387263+00:00",
+     "duration": 0.025457,
+     "end_time": "2026-09-13T00:31:44.438676+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:10:35.373952+00:00",
+     "start_time": "2026-09-13T00:31:44.413219+00:00",
      "status": "completed"
     }
    },
@@ -266,13 +266,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e5009c50",
+   "id": "b199052f",
    "metadata": {
     "papermill": {
-     "duration": 0.00693,
-     "end_time": "2026-09-10T22:10:35.400798+00:00",
+     "duration": 0.006145,
+     "end_time": "2026-09-13T00:31:44.453748+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:10:35.393868+00:00",
+     "start_time": "2026-09-13T00:31:44.447603+00:00",
      "status": "completed"
     }
    },
@@ -289,14 +289,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ef2c5d75",
+   "id": "001c4828",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.00527,
-     "end_time": "2026-09-10T22:10:35.411922+00:00",
+     "duration": 0.004612,
+     "end_time": "2026-09-13T00:31:44.464783+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:10:35.406652+00:00",
+     "start_time": "2026-09-13T00:31:44.460171+00:00",
      "status": "completed"
     }
    },
@@ -322,20 +322,20 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "0f243252",
+   "id": "6594e485",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T22:10:35.423347Z",
-     "iopub.status.busy": "2026-09-10T22:10:35.423108Z",
-     "iopub.status.idle": "2026-09-10T22:10:35.427241Z",
-     "shell.execute_reply": "2026-09-10T22:10:35.426467Z"
+     "iopub.execute_input": "2026-09-13T00:31:44.478636Z",
+     "iopub.status.busy": "2026-09-13T00:31:44.478265Z",
+     "iopub.status.idle": "2026-09-13T00:31:44.483312Z",
+     "shell.execute_reply": "2026-09-13T00:31:44.482491Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.010072,
-     "end_time": "2026-09-10T22:10:35.427593+00:00",
+     "duration": 0.013659,
+     "end_time": "2026-09-13T00:31:44.484368+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:10:35.417521+00:00",
+     "start_time": "2026-09-13T00:31:44.470709+00:00",
      "status": "completed"
     }
    },
@@ -365,14 +365,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bb56e816",
+   "id": "7513c70d",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.003327,
-     "end_time": "2026-09-10T22:10:35.434273+00:00",
+     "duration": 0.011452,
+     "end_time": "2026-09-13T00:31:44.510874+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:10:35.430946+00:00",
+     "start_time": "2026-09-13T00:31:44.499422+00:00",
      "status": "completed"
     }
    },
@@ -385,20 +385,20 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "182f21c1",
+   "id": "1827a405",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T22:10:35.443826Z",
-     "iopub.status.busy": "2026-09-10T22:10:35.443654Z",
-     "iopub.status.idle": "2026-09-10T22:10:35.447012Z",
-     "shell.execute_reply": "2026-09-10T22:10:35.446242Z"
+     "iopub.execute_input": "2026-09-13T00:31:44.531918Z",
+     "iopub.status.busy": "2026-09-13T00:31:44.531531Z",
+     "iopub.status.idle": "2026-09-13T00:31:44.538114Z",
+     "shell.execute_reply": "2026-09-13T00:31:44.537312Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.008828,
-     "end_time": "2026-09-10T22:10:35.447513+00:00",
+     "duration": 0.017024,
+     "end_time": "2026-09-13T00:31:44.538825+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:10:35.438685+00:00",
+     "start_time": "2026-09-13T00:31:44.521801+00:00",
      "status": "completed"
     }
    },
@@ -421,14 +421,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "983cbe61",
+   "id": "752079db",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.004762,
-     "end_time": "2026-09-10T22:10:35.457027+00:00",
+     "duration": 0.008211,
+     "end_time": "2026-09-13T00:31:44.552042+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:10:35.452265+00:00",
+     "start_time": "2026-09-13T00:31:44.543831+00:00",
      "status": "completed"
     }
    },
@@ -442,20 +442,20 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "a0378c3a",
+   "id": "ea9a49c6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T22:10:35.465820Z",
-     "iopub.status.busy": "2026-09-10T22:10:35.465633Z",
-     "iopub.status.idle": "2026-09-10T22:10:35.471374Z",
-     "shell.execute_reply": "2026-09-10T22:10:35.470569Z"
+     "iopub.execute_input": "2026-09-13T00:31:44.569447Z",
+     "iopub.status.busy": "2026-09-13T00:31:44.568983Z",
+     "iopub.status.idle": "2026-09-13T00:31:44.580728Z",
+     "shell.execute_reply": "2026-09-13T00:31:44.579201Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.010759,
-     "end_time": "2026-09-10T22:10:35.471795+00:00",
+     "duration": 0.023205,
+     "end_time": "2026-09-13T00:31:44.581848+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:10:35.461036+00:00",
+     "start_time": "2026-09-13T00:31:44.558643+00:00",
      "status": "completed"
     }
    },
@@ -535,14 +535,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f926575e",
+   "id": "e4570b9c",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.003132,
-     "end_time": "2026-09-10T22:10:35.479310+00:00",
+     "duration": 0.006939,
+     "end_time": "2026-09-13T00:31:44.595486+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:10:35.476178+00:00",
+     "start_time": "2026-09-13T00:31:44.588547+00:00",
      "status": "completed"
     }
    },
@@ -555,14 +555,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9415c7a9",
+   "id": "407cfbe4",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.003492,
-     "end_time": "2026-09-10T22:10:35.486566+00:00",
+     "duration": 0.005653,
+     "end_time": "2026-09-13T00:31:44.609194+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:10:35.483074+00:00",
+     "start_time": "2026-09-13T00:31:44.603541+00:00",
      "status": "completed"
     }
    },
@@ -576,20 +576,20 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "1ff8238a",
+   "id": "f3b15da2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T22:10:35.495463Z",
-     "iopub.status.busy": "2026-09-10T22:10:35.495075Z",
-     "iopub.status.idle": "2026-09-10T22:10:35.499471Z",
-     "shell.execute_reply": "2026-09-10T22:10:35.498563Z"
+     "iopub.execute_input": "2026-09-13T00:31:44.626038Z",
+     "iopub.status.busy": "2026-09-13T00:31:44.625433Z",
+     "iopub.status.idle": "2026-09-13T00:31:44.631290Z",
+     "shell.execute_reply": "2026-09-13T00:31:44.629953Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.00971,
-     "end_time": "2026-09-10T22:10:35.499856+00:00",
+     "duration": 0.016772,
+     "end_time": "2026-09-13T00:31:44.632323+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:10:35.490146+00:00",
+     "start_time": "2026-09-13T00:31:44.615551+00:00",
      "status": "completed"
     }
    },
@@ -613,14 +613,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b42e7d6c",
+   "id": "80367c45",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.003485,
-     "end_time": "2026-09-10T22:10:35.507591+00:00",
+     "duration": 0.005724,
+     "end_time": "2026-09-13T00:31:44.644909+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:10:35.504106+00:00",
+     "start_time": "2026-09-13T00:31:44.639185+00:00",
      "status": "completed"
     }
    },
@@ -637,20 +637,20 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "99336a7e",
+   "id": "c23d6a1c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T22:10:35.521716Z",
-     "iopub.status.busy": "2026-09-10T22:10:35.521468Z",
-     "iopub.status.idle": "2026-09-10T22:10:35.525022Z",
-     "shell.execute_reply": "2026-09-10T22:10:35.524549Z"
+     "iopub.execute_input": "2026-09-13T00:31:44.662804Z",
+     "iopub.status.busy": "2026-09-13T00:31:44.662393Z",
+     "iopub.status.idle": "2026-09-13T00:31:44.669338Z",
+     "shell.execute_reply": "2026-09-13T00:31:44.668105Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.010171,
-     "end_time": "2026-09-10T22:10:35.525678+00:00",
+     "duration": 0.019151,
+     "end_time": "2026-09-13T00:31:44.670060+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:10:35.515507+00:00",
+     "start_time": "2026-09-13T00:31:44.650909+00:00",
      "status": "completed"
     }
    },
@@ -675,14 +675,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "407d5efe",
+   "id": "f3c78221",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.005822,
-     "end_time": "2026-09-10T22:10:35.537977+00:00",
+     "duration": 0.005354,
+     "end_time": "2026-09-13T00:31:44.682156+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:10:35.532155+00:00",
+     "start_time": "2026-09-13T00:31:44.676802+00:00",
      "status": "completed"
     }
    },
@@ -695,20 +695,20 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "3684ad1f",
+   "id": "10f1e7b4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T22:10:35.553322Z",
-     "iopub.status.busy": "2026-09-10T22:10:35.552995Z",
-     "iopub.status.idle": "2026-09-10T22:10:35.557700Z",
-     "shell.execute_reply": "2026-09-10T22:10:35.556891Z"
+     "iopub.execute_input": "2026-09-13T00:31:44.699670Z",
+     "iopub.status.busy": "2026-09-13T00:31:44.699258Z",
+     "iopub.status.idle": "2026-09-13T00:31:44.707379Z",
+     "shell.execute_reply": "2026-09-13T00:31:44.705869Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.013451,
-     "end_time": "2026-09-10T22:10:35.558265+00:00",
+     "duration": 0.018874,
+     "end_time": "2026-09-13T00:31:44.708482+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:10:35.544814+00:00",
+     "start_time": "2026-09-13T00:31:44.689608+00:00",
      "status": "completed"
     }
    },
@@ -740,14 +740,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "361e0cb1",
+   "id": "dfcbae76",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.006799,
-     "end_time": "2026-09-10T22:10:35.573541+00:00",
+     "duration": 0.007208,
+     "end_time": "2026-09-13T00:31:44.724044+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:10:35.566742+00:00",
+     "start_time": "2026-09-13T00:31:44.716836+00:00",
      "status": "completed"
     }
    },
@@ -761,20 +761,20 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "d6a50760",
+   "id": "0546b4be",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T22:10:35.587053Z",
-     "iopub.status.busy": "2026-09-10T22:10:35.586884Z",
-     "iopub.status.idle": "2026-09-10T22:10:35.591275Z",
-     "shell.execute_reply": "2026-09-10T22:10:35.590618Z"
+     "iopub.execute_input": "2026-09-13T00:31:44.739641Z",
+     "iopub.status.busy": "2026-09-13T00:31:44.739283Z",
+     "iopub.status.idle": "2026-09-13T00:31:44.746776Z",
+     "shell.execute_reply": "2026-09-13T00:31:44.745618Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.012153,
-     "end_time": "2026-09-10T22:10:35.591761+00:00",
+     "duration": 0.017876,
+     "end_time": "2026-09-13T00:31:44.748362+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:10:35.579608+00:00",
+     "start_time": "2026-09-13T00:31:44.730486+00:00",
      "status": "completed"
     }
    },
@@ -814,14 +814,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "71eb2d2d",
+   "id": "2ab146d2",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.006269,
-     "end_time": "2026-09-10T22:10:35.605178+00:00",
+     "duration": 0.005573,
+     "end_time": "2026-09-13T00:31:44.760759+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:10:35.598909+00:00",
+     "start_time": "2026-09-13T00:31:44.755186+00:00",
      "status": "completed"
     }
    },
@@ -834,20 +834,20 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "ef212988",
+   "id": "6924cef3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T22:10:35.622424Z",
-     "iopub.status.busy": "2026-09-10T22:10:35.622150Z",
-     "iopub.status.idle": "2026-09-10T22:10:35.626584Z",
-     "shell.execute_reply": "2026-09-10T22:10:35.625908Z"
+     "iopub.execute_input": "2026-09-13T00:31:44.776566Z",
+     "iopub.status.busy": "2026-09-13T00:31:44.776248Z",
+     "iopub.status.idle": "2026-09-13T00:31:44.781852Z",
+     "shell.execute_reply": "2026-09-13T00:31:44.780997Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.015642,
-     "end_time": "2026-09-10T22:10:35.627291+00:00",
+     "duration": 0.014755,
+     "end_time": "2026-09-13T00:31:44.782731+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:10:35.611649+00:00",
+     "start_time": "2026-09-13T00:31:44.767976+00:00",
      "status": "completed"
     }
    },
@@ -876,14 +876,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "010a2a2b",
+   "id": "db955010",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.003274,
-     "end_time": "2026-09-10T22:10:35.634491+00:00",
+     "duration": 0.00637,
+     "end_time": "2026-09-13T00:31:44.794863+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:10:35.631217+00:00",
+     "start_time": "2026-09-13T00:31:44.788493+00:00",
      "status": "completed"
     }
    },
@@ -897,19 +897,19 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "16d3f2e3",
+   "id": "77e86c18",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T22:10:35.642070Z",
-     "iopub.status.busy": "2026-09-10T22:10:35.641905Z",
-     "iopub.status.idle": "2026-09-10T22:10:35.648190Z",
-     "shell.execute_reply": "2026-09-10T22:10:35.647491Z"
+     "iopub.execute_input": "2026-09-13T00:31:44.811335Z",
+     "iopub.status.busy": "2026-09-13T00:31:44.810709Z",
+     "iopub.status.idle": "2026-09-13T00:31:44.827125Z",
+     "shell.execute_reply": "2026-09-13T00:31:44.823422Z"
     },
     "papermill": {
-     "duration": 0.010891,
-     "end_time": "2026-09-10T22:10:35.648751+00:00",
+     "duration": 0.02681,
+     "end_time": "2026-09-13T00:31:44.829390+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:10:35.637860+00:00",
+     "start_time": "2026-09-13T00:31:44.802580+00:00",
      "status": "completed"
     }
    },
@@ -971,19 +971,19 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "id": "5ee7013d",
+   "id": "9bc57230",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T22:10:35.657273Z",
-     "iopub.status.busy": "2026-09-10T22:10:35.657033Z",
-     "iopub.status.idle": "2026-09-10T22:10:35.779066Z",
-     "shell.execute_reply": "2026-09-10T22:10:35.778325Z"
+     "iopub.execute_input": "2026-09-13T00:31:44.869915Z",
+     "iopub.status.busy": "2026-09-13T00:31:44.869404Z",
+     "iopub.status.idle": "2026-09-13T00:31:45.192200Z",
+     "shell.execute_reply": "2026-09-13T00:31:45.189582Z"
     },
     "papermill": {
-     "duration": 0.126997,
-     "end_time": "2026-09-10T22:10:35.779485+00:00",
+     "duration": 0.348696,
+     "end_time": "2026-09-13T00:31:45.194280+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:10:35.652488+00:00",
+     "start_time": "2026-09-13T00:31:44.845584+00:00",
      "status": "completed"
     }
    },
@@ -1059,14 +1059,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "62e08c9d",
+   "id": "ae0feb9f",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.007039,
-     "end_time": "2026-09-10T22:10:35.792292+00:00",
+     "duration": 0.009736,
+     "end_time": "2026-09-13T00:31:45.218218+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:10:35.785253+00:00",
+     "start_time": "2026-09-13T00:31:45.208482+00:00",
      "status": "completed"
     }
    },
@@ -1078,14 +1078,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ae191c0e",
+   "id": "55cedb2a",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.008419,
-     "end_time": "2026-09-10T22:10:35.807087+00:00",
+     "duration": 0.007025,
+     "end_time": "2026-09-13T00:31:45.233848+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:10:35.798668+00:00",
+     "start_time": "2026-09-13T00:31:45.226823+00:00",
      "status": "completed"
     }
    },
@@ -1100,20 +1100,20 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "id": "0c650a2b",
+   "id": "9db483bf",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T22:10:35.817939Z",
-     "iopub.status.busy": "2026-09-10T22:10:35.817625Z",
-     "iopub.status.idle": "2026-09-10T22:10:35.822167Z",
-     "shell.execute_reply": "2026-09-10T22:10:35.821535Z"
+     "iopub.execute_input": "2026-09-13T00:31:45.249434Z",
+     "iopub.status.busy": "2026-09-13T00:31:45.249062Z",
+     "iopub.status.idle": "2026-09-13T00:31:45.261116Z",
+     "shell.execute_reply": "2026-09-13T00:31:45.258209Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.01069,
-     "end_time": "2026-09-10T22:10:35.822567+00:00",
+     "duration": 0.023757,
+     "end_time": "2026-09-13T00:31:45.264435+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:10:35.811877+00:00",
+     "start_time": "2026-09-13T00:31:45.240678+00:00",
      "status": "completed"
     }
    },
@@ -1139,14 +1139,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ff131b60",
+   "id": "7514d2fb",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.003507,
-     "end_time": "2026-09-10T22:10:35.829976+00:00",
+     "duration": 0.010948,
+     "end_time": "2026-09-13T00:31:45.291671+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:10:35.826469+00:00",
+     "start_time": "2026-09-13T00:31:45.280723+00:00",
      "status": "completed"
     }
    },
@@ -1160,20 +1160,20 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "id": "d1c9d235",
+   "id": "67a97351",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T22:10:35.839010Z",
-     "iopub.status.busy": "2026-09-10T22:10:35.838812Z",
-     "iopub.status.idle": "2026-09-10T22:10:35.842668Z",
-     "shell.execute_reply": "2026-09-10T22:10:35.841976Z"
+     "iopub.execute_input": "2026-09-13T00:31:45.314436Z",
+     "iopub.status.busy": "2026-09-13T00:31:45.313733Z",
+     "iopub.status.idle": "2026-09-13T00:31:45.326526Z",
+     "shell.execute_reply": "2026-09-13T00:31:45.324750Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.009329,
-     "end_time": "2026-09-10T22:10:35.843092+00:00",
+     "duration": 0.025147,
+     "end_time": "2026-09-13T00:31:45.328005+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:10:35.833763+00:00",
+     "start_time": "2026-09-13T00:31:45.302858+00:00",
      "status": "completed"
     }
    },
@@ -1191,14 +1191,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5b6cb6d1",
+   "id": "f91685ee",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.00399,
-     "end_time": "2026-09-10T22:10:35.851538+00:00",
+     "duration": 0.007605,
+     "end_time": "2026-09-13T00:31:45.347246+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:10:35.847548+00:00",
+     "start_time": "2026-09-13T00:31:45.339641+00:00",
      "status": "completed"
     }
    },
@@ -1212,19 +1212,19 @@
   {
    "cell_type": "code",
    "execution_count": 17,
-   "id": "ea7921a2",
+   "id": "b0bab9dd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T22:10:35.863308Z",
-     "iopub.status.busy": "2026-09-10T22:10:35.862774Z",
-     "iopub.status.idle": "2026-09-10T22:10:35.869337Z",
-     "shell.execute_reply": "2026-09-10T22:10:35.868625Z"
+     "iopub.execute_input": "2026-09-13T00:31:45.373032Z",
+     "iopub.status.busy": "2026-09-13T00:31:45.372217Z",
+     "iopub.status.idle": "2026-09-13T00:31:45.390927Z",
+     "shell.execute_reply": "2026-09-13T00:31:45.388249Z"
     },
     "papermill": {
-     "duration": 0.01437,
-     "end_time": "2026-09-10T22:10:35.869870+00:00",
+     "duration": 0.037783,
+     "end_time": "2026-09-13T00:31:45.393209+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:10:35.855500+00:00",
+     "start_time": "2026-09-13T00:31:45.355426+00:00",
      "status": "completed"
     }
    },
@@ -1261,13 +1261,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b4892e07",
+   "id": "493660f7",
    "metadata": {
     "papermill": {
-     "duration": 0.003755,
-     "end_time": "2026-09-10T22:10:35.881346+00:00",
+     "duration": 0.009698,
+     "end_time": "2026-09-13T00:31:45.433827+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:10:35.877591+00:00",
+     "start_time": "2026-09-13T00:31:45.424129+00:00",
      "status": "completed"
     }
    },
@@ -1284,19 +1284,19 @@
   {
    "cell_type": "code",
    "execution_count": 18,
-   "id": "920e0ff0",
+   "id": "135b22a6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T22:10:35.890235Z",
-     "iopub.status.busy": "2026-09-10T22:10:35.890054Z",
-     "iopub.status.idle": "2026-09-10T22:10:35.907000Z",
-     "shell.execute_reply": "2026-09-10T22:10:35.906278Z"
+     "iopub.execute_input": "2026-09-13T00:31:45.462182Z",
+     "iopub.status.busy": "2026-09-13T00:31:45.461483Z",
+     "iopub.status.idle": "2026-09-13T00:31:45.536253Z",
+     "shell.execute_reply": "2026-09-13T00:31:45.534462Z"
     },
     "papermill": {
-     "duration": 0.022106,
-     "end_time": "2026-09-10T22:10:35.907460+00:00",
+     "duration": 0.09239,
+     "end_time": "2026-09-13T00:31:45.540258+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:10:35.885354+00:00",
+     "start_time": "2026-09-13T00:31:45.447868+00:00",
      "status": "completed"
     }
    },
@@ -1351,13 +1351,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "770bfeac",
+   "id": "da6f4719",
    "metadata": {
     "papermill": {
-     "duration": 0.005526,
-     "end_time": "2026-09-10T22:10:35.917618+00:00",
+     "duration": 0.009824,
+     "end_time": "2026-09-13T00:31:45.559775+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:10:35.912092+00:00",
+     "start_time": "2026-09-13T00:31:45.549951+00:00",
      "status": "completed"
     }
    },
@@ -1370,19 +1370,19 @@
   {
    "cell_type": "code",
    "execution_count": 19,
-   "id": "906c0e52",
+   "id": "990212b1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T22:10:35.928328Z",
-     "iopub.status.busy": "2026-09-10T22:10:35.928082Z",
-     "iopub.status.idle": "2026-09-10T22:10:35.932961Z",
-     "shell.execute_reply": "2026-09-10T22:10:35.932255Z"
+     "iopub.execute_input": "2026-09-13T00:31:45.584646Z",
+     "iopub.status.busy": "2026-09-13T00:31:45.583960Z",
+     "iopub.status.idle": "2026-09-13T00:31:45.601510Z",
+     "shell.execute_reply": "2026-09-13T00:31:45.598788Z"
     },
     "papermill": {
-     "duration": 0.010423,
-     "end_time": "2026-09-10T22:10:35.933413+00:00",
+     "duration": 0.032663,
+     "end_time": "2026-09-13T00:31:45.603613+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:10:35.922990+00:00",
+     "start_time": "2026-09-13T00:31:45.570950+00:00",
      "status": "completed"
     }
    },
@@ -1432,19 +1432,19 @@
   {
    "cell_type": "code",
    "execution_count": 20,
-   "id": "5459c0e9",
+   "id": "74f38dfa",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T22:10:35.942728Z",
-     "iopub.status.busy": "2026-09-10T22:10:35.942472Z",
-     "iopub.status.idle": "2026-09-10T22:10:35.947206Z",
-     "shell.execute_reply": "2026-09-10T22:10:35.946434Z"
+     "iopub.execute_input": "2026-09-13T00:31:45.627824Z",
+     "iopub.status.busy": "2026-09-13T00:31:45.627130Z",
+     "iopub.status.idle": "2026-09-13T00:31:45.639165Z",
+     "shell.execute_reply": "2026-09-13T00:31:45.637880Z"
     },
     "papermill": {
-     "duration": 0.009814,
-     "end_time": "2026-09-10T22:10:35.947635+00:00",
+     "duration": 0.026689,
+     "end_time": "2026-09-13T00:31:45.641264+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:10:35.937821+00:00",
+     "start_time": "2026-09-13T00:31:45.614575+00:00",
      "status": "completed"
     }
    },
@@ -1485,13 +1485,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "16d16e83",
+   "id": "020c2827",
    "metadata": {
     "papermill": {
-     "duration": 0.00363,
-     "end_time": "2026-09-10T22:10:35.955514+00:00",
+     "duration": 0.009407,
+     "end_time": "2026-09-13T00:31:45.663969+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:10:35.951884+00:00",
+     "start_time": "2026-09-13T00:31:45.654562+00:00",
      "status": "completed"
     }
    },
@@ -1505,19 +1505,19 @@
   {
    "cell_type": "code",
    "execution_count": 21,
-   "id": "681b87a5",
+   "id": "b57039d9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T22:10:35.965194Z",
-     "iopub.status.busy": "2026-09-10T22:10:35.964936Z",
-     "iopub.status.idle": "2026-09-10T22:10:35.979959Z",
-     "shell.execute_reply": "2026-09-10T22:10:35.979427Z"
+     "iopub.execute_input": "2026-09-13T00:31:45.688727Z",
+     "iopub.status.busy": "2026-09-13T00:31:45.688110Z",
+     "iopub.status.idle": "2026-09-13T00:31:45.718936Z",
+     "shell.execute_reply": "2026-09-13T00:31:45.717873Z"
     },
     "papermill": {
-     "duration": 0.020922,
-     "end_time": "2026-09-10T22:10:35.980579+00:00",
+     "duration": 0.047972,
+     "end_time": "2026-09-13T00:31:45.722975+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:10:35.959657+00:00",
+     "start_time": "2026-09-13T00:31:45.675003+00:00",
      "status": "completed"
     }
    },
@@ -1636,13 +1636,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "61edb640",
+   "id": "f5a9bd62",
    "metadata": {
     "papermill": {
-     "duration": 0.006294,
-     "end_time": "2026-09-10T22:10:35.993819+00:00",
+     "duration": 0.010622,
+     "end_time": "2026-09-13T00:31:45.744075+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:10:35.987525+00:00",
+     "start_time": "2026-09-13T00:31:45.733453+00:00",
      "status": "completed"
     }
    },
@@ -1660,19 +1660,19 @@
   {
    "cell_type": "code",
    "execution_count": 22,
-   "id": "3394efb6",
+   "id": "40ef4a1c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T22:10:36.004397Z",
-     "iopub.status.busy": "2026-09-10T22:10:36.004264Z",
-     "iopub.status.idle": "2026-09-10T22:10:36.007918Z",
-     "shell.execute_reply": "2026-09-10T22:10:36.007345Z"
+     "iopub.execute_input": "2026-09-13T00:31:45.768299Z",
+     "iopub.status.busy": "2026-09-13T00:31:45.767720Z",
+     "iopub.status.idle": "2026-09-13T00:31:45.780886Z",
+     "shell.execute_reply": "2026-09-13T00:31:45.779262Z"
     },
     "papermill": {
-     "duration": 0.009198,
-     "end_time": "2026-09-10T22:10:36.008319+00:00",
+     "duration": 0.027545,
+     "end_time": "2026-09-13T00:31:45.782280+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:10:35.999121+00:00",
+     "start_time": "2026-09-13T00:31:45.754735+00:00",
      "status": "completed"
     }
    },
@@ -1728,19 +1728,19 @@
   {
    "cell_type": "code",
    "execution_count": 23,
-   "id": "aab0595c",
+   "id": "d3b164d3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T22:10:36.018722Z",
-     "iopub.status.busy": "2026-09-10T22:10:36.018517Z",
-     "iopub.status.idle": "2026-09-10T22:10:36.023110Z",
-     "shell.execute_reply": "2026-09-10T22:10:36.022480Z"
+     "iopub.execute_input": "2026-09-13T00:31:45.806620Z",
+     "iopub.status.busy": "2026-09-13T00:31:45.805910Z",
+     "iopub.status.idle": "2026-09-13T00:31:45.816508Z",
+     "shell.execute_reply": "2026-09-13T00:31:45.815423Z"
     },
     "papermill": {
-     "duration": 0.011099,
-     "end_time": "2026-09-10T22:10:36.023656+00:00",
+     "duration": 0.026299,
+     "end_time": "2026-09-13T00:31:45.818663+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:10:36.012557+00:00",
+     "start_time": "2026-09-13T00:31:45.792364+00:00",
      "status": "completed"
     }
    },
@@ -1780,13 +1780,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dd3d03da",
+   "id": "b22d5aad",
    "metadata": {
     "papermill": {
-     "duration": 0.006165,
-     "end_time": "2026-09-10T22:10:36.034120+00:00",
+     "duration": 0.009029,
+     "end_time": "2026-09-13T00:31:45.837534+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:10:36.027955+00:00",
+     "start_time": "2026-09-13T00:31:45.828505+00:00",
      "status": "completed"
     }
    },
@@ -1800,13 +1800,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b44c5650",
+   "id": "440b37f1",
    "metadata": {
     "papermill": {
-     "duration": 0.003745,
-     "end_time": "2026-09-10T22:10:36.044074+00:00",
+     "duration": 0.008899,
+     "end_time": "2026-09-13T00:31:45.857954+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:10:36.040329+00:00",
+     "start_time": "2026-09-13T00:31:45.849055+00:00",
      "status": "completed"
     }
    },
@@ -1821,19 +1821,19 @@
   {
    "cell_type": "code",
    "execution_count": 24,
-   "id": "c7d7bf3a",
+   "id": "02a5f1d9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T22:10:36.052545Z",
-     "iopub.status.busy": "2026-09-10T22:10:36.052396Z",
-     "iopub.status.idle": "2026-09-10T22:10:36.054649Z",
-     "shell.execute_reply": "2026-09-10T22:10:36.054310Z"
+     "iopub.execute_input": "2026-09-13T00:31:45.880876Z",
+     "iopub.status.busy": "2026-09-13T00:31:45.880123Z",
+     "iopub.status.idle": "2026-09-13T00:31:45.889728Z",
+     "shell.execute_reply": "2026-09-13T00:31:45.888171Z"
     },
     "papermill": {
-     "duration": 0.007302,
-     "end_time": "2026-09-10T22:10:36.055099+00:00",
+     "duration": 0.022611,
+     "end_time": "2026-09-13T00:31:45.890568+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:10:36.047797+00:00",
+     "start_time": "2026-09-13T00:31:45.867957+00:00",
      "status": "completed"
     }
    },
@@ -1852,14 +1852,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "331a9cd1",
+   "id": "76667ece",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.003746,
-     "end_time": "2026-09-10T22:10:36.063186+00:00",
+     "duration": 0.009053,
+     "end_time": "2026-09-13T00:31:45.909714+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:10:36.059440+00:00",
+     "start_time": "2026-09-13T00:31:45.900661+00:00",
      "status": "completed"
     }
    },
@@ -1874,19 +1874,19 @@
   {
    "cell_type": "code",
    "execution_count": 25,
-   "id": "9cca06ff",
+   "id": "652d54b9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T22:10:36.077122Z",
-     "iopub.status.busy": "2026-09-10T22:10:36.076834Z",
-     "iopub.status.idle": "2026-09-10T22:10:36.080314Z",
-     "shell.execute_reply": "2026-09-10T22:10:36.079851Z"
+     "iopub.execute_input": "2026-09-13T00:31:45.935961Z",
+     "iopub.status.busy": "2026-09-13T00:31:45.935115Z",
+     "iopub.status.idle": "2026-09-13T00:31:45.944353Z",
+     "shell.execute_reply": "2026-09-13T00:31:45.942625Z"
     },
     "papermill": {
-     "duration": 0.013895,
-     "end_time": "2026-09-10T22:10:36.080897+00:00",
+     "duration": 0.028163,
+     "end_time": "2026-09-13T00:31:45.948175+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:10:36.067002+00:00",
+     "start_time": "2026-09-13T00:31:45.920012+00:00",
      "status": "completed"
     }
    },
@@ -1904,19 +1904,19 @@
   {
    "cell_type": "code",
    "execution_count": 26,
-   "id": "2ede7ff8",
+   "id": "ccc17704",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T22:10:36.098526Z",
-     "iopub.status.busy": "2026-09-10T22:10:36.098271Z",
-     "iopub.status.idle": "2026-09-10T22:10:36.107374Z",
-     "shell.execute_reply": "2026-09-10T22:10:36.106962Z"
+     "iopub.execute_input": "2026-09-13T00:31:45.972173Z",
+     "iopub.status.busy": "2026-09-13T00:31:45.971541Z",
+     "iopub.status.idle": "2026-09-13T00:31:45.995359Z",
+     "shell.execute_reply": "2026-09-13T00:31:45.993816Z"
     },
     "papermill": {
-     "duration": 0.017986,
-     "end_time": "2026-09-10T22:10:36.108000+00:00",
+     "duration": 0.039123,
+     "end_time": "2026-09-13T00:31:45.997819+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:10:36.090014+00:00",
+     "start_time": "2026-09-13T00:31:45.958696+00:00",
      "status": "completed"
     }
    },
@@ -1957,14 +1957,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "102a525f",
+   "id": "9fb3db7f",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.006845,
-     "end_time": "2026-09-10T22:10:36.121916+00:00",
+     "duration": 0.008826,
+     "end_time": "2026-09-13T00:31:46.016990+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:10:36.115071+00:00",
+     "start_time": "2026-09-13T00:31:46.008164+00:00",
      "status": "completed"
     }
    },
@@ -1981,19 +1981,19 @@
   {
    "cell_type": "code",
    "execution_count": 27,
-   "id": "78ebc049",
+   "id": "b6c20a48",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T22:10:36.138288Z",
-     "iopub.status.busy": "2026-09-10T22:10:36.138096Z",
-     "iopub.status.idle": "2026-09-10T22:10:36.148697Z",
-     "shell.execute_reply": "2026-09-10T22:10:36.144919Z"
+     "iopub.execute_input": "2026-09-13T00:31:46.038951Z",
+     "iopub.status.busy": "2026-09-13T00:31:46.038398Z",
+     "iopub.status.idle": "2026-09-13T00:31:46.059641Z",
+     "shell.execute_reply": "2026-09-13T00:31:46.055465Z"
     },
     "papermill": {
-     "duration": 0.019691,
-     "end_time": "2026-09-10T22:10:36.149251+00:00",
+     "duration": 0.034787,
+     "end_time": "2026-09-13T00:31:46.061361+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:10:36.129560+00:00",
+     "start_time": "2026-09-13T00:31:46.026574+00:00",
      "status": "completed"
     }
    },
@@ -2064,13 +2064,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "21d075a2",
+   "id": "e4968c53",
    "metadata": {
     "papermill": {
-     "duration": 0.006911,
-     "end_time": "2026-09-10T22:10:36.162681+00:00",
+     "duration": 0.009404,
+     "end_time": "2026-09-13T00:31:46.081558+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:10:36.155770+00:00",
+     "start_time": "2026-09-13T00:31:46.072154+00:00",
      "status": "completed"
     }
    },
@@ -2086,13 +2086,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b797023e",
+   "id": "bc27e99e",
    "metadata": {
     "papermill": {
-     "duration": 0.006898,
-     "end_time": "2026-09-10T22:10:36.176877+00:00",
+     "duration": 0.156782,
+     "end_time": "2026-09-13T00:31:46.249001+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:10:36.169979+00:00",
+     "start_time": "2026-09-13T00:31:46.092219+00:00",
      "status": "completed"
     }
    },
@@ -2109,26 +2109,26 @@
   {
    "cell_type": "code",
    "execution_count": 28,
-   "id": "197ecba2",
+   "id": "6ee455b7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T22:10:36.193241Z",
-     "iopub.status.busy": "2026-09-10T22:10:36.192988Z",
-     "iopub.status.idle": "2026-09-10T22:10:36.642416Z",
-     "shell.execute_reply": "2026-09-10T22:10:36.641728Z"
+     "iopub.execute_input": "2026-09-13T00:31:46.426598Z",
+     "iopub.status.busy": "2026-09-13T00:31:46.426094Z",
+     "iopub.status.idle": "2026-09-13T00:31:47.056611Z",
+     "shell.execute_reply": "2026-09-13T00:31:47.052997Z"
     },
     "papermill": {
-     "duration": 0.459049,
-     "end_time": "2026-09-10T22:10:36.643043+00:00",
+     "duration": 0.725041,
+     "end_time": "2026-09-13T00:31:47.058503+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:10:36.183994+00:00",
+     "start_time": "2026-09-13T00:31:46.333462+00:00",
      "status": "completed"
     }
    },
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAoIAAAH1CAYAAABiP5/xAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjksIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvJkbTWQAAAAlwSFlzAAAPYQAAD2EBqD+naQAA2c1JREFUeJzs3XVYVUkfwPEvcOlQUgQVEBAEuxsbuzuwO7F211pda+1aO9fuWCwwsdfCLlAwUKQMpC4X7vsHcuTKpdzAd53P8/g8MuecOXPmnnMZZubMT0MuT1QiCIIgCIIgfHc087oAgiAIgiAIQt4QDUFBEARBEITvlGgICoIgCIIgfKdEQ1AQBEEQBOE7JRqCwn/OIO9J5C9Umqbt+mS5X8kqjclfqDSDvCf9SyUT/or8hUqTv1BpZs1fkddF+b8wa/4Kqc4E9Xbs8aF8zeZY2Jcnf6HSbN118F8vQ06/r/6KgFv3aNCiOwWdKv8nvvO27jr4f3tvpz2XJas0zuuiSERDUMhTTdv1UftQnLt4VXrQ8+LL+Xsg6lf4N/0bDZ7ciIiMYtjYKTwJfo6VhRkVypbEwtz0HztfXj5vQ8dM4eqN22hryyhfpgQOdoX+9TJ8jbTfD182XC3MTalQtiQVypbMo5L9f0jr7Mjuj2fZv1QeQfhPk8uT0NHRzutiCP8Q8fl+m/7K5xL09BlJSQoADu5cg7OjfZ6W55/08PETAKZOGEmvbu3/cn55fZ2e9WrhWa9Wnp3/W5fbz0f0CAr/V16EvmbAiAkUK1sXC/vyuFVowOjxM3j79n2Wxz1/+YrWXQZQwLEi5Ws2x+foSbX7vf8Qww+TZ1OiciMsHVLzHz91LnHx8dI+6Xs2Fi/fgFuFBhRwrJjpuZVKJWt/30lNzw5YO1aikEtV6jbtwu17D6V9jvidoVHrHtgWq0IBx4rU9OzApu37VPJR16Pw5V/Mz16EquzXscdQCjpVplTVxlJ+ab2taYaMmqzSKxv4JIROvYbjVLo2VkUr4FahAe26DeZ6wJ1Mr/H2vYe06NgPl3L1sCpaARvnytRp2oWdew+pvYalq36n/7CfKORSleLl6zN38WqV/e7ef0z95t0o4FiR6g3ac+nKjUzPnd7H2DhG/TQd94oNsSpaAcdStfFs1YNtu/+Q9on5GMvEafMpU70plg7lcShRi7ZdBxEfnwB8/it60rQFDBk9mSJuNWjTdSAAiYlyZs5bTrkazbF0KI9T6doMGT2ZqOi3KuW4duM27bsPoYhbDQo4VqRWo44cPHT8q+oiJ/ekUqlk+pzfcChRiyJuNRg7cRZJSUk5qjO/k+do0KI7RdxqUNCpMmWrN6PXoLG8e/dB2uf4qfM0adubQi5VsXasROM2PTl74YpKPlnVa8kqjdn+6TO4cPmadO3nLl4FcvZcZ/XcXb1+mxYd++FQohYFHCtSskpjuvQZSXDIC7XXPGv+Chq36SX9XNGjpUp5cvM8Ll6+gW59vbEtVoURP/yS4VzZPW/pbdq2j1JVG1PIpSodewzlTXikyvadew9Rp2kXCjpVppBLVdp2HaTyPZLZuZOTkwHw/nG6Sg/R/YeBdOvrjUOJWlg6lKd0tSZMnbVYehbg83dM/+HjmTRtAU6la1PBowXw+VnpP3w846fOpUjx6hQvX58tOw8Q9iaCDl5DsXGuTPUG7bl8NUDKMyffF/kLlebC5WsAbN/9h1Tfz16EZjo0vGXnATwad8LasRI2zpXxbNWDw76npe05+X7MypOnz+g75EeKla0rPYsTp82Xtr99+54xE2biXrEhFvblcS5Th/7DfuJF6Gu1+R3xO0PlOq2xca5M47a9CHwSkmH7196H+QuV5sXLVwDMXrgyy6F00SMo/N+IiIyiYYvuvH4Tga6uDk5FixD09DnrNu3i0p83OHV4G3p6uhmOUyqVePUfzc3b99HU1EQmkzFg+HiSU1JU9pPLk2jWvg937j1CT1eXYk5FefL0GcvXbOHu/ccc3LEaDQ0Naf+rN25x6coNnB3tSUiUZ1rucZN+Zc3GHQCYmeangJU5dx885vmLV5Ryd2Xn3kMMGDEBACtLc3R1dblz7xHDx04lPCKKMcP7fVV9jfzhFwpaW6GtLeP5i1eM/GEaVSqWxdjYiAplS3LtU8PO3q4QFmamFLCyAKDPkB+4ffch+fOZ4FrMkfCIKE6cuUDrFp6Uz2Qo5vmLV5y/dA1bG2tcizny/MUrAm7dY8CICeTPb5Lhr/dffl2CuZkpurq6vH4TwYy5y6hQtiR1alUlPj6BDl5DeBUWjra2DIVCQccew3J0zTPnLWP95t3o6urgWsyR9x9iuBZwh6IORejSvoX0Gd+68wCAwoVs0JbJOHX2EolyOfr6elJeqzZsQ0tTCwf7wujrpaZ37zcKv1Pn0NLSwrWYIy9evmLrzoNcD7jD6cPb0dfX4/LVAJp36EtSkoICVhYUsDTn9t2H9Bg4hhWLptO5XfMc10VO78nVG7Yzb8kaAGwLFuDAIT/i4uLJTmRUNN36eSOXJ1HItiD5TIx5+eo1+338mDJ+JPnzm7Dvj2P0GfIjSqWSwoVs0NTU4NKVAFp3Gcj+bSupVb1StvVayt2FuLh4oqLfYmxkiItzUQCMjY1y/Vx/+dylpKTQsecwot++w8rSnGK2DrwOC+eI72kG9emKg33hDNdtW7AALs5FeRT4FICS7i7o6uhgbGyU6+dxxrxl6OnqYlfYFh3tjL0w2T1vaW7cvMv1gDvY2hTgY2wcvifPMfGX+az5bRYAi5dv4OeZiwBwKmpHbGwcJ/0vcvlqAKcOb5PqNCfnti1YgEeBT2nY0ouPsXEYGRpQ1L4Ij4OCWbhsPTfv3Gf/tlUqeR045IdSqcS5qD0amqp9SAcPH8fI0BB9fT1ev4lgxLhfcLArRFxcPNo62tx78Ji+Q34k4MIhtLW1c/R9UaFsSR4FPiXmYyzmZqbScLaujk6G6wSYu3g1M+YuA6CQbUGSkpL489pNuvYZyarFM+jYtpnK/pl9PxZzclCb/9Pg59Rt3pX372PQ0tLCqagd795/4My5PwFISEikabve3H8UhEwmw6loEUKehbJr/xHOXbzKOb9dWJibSfm9CY+g16Cx2BW2JT4hkUt/3mDo6J/xPfA7wF+6D7VlMiqULcntew+Ry5OwsbbCpmABtdcFgFyeqBT/xL+8+tegRTelgZVrlv82bNmllMsTlVNmLlQaWLkqjazdlFeu31TK5YnKfX8clfZbv3mnUi5PVPYZMk5pYOWqbNCim1IuT1QeP3VW2mflus0Z0voMGaeUyxOVG7fuVhpYuSrzFyqpfPDwsVIuT1Rev3lb2u/4qbMq+RtYuSoPHzuplMsTlfHxcWqvL/DJU6VhgeJKAytXZQevwcqPHz8q5fJE5avXr5XBIc+VcnmisljZOkoDK1dlLc/2ypiYGGViYoKyg9dgpYGVq9K8SBnlu/fvlHJ5Yob6SF9/adcQ+OSptF/nXsOUiYkJyhs372S4/szyk8sTlVYO5ZQGVq7KsxcuS2mPg54oA588zfRzfPEyVPky9JX084cPH5QlKjVUGli5KnsOHJ3hnLUbd1R+/PhR+TosTJnPtoTSwMpVOX7KbKVcnqhc+/t2ab8jvqcypE2dtSjTcrTu0l9pYOWqnDnvNyntzZtw5fWbt5VyeaLy9217pHzmLV4l7XPrzj3ps3EpV1dpYOWqLOxaVfk05Jn0+Z7yvyAde/rsRaVcnqh8/uKl0rxIGaWBlaty7e/blXJ5orJhy9TPpGm7nsq4uFilXJ6oHD1+utLAylXpXNojV3WR03vSubSH0sDKVVmvWWdlXFys8t37d8rSVRtJ+2VWX1euBSgNrFyVBYqWV75//14plycqExMTlJevXFe+ffdWKZcnKl3Lp9ZH/2E/KhMTE1Tuz3rNOue4Xr98LtP+5fa5/vK5C3vzRkoPefZc5dyhr15leu0nz5yXjkt/b+f2eSxTrbEyPDwiy++BrJ63tOsysnaT7tO089m7V1fK5YnKd+/fKS3sUu+zabMXK+XyRGVcXKyyeoO2GZ6xnJ679+CxSgMrV6WVQznpPl+0fJ2074nT51S+Y/IXKimVL+06056VIsWrKsMjIpQPHwVKx5ev2VQZExOj8l179/7DXH1ffPn9lvZvw5ZdKvf223dvpeewg9dgZUJCvDImJkZZs2E7pYGVq9KlXN1cfz9++a/fsB+UBlauyny2JZTnLv4ppV+9kXrPrt+8U8pn3x9HU5+v6zeVRtZuSgMrV+WUmQuVcnmicuqsRdJ+Bw/7KuXyROWYCdOltLTn8O+4D9M+n6y+M+XyRKUYGha+CTo62tLk3wplS6r96zbg1j0AnB3tKVOyOADNGtXF4FMvzs3b99Xm/eBRkPT/Fk3qA+BRozKm+fOp7Hfj5l0gtWewfK0W5C9UmpoNO0jbr964rbK/s6M9DerWAEBLS0vtuQNu3UOpTI3iOHSAlzRvw8LcDFubAkRERvHy07BB88b10NXVQUNDg7YtGwEQn5DAw0dP1Oadnfatm6ChoYFrsc91GR4Rne1xjep7pJanQ18q1W5F936jOHnmItZWlpkeo6GhwcRf5uFavj7mduWwdqrE05DnAIS9iciwf6vmDdHR0cbczBTLT38lh0dGAZ/nMxno61G/TnUAWjf3zMkl0/hT2WfMXUaJyo1o03UgqzZsx8rCHEAa3tbV1WFI/+7SccVdnDLMqWnRpB6FbKyB1M837f4AaNquN/kLlca1fH3iE1KH0a7dSM07bb/TZy9Lb6OuWLsFgNDXb3j1+k2O6yIn9+SHmI+EfsqzcYPayGQyDPT1aVivZrb15VrMEXu7QsR8jMW5TB1qNerIIO9JhIVHYmhgQGRUNM9fpA4vbdl5ANPCZTAtXIZDx06lXvOn+sxNvX4pt8/1l8+dmWl+KpVPHfIqV6M51eq1lXq1zc1y9/LH1zyPnds1J39+E6k8X8vN1ZmSbi5A6ucCEB7x6Zl49IS4T8O1aW+dWtiXl+ou7d7LjbRjq1YqJ93n7Vt9Hq7+st5rVq0ole/L66xSsSz585lQpLCNlFanVlV0dXWwK2IrpaVdT26/L7Lz8NET6Tls27IRmpqa6OrqSN/3L16+IjJK9bsvt9+Pafd49SoVqFyhjJReukTqPZtWnwb6ejRrVBeAMiWLS3NPv6xPExNjGjeoDYCrs6OUHhEV/a/fh2JoWPgmFLCy5ITPFunncxev0rxD3zwpi46ONqXcXTOk589novKz5afGxb8tbb4PwIeYmEz3y2diDIBM9vkxT2uUZmXl4uk0bujB+UvXeBj4lOOnzuNz9CQPHgUxb8Z4tcf0Hz6eM+cuS1+shgYG0rBOcnJKhv3Tygag9al8XxYt/TB8TvXs1g5nJweOHj/D/YeB3Lz9gFP+lzh42I9LJ1Xn1mSXf1afr7q3Fa2sVPfPbDhGke7zg5zVRU7vydzS09PlzJHt7Nx7iOsBd3gY+JSdew+xY48PG1fOpUbVCtK+acOKX5LLVecifs3nlhvqPpeDO1az+8AR/rx2k0ePn3Lw8An2HjzGm/BIhg/q+c+Wx/Lv+R5QuQ+y+EXu4lwUYyNDlTQz0/x/SxmyktV1GhsbAarfNcZGqWnp74e075/cfl/8E772+/HvPj+Aluzz5/21Zfgr96HoERT+b5Qt7Q6kvsxw89NcpEPHTkl/KZcp5ab2uOIuTtL/Dx1N7ck4e+EKb9+pvmCSln9ycgrzZk7ghM8WTvhs4dDudQwb2JN2rVQnd+fkF17Z0u7SfivWbpV+aUa/fUfoqzdYWphTyLYgAD5HT5KYKEepVLL34DEA9PX0cHVJ/WvR0iK1t+jJ02cAPA4K5v7DIL5W2ry3L+eSXfzzBs0a1WPhr5M4uncDP3gPSE2/fD3TvK596i3t0aUNl07uY/emZRgaGnxVudJ6Q2Lj4jnlfxFInYOUE9cD7lDcxZHpk0azb+tKdm5cCsCDR0+IfvtOmuOYmChn+drPf3g8CnyabYMm7f4A8B7aR7o/ju3fyI+jBtG9U+tP+5UAUufJ+exaK+33+6r5eA/tQ5FCNuRUTu5JE2MjbD81OI+e8EehUBAXH8/xU+ezzf9DzEceBwXTv1dnVi+dxdljO6lbqyoAFy5fx8LcjMKfylu6RHGO7d8olWHl4ulMGDsEHR3tHNVrWg9f+pdc0l9jTp/rLz8XpVLJleu36NqhJcvm/8IJny1079Qq9Rr+zPyeVSc3z2Nm5clMZs9bTri6OErH16tdjeN/bJY+h/mzJjB6eO7/aE6r90tXbhD6KrVHefeBo9L27Or9r8jp94V0z2RTZ+nrZ98fvqSkpJCYKJdeCixcyEZlft7XSLvHL1y+JpUf4M79R8Dn+oyLT5B6zG/eeSC9AJLZ7yd1/q77MKf1J3oEhf8b/Xp2ZNP2fYS9icCzlRdF7QsT+CS1UeTm4kS7luoX6KxVvRKlSrhy++5DRo2fwcr1Wwl5Foq2tkxaPgKgXcvGLF+zhXsPHlO3aRdcnB1ISlLwIvQ1iYlybl06kuseGLvCtvTt0ZE1G3dw8PBxzl+6RgFLc56EPGfdstnY2hRg0rihDBgxgWsBdyhZpRG6urrS216jh/fFQF8fAI/qldlz8Ci/rd7M9Zt3uXP/0V/6C9bZyZ7bdx8yddZitu/+g9o1qzD5x+EMHDGBt+8+YGtTAH19PWmo1r14sUzzci9ejD+v3WTT9v1cvhrA6zcRaPB1vzjat2rCrHnLef0mgk69hlPUvjAvXqp/6+5Lq9ZvY5+PHzYFrTDNn096a9TGOvXnti0asXLdVm7decDEX+azesN2tGUygp+95Okd/yyHMWtWq0g9j2qc9L9I1z4jcXa0R0tLkxcvXxMbF4/PrrXYFbZl/JjBtOzUnz+v3cSlfH3sCtsQFfWW128iqFa5PE096+S4LnJ6Tw4d0IOfpszh0p83KF21CUkKBe8/ZN5bnCYyMpqGLb3In88Em4IFSEpKkn5xlfj0eU/+YRj9hv3EwcPHuXD5GgWtrXgTHkl4RBSd27egTq2qOarXtCGygFv3qFavLQYG+vjsWvvVz3Wa5ORkWnbqj7GRIbY2BdDU0OThp5dASmRxz2Ymp89jbmX2vOWEgb4+Y0f255dfl7B8zRb2/+GLubkZoa/CePvuPT94D1QZrswJ7yG9OXT0JB9j46hcpxW2NtY8DgoGoE6tKtSqXim3l5hjOf2+cHay5/jp1BGJWo06Ymluxt6tGdfEMzQwYNSwPsyYuwyfoycpVbUJSUlJ0lvXE8cO+ctlHj20L4eOneL9+xg8W/fE2dGO9+9jMDc347zfrtRndfVm7j8KoufAsdLLIikpKRQsYEn/Xp1ydb6/4z50drTnUeBTVm3YxvnL1yju4sjyBdMy7Cd6BIX/G5YW5hz/YzMd2zYjn4kxgU+eYWVhRu/u7Tm8Z73aN4Yh9S+lzWsW4FGjMjKZFvEJiSydNwXrAlYq++nq6nB4zzoG9O6CrY01QU+f8e79B8qWcmPSD8OkeWa5NWfaj8ybMZ6S7i7Exsbx7EUo7q7O0nyajm2bsW39YqpULMPHj7GER0RS0t2FJXN/VnkzbMbPY/CsVxN9PV1Cnr1k9NC+VKlY9qvKBDD7lx9wc3VGnpTEjVv3CPrU09ilY0tcXRyJin7Ho8CnFLC0oGfXtsyd/lOmeS1f8As1q1VET1eHuPgEZk0Zl2XDMSv6+nrs3PQb5dL1wG1ZuzBHxzasV4uqlcqSkJDI/YeB6Orq0KiBB7s2LUNDQwMdHW18dq1l6AAv7IrY8josnOi376lds3KmbyOmt3XdIsaNHICjQxFCnr/kTXgUxZyLMmZEP9xcU3ueq1cpz5G962lQpwYaGqm9YjJtGS2a1GfYQK9c1UVO78kBvTvjPaQ3+fOZ8CHmI571ajGwd5ds8zczzU+XDi2wsjTn+YtQQl+FUczJgck/DserSxsgdS7Vzt+XUr1KBRISEgl68gwjQ0M6tWuOV+fUXtCc1Gu3Tq1p0aQ+JibG3H8UxLWAOySnpHz1c51GS0uL3t3bU6SwLa/CInga8oIihW0YNqAH40YOyFV9Q86fx9zK7HnLqVFD+7Bi0XTKlXbn3fsYgkOeY/mpnpo3rpfr8rg4F8Xv4CaaNaqLtrY2T4KfU6SwDd5DerNt3eJc55cbOf2+GDagB7VrVsFAX4/bdx8SkMk8cICxI/qzdN4USpcsTmRkNB8+fKRS+dJsXbcowxvDX6OoQxFO+WylXcvGmJnm40lw6pxGjxqpDWY9PV0O71lP3x4dKWBpTtDT5xgZGdChdRP8/tic6x7Jv+M+nDhuKBXLlUJTQ5OAW/cyHUHSkMsT/71BcUEQBEEQBOGbIXoEBUEQBEEQvlOiISgIX6G110j8L177S3m8Dougqmc3Yj7GftXxazfv5YcpmQ+Z7th3jMFjp2e6vapnNx4/yd3w1L+lS78fOH85IPsdcyksPJK6LfvwMTbub823bss+BAWrj2Lxb1q3ZR+NOwyibss+OZoj+G+L+RhLVc9uvA7L/RIhQtb+6r2d3feF8N8lXhYR8tS0eavwO30R7XSv8C+e9SMl3ZwBUCgULFq5Fb/TFwANPOtWY8TAbshyuU7SYb+z7Nx/jE0rZv6dxRc+OeF/mZ37fQl8+owittYZ6jm3n+O2NbP/lnJV9ezG78tnUMzRDgBrKwtOHVwnbZ82bxVGhgZ4D+qeWRYZtPYayciB3fCo9nlplfR55pU34VFs2HqA3RsXULCARfYH/B9SV/ffosFjp1OragU6tWn0r53zy3v77xT97j2LV24l4M4DYuPisS1YgH7d21Czanlpn4iot8xauJaA2w/JZ2JEry6taNkk9cWo5y9fs2zdDu4+CEIuT8LBzpYhfTtT2v3zvMCqnt3Q1dVB89Pbr7YFC7B5Zdbf1+u27GOvzwkS5XJqVC7HDyN6S2/KAty695hla7cT9PQ5erq6tGpal/492qnN61FgMLMWreNVWARKpRL7IrYM7tORsiU/L9vkf/Eav63ZTkTUW1yc7PlpZF/si+R8FYBvlWgICnmuTbP6mf4i3rDtILfvPWLb6tSGwaiJc/l9+x/06db63yyikA0TYyM6tvbkZegbTn0KuZSe+Bz/ea/fRKCvr/fVjUCFQqGyptp/gSI5GS1NzX98bcM0SqWSlJR/f9r9P/3ZxccnUszRjiF9OmJhbsqFKzeZPHMZ65f+goNd6oLRk2ctw7agFUd2LeNpyEtGjp9D4ULWlCtVnJiPcVStWJofR/TBxNiIQ77+jJ44lz0bF5A/3+f19FYv/Fn6oy07h3z98Tnmz8r5kzDNb8Kkmb+xYPkmJo7uD0DQ0+f8NHURP4zsTbWKZVAkKwh9FZ5pftYFLJg1eSTWn9YD9b9wjTGT5nF453L0dHV49uIVU35dwbTxQ6lYzp3ft//BD1MXsHX17Fx3THxr/ltPvfCfc8jXnxEDu2FhnrqQbY/OLfltzbZMGxDb9x5h535fYj7GYmJiRK/OLXFxdmDOkg0okhXUbdkHSO1xKmBpzva9R9l36AQfYmJxcynK2GG9sC2Y+jZxbGwcKzbs5sKfN/jwMRa7QgWZNWkkBb5YODj67Xu8J86hYtkSDOnTias37rJkzTZeh6XGTq1dvSLjhvfKUNY05y8HsG7LPt5/+EitauX5aWQf6Uv9UWAwS1ZvI/Dpc0yMDeneobn0V/aXnoa8ZObCNQQ/C8XV2YHiLhmjs3wp4PYDJs1cSvTbD1QuX5IfR/bByNCAH6YuxLloEfp2byvtO3vxejQ0NNReS6VyqWvnHfY7q/Y8uf0c0/f8pPXm1q5RkT0Hj4MGeHVsIfW2PAoMZu5vGwl+Hoq2TEaJ4s7M+2U0vYdNBqC/91Q0NTTw6tQCzzrVaNPDG7+9qzh64jy+py6ioQE+x85gbWXBtjWzM/Q6+V+8xqKVW9i/aRHjpy/hTXgUk2ctQ0tTE8+61flhRG+VnkelUpnlfdXaayRtm9XnzIWrBD8LpZiTPVPGDaKAlTlKpZLl63Zy5MQ5EhITMTfNz/D+XalRJeu3w/0vXmPyrGXI5UnUbdkHNxdHfpsznhehYcxf9jv3Hz3FxNiQdi0aSvWWVq81q5bnwJFTlHIrhqNDIR48DsbSwpQTZy5jYmzExNH9iImNY+nqbXyI+UibZvUZ2OtzdJMrN+6ycsMuXoSGYWluyqDeHaSeIrk8iUUrt3DC/zJGhgb07Nwiy+v48/odKS89PR08qlVgWP+u6OnqZFr3X6rq2Y1Rg704cPgUL16FcXTXCt6++8CilVu49zAIPV0dWjSuQ49OLdDU1JTqoWrF0hw4chp9PV26d2xG2+YNAHL0ebZqUpdzl64T+PQ51SqW4dbdR9x9EMTq33dTuoQLC2eMU3uPt2xUh9MXrvDy1RtKFndmwuj+WH56RtJ64a7fuocGGtStVZkhfTqho6PNjVv3+WHqIgb16sCmnT6YmZowY8Jw6d42NjJEoVCwetNe/E5dJFEup3xpN0YP6YHpp+gTufm+sC1oRdf2TaWfa1YpR5HC1tx9GISDnS0vX73h9r1HzJgwDH09PdxdnWhYtxqHfP0pV6o47q6OuLt+XveuZZM6LFu3g6Dg51Qo467ulNk65OtP+5YNKVIodb29/j3aMWjMdMYM7Ymerg7rtx2geSMP6TnW1k6N/5uZfCbG0iLPKSkpaGpqEhefQPTbd9hYW3Hs1AXKlS4uPYu9u7Zizx9+3LrziPJlcr5G4LdINASFPHf0xHmOnjiPhVl+mnl60KlNaoigDzGxhEdG45zu4S3maEdYeJQUKD295y9fs+r3PWz8bTr2RWyIfvue6LfvcSpahHHDe2UYGj5y/Bzb9x1l4YxxFLYtwKoNuxk7eT6bVs5EpqXFtPmrSUhIZPWiKZib5iPw6XN0dVWXGHkRGsaoiXNp07w+ndukrnc2bd4qBvfpROP6NYhPSCDwyfMsr//S1Vv8vnwGcfEJ9B3+M76nLtK0YS2iot8x/KfZjB3Wkzo1KhHyIpSRP83GpqAlFcuWUMlDkZzMuCkLqO9RhRXzJvEwMJjRk+bhVLRwluc+dvICv82ZgJ6uDhNnLGXRis1MHDOA5p61WbhiE326tUFDQ4NEuZwT/pdZPOuHLPNTJ7efozpPn4XSqF4N/ti2hNv3HjP8p9nUqFKWQjYFmLdsEzUql2P1wp9RKJK59yn00vqlv1DVs5tKL0P6uWkdWnnyKCgkV0PDMycOz3Z48uiJ81neVwDHTl1gzhRvzM3y89Mvi1m9aQ+Txgzgyo27+J2+yMZl07E0NyUsPDLDQtfqeFSrwMLpY/lh6iKO71sNpN4TYybPp2bVcsye4s2Ll2F4T5iDaX4TPOtWS63XkJfUrlGRA5sXk5yczJbdh7hy4w7TfhrK2KG9WLdlH1PmrKBS2RJsXjmTsDdR9BwykTo1KuLi7EDQ0+dMnLGEmZNGUK5Uce7cD2T0pHmsWzIVu8I2bNx+kLsPAtm6+lf0dHX4+dflWV6Hro42P47sg5NDEcLCIxk9aR479h6lZ5eWOar7NH6nL7Fo1g/kMzYiJSWFYT/OomOrRsyaNIKot+8YPXEe5mb5adGotlQP1SqV4dD233gYGMzICbMpal+YsiVdc/R5Hjl+ljlTRlHIxpqUlBRGjP81R0PDfxw7w4LpY7G2MmfO0g1Mnb2C3+aMR6lUMu7nBZRyK8aeDQtIlMsZP20JG7YfYECP9kDqwtyBT5+zY+0cAN6++6CS9+87fLjwZwArF0zCxNiIWQvXMmX2chbP+vGrvy/SRL97T8jzVzg5pO4fFPwcc7P8mJl+DttZrKgdew+dUHt8UPAL4uITcEgXfg5g9MS5KJKTcXQozMCeHShR3Ent8Wl59O7W5vP5HO2Qy5N48fI1zo523Lz9EGsrC7wGjZeGcr0HdceucNZDuQ3a9Cc+PoHklBQa16+BjXVqg//J0xcqvZUymQz7IrYEBT//v28IipdFhDzVoWVDdq6by9FdKxg/qh+7Dviy84AvAPGfIgukD6eU1mhQt1K6pqYmSqWS4GcvSUiUY2aaL8u/AI+dvECHlg1xciiMro4OA3t14E1kFPcfPiH67Xv8L1zjx5F9sDQ3RVNTExcne5VhjIePgxkybgZ9u7eVGoEAMpkWL1+94e27D+jr6VHKPev19Hp3bY2hgT6W5qZUqVCKh4Gpi7oePXmeMiVdqO9RBS0tTRztC9O0YS38Tl/KkMfd+4G8ex9D3+5t0NaWUdLNmfoeVbI8L0DX9k2xNDfF2MiQ/j3a4XfmEikpKVStWBp5koKA26mRHvwvXMPKwgy3L1azz4ncfo7q5M9nRJd2TZDJZJQr7UbBAhbSosMymRZh4ZFERr1FR0dbZU5PXsjqvkrTpll9bKyt0NXRwbNuNekzl2lpIU9KIjjkJQqFAmsrC6nHI7fuPXxCVPQ7BvRoj66ODk5Fi9C2RQOOHP/ca2toaEDPzi3R1pZJ6/W5OjtQu0ZFtLQ0aVC7KhGRb+nesTn6eno42Nni6FCYR0EhAOw/coomDWpRoYw7mpqalC7hQvXKZTl5NnV6gN/pi3h1aiHdY9lNBShT0hUXp9SFum0LWtGqSV1ufLoHc6Nbh9T7WkdHmwtXbmJsZEinNo3Q1pZhbWVBh1ae+J2+KO2vp6er8ux41qnO0RPngJx9nq2bpi4crqWlibZ2zvtX2jSrh30RG/T0dBnatzPXb90nPCKKB4+f8iL0DUP7dUZPT5d8Jsb06NSC4+me/ZQUJYP7dERPT1ftWovHTp6nV+dWWFtZYKCvx/ABXbly4y4RUW+/+vsCIClJweSZy6hXqzLFP8XpjY9PxNhQNeydkZGB2uc75mMsk2f+Ro9OLTA3yy+l/zZ7PHt/X8i+TQupVrEMI8b/StinBaHViU9IwNjo8x+RMpkMPV1dKSLNh5iPnPC/xM8/DOLgliU4F7Vj3JSFGUI8fun4vtWcOLCWn8cNpEwJFyk9LiEhwx+txkYG0vn+n4keQSFPuTg7SP8vUdyJ7h2bcfTEeTq3aYz+p0m/H2PjpAZY2htxBgYZV1UvZFOASWMGsOeP40xfsJoSrk4M6ds50zkn4ZHRFCxgKf2so6ONhZkp4ZHRaGlpoaOtjbVV5vOt/jh2hiKFClLPo7JK+q+TR7Jx+x907DMW6wIWeHVsnuWXrLnZ57+i9fR0pWt8/SaSS1dv0aBNf2l7SkoKpdN9OaWJjHqHhbmpyjwh6wLmhLwIzfS8gMp8MmsrC5KSFLx7H4OZaT4a16/B4ePnKFfajSPHz9HMs1aWeWUmt5+jOmb586n8rK/3+Qt/wqh+rNuyn55DJ2FsZEi7Fg1o37LhV5X175DVfZXmy8887VrKl3Gjb/c2rN60h5Dnr6hYtgTD+neWeiVyIyIiGgtzU5WGiW1BK3xPXZB+trRI/SMnvfR1rfepBzx9T4+eng5x8YkAhL2J4NrN+ypTApKTkzE0qJFahqi3Ge6xrNx/9IQV63fxJOQFiXI5yckpX9UQtk4Xd/X1mwiehrxUfY6UKRRIt0C8umcn4PZDIGefp7XV1y02n74+zEzzoaOtTUTU20+95bF4thsobU+df/g5Dq+BgV6GmMPphUdGU9D6c/6W5qboaGsTHhH91d8XSUkKxk9fjK6uDj+N/BzWTl9fN8PbyrGxcRme74+xcYwcP4dSJYrRt3sblW2fe9W06dKuCSf8L3Pxyi3aNKuH94Q53LqbGsrNq1MLenZuib6enso5FcnJJCQmSi+L6Ovr0bRhLRztU3st+3m1ZfveI7x4GcbjJyHMXrw+9bo/TQlJT09Xh0b1atCl3w/YFbahdAkXDPT0+Bineo0fY+NVXk75fyUagsI3RUPj8y8lE2NDrCzMCHzyjEI2qbFUA58+p4CleabDifU9qlDfowoJiXLWbNrD1Dkr2LrqV7WTxa0szHj95vNQYVKSgsjot1hZmFGwgAXypCTehEdlmBOYZuTAbhz2O8uE6UuYMWGY9KXq4uzArMkjSElJ4ezF60ycsZRypYqr/DLNiQKWZnhUq8C08UOz3dfCPD+RUW9VJo2/CY/K9rjXbyJx/xQRIyw8Cm1tmdRYa+7pQc8hE/Hq2JyA2w+ZPG5gVlll6ms+x9woZFOAn8cNRKlUpg4b//grJd2ccXV2yPYlAbXxOfX0SEiQSz9HRb1T2a6ZTZ5Z3Vc50bZ5A9o2b8DH2DjmLNnAguWbmffL6Bwdm56lpVmGe+L1mwiVcmR3LdmxsjCnYytPBvdRHz7L0tw0wz2WlcmzltGsoQdzpnqjr6fHjn3HVHowc1pejXSN2wKW5rg627N28dRM91f37FhamH66xuw/Tw1N1XJpauRssC19j1f0u/fIk5KwNDdFqQTT/CYc2r4s02OzO4eVhRmvwz7XfVT0O+RJSVhZmpGUlJTr74ukJAUTpi8hKUnBnCmjVP7AcHIoQmT0W6LfvZf+kHj85LnUCIO0RuBsHOxs+WF472yfTc10dapujqWTQ2ECnzyXpskEPnmGjrY2hT/94fDlaFD683nWrY5n3epZnh9SG5cvQsMoXcIFx6KFVab5KBQKgp+F4uiVs+H0b5kYGhby1An/y8TGxqFUKnnw+Cmbd/lQu0ZFaXvThrXYuOMgUdHviIp+x+87DtL807yeLz178Yor1++QkChHWybDQF8PrU9zeMxM8xEZ/Y6ExM+/4D3rVWPPH8cJfhaKXJ7Eqt93Y2luhpurI2am+ahVtTxzlq4nMuotKSkpPAoKUVmbTUdHm9lTvElKUvDTtMUkJSlISlJw9MR5PsTEoqmpidGnoQstrdw/ao3q1eD6zfucPncFhUKBQqHg8ZNn3H/0JMO+JYo7YWJsxPqtB0hKUnDvYRAn/DO+vfulbXsOExH1lpiPsazZtIf6HlWkHqLCttYUc7Jn0szfqFKxVIZeufSSk1NIlMtRKJJRKiFRLleZ25abzzG3jhw/R/Tb92hoaGBkZICGpoZ0DWamJoS+epPpsWam+XgVFq4Ss7mYkz3Hz1wiUS4n9HU4e31OZDgmq7cPs7qvsnP/0RNu33tMUpICXR0d9PV0pXsnbd3JnK7B5+5SFDPTfKzetBe5PIknIS/YffA4TRrUzNHxOdGqaV0O+Z3l+s37JCenIJcnced+ICHPU3uWGtSuyuZdPtI9tn7r/izzi4tLwMjIAH09PUKeh7L/cO7qXp3qlcsS/fYDe32OS72Mz1684satz+HKEhISVZ4d31MX8ayT2lD4ms/TzNSE0NeZ33dpDhw5xbMXr0hIlLN87Q7KlHTFytKc4sWKYmVhzqqNu4mNi0epVEojBDnVqF51ft/xB2/Co4iLT2Dxqq1ULFsCS3PTXH9fKBQKJs5YSnxCIrOneGeIyV3IpgCl3IqxcsMuEhISuffwCX6nL9C8kQeQ2jvoPWEOhW0LMt67b4ZG4JOQFzwMDEahUJAol7PrgC/Bz0KpUqFkpmVq6unB7oO+vAgN42NsHGs27aVBnapSL3arJnU44neOZy9eoVAoWLdlH4VsrSlcyFptfucvBxD09Hlqz2JCIhu3HyQ8Mpoyn6aaNKpbnes373Pxyk3k8iQ2bj9I/nzG0vb/Z6JHUMhTe/84zuzF60lOTsbSwpS2zerTpW0TaXvvrq14H/ORzv1S/yL0rFudHpm8eZikSGb1pj0EPw9FU0MTp6JFmPRpKYEKZdwo4epEiy7DUCqVbF45kyb1a/L27QfGTJ5HzMdY3FwcmTt1lDQBfNLYASxbu4NewyYTFx+PfWFbZk1SDRKvq6PDr5NHMn76En78ZSGzJo3E7/RFFq3cgkKhoIClOVN+HCy9jZYbVhZmLJw5juXrdjB7yXpSUpTYF7Ghn1fbDPvKZDLmTB3FrIVr2bHvKMWLFaWZZy0ePH6a5Tk861Zn6LgZREW/p1L5khlemmju6cG0eavUnjO9YyfPM33+aunn2s17Y13Agv2bFgG5+xxz62rAPZat20F8fAJmpvkYmm46QH+vdixYsZlZi9bSrUMzGnhUVTm2RaPaTJyxFM92A7CyNGfLylkM6NmOKb8up0mHwTjY2dK4fg2VSe9enVqwcPlmNmw7QMM6VRk7TPUt6uzuq6zExsWzdPU2Ql+Ho6WlRUk3Jyn/sIgorAtYSD1V2ZHJZMz7ZTTzl/1Os85DMDYypHObxjSsUy1Hx+eEi5M9v/w0hFW/7ybk+Ss0NTVwLmrHsP6pcY57dmnJ23cf6Nr/RwwN9enVuSUXr9zMNL9xI3qxZNU2lq/bgYuzA/U9qnLu0nVpe3Z1r46Bvh5Lfv2RZWt3sH7rAeTypAxvwRa1L0RycjLNOg9FT1eHAT3bS0OVX/N5dmzdiGnzVtOgTX9KuRdj/rQxavdr1tCDyb8u4+WrN5RwdWLqD4OA1D8c500bzfK1O+jcbxyxcfFYW1rQqmndbK9XqquOLYhPSKSf9xTk8iTKlXZjyqf8c/t9cft+IGcvXUdHR5vG7Qd9PsenYVqAqT8NYdbCtTTuMBgTY0OG9OlMuVLFAThz8Rp3HwQR9PQF/heuSsf/MKI3nnWr8+5dDHN/28ib8Ch0dLRxdCjEghnjspwS0dzTgzfhkQzw/oVEuZzqlcuqfH951q1OeEQ0Q8fNJFEuz/Zze/8hhqVrthIRmTrX2NG+MPN/GSONYtgVtuHnHwaycMVmwiOjcXGyZ86UnD3X3zoRa1gQhEwF3HnIxBlLObh1yX/iC+//2bot+zAzzUfrpvXyuij/KXm12Pz/y+LYwn+f6BEUBEGtpCQF2/ccoUXj2qIR+A3o061N9jsJgiDkkpgjKAhCBjduP6Bh2wG8+xBDt3ZNsz9AEARB+L8khoYFQRAEQRC+U6JHUBAEQRAE4TslGoKCIAiCIAjfKdEQFARBEARB+E6JhqCQJ5RKJQqFQmUhX0EQBEEQ/l2iISjkieTkZGo27UlyNgHABUEQBEH454iGoCAIgiAIwndKNAQFQRAEQRC+U6IhKAiCIAiC8J0SDUFBEARBEITvlGgICoIgCIIgfKdEQ1AQBEEQBOE7JRqCgiAIgiAI3ylZXhdA+L5Z2JfP6yIIgiAI/0fevbyV10X4TxENwWzExsXTvPNQ6nlUYcKoflL6jVv3WbRyC5tWzMxwTFXPbhS1L4SmhiYpyhR6d21NvVqV1R7zOiwCr8ETOL5vdY7O6T1xLnaFCgKgUCTTsXUjWjapA8C0eau4cuMupvmMpWM6tPLk9v3HPHwcDEDw81BsrC3R1dEBYMX8SRga6Ev7H/Y7y9mL15k9xZvXYRG06eFNM08PqRxx8QnUa9WXS75bpGP2/HGc/YdOkpySgq6uNnaFCjK4TyesrSy+osYFQRAEQfi3iIZgNk76X8bF2QH/C1fxHtQdA329HB23cv4kjI0MefD4KYPGTKd8abe/5Zx2hQpKDcnwiCja9RpN/dpVpMZc13ZN6dSmkUp+zTw9pP+39hrJtPHDKOZol6Oy6OnqcvnqLYKfheJgZ5th+5pNe7ly4w4LZ4zFytIcgKsBd4mKfi8agoIgCILwjRNzBLPh4+tP9w7NKFPClRP+l3N9fPFiRTHQ0+P1m4i//ZyxcQno6eoik2nlulw5JZNp4dWpBSvW78ywLT4hgS27DzHeu5/UCASoWLYE7q6O/1iZBEEQBEH4e4gewSwEPwvlTUQUlcuXIjk5mU07D9GiUe1c5XHlxl3kSUkUtrXmcVAIz16+xmvQeGl7kkKRq3OmHZ+kUBD6OpxRg72kYV6ArXsOc+T4WennUYO9KFPSNXcX/oXWTeuyc/8xbt17jHPRIlL605BQtGUytT2FgiAIgiB8+0RDMAs+x87QuF4NtLQ0qVqpDLOXrCfkeSj2RbJv+AwcPQ0tTU2MjQyZM8UbI0MDQHVoFz7PEczpOb8cGh4w6heKOzvg4uwAqB8a/qtkMhn9vNqxfN0OFs4Y99X57PnjOHt9jgOgVCr/ruIJgiAIgvCVREMwEwqFgmMnL6Al08LvzCUAEhLk/HHMn+H9u2R7fNocwX/ynFaW5ri5OHL15j2pIfhPaVinKlv3HObcpetSmoOdLUkKRabzB7/UrkUD2rVoAKRea82mPf+p4gqCIAiCkAOiIZiJc5duYFPQkrWLp0ppIc9DGTx2BoN7d/gmzvkxNo5HQSE0qlf9HylPehoaGgzu3ZE5SzZIaQb6enRp14RZi9YyfcIwrCzMALh+8z56erpinqAgCIIgfONEQzATPr7+eNZVbWDZF7HF0sKU85cDMDE2JPh5KC26DpO2lyjuzMyJw//Rc6afYyhPUuBZtzo1q35ei+/LOYIN61ajW/tmX12m9KpUKIVNQUuVF1/6e7Vjl4kv3uPnkJySgoYGOBe1Y0ifTn/LOQVBEARB+OdoyOWJYrKW8K9LGxo+d3gjMpn4e0QQBEEQ8oJYPkYQBEEQBOE7JbpihDwlQswJgiB8W0QIt+/Ld90QbO01Eh1tGbo6OsiTFBRztOMn7z7o6+mphHNLUSrR1dHBe1B3ShR3ko4/fzmA9Vv3ERsXj0KRTKVyJRnatxOGn5aKAQh9HU77XqPp270Nvbu2ltIP+51l4YrN2BS0Qi5PQlsmo3aNCnRt3ww93dR1ARXJyfy+/SB+py8h09JCS0sTNxdHhvTthLGRIeGR0SxdvY37j56gqamJhbkpQ/p0ksp42O8s0+evZviArnRu01g696Ax07l55yF+e1dleLP5yzB4VT27UaGMO0tn/yTt06j9QDYsnUZBa0sATpy5zNY9h4mLj0dfTw8Lc1MG9uqAk0Phv+ujEgRBEAThH/BdNwQBKdxaSkoKY3+ez2G/c9ISJ+nX7Nt90I8ZC1azfc0cAC5dvcXsJeuZ98toXJzsUSQns3jlFsZMns/yeRPR0NAA4JCvP+VLu3HY7yy9urSS0gHKl3Zj9hRvAKLfvWfWwrVMmrmUuVNHAzBzwRo+xMSyZtEUTIwNUSqVnDp3hQ8xschkWgwZO4MWjWozbfxQIDW029if5/PbnPE42qc2woo52XH0+DmpIfgiNIzERHmu6ij0dTiXr92mSoVSGbYd8vVn004fZv/sLS0h8zAwmMiot6IhKAiCIAjfODFH8JMkhYKEBHmma/9VLOtO2Jso6eeN2w/Ss3MLXJzsAZBpaTG8f1dCw8K5fus+AMnJKRw+fpZRg70w0Nfn2s17mZ7fLH8+Jo0ZyNWAezwNecmL0DBOnbvCxNH9MTFOLZOGhgb1alXGtqAVx09fwtjIkO4dm6crYwmaNqzFll2HpTRrSwvy5zPh/qMnQGrDrVnDWrmqm35ebVm+fqfaRaDXbt7HyIHdVNYRdHV2UNtoFARBEATh2/LdNwQnzVyK16DxNOs0FA1NDep5VFa736lzV6hfu4r086OgEEoUd1bZR1tbhquTAw8DgwH48/ptrCzMcLCzpXkjD3yO+WdZFhNjQwrbWPP02UseBYVQ2Maa/PmM1e77KCiEkm5OGdJLFHfi0afzp2nasBaHfM+SnJzCybN/0qBO1SzL8aUaVcpioKeL3+mLKunR797zJiIqQz0IgiAIgvD/QQwNfxoaViQnM3vxepav3cHwAV2Bz3F9o96+Jzk5WWWh55zwOeZPM08PADzrVmPNpr18iImVevjUUfL3r+ZTu0YFVm7chf/Fa7i7OuU64gnA4D6dmDpnBXVrqm8o54QIMScIgiAI35bvvkcwjUxLizo1KnL52m0pLW2O4MEti/GoVoEps5dLDRgXJ3vuPghUySMpScHDoGBcnOx5++4DF6/cZMPWA7T2GknPoZNQKJLxPXUh0zJ8iInl5as3ONoXxsXJnhevwnj/IUbtvi5O9ty5H5Qh/e6DIFyc7VXSdHV0qFqhNHOXbqCZZ+6GhdOUci+Gk0MR9h06IaWZ5c+HlYVZhnrITLsWDdi+Zg7b18xhy8pZX1UOQRAEQRD+PqIhmM61m/cpUrhghnSZTIb3oO6ER0bjf/EaAD06tWDjtoM8fvIMSH3Dd8nqrRQsYEmFMu4cPXGeWtXKc3DrEvZvWsT+TYuYOWk4Pr7qh4ffvvvAjAWrqVjWHQc7WwrbWlOnRkVmLlhLzMdYILUX7fS5K4S+DqdBnap8iPnI5p0+6cp/j0O+/nRt1zRD/p3bNqZb+2ZUKOP+1fUzsFcHNu30ISlJIaX16d6Gxau2EvL8lZT2KCiEP6/f+erzCIIgCILw7/juh4YnzVyKro4OyckpWBcwZ9yw3mr309PTZUDP9qzbvB+PahWoVqkMY4f1YuaCNcQnJKBQJFOxbAnmTxuDhoYGPr5nGPxFmLWK5Uowbd4qaQ7f9Vv38Ro8gcREOTra2nhUL0+3Dp9f/pgwqh8bth2k74if0dLUIkWppExJFyqUdUdfT49lcyawZPVW2nh5o6WliYVZfuZMGYVT0SIZyl/Y1pqu7TM2EHPDwc6WapXKcChdY7ZFo9ro6ugwZfZy4hMS0NLUwtbGikG9Ov6lcwmCIAiC8M8TIeaEPCFCzAmCIAhC3hNDw4IgCIIgCN8p0RUj5CkRYk4QBOHbIkLMfV/yvCGYVRi1jx/j8Bo8geP7VqscU9WzmxQebfDY6YS9icLIUF/aPrhPJ85duo6uri7D+3dROXbczwsoW8qV2tUr0q7XKBztC5O2ksnAXu2pXrmstO/te49ZsWEXkVFvSUlJwd3VkeH9u2JhbgrAtHmr8Dt9kR1r52Jb0AqAJau3YaCvS9/ubdVe754/jrP/0EmSU1LQ1dXGrlBBBvfphLWVBR9j4/ht7Xau3riLTCbD0ECPvt3bUq1SGYBsw96t3byXvT4nsDQ3RZ6kwMmhMOOG986wXM2NW/cZMm4m/bzaSmHvnoS8YMzk+ezftAhQDb+XZvK4QfhfuMqbiCjGe/cD4NbdRwwcPY1lc8ZTrrQbALMXryd/fmMG9GifxScvCIIgCEJey/OGYFZh1DTThWPLyoiBXfGoVkElLX8+Y0ZPmsfgPh2RaWkBEBX9jqsB9/jJuy8JCYkY6OtLIeTOXw5g8q/L8NuzGi0tTYKePmfclAVMGz+UimVLALB5pw9Dxs3g92Uz0NPTBcDS3IxVG3fxy09Dsy3nmk17uXLjDgtnjMXK0hxIDQsXFf2eApbmjJo4l2KO9uxcPw+ZlhaPnzxj9KR5TBrdn0rlSwJZh70DaFinGt6DupOcnMKEGUvYuO2AtC5ieuZm+dhz8DhtmtXPdNHqtDUW04v5GMuM+Z8b5tdv3cfd1ZEbtx9IDcEbt+9n+tKNIAiCIAjfjjydI5hdGLW/wtXZAXPTfFz886aUdvTEeapWLIVpfpMM+1co605cXAIfYj4CsGX3IZp5ekiNQIDuHZtjaGDAcf/LUlrLJnW4fS8wQzSPL8UnJLBl9yHGe/eTGoGQGhbO3dWRqwH3CAuPZMSArlLDtZijHT07t2DDtgNq8/wy7F16WlqaVCzrzrOXr9VuN8ufj0b1qrNh2/4sy/2lEq5OREa/Izwi9bw3bj+gd9fW3Lj9AIDIqLeEhUdRQk3UE0EQBEEQvi152iOYXRg1gLj4eLwGjc8yn8Urt7Ju8z7p55mTRlDIpgDNG9XmsN9ZalVLnYd2yO8sI9T0jgGcPneF8mXcpEbio6AQateomGG/km5OPAwMpvmniCG6Ojr07taaZet2suTXHzMt49OQULRlMpWYvOk9DgrB1ckBbW3Vj6REcWd+W7ND7TFfhr1LLyFRztmL17MM/9ajc0s69x1Hx9aN1G5PW1onzepFU9DT1aFkcWeu33pAvVqVeR0WQbVKZViwfBOJcjnXbz2gZHFnleMEQRAEQfg25fnQcHbSD9+mqerZTeVndUPDkDpMunLDLqLfvedl6Bvi4xOo/GmIFT43Mj/ExPLuQwy/zc66wZmZpg1qsX3vEa78C4soZxf2zu/0RQLuPASgbElXundsri4bAPKZGNGhtSerNu7Bq1PG/dQNDQOUL+3GjdsPsC5ggZuLI5Aa4/ju/SACbj+gXOnias8nQswJgiAIwrclT4eGswuj9lflMzGieuUyHDtxgUN+/jRpWBNNzc+XnNbI3L95Ed07NGfSrN9IlMulst19kDGE2537Qbg42aukaWlpMrBXB5av3wmZNHAc7GxJUigIfhaqdnsxJ3seBgWjUChU0u8+CMTF6XNjLKuwd5Da+N20fAabls/Ae1B39HSz7pnr1LoRAXce8DjoWZb7pVeudHFu3LrPjVv3KVsqtdFXtmRxrt+6z/Vb9ymfSfQSEWJOEARBEL4tedoQzC6M2t+hmWdtDh49zamzV2jW0EPtPhoaGvTu2or8JsbsO3QSgC7tmuJzzJ+rAXel/bbsOkTMx1ga1q6aIQ+PahXQ1tbmzIVras9hoK9Hl3ZNmLVoLeGR0VL69Zv3uffwCRXKuFHA0pxFK7eiSE4G4PGTZ2zc/gc9u7TKkJ+6sHdfQ09Pl15dWrFm094cH+PmUpS37z7ge+oi5dIagqVcOeF/majod7i7FP3q8giCIAiC8O/J86HhrMKoffwYl6M8vpwj2LV9UzzrVgdSX6hISlLgWswhyxdQNDQ0GNa/C5Nm/kbrJnUp5mjHnCnerFi/kzlLNpCcnIKbS1GWzZ0gvTH8pSF9OjJozPRMz9Hfqx27THzxHj+H5JQUNDTAuagdQ/p0QlNTkwXTx/Lbmu106DUGbW0tDPT1GTe8F1UqlFKb35dh775W80a12bHvKPIk1d7IL+cIjhjQjfJl3JDJZJRyL0ZQ8HPsi9gAUKRQQeLi4ynlXkxEChEEQRCE/xMixJyQJ0SIOUEQBEHIeyLEnCAIgiAIwndKdMUIeUqEmBMEQfi2iBBz3xfREPwkq1B3xkaGhEdGs3T1Nu4/eoKmpiYW5qYM6dNJCu8G8DAwmJUbdvEiNAwTYyO0tWV0bd9UZf7eoDHTiYiMZveG+WhkETnlyo27rN+yj8jodxgbGWJoqE/fbm0oU9IVpVLJ1t2H8fH1R0NDA6VSSYtGtenSromUZ/owfOr8Mncl/hevcWj7b+jr6WVajuyu6bDfWbbtPUJycgoKhYK6tSrTr3vbDOshCoIgCILw7RG/rT/JKtSdTKbFkLEzaNGoNtPGp4aSuxpwl7E/z+e3OeNxtC/M05CXjBw/mwmj+1OzSjkAIqLecuXG57UFX4SG8TI0DGMjw0/r7bmpLcuVG3f5Ze4KZk4cQSn3YtKxgU+fA7Bywy5u3n3EqgWTyZ/PmHfvY/hh6kI+xsXlKL5vbGwc5y8H4OxQhFNnr9C0YS21+2V3TQeOnGLHvmMsmD4GG2srEhISmTpnJTMXruHncYNyUu2CIAiCIOQhMUeQ7EPdHT99CWMjQ5XFmSuWLUHThrXYsuswAJt3+dDM00NqMAFYmpvStMHnRpaPrz+e9arTvHFtfHz9My3P+i376NWlldQIhNSldurWrERcfAI79h3jxxF9pIgs+fMZ8+OIPmzbc4T4hIRsr9fvzCUqlnWnU9vG+Bw7k+l+2V3T+q37Gd6/CzbWqW9j6+np8uPI3pw+f5WXr95kWw5BEARBEPKWaAiSfai7R0EhlFQTO7dEcScpxvDDwGCVYeIvJSencPT4OZo19KBxvRqcvxzAx1j1y+M8DArJNDRc8LNQtLUzhqpzsLNFWybLdMHq9HyO+dPM04Malcvy4tUbnr14pb4cWVxT9Lv3RES+zVDOfCbGFLax5lFQSLblEARBEAQhb4mh4X/Jxas3sS5gKa27V7GsO36nLtKmef1c55XV3MLsBAW/ICr6HZXLl0RTUxPPutU55HuWIX07fXWeOSVCzAmCIAjCt0U0BFENdZfPJGOvoIuTPQeOnM6QfvdBEC7O9gC4Ojtw90EQtatXVHuOQ8f8eRH6mtZeIwFITJTz+k2k2oagq5P9p9By9hm2OdjZIpcnEfwsVKVXMPhZKEkKRYaewi/5HDtDXHwCbXuOAkChSEapTGFAr/bItLRUy5HFNZnlz4elhSl3HwRSrVIZKf39hxhevApTW/Z2LRrQrkWDT+dNXUdQEARBEIS8I4aGyT7UXYM6VfkQ85HNO32kY67dvMchX3+6tmsKQNf2zTjk68+FPwOkfaKi33H4+Fmi377n2s177N4wn/2bFrF/0yIObf+NyKi3BD7JGOO3V9fWbNx2UCXW8ctXbzh17goG+np0aOXJ7MXrePc+NUbz+w8xzF68js5tGmf5BnBSkgLfUxdYs2iKVA6fbUspYGnBxT9vZtg/q2sC6NmpJUtWb+NVWGo4wISERH5dtB6PahUoZFMg23oXBEEQBCFvicginygUCjZsO8gJ/0sqoe6G9EldPuZNeBRLVm/lweNgtLQ0sTDLz6DeHVVe6Lj/6AmrNu7m5as36OnpYqCvj1fHZjx78Zp7D58wa/IIlXMuXrWF5OQURg32ylCey9dus2HbAaKi36Grq4NpfhP6dW9L6RIupKSksGX3IQ75nkVTUxOlMoXmnrXp2r6pyvIxFuampB9FHt6/K1t2HWLjMtUweLsO+HI14C5zp47OUI7Mrqlm1dT1//44epqd+31JTkldPqZ2jYr092qHjo52tvVds2lPHty7k+V+giAIwr9LrCP4fRENQSFPiBBzgiAIgpD3xNCwIAiCIAjCd0p0xQh5SoSYEwRB+LaIoeHvi2gI/ktae41ER1uGjrYO8QkJFLUrRLcOzVTmGELGEHRzl25AV1eX4f27qOw37ucFlC3lSu3qFfEaPIHj+1bjNWg8AEkKBc9fvsbRvjAARQoVZPqEYYS+Dqd9r9H07d6G3l1bZ1nW2T97U8zRjmnzVuF3+iI71s7FtmDqwtFLVm/DQF+Xvt3bAqkvsixft4OHgSGYGBuiqalJqyZ1aNG4zt9Wf4IgCIIg/P1EQ/BfNG38MIo52gFw5vxVRk+ax6KZ43B3TV20WV0IuuaNajN60jwG9+koLe8SFf2OqwH3+Mm7LwkJiVL+m1bMBOB1WARegydIP6c55OtP+dJuHPY7S68urXK8HqGluRmrNu7il5+GZtgWFf2OgaN/oV/3dsyclPoyzIeYWE74X85l7QiCIAiC8G8TcwTzSO0aFWndtC5b9xyR0tSFoHN1dsDcNJ/K8i5HT5ynasVSmOY3yfH5kpNTOHz8LKMGe2Ggr8+1m/dyfGzLJnW4fS9QiqKS3h6f45R2d6Flk8+9fybGhrRpVi/H+QuCIAiCkDdEQzAPubk6EvzsJZB1CLrmjWpz2O+sdNwhv7M0b1Q7V+f68/ptrCzMcLCzpXkjD3yOZR7r+Eu6Ojr07taaZet2Ztj2KDCEEm7qw+EJgiAIgvBtE0PDeSndwj1ZhaBrWKcaKzfsIvrde16GviE+PoHK5Uvm6lRp8YUBPOtWY82mvXyIicXE2DBHxzdtUIvte49w5frXr/snQswJgiAIwrdFNATz0P3HTylqVwjIOgRdPhMjqlcuw7ETFwh5EUqThjXR1Mx5Z+7bdx+4eOUm9x894fcdfwCpoeV8T12gfcuGOcpDS0uTgb06sHz9TsqVKi6luzjbc/d+ILRpnG0eIsScIAiCIHxbxNBwHjl78Tr7D52kS7smOQpB18yzNgePnubU2Ss0a+iRq3MdPXGeWtXKc3DrEin/mZOGS/MQc8qjWgW0tbU5c+GalNa2WX0C7jzkULq8Yj7Gsv/wyVzlLQiCIAjCv080BP9Fk2YupfvA8bTrOQof3zPMnzYGd1cnjhw/R6VyJTE2+jxMq6mpSf3aVaTGWsWy7iQlKXAt5iAt45JTPr5naFi3mkpaxXIliIx6q/YFkKwM6dOR128ipJ8tzE1ZtWAyF/68SRsvb7oN/IlhP8wS0UIEQRAE4f+ACDEn5AkRYk4QBEEQ8p7oERQEQRAEQfhOia4YIU+JEHOCIAjfFhFi7vvy3TcEcxL67fa9x6zYsIvIqLekpKTg7urI8P5dsTA3lfY57HeWbXuPkJycgkKhoG6tyvTr3hZtbZnKeXR1dEiUy2nasBZeHVsAqZFA2vUahaN9YZJTUlAokilTwoU+3VpjZWkunSM2Lp7mnYdSz6MKE0b1k9IVCgVLVm/jWsA9tLS0UCQraNGoNp3bNpGijBzft1rluqt6dsNv7yqVeYkAN27dZ9HKLVJUkqqe3ahQxp2ls3+S9mnUfiAblk6joLUlACfOXGbrnsPExcejr6eHhbkpA3t1wMmh8F/6bARBEARB+Gd99w1ByDr0W9DT54ybsoBp44dSsWwJADbv9GHIuBn8vmwGenq6HDhyih37jrFg+hhsrK1ISEhk6pyVzFy4hp/HDcpwnvDIaLr0+4Hypd1xd3UEwEBfX2p8JSUp2LDtAP29f2HLqlkYGRoAcNL/Mi7ODvhfuIr3oO4Y6OsBsHO/L5FRb9m0ciYyLS0S5XJCX4X/bfUT+jqcy9duU6VCqQzbDvn6s2mnD7N/9sbBzhaAh4HBREa9FQ1BQRAEQfjGiTmCX/gy9NuW3Ydo5ukhNQIBundsjqGBAcc/xdNdv3U/w/t3wcY69W1ePT1dfhzZm9Pnr/Ly1ZsM57CyMMOusA1h4ZFqy6CtLaN/j3ZYWphy7OQFKd3H15/uHZpRpoSrSizf8MhoTPObSLGIdXV0KGpf6C/WxGf9vNqyfP1OtYtAr928j5EDu0mNQEgNi6eu0SgIgiAIwrdF9Aiq4ebqyLnLNwB4FBRC7RoVM+xT0s2Jh4HBVK9chojIt5QorhpmLZ+JMYVtrHkUFEIhmwIq20Kev+L9hxiVhZnVlsOlqBSCLvhZKG8ioqhcvhTJycls2nmIFp/CzLVsXAfvCXO4fusBpd2LUaGsO3VrVkZLK7WdHxcfj9eg8V9VFwA1qpTl4JFT+J2+iGfd6lJ69Lv3vImIynDtgiAIgiD8fxANQXX+oQV1Js1cioaGJs9fvmbEgK6Y5jfJuhjpyuFz7AyN69VAS0uTqpXKMHvJekKeh2JfxJai9oXYs3EBt+494s79QNZu3suxk+eZP20soDrsnKaqZ7dclX1wn05MnbOCujUr5+q49ESIOUEQBEH4toiGoBrpQ7+5ONlz90EQtaur9greuR9Eq6Z1McufD0sLU+4+CKRapTLS9vcfYnjxKgwXJ3spLW2O4JUbdxn783zKl3HPch7dg8dPaVSvOgqFgmMnL6Al08LvzCUAEhLk/HHMn+H9uwCpw8kVyrhToYw7LRrVplnnobz/8PFvqhEo5V4MJ4ci7Dt0Qkozy58PKwuzDNeeGRFiThAEQRC+LWKO4BfSh34D6NKuKT7H/LkacFfaZ8uuQ8R8jKVh7aoA9OzUkiWrt/EqLPUFjYSERH5dtB6PahUyDAsDVCpXgjbN6rF64261ZUhKUrBuyz7CI6LxrFudc5duYFPQEp9tS6UQcWsXT+HYyfMoFAoC7jwkMuqtdPzDwGBMjI0wNjL42+oFYGCvDmza6UNSkkJK69O9DYtXbSXk+Ssp7VFQCH9ev/O3nlsQBEEQhL+f6BEkdcg2bfkYBztbKfQbQDFHO+ZM8WbF+p3MWbKB5OQU3FyKsmzuBPT0dAFo07w+MpkWYycv+LT8i4LaNSrS36tdpufs1aU17XuN5mFgMPmMjaR5fMnJKSiSFZQu4cLqhT9jZGiAj6+/ytw8APsitlhamHL+cgAJiYksWrkZuTwJbZkMfX095kzxRlPz723nO9jZUq1SGZW4wi0a1UZXR4cps5cTn5CAlqYWtjZWDOrV8W89tyAIgiAIfz8RYk7IEyLEnCAIgiDkPTE0LAiCIAiC8J0SXTFCnhIh5gRBEL4tIsTc9yVPGoKp4da02br6V2kR5F5DJzGsX2ei331g6+7DbPhtmsox2/cd5cat+8ydOprWXiOZ/bM3xRztmDZvFVdu3MU0vwnx8QmYmeajVZO6NK5fA0BtiLXMQrWps+eP4+w/dJLklBR0dbWxK1SQwX06YW1lwcfYOH5bu52rN+4ik8kwNNCjb/e20hu0N27dx3viXOwKFSRFqURXRwfvQd0pUTx1/uHazXvZ63MCS3NT5EkKnBwKM254b0yMDVEqlWzdfRgfX380NDRQKpW0aFSbLu2aoKGhAaQuAVPUvhCaGpookhV0bdeUZp4eUtmVSiVte4zCpqAlv80eT0TUW0ZPnAtAXHwCEVFvsStUEIBypd2oVbWcSni5nFzfkHEz6efVlt5dWwPwJOQFYybPZ/+mRbm6JwRBEARB+PflWY9gUpICn2NnaN20nkq6R7UKzPttI0HBL1SWVjnk68+AHu3V5tW1XVM6tWkEwOMnz5g0cynv3n+gc9smavfPLFTbl9Zs2suVG3dYOGOsFPP3asBdoqLfU8DSnFET51LM0Z6d6+ch09Li8ZNnjJ40j0mj+1OpfEkA7AoVlBpWuw/6MWPBaravmSOdo2GdangP6k5ycgoTZixh47YDDB/QlZUbdnHz7iNWLZhM/nzGvHsfww9TF/IxLk6lHlbOn4SxkSGBT57Re/hkqlQoJcVAvhpwDyMjA54Ev+BVWDg21lZSWb6MKZyWlkapVObo+szN8rHn4HHaNKtP/nzGautREARBEIRvU57NEezTvTUbth0gISFRJV1bW4Zn3eoqb6bee/iEd+9jqFa5TLb5FnO0Y+TA7mzedSjTRYszC9WWXnxCAlt2H2K8dz+pEQhQsWwJ3F0duRpwj7DwSEYM6Cr1ahZztKNn5xZs2HZAbZ4Vy7oT9iZK7TYtLU0qlnXn2cvXxMUnsGPfMX4c0UdqXOXPZ8yPI/qwbc8R4hMSMhzv7GiHsZEh4ZHRUtoh3zO0bFybhnWq4pOuPnMip9dnlj8fjepVZ8O2/bnKXxAEQRCEvJdnDUHnonaUL+3Gjn3HMmxr3qg2fqcuolCkrld3yNefJvVrSg2S7Li7OvH23Qfevv+QYVv6UG3NG3ngc0x9A+lpSCjaMplKDN30HgeF4OrkgLa2aqdqieLOPAwMUXvMqXNXqF+7itptCYlyzl68jquzA8HPQtHWznhuBztbtGUygp+FZjj+xu0H5DcxxrmoHQDvP3zk8rXbNKxTjeaetTnid46UlBS15/6r19ejc0uOn74sraMoCIIgCML/hzx9WaS/Vzv6DP+Z1s3qqqQ7ORTGuoAF5y8HUKViaU6evcyaRVNynG9W4cuyCtX2T3j28jVeg8YT9fY9ycnJrF08VWW73+mLBNx5CEDZkq5079icJ8EvpHmA2Rk4ehqJiXJev4lgxsThUsPN7/RFqlQojbGRIcZGhpiZ5uPP63eoWrH033uBQD4TIzq09mTVxj14dWqe6X4ixJwgCIIgfFvytCFY0NqSBnWqsmHbwQzbmjfy4JDfWRISEylqVwi7wjY5zvfB46eY5jfBLH8+XodFSOk5CdWWxsHOliSFguBnoWp7BYs52bProC8KhUJlHby7DwJxcbKTfk6bI6hQKJi7dCNTZi9nzaIpUkMvbY7gl+eWy5MynDv4WShJCoVKWtocwcN+Z5k+bzWl3IphZpoPn2NniHr7ntZeIwGIi0vA59iZHDcEc3p9aTq1bkSHPmOoUqFUpnmKEHOCIAiC8G3J83UEe3Vphe+pCyoh0gAa1q7KzTsP2bb3KM0b1c5xfkFPn7No5Ra6d2iWYVt2odrSM9DXo0u7JsxatFZl3t31m/e59/AJFcq4UcDSnEUrt6JITgZSX1TZuP0PenZpleHcMpkM70HdCY+Mxv/itSyvwUBfjw6tPJm9eB3v3scAqbGLZy9eR+c2jdHXy/hyS9OGtahQ1p3fdxzkYWAwb9/HqFznno3z+fP6Hd6+yzhcrk5ur09PT5deXVqxZtPeHOUvCIIgCELey/N1BPPnM6Z9y4YZGhCGhgbUqlYe/4vXqFurUpZ5bN1zmCPHz5KQKMc0vwleHZvTpEHNDPtlF6qtdo2KKtv6e7Vjl4kv3uPnkJySgoZG6tzGIX06oampyYLpY/ltzXY69BqDtrYWBvr6jBveK9NeMT09XQb0bM+6zfvxqFYhy2sa1LsDW3Yfor/3VDQ1NVEqU2juWZuu7ZtmesyQPp3oOXQisbHxNPCoohJiztjIkIrlSnDs5PlM36ZO72uur3mj2uzYdxR5kkLtdkEQBEEQvi0ixJyQJ0SIOUEQBEHIe3k+NCwIgiAIgiDkDdEVI+QpEWJOEATh2yJCzH1f1DYEvQaNByBJoeD5y9c42qdG+ChSqCDTJwwj9HU47XuNpm/3NlJoMYDDfmc5e/E6s6d4M2TsDJo38qBRvdRQbxu2HWDjtoP47VuFro4OAB37jGXM0B5ULFsiQzi0NK/DImjTw5tmnh5SOLi4+ATqterLJd8tGcquUChYsnob1wLuoaWlhSJZQYtGtenctgmvwyJo12uUdD0A2trarFsyVTpPzSrlmDN1lLR9zaa9rN+6n19/HolHtQqs3byXmI9x0pu+L1+9Yfm6HTwMDMHE2BBNTU1aNalDi8Z1ADh/OYD1W/cRGxePQpFMpXIlGdq3E4aGBgAMHjudJ8Ev2fv7Aow+pY2ftpjqlcvStGEtDvudZeGKzdgUtEIuT0JbJqN2jQp0bd8MPd3Ueqzq2Q2/vaswNjKUyp0+DB9kHipv3M8LpDr9MuTcyIHdCHkeytI123j24jUAdoVtGNavC/ZFUt/i/jJMXmHbAvw0si9mpvnU3VqCIAiCIHxD1DYE08KOpcXpTR+GDFIXeC5f2o3Dfmfp1aWV2jXvypV248btB1JD8Pqt+zg7FuHegyDKlXYjMuotYW8iKeVeDFAfDi2Nnq4ul6/eynQpl/R27vclMuotm1bORKalRaJcTuirzwsdG+jrZ7ieNEaGBjwPDSP67XvMTPORkpLC8TOXcEwX6i69qOh3DBz9C/26t2PmpBEAfIiJlaKVXLp6i9lL1jPvl9G4ONmjSE5m8cotjJk8n+XzJkr1Zmigz6adPgzu3VHtecqXdmP2FG8Aot+9Z9bCtUyauZS5U0dnWRdpsgqVl1XIuYiotwweM4MRA7vhWbcakLo+4ZBxM9i0fAbmZvmBz0vgpKSkMGnmb6zbso+xw3rlqGyCIAiCIOSdXM8RTE5O4fDxs4wa7IWBvj7Xbt5Tu1/50sW5cesBkBpX+HVYBC0a1+HG7dS0G7cf4F7cUeodzCocmkymhVenFqxYvzPb8oVHRmOa30SKQqKro0NR+0I5vr5Gdatz5MQ5ILVxWszRDhNjQ7X77vE5Tml3F1o2qSOlmRgb0qZZavzkjdsP0rNzC1yc7FOvQ0uL4f27EhoWzvV0cX27dWjGoWP+RHyxhI46ZvnzMWnMQK4G3ONpyMts988uVF5W9vmcoGwpV6kRCKmNvjIlXNjrcyLD/pqampQv7UZYeGS25RIEQRAEIe/luiH45/XbWFmY4WBnm2WINndXJyKj3/EmPIq7D4Nwc3GkXKniXP/UOLxx6wHlS7sDOQuH1rppXZ4+e8mte4+zLF/LxnU4fzmATn3HMWvhWo6fuURy8ue84uLj8Ro0Xvr386/LVY5v0qAGR4+fB1J7Ppt5emR6rkeBIZRwc858e1AIJYqrbtfWluHq5MDDwGApzdwsHy2b1mFtDtfgMzE2pLCNNU+fZd8QzC5UXlYeBam/vhJuzjwKCs6QLpcnceFKAPVqqQ+jJwiCIAjCtyXXL4v4HPvcOPKsW401m/byISY2Q6+ZtraMUm7FuHH7Aa/CIihbqjiFbAoQERlNolzOjdsPGO/dF8hZODSZTEY/r3YsX7eDhTPGZVq+ovaF2LNxAbfuPeLO/UDWbt7LsZPnmT9tLJD10DCAlaW5tK7gw8Bgpv44mE07/8htNeVat3ZN6dh3LCHPX+VofyXZr/qTsyB1f53f6YsE3H5A6OtwitoXpp5HZbX7iRBzgiAIgvBtyVWP4Nt3H7h45SYbth6gtddIeg6dhEKRjO+pC2r3L1e6ONdv3efGrfuUK1UcSO0pPHX2ChGRb3F3dQJS4/9ev3Wf1l4jae01kldhEfgcO5Mhv4Z1qhKfkMi5S9ezLKe2towKZdzp1aUVy+dO5OKVW7z/8DHH19msoQczFqymfm3VRZm/5OJsz937gZlvd7Ln7gPV7UlJCh4GBUvDxWkMDQ3o1r45KzZkP/z9ISaWl6/eSC+9mOYzyXB979/HYJrfRCVUXm65OKm/vrv3AymWrvwN61Rj04qZ7Nu0iKSkJNZu2qc2v3YtGrB9zRy2r5nDlpWzcl0eQRAEQRD+XrlqCB49cZ5a1cpzcOsSKXTZzEnDM8zpS1O+tBvXAu4RFh4pvWVatpQrG7YdoJS7M9raslyFQ9PQ0GBw746s2rgn0zIG3HmoEq7uYWAwJsZGGBsZ5Pg6a1UrT5e2TWjdtF6W+7VtVp+AOw85lO76Yz7Gsv/wSQB6dGrBxm0HefzkGQCK5GSWrN5KwQKWVCjjniG/Ns3qEfjkOQ8DQzI959t3H5ixYDUVy7pLw72VK5TkwJFT0j5Hjp/DpqAVFuam2YbKy0rrZvW4cfsBvqcuSmmpvX8Padusfob985kY8ZN3X/b6HM8QMlAQBEEQhG9ProaGfXzPMLhPJ5W0iuVKMG3eKh4FZpwzVtylKDEfY6lWqYyUVrakK7MXr6eZZ63UPI+dyTIcWu3qqmHfqlQohU1BS16/iVBbxjfhkSxauVlaakVfX485U7yl/NPmCKa3Yv4klZ91dLTp3rF5NrUBFuamrFowmeXrdrJ+6wEMDPSQaWnRtkUDAKpVKsPYYb2YuWAN8QkJKBTJVCxbgvnTxqh901pHR5t+Xm35Ze5KlfTrt+7jNXgCiYlydLS18ahenm4dPpdv5MBuLFq5hW4Df0JTQwMz03zMmDBM2p5VqLysWFmYsWzOBJau2cbq33ejoaFBkUIFWT5vAhbmpmqPcXGyp27NSvy+4w9GD+mRbR0KgiAIgpB3RIg5IU+IEHOCIAiCkPdEiDlBEARBEITvlOiKEfKUCDEnCILwbREh5r4voiGYC6MmzqVqxdK0b9lQJb37wPH06dYaE2NDvCfOlcK0ARS0tmT2z97cuHVf2paiVKKro4P3oO6UKJ765nT60HXZhcnzGjyB4/tWA6lDrL/v+AO/05fQ0tREpi2joJUFfbq3oZijHTdu3WfIuJn082orhQN8EvKCMZPns3/TogzXmD5MYE7D+2UWvs7ayuJvrX9BEARBEP5eoiGYC809Pfh9xx8qDcEHj58SFf2OGlXKcvveY+wKFcx0ncL023Yf9GPGgtVsXzMnw37ZhclLb/r81cTHJ7Jm0RRpLccrN+7y/MVrKc6wuVk+9hw8Tptm9cmfzzhX15xdeL+swteJhqAgCIIgfNvEHMFcqFm1HOER0QQ9fS6lHfL1p1H9Grl+4aFiWXfC3kSp3ZbTMHkvQsPwv3Cd8aP6qSzoXalcCerX/hzdwyx/PhrVq86GbftzVUbIOrzfXwlfJwiCIAhC3hMNwVyQyWQ0qlddWjcxUS7n+JlLtGj0OQzds5evVULYLV2zTW1ep85dUWmspZddmLw0j4JCKGRTgHwmRtmWvUfnlhw/fZlXYep7FrOSWXi/vxK+ThAEQRCEvCeGhnOpeaPaDB47naF9O3Pm/DXsCttiX+RzQyiroeG0RmLU2/ckJyezdvFUtftlFyYvMy9fvWH8tMUkyuWULO7MxDEDpG35TIzo0NqTVRv34NUp+zUS08tpeL/siBBzgiAIgvBtET2CueRgZ0shmwKcv3yDQ77+NE/XG5idtEbiwS2L8ahWgSmzl2faIMpJmDwXJ3tevnrDh5hYAArZFGDTipl4dWxBzMe4DHl2at2IgDsPeBz0LBdXnEpdeL/chq8TIeYEQRAE4dsiGoJfIe2lkfuPn1DfQ/3wblZkMhneg7oTHhmN/8VrGbbnNExeYVtralYtx8yFa4j5GCulxyckqj2vnp4uvbq0Ys2mvbkus7rwfn8lfJ0gCIIgCHlPDA1/hXoeVVi0cgv1PKpgoK+nsi1t+DeNgb4eKxdMzpCHnp4uA3q2Z93m/XhUq6CyLbsweelNGjOAjdsP0nfEz2hpamFsbEj+fMZ069BMbdmbN6rNjn1HkScpcn3d6sL7fW34OkEQBEEQ8p4IMSfkCRFiThAEQRDynhgaFgRBEARB+E6JrhghT4kQc4IgCN8WEWLu+/KXG4Jnzl9l4/aDpKSkkChPwtLclCW//oimpiaDx04n7E0URob6JMrl1K1ZmQE92wPwMTaO39Zu5+qNu8hkMgwN9OjbvS3VKpXh3KXr0gsNUW/fk5KSgqW5KQBd2zflRWiYFI4tfei2NP282nLC/0+srcwZ1LujlD560lzKlXKja/umUtrMhWt4+DgYgODnodhYW6KrowPAivmT6DbwJ3S0ZVIawORxg3ByKIwiOZnftx/E7/QlZFpaaGlp4ubiyJC+nfj4MU4lFFyaqp7d8Nu7CmMjQwaPnc6T4Jfs/X0BRoapL4KMn7aY6pXL0rRhLQBu33vMig27iIx6S0pKCu6ujgzv3xWLT/Uxbd4qnIva0alNI5XzKJVKtu4+jI+vPxoaGiiVSlo0qk2Xdk3Q0NAAUsPFrdq4mwt/BqCrq4OmhiaODoXo36MdqzbuyVH9AQQFv2DRis28//CRlE9h5iaM7o+jfeEc3EGCIAiCIOSVv9QQjIx6y6+L17Hht+kULJAaTuxRYLDU0AAYMbArHtUq8CEmlh5DJuDm6kiNymUZNXEuxRzt2bl+HjItLR4/ecboSfOYNLo/NauWp2bV1J6i9DF406zdrPrWq7q1+0qXcKXH4PF4VK+Am4sjfxw7Q2xsPJ3bNlbZb7x3P+n/rb1GMm38MCk0Wxp1aQAzF6zhQ0ysFN5NqVRy6twVPsTEopmuDrJiaKDPpp0+DE7X4EoT9PQ546YsYNr4oVQsWwKAzTt9GDJuBr8vm4Genm6m+a7csIubdx+xasFk8ucz5t37GH6YupCPcXEM6NEepVLJ6IlzsStiw5ZVv6Knq0NKSgqnzl3h5atwRg/pkaP6A/h51jL69WhL7eoVAXgTHoW2juhsFgRBEIRv3V+aIxj97gOampoq4c1cnB1UGoJpTIwNcStWlOcvXnM14B5h4ZGMGNBVCqNWzNGOnp1bsGHbgb9SJJXzjRvem+nzVvMiNIw1m/YyaexAtW/efo0XoWGcOneFiaP7S9evoaFBvVqVsS1oleN8unVoxqFj/kSkWy4mzZbdh2jm6SE1AgG6d2yOoYEBx/0vZ5pnXHwCO/Yd48cRfaTYwvnzGfPjiD5s23OE+IQErgbc4/WbSMYM6YGebmpvp6amJvU9qlCpXIlc1V94ZDSW5mbSzwWszDHLny/HdSAIgiAIQt74S902Tg6FKe3uQuvuIylbypWSbs40rFMNKwuzDPuGR0Rx+95j2jSrz4PHT3F1ckBbW/X0JYo789uaHbkux5dLtmz4bTpaWppUrViasxev03vYZAb36ZirBlp6k2YuVRkaXr1oCo+CQihsYy01tNSJi49XKZc65mb5aNm0Dms37eUn774q2x4FhVC7RsUMx5R0c+JhYDDNPdUvZh38LBRt7Yyh3xzsbNGWyQh+FsrjoBCKOdpl+cZuTuuvV5dWDB03E/fijpRwdaJOzUq4ONlned2CIAiCIOS9v9QQ1NTUZNbkEYQ8f0XAnQdcvnqb37f/wfqlv1DY1hqAxSu3sm7zPmQyLXp1aUX5Mm48ePz0byl8mqzCunVt3xS/Mxdp3bTeV+ef2dBwdgz09TOUq6pntwz7dWvXlI59xxLy/NVXl/FL6npls3LzzkMWLN9EXHwCDetUo3+PdkDO6q9LuyY0qledazfvcfPOIwaNnsZ4734ZYimLEHOCIAiC8G35WyZy2Rexwb6IDa2b1mPk+Nmcv3yDzm2bAJ/nCKZXzMmeXQd9USgUKj1Sdx8E4uKU+wZXVrQ0NdHU+PtXyXFxsufFqzDef4ghn0nmvYI5YWhoQLf2zVmxYSda6YZeXZzsufsgSJp7l+bO/SBaNa2baX4OdrbI5UkEPwtV6RUMfhZKkkKBg50tHz/GseeP49JnUKakK5tWzJTmZKbJaf2ZmeajYZ1qNKxTDesC5vievpChIdiuRQPatWgAfF5HUBAEQRCEvPOXWkjhkdHcuvdY+vlDTCyv30RgW7BAlsdVKONGAUtzFq3ciiI5GYDHT56xcfsf9OzS6q8U6V9T2NaaOjUqMnPBWim8m1Kp5PS5K4S+Ds91fm2a1SPwyXMeBoZIaV3aNcXnmD9XA+5KaVt2HSLmYywNa1fNNC8DfT06tPJk9uJ1vHsfA8D7DzHMXryOzm0ao6+nR8VyJbCyNGPhis0kJMqlYzMLT5eVMxeuolCkRipRJCcT9PRFtveAIAiCIAh57y/1CCYnp7Bh635ehUWgp6tDcnIKjevXpFa1rNeG09TUZMH0sfy2Zjsdeo1BW1sLA319xg3vRZUKpf5Kkf4RX84RHDGgG+XLuDFhVD82bPsc3i1FqaRMSRcqlHXnY7petZzQ0dGmn1dbfpm7Ukor5mjHnCnerFi/kzlLNpCcnIKbS1GWzZ2g8sbwui372Lb3sEr5BvXuwJbdh+jvPRVNTU2UyhSae9aWln7R0NBg4fSxrPp9D90G/Iieni4G+nrYFrTCq2OLXJXd/8I1Vqzfiba2Nimfytive5tc5SEIgiAIwr9PhJgT8oQIMScIgiAIeU+EmBMEQRAEQfhOia4YIU+JEHOCIHxvRAg34Vvyn2oIxsbF07zzUOp5VGHCqM8RQ27cus+QcTPp0Koh3oO8pPRf5q7k6Inz/L58hsryMIPGTCciMprdG+ZLy7DsO3SSA4dPqpwvIuotJsZG7Fw3F8hZODi/0xfZsXautCbfktXbMNDXpW/3tmqvac8fx9l/6CTJn0K32RUqyOA+nbC2ssgyTN/XXDfA67AIldB4rb1GoqOtzdbVv0qLf/caOolh/TpTrrQbAFdu3GX9ln1ERr/D2MgQQ0N9+nZrQ5mSrjn52ARBEARByCP/qYbgSf/LuDg74H/hKt6DumOgrydtK2xrzfnLAQzt2wVtbRmxsXHcvvcYSwtTlTxehIbxMjQMYyNDAm4/kBo7bZrVo02zz2vpvX4TSZ/hkxk1OLWBldNwcJbmZqzauItffhqa7fWs2bSXKzfusHDGWKwszQG4GnCXqOj3FLA0zzJMX6XyJXN13VlJSlLgc+yM2rUEr9y4yy9zVzBz4ghKuReT6jDw6fMc5y8IgiAIQt74T80R9PH1p3uHZpQp4cqJL0Kw6enqUKGMO2cvXQfguP9l6tSohNanXq70eXjWq07zxrXx8fVXe56ERDk//rKQTm0aUflTgyun4eBaNqnD7XuBPAoMzvJa4hMS2LL7EOO9+0mNQICKZUvg7uqY4zB9Ob3urPTp3poN2w6QoGZpmfVb9tGrSyupEQipjc+6NSvlOH9BEARBEPLGf6YhGPwslDcRUVQuX4rmjTzwOZaxEde0YS0OfWrcHfY7SzPPWirbk5NTOHr8HM0aetC4Xg3OXw7gY2zGZWBmL16PrbXqMiuPgkIoUdwpw75p4eDS6Oro0Ltba5at25nl9TwNCUVbljFMXJrHQSGZhulLvxZhTq47O85F7Shf2o0d+45l2PYwKIQSxZ1zlZ8gCIIgCN+G/0xD0OfYGRrXq5EaY7hSGV6/CSfkeajKPqXci/EmPIrL126jqamJXWEble0Xr97EuoAl9kVsyJ/PmIpl3fE7dVFln10HfHkUGMzEMQO+uqxNG9QiIiqaK9fvfHUeuZHddedEf6927Drgy/sPMV9djj1/HKdzv3F07jeObgN/+up8BEEQBEH4e/wn5ggqFAqOnbyAlkwLvzOXAEhIkPPHMX+G9++ism/j+jWYOmcFg3p3zJDPoWP+vAh9TWuvkQAkJsp5/SaSNs3rAxBw5yEbth1g1YLJKvMPIXfh4LS0NBnYqwPL1++kXKniaq/Jwc6WJIUiQ5i4NLkN05fVdedEQWtLGtSpyoZtB1XSXZ3sP53TPts8RIg5QRAEQfi2/Cd6BM9duoFNQUt8ti1l/6ZF7N+0iLWLp3Ds5Hkp9Fmapp616Ny2MfU9VOPgRr99z7Wb99i9Yb6Ux6HtvxEZ9ZbAJ88Ij4xm0syljB/VjyKFCmYoQ27DwXlUq4C2tjZnLlxTe00G+np0adeEWYvWEh4ZLaVfv3mfew+f5DpMX2bXnRu9urTC99QFIqPefk7r2pqN2w5y90GQlPby1RtOnbvy1ecRBEEQBOHf8Z/oEfTx9cezbnWVNPsitlhamHL+cgAmxoZSuln+fGpDqB05fo5K5UpibPR5X01NTerXroKPrz9JSQpiPsax5vc9rPl9j8qxm1bMzHE4uPSG9OnIoDHTM72u/l7t2GXii/f4OSSnpKChkTpfb0ifTrkO05fZdedG/nzGtG/ZkDWb9kpplcuXZMLo/ixds42o6Hfo6upgmt+EfpkshyMIgiAIwrdDhJgT8oQIMScIgiAIee8/MTQsCIIgCIIg5J7oihHylAgxJwjC90aEmBO+JaIhmMeyCovnPXEudoUKkqJUYmigz9ihPXEqWoS1m/ey1+cEluamyJMUODkUZtzw3pgYGzJ47HQ6tm6ER7UKKudJf0yaujUr07NLywxlqurZDb+9qzA2Ss3vSfBL9v6+ACNDAwDGT1tM9cpladowdT3Ch4HBrNywixehYZgYG6GtLaNr+6YZyiAIgiAIwrdFNATzWFZh8ewKFWTTipkAbN97hOnzV7NxWerLJQ3rVMN7UHeSk1OYMGMJG7cdYPiArlmeK+2Y3DI00GfTTh8Gq1l65mnIS0aOn82E0f2pWaUckBqD+cqNf2eNREEQBEEQvp6YI5jHsgqLl16VCqV5/vJ1hnQtLU0qlnXnmZptf5duHZpx6Jg/EemWjUmzeZcPzTw9pEYggKW5KU0b5C56iSAIgiAI/z7RI5iH0ofFS05OZtPOQ7RoVFvtvsfPXMLF2SFDekKinLMXr+cozJvf6YsE3H4g/ezVsQX1a2e/rqC5WT5aNq3D2k17+cm7r8q2h4HBDOjZPts8BEEQBEH49oiGYB76Mize7CXrCXkein2R1Egiz16+xmvQeAAK21ozOV1YO7/TFwm48xCAsiVd6d6xebbn+9qhYYBu7ZrSse9YQp6/+qrjITXE3F6f4wAolWLVIkEQBEHIa6IhmEdyEhYv/RzBL/2VRt3XMDQ0oFv75qzYsBMtzc8zClydHdSG1lNHhJgTBEEQhG+LmCOYR3ITFu9b0aZZPQKfPOdhYIiU1rV9Mw75+nPhzwApLSr6HYePn82DEgqCIAiCkBuiRzCP5CYsXm7NWriW+ct+l36eMWE4kHGOYLnSbowc2C3H+eroaNPPqy2/zF0ppTk5FGbB9LGs2ribBcs3oaeni4G+Pl4dm311+QVBEARB+HeIEHNCnhAh5gRBEAQh74mhYUEQBEEQhO+U6IoR8pQIMScIwvdGhJgTviX/eEMwpyHUdHV08B7UnRLFnYDUkGgxH+PwHtQdhULBktXbuBZwDy0tLRTJClo0qk2Zkq7MWrgWgA8xsXyMjcPG2hKAhnWr0e3TiwwzFqxhxbyJlCnpqraMr8MiaNPDm2aeHlIZ4+ITqNeqL5d8twAweOx0wt5EYWSoLx03uE8ndh3wJfLTQsuBT59T1L4QWpqaGOjrUcimALY2BejVpRUAx06eZ+qclez7fSEFP5Vz5PjZ1K1VmRaNavMxNo7f1m7n6o27yGQyDA306Nu9LdUqlcl1nQEcPXGe1b/vZt60MdgVKqi2Dju3bZKhPqbNW4VzUTs6tWnEYb+zTJ+/msljB9K4fg0Azl8OYNvewyyfO1Gqq1Ubd3PhzwD09fTQ0NSgQhl3BvfuIIZ9BUEQBOEb9o//ls5pCLXdB/2YsWA129fMyZDHzv2pja1NK2ci09IiUS4n9FU4Re0LSccf9jvL2YvXmT3FW+VYH19/KpRxx8fXP9OGIICeri6Xr94i+FkoDna2avcZMbBrhvi5VSqUkv5f1bMbK+dPwtgo9UWPI8fPcfTEeakheP3WA9xdHblx+wFNrS1RJCdz+95jxg3vhVKpZNTEuRRztGfn+nnItLR4/OQZoyfNY9Lo/lQqXzJXdbbrgC97/jjOsrkTsLG2Yuvuw2rrMCesC1iwZtNe6ntUQVtb9ZZRKpWMmTyPwjbWbFn1K3q6OigUCv445o88SSEagoIgCILwDfvH5wjmNIRaxbLuhL2JUrstPDIa0/wmyLS0ANDV0aGofaFsz/3sxStehUUwedxAzl68TmxsXKb7ymRaeHVqwYr1O7PNN6fKl3bj7oMgkpJSl4O5fe8RXh1bcOPTm7sPHj0lXz5jbKytuBpwj7DwSEYM6CpdZzFHO3p2bsGGbQfU5p9Zna3bso9Dvv6smDcRG2sr4OvrEKBYUTtcnOzZ82kx6PSu3bzHy1dvGDO0J3q6OgDIZDLaNKun0ugXBEEQBOHb8482BNOHUGveyAOfY/6Z7nvq3JVMw521bFyH85cD6NR3HLMWruX4mUskJ6dke34fX38a16uOpbkp5cu4cTyLhihA66Z1efrsJbfuPVa7ffHKrXgNGi/9e/nqTZb5FbAyx9wsH/ceBhEWHomJsRGVypfkzv1AAK7fuk/50m4APA4KwdXJIUOPW4nizirr9qWnrs58T13g+JnLLJs7AXOz/FL619ZhmoG92rNl16EMjelHgerLLQiCIAjCt+8f/e2d0xBqUW/fk5yczNrFU9XmU9S+EHs2LuDWvUfcuR/I2s17OXbyPPOnjc303IrkZI6eOM/yuRMAaNbQgw3bDtCqSd1Mj5HJZPTzasfydTtYOGNchu3qhoazU760GzduP8DayoKyJV3R09XBNL8Jr8LCCbj9gEb1auQqv+zqzNXZgSchL7nwZ4BK3l9Th+nZFbahZpVybN51KEdxjdURIeYEQRAE4dvyjzUEcxNCTaFQMHfpRqbMXs6aRVPQ0NDIkJ+2towKZdypUMadFo1q06zzUN5/+Eg+EyO157/wZwAfP8YxcsKn+XNKJRFR73gS8gJH+8KZlrthnaps3XOYc5eu/8UaSFWutBs+x85gbWVOPY/U3ruyJV358/odbt8LZMLo/gAUc7Jn10FfFArVeXV3HwTi4mQn/ZxdndkVtmHkwG4M+/FXUlKUNGlQUzo2t3X4pT7d2+A1aDwFC1hKaS7O9uw+6EdSkiLbXkERYk4QBEEQvi3/2NBwbkKoyWQyvAd1JzwyGv+L1zLkFXDnofRmLsDDwGBMjI0wNjLI9Pw+x/wZMbCbdO79mxfTuU3jLIenATQ0NBjcuyOrNu7J5RWrV750ce4+DCLgzkNKl3ABoGyp4mzfexRLC1OsLMwAqFDGjQKW5ixauRVFcjIAj588Y+P2P+j56WWT9LKqM/sitiz99SdWbNjFId/U6/2aOvySpbkpzRvV5vcdf0hpFcq4Y2NtyYLlm0iUy4HU3tgDR04RF5+Q47wFQRAEQfj3/WM9grkNoaanp8uAnu1Zt3l/huHXN+GRLFq5Gbk8CW2ZDH19PeZM8UZTU307NiLqLddu3mPSmP4q6Z51qzHsx1kM6dMpy96rKhVKYVPQktdvIlTSF6/cyrrN+6Sfu7ZvmuEav2RhbkoBS3OMjQyklydKujnzKiyC5p4e0n6amposmD6W39Zsp0OvMWhra2Ggr8+44b1U3kxOL6s6sy9iw2+zf2LYj7NISUlBR0c7V3WYGa+OzTl45LT0s4aGBvOmjWHVxt107f8jujo6pChTqFapDDo62rnKWxAEQRCEf5cIMSfkCRFiThAEQRDynggxJwiCIAiC8J0SXTFCnhIh5gRB+N6IEHPCt+Q/1RBs7TUSHW0Zujo6yJMUFHO04yfvPujrfV7YOLOQc9PmrcLv9EV2rJ2LbcHURZiXrN6Ggb4ufbu35cat+yxauUWK6vH4yTPGTp7PsH5dMl3/8Je5K/G/eI1D239TKUNrr5EkJsj5Y9sSaVj0+s37DP1hJh1aeeI9qLtKOLk0Ba0tmf2zd7ah5r6UXQi4kOehLF2zjWcvXgOpbx4P69cF+yI2QGrour0+J7A0N0WepKCwbQF+GtkXM9N8gGr4vUS5nLo1KzOgZ/vcfXiCIAiCIPzr/lMNQYBp44dRzNGOlJQUxv48n8N+56QlSyDrkHOW5mas2riLX34amuU5bt19xMSZvzFhVL9MX+SIjY3j/OUAnB2KcOrsFZo2rKWyvYCVOecu3aBOzUqfynWG4sUcVPZJH07uSzkNNZddCLi372MYPGYGIwZ2w7NuNQD8Tl9kyLgZbFo+Q1qUumGdangP6k5KSgqTZv7Gui37GDusl3SetDUWP8TE0mPIBNxcHalZpVyW9SgIgiAIQt76z84RTFIoSEiQS3F/IfuQcy2b1OH2vUAeBQZnmu+lq7eYNOs3ZkwYlmkjEMDvzCUqlnWnU9vG+Bw7k2F704a1OOSXurTLx9g47j4IonIW+WUlq/B82YWA2+dzgrKlXKVGIKQ2+sqUcGGvz4kM+WlqalK+tBth4ZFqz2dibIhbsaI8/9S7KAiCIAjCt+s/1xCcNHMpXoPG06zTUDQ0NajnUVnall3IOV0dHXp3a82yderjDYeGhTNxxlIWTBtLKfdiWZbD55g/zTw9qFG5LC9eveHZi1cq20u5F+N1WCQRUW/xO32JurUqo/XFUi5pUUTS/i1ds03tubIKz5ddCLhHQSGUcMsYKaSEmzOPgjI2iOXyJC5cCaBeLfXnC4+I4va9x7g6O6jdLgiCIAjCt+M/OzSsSE5m9uL1LF+7g+EDuuY45FzTBrXYvvcIV67fyZC3Wf58mOY3Yd+hk4wd1lNtBBSAoOAXREW/o3L5kmhqauJZtzqHfM8ypG8nlf0a1a/OYb+znL14nak/Dsb31AWV7VkNDec0PN/fxe/0RQJuPyD0dThF7QurNLDh8xqLMpkWvbq0onwZtwx5iBBzgiAIgvBt+c/1CKaRaWlRp0ZFLl+7DaiGnGvtNZL5yzbyKCiEJyEvVI7T0tJkYK8OLF+/E75orOjr6bJwxjiehLxg9uL1mTZmfI6dIS4+gbY9R9HaayTHz1zi6MlzUsSQNI3r12T3QT90dbQpbGudq+tLayQe3LIYj2oVmDJ7udryuDjb8ygohKQkhZpcwMXJnrv3AzOk370fSDEne+nnhnWqsWnFTPZtWkRSUhJrN+1T2X/EwK5sWjGT9Uun0aZ5fbXnateiAdvXzGH7mjlsWTkrF1crCIIgCMI/4T/bEAS4dvM+RQqnvnWbm5BzHtUqoK2tzZkLGcPdGRros3DGOEKehzJz4VpSUlJUticlKfA9dYE1i6ZI5/LZtpQClhZc/POmyr6W5qYM6tWBwX1UewpzI7vwfNmFgGvdrB43bj/A99RF6ZjU3r+HtG2WsUGXz8SIn7z7stfnuErIOkEQBEEQ/v/85xqCaXMEu/b/kWcvQvEe2F0KOVevViWVfT3rVsP31AW1vWVD+nTMEGIujYG+HgtmjOPlqzfMXLBGpTHof/Ea1lYW0tIr6c/l43smQ17NPD0oqWaOHmScIzhw1C9q90sfau7LXsG0EHDa2jK69v+Rrv1/pPvAn3gRGoaOjjZWFmYsmzOBYyfP07aHN+16juLYyQssnzcBC3NTtedzcbKnbs1KKjGHBUEQBEH4/yNCzAl5QoSYEwRBEIS895/rERQEQRAEQRByRnTFCHlKhJgTBOF7I0LMCd+Sf6QhmF2ot/OXA1i/dR+xcfEoFMlUKleSoX07YWhoAMCN2w9YsX4niYlykhQKjI0M+XXySFZu3MXDx6lr2wU/D8XG2hJdndRFklfMn4SOtjarf9/D6fNXkMlkaGlp0qVdE5o2SI3q8TosgjY9vGnm6cGEUf2A1PBr9Vr15ZLvlgzXoVAoWLJ6G9cC7qGlpYUiWUGLRrXp3LYJANHv3rN87Q4C7jzE0NAADQ2oU6MSPTu3lJaFmT3Fm9dhEbTrNQpH+8JS3tra2qxbMjXbMo2aOFd6KSPw6XOK2hdCS1MTA309Vi6YTFXPbvjtXYWxkaFKqDcAC3NTFkwfq1KW7MqdoQ6Sk/l9+0H8Tl9CpqWFlpYmbi6ODOnbCWMjQ8Ijo1m6ehv3Hz1BU1MTC3NThvTplGm4O0EQBEEQvh3/WI9gZqHeLl29xewl65n3y2hcnOxRJCezeOUWxkyez/J5E0lOSeHHqYtY+uuPuHxalPjZi1fo6eky3ruflH9rr5HSOdJMnrWMpCQFm1fORF9Pj9dhEXhPnEtycgotGtUGQE9Xl8tXbxH8LBQHO9ssr2Hnfl8io96yaeVMZFpaJMrlhL4KByAhUc7gMTOo71GZXd7z0dLSJCEhkYNHT6vNy0BfP9M1AbMq04LpY6X/V/Xsxsr5k1SipXwpLdRbZnJb7pkL1vAhJpY1i6ZgYmyIUqnk1LkrfIiJRSbTYsjYGbRoVJtp41PD8l0NuMvYn+fz25zxKg1fQRAEQRC+Pf/4HMEvQ71t3H6Qnp1b4PJpjTqZlhbD+3clNCyc67fuExeXQFxcPGafYtwC2BW2wUBfL8vzvAgN4+yl6/w4srfU81jQ2pLh/buwfst+aT+ZTAuvTi1YsV599JD0wiOjMc1vgkxLC0iNPFLUvhCQusSKgb4efbu3RUsrtRr19HTp2LpRziomndyU6a/KTblfhIZx6twVJo7uj4lx6uenoaFBvVqVsS1oxfHTlzA2MqR7x+bSMRXLlqBpw1ps2XX4H78WQRAEQRD+mn+sR3DSzKXo6ujw+k0kLs72UiSKR0EhjBrspbKvtrYMVycHHgYGU6GMO21bNKBTn7GULuFCieJO1PeoQpFCBbM836OgEArbWJPPxFglvURxZ95ERPH23QcprXXTuuzcf4xb9x7jXLRIpnm2bFwH7wlzuH7rAaXdi1GhrDt1a1ZGS0uTR4HBlHTL+fBnXHw8XoPGSz872BVi6o+Dc12m7KRF+ABo0bgO7Vo0UNmem3Kn1Wn+fMaZbleXV4niTqzeuCeXJRcEQRAE4d/2jw8NfxnqLSe8B3WnU5vG3Lh1n2s379Fj8EQWzRxH6RIuf0vZZDIZ/bzasXzdDhbOGJfpfkXtC7Fn4wJu3XvEnfuBrN28l2MnzzN/2thMj8lMVkPDuSlTdrIbGs5LIsScIAiCIHxb/vGh4S9Dvbk42XP3gWpIs6QkBQ+DgqXhYoCCBSxo2rAWP48bRKN61Tl59s8sz+PiZM+LV2G8/xCjkn73QSAFLM0xzW+ikt6wTlXiExI5d+l6lvlqa8uoUMadXl1asXzuRC5eucX7Dx9xcXbg7oMn2V1+ruS0TH9FbsqdWZ2m337nflCG9LsPgnBxts+QLkLMCYIgCMK35V9ZRzB9qLcenVqwcdtBHj95BqS+lbpk9VYKFrCkQhl34uITuHT1ltRjlJAoJ+TFK2wLWmV5jsK21tSoXJZfF60nISERSH1LeMnqbfTq0irD/hoaGgzu3ZFVWQxhBtx5qBJG7WFgMCbGRhgbGdCwdlU+xsayfut+kpNTpLLuOuCb84r5ijL9Vbkpd2Fba+rUqMjMBWuJ+RgLpPbknT53hdDX4TSoU5UPMR/ZvNNHOubazXsc8vWna7um/9g1CIIgCILw9/jH5wgmJ6dgXcCcccN6A1CtUhnGDuvFzAVriE9IQKFIpmLZEsyfNgYNDQ2USiX7D51k4YrN6OrooEhWUKVCKdp+MddNncljB7Lq9910G/hT6vIxmpp0bd+U5p4e/2vvvqOjqNo4jn93Nz2kh5DQhdCbgCioKFUQBARRei8KvjTpgoh0pRfpvUkXEFRAUVFAERCUJr2lkRAIkJCym33/QFZiAgQpC+7vc07O2Z25984zdye7z947M5th+fLPlCR7SNbb/pRc1IUYJkxfRHJyCs5OTri7u/HJ4B4YjUbc3FyZOnogU+cu5802PXF3d8VgMPBK5QoZtvXPcwThxi1v7jWm+3WvcQ94rwPzlq6jfbcPMRlNpFqtPF2iEM+ULoa7mxuffjKASTOX0KBlD0wmI4H+vnwy+D1C7+M8RxEREXk09BNzYhf6iTkRERH700/MiYiIiDgoJYIiIiIiDkqJoIiIiIiDUiIoIiIi4qCUCIqIiIg4KCWCIiIiIg5K9+0Qu7h5w3Cz2WznSERE5EljMpkwGAz2DuM/QYmg2IXFYgGgcr32do5ERESeNLoH7YOjXhS7cHFxIXfOYBZPH6lvdf9S83f66zeb74P67/6o//499d39af5Of0wmk73D+M9QIih2YTQaMRqNODs72zuUJ5bBYNA34vug/rs/6r9/T313fwwGgwYQHiBdLCIiIiLioJQIit28Uae6vUN4oqn/7o/67/6o//499d39Uf89WIbk5CSrvYMQERERkUdPI4IiIiIiDkqJoIiIiIiDUiIoIiIi4qB0/brYxbmwSIaMnkHclatk8XRnYM+3yZc3p73DeuwlJSczaMSnnDobhquLC36+3vTu0ppcOYLtHdoTZ8OmHxg+bhajPuzOy88/Y+9wnhjJySlMmrmUX/b8jouLMwXy5WZw3872DuuJsWPXPmYsWIk11YrFkkrTN2tRu/pL9g7rsTRu6kJ+/HkvkVExLJg6nIL58wD6/HjQlAiKXXw8cS6v16pM7VdeYuuPuxg2dgZzJw+1d1hPhHq1KlOhXCkMBgMr121m5ITZTB090N5hPVEiIqNZ99X3FC8Sau9QnjhT5y7HYIAVc8dgMBi4GHvZ3iE9MaxWK4M/nsbU0QMIzZebiMhoGrfvQ6UXyuHp4W7v8B47lSs+S/M3a/N2z7SfDfr8eLA0NSyPXOzlOA4fO0mNqi8AUPnFckRFx3IuLNLOkT3+XF1ceP7Zp203Uy1eJJSIqBg7R/VkSU1NZcT42fR8tyXOzvoufC+uJybyxabveaf1m7ZjMMDf175BPWEMBgNX4xMAiE+4jrd3Flx0Y/0MlS5RmKCsAWmW6fPjwdO7oDxyF6JjCfT3xemvnwgyGAxkyxpAVPRFTXHeoxVrN/FShTL2DuOJ8tnqryhZrCCFCzxl71CeOGHhF/D2ysKCZev59beDuLo4065FA8qVLm7v0J4IBoOBoe//j/5DJuDu5sqVa/GM/KC7vpDcA31+PHgaERR5Qs3/bB3nw6Po1KaRvUN5Ypw4fY7vt/9Km6b17B3KE8lisRAZFUPe3DmYN2UoPTq35IMRU4i9FGfv0J4IZouF+Z+tZeSg7ny+aCKTR/VnyOhpXI67au/QxIHpa4g8ckFZ/YmJvYzZYsHJZMJqtRIVfZFs/5gCkNtbsnIjP2zfzaRR/XBzc7V3OE+M/X/8SURUNG+27QVAbGwcH5+Zy8WLl2lQp5qdo3v8ZQsKxGg0UKPKjWm5QqF5yR6cleOnzvGsn4+do3v8HTtxhpiLlyldojAARQvlJyjQn6PHT/Ns2RJ2ju7JoM+PB08jgvLI+fv6UCg0L5u+3Q7Adz/9SlCgv4b1M+mz1V+y5fudTBzZD68snvYO54nSoE41Nnz2KZ8vnMDnCydQrEh++nZvqyQwk3x9vHjm6WL8sud3AMIjLxAeGU3e3NntHNmTIVvWAC7GXub02TDgxtWv58MvkDtXiJ0je3Lo8+PB00/MiV2cORfOsLEzibtyDU8Pdwb07EjoU7nsHdZj70L0Reo170aOkCA83N0AcHZ2Zs6kj+wc2ZOpc+9hNKpfU7ePuQdhERcYMW4Wl69cxWgw0rbZ61Su+Ky9w3pibP5uBwuWrcdoMJJqTaVlo7rUqPK8vcN6LI2aOIcdu/YRGxuHt3cWPNzdWDV/nD4/HjAlgiIiIiIOSlPDIiIiIg5KiaCIiIiIg1IiKCIiIuKglAiKiIiIOCglgiIiIiIOSomgiIiIiINSIigiIiLioJQIijig+i2788OO3bdd37LT+2zcvO0RRpR56778jteavEuVeu348/jph769KvXacfzUuQfe7r4/jlC3WZcH2mbkhRiq1GvHtfiEB9ru3Xw8cS6fzl72wNrbuHkbLTu9/8Da+7ciIqOpUKM5V6/F2zsUkYdGiaDIE6Zz72EsW/N1uuUVajTn6Ikzdojo0TGbzYybtpBh73dh67o5FArNm67MynWbafO/D3jptdb0HTw+3fr4+AQGjfyUqvXbU6tRZ+Yu+fyO29y6bs59/2pBRgnF0yUKs37JZNvz272ud/LP1zw4KJCt6+aQxdPjvuK9V327teXd9o3/Vd29+w9RvUHHBxzR42v2otUZHpci9uJk7wBE5L/FbDbj5PRw3louxsaRnJxC/jskZlkD/GjdtB6/7j1IdExsuvVjpy7kytVrrF00kUuXr9C13yiCgwKpVb3iQ4lZ5Caz2WzvEETSUSIo8h9ktVr5bPVXrNnwDVeuxlO0UD56d2lDjpCgDMuvXLeZxSs2kJiUTP3aVdKt37X3ANPnreBcWCRZA/zo1PYtKlYoC8DQMTMwGo0kJFzn5z2/807rtyhZtACjp8zn1NkwnJ2cKF6kAGOG9MxU7OfCIhn76QIO/XkSby9PGtZ9hcYNavLn8dO8895QAOo164q/nw+r5o9LV7/Si+UAOHbiTLpEMDExiW9++JkZ4wbhlcUTryyeNKxXnS82/XDbRLBCjeYsmDqcgvnzMHvRao4cO01wUCCbtm7H08Od/7VvQrVK5W/0054/mDRrKRGR0bi6ulDphXL06dqGdl0/tMUNN0bQsgb40fejCWxZM5NJM5aw/8CfHDh8nJkLVlKqeCHGD++TZtsAy9Z8zbadu5k6eiBtuwwCoGOPjzAaDLRsXJcalZ+nQasebF49A68snpjNZmYuXM3mrTtISk6mbKmi9Hy3FX6+3rZ9692lDavXbyEyOoYyJYvwYZ9OZPH0IDk5hU8mz+Onn/diNlvIljWAAT07ULRQ/nR9NHTMDLJ4etCjUwsiIqNp0KoHg3q/w5zFa4i7co2Xni9L/+7t0n1BiLtylR4DR5OcnEKVeu0AGDest2393CWfs2rdFjBAy0Z1adygpm3dlu93smDZeqIuXCRXjmx0f6cFJYsVzPA1TEkxM2/pWjZ/t4NLl68QnC2QQb3eplCBp4hPuM7kmUv56Ze9AFQsX5aubzfF3c3NVv+nn3+77b78sucPPp2zjPCIC+TIHsS77ZrwbJnitn659X+jWcPaLFi2Hmuq1ba/W9fNyTBmkUdFU8Mi/0FfffMTn635ilEf9uCLzyaTL09Oeg8ai9liSVd2976DzJi/kmEDurDhsykAnDx93rb++MmzDBw+ic7tGrFp1XT6dmvLR59M58y5cFuZLd/vpE7NSmxZPZM6NV5mzKcLefG5MmxZPZP1SybT7M3amYrbbLHQa9BYQvPl5ovPJjNqUHeWrNzApq07KBSal6UzRwGwbsmkDJPAuzlzPoKUFDMF/kqsAArmy8OJU2cz3cYve37n6RKF+HrldDq2asjICbOJT7gO3Pjgb9awNt+unc3qBeOoWfUFAOZM+sgW99Z1c6hR5YU0bXZ9uxmliheic9vGbF03h/HD+9w1jrmThwAwc/yHbF03h9ZN6qUrs2DZF2z/5Temj/uA1QvGYzAYGPzx1DRltm77hcmf9GftoolciIll2ZqvAPjymx85fvIsK+eNZcuamYwc1I0AP99M99POX/ezYOpwls76mN2/HWTT1h3pyvh4ezF+WG+yeHqwdd0ctq6bw9MlCgNw8kwYbq6urF86iWHv/48psz/jfHgUADt27WPyrKV80LMjm1ZNp2WjuvT+cBxxV65mGMvUucvY+et+xg/vwzefz2LEwK54e3sBMH7aIs6HR7FkxigWTx/FmfPhTJy+JFP7ci4skj6Dx9G26et8vWo6rRrXo8/gcYRHXrDVvfV/o+kbtWjVuC4vPFfatr8i9qZEUOQJNG3ecqo36Jjm71Zff7udt+q9QuhTuXB1ceGdNm8RFXORQ0dOpGtr09Yd1KjyPCWKFsDZ2Yn2LRrg5uZqW//5l1upVf0lnnm6GEajkVLFC/HCc6X5dtsvtjLPlSlB+WdKYjQacXNzxcnJROSFGGIuXsLFxZnSf324383BIye4GHuZt1u9iauLC6H5cvNG3ep8ueXBXLhy/Xoi7m6uOJlMtmVZsniQkJCY6TYKheal2svlMZmMvFrtRVLMZs6FRQLg5GTifHgUly5fwd3N7bYjVI/K19/+RJsmrxMcFIiHuxtd327Grr0HiL54yVam2Zu18ff1wSuLJ5VfeJYjx04D4GQykXA9kdNnw7FareTOGUK2oIBMb7tts/p4eriTNcCP8s+U5MixU/cUu69PFpo2rIWTkxNlShUlJFsgx/46H3L1F1to1rA2hQo8hdFopNKL5ciTK4Qdu/ana8dqtbJ243d0fbsZuXIEYzAYyJMrOyHZAklNTWXzdzvo1PYtfLy98PXx4p3Wb/HVNz+Rmpp613359odfKFOyCJVeLIeTyUSVis9SqlhBNn+301b3n/8bIo8bTQ2LPIE6tWmUZpoMbkzz3XQhJpaQbFltz11cnAn09+NCBufMxVy8RJmSRWzPnZycCPD3tT2PjIpm975Daa4itlgseHq8aHv+zwRhwHsdmLP4c1r/74Mb0691q/NmvVfuul/R0bEEBvjh7Pz3W1OOkCA2bd1+17qZ4e7uRmJSMmaLxZYMXou/joeH211q/u3WUTGDwYCriwsJf40IjhrUnfmfradRu94EZwukZaM6VHu5/AOJ/d+4EBNLSHCg7XnWAD9cnJ25EB1L1gA/gDSvtZubKwnXb+xLzWovEhN7mU8mzSMq+iIVK5ShS4em+Pp4ZWrbAf4+adq91yuZ/X190jx3d3Ml4fqNhD0iMobp81Yye9Ea23qz2UL0xfTH96W4KyQmJZEre7Z06y7HXSUlxZzmfyVHSBDJKSlcvmV08Xb78s//M4DswUFpTkm4l+RZxB6UCIr8BwUF+hMRFW17npJiJib2EkGB/unKBgb4EXkhxvbcbDZzMfbyLW0F0Oj1GnRud/urQg0GQ5rnObNn48M+72C1Wvn94FG69htFiaIFKFzgqTvGnTWrPzEXL6W54CQiKjrDuP+NPDlDcHIycfzkWVssx06cIX/e+7sq+KZCBZ5i5KBupKamsm3HHgYOn0yZkkUwGA13rWs0pJ+gcXdzJTExyfb81tcF0vf7PwUF+hMRGUOxwqG2+skpKQRlvXt/OplMtG5Sj9ZN6hF7KY5BIz9lzuI19Hy31V3r3guD8d4npoKy+tOw3is0eK3qXcv6+Xjj5urK+fAoAv9Kfm/y9fHC2dmJiKho/P1uJHsRUTG4ODvj6+1FVOLFO8cR6M/+g3+mWRYRFW2b3ob0r5Ehg9dZxJ50RIr8B9Wo+jyr1m/h1JkwkpNTmLFgJVkD/ClaOP2J/tUrVWDT1h0cPHKclBQzc5Z8nib5eL12FTZs3saefYewWFJJTk7hj0PHOH027Lbb/3LLj8ReisNgMJAliwcGowHjXx/4Q8fMYOiYGRnWK1YoH/5+PsxcuJrk5BROnD7HynVb7umKXrPFQlJyMhZLKqnWVJKSk0lJuXG1ppubK1VfKs/MBau4Fp/AubBIVq3fTJ2alTLd/u2kpJj56pufuHI1HqPRSJYsN27hYjIZ8fXxxmg0EBZx4bb1/f28CYuISrOsUGhevv52O2aLhaMnzvD1tz+lrxOets6talZ9wXZBRcL1RCbOWEK50sVto4F3snvfQY6eOIPZYsHNzRUXF2dMt0ypPyj+vt4kXL9O7OW4TNd5o251lq7ayJFjp7BarSQmJrFr7wEuRKdP3AwGA3VfrcSkmUs5FxaJ1WrlzLlwIqJiMBqNvFKpAtPnrSTuyjXirlxl+rwV1Kz6gu14vZOqLz/H3t8Ps23HHswWC9//9Cv7DvxJ9UoVbr+/ft5EXIjJ8HxdEXvQiKDIf1CtahW5dOkKvQaN4eq1eIoWys/oj95Lc27cTc+WKU7HVg3pP3QiSUkp1K9dhXx5c9rWFwrNy5D+7zJjwUpOnw3HaDRQIF8eunRsetvt//rbQT6ds4zr1xPx9/Phf+2b2K58jbpw8bYflE5OTowZ0pOxny7gtSbv4pXFkyYNXuWVys9net/nL13LnMV/3xuwUp22lC5ZmKmjBwLQ692WfDxpLvWadcXVxYU36lZ/YLeO2fzdDiZMX4zZbCZb1gAG9+uMz18XJbRt1oD3BowmxWym1/9akzXAN03dRvVrMnTMTKo36EjJYgUZO7QX73VuydAxM3jlr2WvVq/IgcPHbHU6tmzIuGmLGDlhNs3feo3qL6ft15aN6nI9MYkOPQaTnJxCmVJFGdy3U6b2JfZSHGOmLOBC9EVcXV0oV7oY7ZrXv78OykCeXNmpU6MSTTv0xWJJzdTV5RXLlyE5OYWRE2YTHhGNs7MTRQvlp9f/Mh6tfLddY2YvXkPX/qO4cuUaIcFZ+aDX24RkC6RHpxZMnLmEph372tq+07F9q1w5ghk1qDvT5i7no9HTyBEcxKhB3W97dT5AlYrPsfm7ndR6qxNWK2xZMzNT2xJ5WAzJyUlWewchIo4hOTmFFp36s2TGqId2r0EREck8JYIiIiIiDkrnCIqIiIg4KCWCIiIiIg5KiaCIiIiIg1IiKCIiIuKglAiKiIiIOCglgiIiIiIOSomgiIiIiINSIigiIiLioJQIioiIiDgoJYLyRKpQozk/7Nhtt+3v3X+ICjWac/Va/ANtd+iYGfQdPP6BtinysEVERlOhRnOOnjjzwNuu37I7y9Z8/cDbfVy2OXvRalp2ev+Btfeg3psexHvRw3qflAdLiaDYzZoN31L19faYLRbbsoTribxYqxWdew9LU/bmG8r58KgHtv3MvtF17j2M8dMWPbDt3kmPTi0Y2KvjI9mWSEb+Kx/eG7dso22XD6hUty1VX29Pp17D+Onn39KW2byN6g3s+//WtGFtJn/c364xiGNTIih2U7ZUERKuJ3Lk6Cnbsv0H/iTAz4eDR06QlJxsW75n/2GCgwLImT2bPUJ9ZLJ4euCVxdPeYWTIarWmSdoFzGazvUOQDEyauZRPJs6j6kvlWTRtBHMmfUSpYgXp+9E4Vq7bbJeYUlIyPlY83N3w8fZ6xNGI/M3J3gGI48qTKzuB/r7s/f0QxYuEArB3/2EqVijLnv0HOXj4OGVKFb2x/PfDtsc3xcVdpe9H4/llzx9kDfCja8emVKxQFgCLJZVRE+ewZ98hLl66THBQAA1eq0aj+jWBG9MxX275EbgxzQzw6Sfvp9vG0DEz+O33I/z2+xFWrN0EwJoFf48iHjl2iqlzlnPqbBgF8uVhYM8O5MmV3bZ+2449zFmyhtNnwgkM8KVW9Yq0alIPJ5Mpwz4ZOmYG164l8PHgHgBs/XEXcxav4Xx4FG6urhTMn4dPPuqBu5sbe/cfYsrsZZw6E4aTk4mn8uTgo37vEpItMF07AOOnLeLYyTNMHT0QgNTUVBat2MC6L7/j4qXL5M4RQptmr1Ol4rN/vRaHeLfPCMYN682M+Ss5cfocE0f0TddHsxetZtuOPTR5oxYzF67i6tV4KpQrRb/u7fD0cAdg56/7mf/ZOk6ePo/RaKR4kVB6dGphS+wjIqNp0KoHQ9//H6vWbebwsVPkz5uTwX07cy0+gdGT53PmXDilihdiUO938PP1tm1//VffsXT1V0RERhOcLZC3Xn+FN+pUz7B/79anAF9s+oHPVn3J+YgovL08qfTCs/T6XyvbsdL7f63ZuXs/u387RLM3a9G+xRt3fZ2vXotn8qyl/LhzL8kpKRQpkI9ubzejQP48me7Df9q4eRsTpi/mwz6dmDxrCVHRsTxfrhSDer/Dtz/+wuxFa4iPT6Bm1Rfp9nZzTKYb3/u/+uYnVqzdxNnzEbi5uVK2VFG6d2qOv68PEZHRvNtnBACvvPE2ALWqV+SDXm+TmprK0lVfsvbLrVyIicXf14fXa1WhddN6tpjCIy4wcfpiDv55glzZg+nTtQ0lihawrd9/4E+mzV3O4WOn8PX24uUXnqFT27dsfR97OY4R42bz628HCPDz5e3WDW/7Ot7OgcPH+Wz1l7zXuSVv1nvFtvydNm+RnJzCpJlLeKlCWcIiohg2dqbtdQVo17w+7Vu8AUBiUhLDxs7kux934ZXFk9ZN6/F6rSq29qIuXGTSzCXs2nsAg8HA08UL0aNTC0KCswJ//y8XKZiP1V9swdnZmTUL089A3HztF04bkaZeyWIF+WzNl6SkWKhWqTw93mmOk9ONj+zk5BRmLVzN5u92cCnuCkGB/rRsXJe6NSvdtX2AZWu+Zvnar/l84QTgxvvllNlL2bBpG0ajkTo1X8ZqtaZp527vFwA7du1jwvTFREVfpHjhUGpVr5i5F03sSomg2FWZUkXZu/8wLRvVBWDP/kM0f+s1UlNT2bP/RvKXmJTMoSMneK3GS2nqzln8Oe+2b8z/2jdh1frNDP54GmsWTsDHOwtWaypBgf4MH9gFH+8s/HHoGKMmzCXA35dqL5enacPanD4bTnzCdQb2vDE15O2VJV18PTq14Oz5SPLnzUmHljc+IHx9vImIigZgxvyVdOnYFD8fbz6ZNJfh42Yxc/yHAOz74whDRk+nR+cWPF28MGHhUYyaOBeAds0b3LVvYi5eYtDIT3m3fWMqPf8M8dcT2X/gCFYrmC0W+n40gbqvVmJI/3cxm80c/PMEBkPm+37hsi/4eut2+nRtQ64cwez74wgffTwNXx8vypQsYis3dc5yunRoQvaQoNuOVoZFXGDbjj2MGdKTq1fjGThiMouWf8E7bd4CIDExiSYNXiX/U7m4npjErIWr6DdkAgunDsdo/HtiYvaiNXR/pznBQQEMHzeLD0dNxcPdje6dWuDm6sLA4ZOZtXA1fbq2AWDT1u3MWrianu+2omBoHo4eP8PICXNwc3OldvWX0sV5pz4FWPPFN0ycuYTObRtRoVwprsUn8PvBY2namL14DZ3bNqL7Oy0wmYyZep0HDJuMq6sz44b1JounB59v3EqXfiNZPmcMPt5ZMtWHGUlMSmLluk0M6f8/Eq4n0n/IBPoNmUAWTw/GDe1NWMQF3h82kZJFC1KtUnngxrHTsVVDcucM4dLlK0ycsYRhY2YyblhvgrIGMPKDbvQfOpHlc0bj6eGOq6sLANPmrmDdV9/R7Z1mlCpWiIuxlzlzLjxNPNPnr6RLhybkyhHM9PkrGTTqU1bOG4uTycT58Ch6DPiEjq3eZEDPjly6fIWxUxcwdsoCBva6kXQOGzOTmIuX+PSTATg5mRg3dSGXLl+57f5nZMv3O/Bwd0uTtN3UpGEtPlvzFd/99Ctv1KlG93eaM2vhapbPGQ2Au7ubrexnq7+iY6s3aNW4Lt/9tIvRk+dRukRh8uTKjtlspvuAjylepADTxn6Ak8nIvKXr6D7gExZPH4mz842P1t37DuLh4c7Ekf3uaR/27D9EgL8vUz4ewPnwKD4YMYWC+fJQr1ZlAIaMns6Bw8fp0bkFBfLlITzyAnFx1+5pG7f6bPWXbNz8IwPe60De3NlZuvpLftixm2dKFbOVudv7RdSFi/QfMpE36lSjXq3KHDl2ikkzl/7rmOTRUSIodlW2VBEmTF+M2WIhKSmZoyfOULpEYcxmM59v3ArAgcPHSE5Joew/RqJqvVKRVyo/D9z4tr9i7WYO/XmCCuVK4eTkZEvcALIHB/HHoeNs3fYL1V4uj4e7G66uLqSkmAnw971tfFk8PXB2NuHq6pJhubdbv2lLmlo0qkPPD8aQlJyMq4sLcxZ/TotGdWwJSY6QIDq2eoNPZy/LVCJ4MfYyFouFSi+UIyRbIAChT+UCIO7KNa7FJ/DCc6Vto2p5c+e4a5s3JSensGDZeiaN6mcbsckREsT+g3+yduPWNIlgh5Zv8GzZEndsLzXVysBeHW2jVzWrvsjufQdt6yvfMmoAMOC9jrz6VidOnQ0jf95ctuVNG9ai/DMlAXjr9RoMGvkpkz/uT6liBQGoU/NlNm7+0VZ+1sLVdOnYlEovlgNuvM6nzoaxduN3GSaCd+pTgHmfraPpG7VsI8cARQvlT9PGK5Wf57UaL9ueDx87646v8/4Df3LozxN8uXwqLi7OAHTt2JRtO3bz3U+7bAnL3fowI2azhd5d2tiOgcovPsvX325n4/JP8XB346k8OShTsgh79h+yJYJ1bok9R0gQ73VuQdsug0i4noiHuxveXjeSfT9fb1viH59wnRVrN9Hz3Za2/cyZPRulihdKE0/ThrV44bnSAHRo8QZNO/blfFgUeXNnZ+Hy9bxS5XkaN7jRt7lyBPNep5Z07j2M3l3bEHXhIjt/3c+cSR/Z+vz9Hh1o0qHPHfvgn86ejyRHSJAtGbtV1gA/PD3cORcWgbOzE1k8PTAYDBn+bz//bCnbyHKLt+qwbM3X7Nl/mDy5svPNDz+Tmmrl/R7tMfz17Wtgz45Uf6Mje38/zHN//b+4ubnyfo/2GcZyJ15envR8txUmk5G8ubPz/LOl2L3vIPVqVebs+Qi+3fYLE0f249kyxYEbr+P9WP7517RsXMf2f9Sna1t+2f2HbX1m3i/WbPiGHCFBdH27GXBjxufEqXMsWrHhvmKTh0+JoNhV6ZJFuJ6YxOE/T3L1Wjy5cwTj5+tN6ZJFGD52FknJyezdf5gcIUEEBwWmqRv6VG7bY3c3Nzw93NOMHqxav4UNm34gKvoiSUnJpJjNFMiX54HGf2sMNz9MLl2+QnBQIMdPneX3Q0dZ8Nk6WxlLairJySkkJibh5uZ657bz5eGZp4vR/J1+PFe2JM+VKUHlis/i7eWJj3cWalevSI/3P6FcmeKUK12Mqi89R2CAX6biPh8eRWJSEt36j0qzPMVspmD+vGmWFS74lO1xlXrtbI9rVHmBvt3aAhCSLTDNFGaAv2+a1+JcWCSzFq7i4JETXL5yFWvqjSG4qAsX0ySCtyZl/r4+AGnW+/v62Nq9nphIWMQFRoyfzagJc2xlLJZUPD0znk69U5/GXo4j5uIlnnm6WIZ1bypyS38Ad32dj508y/XERGq++U6aeknJyYSFX7A9v1sfZsTN1TXNebP+fj6EZAvE45aRLX8/Hy7F/d3OkWOnmL1oDcdPnuXqtXhSb3ktnsqT8ZeJ02fDSU5J4ZnSd+6bW18/2/9D3BXykp3jJ89y/NQ5Nm/dYStjtd5IgCMiozl7PhKTyUThAn/3b97c2fHK4nHHbWbkH7Oa/0r+W/bFYDAQ4Pf363Hs5FnCwqOo+nr7NHWSk1MIC4+CvxLB/Hlz3XMSCJAvTw7bVD5AYIAvJ06dB+DoiTOYjEbKlCx8z+1m5Fp8AjGxlylWONS2zMlkuvF//1c/Zub94vS5cIoWTvulqXiRAsjjT4mg2FWuHMEEBfqzZ/8hrl6Lp/Rfb25ZA/wIyurPH4eOsXf/oXSjgQBOTmnPszMYDLbzWrZ8v5PJs5bStWNTihcpgIe7G0tWbeTQkRMPNP5bY7g5MnAzyUm4nkiHFm/w8gvPpKt3c2ToTkwmI5NG9eP3Q8fYtecPVq7fzIz5K5k9aTDZg4MY2Ott3ny9Bj/v/p1vfviFmQtWMXFkP4oXCU3TFzfdeqHH9cREAMYM7UXWfySPLs5pY3O/JWFdMHW47fGtyVa61wIDqbdsv9egsYRkC6Rf93ZkDfAjNdVKs7f7kfKPiy1ungMF2Ka5/9nHN/fr+vUkAPp3b5du1O7WD9F/Lr9dn2b2hP1/JvB3e52vX08kwN+XTz8ZkG79rVPtd+vDjKT/H7jN/8Vfx+T1xES6v/8xz5UtyeC+nfD18SYq+iLd3/843Wtxq5vTw3eT0etnTU0FIOF6Eq/XqpLmvL2bgoMCOXs+MlPbuJvcOYP5/eBRUlLM6ZKw6IuXiE+4Tq4cIXdtx8mUtq7BAFbrjX25fj2JQgWeYnDfTunq3Xr+qvtdvuxldttgIPWvbWf2tbDVNBjTJcZmy71d5HQv7xfy5FEiKHZXplRRfvv9MFevxdO0YW3b8qdLFGbnr/s5dPQk9V+rdk9t/n7wKCWKFkhz0cCtoy8Azk5OWP76kLoTZycnUjNR7p8KheblzPkIcuUIvue6NxkMBkoVK0ipYgVp26w+9Vt244ftu2nyRi3bNgqF5qVV47p06D6Yzd/toHiRUPx8vDl5+nyato6dOGNLEvLmzoGLszNRFy6mmQa+m3+zL3FXrnL2fAT9u7fj6RI3Ev39B/6853b+yd/Ph8AAP8IiLlCjyguZrnenPg3JlpXd+w5S9un0Xzxu526vc6HQvMTGxuFkMtkuJLCXM+ciiLtyjc5tG5EtKACAI8dOpilzM5m79ZjPlSMbrq4u7P7tIHVf/XfTkIVC83LqTNht+ylPrhAsFgtHjp2yJfZnzoVz9VrCPW2n2ssVWLF2M2u/3Jou6Vy6aiNOTiYq/zUF6nQf/9vf/PAz/r7eeHre+4jl/QjNm4tUq5W9vx+xTQ3fiZ+PFxcvXcZqtdq+rB47cda2PounB4H+vhw8cpzSf/1/mi0W/jx2mkKheYHMvV/kzZU93e15Dhw5/m92UR4x3T5G7K5sqSLsP3iUoyfOpnmTKV2iMGu/3EpKipmypTKfrMCNhOXI0VP8vPt3zp6PYMaClRw+mvYDLzhbICdOneXMuXAux1297a1AQrJl5eCRE0RERnM57mqmPzjaNqvPV9/8xJzFazh5+jynz4ax5fudzJi/MlP1Dx45zvzP1nH46EkiL8Tw/fZfuRx3lby5cxAeeYGpc5fzx6FjRETF8MuePzgXFknev65YLvt0UY4cO8WXW378a1p2dZrE0NPDnaYNazFxxmI2btnG+fAo/jx2ipXrNrNxy7ZMxZdZXlluTGWv++o7zoVFsnvfQSbOWPJA2u7QogELl39huwr2+KlzbNj0A5+t/jLD8nfqU4B2LeqzdPWXrFi7iXNhkbY+uZO7vc7lyhSneJFQ2xXuEZHR/H7wKNPnrUh3TD5s2bIG4OzsxMr1mwmLuMCPO/cwb+naNGWCswViMBj46ZffuHT5CgnXE3F1caHFW68xZfYyvtzyI+fDozhw+Djrv/4+09tu8dZr/HH4GGOmLODoiTOcC4u8cXHMlAXAjXPKyj9Tko8nzeXgkeMcOXaKkeNn3/MIWImiBXjr9RpMmfUZS1d9yfnwKE6fDWfG/JWsWLuJrh2b2ZLgkGyBJFxP5NffDnA57iqJiUmZ2kaNKs/j6+NFn8Hj2ffHEcIjL7B3/yHGTV3IheiL9xTvvQoJzkqtai8yYtwsftix27btb374OcPyZUoV4XLcVRav2MD58ChWrd/Czl/3pynz1us1WLR8Az/s2M3ps+GMmTyfq/F/30cyM+8X9V+ryrnwSCbPWsqZc+Fs2rqDLx/we4k8HBoRFLsrW6ooSUnJ5MmVHX8/H9vy0iWLkJCQSO6cIZk+9+2m12tV4ejx03wwYgoGA1SvVIEGdarx8y1vgPVercxvvx+2nSif0e1j4MYJ8EPHzKBJx74kJSWnuX3MnZR/piRjhvRk7pLPWbRiA04mE3lyZc/wFg8Z8fRwZ98fR1jx+SbiE64TnC2ALh2aUqFcKWIvxXHmXDhfbfmRuKvXCPD35Y061Xm9dhXbtts0fZ1P5ywjOTmF12q8xKvVXuTE6XO29ju2aoivjxcLl31BeOQcvDw9KRiah1ZN6t0upH/FaDQypP//GD9tIc3f7k/unCH06NyCd3sPv3vlu6j7amVcXV1ZsmojU2Z/hpurK/mfykWj+jUyLH+nPgWoXf0lkpNTWLbmaybPWoqvt1e6C13+6W6vs8FgYOxft+AZNnYml+OuEODny9MlCtnOg3xU/Hy9GdizI9PnrWTl2s0UDM3L/zo0pc+H42xlggL9ad+iAdPmLmf42Fm8Wu1FPuj1Nm2avo7JaGLWotXEXLxEoL8vr9eumulth+bLzdTRA5gxfyWdeg7FarWSIyQbVV9+zlZmYM+OjBg/m869huPv503HVm8StXBVmnaGjplBRFS07TZIGenRqQWh+XKz5otvmLFgJSajkUKheRn1YQ8qli9jK1eyWEHq167KByOmEHflWprbx9yJm5sr08YM5NM5y+g/dCIJCYlkDfTjmaeL3fZ2Pw9S765tmD5vBWMmzyfu6jWyZQ2gVeO6GZbNmzsHvf7XmoXL1jNv6VoqvViOpg1rse6r72xlmjSsRUzsZYaOnoHRaOC1V17m5eefIT7+uq3M3d4vgoMCGTGwGxNnLGbVui0ULZSPd1q/xfBxsx5uZ8h9MyQnJz2A02pFREQevk69hlG2VJFMJWwicneaGhYRkSfCtfgEwiKi0pxLLCL3RyOCIiIiIg5KI4IiIiIiDkqJoIiIiIiDUiIoIiIi4qCUCIqIiIg4KCWCYhdWqxWz2ZzuZ9BERETk0VEiKHZhsVioWLs1llt+/1ZEREQeLSWCIiIiIg5KiaCIiIiIg1IiKCIiIuKglAiKiIiIOCglgiIiIiIOSomgiIiIiINSIigiIiLioJzsHYA4tsC8Ze0dgoiIPGSXz++3dwhyGxoRFBEREXFQSgRFREREHJQSQREREREHpURQRERExEEpEXQAKSlmPp29jIat36Nx+z40e7sfG7dsAyAiMpo1G75NU75+y+4cPXHGHqGKiIjII6Srhh3A0DEzSEkxs2j6CNzd3IiIjKbHwNFYLKnkDAli7cZvafBa1Qe6TbPFgpPJ9EDbFBERkQdLieB/3LmwSLbt3MO6xRNxd3MDICQ4K107NuWTSfNwdXUh8kIMLTu9T7agAEZ/1BOA73/6ldGT53ExNo46NV+mTdPXAbgYe5lxUxcSERVDUnIyL1Uoy9ut3wRujCRWe6k8e/YfIleOYD7q19ku+ywiIiKZo0TwP+7P46fJlT0YH2+vNMuLFylAVPRFhg3owoLP1rFw2og066/FJzBrwmAux12lYev3qP3KSwQF+jN0zAxaNq5LmZJFMFss9PpgDN9u+4WqLz0HQNzVq8yZ9BEGgyFdLKvWb2H1F1sAsFqtD2mPRUREJLOUCEqGXqn8PAC+Pl5kDwkiIjIarywe7P7tILGX4mzlEq4ncvZ8hO157eovZZgEAjSsW52GdasDYDabqVi79cPbAREREbkrJYL/cYVC83IuPJK4K1fTjAoeOHyMbFkD8PPxyrCei4uz7bHJaMRisXBzEG/WxMG4urhkWM/d3e3BBS8iIiIPla4a/o/LlSOYF58rzagJc0lMTAJuXCk8aeZS2jR9HU8Pd67FX89UWx7ubpQpVZRFy7+wLYu+eIkL0RcfSuwiIiLycGlE0AEM6v0OMxaspPk7/XFycsJkNNLszdrUqfEyZouFp/LkoFnHfmQPyWq7WOR2BvfrxKQZS2jWsR8YwN3Nlb5d2xKUNeAR7Y2IiIg8KIbk5CSdtS+P3M1zBA8f/MPeoYiIyEN2+fx+e4cgt6GpYREREREHpURQRERExEEpERQRERFxULpYROwq5vQenJx0GIqIiNiDRgRFREREHJQSQREREREHpURQRERExEHp5Cyxq8C8Ze0dgkPSPb1ERAQ0IigiIiLisJQIioiIiDgoJYIiIiIiDkqJoIiIiIiD0sUij0DLTu8DkGI2c/Z8BPnz5gIgd84Qhg3okul2IiKjadl5AFvWzHxgsT2MNkVEROTJoETwEVg4bQTwd9J187mIiIiIPSkRtKOfd//OvKVrSUpKxmg08m67xpR9uigAGzb9wIq1m7BawcnJxIiBXW31Zi1czfZffuNafALvdW7J888+DUCFGs15u/WbbNuxh8txV2nb7HVeq/EyAIePnmTc1EVcT0zExdmZbu80p1SxghnGNG3eciyWVLyyeNKnSxueypPDtt1NW7fj7eXJc2VL8vXW7Xy+cAJjpiwgMMCX1k3qAXDmXDhd+41i9cLxOJlMD7MLRURE5D4oEbSTsIgLzFm8hgnD++Dp6cG5sEg69RrKmgUTOHD4GHOXrGXm+EEEBviRmJgEwKXLV7gWn0DoU7no0PINdv66nwnTF9kSQQAXZ2fmTh7C6bPhtOs6iJrVXsSaaqX/kIn0696O8s+UZP+BP3l/6ERWzhubJqbYy3F8OGoqn44eQOhTudi0dTvvD5vI0pkfs2PXPr7/6VcWTB2Oh7sbw8f+PZX8Zr3qdB/wCS3eqoPJZGTNhm+oV6tyuiRw1fotrP5iCwBWq/Uh9ayIiIhklhJBO/l5937Oh0fRqdcw2zKDwUhU9EW279pHzaovEBjgB4Cbm6utjIuLM5VeLAdAiaIFCAu/kKbdGlWeByBv7uyYTEZiYy9z5VoCBqOB8s+UBKBU8UL4+/pw7MQZggL9bXUPHjlB/qdyEvpUrr/aeoExUxYQHRPL7n0HqfLSs3h6uANQp2Yl9vx+GIA8ubLzVO4c/LhzD889U4It3/3M4hkj0+1zw7rVaVi3OgBms5mKtVv/+w4UERGR+6ZE0E6sVihXujhD+r97T/VcnJ0xGAwAGI1GLKmpade7ONseG41GLJa062/6q4l/7x8NvPV6DRav2MCluCuUK1Mcfz+f+9yAiIiIPGy6fYydPFe2BLt/O8jxk2dtyw4eOQHAi+XLsGnrdmIuXgIgMTHJNj38b+TJGYI11cquPX8A8PvBo1y8FEeB/HnSlCteOJQTp85z4vQ5ALZ8v5OsAX5kDfSnbKlifPfTryRcT8RqtbJh0w/p9ufipcvMX7rONuonIiIijzeNCNpJrhzBDO7XmY8nzSUxMZkUs5mC+fMwpP+7lC5RmLbN69N9wCcYMODsbGL4wG7/elvOzk6MHNSNcVMXMWnWUlycnRkxsCse7m7ExV21lfPz9WZw304MGT3ddrHI8IFdMRgMvFi+NAf/PE7LTu/jlcWT0iUK4+XpYatrMBioU6MSm7/bQYmiBe6rb0REROTRMCQnJ+msfcmU+ITreHq4Y7VamTRzCUlJKfTp2sa2vucHY6j2cnlerfbiXdu6eY7g4YN/PMyQ5TYun99v7xBEROQxoBFBybQho6cTERVDcnIK+fLkoE/XtsCNW9N8MGIKT+XJwSuVn7dzlCIiIpJZGhEUu9CIoH1pRFBEREAXi4iIiIg4LE0Ni13FnN6Dk5MOQxEREXvQiKCIiIiIg1IiKCIiIuKglAiKiIiIOCidnCV2FZi3rL1DeGzoSl4REXnUNCIoIiIi4qCUCIqIiIg4KCWCIiIiIg5KiaCIiIiIg9LFIo+B+i274+LshKuLCwDxCdepWKEs3d9p/shjadnpfaaN/QBPD/c7lqtQozmbV8/AK4vnI4pMREREHjQlgo+Joe93oWD+PPYOg4XTRtg7BBEREXlElAg+hjZu3sa2HXv4eHAP9u4/xNhPF/J0iUL8fvAYFouFD3q/TZGC+TBbLPT6YAxxV66RlJRMaL7c9O/RDnc3tzvWA9j+y2/MWbyGlBQLBgP07daWYoVD04z0TZq5lH1/HMZstuDp4U6/7u3Ikyt7mlhTU1MZN3URu/cdxNnJCZPJyIzxg2yjmyIiIvL4UiL4mPhgxGRb8vRq9Ypp1p05F87777Wnd5c2rNnwLTPmr2TCiL6YjEY+6tcZH28vrFYroyfPZ+W6zbRsVPeO9c6ej2D42FlMHTOQvLmzYzabSUxKThdTi7deo2vHpgBs+X4n46ctYsKIvmnKHDt5lt37DrJ05iiMRiPX4hNwvs1vB69av4XVX2wBwGq13l+HiYiIyH1TIviYuHVqeOPmbWnW5ciejWKFQwEoUSSUpas2AjeSqWVrvmb7rn1YLBbi469TomiBu9bbtfcAzz1Tkry5b4zuOTk5kSWD5G3X3gOsWr+ZhIREUq2pXLkan65MjpAgLBYLw8fNokypIrzwbGmMxoyvQWpYtzoN61YHwGw2U7F260z3j4iIiDx4SgSfAK4uzrbHRpMRS2oqAJu/28HufYeYNnoAnp4erFi7iT37Dt21XmZEXohh7KcLmDt5CDmzZ+P4ybN06jUsXbksnh4smTGK3/44wp79h5g+dwVTxwwkV47gf7OrIiIi8gjp9jFPsKvXEvD1yYKnpwfxCdfZuGXb3SsBz5UtwS97fuf02XDgxujctfiENGWuxV/HyclEoL8vVquVVeu3ZNjWpctXuJ6YxHNlS9CpzVsEZ8vK6bNh97djIiIi8khoRPAJ9mq1F9m2Yw+N2vXC18ebp4sXIjLq4l3r5coRzMCeHfnok2mYzRaMJgN9urSlWOH8tjKhT+WieqXyNO3YDx/vLLz0fMa/CXwh+iIjJ8zBbLGQakmlZLGCVChX6oHto4iIiDw8huTkJJ21L4/czXMEDx/8w96hPDYun99v7xBERMTBaGpYRERExEEpERQRERFxUEoERURERByULhYRu4o5vQen29yAWkRERB4ujQiKiIiIOCglgiIiIiIOSomgiIiIiIPSyVliV4F5M75R9ZNO9wQUEZEngUYERURERByUEkERERERB6VEUERERMRBKREUERERcVBKBB+h+i27c/TEmTTLOvcexg87dj+QNjdu3sbps+G2dRs3b6Pv4PH/um0RERH5b1Mi+B+yccs2zpwPv3vBB8RssTyybYmIiMiDp9vHPCbiE64zacYSjp08S3JKCsULh9Lz3VY4Ozvx2eov2fL9TsxmC05OJnp0akmJogXS1F//1XccOXqKidOXMGfRGt5p8xYACdcTGTRyCidOn8fF2ZlhA7qQIyQIgA2bfmDF2k1YreDkZGLEwK5kzepPrw/GEHflGklJyYTmy03/Hu1wd3Nj7/5DjJmygGJFQvnz2ClaNalHwfx5mDB9EZcuXyE5xUy9VyvzZr1XHnn/iYiIyL1TIviIfTBiMq4uLrbn58OjAJg8cymliheif4/2WK1WRk6YzfK1X9P8zdeoWfVFmrxRC4ADh48zdMwMls8Znabduq9W5uut22lUvyYvP/8McGNq+PDRkyycNpzswUFMnbOMRSu+oF+3duzdf4i5S9Yyc/wgAgP8SExMAsBkNPJRv874eHthtVoZPXk+K9dtpmWjugCcPhdOry6tGfBeByyWVNp3+5AP+3Qib+7sJCYm0b77YIoVzk/RQvnT7fuq9VtY/cUWAKxW6wPuWREREblXSgQfsaHvd6Fg/jy25517DwNg2449/HH4GMvWfAVAUnIyRuONmfujJ84w/7N1XLlyDZPJyNnzESQmJePm6pJ+A/9QvEgo2YOD/npcgJXrNgOwfdc+alZ9gcAAPwDc3FwBSE1NZdmar9m+ax8Wi4X4+OtpRh+zB2elTMkiAJw9H8HJM+cZNHKKbX1CQiKnzoZlmAg2rFudhnWrA2A2m6lYu3UmekxEREQeFiWCjwkrVkZ+0I3cOUPSLE9JMdN/yASmfPI+RQvlJz4+gWoNOpKSkpKpRPDW0Uej0Ygl9c7n9W3+bge79x1i2ugBeHp6sGLtJvbsO2Rb7+Hu9nfMViveXllYOG1EZndTREREHiO6WOQx8VKFsixascF2AcaVq/GcC4skOTmZFLOZ4KBAAFau23LbNjw93LkWn5Cp7b1Yvgybtm4n5uIlABITk0hMTOLqtQR8fbLg6elBfMJ1Nm7Zdts2cucKwdPDnQ2bfrAtOxcWSdyVa5mKQUREROxLI4KPiW7vNGfqnOW06jQAg9GAyWTk3XZNyJUjmLdbvUm7roPw8faiWqXyt22j3qtVmDxrCcvXfG27WOR2SpcoTNvm9ek+4BMMGHB2NjF8YDderfYi23bsoVG7Xvj6ePN08UJERl3MsA0nk4kxQ3oyYfpiln3+NamWVHx8vPioX+f76gsRERF5NAzJyUk6a18euZvnCB4++Ie9Q3koLp/fb+8QRERE7kpTwyIiIiIOSomgiIiIiIPSOYJiVzGn9+DkpMNQRETEHjQiKCIiIuKglAiKiIiIOCglgiIiIiIOSomgiIiIiIPSWfpiV4F5yz6ybenefiIiImlpRFBERETEQSkRFBEREXFQSgRFREREHJQSQREREREHpYtF7MxssbDgs3Vs/m4nTiYTJpORooXy8277xnhl8bR3eCIiIvIfpkTQzkaMm8WVq/HMmjAYby9PrFYrW3/cxZWr8U90Imi2WHAymewdhoiIiNyBEkE7OhcWydYfd7F20US8vW4kfQaDgaovPQfA4pUb+HLzjxiMBkKfyk3vLq3J4unB7EWrOX02nMSkZMIiogjw82X4wK74eGfhwOHjjJkyn9TUVCyWVN6oU40GdaoxdMwMCuTLQ+MGNQGYNHMpHu6utG/xBrMXrebUmTCSklM4ez6CXDmC6dyuEZNnLiU8MprCBfIyuG9njEYj8QnXmTRjCcdOniU5JYXihUPp+W4rnJ2d6Nx7GKFP5ebw0ZO4urgw5ZP37da3IiIicndKBO3oz+OnyZU9GF8fr3Trdv66nw2btjFrwod4ZfFk1IQ5TJ2znD5d2wBw8M8TzJ8yFB9vLz4YMYW1X26lVeO6LFy2nqYNa/FK5ecBuHI1PlOxHDl2inlThuGVxYPOvYczcvxsJo7sh6urC23/9wE7f93PC8+VZvLMpZQqXoj+PdpjtVoZOWE2y9d+TfM3XwPg7PkIpo0ZiJNT+kNr1fotrP5iCwBWq/Vf9ZmIiIg8OEoEH1O/7j1AtZefs00P13+tKgOGTbKtL1+2JD7eNxLI4kVCOXH6HABlShVl3tK1nAuL4pmni1KqeKFMbe/ZMiVso5KFQvPi4uyEp4c7AAXz5+FcWBQA23bs4Y/Dx1i25isAkpKTMRr/vuaoZtUXMkwCARrWrU7DutUBMJvNVKzdOlOxiYiIyMOhRNCOCoXm5Vx4JHFXrtqSutsxGAxpnru4ONseG41GLJZUABo3qMlLz5fh170HmT5vBfny5qR3lzaYTEZSU1NtdZKTU/Bwd71te2mem4xYLBYArFgZ+UE3cucMyTBOd3e3u+22iIiIPCZ0+xg7ypUjmMovlmPEuNlcvXZjCtdqtfLdj7vIHhLEt9t+IT4+AYC1G7fyXNkSd23zzLlwsgcHUa9WZVo2rsuBI8cByJk9G4f+PAFA3JWr7Px137+K+aUKZVm0YgPmvxLDK1fjORcW+a/aEhEREfvSiKCdDXivA/OWrqN9tw8xGU2kWq08XaIQ77ZrTGJSEh26f5TmYpG7WbV+C3v2HcLJ2QmT0UjXDs0AqPdqFQYMm0Tj9n3IEZKVYoVD/1W83d5pztQ5y2nVaQAGowGTyci77ZqQK0fwv2pPRERE7MeQnJyks/blkbt5juDhg388sm1ePr//kW1LRETkSaCpYREREREHpURQRERExEHpHEGxq5jTe257uxkRERF5uDQiKCIiIuKglAiKiIiIOCglgiIiIiIOSidniV0F5i37yLal28eIiIikpRFBEREREQelRFBERETEQSkRFBEREXFQSgRFREREHJQSQREREREHpUTQTuq37M7RE2fuqc6kmUuZvWj1v97mDzt2c+Dw8TuWmblgFZu2br9rW0PHzGDZmq//dSwiIiJif7p9jAPZtmMPBfLloXiR0AzXmy0WOrZq+IijEhEREXtRImhnnXsPo3CBfBw6cpyY2MuUK12cvt3aAhBz8RLDxs4kKvoigf5++Pp4kSdXCACzF63m6rUEenRqAcDKdZs5cuwUH/R6mwOHjzNmynxSU1OxWFJ5o041grMF8uPOvezae4Avt2yjYd3q5MyejTFTFlCsSCh/HjtFqyb12LFrHwXy5aFxg5r8+tsBZi5YRVJyCuYUM43feJW6NSul24cff97LjPkrMRoMWCypvN36TV56/tHdH1BERET+HSWCj4GwiCimjB6A2WyhaYe+/HHoGCWKFmDctEUUKZSPCSP6ciEmlladB9gSwTtZuGw9TRvW4pXKzwNw5Wo83l6eVKxQxpbkAezdf4jT58Lp1aU1A97rAMCOXfts7RQKfYrpYwdhMhmJu3KN1u8OoHzZEgRlDUizvZnzV9G3a1tKFC1Aamoq8QnXM4xr1fotrP5iCwBWq/We+0lEREQeLCWCj4FqL5fHyWTCyWSiQP7chEVEUaJoAXb/dpAuHZoCEBToz4vly2SqvTKlijJv6VrOhUXxzNNFKVW80G3LZg/OSpmSRTJcF3flKiPGz+Lc+UhbMnji9Pl0ieAzpYsyftoiqlR8lmfLlqBg/jwZttewbnUa1q0OgNlspmLt1pnaHxEREXk4dLHIY8DFxdn22GQ0YrGkZljOYPj7sclkIjX173LJySm2x40b1GTs0F4E+vsyfd4KRk+ed9tte7i73XbdJ5PmUapYQRbPGMnCaSPIlTOY5JSUdOW6vd2cgT074urqwtDRM1i8YsNt2xQREZHHhxLBx1i50sXYsOkH4Mb5gj/t/M22Lmf2bBw5dgqLJZXExCS+3/6rbd2Zc+FkDw6iXq3KtGxclwNHblwp7OnhTnxCQqa3f/VaPMFBgRgMBn774wjHT57NsNzps+Hky5uTN+u9Qv3Xqtq2JyIiIo83TQ0/xnp0asGwsTNp0qEPWQP8Kft0Udu6Si+UY+u2XTTp0IegQH8K5s9DYlIycONcvD37DuHk7ITJaKRrh2YA1Kz6AsPGzOSHHXtoWKcaObNnu+P2O7dtxOgp85m3dC0F8uehaKGMrzaePn8FZ89F4OTshJurC326tHlAPSAiIiIPkyE5OUln7csjd/McwcMH/3hk27x8fv8j25aIiMiTQFPDIiIiIg5KiaCIiIiIg9I5gmJXMaf34OSkw1BERMQeNCIoIiIi4qCUCIqIiIg4KCWCIiIiIg5KJ2eJXQXmLXvPdXQbGBERkQdDI4IiIiIiDkqJoIiIiIiDUiIoIiIi4qCUCIqIiIg4KF0s8h9Qv2V3XJydcHVxsS0b1KcToU/lsmNUIiIi8rhTIvgfMfT9LhTMn+eBt2u2WHAymR54uyIiImJ/SgT/wyrUaM7brd9k2449XI67Sttmr/NajZcBOBcWyYTpi7h0+QrJKWbqvVqZN+u9YqvXtll9dv66j9Ili9CkwasMHTODCzGxBAX64+2VhTy5QmjRqA4NWvZg7qQhZAsKAGDa3OWkplp5t31ju+23iIiIZI4Swf+ID0ZMTjM1PHPCYABcnJ2ZO3kIp8+G067rIGpWexEDBgaN/JQP+3Qib+7sJCYm0b77YIoVzk/RQvkBMBqNzJ08FID3h02ieJECdGj5BhdjL9Oy8wDy5ArB1cWFOjVeZs2Gb+jUthHJySls3LKNWRM+euT7LyIiIvdOieB/xO2mhmtUeR6AvLmzYzIZiY29THxCIifPnGfQyCm2cgkJiZw6G2ZLBOvUeMm2bvdvB+nSoSkAAf6+vPDc07Z1DepUo13XD2nXvAFbf/yFogXzE5ItMMMYV63fwuovtgBgtVrvb4dFRETkvikR/I9zcXG2PTYajVgsqVitVry9srBw2ojb1nN3d7vtOgMG2+OgQH9KlyjENz/8zOcbv6VDizduW69h3eo0rFsdALPZTMXare9hT0RERORB0+1jHFDuXCF4erizYdMPtmXnwiKJu3Itw/LPPF2UL7dsAyD2Uhzbd/2WZv1br9dkxvyVXL2WQLkyxR9e4CIiIvJAaUTwP+Kf5wh2e7v5bcs6mUyMGdKTCdMXs+zzr0m1pOLj48VH/TpnWL57pxYMHT2DJh36EOjvR7FCoWTx9LStL14klCyeHrxeuwoGgyHDNkREROTxY0hOTtLJWnJHiUnJODmZcDKZiLtylfbdBjO4byeKFQ4F4EJMLG27fMDyOWPw9HDPVJs3p4YPH/zjnuO5fH7/PdcRERGR9DQiKHd1PiySIaOnY7VCitlMgzrVbEngzAWr2LD5Bzq1bZTpJFBEREQeDxoRFLvQiKCIiIj96WIREREREQelqWGxq5jTe3By0mEoIiJiDxoRFBEREXFQSgRFREREHJQSQREREREHpZOzxK4C85a95zq6alhEROTB0IigiIiIiINSIigiIiLioJQIioiIiDgoJYIiIiIiDkoXizwhWnZ6H7jxW79nz0eQP28uAHLnDGHYgC7pyu/df4gJ0xezcNqIRxqniIiIPDmUCD4hbiZ0EZHRtOw8QAmeiIiI3Dclgk+4n3f/zryla0lKSsZoNPJuu8aUfbroPZXbsOkHVqzdhNUKTk4mRgzsSkhwVr765ieWrNoIQLas/vTt1o6gQH82bt7G199ux8/Xi2Mnz5LF05P3e7Rn+vwVnDkXQbas/owc1B0Pd7dH2hciIiJyb5QIPsHCIi4wZ/EaJgzvg6enB+fCIunUayhrFkzIdLkDh48xd8laZo4fRGCAH4mJSQCcOH2OKbM/Y96UoQQF+jN/6TpGjp/N+OF9ADh89CSLZ4wkOCiQjz6ZRu8PxzJz/If4+/nQ84MxfLnlRxrWrf6ou0RERETugRLBJ9jPu/dzPjyKTr2G2ZYZDEaioi9mutz2XfuoWfUFAgP8AHBzcwVg7/7DlH+mJEGB/gA0qFONuUs/x2JJBaB4kVCCgwIBKFzgKcxmC/5+PgAULZSPc2GR6eJdtX4Lq7/YAoDVan0gfSAiIiL/nhLBJ5jVCuVKF2dI/3fTrYuOic1UucwyGNI+d3VxsT02Go24uDineX4zYbxVw7rVbaOEZrOZirVb/+t4RERE5P7p9jFPsOfKlmD3bwc5fvKsbdnBIyfuqdyL5cuwaet2Yi5eAiAxMYnExCTKlCrCz7t/J/qv5Z9v/JZnni6GyaRDRkRE5L9CI4JPsFw5ghncrzMfT5pLYmIyKWYzBfPnSTfyd6dypUsUpm3z+nQf8AkGDDg7mxg+sBv58+bif+2b0GPAJ8CNi0X6dW9nj90UERGRh8SQnJykk7Xkkbs5NXz44B/3XPfy+f0PISIRERHHo3k+EREREQelRFBERETEQSkRFBEREXFQulhE7Crm9B6cnHQYioiI2INGBEVEREQclBJBEREREQelRFBERETEQSkRFBEREXFQSgRFREREHJQSQREREREHpft2iF1YrTd+2dBsNts5EhERedKYTCYMBoO9w/hPUCIodmGxWACoXK+9nSMREZEnzY8b5+setA+IelHswsXFhdw5g1k8faS+1f2l+Tv9WTx9pL3DeGyoP9JSf6Sl/vibI/aFyWSydwj/GUoExS6MRiNGoxFnZ2d7h/LYMBgM+oZ7C/VHWuqPtNQff1NfyP3QxSIiIiIiDkqJoNjNG3Wq2zuEx4r6Iy31R1rqj7TUH39TX8j9MCQnJ1ntHYSIiIiIPHoaERQRERFxUEoERURERByUEkERERERB6XrzcUuzoVFMmT0DOKuXCWLpzsDe75Nvrw57R2W3dRv2R0XZydcXVwAaNmoLtUqlbdzVI/GuKkL+fHnvURGxbBg6nAK5s8DOO4xcrv+cMRjJCk5mUEjPuXU2TBcXVzw8/Wmd5fW5MoRTOzlOIZ8Mp2wiAu4ODvTq0trSpcobO+QH6o79Ufn3sOIjLpIFk93AF6tXpEmDV61c8TyJFAiKHbx8cS5vF6rMrVfeYmtP+5i2NgZzJ081N5h2dXQ97vYPvQdSeWKz9L8zdq83TPt6++ox8jt+gMc8xipV6syFcqVwmAwsHLdZkZOmM3U0QOZOmc5xYuEMmFEXw79eYJ+QyawZsH4//z99G7XHwDd3mnGy88/Y+cI5UmjqWF55GIvx3H42ElqVH0BgMovliMqOpZzYZF2jkzsoXSJwgRlDUizzJGPkYz6w1G5urjw/LNP2359qHiRUCKiYgDYuu0X6teuCkDRQvkJ9Pdj7+9H7Bbro3Cn/hD5t/7bX53ksXQhOpZAf1+c/vqJIIPBQLasAURFXyRXjmA7R2c/Q0ZPx2q1UrRQfjq3bYSfr7e9Q7IbHSMZc/RjZMXaTbxUoQxxV65itlgI8Pe1rQvJFkhU9EX7BWcHN/vjpqlzljNzwSqeyp2DTm0bkSMkyI7RyZNCI4Iij4FpYwayePpIFnw6DF9vL4aOmWHvkOQx4+jHyPzP1nE+PIpObRrZO5THwj/748PenVg+ZzSLp4+kVPFC9Bo0xs4RypNCiaA8ckFZ/YmJvYzZYgHAarUSFX2RbA48HRYcFAiAk5MTjerXYP+BP+0ckX3pGEnPkY+RJSs38sP23Ywb1hs3N1d8vL0wGU1cjL1sKxMRFeMwx8c/+wMgW9CNfTcYDLxZ7xXCI6KJu3LVnmHKE0KJoDxy/r4+FArNy6ZvtwPw3U+/EhTo77BTftcTE7l6Ld72fMv3Ox3ugoB/0jGSliMfI5+t/pIt3+9k4sh+eGXxtC2v8tKzfL7xWwAO/XmC6IuXKFPyv33VMGTcH2aLhdhLcbYy3/24C38/b3y8vewVpjxB9BNzYhdnzoUzbOxM4q5cw9PDnQE9OxL6VC57h2UXYREX6D90IqmpqVitVnIEB9GjUwtCgrPaO7RHYtTEOezYtY/Y2Di8vbPg4e7GqvnjHPYYyag/Jo7s55DHyIXoi9Rr3o0cIUF4uLsB4OzszJxJHxF7KY6PPplGeGQ0zk5O9Hy3FWWfLmrniB+u2/XHlE/607nXcJJTUjAajPj4ZKFbx2YUcJAvC3J/lAiKiIiIOChNDYuIiIg4KCWCIiIiIg5KiaCIiIiIg1IiKCIiIuKglAiKiIiIOCglgiIiIiIOSomgiIiIiINSIigicg9mL1pN38Hj7R3GQ1OhRnOOnjhj7zBE5BFxsncAIiKP2v4DfzL/s3UcPHIcq/XG7/jWqPI8jerXxNn50b8t1m/Zne7vNOfl55+557qzF63m2ImzfDy4x0OITET+65QIiohD+enn3/hw1Kd0aNmQD/t0wtfHi9Nnw1m04gtiYi8Tki3wkcVitlgwGTUxIyL2o5+YExGHYbVaadj6PV6r8TJtmr5+23KHj55k/LRFnDoTRmCAL22avs4rlZ8HbozAHTl2muCgQDZt3Y6nhzv/a9+EapXKA2A2m5m5cDWbt+4gKTmZsqWK0vPdVvj5egM3pl7f69yStRu3ci48kgrlSvHjzr04OzthMhqpUeUF+nZrmy7uqXOW8+U3P5KYlESAny9dOzbDkmph4PDJWFOtuLg4A7B13Zy7xnAx9jKTZy1l976DJCWlEPpULsaP6IubqwsVajRnwdThFMyfh7PnI3hv4Gga1a/Jm/VeYdPW7cxetIbYS3F4eLhTv3YV2jar/6BfJhF5hDQiKCIO41xYJOGR0VSvVOG2Za5ei6fHgE9o17wB9WtX4fdDx+j1wRiyBQVSqlhBAH7Z8zsf9ulEj04t2LR1OyMnzKbCs6Xw9HBnwbIv2P7Lb0wf9wHeXlkYOX42gz+eysSR/Wzb2PzdTiaM7IuPVxacnEy80fq9O04N79p7gM3f7WD+p8PIGuBH5IUYkpNTyJ0zhFaN66abGr5TDKmpqfT+cCxP5cnJ0pmf4OHhxsHDxzEaDGm2efDICfoPnUDXjs2o9nJ5ricmMnTMTCZ/3J/SJQpz9Vo858Ii7+flEJHHgOYkRMRhXIq7CkDWQL/bltmxax++Pt68We8VnJycKFOyCK9Ufp6vtvxoK1MoNC/VXi6PyWTk1WovkmI225Kir7/9iTZNXic4KBAPdze6vt2MXXsPEH3xkq1+87dqkzXADxcXZ4yZmBp2MplITknh1OnzmM1mgoMCyZ0z5Lbl7xTD4aMnOX02nN5d2uDt5YmTyUSp4oVsI4oAP+/eT7+PxjOo9ztUe7n833E4mTh9Noz4+AS8snhStFD+u8YuIo83JYIi4jB8vbMAEB1z6bZlLkTHpjtPMHtIVi7ExNqeB/j52h4bDAZcXVxISLh+o35MLCHBf9fPGuCHi7MzF6L/rh+cNeCe4i77dFHat2jAzIWrqPlmJ/oPmUh45IXb78MdYoiIiiFroB9uri63rb/8802UKVWUZ54uZlvm7ubG6I/e48ede6nXvBtvvzeEPfsO3dN+iMjjR4mgiDiM3DlDCMmWlW++//m2ZYKy+hMRFZNmWURkDEGB/pnaRlCgPxGRf9e/GHuZ5JQUgrL+Xd/wj1HAf07LZuSNOtWZPfEj1i6eiLOzE+OmLrrRliH92/idYgjJFkh0zCWSkpNvu62P+nXm9Lkwxn66IM3ycqWLM25Yb75eOY0qFZ+l70fjSU1NvWvsIvL4UiIoIg7DYDDwXueWLFrxBSvXbSbuyo2p4rPnIxg+bhYRUTFUKPc0ly5fYfUXWzBbLOz74wibv9vBq9VezNQ2alZ9gQXL1hN14SIJ1xOZOGMJ5UoXJ2vA7aej/f18CAu//QjfoT9P8PvBo6SkmHF1ccHdzRWTyfhXXW8iLsRgtlgyFUORgvnInTOE0ZPnc/VaPGaLhf0H/iQ5OcVW39srC5NHvc+Bw8f5ZNI8rFYrsZfi+H77r8QnXMdkMuHp4Y7JZMpUn4jI40sXi4iIQ3mxfGnGDevNvKVrmblgFQDZggKoWfUFAv19b4y2DevNhOmLmTZ3BYEBfvTu0ppSxQtlqv2WjepyPTGJDj0Gk5ycQplSRRnct9Od6zSuy/ipi5i3dC2vVK5A7y5t0qyPT7jO5JlLCYu4gMlkokTRUFuZKhWfY/N3O6n1ViesVtiyZuYdYzAajYwe0pNJM5bQqF1vUlLMFMifm3HD+qTZpreXJ5NG9aP7+58wasIcOrR8gxVrNzF87CxSrankzhHCiIFdM3WOo4g8vnT7GBEREREHpa9yIiIiIg5KiaCIiIiIg1IiKCIiIuKglAiKiIiIOCglgiIiIiIOSomgiIiIiIP6P/t+nk7e5/IdAAAAAElFTkSuQmCC",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAoIAAAH1CAYAAABiP5/xAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjksIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvJkbTWQAAAAlwSFlzAAAPYQAAD2EBqD+naQAA32FJREFUeJzs3XVYVUkfwPEvXVISoqigoCDY3a3Y3YHdibW71uoau3atnWt3oa5iYq+FnagYSJf05cJ5/0COXLmUG/juzud5fB45Z87MnLnnXIaZc+anoVAkSgiCIAiCIAj/OZp5XQFBEARBEAQhb4iOoCAIgiAIwn+U6AgKgiAIgiD8R4mOoCAIgiAIwn+U6AgK/zrDPKZhVrgcLTsNyDJdmerNMStcjmEe0/6hmgl/hlnhcpgVLsfPi1bndVX+L/y8aLXcZoJ6u/d7UqlOayztK2FWuBw79h75x+uQ0++rP8Pn3iOatOlNQcdq/4rvvB17j/zfXttp92WZ6s3zuioy0REU8lTLTgPU3hSXrt6Ub/S8+HL+LxDtK/yT/okOT26EhIYxauIMXr5+i7VlfipXKIOlhfnfVl5e3m8jJ8zg5p376OhoU6l8aYrZFf7H6/A10n4/fNlxtbQwp3KFMlSuUCaPavb/IW2wI7s/nrX/ofoIwr+aQpGErq5OXldD+JuIz/fb9Gc+F99Xb0hKUgJwZM96SjjY52l9/k5Pn78EYOaUsfTr1flP55fX5+nWqC5ujermWfnfutx+PmJEUPi/8s4/gCFjplCyQkMs7SvhUrkJ4yfPISIiKsvj3r7/QPseQyjgUIVKdVrj+ftZtemiPkbz3fR5lK7WDKtiqflPnrmAuPh4OU36kY1lqzbjUrkJBRyqZFq2JEls+G0Pddy6YONQlcJONWjYsgf3Hz2V05zwukCz9n2wLVmdAg5VqOPWha27Dqrko25E4cu/mN+881dJ17XPSAo6VqNsjeZyfmmjrWlGjJuuMir74qUf3fqNxrFcfayLV8alchM69RrObZ8HmZ7j/UdPadN1EE4VG2FdvDKFSlSjQcse7DlwTO05rFj7G4NH/UBhpxqUqtSYBcvWqaR7+Pg5jVv3ooBDFWo16cy1G3cyLTu9mNg4xv0wG9cqTbEuXhmHsvVxa9eHnfuOymmiY2KZOmsR5Wu1xKpYJYqVrkvHnsOIj08APv8VPW3WYkaMn05Rl9p06DkUgMREBXMXrqJi7dZYFauEY7n6jBg/nbDwCJV63Lpzn869R1DUpTYFHKpQt1lXjhw7/VVtkZNrUpIkZs//lWKl61LUpTYTp/5MUlJSjtrM6+wlmrTpTVGX2hR0rEaFWq3oN2wikZEf5TSnz12mRcf+FHaqgY1DVZp36MvFKzdU8smqXctUb86uT5/Bleu35HO/dPUmkLP7Oqv77ubt+7TpOohipetSwKEKZao3p8eAsbz2e6f2nH9etJrmHfrJP1ep11alPrm5H5et2kyvgR7YlqzOmO9+ylBWdvdbelt3HqRsjeYUdqpB1z4jCQoOVdm/58AxGrTsQUHHahR2qkHHnsNUvkcyKzs5ORkAj+9nq4wQPX76gl4DPShWui5WxSpRrmYLZv68TL4X4PN3zODRk5k2azGO5epTuV4b4PO9Mnj0ZCbPXEDRUrUoVakx2/ccJjAohC7uIylUohq1mnTm+k0fOc+cfF+YFS7Hleu3ANi176jc3m/e+Wc6Nbx9z2HqNe+GjUNVCpWohlu7Phw/dV7en5Pvx6y8fPWGgSO+p2SFhvK9OHXWInl/REQUE6bMxbVKUyztK1GifAMGj/qBd/4BavM74XWBag3aU6hENZp37MeLl34Z9n/tdWhWuBzv3n8AYN6SNVlOpYsRQeH/RkhoGE3b9CYgKAQ9PV0cixfF99VbNm7dy7U/7nDu+E709fUyHCdJEu6Dx3P3/mM0NTXR1tZmyOjJJKekqKRTKJJo1XkADx49Q19Pj5KOxXn56g2r1m/n4ePnHNm9Dg0NDTn9zTv3uHbjDiUc7ElIVGRa70nTfmH9lt0A5Dc3o4C1BQ+fPOftuw+UdXVmz4FjDBkzBQBrKwv09PR48OgZoyfOJDgkjAmjB31Ve4397icK2lijo6PN23cfGPvdLKpXqYCxcT4qVyjDrU8dO3u7wljmN6eAtSUAA0Z8x/2HTzEzNcG5pAPBIWGcuXCF9m3cqJTJVMzbdx+4fO0WtoVscC7pwNt3H/C594ghY6ZgZmaS4a/3n35ZjkV+c/T09AgICmHOgpVUrlCGBnVrEB+fQBf3EXwIDEZHRxulUknXPqNydM5zF65k07Z96Onp4lzSgaiP0dzyeUDxYkXp0bmN/Bnfe/AEgCKFC6Gjrc25i9dIVCgwMNCX81q7eSdamloUsy+CgX7q9t6DxuF17hJaWlo4l3Tg3fsP7NhzhNs+Dzh/fBcGBvpcv+lD6y4DSUpSUsDakgJWFtx/+JQ+QyeweulsundqneO2yOk1uW7zLhYuXw+AbcECHD7mRVxcPNkJDQun1yAPFIokCtsWxNTEmPcfAjjk6cWMyWMxMzPh4NGTDBjxPZIkUaRwITQ1Nbh2w4f2PYZyaOca6taqmm27lnV1Ii4unrDwCIzzGeFUojgAxsb5cn1ff3nfpaSk0LXvKMIjIrG2sqCkbTECAoM5ceo8wwb0pJh9kQznbVuwAE4livPsxSsAyrg6oaeri7Fxvlzfj3MWrkRfTw+7Irbo6mQchcnufktz5+5Dbvs8wLZQAWJi4zh19hJTf1rE+l9/BmDZqs38OHcpAI7F7YiNjeOs91Wu3/Th3PGdcpvmpGzbggV49uIVTdu6ExMbRz4jQ4rbF+W572uWrNzE3QePObRzrUpeh495IUkSJYrbo6GpOoZ05Php8hkZYWCgT0BQCGMm/UQxu8LExcWjo6vDoyfPGTjie3yuHENHRydH3xeVK5Th2YtXRMfEYpHfXJ7O1tPVzXCeAAuWrWPOgpUAFLYtSFJSEn/cukvPAWNZu2wOXTu2Ukmf2fdjScdiavN/9fotDVv3JCoqGi0tLRyL2xEZ9ZELl/4AICEhkZad+vP4mS/a2to4Fi+K3xt/9h46waWrN7nktRdLi/xyfkHBIfQbNhG7IrbEJyRy7Y87jBz/I6cO/wbwp65DHW1tKlcow/1HT1EokihkY02hggXUnhcACkWiJP6Jf3n1r0mbXpKhtXOW/zZv3yspFInSjLlLJENrZymfjYt04/ZdSaFIlA4e/V1Ot2nbHkmhSJQGjJgkGVo7S03a9JIUikTp9LmLcpo1G7dl2DZgxCRJoUiUtuzYJxlaO0tmhctIT54+lxSKROn23ftyutPnLqrkb2jtLB0/eVZSKBKl+Pg4tef34uUryahAKcnQ2lnq4j5ciomJkRSKROlDQID02u+tpFAkSiUrNJAMrZ2lum6dpejoaCkxMUHq4j5cMrR2liyKlpcioyIlhSIxQ3ukb7+0c3jx8pWcrnu/UVJiYoJ05+6DDOefWX4KRaJkXayiZGjtLF28cl3e9tz3pfTi5atMP8d37/2l9/4f5J8/fvwola7aVDK0dpb6Dh2focz6zbtKMTExUkBgoGRqW1oytHaWJs+YJykUidKG33bJ6U6cOpdh28yfl2Zaj/Y9BkuG1s7S3IW/ytuCgoKl23fvSwpFovTbzv1yPguXrZXT3HvwSP5snCo2lAytnaUizjWkV35v5M/3nPcV+djzF69KCkWi9Pbde8miaHnJ0NpZ2vDbLkmhSJSatk39TFp26ivFxcVKCkWiNH7ybMnQ2lkqUa5ertoip9dkiXL1JENrZ6lRq+5SXFysFBkVKZWr0UxOl1l73bjlIxlaO0sFileSoqKiJIUiUUpMTJCu37gtRURGSApFouRcKbU9Bo/6XkpMTFC5Phu16p7jdv3yvkz7l9v7+sv7LjAoSN7u9+atStn+Hz5keu5nL1yWj0t/bef2fixfs7kUHByS5fdAVvdb2nnls3GRr9O08uxda0kKRaIUGRUpWdqlXmez5i2TFIpEKS4uVqrVpGOGeyynZfcfPlEytHaWrItVlK/zpas2ymnPnL+k8h1jVriMXL+080y7V4qWqiEFh4RIT5+9kI+vVKelFB0drfJd+/Dx01x9X3z5/Zb2b/P2vSrXdkRkhHwfdnEfLiUkxEvR0dFSnaadJENrZ8mpYsNcfz9++W/QqO8kQ2tnydS2tHTp6h/y9pt3Uq/ZTdv2yPkcPPp76v11+66Uz8ZFMrR2lmbMXSIpFInSzJ+XyumOHD8lKRSJ0oQps+VtaffhX3Edpn0+WX1nKhSJkpgaFr4Juro68sO/lSuUUfvXrc+9RwCUcLCnfJlSALRq1hDDT6M4d+8/Vpv3k2e+8v/btGgMQL3a1TA3M1VJd+fuQyB1ZLBS3TaYFS5HnaZd5P0379xXSV/CwZ4mDWsDoKWlpbZsn3uPkKTUKI4jh7jLz21YWuTHtlABQkLDeP9p2qB180bo6emioaFBx7bNAIhPSODps5dq885O5/Yt0NDQwLnk57YMDgnP9rhmjeul1qfLQKrWb0fvQeM4e+EqNtZWmR6joaHB1J8W4lypMRZ2FbFxrMorv7cABAaFZEjfrnVTdHV1sMhvjtWnv5KDQ8OAz88zGRro07hBLQDat3bLySnT/FPd5yxYSelqzejQcyhrN+/C2tICQJ7e1tPTZcTg3vJxpZwcMzxT06ZFIwoXsgFSP9+06wOgZaf+mBUuh3OlxsQnpE6j3bqTmndauvMXr8tvo67esB0A/4AgPgQE5bgtcnJNfoyOwf9Tns2b1EdbWxtDAwOaNqqTbXs5l3TA3q4w0TGxlCjfgLrNujLMYxqBwaEYGRoSGhbO23ep00vb9xzGvEh5zIuU59jJc6nn/Kk9c9OuX8rtff3lfZff3IyqlVKnvCrWbk3NRh3lUW2L/Ll7+eNr7sfunVpjZmYi1+druTiXoIyLE5D6uQAEh3y6J569JO7TdG3aW6eW9pXktku79nIj7dgaVSvK13nndp+nq79s9zo1qsj1+/I8q1epgJmpCUWLFJK3NahbAz09XeyK2srb0s4nt98X2Xn67KV8H3Zs2wxNTU309HTl7/t37z8QGqb63Zfb78e0a7xW9cpUq1xe3l6udOo1m9aehgb6tGrWEIDyZUrJz55+2Z4mJsY0b1IfAOcSDvL2kLDwf/w6FFPDwjehgLUVZzy3yz9funqT1l0G5klddHV1KOvqnGG7mamJys9WnzoX/7S0530APkZHZ5rO1MQYAG3tz7d5Wqc0K2uWzaZ503pcvnaLpy9ecfrcZTx/P8uTZ74snDNZ7TGDR0/mwqXr8herkaGhPK2TnJySIX1a3QC0PtXvy6qln4bPqb69OlHCsRi/n77A46cvuHv/Cee8r3HkuBfXzqo+W5Nd/ll9vureVrS2Vk2f2XSMMt3nBzlri5xek7mlr6/HhRO72HPgGLd9HvD0xSv2HDjG7v2ebFmzgNo1Kstp06YVv6RQqD6L+DWfW26o+1yO7F7HvsMn+OPWXZ49f8WR42c4cOQkQcGhjB7W9++tj9Vf8z2gch1k8YvcqURxjPMZqWzLb272l9QhK1mdp7FxPkD1u8Y4X+q29NdD2vdPbr8v/g5f+/34V5cPoKX9+fP+2jr8metQjAgK/zcqlHMFUl9muPvpWaRjJ8/JfymXL+ui9rhSTo7y/4/9njqScfHKDSIiVV8wScs/OTmFhXOncMZzO2c8t3Ns30ZGDe1Lp3aqD3fn5BdehXKucrrVG3bIvzTDIyLx/xCElaUFhW0LAuD5+1kSExVIksSBIycBMNDXx9kp9a9FK8vU0aKXr94A8Nz3NY+f+vK10p57+/JZsqt/3KFVs0Ys+WUavx/YzHceQ1K3X7+daV63Po2W9unRgWtnD7Jv60qMjAy/ql5poyGxcfGc874KpD6DlBO3fR5QysmB2dPGc3DHGvZsWQHAk2cvCY+IlJ9xTExUsGrD5z88nr14lW2HJu36APAYOUC+Pk4e2sL344bRu1v7T+lKA6nPyXnu3SCn+23tIjxGDqBo4ULkVE6uSRPjfNh+6nD+fsYbpVJJXHw8p89dzjb/j9ExPPd9zeB+3Vm34mcuntxDw7o1ALhy/TaWFvkp8qm+5UqX4uShLXId1iybzZSJI9DV1clRu6aN8KV/ySX9Oeb0vv7yc5EkiRu379GzS1tWLvqJM57b6d2tXeo5/JH5NatObu7HzOqTmczut5xwdnKQj29Uvyanj26TP4dFP09h/Ojc/9Gc1u7XbtzB/0PqiPK+w7/L+7Nr9z8jp98X8jWTTZulb5+DR0+RkpJCYqJCfimwSOFCKs/nfY20a/zK9Vty/QEePH4GfG7PuPgEecT87oMn8gsgmf1+Uuevug5z2n5iRFD4vzGob1e27jpIYFAIbu3cKW5fhBcvUztFLk6OdGqrfoHOurWqUra0M/cfPmXc5Dms2bQDvzf+6Ohoy8tHAHRq25xV67fz6MlzGrbsgVOJYiQlKXnnH0BiooJ7107kegTGrogtA/t0Zf2W3Rw5fprL125RwMqCl35v2bhyHraFCjBt0kiGjJnCLZ8HlKneDD09Pfltr/GjB2JoYABAvVrV2H/kd35dt43bdx/y4PGzP/UXbAlHe+4/fMrMn5exa99R6tepzvTvRzN0zBQiIj9iW6gABgb68lSta6mSmeblWqokf9y6y9Zdh7h+04eAoBA0+LpfHJ3bteDnhasICAqhW7/RFLcvwrv36t+6+9LaTTs56OlFoYLWmJuZym+NFrJJ/bljm2as2biDew+eMPWnRazbvAsdbW1ev3nPqwfeWU5j1qlZhUb1anLW+yo9B4ylhIM9WlqavHsfQGxcPJ57N2BXxJbJE4bTtttg/rh1F6dKjbErUoiwsAgCgkKoWa0SLd0a5LgtcnpNjhzShx9mzOfaH3coV6MFSUolUR8zHy1OExoaTtO27piZmlCoYAGSkpLkX1ylP33e078bxaBRP3Dk+GmuXL9FQRtrgoJDCQ4Jo3vnNjSoWyNH7Zo2ReZz7xE1G3XE0NAAz70bvvq+TpOcnEzbboMxzmeEbaECaGpo8vTTSyCls7hmM5PT+zG3MrvfcsLQwICJYwfz0y/LWbV+O4eOnsLCIj/+HwKJiIziO4+hKtOVOeExoj/Hfj9LTGwc1Rq0w7aQDc99XwPQoG516taqmttTzLGcfl+UcLTn9PnUGYm6zbpiZZGfAzsyrolnZGjIuFEDmLNgJZ6/n6VsjRYkJSXJb11PnTjiT9d5/MiBHDt5jqioaNza96WEgx1RUdFYWOTnstfe1Ht13TYeP/Ol79CJ8ssiKSkpFCxgxeB+3XJV3l9xHZZwsOfZi1es3byTy9dvUcrJgVWLZ2VIJ0YEhf8bVpYWnD66ja4dW2FqYsyLl2+wtsxP/96dOb5/k9o3hiH1L6Vt6xdTr3Y1tLW1iE9IZMXCGdgUsFZJp6eny/H9GxnSvwe2hWzwffWGyKiPVCjrwrTvRsnPmeXW/Fnfs3DOZMq4OhEbG8ebd/64OpeQn6fp2rEVOzcto3qV8sTExBIcEkoZVyeWL/hR5c2wOT9OwK1RHQz09fB7857xIwdSvUqFr6oTwLyfvsPFuQSKpCTu3HuE76eRxh5d2+Ls5EBYeCTPXryigJUlfXt2ZMHsHzLNa9Xin6hTswr6errExSfw84xJWXYcs2JgoM+erb9SMd0I3PYNS3J0bNNGdalRtQIJCYk8fvoCPT1dmjWpx96tK9HQ0EBXVwfPvRsYOcQdu6K2BAQGEx4RRf061TJ9GzG9HRuXMmnsEByKFcXv7XuCgsMoWaI4E8YMwsU5deS5VvVKnDiwiSYNaqOhkToqpq2jTZsWjRk11D1XbZHTa3JI/+54jOiPmakJH6NjcGtUl6H9e2Sbf35zM3p0aYO1lQVv3/nj/yGQko7FmP79aNx7dABSn6Xa89sKalWvTEJCIr4v35DPyIhunVrj3j11FDQn7dqrW3vatGiMiYkxj5/5csvnAckpKV99X6fR0tKif+/OFC1iy4fAEF75vaNokUKMGtKHSWOH5Kq9Ief3Y25ldr/l1LiRA1i9dDYVy7kSGRXNa7+3WH1qp9bNG+W6Pk4liuN1ZCutmjVER0eHl6/fUrRIITxG9GfnxmW5zi83cvp9MWpIH+rXqY6hgT73Hz7FJ5PnwAEmjhnMioUzKFemFKGh4Xz8GEPVSuXYsXFphjeGv0bxYkU557mDTm2bk9/clJevU59prFc7tcOsr6/H8f2bGNinKwWsLPB99ZZ8+Qzp0r4FXke35XpE8q+4DqdOGkmVimXR1NDE596jTGeQNBSKxH9uUlwQBEEQBEH4ZogRQUEQBEEQhP8o0REUBEEQBEH4jxIdQeH/2oZtB/huRs6eH/t/VMOtF89f5u5Zor9bdEwsNdx6ERCY8/W+hk+cze6DJ/+S8gODQ2nYdgAxsXF/SX7pnTp3hUFjZ/6led598JQ2PXMWGeWv9Gfa/M69xzTpMDjT/c9fvqGGWy/5Z48p8zngmbM3u/8K39p9n6hQ8N3MJTTpMJj+o6bndXXU8r56i/buY/O6GsI3SHQEhTx37+EzPKbMp2nHwTTpMJjeQyezfe8xlTd6/0nt3cfiffXWVx37rf2CyguzFq5lyeptf1v+NtaWnDuykXxfuTxNGnWdHbeGtVi/9Ef559xeCwGBIdRw60V0TKy8rXwZZ47uWPGn6vqtWzJnEh1bN/lb8j7udRH3YerXr/xWnL90g7fvAzi+eyWbVmSMN/z/Tt11/a36Fv94/taJ5WOEPHX5ug8//rKSQe6d+HHSMMxMjfF7+4Ftez0JDY+kYAHL7DP5iyiTk9HSFH8bCYKQOx8CQyhqWzDbKCqZUSqVKgsb/xv80+f0b2zDf4poNSHPSJLEktVb6dWlFd06NJO32xctxLQJn5d9ePL8FUtWb+P1G38sLczo16MdTRvUlPcnp6Sw8NffOHXuCkaGBowc2J3G9asDqV8O67YewOvcVRIVCiqVc2H8iD6YfwrFU8OtF+OGu3P4+DnefQikRpVyBAWHMf3nlWhpauLWsBbfjemfod6rNu7hxJlLJCQmYmFuxujBPUlOSea33UeRUiQath0AwLkjG7OtQ1h4JCvW7+TW3UckJibhWKwIS+Z+h76e6nImb98HMG7qArq2b0bntk05de4KG7YdJDwiCkNDA9q3bEj/nu0ztHNcfAIzflnFwye+KJKSKFG8KOOGu1PCwQ5IHcV8+sIPG2tLtW2oUCSxdM12znhfJ5+RIX27t8n0M917+BSnzl1FQwM8T17AxtqSnevnARAeGcXYyfN48PgFhW0LMG3CUByLFZHruGrjHi5fv4NCkUS1ymUZP8Jd7ahfQGAIHfp44HVgLcb5jJi1cC3aWlrExSdw9cZdLC3M+G50fyqWS13AVV07dWzdGI+pC1AokuTPavHsifgHBLPn0Em2rp7L5NnLM1wL7l1bq5QNsGT1NmJi45g2YQgDRqeOJrbtmbo+3Hdj+mNlYc53M5dy+uA6IHWh7BXrdnL5jzsA1KleidFDemCgry+f2/SJQ9m4/SBRH2OoW7MSP4wdgLa2NlEfY5i7ZD0+958gSWBb0Jqfp4/N9A+mrNo8PCKKRSt/4879J+jp6tKsUS0GundEW01Ui+iYWH5ZupEbdx6S39yUjq0bq+wfPnE2dWtUpluHZty595jvZi5l1KDubNx+iIREBa2b1WPkwO5y+n1HvNi+9xgJiQo6tGrElT986Nq+GS2b1lXJ95mvH/OXb0aZrJQ/p7TrKav7XpIk9h3x4oDnGcIjoijhUJRJo/ph/yncWXv3sbRr0RDvKzd5/eYD5cs4MeO74az7bR9e569hZmrMtAlDKOua/RJIy9fuYN9RL/m+796xBYPcO/LH7Qes3LibDwHB2BayZsSA7lStmLrY+KyFa9HU1CQuLp7rt+8ztG8Xzl++gYuTA09fvObRk5c4FCvM3GljOPr7eQ54nkFHR5txw92pX6tKjs4xOCSMOYvX8/CpL0UK2VC/dpUsz2PXgRMcPHaW8IgozM1M5O8ZQO117dawlsrxaZ/7sH5d2LrHk/zmJmxaMYsbdx6yZvNe3vkHYmVhzrD+XahTo5LcDhoaGkRHx3LT5yGFClozcWRfypVODWWXk3tlyrhBbNl1hLj4BGysU++DwR4z0dTQwL1bG/p2b5vtZ/ifl1UgYvFP/Ps7//m+8pMqNegsvfJ7m2masPBwqWHbftKOfZ5SXFysdP3WXal2817STZ8HkkKRKK3auFOq1qSbdOK0txQfHy8dPn5GqtOitxQRmRqQe/Wm3VLnfh7S2/f+UmRUlPTdjEXSsPEz5fwrNegs9Rk+WfIPCJRiYmKkhIR4qWW3YdLpC1cyrdOla7ek5p2HSP4BgZJCkSi9fe8v+b7yk+vjMfkXlfRZ1SEhIV7qNWSSNG3ucik0LFyKi4+Tbt65L8XExMj1e/jkueRz/7HUrPNg6cRpb0mhSJSiPkZJVRt3k/64fU9up7sPHqutb0REhHTCy1uK+hglRcdES/OWrZfa904NuJ6TNvx1/Q6p24Dxkn9AoBQWHi6NnDRbqtSgs/Tm7Xu15U2bu1yat2yDyraBY6ZJzToPlh49eS7FxcdJP81fJQ0cM03eP3H6Aun7mYulsPBwKepjlPT9zEXSlNnqA6W/efteqtSgsxQWHi6XV6dlb+n6TR8pPj5eWrtlj9Sy27Bs2+n6TR+pXqs+KnkfOnZa6jbgc9D7L6+FL8tWKBKlecs2SNPmLs90/5flTP95hTR47I9SSGioFBwSKg0cM036af4qleO/n7lYioiMlPwDAqXmnYdIh46dlhSKRGnZmq3S6O/nSh8/fpTi4+Olh0+eSyGhYWrbKbs2H+zxo/TDT0ukyKgo6c07f6lTn7HSut/2qq3zlNnLpGHjZ0ph4eGSf0Cg1HPwJKlSg84qZW3dfUQ+tkqjLtKCFRul6Jho6bnvK6lWs17S9Zs+kkKRKF3547ZUv3Ufyef+Yyk2Nlb6df0OqWrjbvI5fvnvy88kJ9fsrgPHpK79x0svX7+R4uLjpO17j0pteoyQYmNj5c+124Dx0rv3H6TwiAipc18PqV2vUZLXuctSfHy8tHLDTqlL/3E5/i778r5/+fqNVMOth+R17rIUFx8nnTx7SarZrKfk9/adfM3WbNZTunj1ppSQEC99/PhRGjhmmtS88xDp6fOXUkxMjDR03EypTY8R0va9R6W4+Dhp/9FTUsO2/aS4uNgcneOAUVOlqXOWSR8/fpSe+76WWnUbLt8X6v6dOntJevf+g5SYmCBdu+Ej1XDrIX/Pqruuv/yX9rnPWrBa+vjxo/Tx40fp8dMXUv3WfaSrN+5ICQnx0s0796W6Ld2lFy9fy+1Qo2kP6ezFa1JcfJy0++AJqX7rvnI5OblXPKb8IoWFh0sfP35U+c7M6Wcn/iVKYh5MyDMRUamRD6wsMw8Mf/XGXcxMTejctina2tpULFuKpg1q8vvpS3IaJ0d7GterjpaWJs0b1yZJqeSdfyAAJ89epl/3dthYW2JooM/oIT25cechIWER8vG9urTEysIcXV0dNHMwNaytpYUiKYnXfu9RKpXYWFtStHDBTNNnVYcnz1/h9/YDE0f1w8TYCG0tLcqVdlKZYrp+6x7fz1zC9IlDaVyv+ud6aGvh99af2Ng4jPMZ4fJFyKE0RkaGNK5fHQN9ffR0dRnYuyNv3weqtEFWbeh1/iru3dpgZWGOcT4jBvTKOOqYE80a1qKEgx3aWlo0b1KHZy/8AIiI/MiFKzeZMLIvxvmMMNDXZ5B7J854X89x3NGaVcpTsZwLWlqatGxal8CgUDmyRk7b6Z+QkpKC1/mrDOvfBVMTY8xMjRnatwu/n7lMSsrnc+3fsz1GhgZYWZhTvXJZnr5IjfiQNir4zj8QLS1NSjrYYWqSL9PyMmvz4NBwbt99zJghPTE00KdgAUv6dG/LiXT3VZrk5BTOXrzO4D6dMc5nhJWFOT07tczyPCUJhvTpjJ6uLvZFbSnjUoKnn8r2On+Npg1q4ersgI6ONv17tsMgm0Wj1cnqmj1w9AyD3DtSxNYGbS0turRzI1GRxKN0C+q2b9WIAtYW5DMypEbVcpia5KN+7SpoaWnSuF51Xvm9/+rnlM96/0HFsqWoX7sK2lpaNKxTlXKuJfE6f01OU61iGapXLoumpqa8aLZbo1oUty+Mrq4O9WpVIiExkS7t3NDW0qJp/RpEfYwhICg023MMCg7j7sNnjBzUHX19PeyLFqJ9y4ZZ1rlBnaoUsLZAQ0ODSuVdqF6pLD73nuTqvFNSJIYP6Iq+vh76+nocOnGOFk3qUrm8K5qampQr7UStahU4e/EP+ZhK5V2oU70i2lpadGjViPzmplz5wyfH98qAXh0wzmeU7cLjQubE1LCQZ8w+/QILCY2gcKECatMEh4RnmPYqVNCKuw+eyT9bpAu4rqGhgZ6urhxbMTg0nII2n4+3sjBHV0eH4JBwrCxSO6A2uQzWXam8CwN7d2Dd1v34vf1AlQqlGTW4O4VsrNWmz6oOAUGhWFmaZ5gGTm/PoVNULu9K5fKfI20Y6OuzYOY4dh34nZUbduNQrAiD3TtRqXzGeJYJiQpWrNvB1Zv3+Bgdg6ZGamc3Kioa60/xi7Nqw5CwCJXPIG36JbfypyvDQF9PjiUbEBRCSopExz4eKuk1NTQJi4iU65h13qYqeQPExSVgamKc43b6J0RGRZOUpKRgASt5m21BaxRJSUSmCwlnkf/z+ejr68lvSPfs3BKFIompc1cQExtP43rVGNa/W6bXT2ZtHhIajq6ujkq72Ra0Jjg0PEMeUR/T6pzuGsjm2V0jQwOVX8ypZadeT6FhEVQsW0rep62tjUV+sy+zyFZW12xAUCgz569W+cMuSalUOb/0566vp0t+M9WfJUkiITERHZ3c/5oMDg1X+YwhNcxhSLryC1hn/N5RrYOe6s+f2jM+ITHbc9TR0U79fNMdn91ndurcFXYeOEFAYKh87gVtrLI85kuGhvryIxMAgUEh3Lr7mONeF+VtycnJGBnW/lyvL75PbKwtCAmNyPG9UiCX399CRqIjKOSZooULUrCAFWcuXKdvD/XPcVhb5Zf/Ak4TEBiao84BgLVlfgICQ3H9FP4rLDwSRVIS1lafj9f4YhRQMwfB1Tu2bkLH1k2IiY1j/vLNLF61jYU/jUdDI+OIYtZ1kAgJjSBRocg0xNnM74ezYv1OFq38jfEj+sjbq1QoTZUKpVEqlRzwPMN3M5fgdWBthlHNXQdO8PSFH2sXTcPayoLomFiadhxCTkMKWVmYExD0uf6BwWFZps9tcPoCVhZoamrguXPF3/JXfWbt9OXnrs6X14LBpyDuCYkK+RdeWHgkep86YhqaWZ+7makxOjraBASFyB2RgKBQdHV0MDMxJigh67Y1NNBnxMBujBjYjQ+BwUycvpiDnmfo0alFtueSnpVlfhSKJMIjotLVI0TtfWVqYoy2thYBQaFy2sDg0AzpcsrSwpygkM8dImVyMmHhkZmmz+31BKnfG2OH9qJGlXJfU8U/zdoyP/cePVPZFhAUQvkyzvLPX3NeKmVkcY5BwWGpn29klNwZDMrivg0MDmXWgrUsnjOJiuVKoa2lxXczlsixzLO7rtNofvH9Z21pQdd2bgwfkHmc3S+vpaCQMKwszXN8r2h+Ubc/267/RWJqWMgzGhoajBvuzra9nuw74iVP5b19H8CcxesJCAqlRpXyRER+5IDnaZTJydx98BSv81dp3rh2NrmnataoFr/tPkpQcBhx8QksW7uDKhVKy6OB6uQ3N8X/Q3Cm+x8/e8n9R89JSlKip6uLgb4eWlqan441ISA4FGVyco7qUKpkcYoWLsiCFVuIjolFmZzMvYfPUCiS5ONNjPOx4pfJPHziy/zlm5EkifCIKC5cuUlsXDxaWloYGRqgpeYhf0h94FpXVwdjYyPi4hNYs3lvjtouTZP6Ndi215OQsAiiY2LZtONQlunzm5vyITBY/iWSHYv8ZtStUZmFK38j8tPjAmHhkVy4cjNX9VQnq3bKb2ZCXHw84ZFRWZ5L+mvBzNQYG2sLTpy+REpKCrfvPubazXvp9pugqamBf4D660dTU5Om9WuwZvM+oj7GEPUxmjWb99KsUa0cPZZw+boPb98HkJKSknou2lrytZcb1pb5qVTOhRXrdxKfkEBgcChbdh2hReM6GdJqaWnSqG411m/dT3RMLCFhEezcfzzXZaZpUr8GXuev8uT5K5RKJVt2HpZHudTJb25KaHgkCYmKHJfRqU0T1m89wJt3HwCIjY3j4tXbxH4aMcyt414Xc7UGX6N61bhz/wkXr95GmZzMhcs3ufvwGU3q1/iq8tXJ6hwLWFtQ1rUkqzbuISFRwZt3Hzh84lymecXHJyIhkd/MBE0NDa7euMsfdx7I+7O7rjPTrmVDjnld5PbdxyQnp6BQJPHg8Qv83vrLaW7ffcyVP3xQJidz5MR5wsIjqVm1wlffK/nNTfD/EJSrev7XiRFBIU/Vrl6BxbMnsnnnYdb9th9InTJp1qgWlvnN0NHRZvHsiSxds53Vm/ZiaWHOxFGf3yrLjnvXNsQnJDLIYwYKRRIVy7kw47thWR/TrQ1LVm1j887DNG1Qg4mj+qnsT3uTzT8gGC0tLcq4OMppGtaphtf5a7ToMgxJgtMH12VZB01NTRb8NJ7la3fQdcBEkpKUlHAoyuLZk1TKNDE2Yvkv3zN28nx+WbqRQe4d2Xv4FHMWrSdFSqGobUHmTh2t9guye4fm/PjLKlp2HYGpqTGD3Ttx8NjZHLUfQN8ebYmI/EjPwd9jZGRAv+5tuXrjbqbp2zSrz9Q5K3DrNARrKwu2r/k52zKmThjMhm0H6D9qOlHR0eQ3M6VxveryG5JfKyUlJdN2sitSiNZu9ekx6DuSk1NY+NP4DMeruxYmjxvEghVb2Lr7KDWrlqdxvepyx19fT5f+PTswbsoCkpRKJozsi5WFmUqeHsN6s2zdDnoM/g6AOtUrMmpwjxydz/sPQSxZvZXwiI8YGOjRoHYVOrRqnP2Basz8fjiLVv5G+95j0dPVxa1hTXp1Uf/s37jhffhl6Qba9x6LRX4zOrZuzJPnr7+q3KoVSzOgV3u+m7mExMQkOrRqRFFbm0ynYCuXd6G0syNteoxCkiS2rZmbbRmd2jRBU1ODH35aRlBoGIYGBpRzLfnVjwQEBodR1iX7N4jTFLG14ZfpY1m9aQ8zF6zG1saaX6aPxbag+sdHvkZ25zjz++HMXbyBll2HU8TWhlZN63Hk5Hm1eRWzs6VPt7aM/G4uKSkp1K5ekTrVK8r71V3Xbg1rqs0rPSdHe376YQRrf9uH39sPaGpqUKK4ncr13qRBDY7+foFpc3+loI0V82aMw8Q4dbT9a+6Vwe6dWLx6Gz8v3UCvLq1w75r5KgdCKg2FIjGnM0SCIAiC8JdKSlLSrPNQFs+ZRLkcLNeSF0Z+N5cJI/rIS7MIf41ZC9eSz8gQj2G987oq/2lialgQBEH4R124fJOERAXxCQms3LgbE5N8uJQsntfVytSv8yaLTqDwryWmhgVBEIR/1O9nLzNn8XokSaKEgx0LZoz7qrdzBUH488TUsCAIgiAIwn+UmBoWBEEQBEH4jxIdQeFfJTA4lIZtB8gL8ObW7oMnGT5x9l9cK0EQBEH4NomHMoR/FRtrS84d2fi35B0eGcWyNTvwefCE2Lh4bAsWYFDvDnIAdUiNwvHzkg343H+KqUk++vVoR9sWDYDU9RFXbtzNwye+KBRJFLOzZcTA7ipvStZw64Wenq68kLFtwQLZLpexcftBDnieIVGhoHa1inw3pj+GnxY+Brj36DkrN+zC99Vb9PX0aNeyIYP7dFKb17MXr/l56UY+BIYgSRL2RW0ZPqArFdIthOt99Ra/rt9FSFgETo72/DB2IPZFC+W+QQVBEIQ8JzqCwr+GUqlEW/vvu6Tj4xMp6WDHiAFdsbQw58qNu0yfu5JNK36imF3qG4XTf16JbUFrTuxdySu/94ydPJ8ihW2oWLYU0TFx1KhSju/HDMDEOB/HTnkzfuoC9m9ZjJmpsVzOuiU/UtLBLkd1OnbKG8+T3qxZNA1zMxOmzf2Vxau2MnX8YAB8X73lh5lL+W5sf2pWKY8yWZnlYtk2BSz5efpYbD6Fv/K+cosJ0xZyfM8q9PV0efPuAzN+Wc2sySOpUtGV33Yd5buZi9mxbh7amSxoLQiCIHy7xNSwkKfau49ly84j9BkxhUbtBzJ28jxCwiLk/eGRUfz4yypadR9B6+4jWbJ6mxx14869xzTpMJiDnmdo12sMgz1mEhAYQg23XkTHxAKpncNVm/bQrtcYmncZxtQ5K4iI/Cjn/8rvPQPH/EijdgMZMXEOoeERZMa2oDU9O7fE2soCTU1N6lSvSNEiNjz8FMj+/Ycg7j96xvD+XTHQ18fV2ZGmDWty7JQ3AK7ODrRr0RBzMxO0tDRp26IBmpqa+L5++9Xtd+yUN53bNqVo4YIY5zNicJ9OnL5wTY7CsGnnYVo3q0e9mpXR0dHGQF8fx+JFM83P1MSYggUs0dDQQJIkNDU1iYtPIDwiEoCT565QsVwpalevgJ6uLv17tiMi8iP3HjzLNE9BEATh2yU6gkKeO3ryAjO/G8HxXSvJb27KzHmrAZAkiUk/LsbC3JT9mxezfe3P+L56y+Zdh+Vj4+LjefHqLbs3zGfVgqkZ8v5ttydX/vBhzeJpHPhtCRoaGsyYtwpIjXE6acZiKpd35eS+NQzt14Wjv1/Icb3DI6Pwe/sBx2JFAPB9/RaL/GYqwexLFrfD9/U7tcf7vn5HXHwCxb5Yn2z81AU07zKMkd/N5eET3yzr4Pv6HSXSjR6WdLBDoUji3fsAAO7ef0qSMhn3YZNp3mUYYyfPk0NSZaVJh8HUbdmX72YuoXnj2hSySY2I8PLVO5XRSm1tbeyL2v6pzqwgCIKQd0RHUMhzHVo1wr5oIfT19Rg5sDu37z0mOCSMJ89f8c4/iJGDuqOvr4epiTF9urXh9Plr8rEpKRLDB3RFX18PfX29DHmfPHuZft3bYWNtiaGBPqOH9OTGnYeEhEXw8PELIqOiGdi7Azo62pRxKUHjetVzVOekJCXT566kUd1qlPq0EG58fCLGRkYq6fLlMyROTXzT6JhYps/9lT7d2mCR30ze/uu8yRz4bQkHty6hZpXyjJn8S4ag7OnFJyRgnM9Q/llbWxt9PT3i4hMA+Bgdwxnva/z43TCObF9OieJ2TJqxRCUWsjqnD67jzOEN/DhpKOXThfOLS0ggn5GhSlrjfIZyeYIgCML/F/GMoJDnbKwt5f/nNzdFV0eHkLAIAoPDiImNxa3TUHm/JEmkpKTIPxsa6mOcT7XzlV5waDgFbT7nb2Vhjq6ODsEh4YSGRWJpYa7yXKFNAQv83vmry0qWlKRk8uxl6Onp8sPYgfJ2AwO9DG8rx8bGYWhooLItJjaOsZPnU7Z0SQb27qCy73MsVB16dGrBGe/rXL1xjw6tGuExZT73HqZOwbp3a0Pf7m0x0NdXKVOZnExCYqL8soiBgT4tm9bFwT511HKQe0d2HTjBu/eBPH/px7xlm1LP29qSnevnqdRFX0+XZo1q02PQd9gVKUS50k4Y6usTE6d6jjGx8SovpwiCIAj/P0RHUMhz6Ue8wiOjUCQlYWVhjiSBuZkJx3atzPRYTY2sB7WtLfMTEBiKq7MjAGHhkSiSkrC2yk9SUhKhYREqL5kEBYdlmV9SkpIps5eTlKRk/hfREByLFSU0PILwyCjym6VODz9/+VbuhEFaJ3Aexexs+W50fzQ+vR2c6flpft6/ZM6kDPsdixXhxcu3VKlQGoAXL9+gq6NDkcIFU/d/8Txg+vLcGtbCrWGtLMuH1M7lO/9AypV2wqF4annyPqWS12/8cXAvkkUOgiAIwrdKTA0Lee7wiXO8efeBhEQFqzbspnwZZ6ytLChVsjjWlhas3bKP2Lh4JEkiICiUazfv5TjvZo1q8dvuowQFhxEXn8CytTuoUqE0VhbmlC7liIlxPjbtOExSkpJHT3054/1HpnkplUqmzllBfEIi82Z4oKuro7K/cKEClHUpyZrNe0lISOTR05d4nb9C62b1gNTRQY8p8yliW5DJHgMzdAJf+r3j6YvXKJVKEhUK9h4+xes3/lSvXCbTOrV0q8e+I6d45x9ITGwc67ceoEmDGujr6QLQrkUDTnhd4s27DyiVSjZuP0hhWxuKFLZRm9/l6z74vnqbOrKYkMiWXUcIDg2n/KflY5o1rMXtu4+5euMuCkUSW3YdwczUWN4vCIIg/H8RI4JCnmvVtB7Tf1nJ+w9BlHZ2ZOZ3wwDQ0tJk4azxrNqwm+6DJhEbF4+NlSXtWjbMcd7uXdsQn5DIII8ZKBRJVCznwoxP+WtrazN/5jh+XrKB3Qd/p1TJ4rRyq8uT56/U5nX/8QsuXruNrq4OzTsP+1zGp2lagJk/jODnJRto3mU4JsZGjBjQnYplSwFw4eotHj7xxffVO7yv3JSP/25Mf9wa1iIyMpoFv24hKDgMXV0dHIoVZvGcSfKLGuq0dqtHUHAoQzx+IlGhoFa1CngM6y3vd2tYi+CQcEZOmkuiQoGLkwMLZo7LdKmXqI/RrFi/g5DQiNQ62Bdh0U8TKFyoAAB2RQrx43dDWbJ6G8Gh4Tg52jN/Rub5CYIgCN82EWtYyFPt3ccydmgv6tWsnNdVEQRBEIT/HDE1LAiCIAiC8B8lOoKCIAiCIAj/UWJqWBAEQRAE4T9KjAgKgiAIgiD8R4mOoCAIgiAIwn+U6AgKeUKSJJRKJZIknkwQBEEQhLwiOoJCnkhOTqZOy74kZxPzVhAEQRCEv4/oCAqCIAiCIPxHiY6gIAiCIAjCf5ToCAqCIAiCIPxHiY6gIAiCIAjCf5ToCAqCIAiCIPxHiY6gIAiCIAjCf5ToCAqCIAiCIPxHaed1BYT/Nkv7SnldBUEQBOE/IvL9vbyuwjdHdASzERsXT+vuI2lUrzpTxg2St9+595ila7azdfXcDMfUcOtFcfvCaGpokiKl0L9nexrVrab2mIDAENyHT+H0wXU5KtNj6gLsChcEQKlMpmv7ZrRt0QCAWQvXcuPOQ8xNjeVjurRz4/7j5zx9/hqA12/9KWRjhZ6uLgCrF03DyNBATn/c6yIXr95m3gwPAgJD6NDHg1Zu9eR6xMUn0KjdQK6d2i4fs//oaQ4dO0tySgp6ejrYFS7I8AHdsLG2/IoWFwRBEAThnyI6gtk4630dpxLF8L5yE49hvTE00M/RcWsWTcM4nxFPnr9i2ITZVCrn8peUaVe4oNyRDA4Jo1O/8TSuX13uzPXs1JJuHZqp5NfKrZ78//buY5k1eRQlHexyVBd9PT2u37zH6zf+FLOzzbB//dYD3LjzgCVzJmJtZQHATZ+HhIVHiY6gIAiCIHzjxDOC2fA85U3vLq0oX9qZM97Xc318qZLFMdTXJyAo5C8vMzYuAX09PbS1tXJdr5zS1tbCvVsbVm/ak2FffEIC2/cdY7LHILkTCFClQmlcnR3+tjoJgiAIgvDXECOCWXj9xp+gkDCqVSpLcnIyW/cco02z+rnK48adhyiSkihia8NzXz/evA/AfdhkeX+SUpmrMtOOT1Iq8Q8IZtxwd3maF2DH/uOcOH1R/nnccHfKl3HO3Yl/oX3Lhuw5dJJ7j55TonhRefsrP390tLXVjhSqs//oaQ54ngZAkqQ/VSdBEARBEP480RHMgufJCzRvVBstLU1qVC3PvOWb8Hvrj33R7Ds+Q8fPQktTE+N8Rsyf4UE+I0NAdWoXPj8jmNMyv5waHjLuJ0qVKIZTiWKA+qnhP0tbW5tB7p1YtXE3S+ZM+up8OrVpQqc2TQBQKpXUadn3L6qhIAiCIAhfQ3QEM6FUKjl59gpa2lp4XbgGQEKCgqMnvRk9uEe2x6c9I/h3lmltZYGLkwM37z6SO4J/l6YNarBj/3EuXbstbytmZ0uSUpnp84OCIAiCIHzbREcwE5eu3aFQQSs2LJspb/N768/wiXMY3r/LN1FmTGwcz3z9aNao1t9Sn/Q0NDQY3r8r85dvlrcZGujTo1MLfl66gdlTRmFtmR+A23cfo6+vJ54TFARBEIRvnOgIZsLzlDduDVU7WPZFbbGyNOfydR9MjI14/dafNj1HyftLlyrB3Kmj/9Yy0z9jqEhS4tawFnVqfF6L78tnBJs2rEmvzq2+uk7pVa9clkIFrVRefBns3om9JqfwmDyf5JQUNDSgRHE7Rgzo9peUKQiCIAjC30dDoUgUT+0L/7i0ZwQvHd+Ctrb4e0QQBEEQ8oJYPkYQBEEQBOE/SgzFCHlKhJgTBEH4dxDh2/4//ac7gu3dx6Kro42eri6KJCUlHez4wWMABvr6KuHcUiQJPV1dPIb1pnQpR/n4y9d92LTjILFx8SiVyVStWIaRA7th9GmpGAD/gGA69xvPwN4d6N+zvbz9uNdFlqzeRqGC1igUSehoa1O/dmV6dm6Fvl7quoDK5GR+23UEr/PX0NbSQktLExcnB0YM7IZxPiOCQ8NZsW4nj5+9RFNTE0sLc0YM6CbX8bjXRWYvWsfoIT3p3qG5XPawCbO5++ApXgfWZniz+csweDXcelG5vCsr5v0gp2nWeSibV8yioI0VAGcuXGfH/uPExcdjoK+PpYU5Q/t1wbFYkb/qoxIEQRAE4W/wn+4IAnK4tZSUFCb+uIjjXpfkte7Sr9m374gXcxavY9f6+QBcu3mPecs3sfCn8Tg52qNMTmbZmu1MmL6IVQunoqGhAcCxU95UKufCca+L9OvRTt4OUKmcC/NmeAAQHhnFz0s2MG3uChbMHA/A3MXr+Rgdy/qlMzAxNkKSJM5dusHH6Fi0tbUYMXEObZrVZ9bkkUBqaLeJPy7i1/mTcbBP7YSVdLTj99OX5I7gO/9AEhMVuWoj/4Bgrt+6T/XKZTPsO3bKm617PJn3o4e8hMzTF68JDYsQHUFBEARB+MaJZwQ/SVIqSUhQZLr2X5UKrgQGhck/b9l1hL7d2+DkaA+AtpYWowf3xD8wmNv3HgOQnJzC8dMXGTfcHUMDA27dfZRp+fnNTJk2YSg3fR7xyu897/wDOXfpBlPHD8bEOLVOGhoaNKpbDduC1pw+fw3jfEb07to6XR1L07JpXbbvPS5vs7GyxMzUhMfPXgKpHbdWTevmqm0GuXdk1aY9aqOBbNh2kLFDe6msI+hcopjaTqMgCIIgCN+W/3xHcNrcFbgPm0yrbiPR0NSgUb1qatOdu3SDxvWryz8/8/WjdKkSKml0dLRxdizG0xevAfjj9n2sLfNTzM6W1s3q4XnSO8u6mBgbUaSQDa/evOeZrx9FCtlgZmqsNu0zXz/KuDhm2F66lCPPPpWfpmXTuhw7dZHk5BTOXvyDJg1qZFmPL9WuXgFDfT28zl9V2R4eGUVQSFiGdsjM/qOn6T5oEt0HTaLX0B+yP0AQBEEQhL+VmBr+NDWsTE5m3rJNrNqwm9FDegKf4/qGRUSRnJysstBzTnie9KaVWz0A3BrWZP3WA3yMjpVH+NSR+OtX86lfuzJrtuzF++otXJ0dcx3xBGD4gG7MnL+ahnXUd5RzQoSYEwRBEIRvy39+RDCNtpYWDWpX4fqt+/K2tGcEj2xfRr2alZkxb5U8PerkaM/DJy9U8khKUvLU9zVOjvZERH7k6o27bN5xmPbuY+k7chpKZTKnzl3JtA4fo2N5/yEIB/siODna8+5DIFEfo9WmdXK058Fj3wzbHz7xxamEvco2PV1dalQux4IVm2nllrtp4TRlXUviWKwoB4+dkbflNzPF2jJ/hnYQBEEQBOH/g+gIpnPr7mOKFimYYbu2tjYew3oTHBqO99VbAPTp1oYtO4/w/OUbIPUN3+XrdlCwgBWVy7vy+5nL1K1ZiSM7lnNo61IObV3K3Gmj8Tylfno4IvIjcxavo0oFV4rZ2VLE1oYGtaswd/EGomNiAZAkifOXbuAfEEyTBjX4GB3Dtj2e6er/iGOnvOnZqWWG/Lt3bE6vzq2oXN71q9tnaL8ubN3jSVKSUt42oHcHlq3dgd/bD/K2Z75+/HH7wVeXIwiCIAjCP+M/PzU8be4K9HR1SU5OwaaABZNG9VebTl9fjyF9O7Nx2yHq1axMzarlmTiqH3MXryc+IQGlMpkqFUqzaNYENDQ08Dx1geFfhFmrUrE0sxaulZ/hu33vMe7Dp5CYqEBXR4d6tSrRq8vnlz+mjBvE5p1HGDjmR7Q0tUiRJMqXcaJyBVcM9PVZOX8Ky9ftoIO7B1pamljmN2P+jHE4Fi+aof5FbG3o2TljBzE3itnZUrNqeY6l68y2aVYfPV1dZsxbRXxCAlqaWtgWsmZYv645yjPU77aILCIIgiAIeUSEmBPyhAgxJwiCIAh5T/wGFvKUiCwiCILw7yAii/x/yvOOYFbRM2Ji4nAfPoXTB9epHFPDrZccFWP4xNkEBoWRz8hA3j98QDcuXbuNnp4eowf3UDl20o+LqVDWmfq1qtCp3zgc7IuQtjze0H6dqVWtgpz2/qPnrN68l9CwCFJSUnB1dmD04J5YWpgDMGvhWrzOX2X3hgXYFrQGYPm6nRga6DGwd0e157v/6GkOHTtLckoKeno62BUuyPAB3bCxtiQmNo5fN+zi5p2HaGtrY2Soz8DeHalZtTxAttFONmw7wAHPM1hZmKNIUuJYrAiTRvfP8JbynXuPGTFpLoPcO8rRTl76vWPC9EUc2roUUI26kmb6pGF4X7lJUEgYkz0GAXDv4TOGjp/FyvmTqVjOBYB5yzZhZmbMkD6ds/jkBUEQBEHIa3neEcwqeoZmuigcWRkztCf1alZW2WZmasz4aQsZPqAr2lpaAISFR3LT5xE/eAwkISERQwMDOXLI5es+TP9lJV7716GlpYnvq7dMmrGYWZNHUqVCaQC27fFkxKQ5/LZyDvr6egBYWeRn7Za9/PTDyGzruX7rAW7cecCSOROxtrIAUqOBhIVHUcDKgnFTF1DSwZ49mxairaXF85dvGD9tIdPGD6ZqpTJA1tFOAJo2qInHsN4kJ6cwZc5ytuw8LC+Hk55FflP2HzlNh1aNM12rMG1pnfSiY2KZs+hzx/z2vce4Ojtw5/4TuSN45/7jTJ+1FARBEATh25Gnbw1nFz3jz3AuUQwLc1Ou/nFX3vb7mcvUqFIWczOTDOkrV3AlLi6Bj9ExAGzfd4xWbvXkTiBA766tMTI05LT3dXlb2xYNuP/oRYZFnL8Un5DA9n3HmOwxSO4EQmo0EFdnB276PCIwOJQxQ3rKHdeSDnb07d6GzTsPq83zy2gn6WlpaVKlgitv3geo3Z/fzJRmjWqxeeehLOv9pdLOjoSGRxIcklrunftP6N+zPXfuPwEgNCyCwOAwSqtZ7FoQBEEQhG9Lno4IZhc9AyAuPh73YZOzzGfZmh1s3HZQ/nnutDEULlSA1s3qc9zrInVrpj6HdszrImPUjI4BnL90g0rlXeRO4jNfP+rXrpIhXRkXR56+eE3rTwtF6+nq0r9Xe1Zu3MPyX77PtI6v/PzR0dZWCcWW3nNfP5wdi6Gjo/qRlC5Vgl/X71Z7zJfRTtJLSFRw8ertLKN+9Onelu4DJ9G1fTO1+9PeqE6zbukM9PV0KVOqBLfvPaFR3WoEBIZQs2p5Fq/aSqJCwe17TyhTqoTKcYIgCIIgfJvyfGo4O+mnb9PUcOul8rO6qWFInSZds3kv4ZFRvPcPIj4+gWqfpljhcyfzY3QskR+j+XVe1h3OzLRsUpddB05w4x9YOy+7aCde56/i8+ApABXKOKvEIv6SqUk+urR3Y+2W/bh3y5hO3dQwQKVyLty5/wSbApa4ODkAqaHtHj72xef+EyqWK6W2vP1HT3PA8zSA2rjFgiAIgiD8s/J0aji76Bl/lqlJPmpVK8/JM1c45uVNi6Z10NT8fMppncxD25bSu0trpv38K4kKhVy3h08yRu548NgXJ0d7lW1aWpoM7deFVZv2QCYdnGJ2tiQplbx+4692f0lHe576vkapVKpsf/jkBU6OnztjWUU7gdTO79ZVc9i6ag4ew3qjr5f1yFy39s3wefCE575vskyXXsVypbhz7zF37j2mQtnUTl+FMqW4fe8xt+89plImi1Z3atOEXevns2v9fLav+TnH5QmCIAiC8PfI045gdtEz/gqt3Opz5PfznLt4g1ZN66lNo6GhQf+e7TAzMebgsbMA9OjUEs+T3tz0eSin2773GNExsTStXyNDHvVqVkZHR4cLV26pLcPQQJ8enVrw89INBIeGy9tv333Mo6cvqVzehQJWFixdswNlcjIAz1++Ycuuo/Tt0S5DfuqinXwNfX09+vVox/qtB3J8jItTcSIiP3Lq3FUqpnUEyzpzxvs6YeGRuDoV/+r6CIIgCILwz8nzqeGsomfExMTlKI8vnxHs2bklbg1rAakvVCQlKXEuWSzLF1A0NDQYNbgH0+b+SvsWDSnpYMf8GR6s3rSH+cs3k5ycgotTcVYumCK/MfylEQO6MmzC7EzLGOzeib0mp/CYPJ/klBQ0NKBEcTtGDOiGpqYmi2dP5Nf1u+jSbwI6OloYGhgwaXQ/qlcuqza/L6OdfK3Wzeqz++DvKJJURyO/fEZwzJBeVCrvgra2NmVdS+L7+i32RQsBULRwQeLi4ynrWlIsEC0IgiAI/ydEZBEhT4jIIoIgCIKQ9/J0algQBEEQBEHIO2IoRshTIsScIAjCv4MIMff/SXQEP8kq1J1xPiOCQ8NZsW4nj5+9RFNTE0sLc0YM6CaHdwN4+uI1azbv5Z1/ICbG+dDR0aZn55Yqz+8NmzCbkNBw9m1ehEYWkVNu3HnIpu0HCQ2PxDifEUZGBgzs1YHyZZyRJIkd+47jecobDQ0NJEmiTbP69OjUQs4zfRg+dX5asAbvq7c4tutXDPT1M61Hdud03OsiOw+cIDk5BaVSScO61RjUu2OG9RAFQRAEQfj2iN/Wn2QV6k5bW4sRE+fQpll9Zk1ODSV30+chE39cxK/zJ+NgX4RXfu8ZO3keU8YPpk71igCEhEVw487ntQXf+Qfy3j8Q43xGn9bbc1Fblxt3HvLTgtXMnTqGsq4l5WNfvHoLwJrNe7n78BlrF0/HzNSYyKhovpu5hJi4uBzF942NjePydR9KFCvKuYs3aNm0rtp02Z3T4RPn2H3wJItnT6CQjTUJCYnMnL+GuUvW8+OkYTlpdkEQBEEQ8pB4RpDsQ92dPn8N43xGKoszV6lQmpZN67J973EAtu31pJVbPbnDBGBlYU7LJp87WZ6nvHFrVIvWzevjeco70/ps2n6Qfj3ayZ1ASF1qp2GdqsTFJ7D74Em+HzNAjshiZmrM92MGsHP/CeITErI9X68L16hSwZVuHZvjefJCpumyO6dNOw4xenAPCtmkvo2tr6/H92P7c/7yTd5/CMq2HoIgCIIg5C3REST7UHfPfP0ooyZ2bulSjnKM4acvXqtME38pOTmF309folXTejRvVJvL132IiVW/PM5TX79MQ8O9fuOPjk7GUHXF7GzR0dbOdMHq9DxPetPKrR61q1Xg3Ycg3rz7oL4eWZxTeGQUIaERGeppamJMkUI2PPP1y3DM/qOn6T5oEt0HTaLX0B+yracgCIIgCH8v0RH8h1y9eRebAlbYFy2EmakxVSq44nXu6lflldWzhdnxff2OsPBIqlUqg7a2Nm4Na3Hs1MWvzi83RGQRQRAEQfi2iI4g2Ye6c3K058HjjOHmHj7xxamEPQDOJYqpDUmX5thJb975B9DefSzt3cdy9+GzTKeHnR3tefjkhdp9xexsUSiSMoz8vX7jT5JSmWGk8EueJy8QF59Ax77jaO8+ltMXrvH72UtyNBOVemRxTvnNTLGyNM9Qz6iP0bz7EJghDJ8gCIIgCN8e0REk+1B3TRrU4GN0DNv2eMrH3Lr7iGOnvOnZqSUAPTu34tgpb6784SOnCQuP5Pjpi4RHRHHr7iP2bV7Eoa1LObR1Kcd2/UpoWAQvXmaM8duvZ3u27Dyi0gl7/yGIc5duYGigT5d2bsxbtpHIqNSOa9THaOYt20j3Ds2zfAM4KUnJqXNXWL90hlwPz50rKGBlydU/7mZIn9U5AfTt1pbl63byITA1HGBCQiK/LN1EvZqVKVyoQLbtLgiCIAhC3hKRRT5RKpVs3nmEM97XVELdjRiQunxMUHAYy9ft4Mnz12hpaWKZ34xh/buqvNDx+NlL1m7Zx/sPQejr62FoYIB711a8eRfAo6cv+Xn6GJUyl63dTnJyCuOGu2eoz/Vb99m88zBh4ZHo6elibmbCoN4dKVfaiZSUFLbvO8axUxfR1NREklJo7Vafnp1bqiwfY2lhTvpZ5NGDe7J97zG2rFQNg7f38Clu+jxkwczxGeqR2TnVqZG6/t/R38+z59ApklNSl4+pX7sKg907oaurk217i8gigiAIgpC3REdQyBOiIygIgiAIeU/8BhbylIgsIgiC8O8gIov8fxIdwX9Ie/ex6Opoo6ujS3xCAsXtCtOrSyuVqWXIGHlkwYrN6OnpMXpwD5V0k35cTIWyztSvVQX34VM4fXAd7sMmA5CkVPL2fQAO9kUAKFq4ILOnjMI/IJjO/cYzsHcH+vdsn2Vd5/3oQUkHO2YtXIvX+avs3rAA24Kp6wUuX7cTQwM9BvbuCKQ+v7hq426evvDDxNgITU1N2rVoQJvmDf6y9hMEQRAE4a8nOoL/oFmTR1HSwQ6AC5dvMn7aQpbOnYSrc+pafeoij7RuVp/x0xYyfEBXtLW0gNQXNm76POIHj4EkJCTK+W9dPReAgMAQ3IdPkX9Oc+yUN5XKuXDc6yL9erTL8TI0Vhb5WbtlLz/9MDLDvrDwSIaO/4lBvTsxd1rqM5Afo2M54309l60jCIIgCMI/Tbw1nEfq165C+5YN2bH/hLxNXeQR5xLFsDA3VXmr9/czl6lRpSzmZiY5Li85OYXjpy8ybrg7hgYG3Lr7KMfHtm3RgPuPXsiLZ6e33/M05VydaNvi8+ifibERHVo1ynH+giAIgiDkDdERzEMuzg68fvMeyDrySOtm9Tnu9XnR52NeF2ndrH6uyvrj9n2sLfNTzM6W1s3q4Xky8xB3X9LT1aV/r/as3Lgnw75nL/wo7aI+CoogCIIgCN82MTWcl9K9r50+8gggRx7p0LoxTRvUZM3mvYRHRvHeP4j4+ASqVSqTq6LSwsoBuDWsyfqtB/gYHSvHVs5OyyZ12XXgBDduP8hVuentP3qaA56ngdR1GgVBEARByFuiI5iHHj9/RXG7woBq5BGAxEQFAUGhdGjdGFOTfNSqVp6TZ67g986fFk3roKmZ88HciMiPXL1xl8fPXvLb7qMAKJXJnDp3hc5tm+YoDy0tTYb268KqTXuoWLaUvN2phD0PH7+ADs2zzaNTmyZ0atPkU/mpy8cIgiAIgpB3xNRwHrl49TaHjp2lR6cWOYo80sqtPkd+P8+5izdo1bRersr6/cxl6tasxJEdy+X8504bnWmIu8zUq1kZHR0dLly5JW/r2KoxPg+ecixdXtExsRw6fjZXeQuCIAiC8M8THcF/0LS5K+g9dDKd+o7D89QFFs2agKuzIydOX6JqxTIY5/s8TaupqUnj+tXlzlqVCq4kJSlxLllMXsYlpzxPXaBpw5oq26pULE1oWITaF0CyMmJAVwKCQuSfLS3MWbt4Olf+uEsHdw96Df2BUd/9LBaJFgRBEIT/AyKyiJAnRGQRQRAEQch7YkRQEARBEAThP0oMxQh5SoSYEwRB+HcQIeb+P/3nO4I5Cf12/9FzVm/eS2hYBCkpKbg6OzB6cE8sLczlNMe9LrLzwAmSk1NQKpU0rFuNQb07oqOjrVKOnq4uiQoFLZvWxb1rGyA1EkinfuNwsC9CckoKSmUy5Us7MaBXe6ytLOQyYuPiad19JI3qVWfKuEHydqVSyfJ1O7nl8wgtLS2UyUraNKtP944t5Cgjpw+uUznvGm698DqwVuW5RIA79x6zdM12OSpJDbdeVC7vyop5P8hpmnUeyuYVsyhoYwXAmQvX2bH/OHHx8Rjo62NpYc7Qfl1wLFbkT302giAIgiD8vf7zHUHIOvSb76u3TJqxmFmTR1KlQmkAtu3xZMSkOfy2cg76+nocPnGO3QdPsnj2BArZWJOQkMjM+WuYu2Q9P04alqGc4NBwegz6jkrlXHF1dgDA0MBA7nwlJSnZvPMwgz1+Yvvan8lnZAjAWe/rOJUohveVm3gM642hgT4Aew6dIjQsgq1r5qKtpUWiQoH/h+C/rH38A4K5fus+1SuXzbDv2Clvtu7xZN6PHhSzswXg6YvXhIZFiI6gIAiCIHzjxDOCX/gy9Nv2fcdo5VZP7gQC9O7aGiNDQ05/iqe7acchRg/uQSGb1Ld59fX1+H5sf85fvsn7D0EZyrC2zI9dkUIEBoeqrYOOjjaD+3TCytKck2evyNs9T3nTu0srypd2VonlGxwajrmZiRyLWE9Xl+L2hf9kS3w2yL0jqzbtUbsI9IZtBxk7tJfcCYTUsHjqOo2CIAiCIHxbxIigGi7ODly6fgeAZ75+1K9dJUOaMi6OPH3xmlrVyhMSGkHpUqph1kxNjClSyIZnvn4ULlRAZZ/f2w9EfYxWWZhZbT2cissh6F6/8ScoJIxqlcqSnJzM1j3HaPMpzFzb5g3wmDKf2/eeUM61JJUruNKwTjW0tFL7+XHx8bgPm/xVbQFQu3oFjpw4h9f5q7g1rCVvD4+MIigkLMO5Z0ZEFhEEQRCEb4voCKrzN/VRps1dgYaGJm/fBzBmSE/MzUyyrka6enievEDzRrXR0tKkRtXyzFu+Cb+3/tgXtaW4fWH2b1nMvUfPePD4BRu2HeDk2cssmjURUJ12TlPDrVeu6j58QDdmzl9NwzrVcnVceiKyiCAIgiB8W8TUsBrpQ785Odrz8IlvhjQPHvvi5GhPfjNTrCzNefjkhcr+qI/RvPsQiJOjvbxt1uRR7N4wn6Vzv2PVpj34vn6XZT2ePH9FcfvCKJVKTp69wokzl2nvPpbO/caTkKDg6MnP0Tx0dLSpXN6Vfj3asWrBVK7euEfUx5g/0QqqyrqWxLFYUQ4eOyNvy29mirVl/gznLgiCIAjC/wfREfxC+tBvAD06tcTzpDc3fR7KabbvPUZ0TCxN69cAoG+3tixft5MPgakvaCQkJPLL0k3Uq1k5w7QwQNWKpenQqhHrtuxTW4ekJCUbtx8kOCQct4a1uHTtDoUKWuG5c4UcIm7DshmcPHsZpVKJz4OnhIZFyMc/ffEaE+N8GOcz/MvaBWBovy5s3eNJUpJS3jagdweWrd2B39sP8rZnvn78cfvBX1q2IAiCIAh/PTE1TOqUbdryMcXsbOXQbwAlHeyYP8OD1Zv2MH/5ZpKTU3BxKs7KBVPQ19cDoEPrxmhrazFx+uJPy78oqV+7CoPdO2VaZr8e7encbzxPX7zG1Dif/BxfcnIKymQl5Uo7sW7Jj+QzMsTzlLfKs3kA9kVtsbI05/J1HxISE1m6ZhsKRRI62toYGOgzf4YHmpp/bT+/mJ0tNauWV4kr3KZZffR0dZkxbxXxCQloaWphW8iaYf265ijPUL/bIrKIIAiCIOQREWJOyBMixJwgCIIg5D3xG1jIUyKyiCAIwr+DiCzy/ylPOoKpUTZ02LHuF3ntu34jpzFqUHfCIz+yY99xNv86S+WYXQd/5869xyyYOZ727mOZ96MHJR3smLVwLTfuPMTczIT4+ATym5vSrkVDmjeuDaA2skZmETrU2X/0NIeOnSU5JQU9PR3sChdk+IBu2FhbEhMbx68bdnHzzkO0tbUxMtRnYO+O1KxaHkiN0uExdQF2hQuSIkno6eriMaw3pUulTjtv2HaAA55nsLIwR5GkxLFYESaN7o+JsRGSJLFj33E8T3mjoaGBJEm0aVafHp1aoKGhAaS++VvcvjCaGpook5X07NSSVm715LpLkkTHPuMoVNCKX+dNJiQsgvFTFwAQF59ASFgEdoULAlCxnAt1a1RUiSqSk/MbMWkug9w70r9newBe+r1jwvRFHNq6NFfXhCAIgiAI/7w8GxFMSlLiefIC7Vs2Utler2ZlFv66Bd/X71QiUxw75c2QPp3V5tWzU0u6dWgGwPOXb5g2dwWRUR/p3rGF2vSZRej40vqtB7hx5wFL5kyUQ73d9HlIWHgUBawsGDd1ASUd7NmzaSHaWlo8f/mG8dMWMm38YKpWKgOAXeGCcsdq3xEv5ixex6718+Uymjaoicew3iQnpzBlznK27DzM6CE9WbN5L3cfPmPt4umYmRoTGRXNdzOXEBMXp9IOaxZNwzifES9evqH/6OlUr1xWDn130+cR+fIZ8vL1Oz4EBlPIxlquy5eh5NK2pZEkKUfnZ5HflP1HTtOhVWPMTI3VtqMgCIIgCN+mPHtreEDv9mzeeZiEhESV7To62rg1rKXyQsKjpy+JjIqmZrXy2eZb0sGOsUN7s23vsUwXLc4sQkd68QkJbN93jMkeg1Ti/VapUBpXZwdu+jwiMDiUMUN6yqOaJR3s6Nu9DZt3HlabZ5UKrgQGhandp6WlSZUKrrx5H0BcfAK7D57k+zED5M6Vmakx348ZwM79J4hPSMhwfAkHO4zzGREcGi5vO3bqAm2b16dpgxp4pmvPnMjp+eU3M6VZo1ps3nkoV/kLgiAIgpD38qwjWKK4HZXKubD74MkM+1o3q4/XuasolanLlBw75U2LxnXkDkl2XJ0diYj8SETUxwz70kfoaN2sHp4n1XeQXvn5o6OtrRI6Lb3nvn44OxZDR0d1ULV0qRI8feGn9phzl27QuH51tfsSEhVcvHob5xLFeP3GHx2djGUXs7NFR1ub12/8Mxx/5/4TzEyMKVE8NWZy1McYrt+6T9MGNWntVp8TXpdISUlRW/afPb8+3dty+vx1efkcQRAEQRD+P+TpyyKD3TsxYPSPtG/VUGW7Y7Ei2BSw5PJ1H6pXKcfZi9dZv3RGjvPNKnxZVhE6/g5v3gfgPmwyYRFRJCcns2HZTJX9Xuev4vPgKQAVyjjTu2trXr5+Jz8HmJ2h42eRmKggICiEOVNHyx03r/NXqV65HMb5jDDOZ0R+c1P+uP2AGlXK/bUnCJia5KNLezfWbtmPe7fWmaYTIeYEQRAE4duSpx3BgjZWNGlQg807j2TY17pZPY55XSQhMZHidoWxK1Iox/k+ef4KczMT8puZEhAYIm9Pi9Chpa2F14VrAHKEjtGDe6jkUczOliSlktdv/NWOCpZ0tGfvkVMolUqV5U8ePnmBk6Od/HPaM4JKpZIFK7YwY94q1i+dIXf00p4R/LJshSIpQ9mv3/iTpFSqbEt7RvC410VmL1xHWZeS5Dc3xfPkBcIiomjvPhaAuLgEPE9eyHFHMKfnl6Zb+2Z0GTCB6pXLZpqnCDEnCIIgCN+WPI8s0q9HO06du6ISGQOgaf0a3H3wlJ0Hfqd1s/o5zs/31VuWrtlO7y6tMuzLLkJHeoYG+vTo1IKfl25Qee7u9t3HPHr6ksrlXShgZcHSNTtQJicDqS+qbNl1lL492mUoW1tbG49hvQkODcf76q0sz8HQQJ8u7dyYt2wjkVHRQGrIunnLNtK9Q3MM9DO+3NKyaV0qV3Dlt91HePriNRFR0SrnuX/LIv64/YCIyIzT5erk9vz09fXo16Md67ceyFH+giAIgiDkvTxfR9DM1JjObZtm6EAYGRlSt2YlvK/eomHdqlnmsWP/cU6cvkhCogJzMxPcu7amRZM6GdJlF6Gjfu0qKvsGu3dir8kpPCbPJzklBQ2N1GcbRwzohqamJotnT+TX9bvo0m8COjpaGBoYMGl0v0xHxfT19RjStzMbtx2iXs3KWZ7TsP5d2L7vGIM9ZqKpqYkkpdDarT49O7fM9JgRA7rRd+RUYmPjaVKvukpkEeN8RlSpWJqTZy9n+jZ1el9zfq2b1Wf3wd9RJCnV7hcEQRAE4dsiIosIeUJEFhEEQRCEvJfnU8OCIAiCIAhC3hBDMUKeEiHmBEEQ/h1EiLn/T2o7gu7DJgOQpFTy9n0ADvapET6KFi7I7Cmj8A8IpnO/8Qzs3UEOLQZw3OsiF6/eZt4MD0ZMnEPrZvVo1ig11NvmnYfZsvMIXgfXoqerC0DXAROZMLIPVSqUzhAOLU1AYAgd+njQyq2eHA4uLj6BRu0Gcu3U9gx1VyqVLF+3k1s+j9DS0kKZrKRNs/p079iCgMAQOvUbJ58PgI6ODhuXz5TLqVO9IvNnjpP3r996gE07DvHLj2OpV7MyG7YdIDomTn7T9/2HIFZt3M3TF36YGBuhqalJuxYNaNO8AQCXr/uwacdBYuPiUSqTqVqxDCMHdsPIyBCA4RNn8/L1ew78tph8n7ZNnrWMWtUq0LJpXY57XWTJ6m0UKmiNQpGEjrY29WtXpmfnVujrpbZjDbdeeB1Yi3E+I7ne6cPwQeah8ib9uFhu0y9Dzo0d2gu/t/6sWL+TN+8CALArUohRg3pgXzT1Le4vw+QVsS3AD2MHkt/cVN2lJQiCIAjCN0RtRzAt7FhanN70YcggdYHnSuVcOO51kX492qld865iORfu3H8idwRv33tMCYeiPHriS8VyLoSGRRAYFEpZ15KA+nBoafT19Lh+816mS7mkt+fQKULDIti6Zi7aWlokKhT4f/i80LGhgUGG80mTz8iQt/6BhEdEkd/clJSUFE5fuIZDulB36YWFRzJ0/E8M6t2JudPGAPAxOlaOVnLt5j3mLd/Ewp/G4+RojzI5mWVrtjNh+iJWLZwqt5uRoQFb93gyvH9XteVUKufCvBkeAIRHRvHzkg1Mm7uCBTPHZ9kWabIKlZdVyLmQsAiGT5jDmKG9cGtYE0hdn3DEpDlsXTUHi/xmwOclcFJSUpg291c2bj/IxFH9clQ3QRAEQRDyTq6fEUxOTuH46YuMG+6OoYEBt+4+UpuuUrlS3Ln3BEiNKxwQGEKb5g24cz912537T3At5SCPDmYVDk1bWwv3bm1YvWlPtvULDg3H3MxEjkKip6tLcfvCOT6/Zg1rceLMJSC1c1rSwQ4TYyO1afd7nqacqxNtWzSQt5kYG9GhVWr85C27jtC3exucHO1Tz0NLi9GDe+IfGMztdHF9e3VpxbGT3oR8sYSOOvnNTJk2YSg3fR7xyu99tumzC5WXlYOeZ6hQ1lnuBEJqp698aScOeJ7JkF5TU5NK5VwIDA7Ntl6CIAiCIOS9XHcE/7h9H2vL/BSzs80yRJursyOh4ZEEBYfx8KkvLk4OVCxbitufOod37j2hUjlXIGfh0Nq3bMirN++59+h5lvVr27wBl6/70G3gJH5esoHTF66RnPw5r7j4eNyHTZb//fjLKpXjWzSpze+nLwOpI5+t3OplWtazF36UdimR+X5fP0qXUt2vo6ONs2Mxnr54LW+zyG9K25YN2JDDNfhMjI0oUsiGV2+y7whmFyovK8981Z9faZcSPPN9nWG7QpHElRs+NKqrPoze/qOn6T5oEt0HTaLX0B9yXR9BEARBEP5auX5ZxPPk586RW8OarN96gI/RsRlGzXR0tCnrUpI795/wITCECmVLUbhQAUJCw0lUKLhz/wmTPQYCOQuHpq2tzSD3TqzauJslcyZlWr/i9oXZv2Ux9x4948HjF2zYdoCTZy+zaNZEIOupYQBrKwt5XcGnL14z8/vhbN1zNLfNlGu9OrWk68CJ+L39kKP0Etmv+pOzIHV/ntf5q/jcf4J/QDDF7YvQqF41telEZBFBEARB+LbkakQwIvIjV2/cZfOOw7R3H0vfkdNQKpM5de6K2vQVy5Xi9r3H3Ln3mIplSwGpI4XnLt4gJDQCV2dHIDX+7+17j2nvPpb27mP5EBiC58kLGfJr2qAG8QmJXLp2O8t66uhoU7m8K/16tGPVgqlcvXGPqI8xOT7PVk3rMWfxOhrXV12U+UtOJex5+PhF5vsd7Xn4RHV/UpKSp76v5eniNEZGhvTq3JrVm7Of/v4YHcv7D0HySy/mpiYZzi8qKhpzMxOVUHm55eSo/vwePn5ByXT1b9qgJltXz+Xg1qUkJSWxYevBXJclCIIgCMI/L1cdwd/PXKZuzUoc2bFcDl02d9roDM/0palUzoVbPo8IDA6V3zKtUNaZzTsPU9a1BDo62rkKh6ahocHw/l1Zu2V/pnX0efBUJVzd0xevMTHOh3E+wxyfZ92alejRsQXtWzbKMl3HVo3xefCUY+nOPzomlkPHzwLQp1sbtuw8wvOXbwBQJiezfN0OChawonJ51wz5dWjViBcv3/L0hV+mZUZEfmTO4nVUqeAqT/dWq1yGwyfOyWlOnL5EoYLWWFqYZxsqLyvtWzXizv0nnDp3Vd6WOvr3lI6tGmdIb2qSjx88BnLA83SGkIGCIAiCIHx7cjU17HnqAsMHdFPZVqViaWYtXMuzFxmfGSvlVJzomFhqVi0vb6tQxpl5yzbRyq1uap4nL2QZDq1+LdWwb9Url6VQQSsCgkLU1jEoOJSla7bJS60YGOgzf4aHnH/aM4LprV40TeVnXV0dendtnU1rgKWFOWsXT2fVxj1s2nEYQ0N9tLW06Php+rNm1fJMHNWPuYvXE5+QgFKZTJUKpVk0a4LaN611dXUY5N6RnxasUdl++95j3IdPITFRga6ODvVqVaJXl8/1Gzu0F0vXbKfX0B/Q1NAgv7kpc6aMkvdnFSovK9aW+Vk5fwor1u9k3W/70NDQoGjhgqxaOAVLC3O1xzg52tOwTlV+232U8SP6ZNuGoX63RWQRQRAEQcgjIsSckCdEiDlBEARByHsixJwgCIIgCMJ/lBiKyYVxUxdQo0o5OrdtqrK999DJDOjVHhNjIzymLpCjcwAUtLFi3o8e3Ln3WN6XIkno6eriMaw3pUulvjCTPmJJdtFR3IdP4fTBdUDqyNpvu4/idf4aWpqaaOtoU9DakgG9O1DSwY479x4zYtJcBrl3lKPAvPR7x4Tpizi0dWmGc0wfHSanUV0yi1piY22ZbZuKEHOCIAj/DiLE3P8n0RHMhdZu9fht91GVjuCT568IC4+kdvUK3H/0HLvCBTNdnib9vn1HvJizeB271s/PkC676CjpzV60jvj4RNYvnSEv4XPjzkPevguQw8tZ5Ddl/5HTdGjVGDNT41ydc3ZRXbKKWpKTjqAgCIIgCHlHTA3nQp0aFQkOCcf31Vt527FT3jRrXDvXz7lVqeBKYFCY2n05jY7yzj8Q7yu3mTxukMo6jlUrlqZx/c+LOuc3M6VZo1ps3nkoV3WErKO6/JmoJYIgCIIg5D3REcwFbW1tmjWqJS+Xk6hQcPrCNdo0+xx95M37AJXIJSvW71Sb17lLN1Q6a+llFx0lzTNfPwoXKoCpSb5s696ne1tOn7/Oh0D1I4tZySyqy5+JWiIIgiAIQt4TU8O51LpZfYZPnM3Igd25cPkWdkVssS/6uSOU1dRwWicxLCKK5ORkNiybqTZddtFRMvP+QxCTZy0jUaGgTKkSTJ0wRN5napKPLu3dWLtlP+7dsl8aJ72cRnXJzv6jpzngeRoASRIvqwuCIAhCXhMjgrlUzM6WwoUKcPn6HY6d8qZ1s8xjEX8prZN4ZPsy6tWszIx5qzLtEOUkOoqToz3vPwTxMToWgMKFCrB19Vzcu7YhOiYuQ57d2jfD58ETnvu+ycUZp1IX1SW3UUs6tWnCrvXz2bV+PtvX/JzrOgiCIAiC8NcSHcGvkPbSyOPnL2lcT/30bla0tbXxGNab4NBwvK/eyrA/p9FRitjaUKdGReYuWU90TKy8PT4hUW25+vp69OvRjvVbD+S6zuqiuvyZqCWCIAiCIOQ9MTX8FRrVq87SNdtpVK86hgb6KvvSpn/TGBros2bx9Ax56OvrMaRvZzZuO0S9mpVV9mUXHSW9aROGsGXXEQaO+REtTS2MjY0wMzWmV5dWauveull9dh/8HUWSMtfnrS6qy9dGLREEQRAEIe+JyCJCnhCRRQRBEAQh74mpYUEQBEEQhP8oMRQj5CkRWUQQBOHfQUQW+f/0pzuCFy7fZMuuI6SkpJCoSMLKwpzlv3yPpqYmwyfOJjAojHxGBiQqFDSsU40hfTsDEBMbx68bdnHzzkO0tbUxMtRnYO+O1KxankvXbssvNIRFRJGSkoKVhTkAPTu35J1/oByOLX3otjSD3DtyxvsPbKwtGNa/q7x9/LQFVCzrQs/OLeVtc5es5+nz1wC8futPIRsr9HR1AVi9aBq9hv6Aro62vA1g+qRhOBYrgjI5md92HcHr/DW0tbTQ0tLExcmBEQO7ERMTpxIKLk0Nt154HViLcT4jhk+czcvX7znw22LyGaW+CDJ51jJqVatAy6Z1Abj/6DmrN+8lNCyClJQUXJ0dGD24J5af2mPWwrWUKG5Htw7NVMqRJIkd+47jecobDQ0NJEmiTbP69OjUAg0NDSA1XNzaLfu48ocPenq6aGpo4lCsMIP7dGLtlv05aj8A39fvWLp6G1EfY0j5FGZuyvjBONgXycEVJAiCIAhCXvlTHcHQsAh+WbaRzb/OpmCB1HBiz168ljsaAGOG9qRezcp8jI6lz4gpuDg7ULtaBcZNXUBJB3v2bFqItpYWz1++Yfy0hUwbP5g6NSpRp0bqSFH6GLxpNmxTfetV3dp95Uo702f4ZOrVqoyLkwNHT14gNjae7h2bq6Sb7DFI/n9797HMmjxKDs2WRt02gLmL1/MxOlYO7yZJEucu3eBjdCya6dogK0aGBmzd48nwdB2uNL6v3jJpxmJmTR5JlQqlAdi2x5MRk+bw28o56OvrZZrvms17ufvwGWsXT8fM1JjIqGi+m7mEmLg4hvTpjCRJjJ+6ALuihdi+9hf09XRJSUnh3KUbvP8QzPgRfXLUfgA//rySQX06Ur9WFQCCgsPQ0RWDzYIgCILwrftTzwiGR35EU1NTJbyZU4liKh3BNCbGRriULM7bdwHc9HlEYHAoY4b0lMOolXSwo2/3NmzeefjPVEmlvEmj+zN74Tre+QeyfusBpk0cqvbN26/xzj+Qc5duMHX8YPn8NTQ0aFS3GrYFrXOcT68urTh20puQdMvFpNm+7xit3OrJnUCA3l1bY2RoyGnv65nmGRefwO6DJ/l+zAA5trCZqTHfjxnAzv0niE9I4KbPIwKCQpkwog/6eqmjnZqamjSuV52qFUvnqv2CQ8Oxssgv/1zA2oL8ZqY5bgNBEARBEPLGnxq2cSxWhHKuTrTvPZYKZZ0p41KCpg1qYm2ZP0Pa4JAw7j96TodWjXny/BXOjsXQ0VEtvnSpEvy6fneu6/Hlki2bf52NlpYmNaqU4+LV2/QfNZ3hA7rmqoOW3rS5K1SmhtctncEzXz+KFLKRO1rqxMXHq9RLHYv8prRt2YANWw/wg8dAlX3PfP2oX7tKhmPKuDjy9MVrWrupX8z69Rt/dHQyhn4rZmeLjrY2r9/489zXj5IOdlm+sZvT9uvXox0jJ83FtZQDpZ0daVCnKk6O9hnSicgigiAIgvBt+VMdQU1NTX6ePga/tx/wefCE6zfv89uuo2xa8RNFbG0AWLZmBxu3HURbW4t+PdpRqbwLT56/+ksqnyarsG49O7fE68JV2rds9NX5ZzY1nB1DA4MM9arh1itDul6dWtJ14ET83n746jp+Sd2obFbuPnjK4lVbiYtPoGmDmgzu0wnIWfv16NSCZo1qcevuI+4+eMaw8bOY7DEoQyzlTm2a0KlNE+Dz8jGCIAiCIOSdv2Se1L5oIdq3bMS8GR64Ojtw+foded+YoT3Zunoum1bMokPrxgCUdLTnqe9rlErVRY0fPnmBk2PuO1xZ0dLURFPjr18lx8nRnncfAon6GP2n8zIyMqRX59as3rwnQxkPn/hmSP/gsa/aEbc0xexsUSiSMoR+e/3GnySlkmJ2tpR0sOP5yzfyZ1C+jDNbV8+lWaNaxMbFy8fktP3ym5vStEFNJo3uR98ebTl1/kq2xwiCIAiCkLf+VA8pODSce4+eyz9/jI4lICgE24IFsjyucnkXClhZsHTNDpTJyQA8f/mGLbuO0rdHuz9TpX9MEVsbGtSuwtzFG+TwbpIkcf7SDfwDgnOdX4dWjXjx8i1PX/jJ23p0aonnSW9u+jyUt23fe4zomFia1q+RaV6GBvp0aefGvGUbiYxK7ahGfYxm3rKNdO/QHAN9fapULI21VX6WrN5GQqJCPjaz8HRZuXDlptyhVCYn4/vqXbbXgCAIgiAIee9PTQ0nJ6ewecchPgSGoK+nS3JyCs0b16FuzazXhtPU1GTx7In8un4XXfpNQEdHC0MDAyaN7kf1ymX/TJX+Fl8+IzhmSC8qlXdhyrhBbN75ObxbiiRRvowTlSu4EhMTl6sydHV1GOTekZ8WrJG3lXSwY/4MD1Zv2sP85ZtJTk7Bxak4KxdMUXljeOP2g+w8cFylfsP6d2H7vmMM9piJpqYmkpRCa7f68tIvGhoaLJk9kbW/7afXkO/R19fD0EAf24LWuHdtk6u6e1+5xepNe9DR0SHlUx0H9e6QqzwEQRAEQfjniRBzQp4QIeYEQRAEIe+JEHOCIAiCIAj/UWIoRshTIsScIAhC1kToNuHv9K/qCMbGxdO6+0ga1avOlHGfI4bcufeYEZPm0qVdUzyGucvbf1qwht/PXOa3VXNUlocZNmE2IaHh7Nu8SF6G5eCxsxw+flalvJCwCEyM87Fn4wIgZ+HgvM5fZfeGBfKafMvX7cTQQI+BvTuqPaf9R09z6NhZkj+FbrMrXJDhA7phY22ZZZi+rzlvgIDAEJXQeO3dx6Kro8OOdb/Ii3/3GzmNUYO6U7GcCwA37jxk0/aDhIZHYpzPCCMjAwb26kD5Ms45+dgEQRAEQcgj/6qO4Fnv6ziVKIb3lZt4DOuNoYG+vK+IrQ2Xr/swcmAPdHS0iY2N4/6j51hZmqvk8c4/kPf+gRjnM8Ln/hO5s9OhVSM6tPq8ll5AUCgDRk9n3PDUDlZOw8FZWeRn7Za9/PTDyGzPZ/3WA9y484AlcyZibWUBwE2fh4SFR1HAyiLLMH1VK5XJ1XlnJSlJiefJC2rXErxx5yE/LVjN3KljKOtaUm7DF6/e5jh/QRAEQRDyxr/qGUHPU9707tKK8qWdOfNFCDZ9PV0ql3fl4rXbAJz2vk6D2lXR+jTKlT4Pt0a1aN28Pp6nvNWWk5Co4PufltCtQzOqfepw5TQcXNsWDbj/6AXPXrzO8lziExLYvu8Ykz0GyZ1AgCoVSuPq7JDjMH05Pe+sDOjdns07D5OgZmmZTdsP0q9HO7kTCKmdz4Z1quY4f0EQBEEQ8sa/piP4+o0/QSFhVKtUltbN6uF5MmMnrmXTuhz71Lk77nWRVm51VfYnJ6fw++lLtGpaj+aNanP5ug8xsRmXgZm3bBO2NqrLrDzz9aN0KccMadPCwaXR09Wlf6/2rNy4J0Pa9F75+aOjnTFMXJrnvn6ZhulLvxZhTs47OyWK21GpnAu7D57MsO+prx+lS5XIUT77j56m+6BJdB80iV5Df8hVHQRBEARB+Ov9azqCnicv0LxR7dQYw1XLExAUjN9b1cgaZV1LEhQcxvVb99HU1MSuSCGV/Vdv3sWmgBX2RQthZmpMlQqueJ27qpJm7+FTPHvxmqkThnx1XVs2qUtIWDg3bj/46jxyI7vzzonB7p3Ye/jUn4qk0qlNE3atn8+u9fPZvubnr85HEARBEIS/xr+iI6hUKjl59gonzlymvftYOvcbT0KCgqNqRgWbN67NzPmradk046jYsZPevPMPoL37WNq7j+Xuw2cq08M+D56yeedhfvlxrMrzh5C7cHBaWpoM7deFVZv2gKR+GcdidrYkKZUZwsSlyW2YvqzOOycK2ljRpEENNu88orLd2dGeh09efFWegiAIgiDkrX9FR/DStTsUKmiF584VHNq6lENbl7Jh2QxOnr2coaPU0q0u3Ts2p3G96irbwyOiuHX3Efs2L5LzOLbrV0LDInjx8g3BoeFMm7uCyeMGUbRwwQx1yG04uHo1K6Ojo8OFK7fUnpOhgT49OrXg56UbCA4Nl7ffvvuYR09f5jpMX2bnnRv9erTj1LkrhIZFfN7Wsz1bdh5R6QS//xDEuUs3vrocQRAEQRD+Gf+Kt4Y9T3nj1rCWyjb7orZYWZpz+boPJsZG8vb8ZqZqQ6idOH2JqhXLYJzvc1pNTU0a16+O5ylvkpKURMfEsf63/az/bb/KsVtXz81xOLj0RgzoyrAJszM9r8HundhrcgqPyfNJTklBQyP1eb0RA7rlOkxfZuedG2amxnRu25T1Ww/I26pVKsOU8YNZsX4nYeGR6OnpYm5mwqBMlsP5UqjfbRFZRBAEQRDyiAgxJ+QJEWJOEARBEPKe+A0s5CkRWUQQBCFrIrKI8HcSHcE8llU0FI+pC7ArXJAUScLI0ICJI/viWLwoG7Yd4IDnGawszFEkKXEsVoRJo/tjYmzE8Imz6dq+GfVqVlYpJ/0xaRrWqUbfHm0z1KmGWy+8DqzFOF9qfi9fv+fAb4vJZ2QIwORZy6hVrYL84snTF69Zs3kv7/wDMTHOh46ONj07t8xQB0EQBEEQvi2iI5jHsoqGYle4IFtXzwVg14ETzF60ji0rU58pbNqgJh7DepOcnMKUOcvZsvMwo4f0zLKstGNyy8jQgK17PBnev2uGfa/83jN28jymjB9MneoVgdTQezfu/DNL4wiCIAiC8PX+FW8N/z/LKhpKetUrl+Pt+4AM27W0NKlSwZU3avb9VXp1acWxk96EpHtbOM22vZ60cqsndwIBrCzMadnk65apEQRBEAThnyNGBPNQ+mgoycnJbN1zjDbN6qtNe/rCNZxKFMuwPSFRwcWrt3MU3cPr/FV87j+Rf3bv2obG9bNfTsYivyltWzZgw9YD/OAxUGXf0xevGdK3c7Z5QGpkkQOepwGQMlk/URAEQRCEf47oCOahL6OhzFu+Cb+3/tgXTQ0r9+Z9AO7DJgOp8Xunp4tm4nX+Kj4PngJQoYwzvbu2zra8r50aBujVqSVdB07E7+2HrzoeUiOLdGrTBPj81rAgCIIgCHlHdATzSFo0FC1tLbwuXAOQo6GMHtwDUH1G8Et/plP3NYyMDOnVuTWrN+9BS/PzEwXOJYrx8Ikv9WtV+cfqIgiCIAjCX0M8I5hHchMN5VvRoVUjXrx8y9MXfvK2np1bceyUN1f+8JG3hYVHcvz0xTyooSAIgiAIuSFGBPNIbqKh5NbPSzawaOVv8s9zpowGMj4jWLGcC2OH9spxvrq6Ogxy78hPC9bI2xyLFWHx7Ims3bKPxau2oq+vh6GBAe5dW311/QVBEARB+GeIyCJCnhCRRQRBEAQh74mpYUEQBEEQhP8oMRQj5CkRYk4QBCFrIsSc8Hf62zuCOQ2hpqeri8ew3pQu5QikhkSLjonDY1hvlEoly9ft5JbPI7S0tFAmK2nTrD7lyzjz85INAHyMjiUmNo5CNlYANG1Yk16fXmSYs3g9qxdOpXwZZ7V1DAgMoUMfD1q51ZPrGBefQKN2A7l2ajsAwyfOJjAojHxGBvJxwwd0Y+/hU4R+Wmj5xau3FLcvjJamJoYG+hQuVADbQgXo16MdACfPXmbm/DUc/G0JBT/Vc+zkeTSsW402zeoTExvHrxt2cfPOQ7S1tTEy1Gdg747UrFo+120G8PuZy6z7bR8LZ03ArnBBtW3YvWOLDO0xa+FaShS3o1uHZhz3usjsReuYPnEozRvXBuDydR92HjjOqgVT5bZau2UfV/7wwUBfHw1NDSqXd2V4/y5i2lcQBEEQvmF/+2/pnIZQ23fEizmL17Fr/fwMeew5lNrZ2rpmLtpaWiQqFPh/CKa4fWH5+ONeF7l49TbzZnioHOt5ypvK5V3xPOWdaUcQQF9Pj+s37/H6jT/F7GzVphkztGeG+LnVK5eV/1/DrRdrFk3DOF/qix4nTl/i9zOX5Y7g7XtPcHV24M79J7S0sUKZnMz9R8+ZNLofkiQxbuoCSjrYs2fTQrS1tHj+8g3jpy1k2vjBVK1UJldttvfwKfYfPc3KBVMoZGPNjn3H1bZhTtgUsGT91gM0rlcdHR3VS0aSJCZMX0iRQjZsX/sL+nq6KJVKjp70RpGkFB1BQRAEQfiG/e3PCOY0hFqVCq4EBoWp3RccGo65mQnaWloA6OnqUty+cLZlv3n3gQ+BIUyfNJSLV28TGxuXaVptbS3cu7Vh9aY92eabU5XKufDwiS9JSanLwdx/9Az3rm248+nN3SfPXmFqakwhG2tu+jwiMDiUMUN6yudZ0sGOvt3bsHnnYbX5Z9ZmG7cf5Ngpb1YvnEohG2vg69sQoGRxO5wc7dn/KSpIerfuPuL9hyAmjOyLvp4uANra2nRo1Uil0y8IgiAIwrfnbx2uyU0ItXOXbmQa7qxt8wZ4TJnP7XtPKOdaksoVXGlYpxpaWln3Yz1PedO8US2sLMypVN6F097XadeiYabp27dsyJ5DJ7n36DklihfNsH/Zmh1s3HZQ/nnutDEULlQg0/wKWFtgkd+UR099sSlgiYlxPqpWKsOvG3YBcPveYyqVcwHgua8fzo7FMoy4lS5Vgl/X71abv7o2O3XuCmamJqxf+qM8Mglf34ZphvbrzPCJc2jjVk9l+7MX6uutjggxJwiCIAjflr+1I5jTEGphEVEkJyezYdlMtfkUty/M/i2LuffoGQ8ev2DDtgOcPHuZRbMmZlq2MjmZ389cZtWCKQC0alqPzTsPZ9kR1NbWZpB7J1Zt3M2SOZMy7Fc3NZydSuVcuHP/CTbWllQo44y+ni7mZiZ8CAzG5/4TmjWqnav8smsz5xLFeOn3nit/+Kjk/TVtmJ5dkULUqV6RbXuP5SiusToixJwgCIIgfFv+tqnhtBBqJ85cpr37WDr3Gy+HUEuT9rzbke3LqFezMjPmrcp0pEhHR5vK5V3p16MdqxZM5eqNe0R9jMm0/Ct/+BATE8fYKfNp7z6WRSu38MzXj5d+77Ksd9MGNYhPSOTStdtfd+JfqFjOhTv3nnDn3mMqlC0FpMYG/uP2A+4/ekGl8qkjgiUd7Xnq+zpDVJGHT17g5Ggn/5xdm9kVKcSKX75n5cY9nDh9SSWv3Lbhlwb07sCR388TFh4pb3MqYc8zXz95+lsQBEEQhP8ff1tHMDch1LS1tfEY1pvg0HC8r97KkJfPg6fym7kAT1+8xsQ4H8b5DDMt3/OkN2OG9pLLPrRtGd07NMczXUdUHQ0NDYb378raLftzecbqVSpXiodPffF58JRypZ0AqFC2FLsO/I6VpTnWlvkBqFzehQJWFixdswNlcjIAz1++Ycuuo/T99LJJelm1mX1RW1b88gOrN+/l2KnU8/2aNvySlYU5rZvV57fdR+Vtlcu7UsjGisWrtpKoUACpo7GHT5wjLj4hx3kLgiAIgvDP+9umhnMbQk1fX48hfTuzcduhDNOvQcGhLF2zDYUiCR1tbQwM9Jk/wwNNTfX92JCwCG7dfcS0CYNVtrs1rMmo739mxIBuWT7TVr1yWQoVtCIgKERl+5fPCPbs3DLDOX7J0sKcAlYWGOczlF+eKONSgg+BIbRO97ydpqYmi2dP5Nf1u+jSbwI6OloYGhgwaXQ/lTeT08uqzeyLFuLXeT8w6vufSUlJQVdXJ1dtmBn3rq05cuK8/LOGhgYLZ01g7ZZ99Bz8PXq6uqRIKdSsWh5dXZ1s8wv1uy3eLBYEQRCEPCJCzAl5QoSYEwRBEIS8J34DC3lKRBYRBEHImogsIvyd/lUdwfbuY9HV0UZPVxdFkpKSDnb84DEAA/3P69llFmlk1sK1eJ2/yu4NC7AtmLr23vJ1OzE00GNg747cufeYpWu2y4s5P3/5honTFzFqUI9Ml735acEavK/e4tiuX1Xq0N59LIkJCo7uXC6Pht2++5iR382lSzs3PIb1VokikqagjRXzfvTINsLIl7KL/OH31p8V63fy5l0AkPrCyahBPbAvWghIjVhywPMMVhbmKJKUFLEtwA9jB5Lf3BRQjbqSqFDQsE41hvTtnLsPTxAEQRCEf9y/qiMIMGvyKEo62JGSksLEHxdx3OuSvGQJZB1pxMoiP2u37OWnH0ZmWca9h8+YOvdXpowblOnze7GxcVy+7kOJYkU5d/EGLZvWVdlfwNqCS9fu0KBO1U/1ukCpksVU0qSPIvKlnEYYyS7yR0RUNMMnzGHM0F64NawJgNf5q4yYNIetq+Zgkd8MgKYNauIxrDcpKSlMm/srG7cfZOKofnI5aUvrfIyOpc+IKbg4O1CnesUs21EQBEEQhLz1t0cWyStJSiUJCQqVRZWzizTStkUD7j96wbMXrzPN99rNe0z7+VfmTBmVaScQwOvCNapUcKVbx+Z4nryQYX/LpnU55pX6Rm9MbBwPn/hSLYv8spJVVJbsIn8c9DxDhbLOcicQUjt95Us7ccDzTIb8NDU1qVTOhcDgULXlmRgb4VKyOG8/jS4KgiAIgvDt+teNCE6buwI9XV0CgkJxKmFPo3rV5H3ZRRrR09Wlf6/2rNy4h+W/fJ8hb//AYKbOWcHaxdNxVBN5JD3Pk94Mcu9IlQquLFixhTfvPmBXpJC8v6xrSQ56niEkLIJL1+7QsG41tL54gzdt8eg0VSqWZtSgHhnKyioqS3aRP575+lGlYukM20u7lOCWz8MM2xWKJK7c8KFRXfXlBYeEcf/Rczq0apxhn4gsIgiCIAjfln9dRzBtaliZnMy8ZZtYtWE3o4f0zHGkkZZN6rLrwAlu3H6QIe/8ZqaYm5lw8NhZJo7qi4aGhto6+L5+R1h4JNUqlUFTUxO3hrU4duoiIwZ2U0nXrHEtjntd5OLV28z8fjinzl1R2Z/V1HBOo7L8VbzOX8Xn/hP8A4Ipbl9EpYMNn5fW0dbWol+PdvJC2emJyCKCIAiC8G35104Na2tp0aB2Fa7fug/kPNKIlpYmQ/t1YdWmPfDFqJWBvh5L5kzipd875i3blOmolufJC8TFJ9Cx7zjau4/l9IVr/H72krxQdJrmjeuw74gXero6FLG1ydX55TQqS3aRP5wc7Xn4+EWG7Q8fv6Cko738c9MGNdm6ei4Hty4lKSmJDVsPqqQfM7QnW1fPZdOKWXRonXE0UBAEQRCEb8+/tiMIcOvuY4oWSX3rNjeRRurVrIyOjg4XrmSMcmJkaMCSOZPwe+vP3CUbSElJUdmflKTk1LkrrF86Qy7Lc+cKClhZcvWPuypprSzMGdavC8MHqI4U5kZ2UVmyi/zRvlUj7tx/wqlzV+VjUkf/ntJRzfSuqUk+fvAYyAHP0yqRSgRBEARB+P/zr+sITpu7Avdhk+k5+HvevPPHY2hvOdJIo7pVVdK6NazJqXNX1I6WjRjQNUNkkTSGBvosnjOJ9x+CmLt4vUpn0PvqLWysLeWlV9KX5XnqQoa8WrnVo4xLCbXlpE3/pv0bOu4ntenSRxj5clQwLfKHjo42PQd/T8/B39N76A+88w9EV1cHa8v8rJw/hZNnL9Oxjwed+o7j5NkrrFo4BUsLc7XlOTna07BOVZVQc4IgCIIg/P8RkUWEPCEiiwiCIAhC3vvXjQgKgiAIgiAIOSOGYoQ8JULMCYIgZE2EmBP+Tn9LRzC7UG+Xr/uwacdBYuPiUSqTqVqxDCMHdsPIyBCAO/efsHrTHhITFST9r737jo6iauM4/t3d9JCQRkjoJRB6R0FBqYIgVZTeiwIvCNIFEelKL9J7ky6oqICCooAiIEhvUtMILUBCym72/SOyEgkQFFhwf59zcs7uzJ07z9yZ7D577xSzGa8Mnowe3IMZC1Zy9HjKzZ5PnwsjS1AmXF1SbpI8fdz7uDg7M2vharb+tAsnJydMJiPNGtWidvWUp3pEREbTsHVPXqvxMgPf7QikPH6tav0O7Ny45K7tMJvNTJ61jN2/HcJkMmG2mKlbsxJNX68FwJVrMUybs5zfDhzF09MDgwEqV3iONk3r2W4L89GQnkRERtOo7bvkzZXdVrezszNzJ3/4wJjeHTTGdlHGiT/OkSdXNkxGIx7ubswYP5jyNVqwac1MvDJ4pnrUG0CAvy/jh/dJFcuD4r6rDSwWFn66nk1bd+JkMmEyGSkUmpeuHZrglcGTi5euMGXWMg4fO4XRaCTA35eu7Zvc83F3IiIi8vR4bD2C93rU285f9/PR5HmMHdqL0JBcmC0WJs1YQu/B45g2dhCW5GT6fziRKaP7E5ov5ZFrZ8+H4+bmyns9O9rqb9Cqh20dtw0e9QlJSWYWzxiJu5sbEZHR9Bw0Boslmbo1KwHg5urKz7/u5/TZMHLnzHrfbVjx2UYuXb7KohkjcTKZSEhMJCz8IgDxCYl06T2Cai8/z8qe4zCZjMTHJ7D+661p1uXh7n7PewLeL6bxw/vYXpev0YIZ495P9bSUv7v9qLd7edi4R46fzfUbscyeOARvL0+sVitbftzF9RuxODmZ6NpnBHVrVmLYeymP5fv1t4P0+WAcUz9+L1XiKyIiIk+fx36O4N8f9bbg0/W0aVqX0D/vUedkMtG9U3PCIi+yZ/9h4uLiiYu7hd+fz7gFyJk9Cx7ubvddz/mwSLbt3EP/Hu1sPY/BQZno3qkZ85Z8Zivn5GSiVZO6TJ+34oGxX7x0BV8fb5xMJiDlySN5cmUDUm6x4uHuRoeWr2MypTSjm5srjRvUTF/D3OFhYvq3Hibu82GRbPlxF4N6dcLbK2X/GQwGqr70PFmDA9m8dSdeGTxp2biObZmyJYtQ+5WXWLJyw2PfFhEREfl3HluP4L0e9Xbs5Bne7dIqVVlnZycKhOTm6InTlClRmNfrVqdJ+z4ULxJKkYIhVHu5HDmyBd93fcdOniF7liAyenulml6kYD6ioi9z9dp127QGtauw4rNv2H/oOPnu86i4eq9WpufAj9mz/wjFC+enTMnCVKn4PCaTkWMnTlO0UPqHP+Nu3Ur1uLjcObPxYf8uDx3Tg9x+wgdA3Vcr257kcdvDxH27TX0yet1zflp1FSkYwqwFq++arkfMiYiIPF0e+9Dw3x/1lh49O7ekScNX2bv/MLv3HaJ1l0FMHNmX4kVCH0lsTk5OdGzViGlzlzNhRN97lsuTKxurF4xn/6FjHDh8gjmL1/DNdz8xblifey5zL/cbGn6YmB7kQUPD9qRHzImIiDxdHvvQ8N8f9RYakouDR1I/0iwpyczRk6dtw8UAwZkDqP3KS3zQtzM1q77Id9t+ue96QkNycT48kpjrN1JNP3jkBJkz+ePr451q+iuVy3MrPoEfd+65b73Ozk6UKVGYts3qM23MIHbs2k/M9ZuE5svNwSOnHrT5DyW9Mf0bDxP3vdr0zvkHDp+8a/rBIycJzZfr34QpIiIiT8ATuY/gnY96a92kLguWref4qbNAylWpk2ctJThzJsqUKEzcrXh2/rrfNnQYn5DImfPhZA0OvO86smcNosLzJRk9cR7x8QlAylXCk2cto22z+neVNxgMdGnXmJlpDGHe9tuBo6keo3b0xGm8vTLglcGDVyqV52ZsLPOWfobFkmyLdeW6jelvmH8Q07/1MHFnzxpE5QplGTl+DjduxgIpQ7pbf9xFWMRFqlcuz/UbN1m84gvbMrv3HeLLjT/QvFHtx7YNIiIi8mg89nMELZZkgjL707dbOwBeeK4Efbq1ZeT42dyKj8dstlC2ZBHGDeuNwWDAarXy2ZffMWH6YlxdXDBbzJQrU4zX/3auW1oG93mbmQtX0eLtASm3jzEaaf5GberUeDnN8uXKFCNLcKZ7Pkou6uIlJs5YTGJiEs5OTri7u/HxkJ4YjUbc3FyZNmYQ0+at4I22vXB3d8VgMPBK5fJp1vX3cwQh5ZY3DxvTv/WwcQ98tyPzl62nwzsfYDKaSLZaKVE0lDIlC+Pu5sYnHw9k8qylNGzVE5PJSICfDx8PeZeQdJ7neOnMHj1ZRERExE70iDmxCz1iTkRExP70iDkRERERB6VEUERERMRBKREUERERcVBKBEVEREQclBJBEREREQelyzXFLm7fJ9JsNts5EhERcSQmkwmDwWDvMJ4aSgTFLiwWCwCV63WwcyQiIuJIdNuy1NQSYhcuLi7kyBbEkhmj9MvsEWjx9gCWzBhl7zD+E9SWj47a8tFQOz46Ld4egMlksncYTxUlgmIXRqMRo9GIs7OzvUP5TzAYDPqF+4ioLR8dteWjoXZ8dAwGgzof/kYXi4iIiIg4KCWCYjev13nw86MlfdSWj47a8tFRWz4aasdHR215Nz1rWERERMRBqUdQRERExEEpERQRERFxUEoERURERByUrkcXuzgfFsnQMTOJuX6DDJ7uDOr1FnlyZbN3WM+UhMREBo/8hNPnwnB1ccHXx5s+3dqQPWuQvUN7pn258QdGjJ/N6A968PILZewdzjMpMTGJybOW8cue33FxcSZfnhwM6dfF3mE9c3bs2sfMhauwJluxWJJp9kYtald/yd5hPRPGT1vEjz/vJTLqEgunjSB/3pyAvnvSokRQ7OKjSfOoX6sytV95iS0/7mL4uJnMmzLM3mE9c+rVqkz5ssUxGAysWr+JURPnMG3MIHuH9cyKiIxm/dffU6RgiL1DeaZNm7cCgwFWzhuLwWDg8pVr9g7pmWO1Whny0XSmjRlISJ4cRERG06RDXyq9WBZPD3d7h/fUq1zxOVq8UZu3eqX+XtF3z900NCxP3JVrMRw58Qc1qr4IQOUKZYmKvsL5sEg7R/ZscXVx4YXnSthujlqkYAgRUZfsHNWzKzk5mZET5tCrayucnfUb+Z+6FR/PFxu/5+02b9iOTX8/H/sG9YwyGAzciI0DIDbuFt7eGXDRTfjTpWTRAgRm8k81Td89adOnnTxxF6OvEODng9Ofj/kxGAxkzuRPVPRlDWv+CyvXbeSl8qXsHcYz69M1X1OscH4K5Mtt71CeaWHhF/H2ysDC5Z/z62+HcHVxpn3LhpQtWcTeoT1TDAYDw977HwOGTsTdzZXrN2MZ9X4P/Uj5F/Tdkzb1CIr8Byz4dD0XwqPo3LaxvUN5Jp06c57vt/9K22b17B3KM89isRAZdYlcObIyf+owenZpxfsjp3Llaoy9Q3ummC0WFny6jlGDe/DZ4klMGT2AoWOmcy3mhr1Dk/8Y/bSQJy4wkx+XrlzDbLHgZDJhtVqJir5M5r9140v6LF21gR+272by6P64ubnaO5xn0v4Dx4iIiuaNdr0BuHIlho/OzuPy5Ws0rFPNztE9WzIHBmA0GqhRJWX4LTQkF1mCMnHy9Hme881o5+ieHSdOneXS5WuULFoAgEKheQkM8OP4yTM8V7qonaN7Num7J23qEZQnzs8nI6Ehudj43XYAtv70K4EBfg7dNf9PfbrmKzZ/v5NJo/rjlcHT3uE8sxrWqcaXn37CZ4sm8tmiiRQumJd+PdopCfwHfDJ6UaZEYX7Z8zsA4ZEXCY+MJleOLHaO7NmSOZM/l69c48y5MCDlatcL4RfJkT3YzpE9u/TdkzY9Yk7s4uz5cIaPm0XM9Zt4ergzsFcnQnJnt3dYz5SL0Zep1+IdsgYH4uHuBoCzszNzJ39o58iefV36DKdxg5q6fcw/FBZxkZHjZ3Pt+g2MBiPtmtencsXn7B3WM2fT1h0sXP45RoORZGsyrRrXpUaVF+wd1jNh9KS57Ni1jytXYvD2zoCHuxurF4zXd08alAiKiIiIOCgNDYuIiIg4KCWCIiIiIg5KiaCIiIiIg1IiKCIiIuKglAiKiIiIOCglgiIiIiIOSomgiIiIiINSIigid2nQqgc/7Nh9z/mtOr/Hhk3bnmBE6bf+q6281rQrVeq159jJM499fVXqtefk6fOPvN59B45St3m3R1pn5MVLVKnXnpuxcY+03gf5aNI8Ppmz/JHVt2HTNlp1fu+R1fdPRURGU75GC27cjLV3KCL/mBJBkf+YLn2Gs3ztN3dNL1+jBcdPnbVDRE+O2Wxm/PRFDH+vG1vWzyU0JNddZVat30Tb/73PS6+1od+QCXfNj42NY/CoT6jaoAO1Gndh3tLP7rvOLevn/usnE6SVUJQoWoDPl06xvb/Xfr2fv+/zoMAAtqyfSwZPj38V78Pq9047unZo8o+W3bv/MNUbdnrEET295ixek+ZxKfK4ONk7ABFxLGazGSenx/PRc/lKDImJSeS9T2KWyd+XNs3q8eveQ0RfunLX/HHTFnH9xk3WLZ7E1WvX6d5/NEGBAdSqXvGxxCxym9lstncI4oCUCIo4IKvVyqdrvmbtl99y/UYshULz0KdbW7IGB6ZZftX6TSxZ+SXxCYk0qF3lrvm79h5kxvyVnA+LJJO/L53bvUnF8qUBGDZ2Jkajkbi4W/y853febvMmxQrlY8zUBZw+F4azkxNFCuZj7NBe6Yr9fFgk4z5ZyOFjf+Dt5Umjuq/QpGFNjp08w9vvDgOgXvPu+PlmZPWC8XctX6lCWQBOnDp7VyIYH5/Atz/8zMzxg/HK4IlXBk8a1avOFxt/uGciWL5GCxZOG0H+vDmZs3gNR0+cISgwgI1btuPp4c7/OjSlWqVyKe205wCTZy8jIjIaV1cXKr1Ylr7d29K++we2uCGlBy2Tvy/9PpzI5rWzmDxzKfsPHuPgkZPMWriK4kVCmTCib6p1Ayxf+w3bdu5m2phBtOs2GIBOPT/EaDDQqkldalR+gYate7JpzUy8MnhiNpuZtWgNm7bsICExkdLFC9Gra2t8fbxt29anW1vWfL6ZyOhLlCpWkA/6diaDpweJiUl8PGU+P/28F7PZQuZM/gzs1ZFCoXnvaqNhY2eSwdODnp1bEhEZTcPWPRnc523mLllLzPWbvPRCaQb0aH/XD4SY6zfoOWgMiYlJVKnXHoDxw/vY5s9b+hmr128GA7RqXJcmDWva5m3+ficLl39O1MXLZM+amR5vt6RY4fxp7sOkJDPzl61j09YdXL12naDMAQzu/Rah+XITG3eLKbOW8dMvewGoWK403d9qhrubm235n37+7Z7b8sueA3wydznhERfJmiWQru2b8lypIrZ2ufN/o3mj2ixc/jnWZKtte7esn5tmzCKPioaGRRzQ19/+xKdrv2b0Bz354tMp5MmZjT6Dx2G2WO4qu3vfIWYuWMXwgd348tOpAPxx5oJt/sk/zjFoxGS6tG/MxtUz6PdOOz78eAZnz4fbymz+fid1alZi85pZ1KnxMmM/WUSF50uxec0sPl86heZv1E5X3GaLhd6DxxGSJwdffDqF0YN7sHTVl2zcsoPQkFwsmzUagPVLJ6eZBD7I2QsRJCWZyfdnYgWQP09OTp0+l+46ftnzOyWKhvLNqhl0at2IURPnEBt3C0j54m/eqDbfrZvDmoXjqVn1RQDmTv7QFveW9XOpUeXFVHV2f6s5xYuE0qVdE7asn8uEEX0fGMe8KUMBmDXhA7asn0ubpvXuKrNw+Rds/+U3Zox/nzULJ2AwGBjy0bRUZbZs+4UpHw9g3eJJXLx0heVrvwbgq29/5OQf51g1fxyb185i1OB38Pf1SXc77fx1PwunjWDZ7I/Y/dshNm7ZcVeZjN5eTBjehwyeHmxZP5ct6+dSomgBAP44G4abqyufL5vM8Pf+x9Q5n3IhPAqAHbv2MWX2Mt7v1YmNq2fQqnFd+nwwnpjrN9KMZdq85ez8dT8TRvTl289mM3JQd7y9vQCYMH0xF8KjWDpzNEtmjObshXAmzViarm05HxZJ3yHjadesPt+snkHrJvXoO2Q84ZEXbcve+b/R7PVatG5SlxefL2nbXpHHTYmgyH/Q9PkrqN6wU6q/O33z3XberPcKIbmz4+riwttt3yTq0mUOHz11V10bt+ygRpUXKFooH87OTnRo2RA3N1fb/M++2kKt6i9RpkRhjEYjxYuE8uLzJflu2y+2Ms+XKkq5MsUwGo24ubni5GQi8uIlLl2+iouLMyX//HJ/kENHT3H5yjXeav0Gri4uhOTJwet1q/PV5kdz4cqtW/G4u7niZDLZpmXI4EFcXHy66wgNyUW1l8thMhl5tVoFksxmzodFAuDkZOJCeBRXr13H3c3tnj1UT8o33/1E26b1CQoMwMPdje5vNWfX3oNEX75qK9P8jdr4+WTEK4MnlV98jqMnzgDgZDIRdyueM+fCsVqt5MgWTOZA/3Svu13zBnh6uJPJ35dyZYpx9MTph4rdJ2MGmjWqhZOTE6WKFyI4cwAn/jwfcs0Xm2neqDah+XJjNBqpVKEsObMHs2PX/rvqsVqtrNuwle5vNSd71iAMBgM5s2chOHMAycnJbNq6g87t3iSjtxc+Gb14u82bfP3tTyQnJz9wW7774RdKFStIpQplcTKZqFLxOYoXzs+mrTtty/79f0PkSdPQsMh/UOe2jVMNk0HKMN9tFy9dIThzJtt7FxdnAvx8uZjGOXOXLl+lVLGCtvdOTk74+/nY3kdGRbN73+FUVxFbLBY8PSrY3v89QRj4bkfmLvmMNv97P2X4tW513qj3ygO3Kzr6CgH+vjg7//XRlTU4kI1btj9w2fRwd3cjPiERs8ViSwZvxt7Cw8PtAUv+5c5eMYPBgKuLC3F/9giOHtyDBZ9+TuP2fQjKHECrxnWo9nK5RxL7P3Hx0hWCgwJs7zP5++Li7MzF6Ctk8vcFSLWv3dxcibuVsi01q1Xg0pVrfDx5PlHRl6lYvhTdOjbDJ6NXutbt75cxVb0PeyWzn0/GVO/d3VyJu5WSsEdEXmLG/FXMWbzWNt9sthB9+e7j+2rMdeITEsieJfNd867F3CApyZzqfyVrcCCJSUlcu6N38V7b8vf/M4AsQYGpTkl4mORZ5HFQIijigAID/IiIira9T0oyc+nKVQID/O4qG+DvS+TFS7b3ZrOZy1eu3VGXP43r16BL+3tfFWowGFK9z5YlMx/0fRur1crvh47Tvf9oihbKR4F8ue8bd6ZMfly6fDXVBScRUdFpxv1P5MwWjJOTiZN/nLPFcuLUWfLm+ndXBd8Wmi83owa/Q3JyMtt27GHQiCmUKlYQg9HwwGWNhrsHcNzdXImPT7C9v3O/wN3t/neBAX5ERF6icIEQ2/KJSUkEZnpwezqZTLRpWo82Tetx5WoMg0d9wtwla+nVtfUDl30YBuPDD1wFZvKjUb1XaPha1QeW9c3ojZurKxfCowj4M/m9zSejF87OTkRERePnm5LsRURdwsXZGR9vL6LiL98/jgA/9h86lmpaRFS0bXgb7t5HhjT2s8jjpCNOxAHVqPoCqz/fzOmzYSQmJjFz4Soy+ftRqMDdJ/pXr1SejVt2cOjoSZKSzMxd+lmq5KN+7Sp8uWkbe/YdxmJJJjExiQOHT3DmXNg91//V5h+5cjUGg8FAhgweGIwGjH9+4Q8bO5NhY2emuVzh0Dz4+WZk1qI1JCYmcerMeVat3/xQV/SaLRYSEhOxWJJJtiaTkJhIUlLK1Zpubq5Ufakcsxau5mZsHOfDIln9+Sbq1KyU7vrvJSnJzNff/sT1G7EYjUYyZEi5hYvJZMQnozdGo4GwiIv3XN7P15uwiKhU00JDcvHNd9sxWywcP3WWb7776e5lwlMvc6eaVV+0XVARdyueSTOXUrZkEVtv4P3s3neI46fOYrZYcHNzxcXFGdMdQ+qPip+PN3G3bnHlWky6l3m9bnWWrd7A0ROnsVqtxMcnsGvvQS5G3524GQwG6r5aicmzlnE+LBKr1crZ8+FERF3CaDTySqXyzJi/ipjrN4m5foMZ81dSs+qLtuP1fqq+/Dx7fz/Cth17MFssfP/Tr+w7eIzqlcrfe3t9vYm4eCnN83VFHgf1CIo4oFrVKnL16nV6Dx7LjZuxFArNy5gP3011btxtz5UqQqfWjRgwbBIJCUk0qF2FPLmy2eaHhuRi6ICuzFy4ijPnwjEaDeTLk5NunZrdc/2//naIT+Yu59atePx8M/K/Dk1tV75GXbx8zy9KJycnxg7txbhPFvJa0654ZfCkacNXeaXyC+ne9gXL1jF3yV/3BqxUpx0lixVg2phBAPTu2oqPJs+jXvPuuLq48Hrd6o/s1jGbtu5g4owlmM1mMmfyZ0j/LmT886KEds0b8u7AMSSZzfT+Xxsy+fukWrZxg5oMGzuL6g07UaxwfsYN6827XVoxbOxMXvlz2qvVK3LwyAnbMp1aNWL89MWMmjiHFm++RvWXU7drq8Z1uRWfQMeeQ0hMTKJU8UIM6dc5Xdty5WoMY6cu5GL0ZVxdXShbsjDtWzT4dw2UhpzZs1CnRiWadeyHxZKcrqvLK5YrRWJiEqMmziE8IhpnZycKheal9//S7q3s2r4Jc5aspfuA0Vy/fpPgoEy83/stgjMH0LNzSybNWkqzTv1sdd/v2L5T9qxBjB7cg+nzVvDhmOlkDQpk9OAe97w6H6BKxefZtHUntd7sjNUKm9fOSte6RP4pQ2JigtXeQYiIACQmJtGy8wCWzhz92O41KCIif1EiKCIiIuKgdI6giIiIiINSIigiIiLioJQIioiIiDgoJYIiIiIiDkqJoIiIiIiDUiIoIiIi4qCUCIqIiIg4KCWCIiIiIg5KiaCIiIiIg1IiKM+k8jVa8MOO3XZb/979hylfowU3bsY+0nqHjZ1JvyETHmmdIo9bRGQ05Wu04Pips4+87gaterB87TePvN6nZZ1zFq+hVef3Hll9j+qz6VF8Fj2uz0l5tJQIit2s/fI7qtbvgNlisU2LuxVPhVqt6dJneKqytz9QLoRHPbL1p/eDrkuf4UyYvviRrfd+enZuyaDenZ7IukTS8l/58t6weRvtur1PpbrtqFq/A517D+enn39LXWbTNqo3tO//W7NGtZny0QC7xiCOTYmg2E3p4gWJuxXP0eOnbdP2HzyGv29GDh09RUJiom36nv1HCAr0J1uWzPYI9YnJ4OmBVwZPe4eRJqvVmippFzCbzfYOQdIwedYyPp40n6ovlWPx9JHMnfwhxQvnp9+H41m1fpNdYkpKSvtY8XB3I6O31xOORuQvTvYOQBxXzuxZCPDzYe/vhylSMASAvfuPULF8afbsP8ShIycpVbxQyvTfj9he3xYTc4N+H07glz0HyOTvS/dOzahYvjQAFksyoyfNZc++w1y+eo2gQH8avlaNxg1qAinDMV9t/hFIGWYG+OTj9+5ax7CxM/nt96P89vtRVq7bCMDahX/1Ih49cZppc1dw+lwY+fLkZFCvjuTMnsU2f9uOPcxdupYzZ8MJ8PehVvWKtG5aDyeTKc02GTZ2JjdvxvHRkJ4AbPlxF3OXrOVCeBRurq7kz5uTjz/sibubG3v3H2bqnOWcPhuGk5OJ3Dmz8mH/rgRnDrirHoAJ0xdz4o+zTBszCIDk5GQWr/yS9V9t5fLVa+TIGkzb5vWpUvG5P/fFYbr2Hcn44X2YuWAVp86cZ9LIfne10ZzFa9i2Yw9NX6/FrEWruXEjlvJli9O/R3s8PdwB2PnrfhZ8up4/zlzAaDRSpGAIPTu3tCX2EZHRNGzdk2Hv/Y/V6zdx5MRp8ubKxpB+XbgZG8eYKQs4ez6c4kVCGdznbXx9vG3r//zrrSxb8zURkdEEZQ7gzfqv8Hqd6mm274PaFOCLjT/w6eqvuBARhbeXJ5VefI7e/2ttO1b6/K8NO3fvZ/dvh2n+Ri06tHz9gfv5xs1Ypsxexo8795KYlETBfHl4563m5MubM91t+HcbNm1j4owlfNC3M1NmLyUq+govlC3O4D5v892PvzBn8VpiY+OoWbUC77zVApMp5Xf/19/+xMp1Gzl3IQI3N1dKFy9Ej84t8PPJSERkNF37jgTgldffAqBW9Yq83/stkpOTWbb6K9Z9tYWLl67g55OR+rWq0KZZPVtM4REXmTRjCYeOnSJ7liD6dm9L0UL5bPP3HzzG9HkrOHLiND7eXrz8Yhk6t3vT1vZXrsUwcvwcfv3tIP6+PrzVptE99+O9HDxykk/XfMW7XVrxRr1XbNPfbvsmiYlJTJ61lJfKlyYsIorh42bZ9itA+xYN6NDydQDiExIYPm4WW3/chVcGT9o0q0f9WlVs9UVdvMzkWUvZtfcgBoOBEkVC6dm5JcFBmYC//pcL5s/Dmi824+zszNpFd49A3N73i6aPTLVcscL5+XTtVyQlWahWqRw9326Bk1PKV3ZiYhKzF61h09YdXI25TmCAH62a1KVuzUoPrB9g+dpvWLHuGz5bNBFI+bycOmcZX27chtFopE7Nl7FaranqedDnBcCOXfuYOGMJUdGXKVIghFrVK6Zvp4ldKREUuypVvBB79x+hVeO6AOzZf5gWb75GcnIye/anJH/xCYkcPnqK12q8lGrZuUs+o2uHJvyvQ1NWf76JIR9NZ+2iiWT0zoDVmkxggB8jBnUjo3cGDhw+weiJ8/D386Hay+Vo1qg2Z86FExt3i0G9UoaGvL0y3BVfz84tOXchkry5stGxVcoXhE9GbyKiogGYuWAV3To1wzejNx9PnseI8bOZNeEDAPYdOMrQMTPo2aUlJYoUICw8itGT5gHQvkXDB7bNpctXGTzqE7p2aEKlF8oQeyue/QePYrWC2WKh34cTqftqJYYO6IrZbObQsVMYDOlv+0XLv+CbLdvp270t2bMGse/AUT78aDo+Gb0oVaygrdy0uSvo1rEpWYID79lbGRZxkW079jB2aC9u3Ihl0MgpLF7xBW+3fROA+PgEmjZ8lby5s3MrPoHZi1bTf+hEFk0bgdH418DEnMVr6fF2C4IC/RkxfjYfjJ6Gh7sbPTq3xM3VhUEjpjB70Rr6dm8LwMYt25m9aA29urYmf0hOjp88y6iJc3Fzc6V29ZfuivN+bQqw9otvmTRrKV3aNaZ82eLcjI3j90MnUtUxZ8laurRrTI+3W2IyGdO1nwcOn4KrqzPjh/chg6cHn23YQrf+o1gxdywZvTOkqw3TEp+QwKr1Gxk64H/E3YpnwNCJ9B86kQyeHowf1oewiIu8N3wSxQrlp1qlckDKsdOpdSNyZAvm6rXrTJq5lOFjZzF+eB8CM/kz6v13GDBsEivmjsHTwx1XVxcAps9byfqvt/LO280pXjiUy1eucfZ8eKp4ZixYRbeOTcmeNYgZC1YxePQnrJo/DieTiQvhUfQc+DGdWr/BwF6duHrtOuOmLWTc1IUM6p2SdA4fO4tLl6/yyccDcXIyMX7aIq5eu37P7U/L5u934OHulippu61po1p8uvZrtv70K6/XqUaPt1swe9EaVswdA4C7u5ut7KdrvqZT69dp3aQuW3/axZgp8ylZtAA5s2fBbDbTY+BHFCmYj+nj3sfJZGT+svX0GPgxS2aMwtk55at1975DeHi4M2lU/4fahj37D+Pv58PUjwZyITyK90dOJX+enNSrVRmAoWNmcPDISXp2aUm+PDkJj7xITMzNh1rHnT5d8xUbNv3IwHc7kitHFpat+YofduymTPHCtjIP+ryIuniZAUMn8XqdatSrVZmjJ04zedayfxyTPDlKBMWuShcvyMQZSzBbLCQkJHL81FlKFi2A2Wzmsw1bADh45ASJSUmU/ltPVK1XKvJK5ReAlF/7K9dt4vCxU5QvWxwnJydb4gaQJSiQA4dPsmXbL1R7uRwe7m64urqQlGTG38/nnvFl8PTA2dmEq6tLmuXeavOGLWlq2bgOvd4fS0JiIq4uLsxd8hktG9exJSRZgwPp1Pp1PpmzPF2J4OUr17BYLFR6sSzBmQMACMmdHYCY6ze5GRvHi8+XtPWq5cqR9YF13paYmMTC5Z8zeXR/W49N1uBA9h86xroNW1Ilgh1bvc5zpYvet77kZCuDeney9V7VrFqB3fsO2eZXvqPXAGDgu5149c3OnD4XRt5c2W3TmzWqRbkyxQB4s34NBo/6hCkfDaB44fwA1Kn5Mhs2/WgrP3vRGrp1akalCmWBlP18+lwY6zZsTTMRvF+bAsz/dD3NXq9l6zkGKBSaN1Udr1R+gddqvGx7P2Lc7Pvu5/0Hj3H42Cm+WjENFxdnALp3asa2HbvZ+tMuW8LyoDZMi9lsoU+3trZjoHKF5/jmu+1sWPEJHu5u5M6ZlVLFCrJn/2FbIljnjtizBgfybpeWtOs2mLhb8Xi4u+HtlZLs+/p42xL/2LhbrFy3kV5dW9m2M1uWzBQvEpoqnmaNavHi8yUB6NjydZp16seFsChy5cjCohWf80qVF2jSMKVts2cN4t3OrejSZzh9urcl6uJldv66n7mTP7S1+Xs9O9K0Y9/7tsHfnbsQSdbgQFsydqdM/r54erhzPiwCZ2cnMnh6YDAY0vzffuG54rae5ZZv1mH52m/Ys/8IObNn4dsffiY52cp7PTtg+PPX16Benaj+eif2/n6E5//8f3Fzc+W9nh3SjOV+vLw86dW1NSaTkVw5svDCc8XZve8Q9WpV5tyFCL7b9guTRvXnuVJFgJT9+G+s+OwbWjWpY/s/6tu9Hb/sPmCbn57Pi7VffkvW4EC6v9UcSBnxOXX6PItXfvmvYpPHT4mg2FXJYgW5FZ/AkWN/cONmLDmyBuHr403JYgUZMW42CYmJ7N1/hKzBgQQFBqRaNiR3Dttrdzc3PD3cU/UerP58M19u/IGo6MskJCSSZDaTL0/ORxr/nTHc/jK5eu06QYEBnDx9jt8PH2fhp+ttZSzJySQmJhEfn4Cbm+v9686TkzIlCtPi7f48X7oYz5cqSuWKz+Ht5UlG7wzUrl6Rnu99TNlSRShbsjBVX3qeAH/fdMV9ITyK+IQE3hkwOtX0JLOZ/HlzpZpWIH9u2+sq9drbXteo8iL93mkHQHDmgFRDmP5+Pqn2xfmwSGYvWs2ho6e4dv0G1uSULrioi5dTJYJ3JmV+PhkBUs3388loq/dWfDxhERcZOWEOoyfOtZWxWJLx9Ex7OPV+bXrlWgyXLl+lTInCaS57W8E72gN44H4+8cc5bsXHU/ONt1Mtl5CYSFj4Rdv7B7VhWtxcXVOdN+vnm5HgzAF43NGz5eebkasxf9Vz9MRp5ixey8k/znHjZizJd+yL3DnT/jFx5lw4iUlJlCl5/7a5c//Z/h9irpOLLJz84xwnT59n05YdtjJWa0oCHBEZzbkLkZhMJgrk+6t9c+XIglcGj/uuMy1/G9X8R/LesS0GgwF/37/2x4k/zhEWHkXV+h1SLZOYmERYeBT8mQjmzZX9oZNAgDw5s9qG8gEC/H04dfoCAMdPncVkNFKqWIGHrjctN2PjuHTlGoULhNimOZlMKf/3f7Zjej4vzpwPp1CB1D+aihTMhzz9lAiKXWXPGkRggB979h/mxs1YSv754ZbJ35fATH4cOHyCvfsP39UbCODklPo8O4PBYDuvZfP3O5kyexndOzWjSMF8eLi7sXT1Bg4fPfVI478zhts9A7eTnLhb8XRs+Tovv1jmruVu9wzdj8lkZPLo/vx++AS79hxg1eebmLlgFXMmDyFLUCCDer/FG/Vr8PPu3/n2h1+YtXA1k0b1p0jBkFRtcdudF3rcio8HYOyw3mT6W/Lo4pw6Nvc7EtaF00bYXt+ZbN21LzCQfMf6ew8eR3DmAPr3aE8mf1+Sk600f6s/SX+72OL2OVCAbZj77218e7tu3UoAYECP9nf12t35Jfr36fdq0/SesP/3BP5B+/nWrXj8/Xz45OOBd82/c6j9QW2Ylrv/B+7xf/HnMXkrPp4e733E86WLMaRfZ3wyehMVfZke731017640+3h4QdJa/9Zk5MBiLuVQP1aVVKdt3dbUGAA5y5EpmsdD5IjWxC/HzpOUpL5riQs+vJVYuNukT1r8APrcTKlXtZgAKs1ZVtu3UogNF9uhvTrfNdyd56/6v6AH3vpXTcYSP5z3endF7YlDca7EmOz5eEucnqYzwt59igRFLsrVbwQv/1+hBs3Y2nWqLZteomiBdj5634OH/+DBq9Ve6g6fz90nKKF8qW6aODO3hcAZycnLH9+Sd2Ps5MTyeko93ehIbk4eyGC7FmDHnrZ2wwGA8UL56d44fy0a96ABq3e4Yftu2n6ei3bOkJDctG6SV069hjCpq07KFIwBN+M3vxx5kKquk6cOmtLEnLlyIqLszNRFy+nGgZ+kH+yLTHXb3DuQgQDerSnRNGURH//wWMPXc/f+flmJMDfl7CIi9So8mK6l7tfmwZnzsTufYcoXeLuHx738qD9HBqSiytXYnAymWwXEtjL2fMRxFy/SZd2jckc6A/A0RN/pCpzO5m785jPnjUzrq4u7P7tEHVf/WfDkKEhuTh9Nuye7ZQzezAWi4WjJ07bEvuz58O5cTPuodZT7eXyrFy3iXVfbbkr6Vy2egNOTiYq/zkE6vQv/re//eFn/Hy88fR8+B7LfyMkV3aSrVb2/n7UNjR8P74Zvbh89RpWq9X2Y/XEqXO2+Rk8PQjw8+HQ0ZOU/PP/02yxcOzEGUJDcgHp+7zIlT3LXbfnOXj05D/ZRHnCdPsYsbvSxQuy/9Bxjp86l+pDpmTRAqz7agtJSWZKF09/sgIpCcvR46f5effvnLsQwcyFqzhyPPUXXlDmAE6dPsfZ8+Fci7lxz1uBBGfOxKGjp4iIjOZazI10f3G0a96Ar7/9iblL1vLHmQucORfG5u93MnPBqnQtf+joSRZ8up4jx/8g8uIlvt/+K9dibpArR1bCIy8ybd4KDhw+QUTUJX7Zc4DzYZHk+vOK5dIlCnH0xGm+2vzjn8Oya1Ilhp4e7jRrVItJM5ewYfM2LoRHcezEaVat38SGzdvSFV96eWVIGcpe//VWzodFsnvfISbNXPpI6u7YsiGLVnxhuwr25OnzfLnxBz5d81Wa5e/XpgDtWzZg2ZqvWLluI+fDIm1tcj8P2s9lSxWhSMEQ2xXuEZHR/H7oODPmr7zrmHzcMmfyx9nZiVWfbyIs4iI/7tzD/GXrUpUJyhyAwWDgp19+4+q168TdisfVxYWWb77G1DnL+Wrzj1wIj+LgkZN8/s336V53yzdf48CRE4ydupDjp85yPiwy5eKYqQuBlHPKypUpxkeT53Ho6EmOnjjNqAlzHroHrGihfLxZvwZTZ3/KstVfcSE8ijPnwpm5YBUr122ke6fmtiQ4OHMAcbfi+fW3g1yLuUF8fEK61lGjygv4ZPSi75AJ7DtwlPDIi+zdf5jx0xZxMfryQ8X7sIKDMlGrWgVGjp/NDzt229b97Q8/p1m+VPGCXIu5wZKVX3IhPIrVn29m56/7U5V5s34NFq/4kh927ObMuXDGTlnAjdi/7iOZns+LBq9V5Xx4JFNmL+Ps+XA2btnBV4/4s0QeD/UIit2VLl6IhIREcmbPgp9vRtv0ksUKEhcXT45swek+9+22+rWqcPzkGd4fORWDAapXKk/DOtX4+Y4PwHqvVua334/YTpRP6/YxkHIC/LCxM2naqR8JCYmpbh9zP+XKFGPs0F7MW/oZi1d+iZPJRM7sWdK8xUNaPD3c2XfgKCs/20hs3C2CMvvTrWMzypctzpWrMZw9H87Xm38k5sZN/P18eL1OderXrmJbd9tm9flk7nISE5N4rcZLvFqtAqfOnLfV36l1I3wyerFo+ReER87Fy9OT/CE5ad203r1C+keMRiNDB/yPCdMX0eKtAeTIFkzPLi3p2mfEgxd+gLqvVsbV1ZWlqzcwdc6nuLm6kjd3dho3qJFm+fu1KUDt6i+RmJjE8rXfMGX2Mny8ve660OXvHrSfDQYD4/68Bc/wcbO4FnMdf18fShQNtZ0H+aT4+ngzqFcnZsxfxap1m8gfkov/dWxG3w/G28oEBvjRoWVDps9bwYhxs3m1WgXe7/0WbZvVx2Q0MXvxGi5dvkqAnw/1a1dN97pD8uRg2piBzFywis69hmG1WskanJmqLz9vKzOoVydGTphDl94j8PP1plPrN4hatDpVPcPGziQiKtp2G6S09OzckpA8OVj7xbfMXLgKk9FIaEguRn/Qk4rlStnKFSucnwa1q/L+yKnEXL+Z6vYx9+Pm5sr0sYP4ZO5yBgybRFxcPJkCfClTovA9b/fzKPXp3pYZ81cydsoCYm7cJHMmf1o3qZtm2Vw5stL7f21YtPxz5i9bR6UKZWnWqBbrv95qK9O0US0uXbnGsDEzMRoNvPbKy7z8QhliY2/Zyjzo8yIoMICRg95h0swlrF6/mUKheXi7zZuMGD/78TaG/GuGxMSER3BarYiIyOPXufdwShcvmK6ETUQeTEPDIiLyTLgZG0dYRFSqc4lF5N9Rj6CIiIiIg1KPoIiIiIiDUiIoIiIi4qCUCIqIiIg4KCWCIiIiIg5KiaDYhdVqxWw23/UYNBEREXlylAiKXVgsFirWboPljuffioiIyJOlRFBERETEQSkRFBEREXFQSgRFREREHJQSQREREREHpURQRERExEEpERQRERFxUE72DkAcW0Cu0vYOQUREnlLXLuy3dwj/eeoRFBEREXFQSgRFREREHJQSQREREREHpURQRERExEEpEXQASUlmPpmznEZt3qVJh740f6s/GzZvAyAiMpq1X36XqnyDVj04fuqsPUIVERGRJ0hXDTuAYWNnkpRkZvGMkbi7uRERGU3PQWOwWJLJFhzIug3f0fC1qo90nWaLBSeT6ZHWKSIiIo+WEsH/uPNhkWzbuYf1Sybh7uYGQHBQJrp3asbHk+fj6upC5MVLtOr8HpkD/RnzYS8Avv/pV8ZMmc/lKzHUqfkybZvVB+DylWuMn7aIiKhLJCQm8lL50rzV5g0gpSex2kvl2LP/MNmzBvFh/y522WYRERFJHyWC/3HHTp4he5YgMnp7pZpepGA+oqIvM3xgNxZ+up5F00emmn8zNo7ZE4dwLeYGjdq8S+1XXiIwwI9hY2fSqkldShUriNlioff7Y/lu2y9Ufel5AGJu3GDu5A8xGAx3xbL6882s+WIzAFar9TFtsYiIiKSXEkFJ0yuVXwDAJ6MXWYIDiYiMxiuDB7t/O8SVqzG2cnG34jl3IcL2vnb1l9JMAgEa1a1Oo7rVATCbzVSs3ebxbYCIiIg8kBLB/7jQkFycD48k5vqNVL2CB4+cIHMmf3wzeqW5nIuLs+21yWjEYrFwuxNv9qQhuLq4pLmcu7vbowteREREHitdNfwflz1rEBWeL8noifOIj08AUq4UnjxrGW2b1cfTw52bsbfSVZeHuxulihdi8YovbNOiL1/lYvTlxxK7iIiIPF7qEXQAg/u8zcyFq2jx9gCcnJwwGY00f6M2dWq8jNliIXfOrDTv1J8swZlsF4vcy5D+nZk8cynNO/UHA7i7udKvezsCM/k/oa0RERGRR8WQmJigs/blibt9juCRQwfsHYqIiDylrl3Yb+8Q/vM0NCwiIiLioJQIioiIiDgonSModnXpzB6cnHQYioiI2IN6BEVEREQclBJBEREREQelRFBERETEQenkLLGrgFyl7R2CoFs0iIg4KvUIioiIiDgoJYIiIiIiDkqJoIiIiIiDUiIoIiIi4qB0scgT0KrzewAkmc2cuxBB3lzZAciRLZjhA7ulu56IyGhadRnI5rWzHllsj6NOEREReTYoEXwCFk0fCfyVdN1+LyIiImJPSgTt6OfdvzN/2ToSEhIxGo10bd+E0iUKAfDlxh9YuW4jVis4OZkYOai7bbnZi9aw/ZffuBkbx7tdWvHCcyUAKF+jBW+1eYNtO/ZwLeYG7ZrX57UaLwNw5PgfjJ+2mFvx8bg4O/PO2y0oXjh/mjFNn78CiyUZrwye9O3Wltw5s9rWu3HLdry9PHm+dDG+2bKdzxZNZOzUhQT4+9CmaT0Azp4Pp3v/0axZNAEnk+lxNqGIiIj8C0oE7SQs4iJzl6xl4oi+eHp6cD4sks69h7F24UQOHjnBvKXrmDVhMAH+vsTHJwBw9dp1bsbGEZI7Ox1bvc7OX/czccZiWyII4OLszLwpQzlzLpz23QdTs1oFrMlWBgydRP8e7SlXphj7Dx7jvWGTWDV/XKqYrlyL4YPR0/hkzEBCcmdn45btvDd8EstmfcSOXfv4/qdfWThtBB7ubowY99dQ8hv1qtNj4Me0fLMOJpORtV9+S71ale9KAld/vpk1X2wGwGq1PqaWFRERkfRSImgnP+/ez4XwKDr3Hm6bZjAYiYq+zPZd+6hZ9UUC/H0BcHNztZVxcXGmUoWyABQtlI+w8Iup6q1R5QUAcuXIgslk5MqVa1y/GYfBaKBcmWIAFC8Sip9PRk6cOktggJ9t2UNHT5E3dzZCcmf/s64XGTt1IdGXrrB73yGqvPQcnh7uANSpWYk9vx8BIGf2LOTOkZUfd+7h+TJF2bz1Z5bMHHXXNjeqW51GdasDYDabqVi7zT9vQBEREfnXlAjaidUKZUsWYeiArg+1nIuzMwaDAQCj0YglOTn1fBdn22uj0YjFknr+bX9W8c/9rYI369dgycovuRpznbKliuDnm/FfrkBEREQeN90+xk6eL12U3b8d4uQf52zTDh09BUCFcqXYuGU7ly5fBSA+PsE2PPxP5MwWjDXZyq49BwD4/dBxLl+NIV/enKnKFSkQwqnTFzh15jwAm7/fSSZ/XzIF+FG6eGG2/vQrcbfisVqtfLnxh7u25/LVayxYtt7W6yciIiJPN/UI2kn2rEEM6d+FjybPIz4+kSSzmfx5czJ0QFdKFi1AuxYN6DHwYwwYcHY2MWLQO/94Xc7OTowa/A7jpy1m8uxluDg7M3JQdzzc3YiJuWEr5+vjzZB+nRk6ZobtYpERg7pjMBioUK4kh46dpFXn9/DK4EnJogXw8vSwLWswGKhToxKbtu6gaKF8/6ptRERE5MkwJCYm6Kx9SZfYuFt4erhjtVqZPGspCQlJ9O3e1ja/1/tjqfZyOV6tVuGBdd0+R/DIoQOPM2RJp2sX9ts7BBERsQP1CEq6DR0zg4ioSyQmJpEnZ1b6dm8HpNya5v2RU8mdMyuvVH7BzlGKiIhIeqlHUOxCPYJPF/UIiog4JvUIil1dOrMHJycdhiIiIvagq4ZFREREHJQSQREREREHpURQRERExEHp5Cyxq4Bcpe0dwlNJF2+IiMiToB5BEREREQelRFBERETEQSkRFBEREXFQSgRFREREHJQuFnkKNGjVAxdnJ1xdXICUZ/pWLF+aHm+3eOKxtOr8HtPHvY+nh/t9y5Wv0YJNa2bilcHzCUUmIiIij5oSwafEsPe6kT9vTnuHwaLpI+0dgoiIiDwhSgSfQhs2bWPbjj18NKQne/cfZtwniyhRNJTfD53AYrHwfp+3KJg/D2aLhd7vjyXm+k0SEhIJyZODAT3b4+7mdt/lALb/8htzl6wlKcmCwQD93mlH4QIhqXr6Js9axr4DRzCbLXh6uNO/R3tyZs+SKtbk5GTGT1vM7n2HcHZywmQyMnPCYFvvpoiIiDy9lAg+Jd4fOcWWPL1avWKqeWfPh/Peux3o060ta7/8jpkLVjFxZD9MRiMf9u9CRm8vrFYrY6YsYNX6TbRqXPe+y527EMGIcbOZNnYQuXJkwWw2E5+QeFdMLd98je6dmgGw+fudTJi+mIkj+6Uqc+KPc+zed4hls0ZjNBq5GRuH8z2eHbz6882s+WIzAFar9d81mIiIiPxrSgSfEncODW/YtC3VvKxZMlO4QAgARQuGsGz1BiAlmVq+9hu279qHxWIhNvYWRQvle+Byu/Ye5PkyxciVI6V3z8nJiQxpJG+79h5k9eebiIuLJ9mazPUbsXeVyRociMViYcT42ZQqXpAXnyuJ0Zj2NUiN6lanUd3qAJjNZirWbpPu9hEREZFHT4ngM8DVxdn22mgyYklOBmDT1h3s3neY6WMG4unpwcp1G9mz7/ADl0uPyIuXGPfJQuZNGUq2LJk5+cc5Ovcefle5DJ4eLJ05mt8OHGXP/sPMmLeSaWMHkT1r0D/ZVBEREXmCdPuYZ9iNm3H4ZMyAp6cHsXG32LB524MXAp4vXZRf9vzOmXPhQErv3M3YuFRlbsbewsnJRICfD1arldWfb06zrqvXrnMrPoHnSxelc9s3CcqciTPnwv7dhomIiMgToR7BZ9ir1SqwbcceGrfvjU9Gb0oUCSUy6vIDl8ueNYhBvTrx4cfTMZstGE0G+nZrR+ECeW1lQnJnp3qlcjTr1J+M3hl46YW0nwl8MfoyoybOxWyxkGxJpljh/JQvW/yRbaOIiIg8PobExASdtS9P3O1zBI8cOmDvUJ5K1y7st3cIIiLiADQ0LCIiIuKglAiKiIiIOCidIyh2denMHpzucd9BERERebzUIygiIiLioJQIioiIiDgoJYIiIiIiDkonZ4ldBeRK+/6E/xW6DYyIiDzN1CMoIiIi4qCUCIqIiIg4KCWCIiIiIg5KiaCIiIiIg1Ii+AQ1aNWD46fOpprWpc9wftix+5HUuWHTNs6cC7fN27BpG/2GTPjHdYuIiMh/mxLB/5ANm7dx9kL4gws+ImaL5YmtS0RERB493T7mKREbd4vJM5dy4o9zJCYlUaRACL26tsbZ2YlP13zF5u93YjZbcHIy0bNzK4oWypdq+c+/3srR46eZNGMpcxev5e22bwIQdyuewaOmcurMBVycnRk+sBtZgwMB+HLjD6xctxGrFZycTIwc1J1Mmfzo/f5YYq7fJCEhkZA8ORjQsz3ubm7s3X+YsVMXUrhgCMdOnKZ103rkz5uTiTMWc/XadRKTzNR7tTJv1HvlibefiIiIPDwlgk/Y+yOn4OriYnt/ITwKgCmzllG8SCgDenbAarUyauIcVqz7hhZvvEbNqhVo+notAA4eOcmwsTNZMXdMqnrrvlqZb7Zsp3GDmrz8QhkgZWj4yPE/WDR9BFmCApk2dzmLV35B/3fas3f/YeYtXcesCYMJ8PclPj4BAJPRyIf9u5DR2wur1cqYKQtYtX4TrRrXBeDM+XB6d2vDwHc7YrEk0+GdD/igb2dy5chCfHwCHXoMoXCBvBQKzXvXtq/+fDNrvtgMgNVqfcQtKyIiIg9LieATNuy9buTPm9P2vkuf4QBs27GHA0dOsHzt1wAkJCZiNKaM3B8/dZYFn67n+vWbmExGzl2IID4hETdXl7tX8DdFCoaQJSjwz9f5WLV+EwDbd+2jZtUXCfD3BcDNzRWA5ORklq/9hu279mGxWIiNvZWq9zFLUCZKFSsIwLkLEfxx9gKDR021zY+Li+f0ubA0E8FGdavTqG51AMxmMxVrt0lHi4mIiMjjokTwKWHFyqj33yFHtuBU05OSzAwYOpGpH79HodC8xMbGUa1hJ5KSktKVCN7Z+2g0GrEk3/+8vk1bd7B732GmjxmIp6cHK9dtZM++w7b5Hu5uf8VsteLtlYFF00emdzNFRETkKaKLRZ4SL5UvzeKVX9ouwLh+I5bzYZEkJiaSZDYTFBgAwKr1m+9Zh6eHOzdj49K1vgrlSrFxy3YuXb4KQHx8AvHxCdy4GYdPxgx4enoQG3eLDZu33bOOHNmD8fRw58uNP9imnQ+LJOb6zXTFICIiIvalHsGnxDtvt2Da3BW07jwQg9GAyWSka/umZM8axFut36B998Fk9PaiWqVy96yj3qtVmDJ7KSvWfmO7WOReShYtQLsWDegx8GMMGHB2NjFi0Du8Wq0C23bsoXH73vhk9KZEkVAioy6nWYeTycTYob2YOGMJyz/7hmRLMhkzevFh/y7/qi1ERETkyTAkJiborH154m6fI3jk0AF7h/JYXbuw394hiIiI3JOGhkVEREQclBJBEREREQelcwTFri6d2YOTkw5DERERe1CPoIiIiIiDUiIoIiIi4qCUCIqIiIg4KJ2cJXYVkKv0E12fbuciIiLyF/UIioiIiDgoJYIiIiIiDkqJoIiIiIiDUiIoIiIi4qB0sYidmS0WFn66nk1bd+JkMmEyGSkUmpeuHZrglcHT3uGJiIjIf5gSQTsbOX4212/EMnviELy9PLFarWz5cRfXb8Q+04mg2WLByWSydxgiIiJyH0oE7eh8WCRbftzFusWT8PZKSfoMBgNVX3oegCWrvuSrTT9iMBoIyZ2DPt3akMHTgzmL13DmXDjxCYmERUTh7+vDiEHdyeidgYNHTjJ26gKSk5OxWJJ5vU41GtapxrCxM8mXJydNGtYEYPKsZXi4u9Kh5evMWbyG02fDSEhM4tyFCLJnDaJL+8ZMmbWM8MhoCuTLxZB+XTAajcTG3WLyzKWc+OMciUlJFCkQQq+urXF2dqJLn+GE5M7BkeN/4OriwtSP37Nb24qIiMiDKRG0o2Mnz5A9SxA+Gb3umrfz1/18uXEbsyd+gFcGT0ZPnMu0uSvo270tAIeOnWLB1GFk9Pbi/ZFTWffVFlo3qcui5Z/TrFEtXqn8AgDXb8SmK5ajJ04zf+pwvDJ40KXPCEZNmMOkUf1xdXWh3f/eZ+ev+3nx+ZJMmbWM4kVCGdCzA1arlVET57Bi3Te0eOM1AM5diGD62EFpPj949eebWfPFZgCsVus/ajMRERF5dJQIPqV+3XuQai8/bxsebvBaVQYOn2ybX650MTJ6pySQRQqGcOrMeQBKFS/E/GXrOB8WRZkShSheJDRd63uuVFFbr2RoSC5cnJ3w9HAHIH/enJwPiwJg2449HDhyguVrvwYgITERo/Gva45qVn0xzSQQoFHd6jSqWx0As9lMxdpt0hWbiIiIPB5KBO0oNCQX58Mjibl+w5bU3YvBYEj13sXF2fbaaDRisSQD0KRhTV56oRS/7j3EjPkryZMrG326tcVkMpKcnGxbJjExCQ9313vWl+q9yYjFYgHAipVR779DjmzBacbp7u72oM0WERGRp4RuH2NH2bMGUblCWUaOn8ONmylDuFarla0/7iJLcCDfbfuF2Ng4ANZt2MLzpYs+sM6z58PJEhRIvVqVadWkLgePngQgW5bMHD52CoCY6zfY+eu+fxTzS+VLs3jll5j/TAyv34jlfFjkP6pLRERE7Es9gnY28N2OzF+2ng7vfIDJaCLZaqVE0VC6tm9CfEICHXt8mOpikQdZ/flm9uw7jJOzEyajke4dmwNQ79UqDBw+mSYd+pI1OBOFC4T8o3jfebsF0+auoHXngRiMBkwmI13bNyV71qB/VJ+IiIjYjyExMUFn7csTd/scwSOHDjzR9V67sP+Jrk9ERORppqFhEREREQelRFBERETEQekcQbGrS2f23PN2MyIiIvJ4qUdQRERExEEpERQRERFxUEoERURERByUTs4SuwrIVfqJrk+3jxEREfmLegRFREREHJQSQREREREHpURQRERExEEpERQRERFxUEoE7aRBqx4cP3X2oZaZPGsZcxav+cfr/GHHbg4eOXnfMrMWrmbjlu0PrGvY2JksX/vNP45FRERE7E9XDTuQbTv2kC9PTooUDElzvtlioVPrRk84KhEREbEXJYJ21qXPcArky8Phoye5dOUaZUsWod877QC4dPkqw8fNIir6MgF+vvhk9CJn9mAA5ixew42bcfTs3BKAVes3cfTEad7v/RYHj5xk7NQFJCcnY7Ek83qdagRlDuDHnXvZtfcgX23eRqO61cmWJTNjpy6kcMEQjp04Teum9dixax/58uSkScOa/PrbQWYtXE1CYhLmJDNNXn+VujUr3bUNP/68l5kLVmE0GLBYknmrzRu89MKTvS2MiIiIPDwlgk+BsIgopo4ZiNlsoVnHfhw4fIKihfIxfvpiCobmYeLIfly8dIXWXQbaEsH7WbT8c5o1qsUrlV8A4PqNWLy9PKlYvpQtyQPYu/8wZ86H07tbGwa+2xGAHbv22eoJDcnNjHGDMZmMxFy/SZuuAylXuiiBmfxTrW/WgtX0696OooXykZycTGzcrTTjWv35ZtZ8sRkAq9X60O0kIiIij5YSwadAtZfL4WQy4WQykS9vDsIioihaKB+7fztEt47NAAgM8KNCuVLpqq9U8ULMX7aO82FRlClRiOJFQu9ZNktQJkoVK5jmvJjrNxg5YTbnL0TaksFTZy7clQiWKVmICdMXU6XiczxXuij58+ZMs75GdavTqG51AMxmMxVrt0nX9oiIiMjjoYtFngIuLs621yajEYslOc1yBsNfr00mE8nJf5VLTEyyvW7SsCbjhvUmwM+HGfNXMmbK/Huu28Pd7Z7zPp48n+KF87Nk5igWTR9J9mxBJCYl3VXunbdaMKhXJ1xdXRg2ZiZLVn55zzpFRETk6aFE8ClWtmRhvtz4A5ByvuBPO3+zzcuWJTNHT5zGYkkmPj6B77f/apt39nw4WYICqVerMq2a1OXg0ZQrhT093ImNi0v3+m/cjCUoMACDwcBvB45y8o9zaZY7cy6cPLmy8Ua9V2jwWlXb+kREROTppqHhp1jPzi0ZPm4WTTv2JZO/H6VLFLLNq/RiWbZs20XTjn0JDPAjf96cxCckAinn4u3ZdxgnZydMRiPdOzYHoGbVFxk+dhY/7NhDozrVyJYl833X36VdY8ZMXcD8ZevIlzcnhULTvtp4xoKVnDsfgZOzE26uLvTt1vYRtYCIiIg8TobExASdtS9P3O1zBI8cOvBE13vtwv4nuj4REZGnmYaGRURERByUEkERERERB6VzBMWuLp3Zg5OTDkMRERF7UI+giIiIiINSIigiIiLioJQIioiIiDgonZwldhWQq/Q/Wk63gREREfn31CMoIiIi4qCUCIqIiIg4KCWCIiIiIg5KiaCIiIiIg9LFIv8BDVr1wMXZCVcXF9u0wX07E5I7ux2jEhERkaedEsH/iGHvdSN/3pyPvF6zxYKTyfTI6xURERH7UyL4H1a+RgveavMG23bs4VrMDdo1r89rNV4G4HxYJBNnLObqteskJpmp92pl3qj3im25ds0bsPPXfZQsVpCmDV9l2NiZXLx0hcAAP7y9MpAzezAtG9ehYauezJs8lMyB/gBMn7eC5GQrXTs0sdt2i4iISPooEfyPeH/klFRDw7MmDgHAxdmZeVOGcuZcOO27D6ZmtQoYMDB41Cd80LczuXJkIT4+gQ49hlC4QF4KheYFwGg0Mm/KMADeGz6ZIgXz0bHV61y+co1WXQaSM3swri4u1KnxMmu//JbO7RqTmJjEhs3bmD3xwzRjXP35ZtZ8sRkAq9X6GFtDRERE0kOJ4H/EvYaGa1R5AYBcObJgMhm5cuUasXHx/HH2AoNHTbWVi4uL5/S5MFsiWKfGS7Z5u387RLeOzQDw9/PhxedL2OY1rFON9t0/oH2Lhmz58RcK5c9LcOaANGNsVLc6jepWB8BsNlOxdpt/tc0iIiLy7ygR/I9zcXG2vTYajVgsyVitVry9MrBo+sh7Lufu7nbPeQYMtteBAX6ULBrKtz/8zGcbvqNjy9cfTeAiIiLy2On2MQ4oR/ZgPD3c+XLjD7Zp58Miibl+M83yZUoU4qvN2wC4cjWG7bt+SzX/zfo1mblgFTduxlG2VJHHF7iIiIg8UuoR/I/4+zmC77zV4p5lnUwmxg7txcQZS1j+2TckW5LJmNGLD/t3SbN8j84tGTZmJk079iXAz5fCoSFk8PS0zS9SMIQMnh7Ur10Fg8GQZh0iIiLy9DEkJiborH25r/iERJycTDiZTMRcv0GHd4YwpF9nChcIAeDipSu06/Y+K+aOxdPDPV113j5H8MihA/8opmsX9v+j5UREROQv6hGUB7oQFsnQMTOwWiHJbKZhnWq2JHDWwtV8uekHOrdrnO4kUERERJ4O6hEUu1CPoIiIiP2pR1Ds6tKZPTg56TAUERGxB101LCIiIuKglAiKiIiIOCglgiIiIiIOSidniV0F5Cr9j5bTxSIiIiL/nnoERURERByUEkERERERB6VEUERERMRBKREUERERcVC6WOQZ0arze0DKI97OXYggb67sAOTIFszwgd3uKr93/2EmzljCoukjn2icIiIi8uxQIviMuJ3QRURG06rLQCV4IiIi8q8pEXzG/bz7d+YvW0dCQiJGo5Gu7ZtQukShhyr35cYfWLluI1YrODmZGDmoO8FBmfj6259YunoDAJkz+dHvnfYEBvixYdM2vvluO74+Xpz44xwZPD15r2cHZixYydnzEWTO5MeowT3wcHd7om0hIiIiD0eJ4DMsLOIic5esZeKIvnh6enA+LJLOvYexduHEdJc7eOQE85auY9aEwQT4+xIfnwDAqTPnmTrnU+ZPHUZggB8Llq1n1IQ5TBjRF4Ajx/9gycxRBAUG8OHH0+nzwThmTfgAP9+M9Hp/LF9t/pFGdaunimP155tZ88VmAKxW6+NvIBEREbkvJYLPsJ937+dCeBSdew+3TTMYjERFX053ue279lGz6osE+PsC4ObmCsDe/UcoV6YYgQF+ADSsU415yz7DYkkGoEjBEIICAwAokC83ZrMFP9+MABQKzcP5sMi74m1Ut7otOTSbzVSs3eZRNIOIiIj8Q0oEn2FWK5QtWYShA7reNS/60pV0lUsvgyH1e1cXF9tro9GIi4tzqve3E0YRERF5eun2Mc+w50sXZfdvhzj5xznbtENHTz1UuQrlSrFxy3YuXb4KQHx8AvHxCZQqXpCfd/9O9J/TP9vwHWVKFMZk0iEjIiLyX6EewWdY9qxBDOnfhY8mzyM+PpEks5n8eXPe1fN3v3IlixagXYsG9Bj4MQYMODubGDHoHfLmys7/OjSl58CPgZSLRfr3aG+PzRQREZHHxJCYmKCz9uWJu32O4JFDB/7R8tcu7H/EEYmIiDgejfOJiIiIOCglgiIiIiIOSucIil1dOrMHJycdhiIiIvagHkERERERB6VEUERERMRBKREUERERcVBKBEVEREQclBJBEREREQelRFBERETEQem+HWIXVmvKA23MZrOdIxEREUdiMpkwGAz2DuOpoURQ7MJisQBQuV4HO0ciIiKO5McNC3T/2juoJcQuXFxcyJEtiCUzRumXWRpavD2AJTNG2TuMp47aJW1ql3tT26TNkdvFZDLZO4SnihJBsQuj0YjRaMTZ2dneoTyVDAaDfrGmQe2SNrXLvalt0qZ2kdt0sYiIiIiIg1IiKHbzep3q9g7hqaW2SZvaJW1ql3tT26RN7SK3GRITE6z2DkJEREREnjz1CIqIiIg4KCWCIiIiIg5KiaCIiIiIg9K142IX58MiGTpmJjHXb5DB051Bvd4iT65s9g7L7hq06oGLsxOuLi4AtGpcl2qVytk5qidv/LRF/PjzXiKjLrFw2gjy580J6LiBe7eNox87CYmJDB75CafPheHq4oKvjzd9urUhe9YgrlyLYejHMwiLuIiLszO9u7WhZNEC9g75ibhfu3TpM5zIqMtk8HQH4NXqFWna8FU7RyxPmhJBsYuPJs2jfq3K1H7lJbb8uIvh42Yyb8owe4f1VBj2Xjfbl7ujqlzxOVq8UZu3eqU+JnTc3LttQMdOvVqVKV+2OAaDgVXrNzFq4hymjRnEtLkrKFIwhIkj+3H42Cn6D53I2oUTHOY+evdqF4B33m7Oyy+UsXOEYk8aGpYn7sq1GI6c+IMaVV8EoHKFskRFX+F8WKSdI5OnRcmiBQjM5J9qmo6bFGm1jYCriwsvPFfC9qSiIgVDiIi6BMCWbb/QoHZVAAqF5iXAz5e9vx+1W6xP0v3aRQTUIyh2cDH6CgF+Pjj9+Zgfg8FA5kz+REVfJnvWIDtHZ39Dx8zAarVSKDQvXdo1xtfH294hPRV03DyYjp2/rFy3kZfKlyLm+g3MFgv+fj62ecGZA4iKvmy/4OzodrvcNm3uCmYtXE3uHFnp3K4xWYMD7Rid2IN6BEWeItPHDmLJjFEs/GQ4Pt5eDBs7094hyTNCx85fFny6ngvhUXRu29jeoTxV/t4uH/TpzIq5Y1gyYxTFi4TSe/BYO0co9qBEUJ64wEx+XLpyDbPFAoDVaiUq+jKZNdxFUGAAAE5OTjRuUIP9B4/ZOaKnh46b+9Oxk2Lpqg38sH0344f3wc3NlYzeXpiMJi5fuWYrExF1yeGOm7+3C0DmwJQ2MBgMvFHvFcIjoom5fsOeYYodKBGUJ87PJyOhIbnY+N12ALb+9CuBAX4OP7x3Kz6eGzdjbe83f7/ToU/8/zsdN/emYyfFp2u+YvP3O5k0qj9eGTxt06u89ByfbfgOgMPHThF9+SqlijnGVcOQdruYLRauXI2xldn64y78fL3J6O1lrzDFTvSIObGLs+fDGT5uFjHXb+Lp4c7AXp0IyZ3d3mHZVVjERQYMm0RycjJWq5WsQYH07NyS4KBM9g7tiRs9aS47du3jypUYvL0z4OHuxuoF43XckHbbTBrV3+GPnYvRl6nX4h2yBgfi4e4GgLOzM3Mnf8iVqzF8+PF0wiOjcXZyolfX1pQuUcjOET8Z92qXqR8PoEvvESQmJWE0GMmYMQPvdGpOPgf8AeHolAiKiIiIOCgNDYuIiIg4KCWCIiIiIg5KiaCIiIiIg1IiKCIiIuKglAiKiIiIOCglgiIiIiIOSomgiIiIiINSIigi8ojMWbyGfkMm2DuMx6Z8jRYcP3XW3mGIyCPkZO8ARESeJvsPHmPBp+s5dPQkVmvKM3xrVHmBxg1q4uz85D8yG7TqQY+3W/DyC2Ueetk5i9dw4tQ5PhrS8zFEJiL/BUoERUT+9NPPv/HB6E/o2KoRH/TtjE9GL86cC2fxyi+4dOUawZkDnlgsZosFk1GDNiLyeOkRcyIigNVqpVGbd3mtxsu0bVb/nuWOHP+DCdMXc/psGAH+PrRtVp9XKr8ApPTAHT1xhqDAADZu2Y6nhzv/69CUapXKAWA2m5m1aA2btuwgITGR0sUL0atra3x9vIGUodd3u7Ri3YYtnA+PpHzZ4vy4cy/Ozk6YjEZqVHmRfu+0uyvuaXNX8NW3PxKfkIC/rw/dOzXHkmxh0IgpWJOtuLg4A7Bl/dwHxnD5yjWmzF7G7n2HSEhIIiR3diaM7Iebqwvla7Rg4bQR5M+bk3MXInh30BgaN6jJG/VeYeOW7cxZvJYrV2Pw8HCnQe0qtGve4FHvJhF5xNQjKCICnA+LJDwymuqVyt+zzI2bsfQc+DHtWzSkQe0q/H74BL3fH0vmwACKF84PwC97fueDvp3p2bklG7dsZ9TEOZR/rjieHu4sXP4F23/5jRnj38fbKwOjJsxhyEfTmDSqv20dm7buZOKofmT0yoCTk4nX27x736HhXXsPsmnrDhZ8MpxM/r5EXrxEYmISObIF07pJ3buGhu8XQ3JyMn0+GEfunNlYNutjPDzcOHTkJEaDIdU6Dx09xYBhE+neqTnVXi7Hrfh4ho2dxZSPBlCyaAFu3IzlfFjkv9kdIvKEaNxBRAS4GnMDgEwBvvcss2PXPnwyevNGvVdwcnKiVLGCvFL5Bb7e/KOtTGhILqq9XA6Tycir1SqQZDbbkqJvvvuJtk3rExQYgIe7G93fas6uvQeJvnzVtnyLN2uTyd8XFxdnjOkYGnYymUhMSuL0mQuYzWaCAgPIkS34nuXvF8OR439w5lw4fbq1xdvLEyeTieJFQm09igA/795P/w8nMLjP21R7udxfcTiZOHMujNjYOLwyeFIoNO8DYxcR+1MiKCIC+HhnACD60tV7lrkYfeWu8wSzBGfi4qUrtvf+vj621waDAVcXF+LibqUsf+kKwUF/LZ/J3xcXZ2cuRv+1fFAm/4eKu3SJQnRo2ZBZi1ZT843ODBg6ifDIi/fehvvEEBF1iUwBvri5utxz+RWfbaRU8UKUKVHYNs3dzY0xH77Ljzv3Uq/FO7z17lD27Dv8UNshIvahRFBEBMiRLZjgzJn49vuf71kmMJMfEVGXUk2LiLxEYIBfutYRGOBHRORfy1++co3EpCQCM/21vOFvvYB/H5ZNy+t1qjNn0oesWzIJZ2cnxk9bnFKX4e6P+PvFEJw5gOhLV0lITLznuj7s34Uz58MY98nCVNPLlizC+OF9+GbVdKpUfI5+H04gOTn5gbGLiH0pERQRIaX37t0urVi88gtWrd9EzPWUoeJzFyIYMX42EVGXKF+2BFevXWfNF5sxWyzsO3CUTVt38Gq1CulaR82qL7Jw+edEXbxM3K14Js1cStmSRcjkf+/haD/fjISF37uH7/CxU/x+6DhJSWZcXVxwd3PFZDL+uaw3ERcvYbZY0hVDwfx5yJEtmDFTFnDjZixmi4X9B4+RmJhkW97bKwNTRr/HwSMn+XjyfKxWK1euxvD99l+JjbuFyWTC08Mdk8mUrjYREfvSxSIiIn+qUK4k44f3Yf6ydcxauBqAzIH+1Kz6IgF+Pim9bcP7MHHGEqbPW0mAvy99urWheJHQdNXfqnFdbsUn0LHnEBITkyhVvBBD+nW+/zJN6jJh2mLmL1vHK5XL06db21TzY+NuMWXWMsIiLmIymShaKMRWpkrF59m0dSe13uyM1Qqb1866bwxGo5ExQ3sxeeZSGrfvQ1KSmXx5czB+eN9U6/T28mTy6P70eO9jRk+cS8dWr7Ny3UZGjJtNsjWZHFmDGTmoe7rOcRQR+9LtY0REREQclH6uiYiIiDgoJYIiIiIiDkqJoIiIiIiDUiIoIiIi4qCUCIqIiIg4KCWCIiIiIg7q/1C5t0yFefriAAAAAElFTkSuQmCC",
       "text/plain": [
        "<Figure size 583.3x500 with 2 Axes>"
       ]
@@ -2180,7 +2180,7 @@
     "    axes[0],\n",
     "    \"Holder counts and screened sectors for the formation cohort\",\n",
     "    subtitle=(\n",
-    "        f\"{len(data_stocks)} stocks held by {len(data_institutions)} institutions, \"\n",
+    "        \"Cohort stocks and the institutions holding them, \"\n",
     "        f\"formed at report period {period_calendar['report_date'][0]}\"\n",
     "    ),\n",
     ")\n",
@@ -2199,13 +2199,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9da444f7",
+   "id": "a9a7b4a0",
    "metadata": {
     "papermill": {
-     "duration": 0.005608,
-     "end_time": "2026-09-10T22:10:36.655462+00:00",
+     "duration": 0.017421,
+     "end_time": "2026-09-13T00:31:47.094158+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:10:36.649854+00:00",
+     "start_time": "2026-09-13T00:31:47.076737+00:00",
      "status": "completed"
     }
    },
@@ -2218,13 +2218,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "88da0fb9",
+   "id": "e1a6f2a4",
    "metadata": {
     "papermill": {
-     "duration": 0.00478,
-     "end_time": "2026-09-10T22:10:36.665316+00:00",
+     "duration": 0.012102,
+     "end_time": "2026-09-13T00:31:47.117569+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:10:36.660536+00:00",
+     "start_time": "2026-09-13T00:31:47.105467+00:00",
      "status": "completed"
     }
    },
@@ -2237,19 +2237,19 @@
   {
    "cell_type": "code",
    "execution_count": 29,
-   "id": "6705e424",
+   "id": "78112395",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T22:10:36.680640Z",
-     "iopub.status.busy": "2026-09-10T22:10:36.680419Z",
-     "iopub.status.idle": "2026-09-10T22:10:36.685012Z",
-     "shell.execute_reply": "2026-09-10T22:10:36.684361Z"
+     "iopub.execute_input": "2026-09-13T00:31:47.151330Z",
+     "iopub.status.busy": "2026-09-13T00:31:47.149395Z",
+     "iopub.status.idle": "2026-09-13T00:31:47.161236Z",
+     "shell.execute_reply": "2026-09-13T00:31:47.159857Z"
     },
     "papermill": {
-     "duration": 0.014652,
-     "end_time": "2026-09-10T22:10:36.685441+00:00",
+     "duration": 0.033959,
+     "end_time": "2026-09-13T00:31:47.165399+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:10:36.670789+00:00",
+     "start_time": "2026-09-13T00:31:47.131440+00:00",
      "status": "completed"
     }
    },
@@ -2291,19 +2291,19 @@
   {
    "cell_type": "code",
    "execution_count": 30,
-   "id": "ea095d09",
+   "id": "cec3dd6b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T22:10:36.699353Z",
-     "iopub.status.busy": "2026-09-10T22:10:36.698915Z",
-     "iopub.status.idle": "2026-09-10T22:10:36.706329Z",
-     "shell.execute_reply": "2026-09-10T22:10:36.705197Z"
+     "iopub.execute_input": "2026-09-13T00:31:47.200109Z",
+     "iopub.status.busy": "2026-09-13T00:31:47.199442Z",
+     "iopub.status.idle": "2026-09-13T00:31:47.211648Z",
+     "shell.execute_reply": "2026-09-13T00:31:47.210029Z"
     },
     "papermill": {
-     "duration": 0.016027,
-     "end_time": "2026-09-10T22:10:36.707271+00:00",
+     "duration": 0.03722,
+     "end_time": "2026-09-13T00:31:47.217275+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:10:36.691244+00:00",
+     "start_time": "2026-09-13T00:31:47.180055+00:00",
      "status": "completed"
     }
    },
@@ -2333,19 +2333,19 @@
   {
    "cell_type": "code",
    "execution_count": 31,
-   "id": "67e380a7",
+   "id": "1bde605c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T22:10:36.720460Z",
-     "iopub.status.busy": "2026-09-10T22:10:36.720203Z",
-     "iopub.status.idle": "2026-09-10T22:10:36.728079Z",
-     "shell.execute_reply": "2026-09-10T22:10:36.727307Z"
+     "iopub.execute_input": "2026-09-13T00:31:47.259494Z",
+     "iopub.status.busy": "2026-09-13T00:31:47.255382Z",
+     "iopub.status.idle": "2026-09-13T00:31:47.285417Z",
+     "shell.execute_reply": "2026-09-13T00:31:47.282384Z"
     },
     "papermill": {
-     "duration": 0.014727,
-     "end_time": "2026-09-10T22:10:36.728587+00:00",
+     "duration": 0.057989,
+     "end_time": "2026-09-13T00:31:47.290734+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:10:36.713860+00:00",
+     "start_time": "2026-09-13T00:31:47.232745+00:00",
      "status": "completed"
     }
    },
@@ -2414,14 +2414,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b82343be",
+   "id": "80f8cea2",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.009974,
-     "end_time": "2026-09-10T22:10:36.744045+00:00",
+     "duration": 0.019575,
+     "end_time": "2026-09-13T00:31:47.333122+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:10:36.734071+00:00",
+     "start_time": "2026-09-13T00:31:47.313547+00:00",
      "status": "completed"
     }
    },
@@ -2433,14 +2433,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c007da7f",
+   "id": "be467baa",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.004318,
-     "end_time": "2026-09-10T22:10:36.753773+00:00",
+     "duration": 0.017749,
+     "end_time": "2026-09-13T00:31:47.372967+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:10:36.749455+00:00",
+     "start_time": "2026-09-13T00:31:47.355218+00:00",
      "status": "completed"
     }
    },
@@ -2454,20 +2454,20 @@
   {
    "cell_type": "code",
    "execution_count": 32,
-   "id": "7efb2198",
+   "id": "bef36c4f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T22:10:36.763404Z",
-     "iopub.status.busy": "2026-09-10T22:10:36.763268Z",
-     "iopub.status.idle": "2026-09-10T22:10:36.765810Z",
-     "shell.execute_reply": "2026-09-10T22:10:36.765271Z"
+     "iopub.execute_input": "2026-09-13T00:31:47.420983Z",
+     "iopub.status.busy": "2026-09-13T00:31:47.420385Z",
+     "iopub.status.idle": "2026-09-13T00:31:47.428289Z",
+     "shell.execute_reply": "2026-09-13T00:31:47.426224Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.008059,
-     "end_time": "2026-09-10T22:10:36.766283+00:00",
+     "duration": 0.041738,
+     "end_time": "2026-09-13T00:31:47.433485+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:10:36.758224+00:00",
+     "start_time": "2026-09-13T00:31:47.391747+00:00",
      "status": "completed"
     }
    },
@@ -2498,14 +2498,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "247cab04",
+   "id": "2845aceb",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.005189,
-     "end_time": "2026-09-10T22:10:36.776558+00:00",
+     "duration": 0.017474,
+     "end_time": "2026-09-13T00:31:47.469987+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:10:36.771369+00:00",
+     "start_time": "2026-09-13T00:31:47.452513+00:00",
      "status": "completed"
     }
    },
@@ -2518,14 +2518,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e42c6682",
+   "id": "c657ccde",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.005007,
-     "end_time": "2026-09-10T22:10:36.787056+00:00",
+     "duration": 0.016128,
+     "end_time": "2026-09-13T00:31:47.503521+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:10:36.782049+00:00",
+     "start_time": "2026-09-13T00:31:47.487393+00:00",
      "status": "completed"
     }
    },
@@ -2539,20 +2539,20 @@
   {
    "cell_type": "code",
    "execution_count": 33,
-   "id": "dc4cbd08",
+   "id": "5a755fdc",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T22:10:36.801793Z",
-     "iopub.status.busy": "2026-09-10T22:10:36.801515Z",
-     "iopub.status.idle": "2026-09-10T22:10:36.806199Z",
-     "shell.execute_reply": "2026-09-10T22:10:36.805237Z"
+     "iopub.execute_input": "2026-09-13T00:31:47.536647Z",
+     "iopub.status.busy": "2026-09-13T00:31:47.536064Z",
+     "iopub.status.idle": "2026-09-13T00:31:47.544778Z",
+     "shell.execute_reply": "2026-09-13T00:31:47.543022Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.014955,
-     "end_time": "2026-09-10T22:10:36.806882+00:00",
+     "duration": 0.02594,
+     "end_time": "2026-09-13T00:31:47.545641+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:10:36.791927+00:00",
+     "start_time": "2026-09-13T00:31:47.519701+00:00",
      "status": "completed"
     }
    },
@@ -2572,14 +2572,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6d4f8772",
+   "id": "221c7c0f",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.007896,
-     "end_time": "2026-09-10T22:10:36.823522+00:00",
+     "duration": 0.009969,
+     "end_time": "2026-09-13T00:31:47.566254+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:10:36.815626+00:00",
+     "start_time": "2026-09-13T00:31:47.556285+00:00",
      "status": "completed"
     }
    },
@@ -2592,19 +2592,19 @@
   {
    "cell_type": "code",
    "execution_count": 34,
-   "id": "833ecb88",
+   "id": "8de51ec1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T22:10:36.836059Z",
-     "iopub.status.busy": "2026-09-10T22:10:36.835781Z",
-     "iopub.status.idle": "2026-09-10T22:10:36.839743Z",
-     "shell.execute_reply": "2026-09-10T22:10:36.839011Z"
+     "iopub.execute_input": "2026-09-13T00:31:47.595540Z",
+     "iopub.status.busy": "2026-09-13T00:31:47.595002Z",
+     "iopub.status.idle": "2026-09-13T00:31:47.603297Z",
+     "shell.execute_reply": "2026-09-13T00:31:47.601444Z"
     },
     "papermill": {
-     "duration": 0.01038,
-     "end_time": "2026-09-10T22:10:36.840223+00:00",
+     "duration": 0.026364,
+     "end_time": "2026-09-13T00:31:47.604710+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:10:36.829843+00:00",
+     "start_time": "2026-09-13T00:31:47.578346+00:00",
      "status": "completed"
     }
    },
@@ -2618,19 +2618,19 @@
   {
    "cell_type": "code",
    "execution_count": 35,
-   "id": "cef624ce",
+   "id": "778bf9b7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T22:10:36.852036Z",
-     "iopub.status.busy": "2026-09-10T22:10:36.851735Z",
-     "iopub.status.idle": "2026-09-10T22:10:36.856516Z",
-     "shell.execute_reply": "2026-09-10T22:10:36.855900Z"
+     "iopub.execute_input": "2026-09-13T00:31:47.643152Z",
+     "iopub.status.busy": "2026-09-13T00:31:47.642451Z",
+     "iopub.status.idle": "2026-09-13T00:31:47.652265Z",
+     "shell.execute_reply": "2026-09-13T00:31:47.650686Z"
     },
     "papermill": {
-     "duration": 0.012304,
-     "end_time": "2026-09-10T22:10:36.857060+00:00",
+     "duration": 0.030897,
+     "end_time": "2026-09-13T00:31:47.655375+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:10:36.844756+00:00",
+     "start_time": "2026-09-13T00:31:47.624478+00:00",
      "status": "completed"
     }
    },
@@ -2664,20 +2664,20 @@
   {
    "cell_type": "code",
    "execution_count": 36,
-   "id": "271e176f",
+   "id": "1958e2ad",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T22:10:36.875760Z",
-     "iopub.status.busy": "2026-09-10T22:10:36.875327Z",
-     "iopub.status.idle": "2026-09-10T22:10:36.880079Z",
-     "shell.execute_reply": "2026-09-10T22:10:36.879319Z"
+     "iopub.execute_input": "2026-09-13T00:31:47.688574Z",
+     "iopub.status.busy": "2026-09-13T00:31:47.687397Z",
+     "iopub.status.idle": "2026-09-13T00:31:47.695803Z",
+     "shell.execute_reply": "2026-09-13T00:31:47.693441Z"
     },
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.015793,
-     "end_time": "2026-09-10T22:10:36.880959+00:00",
+     "duration": 0.029304,
+     "end_time": "2026-09-13T00:31:47.698935+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:10:36.865166+00:00",
+     "start_time": "2026-09-13T00:31:47.669631+00:00",
      "status": "completed"
     }
    },
@@ -2703,14 +2703,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7babbf7c",
+   "id": "58a1c2af",
    "metadata": {
     "lines_to_next_cell": 2,
     "papermill": {
-     "duration": 0.008936,
-     "end_time": "2026-09-10T22:10:36.898204+00:00",
+     "duration": 0.010172,
+     "end_time": "2026-09-13T00:31:47.721664+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:10:36.889268+00:00",
+     "start_time": "2026-09-13T00:31:47.711492+00:00",
      "status": "completed"
     }
    },
@@ -2724,19 +2724,19 @@
   {
    "cell_type": "code",
    "execution_count": 37,
-   "id": "098fcb21",
+   "id": "492be9e2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T22:10:36.915840Z",
-     "iopub.status.busy": "2026-09-10T22:10:36.915662Z",
-     "iopub.status.idle": "2026-09-10T22:10:36.920044Z",
-     "shell.execute_reply": "2026-09-10T22:10:36.919231Z"
+     "iopub.execute_input": "2026-09-13T00:31:47.750225Z",
+     "iopub.status.busy": "2026-09-13T00:31:47.749146Z",
+     "iopub.status.idle": "2026-09-13T00:31:47.761344Z",
+     "shell.execute_reply": "2026-09-13T00:31:47.759233Z"
     },
     "papermill": {
-     "duration": 0.013832,
-     "end_time": "2026-09-10T22:10:36.920502+00:00",
+     "duration": 0.028396,
+     "end_time": "2026-09-13T00:31:47.762302+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:10:36.906670+00:00",
+     "start_time": "2026-09-13T00:31:47.733906+00:00",
      "status": "completed"
     }
    },
@@ -2776,19 +2776,19 @@
   {
    "cell_type": "code",
    "execution_count": 38,
-   "id": "2d05240c",
+   "id": "f5f983af",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T22:10:36.931640Z",
-     "iopub.status.busy": "2026-09-10T22:10:36.931398Z",
-     "iopub.status.idle": "2026-09-10T22:10:37.646882Z",
-     "shell.execute_reply": "2026-09-10T22:10:37.646137Z"
+     "iopub.execute_input": "2026-09-13T00:31:47.779577Z",
+     "iopub.status.busy": "2026-09-13T00:31:47.779255Z",
+     "iopub.status.idle": "2026-09-13T00:31:51.268545Z",
+     "shell.execute_reply": "2026-09-13T00:31:51.267590Z"
     },
     "papermill": {
-     "duration": 0.72292,
-     "end_time": "2026-09-10T22:10:37.647979+00:00",
+     "duration": 3.498969,
+     "end_time": "2026-09-13T00:31:51.269443+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:10:36.925059+00:00",
+     "start_time": "2026-09-13T00:31:47.770474+00:00",
      "status": "completed"
     }
    },
@@ -2816,13 +2816,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c7fceaf6",
+   "id": "f8aa80f0",
    "metadata": {
     "papermill": {
-     "duration": 0.004723,
-     "end_time": "2026-09-10T22:10:37.658967+00:00",
+     "duration": 0.008502,
+     "end_time": "2026-09-13T00:31:51.287648+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:10:37.654244+00:00",
+     "start_time": "2026-09-13T00:31:51.279146+00:00",
      "status": "completed"
     }
    },
@@ -2838,19 +2838,19 @@
   {
    "cell_type": "code",
    "execution_count": 39,
-   "id": "a643b343",
+   "id": "fbca87cf",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T22:10:37.669794Z",
-     "iopub.status.busy": "2026-09-10T22:10:37.669564Z",
-     "iopub.status.idle": "2026-09-10T22:10:37.674787Z",
-     "shell.execute_reply": "2026-09-10T22:10:37.674239Z"
+     "iopub.execute_input": "2026-09-13T00:31:51.307247Z",
+     "iopub.status.busy": "2026-09-13T00:31:51.306880Z",
+     "iopub.status.idle": "2026-09-13T00:31:51.313265Z",
+     "shell.execute_reply": "2026-09-13T00:31:51.312476Z"
     },
     "papermill": {
-     "duration": 0.011758,
-     "end_time": "2026-09-10T22:10:37.675407+00:00",
+     "duration": 0.017672,
+     "end_time": "2026-09-13T00:31:51.313828+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:10:37.663649+00:00",
+     "start_time": "2026-09-13T00:31:51.296156+00:00",
      "status": "completed"
     }
    },
@@ -2883,19 +2883,19 @@
   {
    "cell_type": "code",
    "execution_count": 40,
-   "id": "acbc7f70",
+   "id": "ca817018",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T22:10:37.688964Z",
-     "iopub.status.busy": "2026-09-10T22:10:37.688762Z",
-     "iopub.status.idle": "2026-09-10T22:10:37.696019Z",
-     "shell.execute_reply": "2026-09-10T22:10:37.694465Z"
+     "iopub.execute_input": "2026-09-13T00:31:51.333206Z",
+     "iopub.status.busy": "2026-09-13T00:31:51.332855Z",
+     "iopub.status.idle": "2026-09-13T00:31:51.346334Z",
+     "shell.execute_reply": "2026-09-13T00:31:51.345250Z"
     },
     "papermill": {
-     "duration": 0.015082,
-     "end_time": "2026-09-10T22:10:37.697456+00:00",
+     "duration": 0.024175,
+     "end_time": "2026-09-13T00:31:51.347041+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:10:37.682374+00:00",
+     "start_time": "2026-09-13T00:31:51.322866+00:00",
      "status": "completed"
     }
    },
@@ -2976,13 +2976,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "644ec8d4",
+   "id": "ceb8a633",
    "metadata": {
     "papermill": {
-     "duration": 0.008529,
-     "end_time": "2026-09-10T22:10:37.715336+00:00",
+     "duration": 0.006595,
+     "end_time": "2026-09-13T00:31:51.359915+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:10:37.706807+00:00",
+     "start_time": "2026-09-13T00:31:51.353320+00:00",
      "status": "completed"
     }
    },
@@ -2997,13 +2997,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0d7cb4cf",
+   "id": "89f92c5c",
    "metadata": {
     "papermill": {
-     "duration": 0.007558,
-     "end_time": "2026-09-10T22:10:37.731405+00:00",
+     "duration": 0.006891,
+     "end_time": "2026-09-13T00:31:51.373300+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:10:37.723847+00:00",
+     "start_time": "2026-09-13T00:31:51.366409+00:00",
      "status": "completed"
     }
    },
@@ -3014,19 +3014,19 @@
   {
    "cell_type": "code",
    "execution_count": 41,
-   "id": "44d413b4",
+   "id": "42a344f3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-09-10T22:10:37.744330Z",
-     "iopub.status.busy": "2026-09-10T22:10:37.744051Z",
-     "iopub.status.idle": "2026-09-10T22:10:37.752073Z",
-     "shell.execute_reply": "2026-09-10T22:10:37.751129Z"
+     "iopub.execute_input": "2026-09-13T00:31:51.387697Z",
+     "iopub.status.busy": "2026-09-13T00:31:51.387308Z",
+     "iopub.status.idle": "2026-09-13T00:31:51.396234Z",
+     "shell.execute_reply": "2026-09-13T00:31:51.395193Z"
     },
     "papermill": {
-     "duration": 0.014944,
-     "end_time": "2026-09-10T22:10:37.752893+00:00",
+     "duration": 0.017707,
+     "end_time": "2026-09-13T00:31:51.397202+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:10:37.737949+00:00",
+     "start_time": "2026-09-13T00:31:51.379495+00:00",
      "status": "completed"
     }
    },
@@ -3083,13 +3083,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b4d8d431",
+   "id": "802eab15",
    "metadata": {
     "papermill": {
-     "duration": 0.008873,
-     "end_time": "2026-09-10T22:10:37.767241+00:00",
+     "duration": 0.00607,
+     "end_time": "2026-09-13T00:31:51.411378+00:00",
      "exception": false,
-     "start_time": "2026-09-10T22:10:37.758368+00:00",
+     "start_time": "2026-09-13T00:31:51.405308+00:00",
      "status": "completed"
     }
    },
@@ -3168,25 +3168,24 @@
    "version": "3.14.7"
   },
   "ml4t_provenance": {
-   "executed_at": "2026-09-10T22:10:53.563537+00:00",
+   "executed_at": "2026-09-13T00:32:02.133819+00:00",
    "executor": "ml4t-neo4j",
-   "library_digest": "db0e4f0d654d43415508efb292b96f19a3b684e290b342916c50cce944374962",
-   "outputs_digest": "c124d532cae55503b5242756cfa5fa2c6ebd4b08ccaed677b2b8fd4a3ce77ece",
+   "library_digest": "defb8647b78f870975da75e2937698733079cfc8e87f724b5ea7bee7514e01b3",
+   "outputs_digest": "3136c9d1a24699cd3eb7220c912f0467ae9ff55ea6596a9f66d5245718b90919",
    "parameters": {},
    "production": true,
-   "source_py_blob": "b7ee0bd3dc3256ca38da2c8914c164b6d48e85f1",
-   "notes": "prose synced from the .py at 2026-09-13T00:21:53.982695+00:00 without re-executing; every code cell is identical to blob df33dc3f5091"
+   "source_py_blob": "89e43ba4319121d7c9a5c16442187af98573a2c8"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 15.145794,
-   "end_time": "2026-09-10T22:10:40.460751+00:00",
+   "duration": 28.227983,
+   "end_time": "2026-09-13T00:31:54.248621+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "23_knowledge_graphs/.05_institutional_holdings_kg.build.3780104.ipynb",
-   "output_path": "23_knowledge_graphs/.05_institutional_holdings_kg.papermill.3780104.ipynb",
+   "input_path": "23_knowledge_graphs/.05_institutional_holdings_kg.build.2240533.ipynb",
+   "output_path": "23_knowledge_graphs/.05_institutional_holdings_kg.papermill.2240533.ipynb",
    "parameters": {},
-   "start_time": "2026-09-10T22:10:25.314957+00:00",
+   "start_time": "2026-09-13T00:31:26.020638+00:00",
    "version": "2.7.0"
   }
  },

--- a/23_knowledge_graphs/05_institutional_holdings_kg.py
+++ b/23_knowledge_graphs/05_institutional_holdings_kg.py
@@ -1003,7 +1003,7 @@ show_with_alt(
 # The top panel describes holder overlap inside a fixed ten-institution cohort;
 # it does not measure the price impact of an unwind. The bottom panel describes
 # the name screen, not the market: "Other" is where an issuer whose name nobody
-# wrote into `SECTOR_TERMS` lands, so its height is a property of the term list.
+# wrote into `SECTOR_TERMS` lands, so its length is a property of the term list.
 
 # %% [markdown]
 # ## 6. Top Holdings by Sector

--- a/23_knowledge_graphs/05_institutional_holdings_kg.py
+++ b/23_knowledge_graphs/05_institutional_holdings_kg.py
@@ -983,7 +983,7 @@ add_message_title(
     axes[0],
     "Holder counts and screened sectors for the formation cohort",
     subtitle=(
-        f"{len(data_stocks)} stocks held by {len(data_institutions)} institutions, "
+        "Cohort stocks and the institutions holding them, "
         f"formed at report period {period_calendar['report_date'][0]}"
     ),
 )

--- a/case_studies/nasdaq100_microstructure/05_evaluation.ipynb
+++ b/case_studies/nasdaq100_microstructure/05_evaluation.ipynb
@@ -16137,7 +16137,7 @@
      },
      "metadata": {
       "image/png": {
-       "alt": "A histogram of the Spearman rank correlation between feature pairs over the sampled development bars, with the pairs drawn from within a family separated from those spanning two families."
+       "alt": "A horizontal bar chart of the twenty feature pairs whose Spearman rank correlation across the sampled development bars is largest in size, one bar per pair, ordered with the largest at the top. Each bar is labelled with both feature names and the family each belongs to, is annotated with its correlation, and is blue where that correlation is positive and copper where it is negative."
       }
      },
      "output_type": "display_data"
@@ -16188,7 +16188,11 @@
     "    )\n",
     "    show_plotly_with_alt(\n",
     "        fig,\n",
-    "        \"A histogram of the Spearman rank correlation between feature pairs over the sampled development bars, with the pairs drawn from within a family separated from those spanning two families.\",\n",
+    "        \"A horizontal bar chart of the twenty feature pairs whose Spearman rank correlation \"\n",
+    "        \"across the sampled development bars is largest in size, one bar per pair, ordered \"\n",
+    "        \"with the largest at the top. Each bar is labelled with both feature names and the \"\n",
+    "        \"family each belongs to, is annotated with its correlation, and is blue where that \"\n",
+    "        \"correlation is positive and copper where it is negative.\",\n",
     "    )\n",
     "    print(f\"Of the {len(ranked)} strongest pairs, {cross_family} span two families\")\n",
     "    print(f\"Of the {len(ranked)} strongest pairs, {same_twin} are a level against its own z-score\")"
@@ -16745,7 +16749,8 @@
    "outputs_digest": "77708e59c4ea370e6874c9eb98952b6cbb9cfe63107757490d9fb1ff5730f8f6",
    "parameters": {},
    "production": true,
-   "source_py_blob": "f58e655abd6a2fd94ffe246d7ba90f41558170bf"
+   "source_py_blob": "c2f47066303657566ae5e70cf8d6bd1aa0d6e154",
+   "notes": "alt text synced from the .py at 2026-09-13T00:21:51.220857+00:00 without re-executing; every code cell is identical to blob f58e655abd6a once alt literals are blanked, and 8 output alt(s) were rewritten to match"
   },
   "papermill": {
    "default_parameters": {},

--- a/case_studies/nasdaq100_microstructure/05_evaluation.py
+++ b/case_studies/nasdaq100_microstructure/05_evaluation.py
@@ -1631,7 +1631,11 @@ if high_corr_pairs:
     )
     show_plotly_with_alt(
         fig,
-        "A histogram of the Spearman rank correlation between feature pairs over the sampled development bars, with the pairs drawn from within a family separated from those spanning two families.",
+        "A horizontal bar chart of the twenty feature pairs whose Spearman rank correlation "
+        "across the sampled development bars is largest in size, one bar per pair, ordered "
+        "with the largest at the top. Each bar is labelled with both feature names and the "
+        "family each belongs to, is annotated with its correlation, and is blue where that "
+        "correlation is positive and copper where it is negative.",
     )
     print(f"Of the {len(ranked)} strongest pairs, {cross_family} span two families")
     print(f"Of the {len(ranked)} strongest pairs, {same_twin} are a level against its own z-score")


### PR DESCRIPTION
Four figure descriptions that describe a figure the code does not build, and two subtitles that count what the axes already show.

## Descriptions that name the wrong figure

**`case_studies/nasdaq100_microstructure/05_evaluation`** called the feature-pair redundancy chart "a histogram of the Spearman rank correlation between feature pairs", and said the within-family pairs were drawn separately from the cross-family ones. The call is one `go.Bar` over the twenty pairs with the largest correlation by size, labelled pair by pair; there is no binning, so no histogram, and the only colour rule is the sign of the correlation. A reader who cannot see the figure was handed a distribution that does not exist and a separation that was never drawn.

**`23_knowledge_graphs/05_institutional_holdings_kg`** said the Other category's "height" is a property of the term list. The panel is `axes[1].barh`, so a category's extent is its length.

Both fold into the existing render: alt text through `sync-alt`, prose through `sync-prose`, 0 stale afterwards.

## Subtitles that interpolate a computed value

A subtitle may not name a value the notebook's own code produced. `23_knowledge_graphs/02_supply_chain_kg_construction` said "extraction from `{len(filings_df)}` S&P 100 10-K filings"; the filing count prints in the extraction summary above the figure. `23_knowledge_graphs/05_institutional_holdings_kg` said "`{len(data_stocks)}` stocks held by `{len(data_institutions)}` institutions"; both counts are the axes of the panels the subtitle sits over. The sample period stays in both.

A subtitle is drawn into the image, so these two are re-executed rather than folded in: 20 s and 13 s.

**The graph reproduces exactly.** `02`'s completion record reads the same 106 companies, 995 persisted edges and `graph_sha256 ce7a52bf` as the committed render. The only substantive output that moved is the Neo4j load timing, 0.9 s to 7.2 s, because this run built the database from an empty volume and paid for index creation - a measurement of the machine, not of the data. `05`'s text outputs are identical, and an independent second run of it reproduced the committed render with no non-timestamp difference.

## How the first two were found

By a check rather than by reading, added alongside this in the agents repo as `check_notebook_prose.py` A10. It reads each figure-bearing cell's alt text against the cell's own `ax.*` and trace calls - walking back through the cells that built the same figure, since a stage-05 evaluation notebook builds one figure over four cells - and reports a chart type the alt names and the cell never draws, bars described in groups where one Matplotlib bar call draws one series, and a `barh` bar whose extent is called its height.

Calibrated in both directions against a chapter-20 pass that was corrected by hand: three findings before the fix, none after. Over the whole corpus it reports two more, one of which is on an unmerged teach branch and already fixed there.
