### PR TITLE
Give case-study notebooks a warning policy instead of a blanket ignore

### DIFF
--- a/case_studies/utils/warning_policy.py
+++ b/case_studies/utils/warning_policy.py
@@ -1,0 +1,56 @@
+"""Warning policy for notebooks that would otherwise silence every warning.
+
+`warnings.filterwarnings("ignore")` at notebook import is a catch-all: it hides
+third-party noise, and with it every diagnostic `case_studies.*` raises to reach
+the person reading the executed notebook. `warnings.warn` is then not a channel,
+and a guard written on it reports nothing whether or not it fired.
+
+This module silences the third-party warnings by name and leaves everything else
+audible. Each silenced entry records what was measured when it was added, so a
+later reader can tell a measurement from a guess.
+"""
+
+from __future__ import annotations
+
+import re
+import warnings
+
+# Message prefixes of third-party warnings observed in executed notebooks. The
+# regex is start-anchored and case-insensitive, which is how `filterwarnings`
+# compiles it. Category is deliberately left at `Warning`: `arch`'s
+# DataScaleWarning subclasses `Warning` directly rather than `UserWarning`, so a
+# filter narrowed to `UserWarning` would not reach it.
+#
+# Counted 2026-09-12 over the rendered `.ipynb` of the three case studies that
+# install no filter (crypto_perps_funding, fx_pairs, us_equities_panel):
+#   219  arch/univariate/base.py  DataScaleWarning  "y is poorly scaled, ..."
+_THIRD_PARTY_NOISE: tuple[str, ...] = (r"y is poorly scaled",)
+
+# A warning is issued with a `module` that `warnings` derives from the source
+# filename with its `.py` suffix stripped, not from the dotted import path. The
+# pattern therefore has to match a path segment, and `filterwarnings` anchors it
+# at the start, so it needs the leading `.*`.
+_CASE_STUDIES_MODULE = r".*[/\\]case_studies[/\\].*"
+
+
+def apply_notebook_warning_policy() -> None:
+    """Silence known third-party noise, keep `case_studies.*` diagnostics audible.
+
+    Safe to call more than once. Replaces a bare
+    ``warnings.filterwarnings("ignore")`` at the top of a notebook.
+    """
+    for message in _THIRD_PARTY_NOISE:
+        warnings.filterwarnings("ignore", message=message)
+    # Added last so it is matched first: `filterwarnings` inserts at the front
+    # of the filter list. Without this, a broader ignore added later by a
+    # notebook or a library would take precedence over it.
+    warnings.filterwarnings("default", module=_CASE_STUDIES_MODULE)
+
+
+def is_case_studies_module(filename: str) -> bool:
+    """Whether `filename` is the source of a `case_studies.*` diagnostic.
+
+    Exposed so a test can assert the pattern against a real path rather than
+    restating it.
+    """
+    return re.compile(_CASE_STUDIES_MODULE).match(filename.removesuffix(".py")) is not None

--- a/case_studies/utils/warning_policy.py
+++ b/case_studies/utils/warning_policy.py
@@ -26,11 +26,11 @@ import warnings
 #   219  arch/univariate/base.py  DataScaleWarning  "y is poorly scaled, ..."
 _THIRD_PARTY_NOISE: tuple[str, ...] = (r"y is poorly scaled",)
 
-# A warning is issued with a `module` that `warnings` derives from the source
-# filename with its `.py` suffix stripped, not from the dotted import path. The
-# pattern therefore has to match a path segment, and `filterwarnings` anchors it
-# at the start, so it needs the leading `.*`.
-_CASE_STUDIES_MODULE = r".*[/\\]case_studies[/\\].*"
+# `filterwarnings` matches `module` against the dotted `__name__` of the module
+# that called `warnings.warn`, and anchors the regex at the start. The trailing
+# group is what keeps the pattern from reaching a sibling package whose name
+# merely begins the same way, such as `case_studies_notes`.
+_CASE_STUDIES_MODULE = r"case_studies(\.|$)"
 
 
 def apply_notebook_warning_policy() -> None:
@@ -47,10 +47,11 @@ def apply_notebook_warning_policy() -> None:
     warnings.filterwarnings("default", module=_CASE_STUDIES_MODULE)
 
 
-def is_case_studies_module(filename: str) -> bool:
-    """Whether `filename` is the source of a `case_studies.*` diagnostic.
+def is_case_studies_module(module_name: str) -> bool:
+    """Whether a warning from `module_name` is one this policy keeps audible.
 
-    Exposed so a test can assert the pattern against a real path rather than
+    `module_name` is a dotted import path, the same value `warnings` matches a
+    filter's `module` against. Exposed so a test can assert the pattern without
     restating it.
     """
-    return re.compile(_CASE_STUDIES_MODULE).match(filename.removesuffix(".py")) is not None
+    return re.compile(_CASE_STUDIES_MODULE).match(module_name) is not None

--- a/tests/test_warning_policy.py
+++ b/tests/test_warning_policy.py
@@ -1,12 +1,21 @@
 """The notebook warning policy keeps `case_studies.*` diagnostics audible.
 
-The defect these tests pin is #1078: `warnings.filterwarnings("ignore")` at
-notebook import silences every warning, so a diagnostic a library raises with
+The defect pinned here is ml4t/agent-workspace#1078: `warnings.filterwarnings("ignore")`
+at notebook import silences every warning, so a diagnostic raised with
 `warnings.warn` reaches nobody reading the executed notebook.
+
+Every test drives a real `warnings.warn` from a real imported module. An earlier
+version of this file used `warnings.warn_explicit` with a filename, which takes a
+different branch: `warn_explicit` derives the module it matches from the filename,
+while `warnings.warn` passes the caller's dotted `__name__`. The tests passed
+against a pattern that matched nothing in production.
 """
 
 from __future__ import annotations
 
+import importlib.util
+import sys
+import types
 import warnings
 
 import pytest
@@ -16,91 +25,150 @@ from case_studies.utils.warning_policy import (
     is_case_studies_module,
 )
 
-CASE_STUDY_SOURCE = "/home/x/ml4t/public/case_studies/utils/conformal.py"
-ARCH_SOURCE = "/home/x/ml4t/public/.venv/lib/python3.14/site-packages/arch/univariate/base.py"
-SKLEARN_SOURCE = (
-    "/home/x/ml4t/public/.venv/lib/python3.14/site-packages/sklearn/linear_model/_sag.py"
-)
-
 ARCH_NOISE = "y is poorly scaled, which may affect convergence of the optimizer"
 CASE_STUDY_DIAGNOSTIC = "Sortedness of columns cannot be checked when 'by' groups provided"
 
 
-def _emit(message: str, source: str, category: type[Warning] = UserWarning) -> None:
-    """Raise `message` as if it came from `source`.
+def _module_that_warns(tmp_path, dotted_name: str) -> types.ModuleType:
+    """Import a module under `dotted_name` whose `warn()` raises a warning.
 
-    `warn_explicit` is what `warnings.warn` calls once it has resolved the
-    caller's frame, so passing the filename directly reproduces how a real
-    warning from that file is matched against the filters.
+    The dotted name is what `warnings` matches a filter's `module` against, so it
+    has to be the real name of a real imported module for the test to mean
+    anything.
     """
-    warnings.warn_explicit(message, category, source, 515)
+    source = tmp_path / f"{dotted_name.replace('.', '_')}.py"
+    source.write_text(
+        "import warnings\ndef warn(message, category):\n    warnings.warn(message, category)\n"
+    )
+    spec = importlib.util.spec_from_file_location(dotted_name, source)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[dotted_name] = module
+    spec.loader.exec_module(module)
+    assert module.__name__ == dotted_name
+    return module
 
 
-def _under_policy(emit: list[tuple[str, str, type[Warning]]]) -> list[str]:
-    """Return the messages that survive the policy."""
-    with warnings.catch_warnings(record=True) as recorded:
-        warnings.resetwarnings()
-        apply_notebook_warning_policy()
-        for message, source, category in emit:
-            _emit(message, source, category)
-    return [str(w.message) for w in recorded]
+@pytest.fixture
+def case_study_module(tmp_path):
+    name = "case_studies.utils._warning_probe"
+    try:
+        yield _module_that_warns(tmp_path, name)
+    finally:
+        sys.modules.pop(name, None)
 
 
-def test_blanket_ignore_hides_a_case_studies_diagnostic():
-    """The defect, reproduced: the line the notebooks carry today silences it."""
+@pytest.fixture
+def third_party_module(tmp_path):
+    name = "arch.univariate._warning_probe"
+    try:
+        yield _module_that_warns(tmp_path, name)
+    finally:
+        sys.modules.pop(name, None)
+
+
+def _audible(emit) -> list[str]:
+    """Messages that survive the policy, with a blanket ignore also installed.
+
+    The blanket ignore is what the notebooks carry today. Installing it first and
+    the policy second is the migration state a notebook passes through, and it is
+    the case where a keep-audible rule that matches nothing looks identical to one
+    that works.
+    """
     with warnings.catch_warnings(record=True) as recorded:
         warnings.resetwarnings()
         warnings.filterwarnings("ignore")
-        _emit(CASE_STUDY_DIAGNOSTIC, CASE_STUDY_SOURCE)
+        apply_notebook_warning_policy()
+        emit()
+    return [str(w.message) for w in recorded]
+
+
+def test_blanket_ignore_hides_a_case_studies_diagnostic(case_study_module):
+    """The defect, reproduced against the line the notebooks carry today."""
+    with warnings.catch_warnings(record=True) as recorded:
+        warnings.resetwarnings()
+        warnings.filterwarnings("ignore")
+        case_study_module.warn(CASE_STUDY_DIAGNOSTIC, UserWarning)
     assert [str(w.message) for w in recorded] == []
 
 
-def test_policy_keeps_a_case_studies_diagnostic_audible():
-    survived = _under_policy([(CASE_STUDY_DIAGNOSTIC, CASE_STUDY_SOURCE, UserWarning)])
+def test_policy_keeps_a_case_studies_diagnostic_audible(case_study_module):
+    survived = _audible(lambda: case_study_module.warn(CASE_STUDY_DIAGNOSTIC, UserWarning))
     assert survived == [CASE_STUDY_DIAGNOSTIC]
 
 
-def test_policy_silences_the_measured_third_party_noise():
+def test_policy_silences_the_measured_third_party_noise(third_party_module):
     """arch's DataScaleWarning subclasses Warning, not UserWarning."""
 
     class DataScaleWarning(Warning):
         pass
 
-    survived = _under_policy([(ARCH_NOISE, ARCH_SOURCE, DataScaleWarning)])
-    assert survived == []
+    with warnings.catch_warnings(record=True) as recorded:
+        warnings.resetwarnings()
+        warnings.simplefilter("always")
+        apply_notebook_warning_policy()
+        third_party_module.warn(ARCH_NOISE, DataScaleWarning)
+    assert [str(w.message) for w in recorded] == []
 
 
-def test_policy_does_not_silence_a_third_party_warning_that_reports_a_result():
+def test_a_ignore_narrowed_to_userwarning_would_not_reach_it(third_party_module):
+    """Why the entry does not name a category: the control for the test above."""
+
+    class DataScaleWarning(Warning):
+        pass
+
+    with warnings.catch_warnings(record=True) as recorded:
+        warnings.resetwarnings()
+        warnings.simplefilter("always")
+        warnings.filterwarnings("ignore", category=UserWarning, module="arch")
+        third_party_module.warn(ARCH_NOISE, DataScaleWarning)
+    assert [str(w.message) for w in recorded] == [ARCH_NOISE]
+
+
+def test_policy_does_not_silence_a_third_party_warning_that_reports_a_result(third_party_module):
     """A model that did not converge is a diagnostic, not noise."""
     from sklearn.exceptions import ConvergenceWarning
 
     message = "The max_iter was reached which means the coef_ did not converge"
-    survived = _under_policy([(message, SKLEARN_SOURCE, ConvergenceWarning)])
-    assert survived == [message]
-
-
-def test_policy_is_idempotent():
     with warnings.catch_warnings(record=True) as recorded:
         warnings.resetwarnings()
+        warnings.simplefilter("always")
+        apply_notebook_warning_policy()
+        third_party_module.warn(message, ConvergenceWarning)
+    assert [str(w.message) for w in recorded] == [message]
+
+
+def test_policy_is_idempotent(case_study_module):
+    with warnings.catch_warnings(record=True) as recorded:
+        warnings.resetwarnings()
+        warnings.filterwarnings("ignore")
         apply_notebook_warning_policy()
         apply_notebook_warning_policy()
-        _emit(CASE_STUDY_DIAGNOSTIC, CASE_STUDY_SOURCE)
-        _emit(ARCH_NOISE, ARCH_SOURCE)
+        case_study_module.warn(CASE_STUDY_DIAGNOSTIC, UserWarning)
     assert [str(w.message) for w in recorded] == [CASE_STUDY_DIAGNOSTIC]
 
 
+def test_keep_audible_rule_does_not_reach_a_lookalike_package(tmp_path):
+    """Negative selftest: a package whose name merely starts the same way."""
+    name = "case_studies_notes.scratch"
+    module = _module_that_warns(tmp_path, name)
+    try:
+        survived = _audible(lambda: module.warn("a note", UserWarning))
+    finally:
+        sys.modules.pop(name, None)
+    assert survived == []
+
+
 @pytest.mark.parametrize(
-    ("path", "expected"),
+    ("dotted", "expected"),
     [
-        (CASE_STUDY_SOURCE, True),
-        ("/home/x/ml4t/public/case_studies/research.py", True),
-        (r"C:\ml4t\public\case_studies\utils\conformal.py", True),
-        # Negative selftest: the pattern must not reach anything outside the
-        # package, including a path that merely contains the word.
-        (ARCH_SOURCE, False),
-        ("/home/x/ml4t/public/utils/style.py", False),
-        ("/home/x/my_case_studies_notes/scratch.py", False),
+        ("case_studies.utils.conformal", True),
+        ("case_studies.research", True),
+        ("case_studies", True),
+        ("case_studies_notes.scratch", False),
+        ("arch.univariate.base", False),
+        ("utils.style", False),
     ],
 )
-def test_module_pattern_selects_only_the_package(path: str, expected: bool):
-    assert is_case_studies_module(path) is expected
+def test_module_pattern_selects_only_the_package(dotted: str, expected: bool):
+    assert is_case_studies_module(dotted) is expected

--- a/tests/test_warning_policy.py
+++ b/tests/test_warning_policy.py
@@ -1,0 +1,106 @@
+"""The notebook warning policy keeps `case_studies.*` diagnostics audible.
+
+The defect these tests pin is #1078: `warnings.filterwarnings("ignore")` at
+notebook import silences every warning, so a diagnostic a library raises with
+`warnings.warn` reaches nobody reading the executed notebook.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import pytest
+
+from case_studies.utils.warning_policy import (
+    apply_notebook_warning_policy,
+    is_case_studies_module,
+)
+
+CASE_STUDY_SOURCE = "/home/x/ml4t/public/case_studies/utils/conformal.py"
+ARCH_SOURCE = "/home/x/ml4t/public/.venv/lib/python3.14/site-packages/arch/univariate/base.py"
+SKLEARN_SOURCE = (
+    "/home/x/ml4t/public/.venv/lib/python3.14/site-packages/sklearn/linear_model/_sag.py"
+)
+
+ARCH_NOISE = "y is poorly scaled, which may affect convergence of the optimizer"
+CASE_STUDY_DIAGNOSTIC = "Sortedness of columns cannot be checked when 'by' groups provided"
+
+
+def _emit(message: str, source: str, category: type[Warning] = UserWarning) -> None:
+    """Raise `message` as if it came from `source`.
+
+    `warn_explicit` is what `warnings.warn` calls once it has resolved the
+    caller's frame, so passing the filename directly reproduces how a real
+    warning from that file is matched against the filters.
+    """
+    warnings.warn_explicit(message, category, source, 515)
+
+
+def _under_policy(emit: list[tuple[str, str, type[Warning]]]) -> list[str]:
+    """Return the messages that survive the policy."""
+    with warnings.catch_warnings(record=True) as recorded:
+        warnings.resetwarnings()
+        apply_notebook_warning_policy()
+        for message, source, category in emit:
+            _emit(message, source, category)
+    return [str(w.message) for w in recorded]
+
+
+def test_blanket_ignore_hides_a_case_studies_diagnostic():
+    """The defect, reproduced: the line the notebooks carry today silences it."""
+    with warnings.catch_warnings(record=True) as recorded:
+        warnings.resetwarnings()
+        warnings.filterwarnings("ignore")
+        _emit(CASE_STUDY_DIAGNOSTIC, CASE_STUDY_SOURCE)
+    assert [str(w.message) for w in recorded] == []
+
+
+def test_policy_keeps_a_case_studies_diagnostic_audible():
+    survived = _under_policy([(CASE_STUDY_DIAGNOSTIC, CASE_STUDY_SOURCE, UserWarning)])
+    assert survived == [CASE_STUDY_DIAGNOSTIC]
+
+
+def test_policy_silences_the_measured_third_party_noise():
+    """arch's DataScaleWarning subclasses Warning, not UserWarning."""
+
+    class DataScaleWarning(Warning):
+        pass
+
+    survived = _under_policy([(ARCH_NOISE, ARCH_SOURCE, DataScaleWarning)])
+    assert survived == []
+
+
+def test_policy_does_not_silence_a_third_party_warning_that_reports_a_result():
+    """A model that did not converge is a diagnostic, not noise."""
+    from sklearn.exceptions import ConvergenceWarning
+
+    message = "The max_iter was reached which means the coef_ did not converge"
+    survived = _under_policy([(message, SKLEARN_SOURCE, ConvergenceWarning)])
+    assert survived == [message]
+
+
+def test_policy_is_idempotent():
+    with warnings.catch_warnings(record=True) as recorded:
+        warnings.resetwarnings()
+        apply_notebook_warning_policy()
+        apply_notebook_warning_policy()
+        _emit(CASE_STUDY_DIAGNOSTIC, CASE_STUDY_SOURCE)
+        _emit(ARCH_NOISE, ARCH_SOURCE)
+    assert [str(w.message) for w in recorded] == [CASE_STUDY_DIAGNOSTIC]
+
+
+@pytest.mark.parametrize(
+    ("path", "expected"),
+    [
+        (CASE_STUDY_SOURCE, True),
+        ("/home/x/ml4t/public/case_studies/research.py", True),
+        (r"C:\ml4t\public\case_studies\utils\conformal.py", True),
+        # Negative selftest: the pattern must not reach anything outside the
+        # package, including a path that merely contains the word.
+        (ARCH_SOURCE, False),
+        ("/home/x/ml4t/public/utils/style.py", False),
+        ("/home/x/my_case_studies_notes/scratch.py", False),
+    ],
+)
+def test_module_pattern_selects_only_the_package(path: str, expected: bool):
+    assert is_case_studies_module(path) is expected


### PR DESCRIPTION
A notebook that calls `warnings.filterwarnings("ignore")` at import silences every warning, including the ones `case_studies.*` raises to reach whoever reads the executed notebook. 61 case-study notebooks do this. A guard written on `warnings.warn` reports nothing there whether or not it fired.

This adds `case_studies/utils/warning_policy.py`, which silences the third-party noise by message and leaves everything else audible, plus the tests that pin it. It implements clause M2's prescription (ruled 2026-09-08) as a callable, for the notebooks whose noise is the same noise.

## What is silenced, measured rather than assumed

Warning lines in the rendered `.ipynb` of the three case studies that install no filter (`crypto_perps_funding`, `fx_pairs`, `us_equities_panel`):

| count | source | warning |
|---:|---|---|
| 219 | `arch/univariate/base.py` | `DataScaleWarning`, "y is poorly scaled" |
| 6 | `sklearn/linear_model/` | `ConvergenceWarning` |
| 1 | a notebook cell | `UserWarning`, FigureCanvasAgg is non-interactive |
| 1 | `case_studies/utils/conformal.py` | `UserWarning`, sortedness cannot be checked |

One entry covers the noise. The other three are diagnostics that should have been visible: a model that did not converge, a figure that cannot be shown under Agg, and the engine talking to its reader.

## The category the entry does not name

`arch`'s `DataScaleWarning` subclasses `Warning` directly, not `UserWarning`. A filter narrowed to `UserWarning` reads correctly, silences nothing, and puts 219 lines back. There is a control test for exactly that: `category=UserWarning, module="arch"` leaves the warning fully visible.

## A correction inside this PR, since it is the more useful half

The first commit's keep-audible rule used `module=r".*[/\\]case_studies[/\\].*"`, a **path** pattern. It matches no warning raised by `warnings.warn`, so the rule silenced `case_studies` diagnostics exactly as the blanket ignore did. The correct pattern is the dotted import path, `r"case_studies(\.|$)"`.

The tests passed against the broken pattern because they used `warnings.warn_explicit` with an explicit filename, which takes a different branch: `warn_explicit` derives the module from the filename, `warnings.warn` passes the caller's dotted `__name__`. The test shared the implementation's assumption and could not fail on it.

Second commit rewrites every test to import a real module under a real dotted name and call `warnings.warn` from it. Mutating the pattern back kills five of thirteen, including both behavioural tests. The audibility tests now install the blanket ignore **first** and the policy second, which is the state a notebook passes through during the migration and the only arrangement where a dead keep-audible rule is distinguishable from a working one.

**Consequence for the migration, and it is good news:** the bare module names already in the corpus - `module="polars"`, `module="torch"`, `module="stable_baselines3"` and about sixty more - are correct as written. A bare top-level name matches a submodule because `filterwarnings` anchors the regex at the start of the dotted name. Clause M2's prescribed form needs no change, and no already-migrated notebook carries a dead filter on this account.

## What is not here

The 61 notebooks are not swept. Replacing the line is a code-cell edit, so each notebook needs its next re-render to carry a valid stamp, and clearing 61 stamps to land it sooner would drop every rendered output in the corpus. The sweep rides each case study's next execution wave.

No overlap with #1020, which removes the call outright from twelve unstamped files: none of those twelve imports `arch`, so nothing there needs this policy to stay quiet.

## Verification

`pytest tests/test_warning_policy.py` 13 passed, including the defect reproduced against the line the notebooks carry today and a mutation check that the suite can fail. `ruff` and `ty` clean. RoboRev: no issues found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019xcyuaQpWc4fHFL45FjARQ