### PR TITLE
A fixture value above the patched preset is a decision someone writes down

### DIFF
--- a/tests/test_pm_helpers.py
+++ b/tests/test_pm_helpers.py
@@ -506,6 +506,87 @@ def test_every_declared_reduction_key_is_one_some_family_accepts(overrides: dict
     assert unknown == {}
 
 
+# A fixture entry that RAISES a value the preset patch already floored, with the reason it is
+# worth the cost. `tests/preset_patches.py` patches a copy of `case_studies/config/` that
+# `tests/conftest.py:390` builds, and `overrides.yaml` runs against that copy, so a reduction
+# declared here replaces the patched value rather than reinforcing it. Raising one is
+# sometimes right - it is the only way to keep a dimension the notebook is *about* - but it is
+# a cost decision, and the entry that makes it silently reads as a reduction.
+#
+# `tests/smoke.yaml` is not covered and must not be: `scripts/nb-run.sh` executes it and
+# patches nothing, so a value there is measured against the canonical preset.
+RAISES_THE_PATCHED_PRESET = {
+    "case_studies/cme_futures/07_gbm": (
+        "20 iterations every 10 against the patched 2 every 1. Publishing more than one "
+        "checkpoint is the dimension this notebook demonstrates, and the entry prices the "
+        "fit against production's 500 every 50."
+    ),
+    "case_studies/nasdaq100_microstructure/07_gbm": "As cme_futures/07_gbm.",
+    "case_studies/sp500_options/07_gbm": "As cme_futures/07_gbm.",
+    "case_studies/us_firm_characteristics/06_gbm": "As cme_futures/07_gbm.",
+}
+
+
+def _patched_preset_floor() -> dict[str, float]:
+    """The largest value any preset patch gives each numeric key.
+
+    A declared value above it is a raise whichever `config/<model_type>/` directory the entry
+    resolves to, and one at or below the smallest cannot be - so the comparison needs no map
+    from a notebook stem to a model directory, which is the part a stem heuristic gets wrong
+    on the next notebook named differently.
+    """
+    from tests.preset_patches import _TEST_PRESET_PATCHES
+
+    floor: dict[str, float] = {}
+    for patches in _TEST_PRESET_PATCHES.values():
+        for key, value in patches.items():
+            if isinstance(value, (int, float)) and not isinstance(value, bool):
+                floor[key] = max(floor.get(key, value), value)
+    return floor
+
+
+def _raised_keys(reductions: dict, floor: dict[str, float]) -> list[str]:
+    return sorted(
+        name
+        for name, value in reductions.items()
+        if name in floor
+        and isinstance(value, (int, float))
+        and not isinstance(value, bool)
+        and value > floor[name]
+    )
+
+
+def test_a_reduction_that_raises_the_patched_preset_says_why(overrides: dict) -> None:
+    """A fixture value above the patched preset is a cost decision someone writes down."""
+
+    floor = _patched_preset_floor()
+    undeclared = {
+        key: _raised_keys(reductions, floor)
+        for key, reductions in _declared_reductions(overrides).items()
+        if _raised_keys(reductions, floor) and key not in RAISES_THE_PATCHED_PRESET
+    }
+
+    assert undeclared == {}
+
+
+def test_every_entry_that_claims_a_raise_still_makes_one(overrides: dict) -> None:
+    """The other direction: a reason left behind after the value came down is stale prose.
+
+    Without this the table only ever grows, and an entry reduced back under the patch keeps a
+    row saying it costs more than it does.
+    """
+
+    floor = _patched_preset_floor()
+    declared = _declared_reductions(overrides)
+    stale = [
+        key
+        for key, reason in RAISES_THE_PATCHED_PRESET.items()
+        if not reason.strip() or key not in declared or not _raised_keys(declared[key], floor)
+    ]
+
+    assert stale == []
+
+
 def test_a_causal_reduction_declares_all_four_fields(overrides: dict) -> None:
     """The DML resolver requires its four fields, and a partial mapping is worse than none.
 


### PR DESCRIPTION
`tests/preset_patches.py` floors `n_epochs`, `checkpoint_interval` and `max_iterations` on a copy of `case_studies/config/` that `tests/conftest.py:390` builds, and `tests/overrides.yaml` runs against that copy. A `PREVIEW_REDUCTIONS` value there replaces the patched value rather than reinforcing it, which the `etfs/11c` entry already says in as many words.

Four entries declare above it:

| entry | declares | patched preset |
|---|---|---|
| `cme_futures/07_gbm` | `checkpoint_interval: 10, max_iterations: 20` | `1`, `2` |
| `nasdaq100_microstructure/07_gbm` | same | same |
| `sp500_options/07_gbm` | same | same |
| `us_firm_characteristics/06_gbm` | same | same |

So those fits are ten times the patched length. `cme_futures/07_gbm` gives the reason - publishing more than one checkpoint is the dimension that notebook demonstrates - and prices it against production's 500 every 50 as a 25x cut, which is a baseline that path never starts from. The raise may well be the right call; what it cannot be is invisible, because an entry that raises the cost is indistinguishable in the file from one that lowers it.

## What this adds

Two tests in `tests/test_pm_helpers.py`, beside the reduction checks already there:

- `test_a_reduction_that_raises_the_patched_preset_says_why` - a new raise needs a row in `RAISES_THE_PATCHED_PRESET` with a reason.
- `test_every_entry_that_claims_a_raise_still_makes_one` - a row left behind after the value came down fails the other way, so the table cannot only grow.

The comparison is against the **largest** value any patch gives that key, so no map from a notebook stem to a `config/<model_type>/` directory is needed: a value above every patched one is a raise whichever directory the entry resolves to, and one at or below the smallest cannot be. A stem heuristic is what would go wrong on the next notebook named differently.

`tests/smoke.yaml` is deliberately out of scope. `scripts/nb-run.sh` executes it and patches nothing - `preset`, `conftest` and `generate_intermediates` appear nowhere in it - so a value there is measured against the canonical preset, and `nasdaq100_microstructure/07_gbm`'s `checkpoint_interval: 250` is a real cut from 50, exactly as its comment says.

## Verification

- `tests/test_pm_helpers.py`: 120 passed.
- Negative control both ways: dropping `sp500_options/07_gbm` from the table reds the first test; adding a row for `sp500_options/06_linear`, which raises nothing, reds the second.
- `ruff check` and `ruff format` clean on the file.

No notebook is re-run and nothing is re-keyed: this adds test cases and changes no fixture value.
