### PR TITLE
Return polars' freed pages so the AlgoSeek conversion fits a small container

### DIFF
--- a/data/README.md
+++ b/data/README.md
@@ -175,13 +175,16 @@ conversions resume, so an interrupted run continues where it stopped: the option
 conversion at the last day it wrote, the NASDAQ-100 conversion at the last day it
 staged, part-way through a month.
 
-**Give the conversion at least 2 GB of memory.** The NASDAQ-100 archive peaks around
-1.3 GB, one day of bars while parsing and about two thirds of a month while a month is
-assembled. In Docker the limit that applies is Docker Desktop's own allocation
-(Settings -> Resources -> Memory), not the host's RAM, and it defaults low enough on
-some installs to stop the run. A conversion killed for memory prints nothing and exits
-137, because the kill leaves no traceback; if a run stops with no error, check the exit
-status before anything else.
+**Give the conversion at least 2 GB of memory, and the options archive 3 GB.** The
+NASDAQ-100 conversion peaked at 1.4 GB over all 24 months, measured inside a 2 GB container:
+a parsed day is ~50 MB, an assembly batch a few hundred, and the rest is the interpreter and
+its imports. The options archive adds ~0.9 GB before it parses anything, because reading days
+out of the zip has to hold the index of its 1,275,314 members; extracting the archive first
+avoids that as well as being faster. In
+Docker the limit that applies is Docker Desktop's own allocation (Settings -> Resources ->
+Memory), not the host's RAM, and it defaults low enough on some installs to stop the run.
+A conversion killed for memory prints nothing and exits 137, because the kill leaves no
+traceback; if a run stops with no error, check the exit status before anything else.
 
 The TAQ ticks are already parquet in the layout the loader scans, so unpacking
 them is the whole of the work. Name the members — Dropbox writes a stray root

--- a/data/equities/market/algoseek_convert.py
+++ b/data/equities/market/algoseek_convert.py
@@ -33,6 +33,8 @@ Run from the repository root, once per archive:
 Extracting first is faster for the options archive, which holds **1,275,314** gzip
 members: reading them out of the zip pays the archive's index on every open, and
 unpacking that many small files is slow on any filesystem and slower on Windows.
+Extracting also saves memory - holding that index costs ~0.9 GB for as long as the
+archive is open, before a single row is parsed.
 
 Output, under ``$ML4T_DATA_PATH``:
 
@@ -51,13 +53,28 @@ interrupted run continues where it stopped. The NASDAQ-100 conversion also stage
 day as it is parsed, so a run interrupted midway through a month resumes at the day it
 stopped on rather than restarting the month. Pass ``--force`` to rebuild.
 
-Peak memory is one day of bars while parsing, and about two thirds of a month while a
-month is assembled - roughly 1.3 GB in total for the NASDAQ-100 archive. Give a
-container at least 2 GB; Docker Desktop's own allocation is the ceiling that applies,
-not the host's RAM.
+The data this holds is small - a parsed day is ~50 MB and an assembly batch a few
+hundred - but polars allocates through jemalloc, which by default keeps freed pages
+mapped in one arena per worker thread. Measured on the NASDAQ-100 archive, that
+retention alone reached 3.3 GB of anonymous memory by the fourth month and stayed
+there, against ~100 MB of live data, which is what killed the conversion inside a
+memory-capped container (#558). The preamble below makes jemalloc return freed pages
+immediately. The full 24-month conversion then completes inside a 2 GB container, peaking
+at 1.4 GB and writing the same 48,880,176 rows byte for byte. It has to run before polars
+is imported: jemalloc reads its configuration once, when the extension module loads.
+
+The cost is parse throughput: ten days measured 29.4 s at the default and 36.1 s with
+this setting, against 2,330 MB and 722 MB of resident memory. ``dirty_decay_ms:1000``
+is free but only reaches 1,610 MB, which is not enough to matter for a reader whose
+container is the constraint.
 """
 
 from __future__ import annotations
+
+import os
+
+# Before `import polars`, and for the reason in the module docstring above.
+os.environ.setdefault("_RJEM_MALLOC_CONF", "dirty_decay_ms:0,muzzy_decay_ms:0")
 
 import argparse
 import gzip


### PR DESCRIPTION
Closes the memory half of #558.

**What the reader sees.** The NASDAQ-100 conversion is killed inside Docker on a 16 GB Intel Mac, exit 137, and finishes on a machine whose Docker allocation is 32.5 GB. Staging each day (852a4654) fixed what the run *holds* between days; it did not fix what the process *keeps*.

**What is actually resident.** polars allocates through jemalloc, configured `dirty_decay_ms:500,muzzy_decay_ms:-1` - muzzy pages are never returned - with one arena per worker thread. The converter parses a day, writes it and drops it, so live data never exceeds ~100 MB. Measured on the published archive, anonymous memory still reached **3.2-3.3 GB by the fourth month and stayed there**, about thirty times the data and none of it reachable.

**The change** is two lines: set `_RJEM_MALLOC_CONF=dirty_decay_ms:0,muzzy_decay_ms:0` before `import polars`. It has to be before, because jemalloc reads its configuration once, when the extension module loads.

| run | peak anonymous memory | outcome |
|---|---|---|
| `main`, no limit | 3.32 GB (plateau from month 4) | completes |
| `main`, 2 GB container | 1.98 GB, 45,973 reclaim events | survives by thrashing |
| this branch, 2 GB container | **1.41 GB**, no reclaim events | 24/24 months, exit 0 |

The output is unchanged: 48,880,176 rows, and all 24 monthly parquets compare equal to the published dataset.

The cost is parse throughput - ten days measured 29.4 s unset against 36.1 s with the setting (2,330 MB vs 722 MB resident). `dirty_decay_ms:1000` costs nothing but only reaches 1,610 MB, which does not help a reader whose container is the constraint.

**Docs.** `data/README.md` carried 1.3 GB, which was the live-data estimate rather than a measurement. It now states the measured peak, and that the options archive wants 3 GB because holding the index of its 1,275,314 members costs ~0.9 GB before a row is parsed - one more reason to extract it first.

Not fixed here, and measured while looking: importing anything from `utils` runs `utils/config.py`, which imports **torch** to build an `LD_LIBRARY_PATH` string - 502 MB of resident memory in a CSV-to-parquet converter, and a third of what this run now peaks at.