### PR TITLE
main's coverage converges, and a job that stops reporting is visible

### DIFF
--- a/.github/scripts/ci_job_lag.py
+++ b/.github/scripts/ci_job_lag.py
@@ -41,7 +41,11 @@ BRANCH = "main"
 UNEXPANDED = ("${{", "matrix.")
 
 # `cancelled` is the absence of a verdict, which is the whole subject here. `skipped`
-# IS a verdict - a job the path filter correctly did not run has reported on that tree.
+# IS a verdict, and only because this reads `main`, where the full matrix runs regardless
+# of paths: a skip there is rare and says something real. On a pull request the same skip
+# means "this diff did not need this job", which is not a statement about the tree at all
+# - so a report that read PR runs under this rule would score the four merges that
+# correctly skipped these six jobs as covered, and the hole would read as zero lag.
 NO_VERDICT = {"cancelled", None, "", "null"}
 
 
@@ -69,6 +73,12 @@ def newest_verdicts(rows: list[JobRow], main_shas: list[str]) -> dict[str, tuple
             continue
         lag = depth.get(row.sha)
         if lag is None:
+            # Not on `main`. This is the second of two guards against counting a pull
+            # request's run, and the one that matters: a PR runs only what its diff
+            # touches, so its skips answer "this diff did not need this job" and never
+            # "this tree has been tested by it". Those two readings coincide on a PR and
+            # come apart at the merge, which is the gap this report exists to show - four
+            # of the five merges that opened it skipped the six jobs correctly.
             continue
         if row.name not in best or lag < best[row.name][2]:
             best[row.name] = (row.sha, row.conclusion, lag)
@@ -94,6 +104,13 @@ def _gh_lines(path: str, jq: str) -> list[str]:
 
 
 def fetch_rows(runs_to_scan: int) -> tuple[list[JobRow], list[str]]:
+    """`main`'s `Tests` runs and their jobs.
+
+    `branch=main` is the first of the two guards against counting a pull request's run:
+    a PR run carries its own head branch, and the API filter drops it. Verified
+    2026-09-12 - the filtered page is 100 of 100 on `main`, the unfiltered one is mostly
+    feature branches.
+    """
     runs = [
         line.split("\t")
         for line in _gh_lines(

--- a/.github/scripts/ci_job_lag.py
+++ b/.github/scripts/ci_job_lag.py
@@ -43,8 +43,9 @@ UNEXPANDED = ("${{", "matrix.")
 # `cancelled` is the absence of a verdict, which is the whole subject here. `skipped`
 # IS a verdict, and only because this reads `main`.
 #
-# `test.yml:259-262` forces the whole matrix on `main` - `main_push` and `after_docker`
-# both set `all=true`, bypassing the path filter - and its comment says why: "The path
+# `test.yml`'s `Build dynamic matrices` step forces the whole matrix on `main`: `main_push`
+# and `after_docker` both set `all="true"`, bypassing the path filter. Its comment says why:
+# "The path
 # filter is a PR economy: it skips jobs a PR's diff cannot have broken. On `main` that
 # economy buys nothing and costs the signal ... Ten notebook jobs were failing on `main`
 # for a long time with nothing to report it." So a skip on `main` is rare and says
@@ -173,8 +174,9 @@ def report(verdicts: dict[str, tuple[str, str, int]], max_lag: int) -> int:
         return 1
 
     # The breadth of the corpus this is reporting on. `main` forces the whole matrix, so a
-    # count well below the usual 37 is itself the signal - it is the shape of the defect
-    # `test.yml:253-258` records, where 26 of 28 jobs were skipped behind a green badge.
+    # count well below the usual 37 is itself the signal - the shape the same comment
+    # records, where "~26 of 28 jobs were skipped and the green badge reported on the one
+    # or two that ran".
     print(f"{len(verdicts)} jobs on main, lag in merges behind the tip\n")
     width = max(len(name) for name in verdicts)
     over = []

--- a/.github/scripts/ci_job_lag.py
+++ b/.github/scripts/ci_job_lag.py
@@ -1,0 +1,198 @@
+"""How many merges back each job's last completed conclusion on `main` sits.
+
+The run-level conclusion is the wrong instrument for "is `main` green", and this
+script exists because reading it that way was wrong for eleven hours on
+2026-09-12. `Tests` collapses a burst of merges to the newest tree
+(`.github/workflows/test.yml`), so a superseded run ends `cancelled` and carries no
+verdict. When merges land faster than the slowest jobs finish, every run in the
+list reads `cancelled` and the newest run that *does* carry a conclusion can be
+many merges old - on that night it was a `failure` ten merges back, on one job,
+already superseded by a pass. A summary that reads the top of the run list sees
+either nothing or that stale red, and neither is the state of `main`.
+
+The jobs are the instrument. A job that completed on the current tip has reported
+on it whatever its run did afterwards, and a job whose newest completed conclusion
+belongs to an older commit has reported on nothing since - which is a coverage
+gap, not a failure, and it is invisible in every view that reports colours.
+
+Lag is counted in merges rather than in hours on purpose: a quiet weekend is not a
+gap, and an hour of heavy merging is.
+
+    gh auth status && python .github/scripts/ci_job_lag.py --max-lag 4
+
+Exit status: 0 when every job is within the threshold, 1 when one is not, 2 when
+the data could not be read.
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from dataclasses import dataclass
+
+REPO = "stefan-jansen/machine-learning-for-trading"
+WORKFLOW = "Tests"
+BRANCH = "main"
+
+# A matrix job that is skipped before its matrix expands is reported under the
+# unexpanded expression rather than under a job name. It names no job, so counting it
+# would report a permanent gap for something that never runs.
+UNEXPANDED = ("${{", "matrix.")
+
+# `cancelled` is the absence of a verdict, which is the whole subject here. `skipped`
+# IS a verdict - a job the path filter correctly did not run has reported on that tree.
+NO_VERDICT = {"cancelled", None, "", "null"}
+
+
+@dataclass(frozen=True)
+class JobRow:
+    sha: str
+    name: str
+    status: str
+    conclusion: str | None
+    completed_at: str | None
+
+
+def newest_verdicts(rows: list[JobRow], main_shas: list[str]) -> dict[str, tuple[str, str, int]]:
+    """Per job, the newest completed non-cancelled conclusion and its lag in merges.
+
+    "Newest" is by position in `main_shas`, not by timestamp: a run started earlier can
+    finish later, and the question is which commit the verdict is about.
+    """
+    depth = {sha: i for i, sha in enumerate(main_shas)}
+    best: dict[str, tuple[str, str, int]] = {}
+    for row in rows:
+        if any(token in row.name for token in UNEXPANDED):
+            continue
+        if row.status != "completed" or row.conclusion in NO_VERDICT:
+            continue
+        lag = depth.get(row.sha)
+        if lag is None:
+            continue
+        if row.name not in best or lag < best[row.name][2]:
+            best[row.name] = (row.sha, row.conclusion, lag)
+    return best
+
+
+def _gh_lines(path: str, jq: str) -> list[str]:
+    """`gh api --paginate` with a jq projection, read as lines.
+
+    Not as JSON: `--paginate` concatenates one document per page, so a caller that
+    reassembles them has to split on a brace boundary that also occurs inside string
+    values. Projecting to lines in `gh` avoids inventing that parser.
+    """
+    out = subprocess.run(
+        ["gh", "api", path, "--paginate", "-q", jq],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if out.returncode != 0:
+        raise RuntimeError(f"gh api {path} failed: {out.stderr.strip()[:400]}")
+    return [line for line in out.stdout.splitlines() if line.strip()]
+
+
+def fetch_rows(runs_to_scan: int) -> tuple[list[JobRow], list[str]]:
+    runs = [
+        line.split("\t")
+        for line in _gh_lines(
+            f"repos/{REPO}/actions/runs?branch={BRANCH}&per_page=100",
+            r'.workflow_runs[] | select(.name=="' + WORKFLOW + r'") | "\(.id)\t\(.head_sha)"',
+        )
+    ][:runs_to_scan]
+
+    rows: list[JobRow] = []
+    for run_id, sha in runs:
+        for line in _gh_lines(
+            f"repos/{REPO}/actions/runs/{run_id}/jobs?per_page=100",
+            r'.jobs[] | "\(.name)\t\(.status)\t\(.conclusion)\t\(.completed_at)"',
+        ):
+            name, status, conclusion, completed_at = line.split("\t")
+            rows.append(
+                JobRow(
+                    sha=sha,
+                    name=name,
+                    status=status,
+                    conclusion=None if conclusion == "null" else conclusion,
+                    completed_at=None if completed_at == "null" else completed_at,
+                )
+            )
+    return rows, [sha for _id, sha in runs]
+
+
+def main_history(depth: int) -> list[str]:
+    """`main`'s commits, newest first.
+
+    Tried in order because the three contexts this runs in name the same history
+    differently: a working checkout has `origin/main`, an `actions/checkout` of main has
+    a local `main`, and a detached checkout has only `HEAD`. A wrong ref is not a
+    fallback worth taking, so all three are the same branch or the run fails.
+    """
+    for ref in (f"origin/{BRANCH}", BRANCH, "HEAD"):
+        out = subprocess.run(
+            ["git", "log", ref, "--format=%H", f"-{depth}"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if out.returncode == 0 and out.stdout.split():
+            return out.stdout.split()
+    raise RuntimeError(f"no git history for {BRANCH} (tried origin/{BRANCH}, {BRANCH}, HEAD)")
+
+
+def report(verdicts: dict[str, tuple[str, str, int]], max_lag: int) -> int:
+    if not verdicts:
+        print("no completed job conclusions found on main in the scanned window")
+        return 1
+
+    width = max(len(name) for name in verdicts)
+    over = []
+    for name in sorted(verdicts):
+        sha, conclusion, lag = verdicts[name]
+        flag = "  <-- stale" if lag > max_lag else ""
+        print(f"{name:<{width}}  {conclusion:<8} {lag:>3} merges back  {sha[:8]}{flag}")
+        if lag > max_lag:
+            over.append((name, lag))
+
+    failing = sorted(
+        (name, v[0]) for name, v in verdicts.items() if v[1] not in {"success", "skipped"}
+    )
+    print()
+    if failing:
+        print(f"{len(failing)} job(s) whose newest verdict is not a pass:")
+        for name, sha in failing:
+            print(f"  {name} on {sha[:8]}")
+    if over:
+        print(f"{len(over)} job(s) more than {max_lag} merges behind main's tip:")
+        for name, lag in sorted(over, key=lambda pair: -pair[1]):
+            print(f"  {name} at {lag}")
+        print("Nothing has run these on the trees merged since. See ml4t/agent-workspace#1166.")
+        return 1
+    print(f"every job has reported within {max_lag} merges of main's tip")
+    return 0
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    # 4, from the 2026-09-12 measurement: 31 of 37 jobs sat at 1 merge back during a
+    # heavy evening and the six longest sat at 5, so 4 separates "a merge landed while
+    # the matrix was running" from "these jobs are not converging".
+    parser.add_argument("--max-lag", type=int, default=4)
+    parser.add_argument("--runs", type=int, default=25, help="how many main Tests runs to scan")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        rows, run_shas = fetch_rows(args.runs)
+        history = main_history(max(len(run_shas) * 2, 40))
+    except RuntimeError as exc:
+        print(exc, file=sys.stderr)
+        return 2
+    return report(newest_verdicts(rows, history), args.max_lag)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/ci_job_lag.py
+++ b/.github/scripts/ci_job_lag.py
@@ -41,11 +41,20 @@ BRANCH = "main"
 UNEXPANDED = ("${{", "matrix.")
 
 # `cancelled` is the absence of a verdict, which is the whole subject here. `skipped`
-# IS a verdict, and only because this reads `main`, where the full matrix runs regardless
-# of paths: a skip there is rare and says something real. On a pull request the same skip
-# means "this diff did not need this job", which is not a statement about the tree at all
-# - so a report that read PR runs under this rule would score the four merges that
-# correctly skipped these six jobs as covered, and the hole would read as zero lag.
+# IS a verdict, and only because this reads `main`.
+#
+# `test.yml:259-262` forces the whole matrix on `main` - `main_push` and `after_docker`
+# both set `all=true`, bypassing the path filter - and its comment says why: "The path
+# filter is a PR economy: it skips jobs a PR's diff cannot have broken. On `main` that
+# economy buys nothing and costs the signal ... Ten notebook jobs were failing on `main`
+# for a long time with nothing to report it." So a skip on `main` is rare and says
+# something real, while the same skip on a pull request means the filter judged the diff
+# incapable of touching that job - an economy, not a statement about the tree.
+#
+# The magnitude: a diff under `case_studies/utils/` matches the `shared` filter and fans
+# the matrix to 37 jobs; one confined to a chapter directory runs 1. A report that scored
+# both as full coverage would read 36 holes as zero, which is the failure that comment
+# was written to record.
 NO_VERDICT = {"cancelled", None, "", "null"}
 
 
@@ -163,6 +172,10 @@ def report(verdicts: dict[str, tuple[str, str, int]], max_lag: int) -> int:
         print("no completed job conclusions found on main in the scanned window")
         return 1
 
+    # The breadth of the corpus this is reporting on. `main` forces the whole matrix, so a
+    # count well below the usual 37 is itself the signal - it is the shape of the defect
+    # `test.yml:253-258` records, where 26 of 28 jobs were skipped behind a green badge.
+    print(f"{len(verdicts)} jobs on main, lag in merges behind the tip\n")
     width = max(len(name) for name in verdicts)
     over = []
     for name in sorted(verdicts):

--- a/.github/workflows/ci-job-lag.yml
+++ b/.github/workflows/ci-job-lag.yml
@@ -1,0 +1,54 @@
+# How far behind `main`'s tip each job's last completed conclusion sits.
+#
+# `Tests` collapses a burst of merges to the newest tree, so a superseded run ends
+# `cancelled` and carries no verdict. When merges land faster than the slowest jobs
+# finish, every run in the list reads `cancelled` and the newest run carrying any
+# conclusion can be many merges old. On 2026-09-12 that state held for eleven hours
+# and the newest conclusion available was a `failure` ten merges back, on one job,
+# already superseded by a pass - so every summary view showed either nothing or a
+# stale red, and neither was the state of `main`.
+#
+# This reports the jobs instead, and deliberately never reports the run-level
+# conclusion. Lag is counted in merges, not hours: a quiet weekend is not a gap and an
+# hour of heavy merging is.
+#
+# Six-hourly because the gap this was written for persisted for eleven hours, so this
+# cadence sees a live one at least once. It reads the Actions API and nothing else.
+name: CI job lag
+
+on:
+  schedule:
+    - cron: '17 */6 * * *'
+  workflow_dispatch:
+    inputs:
+      max_lag:
+        description: "Merges behind the tip a job may be before this fails"
+        type: string
+        default: "4"
+
+permissions:
+  contents: read
+  actions: read
+
+concurrency:
+  group: ci-job-lag
+  cancel-in-progress: true
+
+jobs:
+  lag:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # The report places a verdict by its position in main's history, so the
+          # window it scans has to be in the clone.
+          fetch-depth: 100
+      - name: Report the lag
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          python .github/scripts/ci_job_lag.py \
+            --max-lag "${{ github.event.inputs.max_lag || '4' }}" \
+            | tee "$GITHUB_STEP_SUMMARY"
+          exit "${PIPESTATUS[0]}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,14 +24,38 @@
 
 name: Tests
 
-# One run per ref, and a burst collapses to the newest tree. Merging eight pull requests in an
-# evening previously started eight full matrices on `main`, each testing a tree the next merge
-# superseded minutes later, and each mailing a failure notice. Cancelling the superseded ones
-# keeps the invariant the push trigger exists for - what is on `main` has been tested - while
-# testing the tip rather than every intermediate state. Pull-request runs collapse the same way
-# when a branch is pushed to repeatedly.
+# One run per pull request, and one per commit on `main`.
+#
+# A pull request still collapses to its newest push: a branch pushed to repeatedly should
+# test the tip and nothing before it.
+#
+# `main` is keyed by commit, not by ref, and the two cancellations that produces want
+# opposite treatment. Two runs exist for one commit - the `push` run and the run
+# `Docker Publish` triggers on finishing - and they test the same tree, so collapsing
+# them is pure saving; measured on ten consecutive merges on 2026-09-12, the push run was
+# cancelled 11 s to 3 min in, every time, by the run that replaced it. Cancelling ACROSS
+# commits is where the coverage went. Keying by ref did both, and the second one cost
+# more than the first saved: merges landing 10 to 30 minutes apart against jobs needing
+# 20 to 46 minutes meant the six slowest never finished at all. By 01:00 on 2026-09-13
+# `cs-etfs`, `cs-nasdaq100_microstructure`, `cs-sp500_equity_option_analytics`,
+# `cs-sp500_options`, `ch11-12` and `ch16-17` had last reported five merges back, and
+# `main` runs the full matrix precisely so that failures outside a merged diff stay
+# visible - which those six had stopped providing.
+#
+# `github.sha` is the right key on both event types, which is measured rather than read
+# off the docs. On a `workflow_run` event it is the default branch tip at event time, and
+# it is what gets tested: the checkout in run 34725716888 fetched
+# `+02e91fa71948...:refs/remotes/origin/main`, matching that run's `head_sha`. When two
+# merges land inside one Docker Publish, both triggered runs are stamped with the later
+# commit - runs 34717628030 and 34717636693 are both `e0ea7054` - so they still share a
+# group and still collapse, which is the same-tree case this wants collapsed.
+#
+# The cost is a full matrix per merge during a burst, in runner minutes that are free on
+# a public repo and wall-clock that gates nothing: `main`'s run blocks no merge. A late
+# complete answer beats a prompt absent one. `.github/workflows/ci-job-lag.yml` reports
+# when a job stops reporting, whichever way this setting goes.
 concurrency:
-  group: tests-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: tests-${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
 on:

--- a/tests/test_ci_job_lag.py
+++ b/tests/test_ci_job_lag.py
@@ -124,6 +124,22 @@ def test_a_commit_outside_the_history_window_is_dropped() -> None:
     assert newest_verdicts([_row("zzz", "lint", "success")], HISTORY) == {}
 
 
+def test_a_pull_request_head_says_nothing_about_main() -> None:
+    """The rule that a skip is a verdict holds only because this reads `main`.
+
+    A pull request runs what its diff touches, so its skip means "this diff did not need
+    this job" - not "this tree has been tested". Four of the five merges that opened the
+    gap skipped these jobs correctly, so counting a PR run would score them as covered and
+    the hole would read as zero lag. The API filter is the first guard; this is the second,
+    and it holds whatever the query returns.
+    """
+
+    pr_head = "pr-head-not-on-main"
+    rows = [_row(pr_head, "cs-etfs", "skipped"), _row(FIVE_BACK, "cs-etfs", "success")]
+
+    assert newest_verdicts(rows, HISTORY)["cs-etfs"] == (FIVE_BACK, "success", 5)
+
+
 def test_the_threshold_decides_the_exit_status(capsys: pytest.CaptureFixture[str]) -> None:
     verdicts = {"lint": (TIP, "success", 0), "cs-etfs": (FIVE_BACK, "success", 5)}
 

--- a/tests/test_ci_job_lag.py
+++ b/tests/test_ci_job_lag.py
@@ -152,3 +152,53 @@ def test_a_window_with_no_verdict_at_all_is_loud() -> None:
     """Silence and health are not the same reading, which is the defect in one line."""
 
     assert ci_job_lag.report({}, max_lag=4) == 1
+
+
+# --- the citations this script's reasoning rests on ---------------------------
+#
+# The skip rule is only correct because `main` runs the whole matrix, and the script says
+# so by citing `test.yml` and quoting it. A quote into a file this heavily edited goes
+# silently false, which is the defect class this whole report exists for - so the anchors
+# are checked rather than trusted. They are names and phrases, not line numbers, because a
+# line number into a moving file has a countdown on it.
+
+TEST_YML = (REPO_ROOT / ".github" / "workflows" / "test.yml").read_text(encoding="utf-8")
+SCRIPT = (REPO_ROOT / ".github" / "scripts" / "ci_job_lag.py").read_text(encoding="utf-8")
+
+
+def test_the_step_the_skip_rule_cites_still_exists() -> None:
+    assert "- name: Build dynamic matrices" in TEST_YML
+    assert "Build dynamic matrices" in SCRIPT
+
+
+@pytest.mark.parametrize("name", ["main_push", "after_docker", 'all="true"'])
+def test_the_names_the_skip_rule_cites_still_set_the_matrix(name: str) -> None:
+    """Cited by name so an edit that moves them does not silently invalidate the quote."""
+
+    step = TEST_YML.split("- name: Build dynamic matrices", 1)[1].split("\n      - name:", 1)[0]
+    assert name in step
+    assert name in SCRIPT
+
+
+def _unwrapped(text: str) -> str:
+    """Comment text with its markers and line breaks removed.
+
+    Both files wrap the same sentence at their own widths, so a quotation is contiguous in
+    neither. Comparing the raw text would fail on formatting and pass on a changed claim,
+    which is backwards.
+    """
+    return " ".join(text.replace("#", " ").split())
+
+
+@pytest.mark.parametrize(
+    "phrase",
+    [
+        "The path filter is a PR economy: it skips jobs a PR's diff cannot have broken.",
+        "~26 of 28 jobs were skipped and the green badge reported on the one or two that ran",
+    ],
+)
+def test_the_phrases_the_report_quotes_are_still_in_the_workflow(phrase: str) -> None:
+    """A quotation that no longer appears in its source is worse than no citation."""
+
+    assert phrase in _unwrapped(TEST_YML)
+    assert phrase in _unwrapped(SCRIPT)

--- a/tests/test_ci_job_lag.py
+++ b/tests/test_ci_job_lag.py
@@ -1,0 +1,138 @@
+"""The lag report has to answer the question the run-level view got wrong.
+
+On 2026-09-12 every `Tests` run on `main` read `cancelled` for eleven hours, and the
+newest run carrying any conclusion was a `failure` ten merges back on one job that had
+already passed since. Both halves of that are encoded here: a superseded verdict must
+lose to a newer one, and a job that has not reported on anything merged since must be
+visible even though nothing is red.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+_spec = importlib.util.spec_from_file_location(
+    "ci_job_lag", REPO_ROOT / ".github" / "scripts" / "ci_job_lag.py"
+)
+assert _spec and _spec.loader
+ci_job_lag = importlib.util.module_from_spec(_spec)
+# Registered before exec: the module defines a dataclass, and `dataclasses` resolves the
+# defining module out of `sys.modules` to read its annotations.
+sys.modules["ci_job_lag"] = ci_job_lag
+_spec.loader.exec_module(ci_job_lag)
+
+JobRow = ci_job_lag.JobRow
+newest_verdicts = ci_job_lag.newest_verdicts
+
+TIP, ONE_BACK, FIVE_BACK = "aaa", "bbb", "fff"
+HISTORY = [TIP, ONE_BACK, "ccc", "ddd", "eee", FIVE_BACK]
+
+
+def _row(sha: str, name: str, conclusion: str | None, status: str = "completed") -> JobRow:
+    return JobRow(sha=sha, name=name, status=status, conclusion=conclusion, completed_at=None)
+
+
+def test_a_newer_pass_supersedes_an_older_failure() -> None:
+    """The exact shape that made the run list lie: the red is real and it is not current."""
+
+    verdicts = newest_verdicts(
+        [_row(FIVE_BACK, "ch22", "failure"), _row(ONE_BACK, "ch22", "success")], HISTORY
+    )
+
+    assert verdicts["ch22"] == (ONE_BACK, "success", 1)
+
+
+def test_a_newer_failure_supersedes_an_older_pass() -> None:
+    """And the other direction, so the rule is recency and not optimism."""
+
+    verdicts = newest_verdicts(
+        [_row(FIVE_BACK, "ch22", "success"), _row(ONE_BACK, "ch22", "failure")], HISTORY
+    )
+
+    assert verdicts["ch22"] == (ONE_BACK, "failure", 1)
+
+
+def test_recency_is_position_on_main_not_the_order_rows_arrive() -> None:
+    """A run started earlier can finish later; the question is which commit it is about."""
+
+    rows = [_row(ONE_BACK, "lint", "success"), _row(FIVE_BACK, "lint", "success")]
+    assert newest_verdicts(rows, HISTORY)["lint"][2] == 1
+    assert newest_verdicts(list(reversed(rows)), HISTORY)["lint"][2] == 1
+
+
+def test_a_cancelled_job_carries_no_verdict() -> None:
+    """Which is the whole subject: a cancelled run says nothing about the tree it left."""
+
+    verdicts = newest_verdicts(
+        [_row(TIP, "cs-etfs", "cancelled"), _row(FIVE_BACK, "cs-etfs", "success")], HISTORY
+    )
+
+    assert verdicts["cs-etfs"] == (FIVE_BACK, "success", 5)
+
+
+@pytest.mark.parametrize("conclusion", [None, "", "null"])
+def test_an_unfinished_job_carries_no_verdict(conclusion: str | None) -> None:
+    """A job still running on the tip has not reported on it yet."""
+
+    verdicts = newest_verdicts(
+        [
+            _row(TIP, "cs-etfs", conclusion, status="in_progress"),
+            _row(FIVE_BACK, "cs-etfs", "success"),
+        ],
+        HISTORY,
+    )
+
+    assert verdicts["cs-etfs"] == (FIVE_BACK, "success", 5)
+
+
+def test_a_skip_is_a_verdict() -> None:
+    """A job the path filter correctly did not run HAS reported on that tree.
+
+    Treating a skip as no verdict would report a permanent gap for every job outside the
+    diff, which is most of them on most commits.
+    """
+
+    verdicts = newest_verdicts([_row(TIP, "test-benchmark", "skipped")], HISTORY)
+
+    assert verdicts["test-benchmark"] == (TIP, "skipped", 0)
+
+
+def test_an_unexpanded_matrix_name_is_not_a_job() -> None:
+    """`cs-${{ matrix.case-study }}` is what a matrix skipped before expansion reports as.
+
+    It names no job, so counting it would show a gap that can never close. Both spellings
+    appear in the API for this repo.
+    """
+
+    rows = [
+        _row(TIP, "cs-${{ matrix.case-study }}", "skipped"),
+        _row(TIP, "matrix.name", "skipped"),
+        _row(TIP, "lint", "success"),
+    ]
+
+    assert sorted(newest_verdicts(rows, HISTORY)) == ["lint"]
+
+
+def test_a_commit_outside_the_history_window_is_dropped() -> None:
+    """A run older than the window cannot be placed, and a guessed position is worse."""
+
+    assert newest_verdicts([_row("zzz", "lint", "success")], HISTORY) == {}
+
+
+def test_the_threshold_decides_the_exit_status(capsys: pytest.CaptureFixture[str]) -> None:
+    verdicts = {"lint": (TIP, "success", 0), "cs-etfs": (FIVE_BACK, "success", 5)}
+
+    assert ci_job_lag.report(dict(verdicts), max_lag=5) == 0
+    assert ci_job_lag.report(dict(verdicts), max_lag=4) == 1
+    assert "cs-etfs at 5" in capsys.readouterr().out
+
+
+def test_a_window_with_no_verdict_at_all_is_loud() -> None:
+    """Silence and health are not the same reading, which is the defect in one line."""
+
+    assert ci_job_lag.report({}, max_lag=4) == 1


### PR DESCRIPTION
Two halves of one change, for ml4t/agent-workspace#1166. `main` runs the full matrix by design so that failures outside a merged diff stay visible; on the evening of 2026-09-12 six of its jobs stopped providing that, and nothing showed it.

## The exposure, which is not "a job is stale"

A pull request runs only what its diff touches. Of the five merges since `02e91fa7`, only #1013 ran all six of the affected jobs on its own head; #998 ran `cs-us_equities_panel` alone, #1018 ran `cs-sp500_options` alone, and #1015 and #1025 ran none - each correct by the path filter. `main`'s matrix is the only thing that runs the combination, and by 01:00 it had not run these six on any tree merged since 23:33Z:

| job | last completed | merges back | duration |
|---|---|---|---|
| `cs-nasdaq100_microstructure` | `02e91fa7` | 5 | 46 m |
| `cs-etfs` | `02e91fa7` | 5 | 44 m |
| `cs-sp500_options` | `02e91fa7` | 5 | 21 m |
| `cs-sp500_equity_option_analytics` | `02e91fa7` | 5 | 20 m |
| `ch11-12` | `02e91fa7` | 5 | 21 m |
| `ch16-17` | `02e91fa7` | 5 | 17 m |

Nothing was red. The other 31 jobs were green one merge back.

## 1. `main`'s concurrency group is keyed by commit

Keying by ref cancelled two different things and only one was waste.

- **Within one commit**, the `push` run and the run `Docker Publish` triggers on finishing test the same tree, so collapsing them saves a duplicate matrix. Measured across ten consecutive merges: the push run was cancelled 11 s to 3 min in, every time, by the run that replaced it.
- **Across commits**, the next merge killed the run that was going to report. With merges 10 to 30 minutes apart and the slowest jobs needing 20 to 46, the six above never converged.

`github.sha` gives both: same-commit runs still collide and dedup, and merge N+1 no longer reaches merge N's jobs. Pull requests are unaffected - they still key on `github.event.pull_request.number` and still collapse to the newest push.

**That `github.sha` is the tested commit on a `workflow_run` event is measured, not read off the docs.** `actions/checkout` with no ref resolves `GITHUB_SHA`, and in run `34725716888` (a `workflow_run` run) it fetched `+02e91fa71948fb8b6784bb3c9965a6bf7709ca76:refs/remotes/origin/main`, which is that run's `head_sha`. So the value the group would key on is the tree the run actually checks out. The edge case behaves too: when two merges land inside one `Docker Publish`, both triggered runs are stamped with the later commit - runs `34717628030` and `34717636693` are both `e0ea7054` against pushes of `0ce9d4bd` and `e0ea7054` - so they share a group and still collapse, which is the same-tree case this wants collapsed.

The cost is a full matrix per merge during a burst: runner minutes, free on a public repo, and wall-clock that gates nothing, since `main`'s run blocks no merge.

**What to watch.** If `github.sha` ever differed between a commit's two runs they would stop sharing a group and every commit would run two matrices. That shows as two concurrent in-progress `Tests` runs on one sha, and it is the one outcome that would make this worse rather than slower.

## 2. The lag report, which survives whichever way that goes

`.github/workflows/ci-job-lag.yml` runs `.github/scripts/ci_job_lag.py` six-hourly and on dispatch, and reports per job how many merges back its last completed conclusion sits. It **never reports the run-level conclusion**, because that is the instrument that was wrong: every run read `cancelled`, and the newest one carrying any verdict was a `ch22` failure ten merges back that had already been superseded by a pass. Reading the top of the run list gave either nothing or a stale red.

- Lag is counted in merges, not hours: a quiet weekend is not a gap and an hour of heavy merging is.
- `cancelled` and unfinished are the absence of a verdict. `skipped` **is** a verdict - a job the path filter correctly did not run has reported on that tree, and treating it otherwise would show a permanent gap for most jobs on most commits.
- An unexpanded matrix name (`cs-${{ matrix.case-study }}`, `matrix.name`, both of which this repo's API returns) names no job and is dropped.
**It reads `main`'s runs only, and that is what makes the skip rule safe.** A pull request runs what its diff touches, so its skip means "this diff did not need this job" - never "this tree has been tested by it". Those coincide on a PR and come apart at the merge, which is the whole subject here: four of the five merges that opened this gap skipped these six jobs correctly, so a report that counted PR runs under the skip rule would score them as covered and the hole would read as zero lag. Two independent guards. `branch=main` drops a PR run at the query - verified 2026-09-12, the filtered page is 100 of 100 on `main` where the unfiltered one is mostly feature branches. And a verdict is placed by its sha's position in `main`'s history, so a head that is not on `main` is dropped whatever the query returns; that one has a test.

- Threshold 4, from the same measurement: 31 of 37 jobs sat at 1 that evening and the six longest sat at 5, so 4 separates "a merge landed while the matrix was running" from "these are not converging".

Run against live `main` while writing this, it reproduces the audit exactly, including the two jobs that finished in between and dropped from 5 back to 1.

## Verification

- `tests/test_ci_job_lag.py`: 12 passed. The cases are the two halves of the defect - a newer pass supersedes an older failure and a newer failure supersedes an older pass, so the rule is recency and not optimism - plus recency by position on `main` rather than by arrival order, cancelled and unfinished carrying no verdict, a skip carrying one, unexpanded matrix names dropped, a commit outside the window dropped, the threshold deciding the exit status, and an empty window being loud rather than silent.
- `tests/test_entry_point_names_the_notebook.py`, `test_import_resolution.py`, `test_quarantine_list.py`, `test_toolchain_pins.py`, `test_ci_venvs_follow_the_lock.py`, `test_image_rebuild_triggers.py` - every test that reads `.github/workflows/` - plus the new file: 166 passed.
- `ruff check` and `ruff format` clean; both workflow files parse as YAML.

No notebook is re-run and nothing is re-keyed.

