### PR TITLE
Stop paying for memory the reader does not have

### DIFF
--- a/envs/ml4t/Dockerfile
+++ b/envs/ml4t/Dockerfile
@@ -223,6 +223,19 @@ WORKDIR /app
 ENV PATH="/opt/ml4t/bin:$PATH"
 ENV PYTHONPATH="/app"
 
+# polars allocates through jemalloc, which by default keeps freed pages mapped - one
+# arena per worker thread, muzzy pages never returned. On the AlgoSeek conversion that
+# retention reached 3.3 GB of anonymous memory against ~100 MB of live data (#558), and
+# it applies to every notebook that loads a panel. Inside a container the ceiling is
+# Docker Desktop's allocation rather than the host's RAM, so the pages nobody can reach
+# are what gets a run killed. Returning them immediately costs 0-4% on dataset loads and
+# more on tight parse loops; a reader whose container is the constraint wants the memory.
+# polars appends this to its own defaults and jemalloc takes the last setting for a key,
+# so this is its supported override. Set in the image rather than in Python because the
+# assignment only counts if it precedes `import polars` - here it covers every notebook
+# and script without each one remembering. Override with `docker run -e`.
+ENV _RJEM_MALLOC_CONF=dirty_decay_ms:0,muzzy_decay_ms:0
+
 # For GPU users: CUDA libraries are bundled in PyTorch wheel
 # nvidia-container-toolkit passes through /dev/nvidia* and sets these:
 # - NVIDIA_VISIBLE_DEVICES

--- a/envs/py312/Dockerfile
+++ b/envs/py312/Dockerfile
@@ -97,6 +97,19 @@ RUN /opt/ml4t/bin/pip install --no-cache-dir -c /tmp/locked-constraints.txt \
 WORKDIR /app
 ENV PATH="/opt/ml4t/bin:$PATH"
 ENV PYTHONPATH="/app"
+
+# polars allocates through jemalloc, which by default keeps freed pages mapped - one
+# arena per worker thread, muzzy pages never returned. On the AlgoSeek conversion that
+# retention reached 3.3 GB of anonymous memory against ~100 MB of live data (#558), and
+# it applies to every notebook that loads a panel. Inside a container the ceiling is
+# Docker Desktop's allocation rather than the host's RAM, so the pages nobody can reach
+# are what gets a run killed. Returning them immediately costs 0-4% on dataset loads and
+# more on tight parse loops; a reader whose container is the constraint wants the memory.
+# polars appends this to its own defaults and jemalloc takes the last setting for a key,
+# so this is its supported override. Set in the image rather than in Python because the
+# assignment only counts if it precedes `import polars` - here it covers every notebook
+# and script without each one remembering. Override with `docker run -e`.
+ENV _RJEM_MALLOC_CONF=dirty_decay_ms:0,muzzy_decay_ms:0
 ENV JUPYTER_ENABLE_LAB=yes
 
 # Token-less, like envs/ml4t/Dockerfile: safe only because compose binds the

--- a/tests/notebook_worker.py
+++ b/tests/notebook_worker.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import importlib.util
 import json
 import os
 import shutil
@@ -85,16 +86,19 @@ def _run_full_notebook(
         f"{repo_root}:{nb_dir}:{existing}" if existing else f"{repo_root}:{nb_dir}"
     )
 
+    # Located with find_spec rather than by importing torch: this process only needs
+    # the paths, and executing the package to read them costs 502 MB resident in every
+    # worker (#558). The resulting string is identical.
     try:
-        import torch
-
-        torch_lib = str(Path(torch.__file__).parent / "lib")
-        nvidia_libs = list((Path(torch.__file__).parent.parent / "nvidia").glob("*/lib"))
-        cuda_paths = [torch_lib] + [str(p) for p in nvidia_libs]
+        torch_spec = importlib.util.find_spec("torch")
+    except (ImportError, ValueError):
+        torch_spec = None
+    if torch_spec is not None and torch_spec.origin:
+        torch_root = Path(torch_spec.origin).parent
+        nvidia_libs = list((torch_root.parent / "nvidia").glob("*/lib"))
+        cuda_paths = [str(torch_root / "lib")] + [str(p) for p in nvidia_libs]
         existing_ld = os.environ.get("LD_LIBRARY_PATH", "")
         env_vars["LD_LIBRARY_PATH"] = ":".join(cuda_paths + [existing_ld])
-    except ImportError:
-        pass
 
     for key, value in env_vars.items():
         saved_env[key] = os.environ.get(key)

--- a/tests/pm_helpers.py
+++ b/tests/pm_helpers.py
@@ -68,6 +68,7 @@ overrides.yaml schema (per-notebook, all optional):
 
 import ast
 import functools
+import importlib.util
 import json
 import os
 import re
@@ -1616,16 +1617,19 @@ def run_notebook(
     # Ensure torch's bundled CUDA libraries are found before system ones.
     # The system libcudart.so.12 may be outdated and missing symbols like
     # cudaGetDriverEntryPointByVersion that torch's bundled version provides.
+    # Located with find_spec rather than by importing torch: this process only needs
+    # the paths, and executing the package to read them costs 502 MB resident in every
+    # worker (#558). The resulting string is identical.
     try:
-        import torch
-
-        torch_lib = str(Path(torch.__file__).parent / "lib")
-        nvidia_libs = list((Path(torch.__file__).parent.parent / "nvidia").glob("*/lib"))
-        cuda_paths = [torch_lib] + [str(p) for p in nvidia_libs]
+        torch_spec = importlib.util.find_spec("torch")
+    except (ImportError, ValueError):
+        torch_spec = None
+    if torch_spec is not None and torch_spec.origin:
+        torch_root = Path(torch_spec.origin).parent
+        nvidia_libs = list((torch_root.parent / "nvidia").glob("*/lib"))
+        cuda_paths = [str(torch_root / "lib")] + [str(p) for p in nvidia_libs]
         existing_ld = os.environ.get("LD_LIBRARY_PATH", "")
         env_vars["LD_LIBRARY_PATH"] = ":".join(cuda_paths + [existing_ld])
-    except ImportError:
-        pass
 
     # A notebook whose dependencies live in a separate venv runs on its own
     # kernelspec, written to a temp JUPYTER_PATH so nothing global is touched.

--- a/utils/config.py
+++ b/utils/config.py
@@ -11,6 +11,7 @@ Usage:
     from utils import ML4T_PATH, ML4T_DATA_PATH, REPO_ROOT
 """
 
+import importlib.util
 import os
 from pathlib import Path
 
@@ -93,11 +94,19 @@ if not ML4T_DATA_PATH.exists():
 # Without this, torch imports fail with "undefined symbol" errors on systems
 # where the system libcudart.so is older than what torch expects.
 # Docker images don't need this (CUDA is installed system-wide).
+#
+# Located through the import system rather than by importing torch. `import utils`
+# runs this module, so every script and notebook in the repository paid 502 MB of
+# resident memory for a path string - a third of what the AlgoSeek conversion peaks
+# at inside a reader's container (#558). find_spec resolves the same directories
+# without executing the package, and the string built below is byte-identical.
 if not os.environ.get("LD_LIBRARY_PATH", "").startswith("/usr/local/cuda"):
     try:
-        import torch as _torch
-
-        _torch_root = Path(_torch.__file__).parent
+        _torch_spec = importlib.util.find_spec("torch")
+    except (ImportError, ValueError):  # absent, or imported without a spec
+        _torch_spec = None
+    if _torch_spec is not None and _torch_spec.origin:
+        _torch_root = Path(_torch_spec.origin).parent
         _cuda_paths = [str(_torch_root / "lib")]
         _nvidia_dir = _torch_root.parent / "nvidia"
         if _nvidia_dir.exists():
@@ -106,9 +115,8 @@ if not os.environ.get("LD_LIBRARY_PATH", "").startswith("/usr/local/cuda"):
         os.environ["LD_LIBRARY_PATH"] = ":".join(
             _cuda_paths + ([_existing_ld] if _existing_ld else [])
         )
-        del _torch, _torch_root, _cuda_paths, _nvidia_dir, _existing_ld
-    except ImportError:
-        pass
+        del _torch_root, _cuda_paths, _nvidia_dir, _existing_ld
+    del _torch_spec
 
 # ============================================================================
 # API Keys (optional - only needed for data downloads)


### PR DESCRIPTION
Follow-on to #1026, which fixed the AlgoSeek converter. Both items here were measured while diagnosing #558 and neither is specific to that script.

### `utils/config.py` imported torch to read a path

`import utils` runs `utils/config.py`, which imported torch so it could join `torch/lib` and the `nvidia/*/lib` directories into `LD_LIBRARY_PATH`. That is **502 MB resident**, paid by every script and notebook in the repository that touches `utils`, for a string - and a third of what the AlgoSeek conversion peaks at inside a reader's container.

`importlib.util.find_spec` resolves the same directories without executing the package. The sixteen paths are the same set in the same order, verified against the previous implementation. `from utils.downloading import ...` now costs 100 MB instead of 630 MB.

Nothing depended on the eager import:

| checked | result |
|---|---|
| torch imports with `LD_LIBRARY_PATH` unset | venv, `ml4t/ml4t:latest`, `ml4t/ml4t-py312:latest` - all fine, CUDA available |
| `ml4t.diagnostic.metrics` imported *before* torch, then a CUDA tensor op | works in venv and in the image |

The env var is still set, because a child process reads it at exec. The current process never does - glibc's loader caches its search path at startup, so assigning `os.environ` afterwards was never what made torch work.

`tests/pm_helpers.py` and `tests/notebook_worker.py` carried the same pattern to build the environment they hand to papermill, where the parent is a test worker sitting beside notebook kernels. Same change.

### The images do not return polars' freed pages

`scripts/nb-run.sh` sets `_RJEM_MALLOC_CONF` for the repository's own production runs. Nothing a reader executes gets it, and the reader is the one whose ceiling is Docker Desktop's allocation rather than the host's RAM.

polars ships jemalloc as `dirty_decay_ms:500,muzzy_decay_ms:-1` - one arena per worker thread, muzzy pages never returned. In `ml4t/ml4t:latest`, eight rounds of an 8-column 2M-row frame sorted and discarded leave **373 MB** resident at the default and **78 MB** with this setting. On the AlgoSeek conversion the same retention reached 3.3 GB against ~100 MB of live data.

polars appends the value to its own defaults and jemalloc takes the last setting for a key, so this is its supported override. It belongs in the image because the assignment only counts if it precedes `import polars`.

Not applied to the benchmark or rapids images: Chapter 2 publishes storage timings, and changing the allocator underneath a benchmark changes what it measures.